### PR TITLE
Clarify imported-parts stock initialization state in parts UI

### DIFF
--- a/features/parts/app/parts/[id]/page.tsx
+++ b/features/parts/app/parts/[id]/page.tsx
@@ -60,7 +60,10 @@ export default async function PartDetail({ params }: { params: { id: string } })
             </div>
           ) : (
             <div className={`rounded-xl border border-white/10 bg-black/25 p-3 text-sm ${muted}`}>
-              No stock yet
+              <div>No stock yet</div>
+              <div className="mt-1 text-xs text-neutral-500">
+                Parts imported. Stock records not initialized yet.
+              </div>
             </div>
           )}
         </div>

--- a/features/parts/components/PartPicker.tsx
+++ b/features/parts/components/PartPicker.tsx
@@ -351,6 +351,11 @@ export function PartPicker({
     return "in_stock";
   };
 
+  const hasPartsWithoutStockRecords = useMemo(() => {
+    if (parts.length === 0) return false;
+    return Object.keys(stock).length === 0;
+  }, [parts, stock]);
+
   const confirmPick = () => {
     if (!selectedPartId) return;
 
@@ -558,6 +563,12 @@ export function PartPicker({
                 <div className="mb-2 text-xs font-medium uppercase tracking-[0.18em] text-neutral-400">
                   Stock & pricing
                 </div>
+
+                {hasPartsWithoutStockRecords ? (
+                  <div className="mb-2 rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-xs text-neutral-400">
+                    Parts imported. Stock records not initialized yet.
+                  </div>
+                ) : null}
 
                 {!selectedPartId ? (
                   <div className="text-sm text-neutral-400">


### PR DESCRIPTION
### Motivation
- Imported canonical part rows can appear before stock/location records are initialized, which looks like a broken availability state; surface a lightweight helper to make that intentional and non-disruptive.

### Description
- Add a `hasPartsWithoutStockRecords` `useMemo` in `features/parts/components/PartPicker.tsx` that is true when `parts.length > 0 && Object.keys(stock).length === 0`, and show the helper message `Parts imported. Stock records not initialized yet.` in the Part Picker stock panel; also add the same helper under `No stock yet` in `features/parts/app/parts/[id]/page.tsx` (UI-only, non-breaking).

### Testing
- Ran `npx tsc --noEmit` and it completed successfully with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8695cf1208328a7bb3b0f468fc5b0)