### PR TITLE
Normalize cockpit UI foundations for Work Orders/Inspections and add persistent appearance mode

### DIFF
--- a/app/api/branding/user-preferences/route.ts
+++ b/app/api/branding/user-preferences/route.ts
@@ -68,13 +68,20 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const patch = {
+  const patch: Record<string, string | null> = {
     user_id: auth.userId,
     shop_id: auth.shopId,
-    theme_mode: normalizeThemeMode(body.themeMode),
-    radius_scale: normalizeRadiusScale(body.radiusScale),
-    shadow_style: normalizeShadowStyle(body.shadowStyle),
   };
+
+  if ("themeMode" in body) {
+    patch.theme_mode = normalizeThemeMode(body.themeMode);
+  }
+  if ("radiusScale" in body) {
+    patch.radius_scale = normalizeRadiusScale(body.radiusScale);
+  }
+  if ("shadowStyle" in body) {
+    patch.shadow_style = normalizeShadowStyle(body.shadowStyle);
+  }
 
   const { data, error } = await auth.supabase
     .from("user_theme_preferences")

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import { Inter, Black_Ops_One } from "next/font/google";
+import Script from "next/script";
 import Providers from "./providers";
 import AppShell from "@/features/shared/components/AppShell";
 import { cookies } from "next/headers";
@@ -41,11 +42,16 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${blackOps.variable} dark`}
+      className={`${inter.variable} ${blackOps.variable}`}
       suppressHydrationWarning
     >
+      <head>
+        <Script id="pfq-theme-preload" strategy="beforeInteractive">
+          {`(function(){try{var r=document.documentElement;var pref=localStorage.getItem('pfq-theme-mode')||'dark';var resolved=pref==='system'?(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):pref;if(resolved!=='light'&&resolved!=='dark'){resolved='dark';}r.setAttribute('data-theme-preference',pref);r.setAttribute('data-theme-mode',resolved);}catch(_e){}})();`}
+        </Script>
+      </head>
       <body
-        className="min-h-screen text-white antialiased"
+        className="min-h-screen antialiased"
         style={{
           backgroundImage:
             "var(--app-shell-bg, radial-gradient(circle at top, rgba(249,115,22,0.18), transparent 55%), radial-gradient(circle at bottom, rgba(15,23,42,0.96), #020617 70%))",

--- a/app/work-orders/page.tsx
+++ b/app/work-orders/page.tsx
@@ -9,6 +9,8 @@ import type { Role } from "@shared/components/RoleHubTiles/tiles";
 import { TILES } from "@shared/components/RoleHubTiles/tiles";
 import Link from "next/link";
 import PageShell from "@/features/shared/components/PageShell";
+import Card from "@/features/shared/components/ui/Card";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 
 type DB = Database;
 
@@ -40,30 +42,35 @@ export default async function WorkOrdersHome() {
 
   return (
     <PageShell
+      eyebrow="Operations"
       title="Work Orders"
-      description="Create, view, and manage jobs, quotes, and invoices."
+      description="Run the full work-order lifecycle with clear operational entry points for service advisors, techs, and managers."
     >
       {workOrderTiles.length === 0 ? (
-        <div className="rounded border border-neutral-800 bg-neutral-950/60 p-4 text-sm text-neutral-300">
-          No work-order actions available for your role.
-        </div>
+        <Card className="p-4 text-sm" >No work-order actions available for your role.</Card>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {workOrderTiles.map((tile) => (
             <Link
               key={tile.href}
               href={tile.href}
-              className="group rounded-lg border border-neutral-800 bg-neutral-950/60 px-4 py-4 transition hover:border-orange-400 hover:bg-neutral-900"
+              className="group"
             >
-              <div className="flex items-center justify-between gap-2">
-                <h2 className="text-base font-semibold text-neutral-100">{tile.title}</h2>
-                <span className="text-xs text-neutral-500 group-hover:text-orange-300">
-                  {tile.cta ?? "→"}
-                </span>
-              </div>
-              {tile.subtitle ? (
-                <p className="mt-1 text-sm text-neutral-400">{tile.subtitle}</p>
-              ) : null}
+              <Card className="h-full px-5 py-5 transition group-hover:border-[color:var(--brand-accent,#E39A6E)]/60 group-hover:shadow-[var(--theme-shadow-medium)]">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-base font-semibold">{tile.title}</h2>
+                    {tile.subtitle ? (
+                      <p className="mt-1 text-sm text-[var(--theme-text-secondary,#94A3B8)]">
+                        {tile.subtitle}
+                      </p>
+                    ) : null}
+                  </div>
+                  <StatusBadge variant="active" size="sm">
+                    {tile.cta ?? "Open"}
+                  </StatusBadge>
+                </div>
+              </Card>
             </Link>
           ))}
         </div>

--- a/features/branding/components/BrandThemeBoot.tsx
+++ b/features/branding/components/BrandThemeBoot.tsx
@@ -41,6 +41,16 @@ type UserThemePreferences = {
   shadow_style?: string | null;
 };
 
+function resolveThemeMode(mode: string): "light" | "dark" {
+  if (mode === "light") return "light";
+  if (mode === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  return "dark";
+}
+
 function setVar(
   root: HTMLElement,
   name: string,
@@ -398,10 +408,22 @@ export default function BrandThemeBoot() {
       userPrefs.shadow_style || profile.shadow_style || "medium",
     );
 
-    const themeMode = String(
+    const themePreference = String(
       userPrefs.theme_mode || profile.theme_mode || "dark",
     ).toLowerCase();
-    root.setAttribute("data-theme-mode", themeMode);
+    const resolvedTheme = resolveThemeMode(themePreference);
+    root.setAttribute("data-theme-preference", themePreference);
+    root.setAttribute("data-theme-mode", resolvedTheme);
+    window.localStorage.setItem("pfq-theme-mode", themePreference);
+
+    if (themePreference === "system") {
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      const onMediaChange = () => {
+        root.setAttribute("data-theme-mode", resolveThemeMode("system"));
+      };
+      media.addEventListener("change", onMediaChange);
+      return () => media.removeEventListener("change", onMediaChange);
+    }
   }, [data]);
 
   return null;

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -235,6 +235,8 @@ export default function OwnerSettingsPage() {
   // Automation
   const [autoGeneratePdf, setAutoGeneratePdf] = useState(false);
   const [autoSendQuoteEmail, setAutoSendQuoteEmail] = useState(false);
+  const [appearanceMode, setAppearanceMode] = useState<"dark" | "light" | "system">("dark");
+  const [appearanceSaving, setAppearanceSaving] = useState(false);
 
   // Pricing validity
   const [pricingValidDays, setPricingValidDays] = useState<number>(30);
@@ -532,6 +534,21 @@ try {
     // email logs
     await fetchEmailLogs();
 
+    try {
+      const prefRes = await fetch("/api/branding/user-preferences", { cache: "no-store" });
+      if (prefRes.ok) {
+        const prefJson = (await prefRes.json().catch(() => ({}))) as {
+          preferences?: { theme_mode?: string | null } | null;
+        };
+        const nextMode = String(prefJson?.preferences?.theme_mode ?? "dark").toLowerCase();
+        if (nextMode === "light" || nextMode === "system" || nextMode === "dark") {
+          setAppearanceMode(nextMode);
+        }
+      }
+    } catch {
+      // ignore
+    }
+
     setLoading(false);
   }, [supabase, fetchEmailLogs]);
 
@@ -641,6 +658,30 @@ try {
       toast.success("Pricing validity window updated.");
     } finally {
       setPricingValidDaysSaving(false);
+    }
+  };
+
+  const saveAppearanceMode = async (nextMode: "dark" | "light" | "system") => {
+    setAppearanceSaving(true);
+    try {
+      const res = await fetch("/api/branding/user-preferences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ themeMode: nextMode }),
+      });
+
+      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !json?.ok) {
+        toast.error(json?.error || "Failed to save appearance mode");
+        return;
+      }
+
+      setAppearanceMode(nextMode);
+      window.localStorage.setItem("pfq-theme-mode", nextMode);
+      window.dispatchEvent(new Event("profixiq:brand-refresh"));
+      toast.success("Appearance mode updated.");
+    } finally {
+      setAppearanceSaving(false);
     }
   };
 
@@ -1264,6 +1305,8 @@ try {
             requireAuthorization={requireAuthorization}
             autoGeneratePdf={autoGeneratePdf}
             autoSendQuoteEmail={autoSendQuoteEmail}
+            appearanceMode={appearanceMode}
+            appearanceSaving={appearanceSaving}
             onLaborRateChange={setLaborRate}
             onSuppliesPercentChange={setSuppliesPercent}
             onDiagnosticFeeChange={setDiagnosticFee}
@@ -1275,6 +1318,7 @@ try {
             onRequireAuthorizationChange={setRequireAuthorization}
             onAutoGeneratePdfChange={setAutoGeneratePdf}
             onAutoSendQuoteEmailChange={setAutoSendQuoteEmail}
+            onAppearanceModeChange={(value) => void saveAppearanceMode(value)}
           />
           <BrandStudioSummaryCard />
 

--- a/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx
@@ -19,6 +19,8 @@ type Props = {
   requireAuthorization: boolean;
   autoGeneratePdf: boolean;
   autoSendQuoteEmail: boolean;
+  appearanceMode: "dark" | "light" | "system";
+  appearanceSaving: boolean;
   onLaborRateChange: (value: string) => void;
   onSuppliesPercentChange: (value: string) => void;
   onDiagnosticFeeChange: (value: string) => void;
@@ -30,6 +32,7 @@ type Props = {
   onRequireAuthorizationChange: (value: boolean) => void;
   onAutoGeneratePdfChange: (value: boolean) => void;
   onAutoSendQuoteEmailChange: (value: boolean) => void;
+  onAppearanceModeChange: (value: "dark" | "light" | "system") => void;
 };
 
 function SectionShell({
@@ -75,6 +78,8 @@ export default function OwnerSettingsOperationsSection({
   requireAuthorization,
   autoGeneratePdf,
   autoSendQuoteEmail,
+  appearanceMode,
+  appearanceSaving,
   onLaborRateChange,
   onSuppliesPercentChange,
   onDiagnosticFeeChange,
@@ -86,6 +91,7 @@ export default function OwnerSettingsOperationsSection({
   onRequireAuthorizationChange,
   onAutoGeneratePdfChange,
   onAutoSendQuoteEmailChange,
+  onAppearanceModeChange,
 }: Props) {
   return (
     <div className="grid gap-6 md:grid-cols-2">
@@ -151,6 +157,33 @@ export default function OwnerSettingsOperationsSection({
             auto-flow faster; stale or expired pricing requires more review.
           </div>
         </div>
+      </SectionShell>
+
+      <SectionShell
+        title="Appearance"
+        description="Set your operational console mode. Preference persists per user and syncs with brand variables."
+      >
+        <div className="flex flex-wrap gap-2">
+          {([
+            ["dark", "Dark"],
+            ["light", "Light"],
+            ["system", "System"],
+          ] as const).map(([value, label]) => (
+            <Button
+              key={value}
+              type="button"
+              variant={appearanceMode === value ? "default" : "secondary"}
+              size="sm"
+              disabled={appearanceSaving}
+              onClick={() => onAppearanceModeChange(value)}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+        <p className="text-[11px] text-neutral-400">
+          {appearanceSaving ? "Saving appearance preference…" : "Applies immediately after save."}
+        </p>
       </SectionShell>
 
       <SectionShell

--- a/features/inspections/app/inspection/InspectionMenuClient.tsx
+++ b/features/inspections/app/inspection/InspectionMenuClient.tsx
@@ -10,6 +10,8 @@ import type { InspectionCategory } from "@inspections/lib/inspection/types";
 import { toInspectionCategories } from "@inspections/lib/inspection/normalize";
 import { Button } from "@shared/components/ui/Button";
 import PageShell from "@/features/shared/components/PageShell";
+import Card from "@/features/shared/components/ui/Card";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 
 type DB = Database;
 type TemplateRow = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -20,12 +22,15 @@ function TileLink({ href, title, subtitle }: Tile) {
   return (
     <Link
       href={href}
-      className="block rounded-lg border border-white/10 bg-neutral-900 p-4 transition
-                 hover:-translate-y-0.5 hover:border-orange-500 hover:shadow-lg hover:shadow-orange-500/10"
+      className="block"
       aria-label={title}
     >
-      <h3 className="text-lg font-semibold text-white">{title}</h3>
-      {subtitle ? <p className="mt-1 text-sm text-white/70">{subtitle}</p> : null}
+      <Card className="h-full px-5 py-5 transition hover:border-[color:var(--brand-accent,#E39A6E)]/60">
+        <h3 className="text-base font-semibold">{title}</h3>
+        {subtitle ? (
+          <p className="mt-1 text-sm text-[var(--theme-text-secondary,#94A3B8)]">{subtitle}</p>
+        ) : null}
+      </Card>
     </Link>
   );
 }
@@ -95,20 +100,21 @@ export default function InspectionMenuClient() {
 
   return (
     <PageShell
+      eyebrow="Execution"
       title="Inspections"
-      description="Start a new inspection, use a template, or jump back into drafts."
+      description="Launch, resume, and review inspections with a consistent command-grade workflow shell."
     >
       <div className="space-y-8">
         {/* Navigation tiles */}
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold text-white">Get Started</h2>
+          <h2 className="text-base font-semibold">Get Started</h2>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {NAV_MAIN.map((t) => (
               <TileLink key={t.href} {...t} />
             ))}
           </div>
 
-          <h3 className="mt-6 text-sm font-semibold text-neutral-300">More</h3>
+          <h3 className="mt-6 text-sm font-semibold text-[var(--theme-text-secondary,#94A3B8)]">More</h3>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {NAV_UTIL.map((t) => (
               <TileLink key={t.href} {...t} />
@@ -118,12 +124,13 @@ export default function InspectionMenuClient() {
 
         {/* Templates list + preview */}
         <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-white">Inspection Templates</h2>
+          <h2 className="text-base font-semibold">Inspection Templates</h2>
           <div className="grid gap-3 md:grid-cols-2">
             {templates.map((t) => (
-              <div key={t.id} className="rounded border border-neutral-700 p-3">
-                <div className="mb-2 text-white">
+              <Card key={t.id} className="space-y-3 px-4 py-4">
+                <div className="flex items-center justify-between gap-2">
                   {t.template_name ?? "Untitled"}
+                  <StatusBadge variant="info">Template</StatusBadge>
                 </div>
                 <div className="flex gap-2">
                   <Button
@@ -135,26 +142,32 @@ export default function InspectionMenuClient() {
                   </Button>
                   <Link
                     href={`/inspections/templates?id=${t.id}`}
-                    className="rounded border border-white/15 px-3 py-2 text-sm transition hover:border-orange-500"
+                    className="rounded border px-3 py-2 text-sm transition"
+                    style={{ borderColor: "var(--theme-card-border,#334155)" }}
                   >
                     Open
                   </Link>
                 </div>
-              </div>
+              </Card>
             ))}
             {templates.length === 0 && (
-              <p className="text-sm text-neutral-400">
+              <p className="text-sm text-[var(--theme-text-secondary,#94A3B8)]">
                 No templates yet. Create one under{" "}
-                <span className="text-orange-400">Templates</span>.
+                <span style={{ color: "var(--brand-accent,#E39A6E)" }}>Templates</span>.
               </p>
             )}
           </div>
 
           {active && (
-            <div className="rounded-xl border border-neutral-700 bg-neutral-900 p-4">
-              <h3 className="mb-3 text-lg font-semibold text-orange-400">Preview</h3>
+            <Card className="p-4">
+              <h3
+                className="mb-3 text-base font-semibold"
+                style={{ color: "var(--theme-text-primary,#F8FAFC)" }}
+              >
+                Preview
+              </h3>
               <InspectionGroupList categories={active} />
-            </div>
+            </Card>
           )}
         </section>
       </div>

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -233,7 +233,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   if (!isAppRoute) {
     return (
-      <div className="min-h-screen bg-neutral-950 text-foreground">
+      <div className="min-h-screen text-[var(--theme-text-primary,#E2E8F0)]">
         {children}
         <Toaster closeButton richColors position="top-right" theme="dark" />
       </div>

--- a/features/shared/components/PageShell.tsx
+++ b/features/shared/components/PageShell.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 type PageShellProps = {
   title: string;
   description?: string;
+  eyebrow?: string;
   actions?: ReactNode;
   children: ReactNode;
 };
@@ -12,6 +13,7 @@ type PageShellProps = {
 export default function PageShell({
   title,
   description,
+  eyebrow,
   actions,
   children,
 }: PageShellProps) {
@@ -27,11 +29,19 @@ export default function PageShell({
         }}
       >
         <div>
+          {eyebrow ? (
+            <p
+              className="text-[10px] font-semibold uppercase tracking-[0.2em]"
+              style={{ color: "var(--theme-text-muted,#64748B)" }}
+            >
+              {eyebrow}
+            </p>
+          ) : null}
+
           <h1
-            className="text-xl tracking-[0.08em]"
+            className="text-xl font-semibold tracking-[0.03em]"
             style={{
-              fontFamily: "var(--font-blackops), system-ui, sans-serif",
-              color: "var(--brand-accent,#E2A164)",
+              color: "var(--theme-text-primary,#E2E8F0)",
             }}
           >
             {title}

--- a/features/shared/components/ui/Card.tsx
+++ b/features/shared/components/ui/Card.tsx
@@ -13,11 +13,11 @@ export default function Card({ children, onClick, className }: CardProps) {
     <div
       onClick={onClick}
       className={cn(
-        "rounded-[var(--theme-radius-xl,1rem)] border px-6 py-5 backdrop-blur-md transition duration-200",
+        "rounded-[var(--theme-radius-xl,1rem)] border px-6 py-5 backdrop-blur-sm transition duration-200",
         "border-[var(--theme-card-border,#334155)]",
-        "bg-[var(--theme-card-bg,#111827)]",
+        "bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_94%,transparent)]",
         "text-[var(--theme-text-primary,#FFFFFF)]",
-        "shadow-[var(--theme-shadow-medium,0_18px_45px_rgba(0,0,0,0.45))]",
+        "shadow-[var(--theme-shadow-soft,0_14px_30px_rgba(0,0,0,0.35))]",
         onClick
           ? "cursor-pointer hover:-translate-y-[1px] hover:brightness-105"
           : "",

--- a/features/shared/components/ui/StatusBadge.tsx
+++ b/features/shared/components/ui/StatusBadge.tsx
@@ -21,13 +21,14 @@ type StatusBadgeProps = {
 };
 
 const variantClasses: Record<StatusBadgeVariant, string> = {
-  neutral: "border-white/10 bg-white/5 text-neutral-100",
-  info: "border-slate-400/40 bg-slate-400/10 text-slate-100",
+  neutral:
+    "border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_84%,transparent)] text-[var(--theme-text-secondary,#94A3B8)]",
+  info: "border-sky-500/40 bg-sky-500/10 text-sky-200",
   active:
-    "border-[color:var(--accent-copper-soft,#fdba74)]/70 bg-[color:var(--accent-copper,#f97316)]/15 text-[color:var(--accent-copper-light,#fdba74)]",
-  warning: "border-amber-400/60 bg-amber-400/10 text-amber-100",
-  success: "border-emerald-400/60 bg-emerald-400/10 text-emerald-100",
-  danger: "border-rose-400/60 bg-rose-400/10 text-rose-100",
+    "border-[color:var(--accent-copper-soft,#fdba74)]/70 bg-[color:color-mix(in_srgb,var(--accent-copper,#f97316)_20%,transparent)] text-[color:var(--accent-copper-light,#fdba74)]",
+  warning: "border-amber-500/60 bg-amber-500/10 text-amber-200",
+  success: "border-emerald-500/60 bg-emerald-500/10 text-emerald-200",
+  danger: "border-rose-500/60 bg-rose-500/10 text-rose-200",
 };
 
 const sizeClasses: Record<StatusBadgeSize, string> = {


### PR DESCRIPTION
### Motivation
- Move UI toward a single "operational cockpit" language by tightening shared shell/card/badge primitives and reducing per-page visual drift.
- Bring Work Orders and Inspections hubs visually in line with the dashboard widget shell so critical workflows feel cohesive and authoritative.
- Provide a real, persistent appearance mode (dark/light/system) that integrates with the existing branding boot and user preferences without breaking brand customization.

### Description
- Add pre-hydration theme bootstrap in `app/layout.tsx` to read `localStorage` `pfq-theme-mode` and apply `data-theme-mode` before render to avoid flash of wrong theme. (`Script` with `beforeInteractive`).
- Enhance `BrandThemeBoot` (`features/branding/components/BrandThemeBoot.tsx`) to resolve `dark|light|system`, set `data-theme-preference` + `data-theme-mode`, persist preference to `localStorage`, and listen for system changes when `system` is selected.
- Make `user_theme_preferences` POST partial-safe so updates only touch provided fields (avoid overwriting radius/shadow): `app/api/branding/user-preferences/route.ts`.
- Expose appearance controls in owner settings and wire persistence via the existing branding preferences API; added `appearanceMode` state and `saveAppearanceMode` which calls the existing API and updates `localStorage` + dispatches brand-refresh. (changes in `features/dashboard/app/dashboard/owner/settings/page.tsx` and `features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx`).
- Normalize shared primitives: `PageShell` now supports an `eyebrow` and consistent title/description treatment; `Card` has tightened backdrop/shadow/background mixing; `StatusBadge` maps semantic tokens to consistent variable-aware styles; `AppShell` non-app route styling uses theme variables. (modified `features/shared/components/PageShell.tsx`, `features/shared/components/ui/Card.tsx`, `features/shared/components/ui/StatusBadge.tsx`, `features/shared/components/AppShell.tsx`).
- Refactor high-impact surfaces to the new primitives without changing business behavior: `app/work-orders/page.tsx` and `features/inspections/app/inspection/InspectionMenuClient.tsx` now use shared `Card`/`StatusBadge` and the `PageShell` eyebrow/title hierarchy to move toward an operational panel language.

### Testing
- Ran type-check: `npx tsc --noEmit` — succeeded.
- No schema or backend data migrations were added, and the existing `user_theme_preferences` API was reused and verified to accept partial updates.
- Manual runtime validation notes: appearance selection is persisted to `localStorage` under `pfq-theme-mode`, `BrandThemeBoot` applies variables and listens for `system` changes, and the owner settings save flow calls the existing preferences API and triggers a brand refresh event.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9349ca24883288256be8978f9216b)