### PR TITLE
Phase 5.5: execution UX — inline diffs, confidence, undo window, conflict checks & safe bulk apply

### DIFF
--- a/app/api/optimization/actions/route.ts
+++ b/app/api/optimization/actions/route.ts
@@ -26,9 +26,10 @@ export async function GET() {
 
   const { data: actions, error: actionsError } = await supabase
     .from("optimization_actions")
-    .select("opportunity_id, action, type, created_at")
+    .select("opportunity_id, action, type, created_at, payload")
     .eq("shop_id", profile.shop_id)
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: false })
+    .limit(25);
 
   if (actionsError) {
     return NextResponse.json({ error: actionsError.message }, { status: 500 });
@@ -40,6 +41,10 @@ export async function GET() {
       action: action.action,
       type: action.type,
       createdAt: action.created_at,
+      result:
+        action.payload && typeof action.payload === "object" && !Array.isArray(action.payload)
+          ? ((action.payload as Record<string, unknown>).result as string | undefined) ?? null
+          : null,
     })),
   );
 }

--- a/app/api/optimization/apply/route.ts
+++ b/app/api/optimization/apply/route.ts
@@ -15,6 +15,9 @@ type ApplyBody = {
   type?: OptimizationActionType;
   payload?: OptimizationApplyPayload;
   opportunity?: OptimizationOpportunity;
+  preview?: {
+    changes?: Array<{ label?: string; before?: unknown; after?: unknown }>;
+  } | null;
 };
 
 const TYPE_MAP: Record<string, OptimizationActionType> = {
@@ -55,6 +58,11 @@ function toNonEmptyString(value: unknown): string | null {
 function safePayload(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   return value as Record<string, unknown>;
+}
+
+function nearlyEqual(a: number | null, b: number | null, tolerance = 0.01): boolean {
+  if (a === null || b === null) return false;
+  return Math.abs(a - b) <= tolerance;
 }
 
 function getJobsAnalyzed(opportunity: OptimizationOpportunity | null): number {
@@ -107,6 +115,7 @@ export async function POST(req: Request) {
   const type = normalizeType(body?.type);
   const payload = safePayload(body?.payload);
   const opportunity = body?.opportunity ?? null;
+  const previewChanges = Array.isArray(body?.preview?.changes) ? body?.preview?.changes ?? [] : [];
 
   if (!opportunityId || !type) {
     return NextResponse.json({ error: "opportunityId and type are required" }, { status: 400 });
@@ -153,6 +162,20 @@ export async function POST(req: Request) {
   try {
     let entityId: string | null = null;
     const affectedEntityIds: Record<string, string> = {};
+    const undoData: Record<string, unknown> = {};
+
+    const { data: priorApplied } = await supabase
+      .from("optimization_actions")
+      .select("id")
+      .eq("shop_id", profile.shop_id)
+      .eq("opportunity_id", opportunityId)
+      .eq("action", "applied")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (priorApplied?.id) {
+      return NextResponse.json({ blocked: true, reason: "This change is already applied" }, { status: 200 });
+    }
 
     if (type === "pricing") {
       const menuItemId = toNonEmptyString(payload.menuItemId);
@@ -178,18 +201,36 @@ export async function POST(req: Request) {
       }
 
       const expectedCurrent = Number((opportunity?.meta as Record<string, unknown> | undefined)?.currentMenuPrice);
-      if (
-        Number.isFinite(expectedCurrent) &&
-        existingMenu.total_price !== null &&
-        Math.abs(existingMenu.total_price - expectedCurrent) > 1
-      ) {
+      const expectedLaborHours = Number((opportunity?.meta as Record<string, unknown> | undefined)?.currentLaborHours);
+      const previewPriceBefore = previewChanges.find((change) =>
+        String(change?.label ?? "").toLowerCase().includes("price"),
+      )?.before;
+      const previewBefore = Number(previewPriceBefore);
+
+      const hasPricingConflict =
+        (Number.isFinite(expectedCurrent) &&
+          existingMenu.total_price !== null &&
+          Math.abs(existingMenu.total_price - expectedCurrent) > 0.01) ||
+        (Number.isFinite(previewBefore) &&
+          existingMenu.total_price !== null &&
+          Math.abs(existingMenu.total_price - previewBefore) > 0.01) ||
+        (Number.isFinite(expectedLaborHours) &&
+          existingMenu.labor_hours !== null &&
+          Math.abs(existingMenu.labor_hours - expectedLaborHours) > 0.01);
+
+      if (hasPricingConflict) {
         return NextResponse.json(
-          {
-            blocked: true,
-            reason: "Blocked: conflicting existing pricing data detected. Refresh opportunity data and review.",
-          },
+          { blocked: true, reason: "This item changed since preview. Refresh and try again." },
           { status: 200 },
         );
+      }
+
+      if (
+        existingMenu.total_price !== null &&
+        nearlyEqual(existingMenu.total_price, newPrice) &&
+        (newLaborHours === null || existingMenu.labor_hours === null || nearlyEqual(existingMenu.labor_hours, newLaborHours))
+      ) {
+        return NextResponse.json({ blocked: true, reason: "This change is already applied" }, { status: 200 });
       }
 
       const updatePayload: DB["public"]["Tables"]["menu_items"]["Update"] = { total_price: newPrice };
@@ -214,6 +255,10 @@ export async function POST(req: Request) {
 
       entityId = menuItemId;
       affectedEntityIds.menuItemId = menuItemId;
+      undoData.pricingBefore = {
+        totalPrice: existingMenu.total_price,
+        laborHours: existingMenu.labor_hours,
+      };
     }
 
     if (type === "inspection") {
@@ -237,7 +282,44 @@ export async function POST(req: Request) {
             } as DB["public"]["Tables"]["inspection_templates"]["Insert"]["sections"]);
 
       let resolvedTemplateId: string | null = templateId;
+      let previousTemplateSnapshot: {
+        template_name: string | null;
+        sections: DB["public"]["Tables"]["inspection_templates"]["Row"]["sections"] | null;
+        description: string | null;
+      } | null = null;
+      let createdTemplate = false;
       if (templateId) {
+        const { data: existingTemplate, error: existingTemplateError } = await supabase
+          .from("inspection_templates")
+          .select("id,template_name,sections,description,updated_at")
+          .eq("id", templateId)
+          .eq("shop_id", profile.shop_id)
+          .single();
+        if (existingTemplateError || !existingTemplate) {
+          return NextResponse.json({ error: "Inspection template not found in shop context" }, { status: 404 });
+        }
+
+        const expectedUpdatedAt = toNonEmptyString((opportunity?.meta as Record<string, unknown> | undefined)?.currentTemplateUpdatedAt);
+        if (expectedUpdatedAt && existingTemplate.updated_at && existingTemplate.updated_at !== expectedUpdatedAt) {
+          return NextResponse.json(
+            { blocked: true, reason: "This item changed since preview. Refresh and try again." },
+            { status: 200 },
+          );
+        }
+
+        if (
+          existingTemplate.template_name === templateName &&
+          JSON.stringify(existingTemplate.sections ?? {}) === JSON.stringify(sections ?? {})
+        ) {
+          return NextResponse.json({ blocked: true, reason: "This change is already applied" }, { status: 200 });
+        }
+
+        previousTemplateSnapshot = {
+          template_name: existingTemplate.template_name,
+          sections: existingTemplate.sections,
+          description: existingTemplate.description,
+        };
+
         const { error: updateError } = await supabase
           .from("inspection_templates")
           .update({
@@ -271,6 +353,7 @@ export async function POST(req: Request) {
         }
 
         resolvedTemplateId = insertedTemplate?.id ?? null;
+        createdTemplate = true;
       }
 
       if (menuItemId && resolvedTemplateId) {
@@ -283,6 +366,13 @@ export async function POST(req: Request) {
 
         if (menuItemError || !menuItem) {
           return NextResponse.json({ error: "Menu item not found for inspection linkage" }, { status: 404 });
+        }
+
+        if (!templateId && menuItem.inspection_template_id) {
+          return NextResponse.json(
+            { blocked: true, reason: "This item changed since preview. Refresh and try again." },
+            { status: 200 },
+          );
         }
 
         if (menuItem.inspection_template_id && menuItem.inspection_template_id !== resolvedTemplateId) {
@@ -305,12 +395,17 @@ export async function POST(req: Request) {
         }
 
         affectedEntityIds.menuItemId = menuItemId;
+        undoData.previousMenuInspectionTemplateId = menuItem.inspection_template_id;
       }
 
       entityId = resolvedTemplateId;
       if (resolvedTemplateId) {
         affectedEntityIds.inspectionTemplateId = resolvedTemplateId;
       }
+      undoData.inspection = {
+        createdTemplate,
+        previousTemplateSnapshot,
+      };
     }
 
     if (type === "revenue") {
@@ -320,15 +415,28 @@ export async function POST(req: Request) {
         toNonEmptyString(suggestionRaw.suggestedService) ||
         opportunity?.title ||
         "Optimization Revenue Suggestion";
+      const reason =
+        toNonEmptyString(suggestionRaw.reason) ||
+        toNonEmptyString(suggestionRaw.summary) ||
+        opportunity?.summary ||
+        "Created from optimization engine recommendation";
+
+      const { data: existingSuggestion } = await supabase
+        .from("menu_item_suggestions")
+        .select("id")
+        .eq("shop_id", profile.shop_id)
+        .eq("title", title)
+        .eq("reason", reason)
+        .limit(1)
+        .maybeSingle();
+      if (existingSuggestion?.id) {
+        return NextResponse.json({ blocked: true, reason: "This change is already applied" }, { status: 200 });
+      }
 
       const insert: DB["public"]["Tables"]["menu_item_suggestions"]["Insert"] = {
         shop_id: profile.shop_id,
         title,
-        reason:
-          toNonEmptyString(suggestionRaw.reason) ||
-          toNonEmptyString(suggestionRaw.summary) ||
-          opportunity?.summary ||
-          "Created from optimization engine recommendation",
+        reason,
         confidence: (() => {
           const c = Number(suggestionRaw.confidence ?? opportunity?.confidence);
           return Number.isFinite(c) ? Math.max(0, Math.min(1, c)) : 0.7;
@@ -357,6 +465,7 @@ export async function POST(req: Request) {
       if (entityId) {
         affectedEntityIds.suggestionId = entityId;
       }
+      undoData.revenue = { title, reason };
     }
 
     const actionInsert: DB["public"]["Tables"]["optimization_actions"]["Insert"] = {
@@ -368,6 +477,8 @@ export async function POST(req: Request) {
         originalPayload: payload as unknown,
         preview,
         affectedEntityIds,
+        undoData,
+        result: "success",
       } as DB["public"]["Tables"]["optimization_actions"]["Insert"]["payload"],
       created_by: user.id,
     };
@@ -391,6 +502,12 @@ export async function POST(req: Request) {
       affectedEntityIds,
       message,
       impactEstimate: opportunity?.estimatedValue ?? Number((payload.suggestionData as Record<string, unknown> | undefined)?.estimatedValue) ?? null,
+      undoAction: {
+        opportunityId,
+        type,
+        affectedEntityIds,
+        undoData,
+      },
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to apply optimization action";

--- a/app/api/optimization/undo/route.ts
+++ b/app/api/optimization/undo/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { OptimizationActionType } from "@/features/optimization/types";
+
+type UndoBody = {
+  opportunityId?: string;
+  type?: OptimizationActionType;
+  affectedEntityIds?: Record<string, string>;
+  undoData?: Record<string, unknown>;
+};
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const v = value.trim();
+  return v.length > 0 ? v : null;
+}
+
+export async function POST(req: Request) {
+  const supabase = createServerSupabaseRoute();
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .or(`id.eq.${user.id},user_id.eq.${user.id}`)
+    .limit(1)
+    .maybeSingle();
+
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ error: "Unable to resolve shop context" }, { status: 400 });
+  }
+
+  const body = (await req.json().catch(() => null)) as UndoBody | null;
+  const opportunityId = toNonEmptyString(body?.opportunityId);
+  const type = body?.type;
+  const affected = body?.affectedEntityIds ?? {};
+  const undoData = body?.undoData ?? {};
+
+  if (!opportunityId || (type !== "pricing" && type !== "inspection" && type !== "revenue")) {
+    return NextResponse.json({ error: "opportunityId and type are required" }, { status: 400 });
+  }
+
+  if (type === "pricing") {
+    const menuItemId = toNonEmptyString(affected.menuItemId);
+    const pricingBefore = (undoData.pricingBefore ?? {}) as { totalPrice?: number | null; laborHours?: number | null };
+    if (!menuItemId) return NextResponse.json({ error: "Missing menu item context" }, { status: 400 });
+
+    const { error } = await supabase
+      .from("menu_items")
+      .update({
+        total_price: pricingBefore.totalPrice ?? null,
+        labor_hours: pricingBefore.laborHours ?? null,
+      })
+      .eq("id", menuItemId)
+      .eq("shop_id", profile.shop_id);
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (type === "inspection") {
+    const templateId = toNonEmptyString(affected.inspectionTemplateId);
+    const menuItemId = toNonEmptyString(affected.menuItemId);
+    const inspectionUndo = (undoData.inspection ?? {}) as {
+      createdTemplate?: boolean;
+      previousTemplateSnapshot?: { template_name?: string | null; sections?: unknown; description?: string | null } | null;
+    };
+
+    if (inspectionUndo.createdTemplate && templateId) {
+      const { error: deleteError } = await supabase
+        .from("inspection_templates")
+        .delete()
+        .eq("id", templateId)
+        .eq("shop_id", profile.shop_id);
+      if (deleteError) return NextResponse.json({ error: deleteError.message }, { status: 500 });
+    }
+
+    if (!inspectionUndo.createdTemplate && templateId && inspectionUndo.previousTemplateSnapshot) {
+      const snapshot = inspectionUndo.previousTemplateSnapshot;
+      const { error: revertTemplateError } = await supabase
+        .from("inspection_templates")
+        .update({
+          template_name: snapshot.template_name ?? "Optimization Inspection Template",
+          sections: (snapshot.sections ?? {}) as Record<string, unknown>,
+          description: snapshot.description ?? null,
+        })
+        .eq("id", templateId)
+        .eq("shop_id", profile.shop_id);
+      if (revertTemplateError) return NextResponse.json({ error: revertTemplateError.message }, { status: 500 });
+    }
+
+    if (menuItemId) {
+      const previous = toNonEmptyString(undoData.previousMenuInspectionTemplateId) ?? null;
+      const { error: revertLinkError } = await supabase
+        .from("menu_items")
+        .update({ inspection_template_id: previous })
+        .eq("id", menuItemId)
+        .eq("shop_id", profile.shop_id);
+      if (revertLinkError) return NextResponse.json({ error: revertLinkError.message }, { status: 500 });
+    }
+  }
+
+  if (type === "revenue") {
+    const suggestionId = toNonEmptyString(affected.suggestionId);
+    if (!suggestionId) return NextResponse.json({ error: "Missing suggestion context" }, { status: 400 });
+
+    const { error } = await supabase
+      .from("menu_item_suggestions")
+      .delete()
+      .eq("id", suggestionId)
+      .eq("shop_id", profile.shop_id);
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/components/optimization/OptimizationExecutionModal.tsx
+++ b/components/optimization/OptimizationExecutionModal.tsx
@@ -9,8 +9,10 @@ type Props = {
   loadingPreview: boolean;
   applying: boolean;
   blockedReason?: string | null;
+  applyError?: string | null;
   onCancel: () => void;
   onConfirm: () => void;
+  onRetry?: () => void;
 };
 
 function renderValue(value: unknown): string {
@@ -26,6 +28,52 @@ function renderValue(value: unknown): string {
   }
 }
 
+function formatCurrency(value: unknown): string {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric)) return renderValue(value);
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(numeric);
+}
+
+function renderInlineDiff(label: string, before: unknown, after: unknown) {
+  const beforeSections = Array.isArray(before) ? before : null;
+  const afterSections = Array.isArray(after) ? after : null;
+  const isSectionDiff = label.toLowerCase().includes("section") && Array.isArray(afterSections);
+  const isPrice = label.toLowerCase().includes("price");
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/20 p-2 text-xs">
+      <div className="font-semibold text-neutral-100">{label}</div>
+      {isSectionDiff ? (
+        <div className="mt-1.5 space-y-1">
+          {beforeSections && beforeSections.length > 0 ? (
+            <div className="text-neutral-500">Existing: {beforeSections.join(", ")}</div>
+          ) : null}
+          {afterSections?.map((entry) => (
+            <div key={String(entry)} className="text-emerald-300">
+              + {String(entry)}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-1.5 grid grid-cols-2 gap-2">
+          <div className="rounded-md border border-white/10 bg-black/30 p-2">
+            <div className="text-[10px] uppercase tracking-[0.12em] text-neutral-500">Before</div>
+            <div className="mt-1 text-neutral-300">{isPrice ? formatCurrency(before) : renderValue(before)}</div>
+          </div>
+          <div className="rounded-md border border-emerald-400/40 bg-emerald-500/10 p-2">
+            <div className="text-[10px] uppercase tracking-[0.12em] text-emerald-300">After</div>
+            <div className="mt-1 text-neutral-100">{isPrice ? formatCurrency(after) : renderValue(after)}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function OptimizationExecutionModal({
   open,
   opportunity,
@@ -33,8 +81,10 @@ export default function OptimizationExecutionModal({
   loadingPreview,
   applying,
   blockedReason,
+  applyError,
   onCancel,
   onConfirm,
+  onRetry,
 }: Props) {
   if (!open || !opportunity) return null;
 
@@ -67,17 +117,24 @@ export default function OptimizationExecutionModal({
               ))}
             </ul>
           </section>
+          <section className="rounded-xl border border-white/10 bg-black/30 p-3">
+            <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-200">Expected impact</div>
+            <div className="mt-1 text-xs text-neutral-300">
+              Confidence: {opportunity.confidenceLabel ?? `${Math.round(opportunity.confidence * 100)}% confidence`}
+            </div>
+            <div className="text-xs text-neutral-300">
+              Estimated impact:{" "}
+              {opportunity.impactLabel ??
+                (typeof opportunity.estimatedValue === "number" ? `+$${Math.round(opportunity.estimatedValue)}/month` : "Potential impact detected")}
+            </div>
+          </section>
 
           <section className="rounded-xl border border-white/10 bg-black/30 p-3">
             <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-200">Preview of changes</div>
             {preview ? (
               <div className="mt-2 space-y-2">
                 {preview.changes.map((change) => (
-                  <div key={change.label} className="rounded-lg border border-white/10 bg-black/20 p-2 text-xs">
-                    <div className="font-semibold text-neutral-100">{change.label}</div>
-                    <div className="mt-1 text-neutral-400">Before: {renderValue(change.before)}</div>
-                    <div className="text-neutral-300">After: {renderValue(change.after)}</div>
-                  </div>
+                  <div key={change.label}>{renderInlineDiff(change.label, change.before, change.after)}</div>
                 ))}
                 {preview.warnings?.length ? (
                   <ul className="space-y-1 text-xs text-amber-300">
@@ -95,6 +152,21 @@ export default function OptimizationExecutionModal({
           {blockedReason ? (
             <div className="rounded-xl border border-red-400/35 bg-red-500/10 p-3 text-xs text-red-200">{blockedReason}</div>
           ) : null}
+          {applyError ? (
+            <div className="rounded-xl border border-red-400/35 bg-red-500/10 p-3 text-xs text-red-200">
+              <div>Something went wrong.</div>
+              {onRetry ? (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  disabled={applying}
+                  className="mt-2 rounded-md border border-red-300/40 px-2 py-1 text-[11px] font-semibold text-red-100 disabled:opacity-50"
+                >
+                  Retry
+                </button>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         <div className="mt-5 flex justify-end gap-2">
@@ -111,7 +183,14 @@ export default function OptimizationExecutionModal({
             disabled={loadingPreview || applying || Boolean(blockedReason)}
             className="rounded-lg bg-[color:var(--brand-primary)] px-3 py-2 text-xs font-semibold text-black disabled:opacity-40"
           >
-            Confirm
+            {applying ? (
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-3 w-3 animate-spin rounded-full border border-black/40 border-t-black" />
+                Applying…
+              </span>
+            ) : (
+              "Confirm"
+            )}
           </button>
         </div>
       </div>

--- a/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
+++ b/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -20,8 +20,15 @@ type ActionsApiItem = {
   action: ActionState;
   type: OptimizationActionType;
   createdAt: string;
+  result?: string | null;
 };
 type OpportunityFilter = "active" | "all" | "applied" | "dismissed" | "critical";
+type UndoAction = {
+  opportunityId: string;
+  type: OptimizationActionType;
+  affectedEntityIds?: Record<string, string>;
+  undoData?: Record<string, unknown>;
+};
 
 const ACTIONS_SESSION_CACHE_KEY = "optimization-actions-cache-v1";
 const OPPORTUNITIES_SESSION_CACHE_KEY = "optimization-opportunities-cache-v1";
@@ -254,6 +261,15 @@ export default function OptimizationOpportunitiesWidget({
   const [submittingId, setSubmittingId] = useState<string | null>(null);
   const [actionsByOpportunityId, setActionsByOpportunityId] = useState<Record<string, ActionState>>({});
   const [filter, setFilter] = useState<OpportunityFilter>("active");
+  const [activityLog, setActivityLog] = useState<ActionsApiItem[]>([]);
+  const [showRecentChanges, setShowRecentChanges] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [appliedPulseById, setAppliedPulseById] = useState<Record<string, number>>({});
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
+  const [bulkApplying, setBulkApplying] = useState(false);
+  const undoDeadlineRef = useRef<number | null>(null);
+  const undoTimeoutRef = useRef<number | null>(null);
+  const [lastUndoAction, setLastUndoAction] = useState<UndoAction | null>(null);
 
   useEffect(() => {
     if (!shopId) return;
@@ -315,7 +331,8 @@ export default function OptimizationOpportunitiesWidget({
           );
         }
 
-        const hydratedActions = (Array.isArray(actionsPayload) ? actionsPayload : []).reduce<
+        const actionItems = Array.isArray(actionsPayload) ? actionsPayload : [];
+        const hydratedActions = actionItems.reduce<
           Record<string, ActionState>
         >((acc, action) => {
           if (!action.opportunityId) return acc;
@@ -327,6 +344,7 @@ export default function OptimizationOpportunitiesWidget({
           setSummary(opportunitiesPayload?.summary ?? null);
           setGroups(opportunitiesPayload?.groups ?? []);
           setActionsByOpportunityId(hydratedActions);
+          setActivityLog(actionItems.slice(-5).reverse());
           writeActionsCache(shopId, hydratedActions);
           writeOpportunitiesCache(shopId, opportunitiesPayload?.groups ?? [], opportunitiesPayload?.summary ?? null);
         }
@@ -343,6 +361,14 @@ export default function OptimizationOpportunitiesWidget({
       cancelled = true;
     };
   }, [shopId]);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimeoutRef.current) {
+        window.clearTimeout(undoTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const opportunities = useMemo(() => groups.flatMap((group) => group.opportunities ?? []), [groups]);
 
@@ -391,6 +417,30 @@ export default function OptimizationOpportunitiesWidget({
     return { applied, resolved: applied + dismissed };
   }, [actionsByOpportunityId]);
 
+  const highConfidenceCandidates = useMemo(() => {
+    return opportunities.filter((opportunity) => {
+      const actionState = actionsByOpportunityId[opportunity.id];
+      if (actionState) return false;
+      if (opportunity.confidence < 0.85) return false;
+      if (opportunity.priorityBand === "low") return false;
+      return true;
+    });
+  }, [actionsByOpportunityId, opportunities]);
+
+  async function applyAllHighConfidence() {
+    setBulkApplying(true);
+    setError(null);
+    try {
+      for (const opportunity of highConfidenceCandidates) {
+        // sequential on purpose to preserve guardrails and avoid duplicate writes
+        await applyOpportunity(opportunity);
+      }
+      setBulkConfirmOpen(false);
+    } finally {
+      setBulkApplying(false);
+    }
+  }
+
   async function dismissOpportunity(opportunity: OptimizationOpportunity) {
     setSubmittingId(opportunity.id);
     setError(null);
@@ -429,6 +479,7 @@ export default function OptimizationOpportunitiesWidget({
     setBlockedReason(null);
     setLoadingPreview(true);
     setError(null);
+    setApplyError(null);
 
     try {
       const response = await fetch("/api/optimization/apply?dryRun=true", {
@@ -463,10 +514,47 @@ export default function OptimizationOpportunitiesWidget({
     }
   }
 
-  async function confirmApply(opportunity: OptimizationOpportunity) {
+  async function undoLastApply() {
+    if (!lastUndoAction) return;
+    if (undoDeadlineRef.current && Date.now() > undoDeadlineRef.current) {
+      toast.error("Undo window expired");
+      setLastUndoAction(null);
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/optimization/undo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(lastUndoAction),
+      });
+
+      const payload = (await response.json().catch(() => null)) as { success?: boolean; error?: string } | null;
+      if (!response.ok || !payload?.success) {
+        throw new Error(payload?.error ?? "Undo failed");
+      }
+
+      setActionsByOpportunityId((prev) => {
+        const next = { ...prev };
+        delete next[lastUndoAction.opportunityId];
+        if (shopId) writeActionsCache(shopId, next);
+        return next;
+      });
+      setLastUndoAction(null);
+      if (undoTimeoutRef.current) {
+        window.clearTimeout(undoTimeoutRef.current);
+      }
+      toast.success("Change reverted");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Undo failed");
+    }
+  }
+
+  async function applyOpportunity(opportunity: OptimizationOpportunity): Promise<boolean> {
     setSubmittingId(opportunity.id);
     setError(null);
     setBlockedReason(null);
+    setApplyError(null);
 
     try {
       const response = await fetch("/api/optimization/apply", {
@@ -477,6 +565,7 @@ export default function OptimizationOpportunitiesWidget({
           type: actionTypeForOpportunity(opportunity.type),
           payload: getApplyPayload(opportunity),
           opportunity,
+          preview: executionPreview,
         }),
       });
 
@@ -489,13 +578,16 @@ export default function OptimizationOpportunitiesWidget({
             entityId?: string | null;
             message?: string;
             impactEstimate?: number | null;
+            undoAction?: UndoAction;
             error?: string;
           }
         | null;
       if (payload?.blocked) {
-        setBlockedReason(payload.reason ?? "Execution blocked by safety guardrails");
-        toast.error(payload.reason ?? "Execution blocked by safety guardrails");
-        return;
+        const reason = payload.reason ?? "Execution blocked by safety guardrails";
+        setBlockedReason(reason);
+        setApplyError(reason);
+        toast.error(reason);
+        return false;
       }
       if (!response.ok || !payload?.success || !payload.type) {
         throw new Error(payload?.error ?? "Failed to apply opportunity");
@@ -508,6 +600,25 @@ export default function OptimizationOpportunitiesWidget({
       });
       setSelected(null);
       setExecutionPreview(null);
+      setAppliedPulseById((prev) => ({ ...prev, [opportunity.id]: Date.now() }));
+      window.setTimeout(() => {
+        setAppliedPulseById((prev) => {
+          const next = { ...prev };
+          delete next[opportunity.id];
+          return next;
+        });
+      }, 1600);
+
+      if (payload.undoAction) {
+        setLastUndoAction(payload.undoAction);
+        undoDeadlineRef.current = Date.now() + 10_000;
+        if (undoTimeoutRef.current) {
+          window.clearTimeout(undoTimeoutRef.current);
+        }
+        undoTimeoutRef.current = window.setTimeout(() => {
+          setLastUndoAction(null);
+        }, 10_000);
+      }
 
       const destination = toOpportunityPath(payload.type, payload.entityId ?? null);
       const actionLabel =
@@ -517,7 +628,7 @@ export default function OptimizationOpportunitiesWidget({
             ? "View inspection template"
             : "View suggestion";
 
-      toast.success("Change applied successfully", {
+      toast.success("Applied successfully — Undo (10s)", {
         description:
           payload.impactEstimate && payload.impactEstimate > 0
             ? `${payload.message} · Estimated impact ${new Intl.NumberFormat("en-US", {
@@ -527,17 +638,42 @@ export default function OptimizationOpportunitiesWidget({
               }).format(payload.impactEstimate)}`
             : payload.message,
         action: {
+          label: "Undo",
+          onClick: () => {
+            void undoLastApply();
+          },
+        },
+      });
+      toast.message("Quick link", {
+        action: {
           label: actionLabel,
           onClick: () => router.push(destination),
         },
       });
+      return true;
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to apply opportunity";
       setError(message);
-      toast.error(message);
+      setApplyError(message);
+      toast.error("Something went wrong", {
+        description: message,
+        action: selected
+          ? {
+              label: "Retry",
+              onClick: () => {
+                void applyOpportunity(opportunity);
+              },
+            }
+          : undefined,
+      });
+      return false;
     } finally {
       setSubmittingId(null);
     }
+  }
+
+  async function confirmApply(opportunity: OptimizationOpportunity) {
+    await applyOpportunity(opportunity);
   }
 
   return (
@@ -572,6 +708,23 @@ export default function OptimizationOpportunitiesWidget({
           </div>
         ) : (
           <div className="grid gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <button
+                type="button"
+                onClick={() => setBulkConfirmOpen(true)}
+                disabled={highConfidenceCandidates.length === 0 || bulkApplying}
+                className="rounded-lg border border-[color:var(--brand-primary)]/50 bg-[color:color-mix(in_srgb,var(--brand-primary)_14%,transparent)] px-3 py-1.5 text-xs font-semibold text-[color:var(--brand-primary)] disabled:opacity-40"
+              >
+                Apply all high-confidence
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowRecentChanges((prev) => !prev)}
+                className="rounded-lg border border-white/15 px-3 py-1.5 text-xs font-semibold text-neutral-200"
+              >
+                {showRecentChanges ? "Hide recent changes" : "Recent changes"}
+              </button>
+            </div>
             <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-[11px] text-neutral-400">
               Suggestions are advisory only. Confirm with your team before changing menu pricing or inspection templates.
             </div>
@@ -595,6 +748,24 @@ export default function OptimizationOpportunitiesWidget({
                 <div className="mt-1 text-[10px] text-neutral-500">
                   Analyzed {new Date(summary.lastAnalyzedAt).toLocaleString()} · Data {summary.dataFreshness}
                 </div>
+              </div>
+            ) : null}
+
+            {showRecentChanges ? (
+              <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-neutral-300">
+                <div className="font-semibold text-neutral-100">Last 5 changes</div>
+                <ul className="mt-1.5 space-y-1">
+                  {activityLog.length === 0 ? <li className="text-neutral-500">No actions yet.</li> : null}
+                  {activityLog.map((item) => (
+                    <li key={`${item.opportunityId}:${item.createdAt}`} className="flex items-center justify-between gap-2">
+                      <span className="text-neutral-200">
+                        {item.type} · {item.action}
+                        {item.result ? ` · ${item.result}` : ""}
+                      </span>
+                      <span className="text-[10px] text-neutral-500">{new Date(item.createdAt).toLocaleString()}</span>
+                    </li>
+                  ))}
+                </ul>
               </div>
             ) : null}
 
@@ -644,12 +815,13 @@ export default function OptimizationOpportunitiesWidget({
                 <div
                   key={opportunity.id}
                   className={[
-                    "rounded-2xl px-4 py-3",
+                    "rounded-2xl px-4 py-3 transition-all duration-500",
                     isApplied
                       ? "border border-emerald-500/35 bg-[color:color-mix(in_srgb,rgba(16,185,129,0.18)_55%,black)]"
                       : isDismissed
                         ? "border border-white/8 bg-black/15"
                         : "border border-white/10 bg-black/25",
+                    appliedPulseById[opportunity.id] ? "scale-[1.01] shadow-[0_0_0_1px_rgba(16,185,129,0.5)] opacity-90" : "",
                   ].join(" ")}
                 >
                   <div className="flex items-center justify-between gap-2">
@@ -779,16 +951,62 @@ export default function OptimizationOpportunitiesWidget({
         loadingPreview={loadingPreview}
         applying={selected ? submittingId === selected.id : false}
         blockedReason={blockedReason}
+        applyError={applyError}
         onCancel={() => {
           setSelected(null);
           setExecutionPreview(null);
           setBlockedReason(null);
+          setApplyError(null);
         }}
         onConfirm={() => {
           if (!selected) return;
           void confirmApply(selected);
         }}
+        onRetry={() => {
+          if (!selected) return;
+          void confirmApply(selected);
+        }}
       />
+      {bulkConfirmOpen ? (
+        <div className="fixed inset-0 z-[81] flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-xl rounded-2xl border border-white/15 bg-[#101114] p-5 text-neutral-100 shadow-2xl">
+            <div className="text-xs uppercase tracking-[0.16em] text-neutral-400">Batch execution</div>
+            <h3 className="mt-1 text-lg font-semibold">Apply all high-confidence changes?</h3>
+            <p className="mt-1 text-xs text-neutral-300">
+              {highConfidenceCandidates.length} changes will run sequentially with normal guardrails.
+            </p>
+            <ul className="mt-3 max-h-72 space-y-1 overflow-y-auto rounded-lg border border-white/10 bg-black/25 p-2 text-xs">
+              {highConfidenceCandidates.map((opportunity) => (
+                <li key={opportunity.id} className="rounded border border-white/10 bg-black/20 px-2 py-1.5">
+                  <div className="font-semibold text-neutral-100">{opportunity.title}</div>
+                  <div className="text-neutral-400">
+                    {Math.round(opportunity.confidence * 100)}% confidence ·{" "}
+                    {opportunity.impactLabel ?? formatEstimatedImpact(opportunity.estimatedValue)}
+                  </div>
+                </li>
+              ))}
+              {highConfidenceCandidates.length === 0 ? <li className="text-neutral-500">No eligible opportunities.</li> : null}
+            </ul>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setBulkConfirmOpen(false)}
+                className="rounded-lg border border-white/15 px-3 py-1.5 text-xs font-semibold text-neutral-200"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={bulkApplying || highConfidenceCandidates.length === 0}
+                onClick={() => void applyAllHighConfidence()}
+                className="rounded-lg bg-[color:var(--brand-primary)] px-3 py-1.5 text-xs font-semibold text-black disabled:opacity-40"
+              >
+                {bulkApplying ? "Applying…" : "Apply all safe"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/features/optimization/server/buildExecutionPreview.ts
+++ b/features/optimization/server/buildExecutionPreview.ts
@@ -26,7 +26,7 @@ export function buildExecutionPreview(opportunity: OptimizationOpportunity): Exe
 
     const changes: ExecutionPreview["changes"] = [
       {
-        label: "Menu item total price",
+        label: opportunity.title.replace(/^Pricing normalization:\s*/i, "").trim() || "Menu item total price",
         before: currentPrice,
         after: newPrice,
       },
@@ -59,14 +59,14 @@ export function buildExecutionPreview(opportunity: OptimizationOpportunity): Exe
       type: "inspection",
       changes: [
         {
-          label: existingTemplateId ? "Inspection template" : "New inspection template",
+          label: "Inspection template",
           before: existingTemplateId ?? null,
           after: inferredTemplateName,
         },
         {
-          label: "Menu item template linkage",
-          before: existingTemplateId ?? null,
-          after: existingTemplateId ?? "Will link newly created template",
+          label: "Sections",
+          before: [],
+          after: opportunity.reasoning.slice(0, 5),
         },
       ],
     };
@@ -76,18 +76,14 @@ export function buildExecutionPreview(opportunity: OptimizationOpportunity): Exe
     type: "revenue",
     changes: [
       {
-        label: "Suggestion record",
+        label: "Suggestion title",
         before: null,
-        after: {
-          title: opportunity.title,
-          reason: opportunity.suggestedAction ?? opportunity.summary,
-          confidence: opportunity.confidence,
-        },
+        after: opportunity.title,
       },
       {
-        label: "Menu item changes",
-        before: "No menu item mutation",
-        after: "No menu item mutation",
+        label: "Reason shown to advisor",
+        before: null,
+        after: opportunity.suggestedAction ?? opportunity.summary,
       },
     ],
     warnings: ["This creates a suggestion only. Existing menu items are not modified."],


### PR DESCRIPTION
### Motivation
- Improve the execution experience so applying optimizations feels fast, trustworthy, and satisfying while remaining explicitly reversible only via a short, controlled undo window.  
- Surface readable before→after diffs and impact signals so users can evaluate changes without seeing raw JSON.  
- Prevent stale or duplicate writes by checking current entity state before applying and provide clear failure/retry UX.  

### Description
- UI: Added human-friendly inline diffs and currency formatting to the execution modal, an "Expected impact" block (confidence + estimated impact), an apply-loading state with spinner/disable, and an explicit failure panel with `Retry` support; implemented subtle card animation/pulse on successful apply. (changes in `components/optimization/OptimizationExecutionModal.tsx`, `features/optimization/server/buildExecutionPreview.ts`)
- Undo: Implemented a 10s soft-undo flow that stores the last action in memory and exposes an undo toast action; created server-side undo handling that reverts pricing, inspection, or revenue changes when possible. (client: `features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx`, server: `app/api/optimization/undo/route.ts`)
- Safety controls: Added "already applied" detection and conflict detection (compare preview/expected values vs latest entity state) to block stale or duplicate applies, and return helpful blocking messages; persisted `undoData` and `affectedEntityIds` in `optimization_actions` payload for safe reversal. (server: `app/api/optimization/apply/route.ts`)
- Activity & batching: Added a mini "Recent changes" toggle showing the last 5 actions (via updated actions API), and an "Apply all high-confidence" button which opens a confirmation modal and applies candidates sequentially under existing guardrails. (changes in `features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx`, `app/api/optimization/actions/route.ts`)

### Testing
- Ran `npx tsc --noEmit` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d920423dbc8328afe54dac2c3ccb15)