### PR TITLE
Fix assistant_notifications status constraint mismatch

### DIFF
--- a/db/sql/2026-04-10_assistant_notifications_status_contract.sql
+++ b/db/sql/2026-04-10_assistant_notifications_status_contract.sql
@@ -1,0 +1,17 @@
+-- Align assistant_notifications.status check constraint with app canonical writes.
+-- Canonical app statuses: active | acknowledged | resolved.
+-- Backward compatibility: keep accepting legacy "open" rows/queries.
+
+alter table public.assistant_notifications
+  drop constraint if exists assistant_notifications_status_chk;
+
+alter table public.assistant_notifications
+  drop constraint if exists assistant_notifications_status_check;
+
+alter table public.assistant_notifications
+  add constraint assistant_notifications_status_chk
+  check (
+    lower(replace(status, ' ', '_')) = any (
+      array['active'::text, 'open'::text, 'acknowledged'::text, 'resolved'::text]
+    )
+  );


### PR DESCRIPTION
### Motivation
- The DB check constraint for `assistant_notifications.status` was rejecting status values the application now writes (notably `active`), causing upserts/inserts to fail; the change aligns the DB with the app while preserving legacy `open` rows for backwards compatibility.

### Description
- Add a targeted SQL migration `db/sql/2026-04-10_assistant_notifications_status_contract.sql` that drops either existing constraint name and re-adds `assistant_notifications_status_chk` permitting `active`, `open`, `acknowledged`, and `resolved`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d853a16b5c8328bae3b9252a16a549)