### PR TITLE
Expand Shop Boost onboarding/demo to multi-dataset CSV intake

### DIFF
--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -4,6 +4,11 @@ import { randomUUID } from "crypto";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
+import {
+  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  SHOP_BOOST_UPLOAD_DATASETS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
 
@@ -99,11 +104,13 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
       }
     }
 
-    const customersFile = asFile(formData.get("customersFile"));
-    const vehiclesFile = asFile(formData.get("vehiclesFile"));
-    const partsFile = asFile(formData.get("partsFile"));
+    const filesByDataset: Partial<Record<ShopBoostUploadDatasetKey, File>> = {};
+    for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+      const file = asFile(formData.get(`${key}File`));
+      if (file) filesByDataset[key] = file;
+    }
 
-    if (!customersFile && !vehiclesFile && !partsFile) {
+    if (Object.values(filesByDataset).length === 0) {
       return NextResponse.json(
         { ok: false, error: "Please upload at least one CSV so we have some history to analyze." },
         { status: 400 },
@@ -149,8 +156,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
     const intakeId = randomUUID();
 
     const uploadIfPresent = async (
-      file: File | null,
-      kind: "customers" | "vehicles" | "parts",
+      file: File | undefined,
+      kind: ShopBoostUploadDatasetKey,
     ): Promise<string | null> => {
       if (!file) return null;
 
@@ -170,11 +177,28 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
     };
 
     // 2) Upload CSVs
-    const [customersPath, vehiclesPath, partsPath] = await Promise.all([
-      uploadIfPresent(customersFile, "customers"),
-      uploadIfPresent(vehiclesFile, "vehicles"),
-      uploadIfPresent(partsFile, "parts"),
-    ]);
+    const uploadedPathEntries = await Promise.all(
+      SHOP_BOOST_UPLOAD_DATASET_KEYS.map(async (key) => [key, await uploadIfPresent(filesByDataset[key], key)] as const),
+    );
+    const uploadPaths = Object.fromEntries(uploadedPathEntries) as Record<
+      ShopBoostUploadDatasetKey,
+      string | null
+    >;
+    const uploadManifest = SHOP_BOOST_UPLOAD_DATASETS.reduce((acc, dataset) => {
+      const path = uploadPaths[dataset.key];
+      if (!path) return acc;
+      const file = filesByDataset[dataset.key];
+      acc[dataset.key] = {
+        dataset: dataset.key,
+        path,
+        fileName: file?.name ?? null,
+        contentType: file?.type ?? null,
+        sizeBytes: file?.size ?? null,
+        target: dataset.target,
+        importMode: dataset.importMode,
+      };
+      return acc;
+    }, {} as Record<string, unknown>);
 
     // 3) Create intake row
     const intakePayload: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
@@ -182,9 +206,14 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
       shop_id: shopId,
       questionnaire:
         questionnaire as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["questionnaire"],
-      customers_file_path: customersPath,
-      vehicles_file_path: vehiclesPath,
-      parts_file_path: partsPath,
+      customers_file_path: uploadPaths.customers,
+      vehicles_file_path: uploadPaths.vehicles,
+      parts_file_path: uploadPaths.parts,
+      history_file_path: uploadPaths.history,
+      staff_file_path: uploadPaths.staff,
+      intake_basics: {
+        uploadManifest,
+      } as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["intake_basics"],
       status: "pending",
     };
 

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -4,6 +4,10 @@
 import React, { useMemo, useState, type FormEvent } from "react";
 import type { ShopHealthSnapshot } from "@/features/integrations/ai/shopBoostType";
 import ShopHealthSnapshotView from "@/features/shops/components/ShopHealthSnapshot";
+import {
+  SHOP_BOOST_UPLOAD_DATASETS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
 
 type Country = "US" | "CA";
 
@@ -87,9 +91,7 @@ export default function InstantShopAnalysisPage() {
     avgMonthlyRos: "",
   });
 
-  const [customersFile, setCustomersFile] = useState<File | null>(null);
-  const [vehiclesFile, setVehiclesFile] = useState<File | null>(null);
-  const [partsFile, setPartsFile] = useState<File | null>(null);
+  const [uploadFiles, setUploadFiles] = useState<Partial<Record<ShopBoostUploadDatasetKey, File>>>({});
 
   const [step, setStep] = useState<DemoStep>("form");
   const [demoId, setDemoId] = useState<string | null>(null);
@@ -129,7 +131,10 @@ export default function InstantShopAnalysisPage() {
       return;
     }
 
-    if (!customersFile && !vehiclesFile && !partsFile) {
+    const selectedEntries = Object.entries(uploadFiles).filter(
+      (entry): entry is [ShopBoostUploadDatasetKey, File] => !!entry[1],
+    );
+    if (selectedEntries.length === 0) {
       setRunError("Upload at least one CSV so we have some history to scan.");
       return;
     }
@@ -142,9 +147,9 @@ export default function InstantShopAnalysisPage() {
       form.append("shopName", shopName.trim());
       form.append("country", country);
       form.append("questionnaire", JSON.stringify({ ...questionnaire }));
-      if (customersFile) form.append("customersFile", customersFile);
-      if (vehiclesFile) form.append("vehiclesFile", vehiclesFile);
-      if (partsFile) form.append("partsFile", partsFile);
+      for (const [dataset, file] of selectedEntries) {
+        form.append(`${dataset}File`, file);
+      }
 
       const res = await fetch("/api/demo/shop-boost/run", {
         method: "POST",
@@ -390,30 +395,24 @@ export default function InstantShopAnalysisPage() {
               </div>
 
               <div className="space-y-3 text-xs">
-                <FileRow
-                  id="demo-customers"
-                  label="Customers"
-                  description="Names, phones, emails — helps connect vehicles and approvals."
-                  file={customersFile}
-                  accept=".csv,text/csv"
-                  onChange={setCustomersFile}
-                />
-                <FileRow
-                  id="demo-vehicles"
-                  label="Repair orders / vehicle history"
-                  description="RO exports, dates, complaint/cause/correction, totals."
-                  file={vehiclesFile}
-                  accept=".csv,text/csv"
-                  onChange={setVehiclesFile}
-                />
-                <FileRow
-                  id="demo-parts"
-                  label="Parts / inventory"
-                  description="Part numbers, cost, sell prices, preferred vendors."
-                  file={partsFile}
-                  accept=".csv,text/csv"
-                  onChange={setPartsFile}
-                />
+                {SHOP_BOOST_UPLOAD_DATASETS.map((dataset) => (
+                  <FileRow
+                    key={dataset.key}
+                    id={`demo-${dataset.key}`}
+                    label={dataset.label}
+                    description={dataset.description}
+                    file={uploadFiles[dataset.key] ?? null}
+                    accept=".csv,text/csv"
+                    onChange={(file) =>
+                      setUploadFiles((prev) => {
+                        const next = { ...prev };
+                        if (!file) delete next[dataset.key];
+                        else next[dataset.key] = file;
+                        return next;
+                      })
+                    }
+                  />
+                ))}
 
                 <p className={THEME.help}>
                   We use AI to interpret columns, so exports don&apos;t need to be perfect. Data
@@ -692,6 +691,15 @@ function FileRow({ id, label, description, file, accept, onChange }: FileRowProp
             onChange(selectedFile);
           }}
         />
+        {file ? (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className="inline-flex cursor-pointer items-center rounded-md border border-white/10 bg-black/40 px-3 py-1.5 text-[11px] font-semibold text-neutral-200 transition hover:border-white/20 hover:bg-white/[0.04]"
+          >
+            Remove
+          </button>
+        ) : null}
         {!file ? (
           <span className="text-[10px] text-neutral-500">
             Optional, but highly recommended

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -8,6 +8,10 @@ import type { Database } from "@shared/types/types/supabase";
 
 import type { ShopHealthSnapshot } from "@/features/integrations/ai/shopBoostType";
 import ShopHealthSnapshotView from "@/features/shops/components/ShopHealthSnapshot";
+import {
+  SHOP_BOOST_UPLOAD_DATASETS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
 
@@ -40,6 +44,7 @@ type LinkageSummary = {
 };
 
 const SHOP_IMPORT_BUCKET = "shop-imports";
+const UPLOAD_SESSION_STORAGE_KEY = "shop-boost-upload-session-v1";
 
 function safeFileName(name: string): string {
   const base = (name || "upload.csv").trim();
@@ -99,11 +104,7 @@ export default function ShopBoostOnboardingPage() {
     wantsPowerAddOns: true,
   });
 
-  const [customersFile, setCustomersFile] = useState<File | null>(null);
-  const [vehiclesFile, setVehiclesFile] = useState<File | null>(null);
-  const [partsFile, setPartsFile] = useState<File | null>(null);
-  const [historyFile, setHistoryFile] = useState<File | null>(null);
-  const [staffFile, setStaffFile] = useState<File | null>(null);
+  const [uploadFiles, setUploadFiles] = useState<Partial<Record<ShopBoostUploadDatasetKey, File>>>({});
 
   const [stepStatus, setStepStatus] = useState<StepStatus>("idle");
   const [snapshot, setSnapshot] = useState<ShopHealthSnapshot | null>(null);
@@ -150,6 +151,32 @@ export default function ShopBoostOnboardingPage() {
     })();
   }, [supabase]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const existing = window.localStorage.getItem(UPLOAD_SESSION_STORAGE_KEY);
+    if (!existing) return;
+    try {
+      const parsed = JSON.parse(existing) as Partial<Record<ShopBoostUploadDatasetKey, string>>;
+      const draftFiles: Partial<Record<ShopBoostUploadDatasetKey, File>> = {};
+      for (const dataset of SHOP_BOOST_UPLOAD_DATASETS) {
+        const fileName = parsed[dataset.key];
+        if (!fileName) continue;
+        draftFiles[dataset.key] = new File([], fileName, { type: "text/csv" });
+      }
+      setUploadFiles(draftFiles);
+    } catch {
+      // ignore draft parse errors
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const draft = Object.fromEntries(
+      SHOP_BOOST_UPLOAD_DATASETS.map((dataset) => [dataset.key, uploadFiles[dataset.key]?.name ?? null]),
+    );
+    window.localStorage.setItem(UPLOAD_SESSION_STORAGE_KEY, JSON.stringify(draft));
+  }, [uploadFiles]);
+
   const handleQuestionToggle =
     (key: keyof QuestionnaireState) => (value: boolean) => {
       setQuestionnaire((prev) => ({
@@ -176,7 +203,11 @@ export default function ShopBoostOnboardingPage() {
       return;
     }
 
-    if (!customersFile && !vehiclesFile && !partsFile && !historyFile && !staffFile) {
+    const selectedEntries = Object.entries(uploadFiles).filter(
+      (entry): entry is [ShopBoostUploadDatasetKey, File] => !!entry[1],
+    );
+
+    if (selectedEntries.length === 0) {
       setError("Please upload at least one CSV file so we have data to scan.");
       return;
     }
@@ -186,13 +217,10 @@ export default function ShopBoostOnboardingPage() {
     // ✅ intakeId is ALWAYS UUID format now
     const intakeId = uuidv4();
 
-    const uploadIfPresent = async (
-      file: File | null,
-      kind: "customers" | "vehicles" | "parts" | "history" | "staff",
-    ): Promise<string | null> => {
-      if (!file) return null;
-
-      // ✅ RLS policy expects first path segment == shopId
+    const uploadDatasetFile = async (
+      kind: ShopBoostUploadDatasetKey,
+      file: File,
+    ): Promise<string> => {
       const safeName = safeFileName(file.name || `${kind}.csv`);
       const path = `shops/${shopId}/${intakeId}/${kind}-${safeName}`;
 
@@ -212,14 +240,10 @@ export default function ShopBoostOnboardingPage() {
     };
 
     try {
-      const [customersPath, vehiclesPath, partsPath, historyPath, staffPath] =
-        await Promise.all([
-          uploadIfPresent(customersFile, "customers"),
-          uploadIfPresent(vehiclesFile, "vehicles"),
-          uploadIfPresent(partsFile, "parts"),
-          uploadIfPresent(historyFile, "history"),
-          uploadIfPresent(staffFile, "staff"),
-        ]);
+      const uploadedPathEntries = await Promise.all(
+        selectedEntries.map(async ([kind, file]) => [kind, await uploadDatasetFile(kind, file)] as const),
+      );
+      const uploadPaths = Object.fromEntries(uploadedPathEntries);
 
       setStepStatus("processing");
 
@@ -230,11 +254,7 @@ export default function ShopBoostOnboardingPage() {
         body: JSON.stringify({
           intakeId,
           questionnaire,
-          customersPath,
-          vehiclesPath,
-          partsPath,
-          historyPath,
-          staffPath,
+          uploadPaths,
         }),
       });
 
@@ -455,41 +475,27 @@ export default function ShopBoostOnboardingPage() {
               </div>
 
               <div className="space-y-4 text-sm">
-                <UploadRow
-                  id="customers-upload"
-                  label="Customers"
-                  description="Names, phones, emails — we’ll attach vehicles and history where possible."
-                  currentFile={customersFile}
-                  onFileChange={setCustomersFile}
-                />
-                <UploadRow
-                  id="vehicles-upload"
-                  label="Vehicles"
-                  description="VIN/plate, unit #, year/make/model — links to customers and history."
-                  currentFile={vehiclesFile}
-                  onFileChange={setVehiclesFile}
-                />
-                <UploadRow
-                  id="parts-upload"
-                  label="Parts inventory"
-                  description="Part numbers, descriptions, cost and sell prices, preferred vendors."
-                  currentFile={partsFile}
-                  onFileChange={setPartsFile}
-                />
-                <UploadRow
-                  id="history-upload"
-                  label="History (repair orders)"
-                  description="RO#, date, complaint/cause/correction, totals — builds Work Orders + Lines so history works day 1."
-                  currentFile={historyFile}
-                  onFileChange={setHistoryFile}
-                />
-                <UploadRow
-                  id="staff-upload"
-                  label="Staff / team roster"
-                  description="Names, roles, phone/email/usernames — creates accounts and profiles."
-                  currentFile={staffFile}
-                  onFileChange={setStaffFile}
-                />
+                {SHOP_BOOST_UPLOAD_DATASETS.map((dataset) => (
+                  <UploadRow
+                    key={dataset.key}
+                    id={`${dataset.key}-upload`}
+                    label={dataset.label}
+                    description={dataset.description}
+                    helper={dataset.help}
+                    currentFile={uploadFiles[dataset.key] ?? null}
+                    onFileChange={(file) =>
+                      setUploadFiles((prev) => {
+                        const next = { ...prev };
+                        if (!file) {
+                          delete next[dataset.key];
+                        } else {
+                          next[dataset.key] = file;
+                        }
+                        return next;
+                      })
+                    }
+                  />
+                ))}
 
                 <p className="text-[11px] text-neutral-500">
                   Don&apos;t worry about perfect formatting — we interpret columns and map them into ProFixIQ.
@@ -672,17 +678,19 @@ type UploadRowProps = {
   id: string;
   label: string;
   description: string;
+  helper?: string;
   currentFile: File | null;
   onFileChange: (f: File | null) => void;
 };
 
-function UploadRow({ id, label, description, currentFile, onFileChange }: UploadRowProps) {
+function UploadRow({ id, label, description, helper, currentFile, onFileChange }: UploadRowProps) {
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between gap-2">
         <div>
           <label className="text-xs text-neutral-300">{label}</label>
           <p className="text-[11px] text-neutral-500">{description}</p>
+          {helper ? <p className="text-[10px] text-neutral-400">{helper}</p> : null}
         </div>
         <span className="max-w-[140px] truncate text-[10px] text-neutral-400">
           {currentFile ? currentFile.name : "No file selected"}
@@ -705,6 +713,15 @@ function UploadRow({ id, label, description, currentFile, onFileChange }: Upload
             onFileChange(file);
           }}
         />
+        {currentFile ? (
+          <button
+            type="button"
+            onClick={() => onFileChange(null)}
+            className="inline-flex cursor-pointer items-center rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-[11px] font-semibold text-neutral-200 hover:border-neutral-500"
+          >
+            Remove
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/features/integrations/ai/shopBoost/index.ts
+++ b/features/integrations/ai/shopBoost/index.ts
@@ -13,6 +13,7 @@ import {
   type ShopHealthScoringInput,
 } from "./healthScoring";
 import type { ShopHealthSnapshot } from "@/features/integrations/ai/shopBoostType";
+import { SHOP_BOOST_UPLOAD_DATASET_KEYS, type ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
 
@@ -26,6 +27,10 @@ type BuildArgs = {
 };
 
 type IntakeRow = DB["public"]["Tables"]["shop_boost_intakes"]["Row"];
+
+type UploadManifestRecord = Partial<
+  Record<ShopBoostUploadDatasetKey, { path?: string; fileName?: string | null; importMode?: "direct" | "staging" }>
+>;
 
 function nowIso() {
   return new Date().toISOString();
@@ -208,6 +213,8 @@ export async function buildShopBoostProfile(
 
   try {
     const intake = await loadIntake(shopId, intakeId);
+    const intakeBasics = (intake.intake_basics ?? {}) as Record<string, unknown>;
+    const uploadManifest = (intakeBasics.uploadManifest ?? {}) as UploadManifestRecord;
 
     const questionnaire = args.questionnaire ?? intake.questionnaire ?? {};
     const customersText = await downloadCsvIfPresent(
@@ -225,36 +232,31 @@ export async function buildShopBoostProfile(
     // ---------------------------------------------------------------------
     // 1) STORE IMPORT FILE METADATA
     // ---------------------------------------------------------------------
-    const filesToInsert: Array<
-      DB["public"]["Tables"]["shop_import_files"]["Insert"]
-    > = [];
+    const filesToInsert: Array<DB["public"]["Tables"]["shop_import_files"]["Insert"]> = [];
+    const rowCountByKind: Partial<Record<ShopBoostUploadDatasetKey, number>> = {
+      customers: customersRows.length,
+      vehicles: vehiclesRows.length,
+      parts: partsRows.length,
+    };
 
-    if (intake.customers_file_path) {
+    for (const kind of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+      const path =
+        kind === "customers"
+          ? intake.customers_file_path
+          : kind === "vehicles"
+            ? intake.vehicles_file_path
+            : kind === "parts"
+              ? intake.parts_file_path
+              : uploadManifest[kind]?.path ?? null;
+      if (!path) continue;
       filesToInsert.push({
-        shop_id: shopId,
         intake_id: intakeId,
-        kind: "customers",
-        storage_path: intake.customers_file_path,
-        row_count: customersRows.length,
-      } as unknown as DB["public"]["Tables"]["shop_import_files"]["Insert"]);
-    }
-    if (intake.vehicles_file_path) {
-      filesToInsert.push({
-        shop_id: shopId,
-        intake_id: intakeId,
-        kind: "vehicles",
-        storage_path: intake.vehicles_file_path,
-        row_count: vehiclesRows.length,
-      } as unknown as DB["public"]["Tables"]["shop_import_files"]["Insert"]);
-    }
-    if (intake.parts_file_path) {
-      filesToInsert.push({
-        shop_id: shopId,
-        intake_id: intakeId,
-        kind: "parts",
-        storage_path: intake.parts_file_path,
-        row_count: partsRows.length,
-      } as unknown as DB["public"]["Tables"]["shop_import_files"]["Insert"]);
+        kind,
+        storage_path: path,
+        original_filename: uploadManifest[kind]?.fileName ?? null,
+        parsed_row_count: rowCountByKind[kind] ?? null,
+        status: uploadManifest[kind]?.importMode === "staging" ? "needs_review" : "parsed",
+      } as DB["public"]["Tables"]["shop_import_files"]["Insert"]);
     }
 
     if (filesToInsert.length) {

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -2,6 +2,11 @@
 import { createHash } from "crypto";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  SHOP_BOOST_DIRECT_IMPORT_DATASETS,
+  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
 
@@ -53,6 +58,9 @@ export type ShopBoostImportSummary = {
 };
 
 type CsvRow = Record<string, string>;
+type UploadManifestRecord = Partial<
+  Record<ShopBoostUploadDatasetKey, { path?: string; fileName?: string | null; importMode?: "direct" | "staging" }>
+>;
 
 function norm(s: string): string {
   return (s ?? "").trim();
@@ -273,6 +281,64 @@ async function downloadCsv(path: string | null): Promise<string | null> {
   return data.text();
 }
 
+async function stageSupplementalUploads(args: {
+  shopId: string;
+  intakeId: string;
+  uploadManifest: UploadManifestRecord;
+}): Promise<void> {
+  const supabase = createAdminSupabase();
+  const stagedKinds = SHOP_BOOST_UPLOAD_DATASET_KEYS.filter(
+    (key) => !SHOP_BOOST_DIRECT_IMPORT_DATASETS.includes(key),
+  );
+
+  for (const kind of stagedKinds) {
+    const path = args.uploadManifest[kind]?.path ?? null;
+    if (!path) continue;
+    const csv = await downloadCsv(path);
+    if (!csv) continue;
+    const { rows } = parseCsv(csv);
+
+    const { data: existingFile } = await supabase
+      .from("shop_import_files")
+      .select("id")
+      .eq("intake_id", args.intakeId)
+      .eq("storage_path", path)
+      .maybeSingle<{ id: string }>();
+
+    let fileId = existingFile?.id ?? null;
+    if (!fileId) {
+      const inserted = await supabase
+        .from("shop_import_files")
+        .insert({
+          intake_id: args.intakeId,
+          kind,
+          storage_path: path,
+          original_filename: args.uploadManifest[kind]?.fileName ?? null,
+          parsed_row_count: rows.length,
+          status: "needs_review",
+        } as DB["public"]["Tables"]["shop_import_files"]["Insert"])
+        .select("id")
+        .limit(1)
+        .maybeSingle<{ id: string }>();
+      fileId = inserted.data?.id ?? null;
+    }
+    if (!fileId || rows.length === 0) continue;
+
+    await supabase.from("shop_import_rows").delete().eq("file_id", fileId);
+
+    const payload = rows.slice(0, 500).map((row, index) => ({
+      intake_id: args.intakeId,
+      file_id: fileId,
+      row_number: index + 1,
+      entity_type: kind,
+      raw: row,
+      normalized: {},
+      errors: ["Auto-staged for mapping review"],
+    }));
+    await supabase.from("shop_import_rows").insert(payload);
+  }
+}
+
 export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImportSummary> {
   const { shopId, intakeId } = args;
   const supabase = createAdminSupabase();
@@ -317,6 +383,12 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   const intakeRow = intake as IntakeRow;
+  const intakeBasics = isRecord((intakeRow as unknown as Record<string, unknown>).intake_basics)
+    ? ((intakeRow as unknown as Record<string, unknown>).intake_basics as Record<string, unknown>)
+    : {};
+  const uploadManifest = isRecord(intakeBasics.uploadManifest)
+    ? (intakeBasics.uploadManifest as UploadManifestRecord)
+    : {};
 
   const [customersCsv, vehiclesCsv, partsCsv, historyCsv, staffCsv] = await Promise.all([
     downloadCsv(intakeRow.customers_file_path ?? null),
@@ -325,6 +397,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     downloadCsv(intakeRow.history_file_path ?? null),
     downloadCsv(intakeRow.staff_file_path ?? null),
   ]);
+
+  await stageSupplementalUploads({ shopId, intakeId, uploadManifest });
 
   // Build caches (keep light: only key columns)
   const customersByEmail = new Map<string, string>();

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -8,6 +8,11 @@ import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 import { runShopBoostImport, type ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
+import {
+  SHOP_BOOST_UPLOAD_DATASETS,
+  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
 
@@ -33,6 +38,16 @@ type RunMode = {
   runImport: boolean;
   // If true, allow JSON body to provide file paths (must be shop-scoped).
   allowProvidedPaths: boolean;
+};
+
+type UploadManifestEntry = {
+  dataset: ShopBoostUploadDatasetKey;
+  path: string;
+  fileName: string | null;
+  contentType: string | null;
+  sizeBytes: number | null;
+  target: string;
+  importMode: "direct" | "staging";
 };
 
 function safeFileName(name: string): string {
@@ -134,19 +149,11 @@ export async function runShopBoostIntake(
 
   let questionnaire: unknown = {};
 
-  let customersFile: File | null = null;
-  let vehiclesFile: File | null = null;
-  let partsFile: File | null = null;
-  let historyFile: File | null = null;
-  let staffFile: File | null = null;
+  const filesByDataset: Partial<Record<ShopBoostUploadDatasetKey, File>> = {};
 
   let providedIntakeId: string | null = null;
 
-  let providedCustomersPath: string | null = null;
-  let providedVehiclesPath: string | null = null;
-  let providedPartsPath: string | null = null;
-  let providedHistoryPath: string | null = null;
-  let providedStaffPath: string | null = null;
+  let providedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
 
   if (contentType.includes("multipart/form-data")) {
     const formData = await req.formData().catch(() => null);
@@ -159,13 +166,10 @@ export async function runShopBoostIntake(
 
     questionnaire = parseQuestionnaire(formData.get("questionnaire"));
 
-    customersFile = asFile(formData.get("customersFile"));
-    vehiclesFile = asFile(formData.get("vehiclesFile"));
-    partsFile = asFile(formData.get("partsFile"));
-
-    if (mode.allowHistoryAndStaff) {
-      historyFile = asFile(formData.get("historyFile"));
-      staffFile = asFile(formData.get("staffFile"));
+    for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+      if (!mode.allowHistoryAndStaff && (key === "history" || key === "staff")) continue;
+      const file = asFile(formData.get(`${key}File`));
+      if (file) filesByDataset[key] = file;
     }
 
     const rawIntake = formData.get("intakeId");
@@ -177,12 +181,23 @@ export async function runShopBoostIntake(
       if ("intakeId" in body) providedIntakeId = asString(body["intakeId"]);
 
       if (mode.allowProvidedPaths) {
-        if ("customersPath" in body) providedCustomersPath = asString(body["customersPath"]);
-        if ("vehiclesPath" in body) providedVehiclesPath = asString(body["vehiclesPath"]);
-        if ("partsPath" in body) providedPartsPath = asString(body["partsPath"]);
-        if (mode.allowHistoryAndStaff) {
-          if ("historyPath" in body) providedHistoryPath = asString(body["historyPath"]);
-          if ("staffPath" in body) providedStaffPath = asString(body["staffPath"]);
+        if ("uploadPaths" in body && isRecord(body["uploadPaths"])) {
+          for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+            if (!mode.allowHistoryAndStaff && (key === "history" || key === "staff")) continue;
+            const maybePath = asString(body["uploadPaths"][key]);
+            if (maybePath) providedPaths[key] = maybePath;
+          }
+        } else {
+          const legacy: Partial<Record<ShopBoostUploadDatasetKey, string | null>> = {
+            customers: asString(body["customersPath"]),
+            vehicles: asString(body["vehiclesPath"]),
+            parts: asString(body["partsPath"]),
+            history: mode.allowHistoryAndStaff ? asString(body["historyPath"]) : null,
+            staff: mode.allowHistoryAndStaff ? asString(body["staffPath"]) : null,
+          };
+          for (const [key, value] of Object.entries(legacy) as Array<[ShopBoostUploadDatasetKey, string | null]>) {
+            if (value) providedPaths[key] = value;
+          }
         }
       }
     }
@@ -196,8 +211,8 @@ export async function runShopBoostIntake(
     providedIntakeId && UUID_RE.test(providedIntakeId) ? providedIntakeId : randomUUID();
 
   const uploadIfPresent = async (
-    file: File | null,
-    kind: "customers" | "vehicles" | "parts" | "history" | "staff",
+    kind: ShopBoostUploadDatasetKey,
+    file: File | undefined,
   ): Promise<string | null> => {
     if (!file) return null;
 
@@ -215,45 +230,22 @@ export async function runShopBoostIntake(
     return path;
   };
 
-  const [
-    customersPathUploaded,
-    vehiclesPathUploaded,
-    partsPathUploaded,
-    historyPathUploaded,
-    staffPathUploaded,
-  ] = await Promise.all([
-    uploadIfPresent(customersFile, "customers"),
-    uploadIfPresent(vehiclesFile, "vehicles"),
-    uploadIfPresent(partsFile, "parts"),
-    mode.allowHistoryAndStaff ? uploadIfPresent(historyFile, "history") : Promise.resolve(null),
-    mode.allowHistoryAndStaff ? uploadIfPresent(staffFile, "staff") : Promise.resolve(null),
-  ]);
-
-  const noUploads =
-    !customersFile &&
-    !vehiclesFile &&
-    !partsFile &&
-    (!mode.allowHistoryAndStaff || (!historyFile && !staffFile));
-
-  const jsonProvidedAny =
-    !!providedCustomersPath ||
-    !!providedVehiclesPath ||
-    !!providedPartsPath ||
-    (mode.allowHistoryAndStaff && (!!providedHistoryPath || !!providedStaffPath));
+  const uploadedPathEntries = await Promise.all(
+    SHOP_BOOST_UPLOAD_DATASET_KEYS.map(async (key) => [key, await uploadIfPresent(key, filesByDataset[key])] as const),
+  );
+  const uploadedPaths = Object.fromEntries(uploadedPathEntries) as Partial<
+    Record<ShopBoostUploadDatasetKey, string | null>
+  >;
+  const noUploads = Object.values(filesByDataset).length === 0;
+  const jsonProvidedAny = Object.values(providedPaths).some(Boolean);
 
   // ✅ fallback to latest intake paths when re-running with no uploads and no provided paths
-  let fallbackPaths: {
-    customersPath: string | null;
-    vehiclesPath: string | null;
-    partsPath: string | null;
-    historyPath: string | null;
-    staffPath: string | null;
-  } = { customersPath: null, vehiclesPath: null, partsPath: null, historyPath: null, staffPath: null };
+  let fallbackPaths: Partial<Record<ShopBoostUploadDatasetKey, string | null>> = {};
 
   if (noUploads && !jsonProvidedAny) {
     const { data: latestIntake } = await supabaseAdmin
       .from("shop_boost_intakes")
-      .select("customers_file_path, vehicles_file_path, parts_file_path, history_file_path, staff_file_path")
+      .select("customers_file_path, vehicles_file_path, parts_file_path, history_file_path, staff_file_path, intake_basics")
       .eq("shop_id", shopId)
       .order("created_at", { ascending: false })
       .limit(1)
@@ -263,66 +255,83 @@ export async function runShopBoostIntake(
         parts_file_path: string | null;
         history_file_path: string | null;
         staff_file_path: string | null;
+        intake_basics: unknown;
       }>();
 
+    const intakeBasics = isRecord(latestIntake?.intake_basics) ? latestIntake.intake_basics : {};
+    const existingManifest = isRecord(intakeBasics.uploadManifest)
+      ? (intakeBasics.uploadManifest as Record<string, unknown>)
+      : {};
     fallbackPaths = {
-      customersPath: latestIntake?.customers_file_path ?? null,
-      vehiclesPath: latestIntake?.vehicles_file_path ?? null,
-      partsPath: latestIntake?.parts_file_path ?? null,
-      historyPath: latestIntake?.history_file_path ?? null,
-      staffPath: latestIntake?.staff_file_path ?? null,
+      customers: latestIntake?.customers_file_path ?? null,
+      vehicles: latestIntake?.vehicles_file_path ?? null,
+      parts: latestIntake?.parts_file_path ?? null,
+      history: latestIntake?.history_file_path ?? null,
+      staff: latestIntake?.staff_file_path ?? null,
     };
+    for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+      const manifestEntry = existingManifest[key];
+      const fromManifest = isRecord(manifestEntry) ? asString(manifestEntry.path) : null;
+      if (fromManifest) fallbackPaths[key] = fromManifest;
+    }
   }
 
-  const customersFinal = customersPathUploaded ?? providedCustomersPath ?? fallbackPaths.customersPath;
-  const vehiclesFinal = vehiclesPathUploaded ?? providedVehiclesPath ?? fallbackPaths.vehiclesPath;
-  const partsFinal = partsPathUploaded ?? providedPartsPath ?? fallbackPaths.partsPath;
-
-  const historyFinal = mode.allowHistoryAndStaff
-    ? historyPathUploaded ?? providedHistoryPath ?? fallbackPaths.historyPath
-    : null;
-
-  const staffFinal = mode.allowHistoryAndStaff
-    ? staffPathUploaded ?? providedStaffPath ?? fallbackPaths.staffPath
-    : null;
+  const finalPaths = Object.fromEntries(
+    SHOP_BOOST_UPLOAD_DATASET_KEYS.map((key) => [
+      key,
+      uploadedPaths[key] ?? providedPaths[key] ?? fallbackPaths[key] ?? null,
+    ]),
+  ) as Record<ShopBoostUploadDatasetKey, string | null>;
 
   // ✅ normalize legacy paths to canonical before enforcing + inserting
-  const customersFinalN = normalizeShopPath(shopId, customersFinal);
-  const vehiclesFinalN = normalizeShopPath(shopId, vehiclesFinal);
-  const partsFinalN = normalizeShopPath(shopId, partsFinal);
-
-  const historyFinalN = mode.allowHistoryAndStaff ? normalizeShopPath(shopId, historyFinal) : null;
-
-  const staffFinalN = mode.allowHistoryAndStaff ? normalizeShopPath(shopId, staffFinal) : null;
+  const normalizedPaths = Object.fromEntries(
+    Object.entries(finalPaths).map(([key, path]) => [key, normalizeShopPath(shopId, path)]),
+  ) as Record<ShopBoostUploadDatasetKey, string | null>;
 
   // ✅ enforce shop-scoped paths for any provided/fallback content
   if (
-    !isShopScopedPath(shopId, customersFinalN) ||
-    !isShopScopedPath(shopId, vehiclesFinalN) ||
-    !isShopScopedPath(shopId, partsFinalN) ||
-    !isShopScopedPath(shopId, historyFinalN) ||
-    !isShopScopedPath(shopId, staffFinalN)
+    Object.values(normalizedPaths).some((path) => !isShopScopedPath(shopId, path))
   ) {
     return { ok: false, error: "Invalid file path (must start with shops/<shopId>/)." };
   }
 
-  if (!customersFinalN && !vehiclesFinalN && !partsFinalN && !historyFinalN && !staffFinalN) {
+  if (!Object.values(normalizedPaths).some(Boolean)) {
     return {
       ok: false,
       error: "No uploads found and no previous intake files exist yet. Upload at least one CSV first.",
     };
   }
 
+  const uploadManifest = SHOP_BOOST_UPLOAD_DATASETS.reduce((acc, dataset) => {
+    const key = dataset.key;
+    const path = normalizedPaths[key];
+    if (!path) return acc;
+    const sourceFile = filesByDataset[key];
+    acc[key] = {
+      dataset: key,
+      path,
+      fileName: sourceFile?.name ?? null,
+      contentType: sourceFile?.type ?? null,
+      sizeBytes: sourceFile?.size ?? null,
+      target: dataset.target,
+      importMode: dataset.importMode,
+    } satisfies UploadManifestEntry;
+    return acc;
+  }, {} as Record<ShopBoostUploadDatasetKey, UploadManifestEntry>);
+
   const intakeInsert: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
     id: intakeId,
     shop_id: shopId,
     questionnaire:
       questionnaire as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["questionnaire"],
-    customers_file_path: customersFinalN,
-    vehicles_file_path: vehiclesFinalN,
-    parts_file_path: partsFinalN,
-    history_file_path: historyFinalN,
-    staff_file_path: staffFinalN,
+    customers_file_path: normalizedPaths.customers,
+    vehicles_file_path: normalizedPaths.vehicles,
+    parts_file_path: normalizedPaths.parts,
+    history_file_path: mode.allowHistoryAndStaff ? normalizedPaths.history : null,
+    staff_file_path: mode.allowHistoryAndStaff ? normalizedPaths.staff : null,
+    intake_basics: {
+      uploadManifest,
+    } as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["intake_basics"],
     status: "pending",
   };
 

--- a/features/integrations/shopBoost/uploadDatasets.ts
+++ b/features/integrations/shopBoost/uploadDatasets.ts
@@ -1,0 +1,95 @@
+export const SHOP_BOOST_UPLOAD_DATASETS = [
+  {
+    key: "customers",
+    label: "Customers",
+    description: "Names, phones, emails — anchors customer records and future approvals.",
+    help: "Optional but recommended",
+    target: "customers import/staging",
+    importMode: "direct",
+  },
+  {
+    key: "vehicles",
+    label: "Vehicles",
+    description: "VIN, plate, unit, year/make/model — links assets to customers and repair history.",
+    help: "Optional",
+    target: "vehicles import/staging",
+    importMode: "direct",
+  },
+  {
+    key: "history",
+    label: "Work orders / repair history",
+    description: "RO numbers, dates, concerns, corrections, totals — drives work order + invoice history import.",
+    help: "Optional",
+    target: "work_orders/work_order_lines + invoice history pipeline",
+    importMode: "direct",
+  },
+  {
+    key: "invoices",
+    label: "Invoices / payment history",
+    description: "Invoice exports and payment events for reconciliation and later mapping review.",
+    help: "Optional · staged for safe review",
+    target: "invoice history staging",
+    importMode: "staging",
+  },
+  {
+    key: "parts",
+    label: "Parts / inventory",
+    description: "Part numbers, descriptions, costs, sell prices, preferred vendors.",
+    help: "Optional",
+    target: "parts/inventory import",
+    importMode: "direct",
+  },
+  {
+    key: "vendors",
+    label: "Vendors",
+    description: "Supplier records, contacts, terms, and account references.",
+    help: "Optional · staged for safe review",
+    target: "vendor staging",
+    importMode: "staging",
+  },
+  {
+    key: "staff",
+    label: "Staff / users / technicians",
+    description: "Team roster with role hints, emails, and phone numbers.",
+    help: "Optional",
+    target: "staff invite suggestion staging",
+    importMode: "direct",
+  },
+  {
+    key: "serviceCatalog",
+    label: "Service catalog / canned jobs",
+    description: "Menu services, canned jobs, labor presets, and operation templates.",
+    help: "Optional · staged for safe review",
+    target: "service catalog staging",
+    importMode: "staging",
+  },
+  {
+    key: "appointments",
+    label: "Appointments / bookings",
+    description: "Scheduled visits, promised times, advisor notes, and booking channels.",
+    help: "Optional · staged for safe review",
+    target: "appointments staging",
+    importMode: "staging",
+  },
+  {
+    key: "other",
+    label: "Other / unknown CSV",
+    description: "Upload anything not listed above. We stage it for mapping review.",
+    help: "Optional · review queue",
+    target: "unknown CSV review staging",
+    importMode: "staging",
+  },
+] as const;
+
+export type ShopBoostUploadDataset = (typeof SHOP_BOOST_UPLOAD_DATASETS)[number];
+export type ShopBoostUploadDatasetKey = ShopBoostUploadDataset["key"];
+
+export const SHOP_BOOST_DIRECT_IMPORT_DATASETS: ShopBoostUploadDatasetKey[] = [
+  "customers",
+  "vehicles",
+  "history",
+  "parts",
+  "staff",
+];
+
+export const SHOP_BOOST_UPLOAD_DATASET_KEYS = SHOP_BOOST_UPLOAD_DATASETS.map((d) => d.key);


### PR DESCRIPTION
### Motivation
- Restore and expand the reduced single-file upload to a flexible multi-upload session so users can attach many distinct CSV exports in one onboarding/demo run.
- Ensure each uploaded CSV is explicitly classified and routed into the correct import/staging path so mapping/import behavior is safe for messy real-world exports.
- Keep the flow non-breaking and multi-tenant-safe by preserving `shop_id` storage paths and using staging for datasets that are not safe to directly import.

### Description
- Added a central dataset manifest `features/integrations/shopBoost/uploadDatasets.ts` that defines the supported upload categories, user-facing labels/descriptions, an import target label, and `importMode` (`direct` vs `staging`).
- Restored and extended onboarding and demo UIs to allow multiple upload slots (one per dataset), per-slot remove/replace, multi-file upload before analysis, and a local draft using `localStorage`; updated pages: `app/onboarding/shop-boost/page.tsx` and `app/demo/instant-shop-analysis/page.tsx`.
- Generalized intake handling so routes accept dynamic multipart fields for each dataset and JSON `uploadPaths`; intake handler now persists an `uploadManifest` into `shop_boost_intakes.intake_basics` and enforces shop-scoped storage paths: `features/integrations/shopBoost/runIntakeHandler.ts` and `app/api/demo/shop-boost/run/route.ts`.
- Pipeline safety: `buildShopBoostProfile` now inserts `shop_import_files` metadata for all datasets and uses `parsed`/`needs_review` status per dataset importMode, and `runFullImport` stages supplemental/staged datasets into `shop_import_files` + sampled `shop_import_rows` (no risky direct writes for unsupported categories); files changed: `features/integrations/ai/shopBoost/index.ts`, `features/integrations/imports/runFullImport.ts`.
- Files changed (exact): `features/integrations/shopBoost/uploadDatasets.ts`, `app/onboarding/shop-boost/page.tsx`, `app/demo/instant-shop-analysis/page.tsx`, `app/api/demo/shop-boost/run/route.ts`, `features/integrations/shopBoost/runIntakeHandler.ts`, `features/integrations/ai/shopBoost/index.ts`, `features/integrations/imports/runFullImport.ts`.
- No schema migrations were added; the work reuses `shop_boost_intakes.intake_basics`, `shop_import_files`, and `shop_import_rows` (existing staging tables) so there are no DB changes required.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`; result: success (pass).
- No DB migrations were applied during this change and no automated runtime integration tests were added; static type check passed and the changes preserve existing intake shapes and legacy path compatibility.
- Manual UI/UX validation is recommended in a review environment to confirm multi-file selection, removal, local draft behavior, and that uploads produce `shop_boost_intakes` rows with `intake_basics.uploadManifest` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90034f72883288b30e4ef0a568e21)