### PR TITLE
Connect ShopBoost completion to optimization and planner operations loop

### DIFF
--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -12,6 +12,7 @@ import {
   SHOP_BOOST_UPLOAD_DATASETS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
+import type { OnboardingOptimizationAction } from "@/features/optimization/server/selectOnboardingRecommendedActions";
 
 type DB = Database;
 
@@ -48,6 +49,14 @@ type ShopBuildSummary = {
   linkedMenuToInspection: number;
   menuSuggestions: number;
   inspectionSuggestions: number;
+};
+type OnboardingOptimizationSummary = {
+  totalOpportunities: number;
+  criticalCount: number;
+  highCount: number;
+  potentialMonthlyValue: number;
+  dataFreshness: "fresh" | "stale";
+  lastAnalyzedAt: string;
 };
 
 const SHOP_IMPORT_BUCKET = "shop-imports";
@@ -117,6 +126,8 @@ export default function ShopBoostOnboardingPage() {
   const [snapshot, setSnapshot] = useState<ShopHealthSnapshot | null>(null);
   const [linkageSummary, setLinkageSummary] = useState<LinkageSummary | null>(null);
   const [shopBuildSummary, setShopBuildSummary] = useState<ShopBuildSummary | null>(null);
+  const [optimizationSummary, setOptimizationSummary] = useState<OnboardingOptimizationSummary | null>(null);
+  const [optimizationNextActions, setOptimizationNextActions] = useState<OnboardingOptimizationAction[]>([]);
 
   // Load profile → shop_id + shop name
   useEffect(() => {
@@ -206,6 +217,8 @@ export default function ShopBoostOnboardingPage() {
     setSnapshot(null);
     setLinkageSummary(null);
     setShopBuildSummary(null);
+    setOptimizationSummary(null);
+    setOptimizationNextActions([]);
 
     if (!shopId) {
       setError("Shop not loaded yet.");
@@ -275,6 +288,10 @@ export default function ShopBoostOnboardingPage() {
           shopBuildSummary?: ShopBuildSummary;
         };
         shopBuildSummary?: ShopBuildSummary;
+        onboardingOptimization?: {
+          summary?: OnboardingOptimizationSummary | null;
+          nextActions?: OnboardingOptimizationAction[];
+        };
         error?: string;
       };
 
@@ -287,6 +304,8 @@ export default function ShopBoostOnboardingPage() {
       setSnapshot(json.snapshot);
       setLinkageSummary(json.importSummary?.linkageSummary ?? null);
       setShopBuildSummary(json.shopBuildSummary ?? json.importSummary?.shopBuildSummary ?? null);
+      setOptimizationSummary(json.onboardingOptimization?.summary ?? null);
+      setOptimizationNextActions(json.onboardingOptimization?.nextActions ?? []);
       setStepStatus("done");
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unexpected error during upload.";
@@ -342,6 +361,7 @@ export default function ShopBoostOnboardingPage() {
   const hasUnresolvedItems = itemsNeedingReview > 0;
   const reviewItemsCount =
     (shopBuildSummary?.menuSuggestions ?? 0) + (shopBuildSummary?.inspectionSuggestions ?? 0);
+  const topNextActions = optimizationNextActions.slice(0, 5);
 
   return (
     <div className="min-h-screen bg-black text-white">
@@ -537,16 +557,45 @@ export default function ShopBoostOnboardingPage() {
             {stepStatus === "done" && (linkageSummary || shopBuildSummary) && (
               <section className="rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-neutral-950 p-4 sm:p-5">
                 <h2 className="text-base font-semibold text-neutral-100">Your shop is ready</h2>
-                <div className="mt-3 space-y-1 text-sm text-neutral-300">
-                  <p>✔ {(shopBuildSummary?.menuItemsCreated ?? 0).toLocaleString()} services created</p>
-                  <p>
-                    ✔ {(shopBuildSummary?.inspectionTemplatesCreated ?? 0).toLocaleString()} inspections created
-                  </p>
-                  <p>
-                    ✔ {(shopBuildSummary?.linkedMenuToInspection ?? 0).toLocaleString()} services linked to
-                    inspections
-                  </p>
-                  <p>⚠ {reviewItemsCount.toLocaleString()} items need review</p>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/10 p-3">
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-emerald-200">
+                      What we built
+                    </h3>
+                    <div className="mt-2 space-y-1 text-xs text-emerald-100/90">
+                      <p>✔ {(shopBuildSummary?.menuItemsCreated ?? 0).toLocaleString()} services created</p>
+                      <p>
+                        ✔ {(shopBuildSummary?.inspectionTemplatesCreated ?? 0).toLocaleString()} inspections created
+                      </p>
+                      <p>
+                        ✔ {(shopBuildSummary?.linkedMenuToInspection ?? 0).toLocaleString()} services linked
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-3">
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-amber-200">
+                      What still needs review
+                    </h3>
+                    <div className="mt-2 space-y-1 text-xs text-amber-100/90">
+                      <p>⚠ {reviewItemsCount.toLocaleString()} suggestion items pending review</p>
+                      <p>⚠ {itemsNeedingReview.toLocaleString()} linkage issues need attention</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-sky-500/25 bg-sky-500/10 p-3">
+                    <h3 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-sky-200">
+                      What we recommend next
+                    </h3>
+                    <div className="mt-2 space-y-1 text-xs text-sky-100/90">
+                      <p>{(optimizationSummary?.totalOpportunities ?? 0).toLocaleString()} optimization opportunities found</p>
+                      <p>
+                        {(optimizationSummary?.criticalCount ?? 0).toLocaleString()} critical,{" "}
+                        {(optimizationSummary?.highCount ?? 0).toLocaleString()} high-priority
+                      </p>
+                    </div>
+                  </div>
                 </div>
 
                 <div className="mt-3 flex flex-wrap gap-2 text-xs">
@@ -629,6 +678,48 @@ export default function ShopBoostOnboardingPage() {
                     <p>{linkedVehicles} vehicles linked</p>
                     <p>{fullyConnectedWorkOrders} work orders fully connected</p>
                     <p>{itemsNeedingReview} operational linkage items need review</p>
+                  </div>
+                ) : null}
+
+                {topNextActions.length > 0 ? (
+                  <div className="mt-4 rounded-lg border border-sky-500/30 bg-sky-500/10 p-3">
+                    <h3 className="text-xs font-semibold uppercase tracking-[0.15em] text-sky-200">
+                      Next recommended actions
+                    </h3>
+                    <p className="mt-1 text-[11px] text-sky-100/85">
+                      These recommendations also appear in your AI operations workflow.
+                    </p>
+                    <div className="mt-3 space-y-2">
+                      {topNextActions.map((action) => (
+                        <div
+                          key={action.id}
+                          className="rounded-md border border-sky-300/20 bg-black/25 p-2 text-xs"
+                        >
+                          <p className="font-medium text-sky-100">{action.title}</p>
+                          <p className="mt-0.5 text-sky-100/80">{action.summary}</p>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={() => router.push(action.href)}
+                              className="rounded-md border border-sky-300/35 px-2 py-1 text-sky-100 hover:bg-white/5"
+                            >
+                              Open
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                router.push(
+                                  `/agent/planner?planner=ops&allowCreate=0&goal=${encodeURIComponent(action.plannerGoal)}`,
+                                )
+                              }
+                              className="rounded-md border border-sky-300/35 px-2 py-1 text-sky-100 hover:bg-white/5"
+                            >
+                              Send to planner
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 ) : null}
               </section>

--- a/features/agent/hooks/useOpsNotifications.ts
+++ b/features/agent/hooks/useOpsNotifications.ts
@@ -18,7 +18,11 @@ export type OpsNotification = {
     | "shop_overloaded"
     | "tech_underutilized_capacity"
     | "active_job_running_too_long"
-    | "shop_throughput_below_capacity";
+    | "shop_throughput_below_capacity"
+    | "optimization_pricing_normalization"
+    | "optimization_inspection_coverage_gap"
+    | "optimization_missed_revenue"
+    | "optimization_review_queued_suggestions";
   title: string;
   message: string;
   href?: string;

--- a/features/agent/server/getOpsNotifications.ts
+++ b/features/agent/server/getOpsNotifications.ts
@@ -1,6 +1,8 @@
 import { getServerSupabase } from "./supabase";
 import { FLOW_HEALTH_THRESHOLDS, ageHours } from "./flowHealth";
 import { getTechnicianLoadMetricsWithClient } from "@shared/lib/stats/getTechnicianLoadMetricsCore";
+import { buildOptimizationOpportunities } from "@/features/optimization/server/buildOptimizationOpportunities";
+import type { OptimizationOpportunity } from "@/features/optimization/types";
 
 export type OpsNotificationLevel = "info" | "warning" | "urgent";
 
@@ -15,7 +17,11 @@ export type OpsNotificationCode =
   | "shop_overloaded"
   | "tech_underutilized_capacity"
   | "active_job_running_too_long"
-  | "shop_throughput_below_capacity";
+  | "shop_throughput_below_capacity"
+  | "optimization_pricing_normalization"
+  | "optimization_inspection_coverage_gap"
+  | "optimization_missed_revenue"
+  | "optimization_review_queued_suggestions";
 
 export type OpsNotification = {
   level: OpsNotificationLevel;
@@ -91,6 +97,32 @@ function isInvoiceReadyToSend(status: string | null | undefined): boolean {
     normalized === "completed" ||
     normalized === "invoiced"
   );
+}
+
+function optimizationHref(opportunity: OptimizationOpportunity): string {
+  if (opportunity.type === "pricing_normalization") {
+    return opportunity.targetRefs?.menuItemId
+      ? `/menu/item/${opportunity.targetRefs.menuItemId}`
+      : "/dashboard";
+  }
+  if (opportunity.type === "inspection_coverage_gap") {
+    return opportunity.targetRefs?.inspectionTemplateId
+      ? `/inspections/templates?templateId=${encodeURIComponent(opportunity.targetRefs.inspectionTemplateId)}`
+      : "/inspection_template_suggestions";
+  }
+  return "/menu_item_suggestions";
+}
+
+function toOptimizationCode(
+  type: OptimizationOpportunity["type"],
+): OpsNotificationCode {
+  if (type === "pricing_normalization") {
+    return "optimization_pricing_normalization";
+  }
+  if (type === "inspection_coverage_gap") {
+    return "optimization_inspection_coverage_gap";
+  }
+  return "optimization_missed_revenue";
 }
 
 export async function getOpsNotifications(
@@ -389,6 +421,65 @@ export async function getOpsNotifications(
       title: "Low throughput vs current shift capacity",
       message: `${shiftedTechs.length} shifted tech(s) have completed ${completedJobs} jobs so far (${completedPerShiftedTech.toFixed(1)} each) while utilization is ${loadMetrics.summary.shopUtilizationPct}%. Check blockers and handoffs.`,
       href: "/dashboard",
+      entityType: "shop",
+      entityId: shopId,
+    });
+  }
+
+  try {
+    const optimization = await buildOptimizationOpportunities({
+      supabase,
+      shopId,
+      lookbackDays: 365,
+      limit: 8,
+    });
+    const opportunities = optimization.groups.flatMap((group) => group.opportunities ?? []);
+    const selected = opportunities
+      .filter(
+        (item) =>
+          item.priorityBand === "critical" ||
+          item.priorityBand === "high" ||
+          (item.priorityBand === "medium" && item.confidence >= 0.72),
+      )
+      .slice(0, 3);
+
+    for (const item of selected) {
+      notifications.push({
+        level: item.priorityBand === "critical" ? "urgent" : "warning",
+        code: toOptimizationCode(item.type),
+        title: item.title,
+        message: item.summary,
+        href: optimizationHref(item),
+        entityType: "optimization_opportunity",
+        entityId: item.id,
+        createdAt: optimization.generatedAt,
+      });
+    }
+  } catch (error) {
+    console.warn("[ops notifications] optimization enrichment skipped", error);
+  }
+
+  const [{ count: menuSuggestionCount }, { count: inspectionSuggestionCount }] =
+    await Promise.all([
+      supabase
+        .from("menu_item_suggestions")
+        .select("*", { count: "exact", head: true })
+        .eq("shop_id", shopId),
+      supabase
+        .from("inspection_template_suggestions")
+        .select("*", { count: "exact", head: true })
+        .eq("shop_id", shopId),
+    ]);
+
+  const totalQueuedSuggestions =
+    (menuSuggestionCount ?? 0) + (inspectionSuggestionCount ?? 0);
+  if (totalQueuedSuggestions > 0) {
+    notifications.push({
+      level: totalQueuedSuggestions >= 6 ? "warning" : "info",
+      code: "optimization_review_queued_suggestions",
+      title: "Queued ShopBoost suggestions need review",
+      message: `${menuSuggestionCount ?? 0} service suggestions and ${inspectionSuggestionCount ?? 0} inspection suggestions are waiting for approval.`,
+      href: "/menu_item_suggestions",
       entityType: "shop",
       entityId: shopId,
     });

--- a/features/agent/server/getRoleDailySummary.ts
+++ b/features/agent/server/getRoleDailySummary.ts
@@ -132,7 +132,11 @@ function topUrgentAlerts(
       hours: parseHoursFromMessage(item.message),
       workOrderLabel: extractWorkOrderLabel(item),
       levelRank:
-        item.level === "urgent" ? 3 : item.level === "warning" ? 2 : 1,
+        item.level === "urgent" || item.level === "critical"
+          ? 3
+          : item.level === "warning"
+            ? 2
+            : 1,
     }))
     .sort((a, b) => {
       if (b.levelRank !== a.levelRank) return b.levelRank - a.levelRank;
@@ -223,6 +227,18 @@ function buildOwnerSummary(params: {
   if ((counts.shop_throughput_below_capacity ?? 0) > 0) {
     breakdown.push(`${counts.shop_throughput_below_capacity} throughput below capacity`);
   }
+  if ((counts.optimization_pricing_normalization ?? 0) > 0) {
+    breakdown.push(`${counts.optimization_pricing_normalization} pricing standardization opportunities`);
+  }
+  if ((counts.optimization_inspection_coverage_gap ?? 0) > 0) {
+    breakdown.push(`${counts.optimization_inspection_coverage_gap} inspection coverage opportunities`);
+  }
+  if ((counts.optimization_missed_revenue ?? 0) > 0) {
+    breakdown.push(`${counts.optimization_missed_revenue} missed-revenue opportunities`);
+  }
+  if ((counts.optimization_review_queued_suggestions ?? 0) > 0) {
+    breakdown.push(`${counts.optimization_review_queued_suggestions} queued ShopBoost review reminders`);
+  }
 
   if (breakdown.length > 0) {
     lines.push("");
@@ -283,6 +299,15 @@ function buildAdvisorSummary(params: {
   }
   if ((counts.shop_throughput_below_capacity ?? 0) > 0) {
     parts.push(`${counts.shop_throughput_below_capacity} throughput below capacity`);
+  }
+  if ((counts.optimization_pricing_normalization ?? 0) > 0) {
+    parts.push(`${counts.optimization_pricing_normalization} pricing optimization actions`);
+  }
+  if ((counts.optimization_inspection_coverage_gap ?? 0) > 0) {
+    parts.push(`${counts.optimization_inspection_coverage_gap} inspection optimization actions`);
+  }
+  if ((counts.optimization_missed_revenue ?? 0) > 0) {
+    parts.push(`${counts.optimization_missed_revenue} missed-revenue actions`);
   }
 
   const lines: string[] = [];
@@ -349,6 +374,15 @@ function buildManagerSummary(params: {
   if ((counts.shop_throughput_below_capacity ?? 0) > 0) {
     items.push(`${counts.shop_throughput_below_capacity} throughput below capacity`);
   }
+  if ((counts.optimization_pricing_normalization ?? 0) > 0) {
+    items.push(`${counts.optimization_pricing_normalization} pricing optimization opportunities`);
+  }
+  if ((counts.optimization_inspection_coverage_gap ?? 0) > 0) {
+    items.push(`${counts.optimization_inspection_coverage_gap} inspection optimization opportunities`);
+  }
+  if ((counts.optimization_missed_revenue ?? 0) > 0) {
+    items.push(`${counts.optimization_missed_revenue} missed-revenue opportunities`);
+  }
 
   if (items.length > 0) {
     lines.push("");
@@ -389,6 +423,9 @@ function buildTechSummary(params: {
   if ((counts.parts_waiting_too_long ?? 0) > 0) {
     items.push(`${counts.parts_waiting_too_long} jobs waiting on parts too long`);
   }
+  if ((counts.optimization_review_queued_suggestions ?? 0) > 0) {
+    items.push(`${counts.optimization_review_queued_suggestions} queued suggestions pending advisor review`);
+  }
 
   if (items.length > 0) {
     lines.push("");
@@ -420,6 +457,9 @@ function buildFleetSummary(params: {
   }
   if ((counts.parts_waiting_too_long ?? 0) > 0) {
     items.push(`${counts.parts_waiting_too_long} jobs waiting on parts too long`);
+  }
+  if ((counts.optimization_missed_revenue ?? 0) > 0) {
+    items.push(`${counts.optimization_missed_revenue} missed-revenue opportunities`);
   }
 
   if (items.length > 0) {
@@ -534,6 +574,12 @@ export async function getRoleDailySummary(params: {
         techOverloaded: notificationCounts.tech_overloaded ?? 0,
         idleCapacity: notificationCounts.tech_underutilized_capacity ?? 0,
         throughputIssues: notificationCounts.shop_throughput_below_capacity ?? 0,
+      },
+      optimizationSignals: {
+        pricing: notificationCounts.optimization_pricing_normalization ?? 0,
+        inspectionCoverage: notificationCounts.optimization_inspection_coverage_gap ?? 0,
+        missedRevenue: notificationCounts.optimization_missed_revenue ?? 0,
+        queuedSuggestions: notificationCounts.optimization_review_queued_suggestions ?? 0,
       },
       bookingsSummary: bookings.summary,
       stalledSummary: stalled.summary,

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -8,6 +8,11 @@ import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 import { runShopBoostImport, type ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
+import { buildOptimizationOpportunities } from "@/features/optimization/server/buildOptimizationOpportunities";
+import {
+  selectTopOnboardingOptimizationActions,
+  type OnboardingOptimizationAction,
+} from "@/features/optimization/server/selectOnboardingRecommendedActions";
 import {
   SHOP_BOOST_UPLOAD_DATASETS,
   SHOP_BOOST_UPLOAD_DATASET_KEYS,
@@ -31,6 +36,17 @@ export type ShopBoostRunResp =
         linkedMenuToInspection: number;
         menuSuggestions: number;
         inspectionSuggestions: number;
+      };
+      onboardingOptimization: {
+        summary: {
+          totalOpportunities: number;
+          criticalCount: number;
+          highCount: number;
+          potentialMonthlyValue: number;
+          dataFreshness: "fresh" | "stale";
+          lastAnalyzedAt: string;
+        } | null;
+        nextActions: OnboardingOptimizationAction[];
       };
     }
   | { ok: false; error: string };
@@ -155,7 +171,7 @@ export async function runShopBoostIntake(
 
   let providedIntakeId: string | null = null;
 
-  let providedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
+  const providedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
 
   if (contentType.includes("multipart/form-data")) {
     const formData = await req.formData().catch(() => null);
@@ -385,6 +401,37 @@ export async function runShopBoostIntake(
     });
   }
 
+  let onboardingOptimization: {
+    summary: {
+      totalOpportunities: number;
+      criticalCount: number;
+      highCount: number;
+      potentialMonthlyValue: number;
+      dataFreshness: "fresh" | "stale";
+      lastAnalyzedAt: string;
+    } | null;
+    nextActions: OnboardingOptimizationAction[];
+  } = {
+    summary: null,
+    nextActions: [],
+  };
+
+  try {
+    const optimizationOutput = await buildOptimizationOpportunities({
+      supabase: supabaseAdmin,
+      shopId,
+      limit: 10,
+      lookbackDays: 365,
+    });
+
+    onboardingOptimization = {
+      summary: optimizationOutput.summary,
+      nextActions: selectTopOnboardingOptimizationActions(optimizationOutput, 5),
+    };
+  } catch (error) {
+    console.warn("[shop-boost/intake] optimization handoff skipped", error);
+  }
+
   return {
     ok: true,
     shopId,
@@ -392,5 +439,6 @@ export async function runShopBoostIntake(
     snapshot,
     importSummary,
     shopBuildSummary: importSummary.shopBuildSummary,
+    onboardingOptimization,
   };
 }

--- a/features/optimization/server/selectOnboardingRecommendedActions.ts
+++ b/features/optimization/server/selectOnboardingRecommendedActions.ts
@@ -1,0 +1,94 @@
+import type {
+  OptimizationEngineOutput,
+  OptimizationOpportunity,
+} from "@/features/optimization/types";
+
+export type OnboardingOptimizationAction = {
+  id: string;
+  type: OptimizationOpportunity["type"];
+  title: string;
+  summary: string;
+  priorityBand: OptimizationOpportunity["priorityBand"];
+  confidence: number;
+  estimatedValue?: number;
+  href: string;
+  plannerGoal: string;
+};
+
+function toMenuItemPath(menuItemId?: string): string {
+  return menuItemId ? `/menu/item/${menuItemId}` : "/menu";
+}
+
+function toInspectionTemplatePath(templateId?: string): string {
+  return templateId
+    ? `/inspections/templates?templateId=${encodeURIComponent(templateId)}`
+    : "/inspection_template_suggestions";
+}
+
+function toActionHref(opportunity: OptimizationOpportunity): string {
+  if (opportunity.type === "pricing_normalization") {
+    return toMenuItemPath(opportunity.targetRefs?.menuItemId);
+  }
+
+  if (opportunity.type === "inspection_coverage_gap") {
+    return opportunity.targetRefs?.inspectionTemplateId
+      ? toInspectionTemplatePath(opportunity.targetRefs?.inspectionTemplateId)
+      : "/inspection_template_suggestions";
+  }
+
+  return "/menu_item_suggestions";
+}
+
+function toPlannerGoal(opportunity: OptimizationOpportunity): string {
+  if (opportunity.type === "pricing_normalization") {
+    return `Standardize pricing: ${opportunity.title}. ${opportunity.summary}`;
+  }
+  if (opportunity.type === "inspection_coverage_gap") {
+    return `Improve inspection coverage: ${opportunity.title}. ${opportunity.summary}`;
+  }
+  return `Review missed-revenue opportunity: ${opportunity.title}. ${opportunity.summary}`;
+}
+
+function rankOpportunity(opportunity: OptimizationOpportunity): number {
+  const bandWeight: Record<OptimizationOpportunity["priorityBand"], number> = {
+    critical: 4,
+    high: 3,
+    medium: 2,
+    low: 1,
+  };
+  return (
+    bandWeight[opportunity.priorityBand] * 1000 +
+    opportunity.priorityScore * 100 +
+    (opportunity.estimatedValue ?? 0) / 10
+  );
+}
+
+export function selectTopOnboardingOptimizationActions(
+  payload: OptimizationEngineOutput | null,
+  limit = 5,
+): OnboardingOptimizationAction[] {
+  if (!payload) return [];
+
+  const flattened = payload.groups.flatMap((group) => group.opportunities ?? []);
+  const highSignal = flattened
+    .filter((opportunity) => {
+      if (opportunity.priorityBand === "critical" || opportunity.priorityBand === "high") {
+        return true;
+      }
+      return opportunity.confidence >= 0.65 && opportunity.priorityBand !== "low";
+    })
+    .sort((a, b) => rankOpportunity(b) - rankOpportunity(a))
+    .slice(0, Math.max(1, limit));
+
+  return highSignal.map((opportunity) => ({
+    id: opportunity.id,
+    type: opportunity.type,
+    title: opportunity.title,
+    summary: opportunity.summary,
+    priorityBand: opportunity.priorityBand,
+    confidence: opportunity.confidence,
+    estimatedValue: opportunity.estimatedValue,
+    href: toActionHref(opportunity),
+    plannerGoal: toPlannerGoal(opportunity),
+  }));
+}

--- a/features/shared/components/DailySummaryCard.tsx
+++ b/features/shared/components/DailySummaryCard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useDailySummary } from "@/features/agent/hooks/useDailySummary";
 
 function levelClasses(level: string): string {
-  if (level === "urgent") return "border-red-500/30 bg-red-500/10 text-red-200";
+  if (level === "urgent" || level === "critical") return "border-red-500/30 bg-red-500/10 text-red-200";
   if (level === "warning") return "border-amber-500/30 bg-amber-500/10 text-amber-200";
   return "border-sky-500/30 bg-sky-500/10 text-sky-200";
 }


### PR DESCRIPTION
### Motivation
- Close the loop between ShopBoost onboarding, the existing Optimization Engine, and the AI/planner daily-ops so users see immediate next steps after shop build. 
- Surface only high-signal optimization items at onboarding completion and route them into the planner/assistant pipeline rather than duplicating logic.
- Keep the change incremental and non-breaking by reusing `buildOptimizationOpportunities` and existing planner/notification flows.

### Description
- Added a small selector helper `selectTopOnboardingOptimizationActions` that consumes the existing `OptimizationEngineOutput` and picks the top onboarding-relevant opportunities. (new file: `features/optimization/server/selectOnboardingRecommendedActions.ts`).
- Extended `runShopBoostIntake` to call `buildOptimizationOpportunities` and return an `onboardingOptimization` payload with `summary` + `nextActions` so the onboarding completion can show recommendations (`features/integrations/shopBoost/runIntakeHandler.ts`).
- Updated the ShopBoost completion UI to present three tiers: "What we built", "What still needs review", and "What we recommend next", and added compact CTAs to `Open` or `Send to planner` for each recommendation (`app/onboarding/shop-boost/page.tsx`).
- Plugged optimization signals into the existing ops notification / daily summary pipeline by enriching `getOpsNotifications` with a small selection of high-signal optimization advisories and a queued-suggestions reminder, added new notification codes, and surfaced counts into `getRoleDailySummary` `sourceSnapshot` (`features/agent/server/getOpsNotifications.ts`, `features/agent/server/getRoleDailySummary.ts`, `features/agent/hooks/useOpsNotifications.ts`).
- Minor UI/typing polish: extended client hook notification codes, and adjusted `DailySummaryCard` rendering to treat `critical` like `urgent` for consistent presentation (`features/shared/components/DailySummaryCard.tsx`).

### Testing
- Ran TypeScript checks: `npx tsc --noEmit` and it succeeded with no type errors. 
- Ran targeted linting: `npx eslint app/onboarding/shop-boost/page.tsx features/integrations/shopBoost/runIntakeHandler.ts features/optimization/server/selectOnboardingRecommendedActions.ts features/agent/server/getOpsNotifications.ts features/agent/server/getRoleDailySummary.ts features/agent/hooks/useOpsNotifications.ts features/shared/components/DailySummaryCard.tsx` and it passed after a small `prefer-const` fix. 
- Confirmed the following files were modified/added: `app/onboarding/shop-boost/page.tsx`, `features/integrations/shopBoost/runIntakeHandler.ts`, `features/optimization/server/selectOnboardingRecommendedActions.ts`, `features/agent/server/getOpsNotifications.ts`, `features/agent/server/getRoleDailySummary.ts`, `features/agent/hooks/useOpsNotifications.ts`, and `features/shared/components/DailySummaryCard.tsx`.
- Notes: no schema changes were made and the optimization engine remains the single source of truth; the onboarding-to-planner handoff is an explicit user action (no auto-apply).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92568427483288924913cf8e1780f)