### PR TITLE
Add review-first optimization actions: apply/dismiss APIs, migration, and widget UX

### DIFF
--- a/app/api/optimization/apply/route.ts
+++ b/app/api/optimization/apply/route.ts
@@ -1,0 +1,207 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { OptimizationActionType, OptimizationApplyPayload } from "@/features/optimization/types";
+
+type DB = Database;
+
+type ApplyBody = {
+  opportunityId?: string;
+  type?: OptimizationActionType;
+  payload?: OptimizationApplyPayload;
+};
+
+const TYPE_MAP: Record<string, OptimizationActionType> = {
+  pricing_normalization: "pricing",
+  inspection_coverage_gap: "inspection",
+  missed_revenue: "revenue",
+};
+
+function isActionType(value: unknown): value is OptimizationActionType {
+  return value === "pricing" || value === "inspection" || value === "revenue";
+}
+
+function normalizeType(value: unknown): OptimizationActionType | null {
+  if (typeof value !== "string") return null;
+  if (isActionType(value)) return value;
+  return TYPE_MAP[value] ?? null;
+}
+
+function parsePrice(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n * 100) / 100;
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const v = value.trim();
+  return v.length > 0 ? v : null;
+}
+
+function safePayload(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+export async function POST(req: Request) {
+  const supabase = createServerSupabaseRoute();
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .or(`id.eq.${user.id},user_id.eq.${user.id}`)
+    .limit(1)
+    .maybeSingle();
+
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ error: "Unable to resolve shop context" }, { status: 400 });
+  }
+
+  const body = (await req.json().catch(() => null)) as ApplyBody | null;
+  const opportunityId = toNonEmptyString(body?.opportunityId);
+  const type = normalizeType(body?.type);
+  const payload = safePayload(body?.payload);
+
+  if (!opportunityId || !type) {
+    return NextResponse.json({ error: "opportunityId and type are required" }, { status: 400 });
+  }
+
+  try {
+    if (type === "pricing") {
+      const menuItemId = toNonEmptyString(payload.menuItemId);
+      const newPrice = parsePrice(payload.newPrice);
+
+      if (!menuItemId || newPrice === null) {
+        return NextResponse.json(
+          { error: "pricing apply requires payload.menuItemId and payload.newPrice" },
+          { status: 400 },
+        );
+      }
+
+      const { error: updateError } = await supabase
+        .from("menu_items")
+        .update({ total_price: newPrice })
+        .eq("id", menuItemId)
+        .eq("shop_id", profile.shop_id);
+
+      if (updateError) {
+        return NextResponse.json({ error: updateError.message }, { status: 500 });
+      }
+    }
+
+    if (type === "inspection") {
+      const templateRaw = safePayload(payload.inspectionTemplate);
+      const templateId = toNonEmptyString(templateRaw.templateId);
+      const templateName =
+        toNonEmptyString(templateRaw.templateName) ||
+        toNonEmptyString(templateRaw.name) ||
+        "Optimization Inspection Template";
+
+      const sections =
+        templateRaw.sections && typeof templateRaw.sections === "object"
+          ? (templateRaw.sections as DB["public"]["Tables"]["inspection_templates"]["Insert"]["sections"])
+          : ({
+              generated: {
+                title: "Generated from optimization suggestion",
+                items: Array.isArray(templateRaw.items) ? templateRaw.items : [],
+              },
+            } as DB["public"]["Tables"]["inspection_templates"]["Insert"]["sections"]);
+
+      if (templateId) {
+        const { error: updateError } = await supabase
+          .from("inspection_templates")
+          .update({
+            template_name: templateName,
+            sections,
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", templateId)
+          .eq("shop_id", profile.shop_id);
+
+        if (updateError) {
+          return NextResponse.json({ error: updateError.message }, { status: 500 });
+        }
+      } else {
+        const insert: DB["public"]["Tables"]["inspection_templates"]["Insert"] = {
+          shop_id: profile.shop_id,
+          user_id: user.id,
+          template_name: templateName,
+          sections,
+          description: toNonEmptyString(templateRaw.description),
+          tags: ["optimization_engine"],
+        };
+
+        const { error: insertError } = await supabase.from("inspection_templates").insert(insert);
+        if (insertError) {
+          return NextResponse.json({ error: insertError.message }, { status: 500 });
+        }
+      }
+    }
+
+    if (type === "revenue") {
+      const suggestionRaw = safePayload(payload.suggestionData);
+      const title =
+        toNonEmptyString(suggestionRaw.title) ||
+        toNonEmptyString(suggestionRaw.suggestedService) ||
+        "Optimization Revenue Suggestion";
+
+      const insert: DB["public"]["Tables"]["menu_item_suggestions"]["Insert"] = {
+        shop_id: profile.shop_id,
+        title,
+        reason:
+          toNonEmptyString(suggestionRaw.reason) ||
+          toNonEmptyString(suggestionRaw.summary) ||
+          "Created from optimization engine recommendation",
+        confidence: (() => {
+          const c = Number(suggestionRaw.confidence);
+          return Number.isFinite(c) ? Math.max(0, Math.min(1, c)) : 0.7;
+        })(),
+        category: toNonEmptyString(suggestionRaw.category),
+        labor_hours_suggestion: (() => {
+          const h = Number(suggestionRaw.laborHours);
+          return Number.isFinite(h) ? h : null;
+        })(),
+        price_suggestion: (() => {
+          const p = Number(suggestionRaw.priceSuggestion);
+          return Number.isFinite(p) ? p : null;
+        })(),
+      };
+
+      const { error: insertError } = await supabase.from("menu_item_suggestions").insert(insert);
+      if (insertError) {
+        return NextResponse.json({ error: insertError.message }, { status: 500 });
+      }
+    }
+
+    const actionInsert: DB["public"]["Tables"]["optimization_actions"]["Insert"] = {
+      shop_id: profile.shop_id,
+      opportunity_id: opportunityId,
+      type,
+      action: "applied",
+      payload: {
+        originalPayload: payload as unknown,
+      } as DB["public"]["Tables"]["optimization_actions"]["Insert"]["payload"],
+      created_by: user.id,
+    };
+
+    const { error: actionError } = await supabase.from("optimization_actions").insert(actionInsert);
+    if (actionError) {
+      return NextResponse.json({ error: actionError.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to apply optimization action";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/optimization/dismiss/route.ts
+++ b/app/api/optimization/dismiss/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { OptimizationActionType } from "@/features/optimization/types";
+
+type DB = Database;
+
+type DismissBody = {
+  opportunityId?: string;
+  type?: OptimizationActionType;
+};
+
+const TYPE_MAP: Record<string, OptimizationActionType> = {
+  pricing_normalization: "pricing",
+  inspection_coverage_gap: "inspection",
+  missed_revenue: "revenue",
+};
+
+function normalizeType(value: unknown): OptimizationActionType | null {
+  if (value === "pricing" || value === "inspection" || value === "revenue") return value;
+  if (typeof value === "string") return TYPE_MAP[value] ?? null;
+  return null;
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const v = value.trim();
+  return v.length > 0 ? v : null;
+}
+
+export async function POST(req: Request) {
+  const supabase = createServerSupabaseRoute();
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .or(`id.eq.${user.id},user_id.eq.${user.id}`)
+    .limit(1)
+    .maybeSingle();
+
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ error: "Unable to resolve shop context" }, { status: 400 });
+  }
+
+  const body = (await req.json().catch(() => null)) as DismissBody | null;
+  const opportunityId = toNonEmptyString(body?.opportunityId);
+  const type = normalizeType(body?.type);
+
+  if (!opportunityId || !type) {
+    return NextResponse.json({ error: "opportunityId and type are required" }, { status: 400 });
+  }
+
+  const actionInsert: DB["public"]["Tables"]["optimization_actions"]["Insert"] = {
+    shop_id: profile.shop_id,
+    opportunity_id: opportunityId,
+    type,
+    action: "dismissed",
+    payload: {},
+    created_by: user.id,
+  };
+
+  const { error: actionError } = await supabase.from("optimization_actions").insert(actionInsert);
+  if (actionError) {
+    return NextResponse.json({ error: actionError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/db/sql/2026-04-10_optimization_actions.sql
+++ b/db/sql/2026-04-10_optimization_actions.sql
@@ -1,0 +1,46 @@
+-- Phase 4.5 optimization action audit + review log (non-breaking)
+-- Suggestions remain read-only until explicitly applied/dismissed by a user.
+
+create table if not exists public.optimization_actions (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  opportunity_id text not null,
+  type text not null check (type in ('pricing', 'inspection', 'revenue')),
+  action text not null check (action in ('applied', 'dismissed')),
+  payload jsonb not null default '{}'::jsonb,
+  created_by uuid null references auth.users(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists optimization_actions_shop_created_idx
+  on public.optimization_actions (shop_id, created_at desc);
+
+create index if not exists optimization_actions_shop_opportunity_idx
+  on public.optimization_actions (shop_id, opportunity_id);
+
+alter table public.optimization_actions enable row level security;
+
+create policy "optimization_actions_select"
+on public.optimization_actions
+for select
+to authenticated
+using (shop_id = public.current_shop_id());
+
+create policy "optimization_actions_insert"
+on public.optimization_actions
+for insert
+to authenticated
+with check (
+  shop_id = public.current_shop_id()
+  and (created_by is null or created_by = auth.uid())
+);
+
+create policy "optimization_actions_update"
+on public.optimization_actions
+for update
+to authenticated
+using (shop_id = public.current_shop_id())
+with check (shop_id = public.current_shop_id());
+
+grant select, insert, update, delete on public.optimization_actions to authenticated;
+grant all on public.optimization_actions to service_role;

--- a/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
+++ b/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
@@ -3,7 +3,11 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
-import type { OptimizationOpportunity } from "@/features/optimization/types";
+import type {
+  OptimizationActionType,
+  OptimizationApplyPayload,
+  OptimizationOpportunity,
+} from "@/features/optimization/types";
 
 function badgeTone(type: OptimizationOpportunity["optimizationType"]): string {
   if (type === "pricing_normalization") return "text-[color:var(--brand-primary)]";
@@ -17,6 +21,77 @@ function typeLabel(type: OptimizationOpportunity["optimizationType"]): string {
   return "Missed revenue";
 }
 
+function actionTypeForOpportunity(type: OptimizationOpportunity["optimizationType"]): OptimizationActionType {
+  if (type === "pricing_normalization") return "pricing";
+  if (type === "inspection_coverage_gap") return "inspection";
+  return "revenue";
+}
+
+function confidenceLabel(confidence: number): string {
+  if (confidence >= 0.85) return "High confidence";
+  if (confidence >= 0.6) return "Review recommended";
+  return "Low confidence";
+}
+
+function toNumber(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseCurrentPriceFromSource(sourceBasis: string[]): number | null {
+  const anchor = sourceBasis.find((line) => line.toLowerCase().includes("current menu price observed at"));
+  if (!anchor) return null;
+  const match = anchor.match(/\$([0-9]+(?:\.[0-9]+)?)/);
+  if (!match) return null;
+  return toNumber(match[1]);
+}
+
+function getApplyPayload(opportunity: OptimizationOpportunity): OptimizationApplyPayload {
+  const actionType = actionTypeForOpportunity(opportunity.optimizationType);
+  const meta = (opportunity.meta ?? {}) as Record<string, unknown>;
+
+  if (actionType === "pricing") {
+    const menuItemRef = opportunity.targetRefs.find((ref) => ref.entityType === "menu_item");
+    return {
+      menuItemId: menuItemRef?.id,
+      newPrice: toNumber(meta.recommendedPrice) ?? undefined,
+      suggestionData: {
+        title: opportunity.title,
+        summary: opportunity.summary,
+        sourceBasis: opportunity.sourceBasis,
+      },
+    };
+  }
+
+  if (actionType === "inspection") {
+    return {
+      inspectionTemplate: {
+        templateName: opportunity.title.replace(/^Inspection coverage gap:\s*/i, "").trim() || opportunity.title,
+        description: opportunity.summary,
+        sections: {
+          optimization_recommended: {
+            title: "Optimization recommendation",
+            items: opportunity.sourceBasis.map((basis, idx) => ({ id: `basis_${idx + 1}`, label: basis })),
+          },
+        },
+      },
+      suggestionData: {
+        sourceBasis: opportunity.sourceBasis,
+      },
+    };
+  }
+
+  return {
+    suggestionData: {
+      title: opportunity.title,
+      summary: opportunity.summary,
+      reason: opportunity.suggestedAction,
+      confidence: opportunity.confidence,
+      estimatedValue: opportunity.estimatedValue,
+    },
+  };
+}
+
 export default function OptimizationOpportunitiesWidget({
   shopId,
 }: {
@@ -25,6 +100,9 @@ export default function OptimizationOpportunitiesWidget({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [opportunities, setOpportunities] = useState<OptimizationOpportunity[]>([]);
+  const [selected, setSelected] = useState<OptimizationOpportunity | null>(null);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const [actionsByOpportunityId, setActionsByOpportunityId] = useState<Record<string, "applied" | "dismissed">>({});
 
   useEffect(() => {
     if (!shopId) return;
@@ -68,59 +146,233 @@ export default function OptimizationOpportunitiesWidget({
 
   const top = useMemo(() => opportunities.slice(0, 4), [opportunities]);
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Optimization"
-      title="Optimization opportunities"
-      subtitle="Reviewable recommendations only. Nothing auto-applies."
-      rightSlot={
-        <Link
-          href="/dashboard/owner/reports"
-          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
-        >
-          Review data →
-        </Link>
+  async function dismissOpportunity(opportunity: OptimizationOpportunity) {
+    setSubmittingId(opportunity.id);
+    setError(null);
+    try {
+      const response = await fetch("/api/optimization/dismiss", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          opportunityId: opportunity.id,
+          type: actionTypeForOpportunity(opportunity.optimizationType),
+        }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "Failed to dismiss opportunity");
       }
-    >
-      {loading ? (
-        <div className="rounded-xl border border-white/10 bg-black/25 px-4 py-4 text-sm text-neutral-300">
-          Scanning pricing, inspections, and revenue patterns…
-        </div>
-      ) : error ? (
-        <div className="rounded-xl border border-[color:color-mix(in_srgb,var(--brand-accent)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent)_14%,transparent)] px-4 py-4 text-sm text-[color:var(--brand-accent)]">
-          {error}
-        </div>
-      ) : top.length === 0 ? (
-        <div className="rounded-xl border border-white/10 bg-black/25 px-4 py-4 text-sm text-neutral-300">
-          No high-signal opportunities right now. Keep capturing clean line, labor, and inspection data.
-        </div>
-      ) : (
-        <div className="grid gap-3">
-          <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-[11px] text-neutral-400">
-            Suggestions are advisory only. Confirm with your team before changing menu pricing or inspection templates.
+
+      setActionsByOpportunityId((prev) => ({ ...prev, [opportunity.id]: "dismissed" }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to dismiss opportunity");
+    } finally {
+      setSubmittingId(null);
+    }
+  }
+
+  async function confirmApply(opportunity: OptimizationOpportunity) {
+    setSubmittingId(opportunity.id);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/optimization/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          opportunityId: opportunity.id,
+          type: actionTypeForOpportunity(opportunity.optimizationType),
+          payload: getApplyPayload(opportunity),
+        }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "Failed to apply opportunity");
+      }
+
+      setActionsByOpportunityId((prev) => ({ ...prev, [opportunity.id]: "applied" }));
+      setSelected(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to apply opportunity");
+    } finally {
+      setSubmittingId(null);
+    }
+  }
+
+  return (
+    <>
+      <DashboardWidgetShell
+        eyebrow="AI · Optimization"
+        title="Optimization opportunities"
+        subtitle="Reviewable recommendations only. Nothing auto-applies."
+        rightSlot={
+          <Link
+            href="/dashboard/owner/reports"
+            className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
+          >
+            Review data →
+          </Link>
+        }
+      >
+        {loading ? (
+          <div className="rounded-xl border border-white/10 bg-black/25 px-4 py-4 text-sm text-neutral-300">
+            Scanning pricing, inspections, and revenue patterns…
           </div>
-
-          {top.map((opportunity) => (
-            <div
-              key={opportunity.id}
-              className="rounded-2xl border border-white/10 bg-black/25 px-4 py-3"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <div className={["text-[11px] uppercase tracking-[0.15em]", badgeTone(opportunity.optimizationType)].join(" ")}>
-                  {typeLabel(opportunity.optimizationType)} · {Math.round(opportunity.confidence * 100)}% confidence
-                </div>
-                <div className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">
-                  {opportunity.impactLevel} impact
-                </div>
-              </div>
-
-              <div className="mt-1 text-sm font-semibold text-neutral-100">{opportunity.title}</div>
-              <div className="mt-1 text-xs text-neutral-300">{opportunity.summary}</div>
-              <div className="mt-2 text-[11px] text-neutral-400">Suggested action: {opportunity.suggestedAction}</div>
+        ) : error ? (
+          <div className="rounded-xl border border-[color:color-mix(in_srgb,var(--brand-accent)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent)_14%,transparent)] px-4 py-4 text-sm text-[color:var(--brand-accent)]">
+            {error}
+          </div>
+        ) : top.length === 0 ? (
+          <div className="rounded-xl border border-white/10 bg-black/25 px-4 py-4 text-sm text-neutral-300">
+            No high-signal opportunities right now. Keep capturing clean line, labor, and inspection data.
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-[11px] text-neutral-400">
+              Suggestions are advisory only. Confirm with your team before changing menu pricing or inspection templates.
             </div>
-          ))}
+
+            {top.map((opportunity) => {
+              const actionState = actionsByOpportunityId[opportunity.id];
+              const meta = (opportunity.meta ?? {}) as Record<string, unknown>;
+              const jobsAnalyzed =
+                toNumber(meta.jobsAnalyzed) ??
+                toNumber(meta.jobs) ??
+                toNumber(meta.sourceFamilyCount) ??
+                toNumber(meta.flaggedFindings);
+
+              return (
+                <div
+                  key={opportunity.id}
+                  className="rounded-2xl border border-white/10 bg-black/25 px-4 py-3"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className={["text-[11px] uppercase tracking-[0.15em]", badgeTone(opportunity.optimizationType)].join(" ")}>
+                      {typeLabel(opportunity.optimizationType)} · {Math.round(opportunity.confidence * 100)}% confidence
+                    </div>
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                      {opportunity.impactLevel} impact
+                    </div>
+                  </div>
+
+                  <div className="mt-1 text-sm font-semibold text-neutral-100">{opportunity.title}</div>
+                  <div className="mt-1 text-xs text-neutral-300">{opportunity.summary}</div>
+                  <div className="mt-2 text-[11px] text-neutral-400">Suggested action: {opportunity.suggestedAction}</div>
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-neutral-400">
+                    <span className="rounded-full border border-white/10 px-2 py-0.5">
+                      {confidenceLabel(opportunity.confidence)}
+                    </span>
+                    {typeof opportunity.estimatedValue === "number" ? (
+                      <span>Est. value ${opportunity.estimatedValue.toFixed(2)}</span>
+                    ) : null}
+                    {jobsAnalyzed ? <span>Based on {jobsAnalyzed} jobs</span> : null}
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setSelected(opportunity)}
+                      disabled={Boolean(actionState) || submittingId === opportunity.id}
+                      className="rounded-lg bg-[color:var(--brand-primary)] px-3 py-1.5 text-xs font-semibold text-black disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {actionState === "applied" ? "Applied" : "Apply"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => dismissOpportunity(opportunity)}
+                      disabled={Boolean(actionState) || submittingId === opportunity.id}
+                      className="rounded-lg border border-white/15 px-3 py-1.5 text-xs font-semibold text-neutral-200 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {actionState === "dismissed" ? "Dismissed" : "Dismiss"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(opportunity)}
+                      className="rounded-lg border border-white/10 px-3 py-1.5 text-xs text-neutral-300"
+                    >
+                      View details
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </DashboardWidgetShell>
+
+      {selected ? (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/65 p-4">
+          <div className="w-full max-w-xl rounded-2xl border border-white/15 bg-[#101114] p-5 text-neutral-100 shadow-2xl">
+            <div className="text-xs uppercase tracking-[0.16em] text-neutral-400">Apply suggestion</div>
+            <h3 className="mt-1 text-lg font-semibold">{selected.title}</h3>
+            <p className="mt-2 text-sm text-neutral-300">{selected.summary}</p>
+            <div className="mt-3 space-y-1 text-xs text-neutral-400">
+              <div>Why: {selected.sourceBasis.join(" · ")}</div>
+              <div>Confidence: {Math.round(selected.confidence * 100)}% ({confidenceLabel(selected.confidence)})</div>
+              {typeof selected.estimatedValue === "number" ? <div>Estimated value: ${selected.estimatedValue.toFixed(2)}</div> : null}
+            </div>
+
+            <div className="mt-4 rounded-xl border border-white/10 bg-black/30 p-3 text-xs text-neutral-300">
+              {actionTypeForOpportunity(selected.optimizationType) === "pricing" ? (
+                <>
+                  <div className="font-semibold text-neutral-100">Pricing preview</div>
+                  <div className="mt-1">
+                    {(() => {
+                      const currentPrice = parseCurrentPriceFromSource(selected.sourceBasis);
+                      const nextPrice = Number((selected.meta as Record<string, unknown> | undefined)?.recommendedPrice ?? 0);
+                      return (
+                        <>
+                          Current price → New price: <span className="text-neutral-100">{typeof currentPrice === "number" ? `$${currentPrice.toFixed(2)}` : "Not available"}</span> →
+                          <span className="text-neutral-100"> ${nextPrice.toFixed(2)}</span>
+                        </>
+                      );
+                    })()}
+                  </div>
+                </>
+              ) : null}
+
+              {actionTypeForOpportunity(selected.optimizationType) === "inspection" ? (
+                <>
+                  <div className="font-semibold text-neutral-100">Inspection preview</div>
+                  <ul className="mt-1 list-disc space-y-1 pl-5">
+                    {selected.sourceBasis.slice(0, 3).map((basis) => (
+                      <li key={basis}>{basis}</li>
+                    ))}
+                  </ul>
+                </>
+              ) : null}
+
+              {actionTypeForOpportunity(selected.optimizationType) === "revenue" ? (
+                <>
+                  <div className="font-semibold text-neutral-100">Missed revenue preview</div>
+                  <div className="mt-1">Suggested service: {selected.title}</div>
+                  <div className="mt-1">Reason: {selected.suggestedAction}</div>
+                </>
+              ) : null}
+            </div>
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="rounded-lg border border-white/15 px-3 py-2 text-xs font-semibold text-neutral-200"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmApply(selected)}
+                disabled={submittingId === selected.id}
+                className="rounded-lg bg-[color:var(--brand-primary)] px-3 py-2 text-xs font-semibold text-black disabled:opacity-40"
+              >
+                Confirm Apply
+              </button>
+            </div>
+          </div>
         </div>
-      )}
-    </DashboardWidgetShell>
+      ) : null}
+    </>
   );
 }

--- a/features/optimization/types.ts
+++ b/features/optimization/types.ts
@@ -36,3 +36,12 @@ export type OptimizationEngineOutput = {
   shopId: string;
   opportunities: OptimizationOpportunity[];
 };
+
+export type OptimizationActionType = "pricing" | "inspection" | "revenue";
+
+export type OptimizationApplyPayload = {
+  menuItemId?: string;
+  newPrice?: number;
+  inspectionTemplate?: unknown;
+  suggestionData?: unknown;
+};

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -6924,6 +6924,54 @@ export type Database = {
           },
         ]
       }
+      optimization_actions: {
+        Row: {
+          action: string
+          created_at: string
+          created_by: string | null
+          id: string
+          opportunity_id: string
+          payload: Json
+          shop_id: string
+          type: string
+        }
+        Insert: {
+          action: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          opportunity_id: string
+          payload?: Json
+          shop_id: string
+          type: string
+        }
+        Update: {
+          action?: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          opportunity_id?: string
+          payload?: Json
+          shop_id?: string
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "optimization_actions_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "optimization_actions_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       part_barcodes: {
         Row: {
           barcode: string

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -5823,6 +5823,54 @@ export type Database = {
           },
         ]
       }
+      optimization_actions: {
+        Row: {
+          action: string
+          created_at: string
+          created_by: string | null
+          id: string
+          opportunity_id: string
+          payload: Json
+          shop_id: string
+          type: string
+        }
+        Insert: {
+          action: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          opportunity_id: string
+          payload?: Json
+          shop_id: string
+          type: string
+        }
+        Update: {
+          action?: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          opportunity_id?: string
+          payload?: Json
+          shop_id?: string
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "optimization_actions_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "optimization_actions_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       part_barcodes: {
         Row: {
           barcode: string


### PR DESCRIPTION
### Motivation

- Enable a safe review-and-apply workflow so engine suggestions can be acted on only with explicit user intent and audit logging. 
- Provide an auditable, shop-scoped record of decisions so tenants remain isolated and actions are reviewable. 
- Preserve the optimization engine as read-only while allowing operators to apply pricing, inspection, or revenue suggestions through guarded paths.

### Description

- Add an additive DB migration `db/sql/2026-04-10_optimization_actions.sql` to create `optimization_actions` with `shop_id`-scoped RLS, type/action checks, `payload jsonb`, indexes, and audit timestamps. 
- Implement `POST /api/optimization/apply` in `app/api/optimization/apply/route.ts` which enforces auth/shop context and implements per-type, review-first behavior: pricing updates `menu_items.total_price` only when `menuItemId` is provided, inspection creates/updates `inspection_templates` scoped to the caller shop, and revenue inserts into `menu_item_suggestions` (never mutating `menu_items`); every apply is logged to `optimization_actions`. 
- Implement `POST /api/optimization/dismiss` in `app/api/optimization/dismiss/route.ts` which logs dismissals to `optimization_actions` without mutating business data. 
- Extend types in `features/optimization/types.ts` with `OptimizationActionType` and `OptimizationApplyPayload` to model the new action contracts. 
- Update the dashboard widget `features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx` to add per-card `Apply / Dismiss / View details` controls, a confirmation modal that shows title/summary/`sourceBasis`/confidence/estimated value and a type-specific preview, confidence-band labels, and an in-session disable for already-applied or dismissed opportunities. 
- Add `optimization_actions` definitions to the generated Supabase TS types in `features/shared/types/types/supabase.ts` and `shared/types/types/supabase.ts` so server code can type the insert payloads safely. 

### Testing

- Ran type-checking with `npx tsc --noEmit`, which completed successfully. 
- No automated unit tests were added in this change set; runtime behavior for `pricing`/`inspection`/`revenue` flows should be validated in integration/staging environments using the new endpoints and migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9112a6cdc83289e73d58f06ab6e74)