### PR TITLE
Phase 3: strengthen work-order + inspection operational panel hierarchy

### DIFF
--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -48,8 +48,9 @@ import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicl
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
-import Card from "@/features/shared/components/ui/Card";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+import { cn } from "@shared/lib/utils";
 
 /* -------------------------- helpers -------------------------- */
 
@@ -2454,13 +2455,10 @@ type SmartMatchRow = {
     ? "relative mx-auto max-w-[1100px] px-3 py-4 pb-36"
     : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-40";
 
-  const cardBase =
-    "rounded-[var(--theme-radius-xl,1rem)] border border-[var(--theme-card-border,#334155)] " +
-    "bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_95%,transparent)] " +
-    "text-[var(--theme-text-primary,#E2E8F0)] shadow-[var(--theme-shadow-medium,0_18px_45px_rgba(0,0,0,0.45))] backdrop-blur-xl";
-
-  const headerCard = `${cardBase} px-3 py-3 md:px-6 md:py-5 mb-4 md:mb-6`;
-  const sectionCard = `${cardBase} px-3 py-3 md:px-5 md:py-5 mb-4 md:mb-6`;
+  const headerCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-6 md:py-5 mb-4 md:mb-6`;
+  const sectionCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-5 mb-4 md:mb-6`;
+  const supportCard = `${PANEL_VARIANTS.secondary} px-3 py-2.5 md:px-4 md:py-3`;
+  const passiveCard = `${PANEL_VARIANTS.passive} px-3 py-2.5 md:px-4 md:py-3`;
 
   const sectionTitle =
     "text-base md:text-lg font-semibold text-[var(--theme-text-primary,#E2E8F0)] text-center tracking-[0.12em] uppercase";
@@ -2585,7 +2583,9 @@ type SmartMatchRow = {
           </Button>
         </div>
 
-        <div className="mt-1 flex items-center justify-center gap-2">
+        <div className="mt-1 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.85fr)] lg:items-start">
+          <section className="space-y-2">
+            <div className="flex items-center justify-center gap-2 lg:justify-start">
           <div className={voicePulse ? "rounded-full shadow-[0_0_0_6px_rgba(16,185,129,0.12)]" : ""}>
             <StatusBadge
               variant={
@@ -2632,8 +2632,9 @@ type SmartMatchRow = {
           )}
         </div>
 
-        {/* ✅ UI ADDITION: Summary + Voice Log */}
-        {(() => {
+
+            {/* ✅ UI ADDITION: Summary + Voice Log */}
+            {(() => {
           const sections = session.sections ?? [];
           const allItems = sections.flatMap((s) => s.items ?? []);
 
@@ -2652,7 +2653,7 @@ type SmartMatchRow = {
           const linesAdded = session.voiceMeta?.linesAddedToWorkOrder ?? 0;
 
           return (
-            <Card className="mt-2 px-3 py-2.5 md:px-4 md:py-3">
+            <div className={supportCard}>
               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
                 Inspection Summary
               </div>
@@ -2726,12 +2727,14 @@ type SmartMatchRow = {
                   </span>
                 </li>
               </ul>
-            </Card>
+            </div>
           );
         })()}
+          </section>
 
+          <aside className="space-y-2 lg:sticky lg:top-4">
         {Array.isArray(session.voiceTrace) && session.voiceTrace.length > 0 ? (
-          <Card className="mt-2 px-3 py-2.5 md:px-4 md:py-3">
+          <div className={passiveCard}>
             <div className="flex items-center justify-between gap-2">
               <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
                 Voice Log
@@ -2780,21 +2783,23 @@ type SmartMatchRow = {
                   );
                 })}
             </div>
-          </Card>
+          </div>
         ) : (
           <div className="mt-2 text-center text-[11px] text-neutral-500">
             No voice commands captured yet.
           </div>
         )}
 
-        <Card className="mb-4 px-3 py-2.5 md:px-4 md:py-3">
+        <div className={supportCard + " mb-4"}>
           <ProgressTracker
             currentItem={session.currentItemIndex}
             currentSection={session.currentSectionIndex}
             totalSections={session.sections.length}
             totalItems={session.sections[safeSectionIndex]?.items?.length ?? 0}
           />
-        </Card>
+        </div>
+          </aside>
+        </div>
 
         <InspectionFormCtx.Provider value={{ updateItem, updateSection }}>
           {session.sections.map((section, sectionIndex) => {
@@ -2855,7 +2860,7 @@ type SmartMatchRow = {
             return (
               <div
                 key={`${section.title}-${sectionIndex}`}
-                className={sectionCard}
+                className={cn(sectionCard, safeSectionIndex === sectionIndex ? "" : "opacity-95")}
                 data-section-index={sectionIndex}
               >
                 {/* ✅ Only show the OUTER header for GRID sections.

--- a/features/shared/components/ui/panelHierarchy.ts
+++ b/features/shared/components/ui/panelHierarchy.ts
@@ -1,0 +1,28 @@
+import { cn } from "@shared/lib/utils";
+
+const PANEL_BASE =
+  "rounded-[var(--theme-radius-xl,1rem)] border text-[var(--theme-text-primary,#E2E8F0)] backdrop-blur-xl";
+
+export const PANEL_VARIANTS = {
+  primary: cn(
+    PANEL_BASE,
+    "border-[color:color-mix(in_srgb,var(--theme-card-border,#334155)_92%,var(--brand-accent,#E39A6E)_8%)]",
+    "bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_95%,transparent)]",
+    "shadow-[var(--theme-shadow-medium,0_20px_48px_rgba(0,0,0,0.5))]",
+  ),
+  secondary: cn(
+    PANEL_BASE,
+    "border-[var(--theme-card-border,#334155)]",
+    "bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_90%,transparent)]",
+    "shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))]",
+  ),
+  passive: cn(
+    PANEL_BASE,
+    "border-[color:color-mix(in_srgb,var(--theme-card-border,#334155)_85%,transparent)]",
+    "bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_88%,transparent)]",
+    "shadow-[0_8px_22px_rgba(0,0,0,0.22)]",
+  ),
+} as const;
+
+export const OPERATIONAL_META_ROW =
+  "flex items-center justify-between gap-3 border-b border-[var(--theme-card-border,#334155)]/70 pb-2";

--- a/features/work-orders/app/work-orders/editor/page.tsx
+++ b/features/work-orders/app/work-orders/editor/page.tsx
@@ -4,6 +4,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import PageShell from "@/features/shared/components/PageShell";
+import { Button } from "@shared/components/ui/Button";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+import { cn } from "@shared/lib/utils";
 
 type DB = Database;
 type MenuItem = DB["public"]["Tables"]["menu_items"]["Row"];
@@ -26,18 +30,19 @@ type LineDraft = {
   job_type?: "maintenance" | "diagnosis" | "inspection";
 };
 
+const fieldClass =
+  "w-full rounded-lg border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_75%,transparent)] px-3 py-2 text-sm text-[var(--theme-text-primary,#E2E8F0)] placeholder:text-[var(--theme-text-muted,#64748B)] focus:border-[var(--brand-accent,#E39A6E)] focus:outline-none focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_45%,transparent)]";
+
 export default function WorkOrderEditorPage() {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
   const [query, setQuery] = useState("");
   const [filtered, setFiltered] = useState<MenuItem[]>([]);
 
-  // drafts composed in the editor
   const [lines, setLines] = useState<LineDraft[]>([
     { complaint: "", status: "awaiting", job_type: "maintenance" },
   ]);
 
-  // pick a work order to save into
   const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
   const [selectedWOId, setSelectedWOId] = useState<string>("");
 
@@ -45,7 +50,6 @@ export default function WorkOrderEditorPage() {
   const [error, setError] = useState<string>("");
   const [ok, setOk] = useState<string>("");
 
-  // Load recent WOs for the user’s shop + menu items for the user
   useEffect(() => {
     (async () => {
       const {
@@ -53,7 +57,6 @@ export default function WorkOrderEditorPage() {
       } = await supabase.auth.getUser();
       if (!user?.id) return;
 
-      // Pull recent WOs for the user’s shop
       const { data: prof } = await supabase
         .from("profiles")
         .select("shop_id")
@@ -74,7 +77,6 @@ export default function WorkOrderEditorPage() {
         setWorkOrders(wos ?? []);
       }
 
-      // User’s menu items
       const { data: items } = await supabase
         .from("menu_items")
         .select("*")
@@ -143,7 +145,6 @@ export default function WorkOrderEditorPage() {
       return;
     }
 
-    // fetch the WO to pick up vehicle_id
     const { data: wo } = await supabase
       .from("work_orders")
       .select("id, vehicle_id")
@@ -193,169 +194,181 @@ export default function WorkOrderEditorPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl p-6 text-white">
-      <h1 className="text-2xl font-bold mb-4">Work Order Editor</h1>
-
-      {/* Pick a target WO */}
-      <div className="rounded border border-neutral-800 bg-neutral-900 p-4 mb-6">
-        <label className="block text-sm text-neutral-300 mb-1">Save to Work Order</label>
-        <select
-          value={selectedWOId}
-          onChange={(e) => setSelectedWOId(e.target.value)}
-          className="w-full rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-        >
-          <option value="">— Select a recent Work Order —</option>
-          {workOrders.map((wo) => (
-            <option key={wo.id} value={wo.id}>
-              {wo.id.slice(0, 8)} • {wo.type ?? "wo"} • {new Date(wo.created_at!).toLocaleString()}
-            </option>
-          ))}
-        </select>
-        <p className="mt-2 text-xs text-neutral-400">
-          Tip: Create a new work order first from “Create Work Order”, then compose lines here and save into it.
-        </p>
-      </div>
-
-      {/* Quick menu suggestions */}
-      <div className="rounded border border-neutral-800 bg-neutral-900 p-4 mb-6">
-        <label className="block text-sm text-neutral-300 mb-1">Quick Add from Menu</label>
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search your saved menu items"
-          className="w-full rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-        />
-        {filtered.length > 0 && (
-          <ul className="mt-2 max-h-48 overflow-auto rounded border border-neutral-800 bg-neutral-950">
-            {filtered.map((mi) => (
-              <li
-                key={mi.id}
-                className="px-3 py-2 text-sm hover:bg-neutral-800 cursor-pointer"
-                onClick={() => addFromMenu(mi)}
-              >
-                {(mi.name ?? mi.complaint ?? "Untitled")}{" "}
-                {typeof mi.labor_time === "number" ? `• ${mi.labor_time}h` : ""}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      {/* Line editor */}
-      <div className="space-y-4">
-        {lines.map((ln, idx) => (
-          <div key={idx} className="rounded border border-neutral-800 bg-neutral-900 p-4">
-            <div className="grid gap-2 sm:grid-cols-2">
-              <input
-                value={ln.complaint}
-                onChange={(e) => updateLine(idx, { complaint: e.target.value })}
-                placeholder="Complaint"
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              />
-              <input
-                value={ln.cause ?? ""}
-                onChange={(e) => updateLine(idx, { cause: e.target.value })}
-                placeholder="Cause"
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              />
-              <input
-                value={ln.correction ?? ""}
-                onChange={(e) => updateLine(idx, { correction: e.target.value })}
-                placeholder="Correction"
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              />
-              <input
-                value={ln.tools ?? ""}
-                onChange={(e) => updateLine(idx, { tools: e.target.value })}
-                placeholder="Tools"
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              />
-              <input
-                inputMode="decimal"
-                value={ln.labor_time ?? ""}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  updateLine(idx, { labor_time: v === "" ? undefined : Number(v) });
-                }}
-                placeholder="Labor time (hrs)"
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              />
-              <select
-                value={ln.job_type ?? "maintenance"}
-                onChange={(e) => updateLine(idx, { job_type: e.target.value as LineDraft["job_type"] })}
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              >
-                <option value="maintenance">Maintenance</option>
-                <option value="diagnosis">Diagnosis</option>
-                <option value="inspection">Inspection</option>
-              </select>
-              <select
-                value={ln.status ?? "awaiting"}
-                onChange={(e) =>
-                  updateLine(idx, { status: e.target.value as NonNullable<LineDraft["status"]> })
-                }
-                className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-              >
-                <option value="unassigned">Unassigned</option>
-                <option value="assigned">Assigned</option>
-                <option value="awaiting">Awaiting</option>
-                <option value="in_progress">In Progress</option>
-                <option value="on_hold">On Hold</option>
-                <option value="completed">Completed</option>
-              </select>
-              {ln.status === "on_hold" && (
-                <select
-                  value={ln.hold_reason ?? ""}
-                  onChange={(e) =>
-                    updateLine(idx, {
-                      hold_reason: (e.target.value || undefined) as LineDraft["hold_reason"],
-                    })
-                  }
-                  className="rounded bg-neutral-800 border border-neutral-700 p-2 text-white"
-                >
-                  <option value="">Select hold reason</option>
-                  <option value="parts">Parts Hold</option>
-                  <option value="authorization">Awaiting Authorization</option>
-                  <option value="diagnosis_pending">Waiting Diagnosis</option>
-                  <option value="other">Other</option>
-                </select>
-              )}
-            </div>
-
-            <div className="mt-3 flex gap-2">
-              <button
-                type="button"
-                onClick={() => removeLine(idx)}
-                className="text-sm text-red-400 hover:underline"
-              >
-                Remove line
-              </button>
-            </div>
-          </div>
-        ))}
-
-        <button
-          type="button"
-          onClick={addEmptyLine}
-          className="rounded bg-neutral-800 border border-neutral-700 px-3 py-2 text-sm hover:bg-neutral-700"
-        >
-          + Add another line
-        </button>
-      </div>
-
-      {/* Save */}
-      <div className="mt-6">
-        {error && <div className="mb-2 rounded bg-red-100 px-3 py-2 text-red-700">{error}</div>}
-        {ok && <div className="mb-2 rounded bg-green-100 px-3 py-2 text-green-800">{ok}</div>}
-
-        <button
+    <PageShell
+      title="Work Order Editor"
+      eyebrow="Work Orders"
+      description="Compose operational line items, then commit them to an active work order with clear execution ownership."
+      actions={
+        <Button
           onClick={saveToWorkOrder}
           disabled={saving}
-          className="rounded bg-orange-500 px-4 py-2 font-semibold text-black hover:bg-orange-600 disabled:opacity-60"
+          className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em]"
         >
-          {saving ? "Saving…" : "Save lines to selected Work Order"}
-        </button>
+          {saving ? "Saving…" : "Save to selected work order"}
+        </Button>
+      }
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.9fr)]">
+        <section className={cn(PANEL_VARIANTS.primary, "space-y-4 px-4 py-4 md:px-5 md:py-5")}>
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--theme-card-border,#334155)] pb-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-muted,#64748B)]">
+                Primary workflow zone
+              </p>
+              <h2 className="text-lg font-semibold text-[var(--theme-text-primary,#E2E8F0)]">
+                Compose and stage work-order lines
+              </h2>
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={addEmptyLine}>
+              + Add line
+            </Button>
+          </div>
+
+          <div className="space-y-3">
+            {lines.map((ln, idx) => (
+              <article
+                key={idx}
+                className={cn(
+                  PANEL_VARIANTS.secondary,
+                  "space-y-3 px-3 py-3 md:px-4",
+                )}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-text-muted,#64748B)]">
+                    Line {idx + 1}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => removeLine(idx)}
+                    className="text-xs font-medium text-rose-300 hover:text-rose-200"
+                  >
+                    Remove
+                  </button>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <input value={ln.complaint} onChange={(e) => updateLine(idx, { complaint: e.target.value })} placeholder="Complaint" className={fieldClass} />
+                  <input value={ln.cause ?? ""} onChange={(e) => updateLine(idx, { cause: e.target.value })} placeholder="Cause" className={fieldClass} />
+                  <input value={ln.correction ?? ""} onChange={(e) => updateLine(idx, { correction: e.target.value })} placeholder="Correction" className={fieldClass} />
+                  <input value={ln.tools ?? ""} onChange={(e) => updateLine(idx, { tools: e.target.value })} placeholder="Tools" className={fieldClass} />
+                  <input
+                    inputMode="decimal"
+                    value={ln.labor_time ?? ""}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      updateLine(idx, { labor_time: v === "" ? undefined : Number(v) });
+                    }}
+                    placeholder="Labor time (hrs)"
+                    className={fieldClass}
+                  />
+                  <select value={ln.job_type ?? "maintenance"} onChange={(e) => updateLine(idx, { job_type: e.target.value as LineDraft["job_type"] })} className={fieldClass}>
+                    <option value="maintenance">Maintenance</option>
+                    <option value="diagnosis">Diagnosis</option>
+                    <option value="inspection">Inspection</option>
+                  </select>
+                  <select
+                    value={ln.status ?? "awaiting"}
+                    onChange={(e) => updateLine(idx, { status: e.target.value as NonNullable<LineDraft["status"]> })}
+                    className={fieldClass}
+                  >
+                    <option value="unassigned">Unassigned</option>
+                    <option value="assigned">Assigned</option>
+                    <option value="awaiting">Awaiting</option>
+                    <option value="in_progress">In Progress</option>
+                    <option value="on_hold">On Hold</option>
+                    <option value="completed">Completed</option>
+                  </select>
+                  {ln.status === "on_hold" && (
+                    <select
+                      value={ln.hold_reason ?? ""}
+                      onChange={(e) =>
+                        updateLine(idx, {
+                          hold_reason: (e.target.value || undefined) as LineDraft["hold_reason"],
+                        })
+                      }
+                      className={fieldClass}
+                    >
+                      <option value="">Select hold reason</option>
+                      <option value="parts">Parts Hold</option>
+                      <option value="authorization">Awaiting Authorization</option>
+                      <option value="diagnosis_pending">Waiting Diagnosis</option>
+                      <option value="other">Other</option>
+                    </select>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <section className={cn(PANEL_VARIANTS.secondary, "space-y-3 px-4 py-4") }>
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-muted,#64748B)]">
+                Secondary context
+              </p>
+              <h3 className="text-sm font-semibold">Target work order</h3>
+            </div>
+            <select value={selectedWOId} onChange={(e) => setSelectedWOId(e.target.value)} className={fieldClass}>
+              <option value="">— Select a recent Work Order —</option>
+              {workOrders.map((wo) => (
+                <option key={wo.id} value={wo.id}>
+                  {wo.id.slice(0, 8)} • {wo.type ?? "wo"} • {new Date(wo.created_at!).toLocaleString()}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-[var(--theme-text-muted,#64748B)]">
+              Select one active order, then commit staged lines when ready.
+            </p>
+          </section>
+
+          <section className={cn(PANEL_VARIANTS.passive, "space-y-3 px-4 py-4") }>
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-muted,#64748B)]">
+                Passive support
+              </p>
+              <h3 className="text-sm font-semibold">Quick add from menu</h3>
+            </div>
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search saved menu items"
+              className={fieldClass}
+            />
+            {filtered.length > 0 && (
+              <ul className="max-h-56 space-y-1 overflow-auto">
+                {filtered.map((mi) => (
+                  <li key={mi.id}>
+                    <button
+                      type="button"
+                      className="w-full rounded-md border border-[var(--theme-card-border,#334155)] bg-black/20 px-2.5 py-2 text-left text-xs text-[var(--theme-text-secondary,#94A3B8)] hover:border-[var(--brand-accent,#E39A6E)]/70"
+                      onClick={() => addFromMenu(mi)}
+                    >
+                      {(mi.name ?? mi.complaint ?? "Untitled")}
+                      {typeof mi.labor_time === "number" ? ` • ${mi.labor_time}h` : ""}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {(error || ok) && (
+            <section
+              className={cn(
+                PANEL_VARIANTS.passive,
+                "px-4 py-3 text-sm",
+                error ? "border-rose-500/40" : "border-emerald-500/40",
+              )}
+            >
+              {error ? (
+                <p className="text-rose-200">{error}</p>
+              ) : (
+                <p className="text-emerald-200">{ok}</p>
+              )}
+            </section>
+          )}
+        </aside>
       </div>
-    </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Introduce a lightweight, reusable panel hierarchy to advance Phase 3 operational cockpit goals (primary/secondary/passive) without changing workflows or theme variables.  
- Improve visual ownership and action hierarchy on the highest-value operational surfaces (Work Orders editor and Inspection execution) so the main execution area is dominant and supporting context is quieter.  
- Keep changes additive and non-breaking, preserving routing, auth, business logic, and branding variables.

### Description
- Added a shared primitive `PANEL_VARIANTS` in `features/shared/components/ui/panelHierarchy.ts` that exposes `primary`, `secondary`, and `passive` variants driven by existing theme CSS variables.  
- Refactored the Work Order Editor (`features/work-orders/app/work-orders/editor/page.tsx`) into a command-oriented layout with a dominant primary composition zone, a secondary target-work-order panel, and a passive quick-add/search panel, and promoted the primary CTA into `PageShell` actions.  
- Reworked the Inspection execution screen (`features/inspections/screens/GenericInspectionScreen.tsx`) to place the summary into a support panel, the voice log into a passive right rail, and the progress tracker into a support signal region while preserving all inspection logic and actions.  
- Changes are presentational only and reuse existing primitives (`PageShell`, `Button`, theme variables), with no schema, route, auth, or workflow logic modifications.

### Testing
- Ran type-checking with `npx tsc --noEmit`, which completed successfully (type-check passed).  
- No automated UI tests were added; the change is layout/presentation focused and validated via static type-checking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d940c0c8e48328bc34c8dc7baf2082)