### PR TITLE
Expand customer autocomplete matching fields

### DIFF
--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -166,17 +166,19 @@ type CustomerPick = {
   business_name: string | null;
   first_name: string | null;
   last_name: string | null;
+  name: string | null;
   phone: string | null;
+  phone_number: string | null;
   email: string | null;
 };
 
 function formatCustomerTitle(c: CustomerPick): string {
   const person = [c.first_name, c.last_name].filter(Boolean).join(" ").trim();
-  return c.business_name || person || "Unnamed";
+  return c.business_name || person || c.name || "Unnamed";
 }
 
 function formatCustomerSub(c: CustomerPick): string {
-  const bits = [c.phone, c.email].filter(Boolean).join(" · ");
+  const bits = [c.phone, c.phone_number, c.email].filter(Boolean).join(" · ");
   const person = [c.first_name, c.last_name].filter(Boolean).join(" ").trim();
   if (c.business_name && person) return person;
   return bits || "—";
@@ -216,15 +218,17 @@ function CustomerSearch({
         const like = `%${term}%`;
         const { data, error } = await supabase
           .from("customers")
-          .select("id,business_name,first_name,last_name,phone,email,created_at")
+          .select("id,business_name,first_name,last_name,name,phone,phone_number,email,created_at")
           .eq("shop_id", shopId)
           .or(
             [
               `business_name.ilike.${like}`,
               `first_name.ilike.${like}`,
               `last_name.ilike.${like}`,
-              `phone.ilike.${like}`,
+              `name.ilike.${like}`,
               `email.ilike.${like}`,
+              `phone.ilike.${like}`,
+              `phone_number.ilike.${like}`,
             ].join(","),
           )
           .order("created_at", { ascending: false })

--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -16,6 +16,7 @@ type CustomerRow = {
   last_name?: string | null;
   name?: string | null;
   phone?: string | null;
+  phone_number?: string | null;
   email?: string | null;
   address?: string | null;
   city?: string | null;
@@ -125,11 +126,19 @@ function CustomerAutocomplete({
         const { data, error } = await supabase
           .from("customers")
           .select(
-            "id, business_name, first_name, last_name, name, phone, email, address, city, province, postal_code, created_at",
+            "id, business_name, first_name, last_name, name, phone, phone_number, email, address, city, province, postal_code, created_at",
           )
           .eq("shop_id", shopId)
           .or(
-            `business_name.ilike.${like},first_name.ilike.${like},last_name.ilike.${like},name.ilike.${like}`,
+            [
+              `business_name.ilike.${like}`,
+              `first_name.ilike.${like}`,
+              `last_name.ilike.${like}`,
+              `name.ilike.${like}`,
+              `email.ilike.${like}`,
+              `phone.ilike.${like}`,
+              `phone_number.ilike.${like}`,
+            ].join(","),
           )
           .order("created_at", { ascending: false })
           .limit(12);


### PR DESCRIPTION
### Motivation
- Imported customer rows sometimes only contain `email`, `phone`, or `phone_number`, so autocomplete failed to surface those matches when creating inspections or work orders.
- The intention is to make in-place autocomplete reuse the same searchable fields as `/customers/search` without changing schema or UI and without regressing performance.

### Description
- Added `email`, `phone`, and `phone_number` to the customer autocomplete `select` and `or(...ilike...)` clauses so suggestions match imported contact data while preserving `business_name`, `name`, and first/last name matching.
- Kept the shop scoping, debounce (150ms), ordering by `created_at`, and `limit(12)` to avoid performance regressions and preserve existing behavior.
- Updated suggestion formatting to include `name` and prefer showing `phone_number` alongside `phone` and `email` in the subtitle so imported rows render clearly.
- Files changed: `features/inspections/components/inspection/CustomerVehicleForm.tsx`, `app/mobile/work-orders/create/page.tsx`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully.
- No other automated tests were changed or run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8651b6ee4832891823703d92f4e13)