### PR TITLE
Harden Shop Boost ingestion idempotency, traceability, and confidence scoring

### DIFF
--- a/db/sql/2026-04-10_shop_boost_ingestion_hardening.sql
+++ b/db/sql/2026-04-10_shop_boost_ingestion_hardening.sql
@@ -1,0 +1,28 @@
+-- Shop Boost ingestion hardening (additive, non-breaking)
+-- 1) Add part-level idempotency + traceability fields.
+alter table public.parts
+  add column if not exists normalized_part_key text,
+  add column if not exists source_intake_id uuid,
+  add column if not exists external_id text,
+  add column if not exists import_notes text;
+
+-- 2) Backfill normalized_part_key for existing rows where possible.
+update public.parts
+set normalized_part_key = lower(
+  coalesce(regexp_replace(part_number, '[^a-zA-Z0-9]+', '', 'g'), '') || '|' ||
+  coalesce(regexp_replace(sku, '[^a-zA-Z0-9]+', '', 'g'), '') || '|' ||
+  coalesce(regexp_replace(name, '[^a-zA-Z0-9]+', '', 'g'), '') || '|' ||
+  coalesce(regexp_replace(supplier, '[^a-zA-Z0-9]+', '', 'g'), '') || '|' ||
+  coalesce(regexp_replace(category, '[^a-zA-Z0-9]+', '', 'g')
+))
+where normalized_part_key is null;
+
+-- 3) Lightweight indexes to support rerun dedupe + intake trace lookups.
+create index if not exists idx_parts_shop_normalized_part_key
+  on public.parts (shop_id, normalized_part_key);
+
+create index if not exists idx_parts_source_intake_id
+  on public.parts (source_intake_id);
+
+create index if not exists idx_parts_shop_external_id
+  on public.parts (shop_id, external_id);

--- a/features/integrations/ai/shopBoost.ts
+++ b/features/integrations/ai/shopBoost.ts
@@ -166,6 +166,7 @@ export async function buildShopBoostProfile(
     shopId,
     intakeId: intakeRow.id,
     aiSnapshot,
+    mergedStats,
   });
 
   // ✅ NEW: persist staff candidates from staff CSV (per-person)
@@ -1326,6 +1327,77 @@ function slugKey(v: string): string {
     .slice(0, 80);
 }
 
