### PR TITLE
Refine dashboard alert strip hierarchy and actionability

### DIFF
--- a/features/dashboard/components/DashboardAlertStrip.tsx
+++ b/features/dashboard/components/DashboardAlertStrip.tsx
@@ -16,6 +16,54 @@ const PRIORITY_CODES: readonly PriorityAlertCode[] = [
   "active_job_running_too_long",
 ];
 
+const LEVEL_META: Record<
+  OpsNotification["level"],
+  { label: string; badgeClass: string }
+> = {
+  critical: {
+    label: "Urgent",
+    badgeClass:
+      "border-[color:color-mix(in_srgb,#ef4444_65%,transparent)] bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] text-red-100",
+  },
+  warning: {
+    label: "Needs attention",
+    badgeClass:
+      "border-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_62%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_20%,transparent)] text-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_90%,white)]",
+  },
+  info: {
+    label: "Informational",
+    badgeClass:
+      "border-[color:color-mix(in_srgb,var(--brand-primary,#C1663B)_55%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-primary,#C1663B)_16%,transparent)] text-neutral-100",
+  },
+};
+
+const ALERT_COPY: Partial<
+  Record<
+    PriorityAlertCode,
+    {
+      shortLabel: string;
+      thresholdCue: string;
+      cta: string;
+    }
+  >
+> = {
+  shop_overloaded: {
+    shortLabel: "Shop load",
+    thresholdCue: "Bay load is above safe throughput.",
+    cta: "Rebalance shop load",
+  },
+  tech_underutilized_capacity: {
+    shortLabel: "Tech capacity",
+    thresholdCue: "Available labor hours are underused.",
+    cta: "Assign waiting work",
+  },
+  active_job_running_too_long: {
+    shortLabel: "Stalled job",
+    thresholdCue: "An active line crossed runtime threshold.",
+    cta: "Review delayed job",
+  },
+};
+
 function alertOrder(code: OpsNotification["code"]): number {
   const index = PRIORITY_CODES.indexOf(code as PriorityAlertCode);
   return index === -1 ? 99 : index;
@@ -23,11 +71,11 @@ function alertOrder(code: OpsNotification["code"]): number {
 
 function toneClasses(level: OpsNotification["level"]): string {
   if (level === "critical") {
-    return "border-[color:color-mix(in_srgb,#ef4444_55%,transparent)] bg-[color:color-mix(in_srgb,#ef4444_13%,transparent)]";
+    return "border-[color:color-mix(in_srgb,#ef4444_55%,transparent)] bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]";
   }
 
   if (level === "warning") {
-    return "border-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_48%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_14%,transparent)]";
+    return "border-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_48%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
   }
 
   return "border-[color:color-mix(in_srgb,var(--brand-primary,#C1663B)_42%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-primary,#C1663B)_10%,transparent)]";
@@ -55,6 +103,9 @@ export default function DashboardAlertStrip() {
         .slice(0, 3),
     [items],
   );
+
+  const urgentCount = priorityAlerts.filter((item) => item.level === "critical").length;
+  const needsAttentionCount = priorityAlerts.filter((item) => item.level === "warning").length;
 
   if (loading && priorityAlerts.length === 0) {
     return (
@@ -85,36 +136,80 @@ export default function DashboardAlertStrip() {
           "linear-gradient(180deg, color-mix(in srgb, var(--theme-card-bg,#111827) 92%, black), color-mix(in srgb, var(--brand-secondary,#0F172A) 58%, black))",
       }}
     >
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
           <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--brand-accent,#E39A6E)]">
             AI Operations Alerts
           </div>
-          <div className="mt-1 text-sm text-neutral-300">
-            High-signal load alerts for overloaded capacity, idle bandwidth, and long-running work.
+          <div className="mt-1 text-sm text-neutral-200">
+            Focus first on alerts that block throughput or stall active repair flow.
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-neutral-200">
+            {urgentCount > 0 ? (
+              <span className="rounded-full border border-red-400/45 bg-red-500/15 px-2 py-0.5 text-red-100">
+                {urgentCount} urgent now
+              </span>
+            ) : null}
+            {needsAttentionCount > 0 ? (
+              <span className="rounded-full border border-[var(--brand-accent,#E39A6E)]/45 bg-[var(--brand-accent,#E39A6E)]/15 px-2 py-0.5">
+                {needsAttentionCount} needs attention
+              </span>
+            ) : null}
+            <span className="rounded-full border border-white/15 bg-black/25 px-2 py-0.5">
+              Showing top {priorityAlerts.length}
+            </span>
           </div>
         </div>
 
         <Link
           href="/agent/planner"
-          className="shrink-0 rounded-full border border-white/15 bg-black/35 px-3 py-1.5 text-xs text-neutral-200 transition hover:bg-black/50"
+          className="shrink-0 self-start rounded-full border border-white/15 bg-black/35 px-3 py-1.5 text-xs font-medium text-neutral-100 transition hover:bg-black/50"
         >
-          Open planner
+          Open full AI planner
         </Link>
       </div>
 
-      <div className="mt-3 grid gap-2 lg:grid-cols-3">
-        {priorityAlerts.map((alert) => (
-          <Link
-            key={alert.id}
-            href={alert.href ?? "/dashboard"}
-            className={`rounded-xl border px-3 py-3 transition hover:bg-white/5 ${toneClasses(alert.level)}`}
-          >
-            <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-300">{alert.code.replaceAll("_", " ")}</div>
-            <div className="mt-1 text-sm font-semibold text-white">{alert.title}</div>
-            <div className="mt-1 line-clamp-2 text-xs text-neutral-300">{alert.message}</div>
-          </Link>
-        ))}
+      <div className="mt-3 grid gap-2.5 md:grid-cols-2 xl:grid-cols-3">
+        {priorityAlerts.map((alert, index) => {
+          const copy = ALERT_COPY[alert.code as PriorityAlertCode];
+          const levelMeta = LEVEL_META[alert.level];
+          const isTopPriority = index === 0;
+
+          return (
+            <Link
+              key={alert.id}
+              href={alert.href ?? "/dashboard"}
+              className={`group rounded-xl border px-3 py-3 transition hover:bg-white/5 ${toneClasses(alert.level)} ${
+                isTopPriority
+                  ? "ring-1 ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_50%,transparent)]"
+                  : ""
+              }`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-300">
+                    {copy?.shortLabel ?? alert.code.replaceAll("_", " ")}
+                  </div>
+                  <div className="mt-1 line-clamp-2 text-sm font-semibold text-white">{alert.title}</div>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${levelMeta.badgeClass}`}
+                >
+                  {levelMeta.label}
+                </span>
+              </div>
+
+              <div className="mt-1.5 line-clamp-2 text-xs text-neutral-300">{alert.message}</div>
+
+              <div className="mt-2.5 flex items-center justify-between gap-2">
+                <div className="line-clamp-1 text-[11px] text-neutral-400">{copy?.thresholdCue ?? "Threshold alert triggered."}</div>
+                <div className="shrink-0 rounded-full border border-white/20 bg-black/30 px-2.5 py-1 text-[11px] font-semibold text-neutral-100 transition group-hover:bg-black/45">
+                  {copy?.cta ?? "Take action"}
+                </div>
+              </div>
+            </Link>
+          );
+        })}
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Improve the AI/operations alert strip so urgent issues and required actions are obvious at a glance without changing the alert pipeline or data sources. 
- Make per-alert CTAs and labels more concise and operationally actionable while keeping the existing dark industrial/glass design tokens. 
- Reduce visual density on small screens by introducing a clearer header summary and responsive card layout.

### Description
- Added severity metadata and styled badges (`Urgent`, `Needs attention`, `Informational`) via a new `LEVEL_META` mapping to surface alert priority quickly. 
- Introduced `ALERT_COPY` for each priority code with `shortLabel`, `thresholdCue`, and stronger `cta` text to improve per-alert actionability. 
- Added compact header chips that show counts (`urgent now`, `needs attention`, `Showing top N`) and updated header copy and planner CTA to emphasize operational next steps. 
- Emphasized the top-ranked alert visually with a subtle ring and tightened card layout and responsive grid (`md:grid-cols-2`, `xl:grid-cols-3`) plus text clamping to keep the strip readable on tablet/phone. 
- Preserved existing behavior: the patch keeps `useOpsNotifications` polling, the `PRIORITY_CODES` list, filtering, sorting logic, and notification links unchanged.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82976dca88328a322ea8a07143401)