### PR TITLE
Improve create-flow customer autocomplete discoverability for imported customers

### DIFF
--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -122,7 +122,7 @@ function CustomerAutocomplete({
     const t = window.setTimeout(async () => {
       setBusy(true);
       try {
-        const like = `%${term}%`;
+        const like = `%${term.replaceAll("%", "").replaceAll("_", "")}%`;
         const { data, error } = await supabase
           .from("customers")
           .select(
@@ -600,6 +600,11 @@ export default function CustomerVehicleForm({
                 value={customer.phone ?? ""}
                 onChange={(e) => safeSetCustomer("phone", e.target.value || null)}
               />
+              <CustomerAutocomplete
+                q={customer.phone ?? ""}
+                shopId={shopId}
+                onPick={handlePickedCustomer}
+              />
             </div>
 
             {/* Email */}
@@ -611,6 +616,11 @@ export default function CustomerVehicleForm({
                 placeholder="Email"
                 value={customer.email ?? ""}
                 onChange={(e) => safeSetCustomer("email", e.target.value || null)}
+              />
+              <CustomerAutocomplete
+                q={customer.email ?? ""}
+                shopId={shopId}
+                onPick={handlePickedCustomer}
               />
             </div>
 


### PR DESCRIPTION
### Motivation
- Imported customers sometimes have weak or inconsistent name/business fields but valid phone/email, causing the create-flow autocomplete to miss matches.
- The create-flow should surface the same customer search behavior used elsewhere so contact-field lookups (email/phone) return imported records without changing UI or schema.

### Description
- Sanitize the search term before building the `ilike` pattern by stripping `%` and `_` so the autocomplete mirrors broader customer search handling (`const like = `%${term.replaceAll("%", "").replaceAll("_", "")}%``). 
- Keep the existing `.eq("shop_id", shopId)` scoping and `.limit(12)` result cap while preserving matches for `business_name`, `first_name`, `last_name`, `name`, `email`, `phone`, and `phone_number`.
- Wire the existing `CustomerAutocomplete` into the Phone and Email inputs so typing into those fields triggers the same autocomplete as Business/First/Last inputs without redesigning the UI.
- No schema changes or broad refactors were made. The only file modified is listed below.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed. 

Files changed:
- `features/inspections/components/inspection/CustomerVehicleForm.tsx`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86888ae748328ada03a0aae423ab0)