### PR TITLE
Add Shop Boost build summary, review screens, and menu linkage badges

### DIFF
--- a/app/inspection_template_suggestions/page.tsx
+++ b/app/inspection_template_suggestions/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type InspectionSuggestion = DB["public"]["Tables"]["inspection_template_suggestions"]["Row"];
+
+export default function InspectionTemplateSuggestionsPage() {
+  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const [rows, setRows] = useState<InspectionSuggestion[]>([]);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user?.id) {
+        setError("Sign in required.");
+        return;
+      }
+
+      const { data: profile } = await supabase.from("profiles").select("shop_id").eq("id", user.id).maybeSingle();
+      if (!profile?.shop_id) {
+        setError("No shop found for your profile.");
+        return;
+      }
+
+      const { data, error: loadErr } = await supabase
+        .from("inspection_template_suggestions")
+        .select("*")
+        .eq("shop_id", profile.shop_id)
+        .order("created_at", { ascending: false })
+        .limit(200);
+      if (loadErr) {
+        setError(loadErr.message);
+        return;
+      }
+      setRows(data ?? []);
+    })();
+  }, [supabase]);
+
+  return (
+    <div className="min-h-screen bg-black p-6 text-white">
+      <h1 className="text-xl font-semibold text-[color:var(--accent-copper-light,#fdba74)]">Review inspections</h1>
+      <p className="mt-1 text-xs text-neutral-400">inspection_template_suggestions</p>
+      {error ? <p className="mt-4 text-sm text-red-400">{error}</p> : null}
+      <div className="mt-4 space-y-2">
+        {rows.map((row) => (
+          <div key={row.id} className="rounded-lg border border-neutral-800 bg-neutral-950 p-3 text-sm">
+            <p className="font-medium text-neutral-100">{row.name ?? "Untitled suggestion"}</p>
+            <p className="mt-1 text-xs text-neutral-400">
+              Confidence: {typeof row.confidence === "number" ? row.confidence.toFixed(2) : "n/a"}
+            </p>
+          </div>
+        ))}
+        {rows.length === 0 && !error ? (
+          <p className="text-sm text-neutral-400">No inspection suggestions.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -19,7 +19,9 @@ import { masterServicesList } from "@inspections/lib/inspection/masterServicesLi
 
 type DB = Database;
 
-type MenuItemRow = DB["public"]["Tables"]["menu_items"]["Row"];
+type MenuItemRow = DB["public"]["Tables"]["menu_items"]["Row"] & {
+  inspection_template?: { template_name: string | null } | null;
+};
 type TemplateRow = DB["public"]["Tables"]["inspection_templates"]["Row"] & {
   labor_hours?: number | null;
 };
@@ -244,7 +246,7 @@ export default function MenuItemsPage() {
 
     const { data, error } = await supabase
       .from("menu_items")
-      .select("*")
+      .select("*, inspection_template:inspection_templates(template_name)")
       .eq("shop_id", shopId)
       .order("created_at", { ascending: false })
       .limit(200);
@@ -966,6 +968,12 @@ export default function MenuItemsPage() {
                     <div className={`text-sm font-semibold text-[${COPPER}]`}>
                       {mi.name}
                     </div>
+                    {mi.inspection_template_id ? (
+                      <div className="mt-1 inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-emerald-200">
+                        Includes inspection
+                        {mi.inspection_template?.template_name ? ` • ${mi.inspection_template.template_name}` : ""}
+                      </div>
+                    ) : null}
 
                     {mi.description ? (
                       <span className="block line-clamp-2 text-xs text-neutral-400">
@@ -1025,6 +1033,12 @@ export default function MenuItemsPage() {
                     <div className={`text-sm font-semibold text-[${COPPER}]`}>
                       {mi.name}
                     </div>
+                    {mi.inspection_template_id ? (
+                      <div className="mt-1 inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-emerald-200">
+                        Includes inspection
+                        {mi.inspection_template?.template_name ? ` • ${mi.inspection_template.template_name}` : ""}
+                      </div>
+                    ) : null}
 
                     {mi.description ? (
                       <span className="block line-clamp-2 text-xs text-neutral-400">

--- a/app/menu_item_suggestions/page.tsx
+++ b/app/menu_item_suggestions/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type MenuSuggestion = DB["public"]["Tables"]["menu_item_suggestions"]["Row"];
+
+export default function MenuItemSuggestionsPage() {
+  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const [rows, setRows] = useState<MenuSuggestion[]>([]);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user?.id) {
+        setError("Sign in required.");
+        return;
+      }
+
+      const { data: profile } = await supabase.from("profiles").select("shop_id").eq("id", user.id).maybeSingle();
+      if (!profile?.shop_id) {
+        setError("No shop found for your profile.");
+        return;
+      }
+
+      const { data, error: loadErr } = await supabase
+        .from("menu_item_suggestions")
+        .select("*")
+        .eq("shop_id", profile.shop_id)
+        .order("created_at", { ascending: false })
+        .limit(200);
+      if (loadErr) {
+        setError(loadErr.message);
+        return;
+      }
+      setRows(data ?? []);
+    })();
+  }, [supabase]);
+
+  return (
+    <div className="min-h-screen bg-black p-6 text-white">
+      <h1 className="text-xl font-semibold text-[color:var(--accent-copper-light,#fdba74)]">Review services</h1>
+      <p className="mt-1 text-xs text-neutral-400">menu_item_suggestions</p>
+      {error ? <p className="mt-4 text-sm text-red-400">{error}</p> : null}
+      <div className="mt-4 space-y-2">
+        {rows.map((row) => (
+          <div key={row.id} className="rounded-lg border border-neutral-800 bg-neutral-950 p-3 text-sm">
+            <p className="font-medium text-neutral-100">{row.title ?? "Untitled suggestion"}</p>
+            <p className="mt-1 text-xs text-neutral-400">{row.reason ?? "No reason provided."}</p>
+          </div>
+        ))}
+        {rows.length === 0 && !error ? <p className="text-sm text-neutral-400">No service suggestions.</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -42,6 +42,13 @@ type LinkageSummary = {
     invoicesCustomerId: number;
   };
 };
+type ShopBuildSummary = {
+  menuItemsCreated: number;
+  inspectionTemplatesCreated: number;
+  linkedMenuToInspection: number;
+  menuSuggestions: number;
+  inspectionSuggestions: number;
+};
 
 const SHOP_IMPORT_BUCKET = "shop-imports";
 const UPLOAD_SESSION_STORAGE_KEY = "shop-boost-upload-session-v1";
@@ -109,6 +116,7 @@ export default function ShopBoostOnboardingPage() {
   const [stepStatus, setStepStatus] = useState<StepStatus>("idle");
   const [snapshot, setSnapshot] = useState<ShopHealthSnapshot | null>(null);
   const [linkageSummary, setLinkageSummary] = useState<LinkageSummary | null>(null);
+  const [shopBuildSummary, setShopBuildSummary] = useState<ShopBuildSummary | null>(null);
 
   // Load profile → shop_id + shop name
   useEffect(() => {
@@ -197,6 +205,7 @@ export default function ShopBoostOnboardingPage() {
     setError("");
     setSnapshot(null);
     setLinkageSummary(null);
+    setShopBuildSummary(null);
 
     if (!shopId) {
       setError("Shop not loaded yet.");
@@ -263,7 +272,9 @@ export default function ShopBoostOnboardingPage() {
         snapshot?: ShopHealthSnapshot | null;
         importSummary?: {
           linkageSummary?: LinkageSummary;
+          shopBuildSummary?: ShopBuildSummary;
         };
+        shopBuildSummary?: ShopBuildSummary;
         error?: string;
       };
 
@@ -275,6 +286,7 @@ export default function ShopBoostOnboardingPage() {
 
       setSnapshot(json.snapshot);
       setLinkageSummary(json.importSummary?.linkageSummary ?? null);
+      setShopBuildSummary(json.shopBuildSummary ?? json.importSummary?.shopBuildSummary ?? null);
       setStepStatus("done");
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unexpected error during upload.";
@@ -328,6 +340,8 @@ export default function ShopBoostOnboardingPage() {
     (linkageSummary?.unresolved.invoicesCustomerId ?? 0);
   const unresolvedCounts = linkageSummary?.unresolved;
   const hasUnresolvedItems = itemsNeedingReview > 0;
+  const reviewItemsCount =
+    (shopBuildSummary?.menuSuggestions ?? 0) + (shopBuildSummary?.inspectionSuggestions ?? 0);
 
   return (
     <div className="min-h-screen bg-black text-white">
@@ -520,16 +534,39 @@ export default function ShopBoostOnboardingPage() {
               {error && <p className="text-xs text-red-400">{error}</p>}
             </div>
 
-            {stepStatus === "done" && linkageSummary && (
+            {stepStatus === "done" && (linkageSummary || shopBuildSummary) && (
               <section className="rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-neutral-950 p-4 sm:p-5">
-                <h2 className="text-sm font-semibold text-neutral-100">Import linkage summary</h2>
+                <h2 className="text-base font-semibold text-neutral-100">Your shop is ready</h2>
                 <div className="mt-3 space-y-1 text-sm text-neutral-300">
-                  <p>{linkedVehicles} vehicles linked</p>
-                  <p>{fullyConnectedWorkOrders} work orders fully connected</p>
-                  <p>{itemsNeedingReview} items need review</p>
+                  <p>✔ {(shopBuildSummary?.menuItemsCreated ?? 0).toLocaleString()} services created</p>
+                  <p>
+                    ✔ {(shopBuildSummary?.inspectionTemplatesCreated ?? 0).toLocaleString()} inspections created
+                  </p>
+                  <p>
+                    ✔ {(shopBuildSummary?.linkedMenuToInspection ?? 0).toLocaleString()} services linked to
+                    inspections
+                  </p>
+                  <p>⚠ {reviewItemsCount.toLocaleString()} items need review</p>
                 </div>
 
-                {hasUnresolvedItems && unresolvedCounts && (
+                <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => router.push("/menu_item_suggestions")}
+                    className="rounded-md border border-neutral-600 px-2.5 py-1 text-neutral-100 hover:bg-white/5"
+                  >
+                    Review services
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => router.push("/inspection_template_suggestions")}
+                    className="rounded-md border border-neutral-600 px-2.5 py-1 text-neutral-100 hover:bg-white/5"
+                  >
+                    Review inspections
+                  </button>
+                </div>
+
+                {hasUnresolvedItems && unresolvedCounts ? (
                   <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
                     <h3 className="text-xs font-semibold uppercase tracking-[0.15em] text-amber-200">
                       Needs review
@@ -585,7 +622,15 @@ export default function ShopBoostOnboardingPage() {
                       </button>
                     </div>
                   </div>
-                )}
+                ) : null}
+
+                {linkageSummary ? (
+                  <div className="mt-4 rounded-lg border border-neutral-700 bg-black/30 p-3 text-xs text-neutral-400">
+                    <p>{linkedVehicles} vehicles linked</p>
+                    <p>{fullyConnectedWorkOrders} work orders fully connected</p>
+                    <p>{itemsNeedingReview} operational linkage items need review</p>
+                  </div>
+                ) : null}
               </section>
             )}
           </form>

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -55,6 +55,13 @@ export type ShopBoostImportSummary = {
       invoicesCustomerId: number;
     };
   };
+  shopBuildSummary: {
+    menuItemsCreated: number;
+    inspectionTemplatesCreated: number;
+    linkedMenuToInspection: number;
+    menuSuggestions: number;
+    inspectionSuggestions: number;
+  };
 };
 
 type CsvRow = Record<string, string>;
@@ -484,9 +491,16 @@ async function bridgeOperatingLayerFromCsv(args: {
   intakeId: string;
   serviceCatalogCsv: string | null;
   historyCsv: string | null;
-}): Promise<void> {
+}): Promise<ShopBoostImportSummary["shopBuildSummary"]> {
   const { supabase, shopId, intakeId, serviceCatalogCsv, historyCsv } = args;
-  if (!serviceCatalogCsv && !historyCsv) return;
+  const summary: ShopBoostImportSummary["shopBuildSummary"] = {
+    menuItemsCreated: 0,
+    inspectionTemplatesCreated: 0,
+    linkedMenuToInspection: 0,
+    menuSuggestions: 0,
+    inspectionSuggestions: 0,
+  };
+  if (!serviceCatalogCsv && !historyCsv) return summary;
 
   const menuCandidates: MenuBridgeCandidate[] = [];
   const inspectionCandidates: InspectionBridgeCandidate[] = [];
@@ -548,6 +562,7 @@ async function bridgeOperatingLayerFromCsv(args: {
           .maybeSingle<{ id: string }>();
 
         if (created?.id) {
+          summary.inspectionTemplatesCreated += 1;
           highConfidenceTemplates.push({
             id: created.id,
             source: candidate.source,
@@ -589,6 +604,7 @@ async function bridgeOperatingLayerFromCsv(args: {
       .maybeSingle<{ id: string }>();
 
     if (createdSuggestion?.id) {
+      summary.inspectionSuggestions += 1;
       lowConfidenceTemplateSuggestions.push({
         id: createdSuggestion.id,
         source: candidate.source,
@@ -622,6 +638,8 @@ async function bridgeOperatingLayerFromCsv(args: {
           is_active: false,
           inspection_template_id: matchedTemplate?.id ?? null,
         } as DB["public"]["Tables"]["menu_items"]["Insert"]);
+        summary.menuItemsCreated += 1;
+        if (matchedTemplate?.id) summary.linkedMenuToInspection += 1;
       }
       continue;
     }
@@ -640,7 +658,10 @@ async function bridgeOperatingLayerFromCsv(args: {
       reason: `Derived from ${candidate.source} upload; review recommended.`,
       inspection_template_suggestion_id: matchedTemplateSuggestion?.id ?? null,
     } as DB["public"]["Tables"]["menu_item_suggestions"]["Insert"]);
+    summary.menuSuggestions += 1;
   }
+
+  return summary;
 }
 
 function parseDateIso(v: string | null): string | null {
@@ -743,6 +764,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
   if (intakeErr || !intake) {
     console.warn("[runShopBoostImport] intake missing", intakeErr);
+    const emptyShopBuildSummary: ShopBoostImportSummary["shopBuildSummary"] = {
+      menuItemsCreated: 0,
+      inspectionTemplatesCreated: 0,
+      linkedMenuToInspection: 0,
+      menuSuggestions: 0,
+      inspectionSuggestions: 0,
+    };
     return {
       customersImported: 0,
       vehiclesImported: 0,
@@ -764,6 +792,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           invoicesCustomerId: 0,
         },
       },
+      shopBuildSummary: emptyShopBuildSummary,
     };
   }
 
@@ -785,7 +814,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
   await stageSupplementalUploads({ shopId, intakeId, uploadManifest });
   const serviceCatalogCsv = await downloadCsv(uploadManifest.serviceCatalog?.path ?? null);
-  await bridgeOperatingLayerFromCsv({
+  const shopBuildSummary = await bridgeOperatingLayerFromCsv({
     supabase,
     shopId,
     intakeId,
@@ -1640,7 +1669,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
                 invoicesCustomerId: unresolvedInvoicesMissingCustomer.count ?? 0,
               },
             },
+            shopBuildSummary,
           },
+          shopBuildSummary,
         },
       } satisfies DB["public"]["Tables"]["shop_boost_intakes"]["Update"],
     )
@@ -1667,6 +1698,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         invoicesCustomerId: unresolvedInvoicesMissingCustomer.count ?? 0,
       },
     },
+    shopBuildSummary,
   };
 }
 

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -25,10 +25,12 @@ export type ShopBoostRunResp =
       intakeId: string;
       snapshot: unknown;
       importSummary: ShopBoostImportSummary;
-      operatingLayerSummary: {
+      shopBuildSummary: {
         menuItemsCreated: number;
         inspectionTemplatesCreated: number;
-        itemsNeedReview: number;
+        linkedMenuToInspection: number;
+        menuSuggestions: number;
+        inspectionSuggestions: number;
       };
     }
   | { ok: false; error: string };
@@ -365,6 +367,13 @@ export async function runShopBoostIntake(
         invoicesCustomerId: 0,
       },
     },
+    shopBuildSummary: {
+      menuItemsCreated: 0,
+      inspectionTemplatesCreated: 0,
+      linkedMenuToInspection: 0,
+      menuSuggestions: 0,
+      inspectionSuggestions: 0,
+    },
   };
 
   if (mode.runImport) {
@@ -376,21 +385,12 @@ export async function runShopBoostIntake(
     });
   }
 
-  const intakeBasics = (snapshot as { meta?: { operatingLayerSummary?: unknown } })?.meta
-    ?.operatingLayerSummary as
-    | { menuItemsCreated?: number; inspectionTemplatesCreated?: number; itemsNeedReview?: number }
-    | undefined;
-
   return {
     ok: true,
     shopId,
     intakeId,
     snapshot,
     importSummary,
-    operatingLayerSummary: {
-      menuItemsCreated: intakeBasics?.menuItemsCreated ?? 0,
-      inspectionTemplatesCreated: intakeBasics?.inspectionTemplatesCreated ?? 0,
-      itemsNeedReview: intakeBasics?.itemsNeedReview ?? 0,
-    },
+    shopBuildSummary: importSummary.shopBuildSummary,
   };
 }


### PR DESCRIPTION
### Motivation
- Shop Boost creates menu items, inspections, and low-confidence suggestions but the results are invisible to users after onboarding.  
- Owners need a compact summary of what was auto-built, what was linked, and what needs review.  
- Provide direct review CTAs so shops can quickly validate suggestions and linkage without changing import logic or schema.

### Description
- Add a new `shopBuildSummary` object to `ShopBoostImportSummary` with the shape: `{ menuItemsCreated, inspectionTemplatesCreated, linkedMenuToInspection, menuSuggestions, inspectionSuggestions }`.  
- Compute and return these counters from the CSV bridge import (`bridgeOperatingLayerFromCsv`) and propagate the `shopBuildSummary` through `runShopBoostImport` → `runShopBoostIntake` responses.  
- Persist the summary into `shop_boost_intakes.intake_basics` (added under `importSummary.shopBuildSummary` and top-level `shopBuildSummary`) so onboarding metadata is available after import.  
- UI additions: show a new “Your shop is ready” panel on the onboarding completion screen with counts and two CTAs (`Review services` → `/menu_item_suggestions`, `Review inspections` → `/inspection_template_suggestions`), add two review pages (`app/menu_item_suggestions/page.tsx`, `app/inspection_template_suggestions/page.tsx`), and add a badge in the Menu list UI that shows `Includes inspection` and optionally the inspection template name.  
- Files changed: `features/integrations/imports/runFullImport.ts`, `features/integrations/shopBoost/runIntakeHandler.ts`, `app/onboarding/shop-boost/page.tsx`, `app/menu/page.tsx`, plus new routes `app/menu_item_suggestions/page.tsx` and `app/inspection_template_suggestions/page.tsx`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed without type errors.  
- No database schema migrations were run and import decision logic/thresholds were not changed, so no additional automated DB tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d908d833e883288b00b9c943648e8c)