+function normalizeSuggestionText(v: string | null | undefined): string {
+  return String(v ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function usageBucket(v: string | null | undefined): "fleet" | "retail" | "both" {
+  return v === "fleet" ? "fleet" : v === "retail" ? "retail" : "both";
+}
+
+function countOccurrencesForSuggestion(name: string, stats: DerivedStats): number {
+  const needle = normalizeSuggestionText(name);
+  if (!needle) return 0;
+  return (stats.mostCommonRepairs ?? []).reduce((sum, repair) => {
+    const label = normalizeSuggestionText(repair.label);
+    if (!label) return sum;
+    return label.includes(needle) || needle.includes(label) ? sum + (repair.count ?? 0) : sum;
+  }, 0);
+}
+
+function weightedRevenueForSuggestion(name: string, stats: DerivedStats): number {
+  const needle = normalizeSuggestionText(name);
+  if (!needle) return 0;
+  return (stats.highValueRepairs ?? []).reduce((sum, repair) => {
+    const label = normalizeSuggestionText(repair.label);
+    if (!label) return sum;
+    return label.includes(needle) || needle.includes(label) ? sum + (repair.revenue ?? 0) : sum;
+  }, 0);
+}
+
+function computeSuggestionConfidence(args: {
+  label: string;
+  stats: DerivedStats;
+  kind: "menu" | "inspection";
+}): number {
+  const { label, stats, kind } = args;
+  const totalRos = Math.max(1, stats.totalRepairOrders || 0);
+  const occurrence = countOccurrencesForSuggestion(label, stats);
+  const occurrenceRatio = Math.min(1, occurrence / totalRos);
+  const repetitionBoost = Math.min(0.22, occurrenceRatio * 0.75);
+  const revenueWeight = Math.min(
+    0.16,
+    weightedRevenueForSuggestion(label, stats) / Math.max(1, stats.totalRevenue || 1),
+  );
+
+  const base = kind === "inspection" ? 0.48 : 0.44;
+  return Math.max(0.2, Math.min(0.97, base + repetitionBoost + revenueWeight));
+}
+
+function confidenceBucket(confidence: number): "low" | "medium" | "high" {
+  if (confidence >= 0.8) return "high";
+  if (confidence >= 0.5) return "medium";
+  return "low";
+}
+
+function inspectionStructureFingerprint(suggestion: {
+  name: string | null | undefined;
+  note?: string | null | undefined;
+  usageContext?: string | null | undefined;
+}): string {
+  const shape = [
+    normalizeSuggestionText(suggestion.name),
+    normalizeSuggestionText(suggestion.note),
+    usageBucket(suggestion.usageContext),
+  ].join("|");
+  return createHash("sha1").update(shape, "utf8").digest("hex").slice(0, 24);
+}
+
 /* -------------------------------------------------------------------------- */
 /* ✅ Persist suggestions                                                       */
 /* -------------------------------------------------------------------------- */
@@ -1338,7 +1410,7 @@ async function persistSuggestions(args: {
   issuesDetected: ShopHealthIssue[];
   mergedStats: DerivedStats;
 }): Promise<void> {
-  const { supabase, shopId, intakeId, aiSnapshot } = args;
+  const { supabase, shopId, intakeId, aiSnapshot, mergedStats } = args;
 
   const menuInserts: DB["public"]["Tables"]["menu_item_suggestions"]["Insert"][] = (
     aiSnapshot.menuSuggestions ?? []
@@ -1351,7 +1423,11 @@ async function persistSuggestions(args: {
     labor_hours_suggestion: Number.isFinite(Number(m.estimatedLaborHours))
       ? Number(m.estimatedLaborHours)
       : null,
-    confidence: 0.75,
+    confidence: computeSuggestionConfidence({
+      label: m.name ?? m.description ?? "menu",
+      stats: mergedStats,
+      kind: "menu",
+    }),
     reason: m.description ?? null,
   })) as DB["public"]["Tables"]["menu_item_suggestions"]["Insert"][];
 
@@ -1368,9 +1444,12 @@ async function persistSuggestions(args: {
     template_key: null,
     name: i.name ?? "Suggested inspection",
     items: { note: i.note ?? null, usageContext: i.usageContext ?? null },
-    applies_to:
-      i.usageContext === "fleet" ? "fleet" : i.usageContext === "retail" ? "retail" : "both",
-    confidence: 0.8,
+    applies_to: usageBucket(i.usageContext),
+    confidence: computeSuggestionConfidence({
+      label: i.name ?? i.note ?? "inspection",
+      stats: mergedStats,
+      kind: "inspection",
+    }),
   })) as DB["public"]["Tables"]["inspection_template_suggestions"]["Insert"][];
 
   if (inspInserts.length > 0) {
@@ -1384,15 +1463,20 @@ async function materializeOperatingLayer(args: {
   shopId: string;
   intakeId: string;
   aiSnapshot: ShopHealthSnapshot;
+  mergedStats: DerivedStats;
 }): Promise<OperatingLayerSummary> {
-  const { supabase, shopId, intakeId, aiSnapshot } = args;
+  const { supabase, shopId, intakeId, aiSnapshot, mergedStats } = args;
 
   let menuItemsCreated = 0;
   let inspectionTemplatesCreated = 0;
   let itemsNeedReview = 0;
 
   for (const suggestion of aiSnapshot.menuSuggestions ?? []) {
-    const confidence = 0.75;
+    const confidence = computeSuggestionConfidence({
+      label: suggestion.name ?? suggestion.description ?? "menu",
+      stats: mergedStats,
+      kind: "menu",
+    });
     if (confidence < 0.5) {
       itemsNeedReview += 1;
       continue;
@@ -1433,7 +1517,11 @@ async function materializeOperatingLayer(args: {
   }
 
   for (const suggestion of aiSnapshot.inspectionSuggestions ?? []) {
-    const confidence = 0.8;
+    const confidence = computeSuggestionConfidence({
+      label: suggestion.name ?? suggestion.note ?? "inspection",
+      stats: mergedStats,
+      kind: "inspection",
+    });
     if (confidence < 0.5) {
       itemsNeedReview += 1;
       continue;
@@ -1443,14 +1531,20 @@ async function materializeOperatingLayer(args: {
     }
 
     const templateName = suggestion.name ?? "Shop Boost Inspection";
-    const { data: existing } = await supabase
+    const fingerprint = inspectionStructureFingerprint(suggestion);
+    const { data: existingByName } = await supabase
       .from("inspection_templates")
-      .select("id")
+      .select("id,sections")
       .eq("shop_id", shopId)
       .eq("template_name", templateName)
-      .maybeSingle<{ id: string }>();
+      .limit(50);
 
-    if (existing?.id) continue;
+    const hasFingerprintMatch = (existingByName ?? []).some((row) => {
+      const sections = (row as { sections?: unknown }).sections;
+      const secRecord = sections && typeof sections === "object" ? (sections as Record<string, unknown>) : null;
+      return String(secRecord?.structure_fingerprint ?? "") === fingerprint;
+    });
+    if (hasFingerprintMatch) continue;
 
     const { error } = await supabase.from("inspection_templates").insert({
       shop_id: shopId,
@@ -1460,13 +1554,15 @@ async function materializeOperatingLayer(args: {
       tags: [
         "shop_boost",
         `source_intake:${intakeId}`,
-        confidence >= 0.8 ? "confidence:high" : "confidence:medium",
+        `confidence:${confidenceBucket(confidence)}`,
       ],
       is_public: false,
       sections: {
         generated_by: "shop_boost",
         source_intake_id: intakeId,
         confidence,
+        confidence_bucket: confidenceBucket(confidence),
+        structure_fingerprint: fingerprint,
         note: suggestion.note ?? null,
       },
     } as DB["public"]["Tables"]["inspection_templates"]["Insert"]);

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -48,6 +48,42 @@ function lower(s: string): string {
   return norm(s).toLowerCase();
 }
 
+function normalizeText(s: string | null | undefined): string {
+  return String(s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizePartToken(s: string | null | undefined): string {
+  return String(s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function buildNormalizedPartKey(args: {
+  partNumber: string | null;
+  sku: string | null;
+  name: string;
+  supplier: string | null;
+  category: string | null;
+}): string {
+  const partNo = normalizePartToken(args.partNumber);
+  const sku = normalizePartToken(args.sku);
+  const fallbackName = normalizeText(args.name);
+  const supplier = normalizeText(args.supplier);
+  const category = normalizeText(args.category);
+  return [partNo || "-", sku || "-", fallbackName || "-", supplier || "-", category || "-"].join("|");
+}
+
+function dateOnly(iso: string | null): string {
+  if (!iso) return "unknown";
+  return iso.slice(0, 10);
+}
+
 function sha1(text: string): string {
   return createHash("sha1").update(text, "utf8").digest("hex");
 }
@@ -245,7 +281,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const vehiclesByPlate = new Map<string, string>();
   const partsByNumber = new Map<string, string>();
   const partsBySku = new Map<string, string>();
-  const partsByName = new Map<string, string>();
+  const partsByNormalizedKey = new Map<string, string>();
   const staffByEmail = new Map<string, string>();
   const staffByName = new Map<string, string>();
 
@@ -307,7 +343,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   {
     const { data } = await supabase
       .from("parts")
-      .select("id,part_number,sku,name,shop_id")
+      .select("id,part_number,sku,name,supplier,category,shop_id,normalized_part_key")
       .eq("shop_id", shopId)
       .limit(5000);
 
@@ -315,11 +351,22 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const rec = r as unknown as Record<string, unknown>;
       const partNumber = lower(String(rec.part_number ?? ""));
       const sku = lower(String(rec.sku ?? ""));
-      const name = lower(String(rec.name ?? ""));
+      const supplier = String(rec.supplier ?? "");
+      const category = String(rec.category ?? "");
+      const normalizedPartKeyRaw = String(rec.normalized_part_key ?? "").trim();
+      const normalizedPartKey =
+        normalizedPartKeyRaw ||
+        buildNormalizedPartKey({
+          partNumber: String(rec.part_number ?? ""),
+          sku: String(rec.sku ?? ""),
+          name: String(rec.name ?? ""),
+          supplier,
+          category,
+        });
       const id = String(rec.id ?? "");
       if (partNumber && id) partsByNumber.set(partNumber, id);
       if (sku && id) partsBySku.set(sku, id);
-      if (name && id) partsByName.set(name, id);
+      if (id) partsByNormalizedKey.set(normalizedPartKey, id);
     }
   }
 
@@ -502,12 +549,19 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const price = parseMoney(pick(row, [/^price$/, /sell/, /retail/]));
       const supplier = pick(row, [/supplier/, /vendor/]);
       const category = pick(row, [/category/]);
+      const normalizedPartKey = buildNormalizedPartKey({
+        partNumber,
+        sku,
+        name,
+        supplier,
+        category,
+      });
+      const external_id = `import:${intakeId}:part:${sha1(normalizedPartKey).slice(0, 20)}`;
 
-      const intakeTag = `[shop_boost:${intakeId}]`;
       const existingId =
+        partsByNormalizedKey.get(normalizedPartKey) ||
         (partNumber && partsByNumber.get(lower(partNumber))) ||
-        (sku && partsBySku.get(lower(sku))) ||
-        (name && partsByName.get(lower(name)));
+        (sku && partsBySku.get(lower(sku)));
 
       if (existingId) {
         await supabase
@@ -523,7 +577,14 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             price: price ?? null,
             default_cost: cost ?? null,
             default_price: price ?? null,
-            description: `${intakeTag} imported`,
+            normalized_part_key: normalizedPartKey,
+            source_intake_id: intakeId,
+            external_id,
+            import_notes: JSON.stringify({
+              source: "shop_boost",
+              source_intake_id: intakeId,
+              normalized_part_key: normalizedPartKey,
+            }),
           } as DB["public"]["Tables"]["parts"]["Update"])
           .eq("id", existingId);
         continue;
@@ -542,7 +603,14 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           price: price ?? null,
           default_cost: cost ?? null,
           default_price: price ?? null,
-          description: `${intakeTag} imported`,
+          normalized_part_key: normalizedPartKey,
+          source_intake_id: intakeId,
+          external_id,
+          import_notes: JSON.stringify({
+            source: "shop_boost",
+            source_intake_id: intakeId,
+            normalized_part_key: normalizedPartKey,
+          }),
         } as DB["public"]["Tables"]["parts"]["Insert"])
         .select("id")
         .limit(1);
@@ -551,7 +619,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       if (id) {
         if (partNumber) partsByNumber.set(lower(partNumber), id);
         if (sku) partsBySku.set(lower(sku), id);
-        partsByName.set(lower(name), id);
+        partsByNormalizedKey.set(normalizedPartKey, id);
       }
     }
   }
@@ -649,7 +717,15 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         (vin && vehiclesByVin.get(vin)) || (plate && vehiclesByPlate.get(plate)) || null;
 
       const historyFingerprint = sha1(
-        `${ro ?? ""}|${dateIso}|${vin}|${plate}|${correction ?? complaint ?? ""}|${total ?? ""}`,
+        [
+          ro ?? "",
+          dateOnly(dateIso),
+          vehicle_id ?? "",
+          vin,
+          plate,
+          String(total ?? ""),
+          normalizeText(correction ?? complaint ?? ""),
+        ].join("|"),
       ).slice(0, 20);
       const external_id = `import:${intakeId}:history:${historyFingerprint}`;
 
@@ -684,7 +760,12 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         updated_at: dateIso,
         source_intake_id: intakeId,
         external_id,
-        import_confidence: 0.7,
+        import_confidence: 0.78,
+        import_notes: JSON.stringify({
+          source: "shop_boost",
+          source_intake_id: intakeId,
+          history_fingerprint: historyFingerprint,
+        }),
       };
 
       let woInserted: Array<{ id: string }> | null = null;
@@ -808,7 +889,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         .from("parts")
         .select("id", { count: "exact", head: true })
         .eq("shop_id", shopId)
-        .ilike("description", `%[shop_boost:${intakeId}]%`),
+        .eq("source_intake_id", intakeId),
     ]);
 
   await supabase
@@ -871,7 +952,12 @@ async function upsertHistoryLine(args: {
     line_no: rowIndex,
     source_intake_id: intakeId,
     external_id,
-    import_confidence: 0.7,
+    import_confidence: 0.78,
+    import_notes: JSON.stringify({
+      source: "shop_boost",
+      source_intake_id: intakeId,
+      external_id,
+    }),
   } as DB["public"]["Tables"]["work_order_lines"]["Insert"];
 
   const { data: existing } = await supabase

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -6546,12 +6546,16 @@ export type Database = {
           default_cost: number | null
           default_price: number | null
           description: string | null
+          external_id: string | null
           id: string
+          import_notes: string | null
           low_stock_threshold: number | null
           name: string
+          normalized_part_key: string | null
           part_number: string | null
           price: number | null
           shop_id: string | null
+          source_intake_id: string | null
           sku: string | null
           subcategory: string | null
           supplier: string | null
@@ -6566,12 +6570,16 @@ export type Database = {
           default_cost?: number | null
           default_price?: number | null
           description?: string | null
+          external_id?: string | null
           id?: string
+          import_notes?: string | null
           low_stock_threshold?: number | null
           name: string
+          normalized_part_key?: string | null
           part_number?: string | null
           price?: number | null
           shop_id?: string | null
+          source_intake_id?: string | null
           sku?: string | null
           subcategory?: string | null
           supplier?: string | null
@@ -6586,12 +6594,16 @@ export type Database = {
           default_cost?: number | null
           default_price?: number | null
           description?: string | null
+          external_id?: string | null
           id?: string
+          import_notes?: string | null
           low_stock_threshold?: number | null
           name?: string
+          normalized_part_key?: string | null
           part_number?: string | null
           price?: number | null
           shop_id?: string | null
+          source_intake_id?: string | null
           sku?: string | null
           subcategory?: string | null
           supplier?: string | null
@@ -15824,4 +15836,3 @@ export const Constants = {
     },
   },
 } as const
-


### PR DESCRIPTION
### Motivation
- Ensure Shop Boost imports produce UI-usable, non-duplicative data by strengthening idempotency, traceability, and confidence signals without breaking existing flows.
- Fix areas where the importer relied on fragile description tags or weak fingerprints and replace them with deterministic keys and recorded metadata.

### Description
- Introduced normalized part key generation (`buildNormalizedPartKey`, `normalizePartToken`, `normalizeText`) and prefer `normalized_part_key` for part deduplication while keeping part number and SKU as fallbacks; importer now writes `normalized_part_key`, `source_intake_id`, `external_id`, and `import_notes` to `parts` for traceability (files changed: `features/integrations/imports/runFullImport.ts`, `shared/types/types/supabase.ts`).
- Added DB migration `db/sql/2026-04-10_shop_boost_ingestion_hardening.sql` to add columns (`normalized_part_key`, `source_intake_id`, `external_id`, `import_notes`) and lightweight indexes, plus a backfill for existing `normalized_part_key` values.
- Strengthened work order history fingerprint to include date-only, vehicle id, VIN/plate, total, and normalized repair text to reduce collisions, and added structured `import_notes` and a small import confidence bump for history-derived work orders and lines (file: `features/integrations/imports/runFullImport.ts`).
- Replaced inspection-template name-only dedupe with a structure-based fingerprint (`inspectionStructureFingerprint`) stored in `inspection_templates.sections.structure_fingerprint` and used that for idempotent materialization; added deterministic confidence bucket metadata to created templates (file: `features/integrations/ai/shopBoost.ts`).
- Replaced static suggestion confidence constants with a frequency/repetition/revenue-weighted scorer (`computeSuggestionConfidence`) and applied it to both suggestion persistence and operating-layer materialization while preserving the high/medium/low gating behavior (file: `features/integrations/ai/shopBoost.ts`).
- Updated Supabase TypeScript types to include the new `parts` columns (file: `shared/types/types/supabase.ts`).

### Testing
- Ran TypeScript type-check: `npx tsc --noEmit` and it passed with no type errors.
- Static code validation only; full runtime UI verification (pages, rendering, click-throughs) was not possible in this environment because a live Shop Boost-seeded tenant was not available, so runtime surface checks remain pending against a staging tenant.
- SQL migration added as `db/sql/2026-04-10_shop_boost_ingestion_hardening.sql` and is additive and reversible by manual rollback if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85e71a8208328a2a769674b5d4a7a)