### PR TITLE
Normalize inspection workspace to shared shell/card/status primitives

### DIFF
--- a/features/inspections/app/inspection/[id]/page.tsx
+++ b/features/inspections/app/inspection/[id]/page.tsx
@@ -6,6 +6,9 @@ import { createClient } from "@supabase/supabase-js";
 import { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import PreviousPageButton from "@shared/components/ui/PreviousPageButton";
+import PageShell from "@/features/shared/components/PageShell";
+import Card from "@/features/shared/components/ui/Card";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 
 const supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -64,68 +67,75 @@ export default function InspectionDetailPage() {
     }
   }, [id, router]);
 
+  const statusVariant = (status: string) => {
+    const s = status.toLowerCase();
+    if (s === "completed" || s === "done") return "success" as const;
+    if (s === "in_progress" || s === "running") return "active" as const;
+    if (s === "failed") return "danger" as const;
+    return "neutral" as const;
+  };
+
   if (loading) {
     return (
-      <div className="min-h-screen bg-black text-white px-4 py-6">
-        <p className="text-center text-white/70">Loading inspection...</p>
-      </div>
+      <PageShell title="Inspection details" description="Loading inspection result.">
+        <Card className="px-4 py-6 text-center text-sm text-[var(--theme-text-secondary,#94A3B8)]">
+          Loading inspection...
+        </Card>
+      </PageShell>
     );
   }
 
   if (!inspection) {
     return (
-      <div className="min-h-screen bg-black text-white px-4 py-6">
-        <p className="text-center text-red-500">Inspection not found.</p>
-      </div>
+      <PageShell title="Inspection details" description="Inspection result lookup.">
+        <Card className="px-4 py-6 text-center text-sm text-rose-300">
+          Inspection not found.
+        </Card>
+      </PageShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-black text-white px-4 py-6">
-      <PreviousPageButton to="/inspection/saved" />
-      <h1 className="text-3xl text-orange-400 font-blackops mb-4 text-center">
-        {inspection.template_name || "Inspection Details"}
-      </h1>
+    <PageShell
+      eyebrow="Inspection"
+      title={inspection.template_name || "Inspection Details"}
+      description="Evidence-forward review of captured inspection findings."
+      actions={<PreviousPageButton to="/inspection/saved" />}
+    >
+      <Card className="mb-5 px-4 py-4">
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <StatusBadge variant={statusVariant(inspection.status)}>
+            {inspection.status}
+          </StatusBadge>
+          <span className="text-[var(--theme-text-secondary,#94A3B8)]">
+            Created: {format(new Date(inspection.created_at), "PPpp")}
+          </span>
+        </div>
+      </Card>
 
-      <p className="text-white/80 text-center mb-2">
-        Created: {format(new Date(inspection.created_at), "PPpp")}
-      </p>
-      <p className="text-white/70 text-center mb-6 capitalize">
-        Status: {inspection.status}
-      </p>
-
-      <div className="space-y-6">
+      <div className="space-y-4">
         {inspection.result?.map((section, index) => (
-          <div
-            key={index}
-            className="border border-white/10 p-4 rounded-md bg-white/5"
-          >
-            <h2 className="text-lg font-bold text-orange-300 mb-2">
-              {section.title}
-            </h2>
+          <Card key={index} className="px-4 py-4">
+            <h2 className="mb-2 text-lg font-semibold">{section.title}</h2>
             <ul className="space-y-2">
               {section.items?.map((item, i) => (
-                <li key={i} className="text-sm text-white/90">
-                  <span className="font-semibold text-white">{item.name}:</span>{" "}
+                <li key={i} className="text-sm text-[var(--theme-text-secondary,#94A3B8)]">
+                  <span className="font-semibold text-[var(--theme-text-primary,#E2E8F0)]">{item.name}:</span>{" "}
                   {item.status || "N/A"}
-                  {item.notes && (
-                    <span className="block text-white/60">
-                      Note: {item.notes}
-                    </span>
-                  )}
+                  {item.notes && <span className="block">Note: {item.notes}</span>}
                   {item.value && (
-                    <span className="block text-white/60">
+                    <span className="block">
                       {item.unit ? `${item.value} ${item.unit}` : item.value}
                     </span>
                   )}
                   {(item.photoUrls?.length ?? 0) > 0 && (
-                    <div className="mt-2 flex gap-2 flex-wrap">
+                    <div className="mt-2 flex flex-wrap gap-2">
                       {item.photoUrls?.map((url, idx) => (
                         <img
                           key={idx}
                           src={url}
                           alt="Photo"
-                          className="w-24 h-24 object-cover rounded border border-white/20"
+                          className="h-24 w-24 rounded border border-[var(--theme-card-border,#334155)] object-cover"
                         />
                       ))}
                     </div>
@@ -133,9 +143,9 @@ export default function InspectionDetailPage() {
                 </li>
               ))}
             </ul>
-          </div>
+          </Card>
         ))}
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/features/inspections/app/inspection/run/page.tsx
+++ b/features/inspections/app/inspection/run/page.tsx
@@ -7,6 +7,8 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
 import type { Database } from "@shared/types/types/supabase";
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
+import PageShell from "@/features/shared/components/PageShell";
+import Card from "@/features/shared/components/ui/Card";
 
 type DB = Database;
 type TemplateRow = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -163,12 +165,14 @@ export default function RunInspectionPage() {
   }, [sp, router, supabase]);
 
   return (
-    <div className="flex min-h-[60vh] items-center justify-center bg-background px-3 py-4 text-foreground sm:px-6 lg:px-10 xl:px-16">
-      <div className="mx-auto w-full max-w-6xl rounded-2xl border border-slate-700/70 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.10),rgba(15,23,42,0.98))] shadow-[0_18px_45px_rgba(0,0,0,0.85)] backdrop-blur-xl px-4 py-3 text-sm text-muted-foreground">
-        <div className="rounded-xl border border-slate-700/60 bg-slate-950/80 px-4 py-3 text-sm">
-          Preparing inspection…
-        </div>
-      </div>
-    </div>
+    <PageShell
+      eyebrow="Inspection"
+      title="Preparing inspection"
+      description="Normalizing template sections and launching run mode."
+    >
+      <Card className="mx-auto w-full max-w-3xl px-4 py-4 text-sm text-[var(--theme-text-secondary,#94A3B8)]">
+        Preparing inspection…
+      </Card>
+    </PageShell>
   );
 }

--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -10,6 +10,8 @@ import type {
 } from "@inspections/lib/inspection/types";
 import InspectionItemCard from "./InspectionItemCard";
 import { Button } from "@shared/components/ui/Button";
+import Card from "@/features/shared/components/ui/Card";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { pricingStatusClass, pricingStatusText } from "@/features/menu-repair-items/lib/pricingStatus";
 
 interface SectionDisplayProps {
@@ -89,8 +91,6 @@ type ItemExtended = InspectionSection["items"][number] & {
   parts?: PartRow[];
   laborHours?: number | null;
 };
-
-const COPPER = "var(--pfq-copper,#C57A4A)";
 
 function isGridSection(title: string): boolean {
   const t = (title || "").toLowerCase();
@@ -253,27 +253,17 @@ export default function SectionDisplay(props: SectionDisplayProps) {
   };
 
   return (
-    <div className="mb-6 rounded-2xl border border-white/10 bg-black/40 px-4 py-3 shadow-card backdrop-blur-md md:px-5 md:py-4">
+    <Card className="mb-6 px-4 py-3 md:px-5 md:py-4">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--theme-card-border,#334155)] pb-3">
         {gridSection ? (
-          <div
-            className="text-left text-lg font-semibold tracking-wide transition-opacity hover:opacity-80"
-            style={{
-              fontFamily: "Black Ops One, system-ui, sans-serif",
-              color: COPPER,
-            }}
-          >
+          <div className="text-left text-base font-semibold tracking-[0.08em] text-[var(--theme-text-primary,#E2E8F0)] transition-opacity hover:opacity-80 md:text-lg">
             {resolvedTitle}
           </div>
         ) : (
           <button
             onClick={toggleOpen}
-            className="text-left text-lg font-semibold tracking-wide transition-opacity hover:opacity-80"
-            style={{
-              fontFamily: "Black Ops One, system-ui, sans-serif",
-              color: COPPER,
-            }}
+            className="text-left text-base font-semibold tracking-[0.08em] text-[var(--theme-text-primary,#E2E8F0)] transition-opacity hover:opacity-80 md:text-lg"
             aria-expanded={open}
             type="button"
           >
@@ -282,13 +272,13 @@ export default function SectionDisplay(props: SectionDisplayProps) {
         )}
 
         <div className="flex flex-wrap items-center gap-2">
-          <span
-            className="hidden text-[11px] uppercase tracking-wide text-neutral-400 md:inline"
-            style={{ fontFamily: "Roboto, system-ui, sans-serif" }}
-          >
-            {stats.ok} OK · {stats.fail} FAIL · {stats.na} NA · {stats.recommend}{" "}
-            REC · {stats.unset} —
-          </span>
+          <div className="hidden items-center gap-1.5 md:flex">
+            <StatusBadge variant="success">{stats.ok} OK</StatusBadge>
+            <StatusBadge variant="danger">{stats.fail} FAIL</StatusBadge>
+            <StatusBadge variant="info">{stats.na} NA</StatusBadge>
+            <StatusBadge variant="warning">{stats.recommend} REC</StatusBadge>
+            <StatusBadge variant="neutral">{stats.unset} Open</StatusBadge>
+          </div>
 
           {showBulkButtons ? (
             <div className="flex flex-wrap items-center gap-1">
@@ -953,6 +943,6 @@ export default function SectionDisplay(props: SectionDisplayProps) {
           )}
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -48,6 +48,8 @@ import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicl
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
+import Card from "@/features/shared/components/ui/Card";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 
 /* -------------------------- helpers -------------------------- */
 
@@ -2453,14 +2455,15 @@ type SmartMatchRow = {
     : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-40";
 
   const cardBase =
-    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/65 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+    "rounded-[var(--theme-radius-xl,1rem)] border border-[var(--theme-card-border,#334155)] " +
+    "bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_95%,transparent)] " +
+    "text-[var(--theme-text-primary,#E2E8F0)] shadow-[var(--theme-shadow-medium,0_18px_45px_rgba(0,0,0,0.45))] backdrop-blur-xl";
 
   const headerCard = `${cardBase} px-3 py-3 md:px-6 md:py-5 mb-4 md:mb-6`;
   const sectionCard = `${cardBase} px-3 py-3 md:px-5 md:py-5 mb-4 md:mb-6`;
 
   const sectionTitle =
-    "text-base md:text-xl font-semibold text-orange-300 text-center tracking-[0.16em] uppercase";
+    "text-base md:text-lg font-semibold text-[var(--theme-text-primary,#E2E8F0)] text-center tracking-[0.12em] uppercase";
 
   const hint =
     "mt-1 block text-center text-[11px] uppercase tracking-[0.14em] text-neutral-400";
@@ -2527,16 +2530,16 @@ type SmartMatchRow = {
 
       <div
         aria-hidden
-        className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]"
+        className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--brand-accent,#E39A6E)_18%,transparent),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]"
       />
 
       <div className="relative space-y-4">
         <div className={headerCard}>
-          <div className="mb-3 border-b border-orange-300/40 pb-3 text-center">
-            <div className="text-[11px] font-blackops uppercase tracking-[0.22em] text-neutral-400">
+          <div className="mb-3 border-b border-[var(--theme-card-border,#334155)] pb-3 text-center">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--theme-text-muted,#64748B)]">
               Inspection
             </div>
-            <div className="mt-1 text-lg md:text-xl font-blackops text-neutral-50">
+            <div className="mt-1 text-lg md:text-xl font-semibold text-[var(--theme-text-primary,#E2E8F0)]">
               {session?.templateitem || templateName || "Inspection"}
             </div>
           </div>
@@ -2583,19 +2586,20 @@ type SmartMatchRow = {
         </div>
 
         <div className="mt-1 flex items-center justify-center gap-2">
-          <div
-            className={[
-              "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] backdrop-blur",
-              voiceState === "listening"
-                ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-200"
-                : voiceState === "connecting"
-                  ? "border-amber-500/50 bg-amber-500/10 text-amber-200"
-                  : voiceState === "error"
-                    ? "border-red-500/50 bg-red-500/10 text-red-200"
-                    : "border-neutral-600/50 bg-black/40 text-neutral-300",
-              voicePulse ? "shadow-[0_0_0_6px_rgba(16,185,129,0.12)]" : "",
-            ].join(" ")}
-          >
+          <div className={voicePulse ? "rounded-full shadow-[0_0_0_6px_rgba(16,185,129,0.12)]" : ""}>
+            <StatusBadge
+              variant={
+                voiceState === "listening"
+                  ? "success"
+                  : voiceState === "connecting"
+                    ? "warning"
+                    : voiceState === "error"
+                      ? "danger"
+                      : "neutral"
+              }
+              size="md"
+              className="inline-flex items-center gap-2 px-3 py-1"
+            >
             <span
               className={[
                 "h-2 w-2 rounded-full",
@@ -2614,9 +2618,10 @@ type SmartMatchRow = {
               : voiceState === "connecting"
                 ? "Connecting…"
                 : voiceState === "error"
-                  ? "Voice error"
+                ? "Voice error"
                   : "Voice idle"}
             {voicePulse && <span className="text-emerald-200/80">• audio</span>}
+            </StatusBadge>
           </div>
 
           {/* ✅ visible wake indicator so you’re not relying on toast/beep */}
@@ -2647,7 +2652,7 @@ type SmartMatchRow = {
           const linesAdded = session.voiceMeta?.linesAddedToWorkOrder ?? 0;
 
           return (
-            <div className="mt-2 rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 px-3 py-2.5 md:px-4 md:py-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)] backdrop-blur-xl">
+            <Card className="mt-2 px-3 py-2.5 md:px-4 md:py-3">
               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
                 Inspection Summary
               </div>
@@ -2721,12 +2726,12 @@ type SmartMatchRow = {
                   </span>
                 </li>
               </ul>
-            </div>
+            </Card>
           );
         })()}
 
         {Array.isArray(session.voiceTrace) && session.voiceTrace.length > 0 ? (
-          <div className="mt-2 rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/55 px-3 py-2.5 md:px-4 md:py-3 backdrop-blur-xl">
+          <Card className="mt-2 px-3 py-2.5 md:px-4 md:py-3">
             <div className="flex items-center justify-between gap-2">
               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
                 Voice Log
@@ -2775,21 +2780,21 @@ type SmartMatchRow = {
                   );
                 })}
             </div>
-          </div>
+          </Card>
         ) : (
           <div className="mt-2 text-center text-[11px] text-neutral-500">
             No voice commands captured yet.
           </div>
         )}
 
-        <div className="mb-4 rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 px-3 py-2.5 md:px-4 md:py-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)] backdrop-blur-xl">
+        <Card className="mb-4 px-3 py-2.5 md:px-4 md:py-3">
           <ProgressTracker
             currentItem={session.currentItemIndex}
             currentSection={session.currentSectionIndex}
             totalSections={session.sections.length}
             totalItems={session.sections[safeSectionIndex]?.items?.length ?? 0}
           />
-        </div>
+        </Card>
 
         <InspectionFormCtx.Provider value={{ updateItem, updateSection }}>
           {session.sections.map((section, sectionIndex) => {
@@ -3102,13 +3107,13 @@ type SmartMatchRow = {
                             onDismissSmartMatch={dismissSmartMatch}
                           />
 
-                          <div className="mt-4 border-t border-white/10 pt-3">
-                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-400">
+                          <div className="mt-4 border-t border-[var(--theme-card-border,#334155)] pt-3">
+                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-muted,#64748B)]">
                               Add custom item
                             </div>
                             <div className="flex flex-col gap-2 md:flex-row md:items-center">
                               <input
-                                className="flex-1 rounded-lg border border-neutral-700 bg-neutral-900/80 px-3 py-1.5 text-sm text-white placeholder:text-neutral-500 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                                className="flex-1 rounded-lg border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_80%,transparent)] px-3 py-1.5 text-sm text-[var(--theme-text-primary,#E2E8F0)] placeholder:text-[var(--theme-text-muted,#64748B)] focus:border-[var(--brand-accent,#E39A6E)] focus:outline-none focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_55%,transparent)]"
                                 placeholder="Item label (e.g. Rear frame inspection)"
                                 value={newLabel}
                                 onChange={(e) =>
@@ -3121,7 +3126,7 @@ type SmartMatchRow = {
                               />
                               <div className="flex items-center gap-2 md:w-auto">
                                 <select
-                                  className="rounded-lg border border-neutral-700 bg-neutral-900/80 px-2 py-1.5 text-sm text-white focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-400/70"
+                                  className="rounded-lg border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_80%,transparent)] px-2 py-1.5 text-sm text-[var(--theme-text-primary,#E2E8F0)] focus:border-[var(--brand-accent,#E39A6E)] focus:outline-none focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_55%,transparent)]"
                                   value={newUnit}
                                   onChange={(e) =>
                                     setNewItemUnits((prev) => ({


### PR DESCRIPTION
### Motivation
- Reduce visual drift by bringing the generic inspection workspace inline with the app-wide shell/card/status language while keeping inspection workflows intact. 
- Expand system-first UI primitives (shell, card, status badges, typography/spacing tokens) to inspection surfaces without changing business logic or data shape. 

### Description
- Reworked the generic inspection screen to adopt shared primitives and theme tokens by replacing bespoke panel styling with `Card`/`StatusBadge` and variable-driven colors, and normalized custom-input/select styling; preserved all inspection voice/work-order flows and behaviors (`features/inspections/screens/GenericInspectionScreen.tsx`).
- Normalized non-grid section rendering to use `Card` and semantic badges and simplified header typography and section status chips (`features/inspections/lib/inspection/SectionDisplay.tsx`).
- Brought two adjacent inspection surfaces into the same shell language by migrating the inspection detail page and the run/prep page to `PageShell` + `Card` + `StatusBadge` where appropriate, preserving their existing data loading and redirect logic (`features/inspections/app/inspection/[id]/page.tsx`, `features/inspections/app/inspection/run/page.tsx`).
- No API, DB, or workflow changes; changes are purely UI/system normalization scoped to inspection surfaces (theme variable usage, class/token swaps, and visual hierarchy updates). 

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check completed successfully. 
- Verified only UI/presentation files were touched and no schema, API route signatures, or business logic tests were modified or required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93a14541c8328b8ac1720b265140a)