### PR TITLE
Show imported completed work orders in default view for seeded shops

### DIFF
--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -54,6 +54,7 @@ const ACTIVE_FLOW_STATUSES: StatusKey[] = [
   "on_hold",
   "planned",
 ];
+const SEEDED_DEFAULT_STATUSES: StatusKey[] = [...ACTIVE_FLOW_STATUSES, "completed"];
 
 const ASSIGN_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 const STATUS_PICKER_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
@@ -208,6 +209,7 @@ export default function WorkOrdersView(): JSX.Element {
   const [q, setQ] = useState("");
   const [status, setStatus] = useState<string>("");
   const [err, setErr] = useState<string | null>(null);
+  const [isSeededShop, setIsSeededShop] = useState(false);
 
   const [assigningFor, setAssigningFor] = useState<string | null>(null);
   const [techs, setTechs] = useState<
@@ -275,7 +277,8 @@ export default function WorkOrdersView(): JSX.Element {
       .limit(100);
 
     if (status === "") {
-      query = query.in("status", ACTIVE_FLOW_STATUSES as unknown as string[]);
+      const defaultStatuses = isSeededShop ? SEEDED_DEFAULT_STATUSES : ACTIVE_FLOW_STATUSES;
+      query = query.in("status", defaultStatuses as unknown as string[]);
     } else {
       query = query.eq("status", status);
     }
@@ -359,7 +362,7 @@ export default function WorkOrdersView(): JSX.Element {
 
     setTechRollupByWo(rollups);
     setLoading(false);
-  }, [q, status, supabase]);
+  }, [isSeededShop, q, status, supabase]);
 
   const runInvoiceReview = useCallback(
     async (woId: string) => {
@@ -470,6 +473,18 @@ export default function WorkOrdersView(): JSX.Element {
 
         setCurrentRole(prof?.role ?? null);
       }
+
+      const { data: seededRow, error: seededErr } = await supabase
+        .from("work_orders")
+        .select("id")
+        .not("source_intake_id", "is", null)
+        .limit(1)
+        .maybeSingle();
+
+      if (seededErr) {
+        console.warn("[WorkOrdersView] failed to detect Shop Boost seed state:", seededErr.message);
+      }
+      setIsSeededShop(Boolean(seededRow?.id));
 
       try {
         const res = await fetch("/api/assignables");


### PR DESCRIPTION
### Motivation
- Imported work orders created by Shop Boost (seeded shops) were not visible in the default board because the initial filter excluded completed work orders. This makes newly-imported history hard to find immediately after Shop Boost.
- The fix should be non-breaking and minimal UI-wise while preserving existing behavior for non-seeded shops.

### Description
- Detect seeded shops by checking for any `work_orders` row with `source_intake_id IS NOT NULL` and set a local `isSeededShop` flag during initial bootstrap. (file: `features/work-orders/app/work-orders/view/page.tsx`)
- Add a `SEEDED_DEFAULT_STATUSES` array equal to `ACTIVE_FLOW_STATUSES + "completed"` and use it as the default status set only when `isSeededShop` is true so imported completed work orders appear in the initial list.
- Wire `isSeededShop` into the main `load()` query and update hook dependencies to ensure the proper default set is applied when loading rows.
- No new UI controls were introduced and explicit user-selected status filters continue to behave unchanged.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it passed.
- No other automated tests were modified or required for this small, non-breaking UI behavior change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86464fd8c8328a32fabfd7b3c5c63)