### PR TITLE
Phase 4: Normalize owner settings panel hierarchy and branding controls

### DIFF
--- a/features/branding/components/BrandStudioSummaryCard.tsx
+++ b/features/branding/components/BrandStudioSummaryCard.tsx
@@ -4,18 +4,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { useActiveBrand } from "@/features/branding/hooks/useActiveBrand";
 import { Button } from "@shared/components/ui/Button";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 
 function Swatch({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
-        {label}
-      </div>
+      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">{label}</div>
       <div className="mt-2 flex items-center gap-3">
-        <span
-          className="h-8 w-8 rounded-md border border-white/10"
-          style={{ backgroundColor: value }}
-        />
+        <span className="h-8 w-8 rounded-md border border-white/10" style={{ backgroundColor: value }} />
         <span className="text-sm text-neutral-200">{value}</span>
       </div>
     </div>
@@ -29,17 +25,13 @@ export default function BrandStudioSummaryCard() {
   const profile = data?.profile ?? null;
 
   return (
-    <section className="space-y-4 rounded-2xl border border-white/10 bg-black/25 p-5">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <section id="branding-system" className={`${PANEL_VARIANTS.primary} space-y-4 p-5`}>
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--theme-card-border,#334155)]/70 pb-3">
         <div>
-          <div className="text-xs uppercase tracking-[0.18em] text-neutral-400">
-            Brand identity
-          </div>
-          <h2 className="mt-1 text-sm font-semibold text-neutral-50">
-            Brand Studio
-          </h2>
+          <div className="text-xs uppercase tracking-[0.18em] text-neutral-400">Brand system</div>
+          <h2 className="mt-1 text-sm font-semibold text-neutral-50">Brand Studio</h2>
           <p className="mt-1 text-[12px] text-neutral-400">
-            Manage active logo, colors, style preset, and generated assets.
+            Configure active logo, theme palette, and style preset used across the app.
           </p>
         </div>
 
@@ -49,54 +41,31 @@ export default function BrandStudioSummaryCard() {
       </div>
 
       {loading ? (
-        <div className="text-sm text-neutral-400">Loading brand…</div>
+        <div className="text-sm text-neutral-400">Loading brand...</div>
       ) : (
         <>
           <div className="grid gap-4 md:grid-cols-[180px_1fr]">
             <div className="rounded-xl border border-white/10 bg-black/30 p-4">
-              <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
-                Active logo
-              </div>
+              <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Active logo</div>
 
               <div className="mt-3 flex h-28 items-center justify-center rounded-lg border border-white/10 bg-black/30">
                 {logoUrl ? (
-                  <Image
-                    src={logoUrl}
-                    alt="Active logo"
-                    width={160}
-                    height={80}
-                    className="max-h-20 max-w-full object-contain"
-                    unoptimized
-                  />
+                  <Image src={logoUrl} alt="Active logo" width={160} height={80} className="max-h-20 max-w-full object-contain" unoptimized />
                 ) : (
-                  <span className="text-sm text-neutral-500">
-                    No active logo
-                  </span>
+                  <span className="text-sm text-neutral-500">No active logo</span>
                 )}
               </div>
             </div>
 
             <div className="grid gap-3 md:grid-cols-3">
-              <Swatch
-                label="Primary"
-                value={profile?.primary_color ?? "#C1663B"}
-              />
-              <Swatch
-                label="Secondary"
-                value={profile?.secondary_color ?? "#050910"}
-              />
-              <Swatch
-                label="Accent"
-                value={profile?.accent_color ?? "#E39A6E"}
-              />
+              <Swatch label="Primary" value={profile?.primary_color ?? "#C1663B"} />
+              <Swatch label="Secondary" value={profile?.secondary_color ?? "#050910"} />
+              <Swatch label="Accent" value={profile?.accent_color ?? "#E39A6E"} />
             </div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-neutral-300">
-            Active style:{" "}
-            <span className="font-medium text-neutral-100">
-              {profile?.style_preset ?? "clean-oem"}
-            </span>
+            Active style: <span className="font-medium text-neutral-100">{profile?.style_preset ?? "clean-oem"}</span>
           </div>
         </>
       )}

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -9,13 +9,13 @@ import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
 import { Input } from "@shared/components/ui/input";
-import { Button } from "@shared/components/ui/Button";
 import OwnerPinModal from "@shared/components/OwnerPinModal";
 import OwnerSettingsHeader from "@/features/dashboard/components/owner-settings/OwnerSettingsHeader";
 import OwnerSettingsBusinessSection from "@/features/dashboard/components/owner-settings/OwnerSettingsBusinessSection";
 import OwnerSettingsOperationsSection from "@/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection";
 import OwnerSettingsSchedulingSection from "@/features/dashboard/components/owner-settings/OwnerSettingsSchedulingSection";
 import OwnerSettingsSidebar from "@/features/dashboard/components/owner-settings/OwnerSettingsSidebar";
+import { OwnerSettingsPanel, OwnerSettingsSectionIntro, OwnerSettingsStat } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSummaryCard";
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
 
@@ -283,7 +283,6 @@ export default function OwnerSettingsPage() {
   const labelClass = "text-xs text-neutral-400";
   const navChipClass =
     "inline-flex items-center rounded-full border border-white/10 bg-black/30 px-3 py-1.5 text-xs font-semibold text-neutral-300 transition hover:bg-black/40 hover:text-white";
-  const sectionClass = "space-y-3 rounded-2xl border border-white/10 bg-black/25 p-5";
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1000);
@@ -1004,43 +1003,7 @@ try {
     );
   })();
 
-  const seatLimitLabel =
-    seatsLimit == null ? "Unlimited" : `${seatsUsed}/${seatsLimit}`;
-
-  const seatPill = (() => {
-    const base =
-      "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold";
-
-    if (seatsLimit == null) {
-      return (
-        <span className={`${base} border-white/10 bg-black/40 text-neutral-200`}>
-          Seats: Unlimited
-        </span>
-      );
-    }
-
-    if (seatsUsed >= seatsLimit) {
-      return (
-        <span className={`${base} border-red-500/25 bg-red-950/25 text-red-100`}>
-          Seats: {seatLimitLabel}
-        </span>
-      );
-    }
-
-    if (seatsLimit > 0 && seatsUsed / seatsLimit >= 0.9) {
-      return (
-        <span className={`${base} border-amber-500/25 bg-amber-950/20 text-amber-100`}>
-          Seats: {seatLimitLabel}
-        </span>
-      );
-    }
-
-    return (
-      <span className={`${base} border-white/10 bg-black/40 text-neutral-200`}>
-        Seats: {seatLimitLabel}
-      </span>
-    );
-  })();
+  const seatLimitLabel = seatsLimit == null ? "Unlimited" : `${seatsUsed}/${seatsLimit}`;
 
     return (
     <div className="mx-auto flex max-w-7xl flex-col gap-5 p-5 text-foreground lg:p-6">
@@ -1052,196 +1015,21 @@ try {
         onSave={handleSave}
       />
 
-      <section className={sectionClass}>
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-            Plan: <span className="text-neutral-100">{planLabel(plan)}</span>
-          </span>
-          <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-            Seats: <span className="text-neutral-100">{seatLimitLabel}</span>
-          </span>
-          <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-            Billing: <span className="text-neutral-100">{String(subStatus).toUpperCase()}</span>
-          </span>
-          <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-            Stripe: <span className="text-neutral-100">{stripeAccountId ? "Connected" : "Not connected"}</span>
-          </span>
-          {orgId ? (
-            <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-              Org: <span className="text-neutral-100">{orgName || "Linked"}</span>
-            </span>
-          ) : null}
+      <OwnerSettingsPanel
+        tone="passive"
+        title="System summary"
+        description="Current plan, seat utilization, and organization scope."
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <OwnerSettingsStat label="Plan" value={planLabel(plan)} />
+          <OwnerSettingsStat label="Seats" value={seatLimitLabel} />
+          <OwnerSettingsStat label="Billing" value={String(subStatus).toUpperCase()} />
+          <OwnerSettingsStat
+            label="Stripe"
+            value={stripeAccountId ? "Connected" : "Not connected"}
+          />
         </div>
-      </section>
-
-      {/* ✅ Plan + Seats */}
-      <section className={sectionClass}>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="text-sm font-semibold text-neutral-50">Plan & seats</h2>
-            <p className="text-[11px] text-neutral-400">
-              Staff users are counted from{" "}
-              <span className="font-mono">profiles</span> for this shop. Starter and
-              Pro are limited.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-              Plan: <span className="text-neutral-100">{planLabel(plan)}</span>
-            </span>
-            {seatPill}
-          </div>
-        </div>
-
-        <div className="grid gap-2 md:grid-cols-3 text-sm">
-          <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-            <div className="text-[11px] text-neutral-400">Seats used</div>
-            <div className="mt-1 text-sm font-semibold text-neutral-100">
-              {seatsUsed}
-            </div>
-          </div>
-
-          <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-            <div className="text-[11px] text-neutral-400">Seat limit</div>
-            <div className="mt-1 text-sm font-semibold text-neutral-100">
-              {seatsLimit == null ? "Unlimited" : seatsLimit}
-            </div>
-          </div>
-
-          <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-            <div className="text-[11px] text-neutral-400">Remaining</div>
-            <div className="mt-1 text-sm font-semibold text-neutral-100">
-              {seatsLimit == null ? "—" : Math.max(0, seatsLimit - seatsUsed)}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ✅ Organization + Locations */}
-      <section className={sectionClass}>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="text-sm font-semibold text-neutral-50">Organization</h2>
-            <p className="text-[11px] text-neutral-400">
-              Manage multi-location accounts. Each location is billed separately.
-            </p>
-          </div>
-          <div className="text-xs text-neutral-300">
-            {orgId ? (
-              <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1">
-                Org: <span className="text-neutral-100">{orgName || "—"}</span>
-              </span>
-            ) : (
-              <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1">
-                No organization linked
-              </span>
-            )}
-          </div>
-        </div>
-
-        {orgId ? (
-          <>
-            <div className="grid gap-2 md:grid-cols-3 text-sm">
-              <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-                <div className="text-[11px] text-neutral-400">Organization name</div>
-                <div className="mt-1 text-sm font-semibold text-neutral-100">
-                  {orgName || "—"}
-                </div>
-              </div>
-
-              <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-                <div className="text-[11px] text-neutral-400">Organization ID</div>
-                <div className="mt-1 truncate text-sm font-semibold text-neutral-100">
-                  {orgId}
-                </div>
-              </div>
-
-              <div className="rounded-lg border border-white/10 bg-black/25 p-3">
-                <div className="text-[11px] text-neutral-400">Locations</div>
-                <div className="mt-1 text-sm font-semibold text-neutral-100">
-                  {locations.length}
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <div className="text-xs font-semibold text-neutral-200">Locations</div>
-
-              {locations.length === 0 ? (
-                <div className="text-xs text-neutral-500">No locations found.</div>
-              ) : (
-                <ul className="space-y-3">
-                  {locations.map((loc) => {
-                    const isCurrent = loc.id === shopId;
-                    const status = parseStripeStatus(loc.stripe_subscription_status);
-
-                    const statusChip =
-                      status === "active" ? (
-                        <span className="rounded-full border border-emerald-500/20 bg-emerald-950/20 px-2 py-0.5 text-[10px] font-semibold text-emerald-100">
-                          ACTIVE
-                        </span>
-                      ) : status === "trialing" ? (
-                        <span className="rounded-full border border-white/10 bg-black/40 px-2 py-0.5 text-[10px] font-semibold text-neutral-200">
-                          TRIAL
-                        </span>
-                      ) : status === "past_due" ||
-                        status === "unpaid" ||
-                        status === "incomplete" ? (
-                        <span className="rounded-full border border-red-500/25 bg-red-950/25 px-2 py-0.5 text-[10px] font-semibold text-red-100">
-                          BILLING ISSUE
-                        </span>
-                      ) : (
-                        <span className="rounded-full border border-white/10 bg-black/40 px-2 py-0.5 text-[10px] font-semibold text-neutral-200">
-                          {String(status).toUpperCase()}
-                        </span>
-                      );
-
-                    return (
-                      <li
-                        key={loc.id}
-                        className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-black/25 px-3 py-2"
-                      >
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-2">
-                            <div className="truncate text-sm font-semibold text-neutral-100">
-                              {locationName(loc)}
-                            </div>
-                            {statusChip}
-                            {isCurrent ? (
-                              <span className="rounded-full border border-white/10 bg-black/40 px-2 py-0.5 text-[10px] font-semibold text-neutral-200">
-                                CURRENT
-                              </span>
-                            ) : null}
-                          </div>
-                          <div className="text-xs text-neutral-400">
-                            {formatLocationLine({
-                              city: loc.city ?? null,
-                              province: loc.province ?? null,
-                            })}
-                          </div>
-                        </div>
-
-                        <Button
-                          size="sm"
-                          variant={isCurrent ? "secondary" : "default"}
-                          disabled={!isUnlocked || isCurrent}
-                          onClick={() => void switchLocation(loc.id)}
-                        >
-                          {isCurrent ? "Selected" : "Switch"}
-                        </Button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
-          </>
-        ) : (
-          <div className="text-xs text-neutral-500">
-            This account is not linked to an organization yet.
-          </div>
-        )}
-      </section>
+      </OwnerSettingsPanel>
 
 
       <div className="sticky top-2 z-10 rounded-2xl border border-white/10 bg-black/35 p-3 backdrop-blur">
@@ -1260,6 +1048,10 @@ try {
 
       <div className="grid gap-5 lg:grid-cols-[1.7fr_0.95fr] lg:items-start">
         <div className="space-y-5">
+          <OwnerSettingsSectionIntro
+            title="Primary configuration"
+            description="Core identity and experience controls for your operational cockpit."
+          />
           <OwnerSettingsBusinessSection
             isUnlocked={isUnlocked}
             country={country}
@@ -1322,12 +1114,21 @@ try {
           />
           <BrandStudioSummaryCard />
 
-          <section id="quickbooks-integration" className={sectionClass}>
-            <QuickBooksConnectCard />
-          </section>
+          <OwnerSettingsSectionIntro
+            title="Secondary configuration"
+            description="Operational defaults, communication, and integrations."
+          />
 
-          <section id="communication-branding" className={sectionClass}>
-            <h2 className="text-sm font-semibold text-neutral-50">Communication</h2>
+          <OwnerSettingsPanel id="quickbooks-integration" tone="secondary" title="Accounting integration">
+            <QuickBooksConnectCard />
+          </OwnerSettingsPanel>
+
+          <OwnerSettingsPanel
+            id="communication-branding"
+            tone="secondary"
+            title="Communication"
+            description="Invoice defaults and completion messaging."
+          >
             <Input
               value={invoiceTerms}
               onChange={(e) => setInvoiceTerms(e.target.value)}
@@ -1349,7 +1150,12 @@ try {
               />
               Email customer when job is complete
             </label>
-          </section>
+          </OwnerSettingsPanel>
+
+          <OwnerSettingsSectionIntro
+            title="Passive controls"
+            description="Scheduling and calendar constraints that support shop operations."
+          />
 
           <OwnerSettingsSchedulingSection
             isUnlocked={isUnlocked}

--- a/features/dashboard/components/owner-settings/OwnerSettingsBusinessSection.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsBusinessSection.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
+import { OwnerSettingsPanel } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 
 type FileInputChangeEvent = {
   target: {
@@ -84,14 +85,12 @@ export default function OwnerSettingsBusinessSection({
   onGenerateLogo,
 }: Props) {
   return (
-    <SettingsSectionLike>
-      <div>
-        <h2 className="text-sm font-semibold text-neutral-50">Shop info</h2>
-        <p className="text-[11px] text-neutral-400">
-          Business identity, contact details, and location defaults.
-        </p>
-      </div>
-
+    <OwnerSettingsPanel
+      id="shop-info"
+      tone="secondary"
+      title="Business profile"
+      description="Business identity, contact details, and location defaults."
+    >
       <div className="grid gap-2 md:grid-cols-2">
         <div className="space-y-1">
           <div className={labelClass}>Country</div>
@@ -188,12 +187,7 @@ export default function OwnerSettingsBusinessSection({
           />
         </div>
 
-        <Button
-          onClick={onGenerateLogo}
-          variant="secondary"
-          className="mt-1"
-          disabled={!isUnlocked}
-        >
+        <Button onClick={onGenerateLogo} variant="secondary" className="mt-1" disabled={!isUnlocked}>
           Generate logo with AI
         </Button>
 
@@ -208,14 +202,6 @@ export default function OwnerSettingsBusinessSection({
           />
         ) : null}
       </div>
-    </SettingsSectionLike>
-  );
-}
-
-function SettingsSectionLike({ children }: { children: React.ReactNode }) {
-  return (
-    <section className="space-y-3 rounded-2xl border border-white/10 bg-black/25 p-4 shadow-[0_8px_30px_rgba(0,0,0,0.18)]">
-      {children}
-    </section>
+    </OwnerSettingsPanel>
   );
 }

--- a/features/dashboard/components/owner-settings/OwnerSettingsHeader.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsHeader.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@shared/components/ui/Button";
 import OwnerPinBadge from "@shared/components/OwnerPinBadge";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 
 type Props = {
   isUnlocked: boolean;
@@ -19,24 +20,27 @@ export default function OwnerSettingsHeader({
   onSave,
 }: Props) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3">
+    <div className={`${PANEL_VARIANTS.primary} flex flex-wrap items-center justify-between gap-4 p-5`}>
       <div>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted,#64748B)]">
+          Owner control center
+        </p>
         <h1 className="text-2xl font-blackops text-orange-400">Shop Settings</h1>
-        <p className="text-xs text-neutral-400">
-          Location, billing, operations, and scheduling.
+        <p className="text-xs text-[color:var(--theme-text-secondary,#94A3B8)]">
+          Configure branding, operations, billing, and scheduling from one operational console.
         </p>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-end gap-2">
         <OwnerPinBadge expiresAt={pinExpiresAt} />
-        <Button size="sm" onClick={onUnlock}>
-          {isUnlocked ? "Re-unlock" : "Unlock"}
+        <Button size="sm" variant="secondary" onClick={onUnlock}>
+          {isUnlocked ? "Re-unlock" : "Unlock controls"}
         </Button>
         <Button size="sm" variant="secondary" onClick={onLock}>
           Lock
         </Button>
         <Button size="sm" onClick={onSave} disabled={!isUnlocked}>
-          {isUnlocked ? "Save all" : "Unlock to save"}
+          {isUnlocked ? "Save settings" : "Unlock to save"}
         </Button>
       </div>
     </div>

--- a/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx
@@ -2,6 +2,7 @@
 
 import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
+import { OwnerSettingsPanel } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 
 type Props = {
   isUnlocked: boolean;
@@ -35,33 +36,6 @@ type Props = {
   onAppearanceModeChange: (value: "dark" | "light" | "system") => void;
 };
 
-function SectionShell({
-  title,
-  description,
-  action,
-  children,
-}: {
-  title: string;
-  description?: string;
-  action?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="space-y-3 rounded-2xl border border-white/10 bg-black/25 p-4 shadow-[0_8px_30px_rgba(0,0,0,0.18)]">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-semibold text-neutral-50">{title}</h2>
-          {description ? (
-            <p className="text-[11px] text-neutral-400">{description}</p>
-          ) : null}
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
-      </div>
-      {children}
-    </section>
-  );
-}
-
 export default function OwnerSettingsOperationsSection({
   isUnlocked,
   currency,
@@ -94,12 +68,14 @@ export default function OwnerSettingsOperationsSection({
   onAppearanceModeChange,
 }: Props) {
   return (
-    <div className="grid gap-6 md:grid-cols-2">
-      <SectionShell
+    <div className="grid gap-5 md:grid-cols-2">
+      <OwnerSettingsPanel
+        id="operations-defaults"
+        tone="secondary"
         title="Operations defaults"
         description="Default pricing values used across work orders and quotes."
       >
-        <div className="grid gap-3 md:grid-cols-2 text-sm">
+        <div className="grid gap-3 text-sm md:grid-cols-2">
           <Input
             value={laborRate}
             onChange={(e) => onLaborRateChange(e.target.value)}
@@ -125,11 +101,13 @@ export default function OwnerSettingsOperationsSection({
             disabled={!isUnlocked}
           />
         </div>
-      </SectionShell>
+      </OwnerSettingsPanel>
 
-      <SectionShell
+      <OwnerSettingsPanel
+        id="pricing-validity"
+        tone="passive"
         title="Pricing validity"
-        description="Controls how many days menu repair pricing stays fresh before it becomes stale or expired."
+        description="Controls how long menu pricing remains fresh before requiring review."
         action={
           <Button
             onClick={onSavePricingValidDays}
@@ -140,7 +118,7 @@ export default function OwnerSettingsOperationsSection({
           </Button>
         }
       >
-        <div className="grid gap-3 md:grid-cols-[160px_1fr] text-sm">
+        <div className="grid gap-3 text-sm md:grid-cols-[160px_1fr]">
           <Input
             type="number"
             min={1}
@@ -153,15 +131,16 @@ export default function OwnerSettingsOperationsSection({
             disabled={!isUnlocked || pricingValidDaysLoading || pricingValidDaysSaving}
           />
           <div className="rounded-lg border border-white/10 bg-black/25 p-3 text-[11px] text-neutral-400">
-            Default is 30 days. Allowed range is 1 to 90 days. Fresh pricing can
-            auto-flow faster; stale or expired pricing requires more review.
+            Default is 30 days. Allowed range is 1 to 90 days.
           </div>
         </div>
-      </SectionShell>
+      </OwnerSettingsPanel>
 
-      <SectionShell
-        title="Appearance"
-        description="Set your operational console mode. Preference persists per user and syncs with brand variables."
+      <OwnerSettingsPanel
+        id="appearance-mode"
+        tone="primary"
+        title="Appearance mode"
+        description="Select Dark, Light, or System mode as part of your shop branding profile."
       >
         <div className="flex flex-wrap gap-2">
           {([
@@ -181,63 +160,40 @@ export default function OwnerSettingsOperationsSection({
             </Button>
           ))}
         </div>
-        <p className="text-[11px] text-neutral-400">
-          {appearanceSaving ? "Saving appearance preference…" : "Applies immediately after save."}
+        <p className="text-[11px] text-[color:var(--theme-text-secondary,#94A3B8)]">
+          {appearanceSaving ? "Saving appearance preference..." : "Preference persists per user and applies immediately."}
         </p>
-      </SectionShell>
+      </OwnerSettingsPanel>
 
-      <SectionShell
+      <OwnerSettingsPanel
+        id="workflow-automation"
+        tone="secondary"
         title="Workflow & automation"
         description="Operational rules and automatic behaviors for shop workflows."
       >
         <div className="space-y-3">
           <label className="flex items-center gap-2 text-sm text-neutral-200">
-            <input
-              type="checkbox"
-              checked={useAi}
-              onChange={(e) => onUseAiChange(e.target.checked)}
-              disabled={!isUnlocked}
-            />
+            <input type="checkbox" checked={useAi} onChange={(e) => onUseAiChange(e.target.checked)} disabled={!isUnlocked} />
             Use AI features
           </label>
           <label className="flex items-center gap-2 text-sm text-neutral-200">
-            <input
-              type="checkbox"
-              checked={requireCauseCorrection}
-              onChange={(e) => onRequireCauseCorrectionChange(e.target.checked)}
-              disabled={!isUnlocked}
-            />
+            <input type="checkbox" checked={requireCauseCorrection} onChange={(e) => onRequireCauseCorrectionChange(e.target.checked)} disabled={!isUnlocked} />
             Require cause / correction on lines
           </label>
           <label className="flex items-center gap-2 text-sm text-neutral-200">
-            <input
-              type="checkbox"
-              checked={requireAuthorization}
-              onChange={(e) => onRequireAuthorizationChange(e.target.checked)}
-              disabled={!isUnlocked}
-            />
+            <input type="checkbox" checked={requireAuthorization} onChange={(e) => onRequireAuthorizationChange(e.target.checked)} disabled={!isUnlocked} />
             Require customer authorization
           </label>
           <label className="flex items-center gap-2 text-sm text-neutral-200">
-            <input
-              type="checkbox"
-              checked={autoGeneratePdf}
-              onChange={(e) => onAutoGeneratePdfChange(e.target.checked)}
-              disabled={!isUnlocked}
-            />
+            <input type="checkbox" checked={autoGeneratePdf} onChange={(e) => onAutoGeneratePdfChange(e.target.checked)} disabled={!isUnlocked} />
             Auto-generate quote PDF
           </label>
           <label className="flex items-center gap-2 text-sm text-neutral-200">
-            <input
-              type="checkbox"
-              checked={autoSendQuoteEmail}
-              onChange={(e) => onAutoSendQuoteEmailChange(e.target.checked)}
-              disabled={!isUnlocked}
-            />
+            <input type="checkbox" checked={autoSendQuoteEmail} onChange={(e) => onAutoSendQuoteEmailChange(e.target.checked)} disabled={!isUnlocked} />
             Auto-send quote email
           </label>
         </div>
-      </SectionShell>
+      </OwnerSettingsPanel>
     </div>
   );
 }

--- a/features/dashboard/components/owner-settings/OwnerSettingsPanels.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsPanels.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { cn } from "@shared/lib/utils";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+
+type PanelTone = keyof typeof PANEL_VARIANTS;
+
+export function OwnerSettingsPanel({
+  id,
+  tone = "secondary",
+  title,
+  description,
+  action,
+  children,
+  className,
+  bodyClassName,
+}: {
+  id?: string;
+  tone?: PanelTone;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  bodyClassName?: string;
+}) {
+  return (
+    <section id={id} className={cn(PANEL_VARIANTS[tone], "space-y-4 p-5", className)}>
+      <header className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--theme-card-border,#334155)]/70 pb-3">
+        <div>
+          <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary,#E2E8F0)]">
+            {title}
+          </h2>
+          {description ? (
+            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary,#94A3B8)]">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </header>
+
+      <div className={cn("space-y-3", bodyClassName)}>{children}</div>
+    </section>
+  );
+}
+
+export function OwnerSettingsSectionIntro({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted,#64748B)]">
+        {title}
+      </p>
+      <p className="text-sm text-[color:var(--theme-text-secondary,#94A3B8)]">{description}</p>
+    </div>
+  );
+}
+
+export function OwnerSettingsStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--theme-card-border,#334155)]/70 bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_85%,transparent)] p-3">
+      <div className="text-[11px] text-[color:var(--theme-text-muted,#64748B)]">{label}</div>
+      <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary,#E2E8F0)]">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/features/dashboard/components/owner-settings/OwnerSettingsSchedulingSection.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSchedulingSection.tsx
@@ -2,6 +2,7 @@
 
 import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
+import { OwnerSettingsPanel } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 
 type HourRow = {
   weekday: number;
@@ -19,38 +20,6 @@ type TimeOffRow = {
 };
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
-function SectionShell({
-  id,
-  title,
-  description,
-  action,
-  children,
-}: {
-  id?: string;
-  title: string;
-  description?: string;
-  action?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <section
-      id={id}
-      className="space-y-3 rounded-2xl border border-white/10 bg-black/25 p-4 shadow-[0_8px_30px_rgba(0,0,0,0.18)]"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-semibold text-neutral-50">{title}</h2>
-          {description ? (
-            <p className="text-[11px] text-neutral-400">{description}</p>
-          ) : null}
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
-      </div>
-      {children}
-    </section>
-  );
-}
 
 type Props = {
   isUnlocked: boolean;
@@ -85,8 +54,9 @@ export default function OwnerSettingsSchedulingSection({
 }: Props) {
   return (
     <div className="space-y-5">
-      <SectionShell
+      <OwnerSettingsPanel
         id="hours-settings"
+        tone="secondary"
         title="Hours"
         description="Controls public booking availability for each day."
         action={
@@ -108,13 +78,8 @@ export default function OwnerSettingsSchedulingSection({
               const closed = !!row.closed;
 
               return (
-                <div
-                  key={row.weekday}
-                  className="grid gap-3 px-4 py-3 md:grid-cols-[90px_110px_1fr_1fr] md:items-center"
-                >
-                  <div className="text-sm font-semibold text-neutral-100">
-                    {WEEKDAYS[row.weekday]}
-                  </div>
+                <div key={row.weekday} className="grid gap-3 px-4 py-3 md:grid-cols-[90px_110px_1fr_1fr] md:items-center">
+                  <div className="text-sm font-semibold text-neutral-100">{WEEKDAYS[row.weekday]}</div>
 
                   <label className="flex items-center gap-2 text-sm text-neutral-300">
                     <input
@@ -173,37 +138,19 @@ export default function OwnerSettingsSchedulingSection({
             })}
           </div>
         </div>
-      </SectionShell>
+      </OwnerSettingsPanel>
 
-      <SectionShell
+      <OwnerSettingsPanel
         id="timeoff-settings"
+        tone="passive"
         title="Time off / blackouts"
         description="Block public availability for closures, holidays, and special events."
       >
         <div className="grid gap-3 md:grid-cols-4">
-          <input
-            type="datetime-local"
-            className="rounded-md border border-white/10 bg-neutral-900 px-3 py-2 text-sm text-neutral-100"
-            value={newOffStart}
-            onChange={(e) => onNewOffStartChange(e.target.value)}
-            disabled={!isUnlocked}
-          />
-          <input
-            type="datetime-local"
-            className="rounded-md border border-white/10 bg-neutral-900 px-3 py-2 text-sm text-neutral-100"
-            value={newOffEnd}
-            onChange={(e) => onNewOffEndChange(e.target.value)}
-            disabled={!isUnlocked}
-          />
-          <Input
-            placeholder="Reason (optional)"
-            value={newOffReason}
-            onChange={(e) => onNewOffReasonChange(e.target.value)}
-            disabled={!isUnlocked}
-          />
-          <Button onClick={onAddTimeOff} disabled={!isUnlocked}>
-            Add
-          </Button>
+          <input type="datetime-local" className="rounded-md border border-white/10 bg-neutral-900 px-3 py-2 text-sm text-neutral-100" value={newOffStart} onChange={(e) => onNewOffStartChange(e.target.value)} disabled={!isUnlocked} />
+          <input type="datetime-local" className="rounded-md border border-white/10 bg-neutral-900 px-3 py-2 text-sm text-neutral-100" value={newOffEnd} onChange={(e) => onNewOffEndChange(e.target.value)} disabled={!isUnlocked} />
+          <Input placeholder="Reason (optional)" value={newOffReason} onChange={(e) => onNewOffReasonChange(e.target.value)} disabled={!isUnlocked} />
+          <Button onClick={onAddTimeOff} disabled={!isUnlocked}>Add</Button>
         </div>
 
         {timeOff.length === 0 ? (
@@ -215,24 +162,14 @@ export default function OwnerSettingsSchedulingSection({
               const end = new Date(t.end_date);
 
               return (
-                <li
-                  key={t.id}
-                  className="flex items-center justify-between rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm"
-                >
+                <li key={t.id} className="flex items-center justify-between rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm">
                   <div>
                     <div className="text-neutral-100">
                       {start.toLocaleString()} → {end.toLocaleString()}
                     </div>
-                    {t.label ? (
-                      <div className="text-xs text-neutral-400">Reason: {t.label}</div>
-                    ) : null}
+                    {t.label ? <div className="text-xs text-neutral-400">Reason: {t.label}</div> : null}
                   </div>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => onDeleteTimeOff(t.id)}
-                    disabled={!isUnlocked}
-                  >
+                  <Button variant="secondary" size="sm" onClick={() => onDeleteTimeOff(t.id)} disabled={!isUnlocked}>
                     Remove
                   </Button>
                 </li>
@@ -240,7 +177,7 @@ export default function OwnerSettingsSchedulingSection({
             })}
           </ul>
         )}
-      </SectionShell>
+      </OwnerSettingsPanel>
     </div>
   );
 }

--- a/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { Button } from "@shared/components/ui/Button";
 import ShopPublicProfileSection from "@/features/shops/components/ShopPublicProfileSection";
+import { OwnerSettingsPanel, OwnerSettingsStat } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 
 type StripeSubStatus =
   | "incomplete"
@@ -38,53 +39,6 @@ type EmailLogRow = {
   sent_at: string | null;
   metadata?: Record<string, unknown> | null;
 };
-
-function SettingsSection({
-  id,
-  title,
-  description,
-  action,
-  children,
-}: {
-  id?: string;
-  title: string;
-  description?: string;
-  action?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <section
-      id={id}
-      className="space-y-3 rounded-2xl border border-white/10 bg-black/25 p-4 shadow-[0_8px_30px_rgba(0,0,0,0.18)]"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-semibold text-neutral-50">{title}</h2>
-          {description ? (
-            <p className="text-[11px] text-neutral-400">{description}</p>
-          ) : null}
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function SettingsStat({
-  label,
-  value,
-}: {
-  label: string;
-  value: React.ReactNode;
-}) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-black/25 p-3">
-      <div className="text-[11px] text-neutral-400">{label}</div>
-      <div className="mt-1 text-sm font-semibold text-neutral-100">{value}</div>
-    </div>
-  );
-}
 
 type Props = {
   shopId: string | null;
@@ -171,24 +125,25 @@ export default function OwnerSettingsSidebar({
 }: Props) {
   return (
     <div className="space-y-5 lg:sticky lg:top-20">
-      <SettingsSection
+      <OwnerSettingsPanel
         id="billing-stripe"
+        tone="secondary"
         title="Billing & Stripe"
         description="Subscription and payment setup for this location."
         action={<div className="flex items-center gap-2">{billingPill}</div>}
       >
         <div className="grid gap-2">
-          <SettingsStat label="Status" value={String(subStatus).toUpperCase()} />
-          <SettingsStat
+          <OwnerSettingsStat label="Status" value={String(subStatus).toUpperCase()} />
+          <OwnerSettingsStat
             label="Stripe Connect"
             value={stripeAccountId ? "Connected" : "Not connected"}
           />
-          <SettingsStat label="Trial ends" value={formatDate(trialEndIso)} />
-          <SettingsStat
+          <OwnerSettingsStat label="Trial ends" value={formatDate(trialEndIso)} />
+          <OwnerSettingsStat
             label="Current period ends"
             value={formatDate(periodEndIso)}
           />
-          <SettingsStat
+          <OwnerSettingsStat
             label="Connected payout account"
             value={stripeAccountId || "No Stripe Connect account linked yet"}
           />
@@ -228,27 +183,29 @@ export default function OwnerSettingsSidebar({
             </p>
           </div>
         </div>
-      </SettingsSection>
+      </OwnerSettingsPanel>
 
-      <SettingsSection
+      <OwnerSettingsPanel
+        tone="passive"
         title="Plan & seats"
         description="Plan limits and active staff seats."
       >
         <div className="grid gap-2">
-          <SettingsStat label="Plan" value={planLabel(plan)} />
-          <SettingsStat label="Seats used" value={seatsUsed} />
-          <SettingsStat
+          <OwnerSettingsStat label="Plan" value={planLabel(plan)} />
+          <OwnerSettingsStat label="Seats used" value={seatsUsed} />
+          <OwnerSettingsStat
             label="Seat limit"
             value={seatsLimit == null ? "Unlimited" : seatsLimit}
           />
-          <SettingsStat
+          <OwnerSettingsStat
             label="Remaining"
             value={seatsLimit == null ? "—" : Math.max(0, seatsLimit - seatsUsed)}
           />
         </div>
-      </SettingsSection>
+      </OwnerSettingsPanel>
 
-      <SettingsSection
+      <OwnerSettingsPanel
+        tone="secondary"
         title="Organization"
         description={
           orgId
@@ -327,13 +284,13 @@ export default function OwnerSettingsSidebar({
             Your current shop will be linked automatically.
           </div>
         )}
-      </SettingsSection>
+      </OwnerSettingsPanel>
 
       {shopId ? (
         <ShopPublicProfileSection shopId={shopId} isUnlocked={isUnlocked} />
       ) : null}
 
-      <SettingsSection title="Invoice preview">
+      <OwnerSettingsPanel tone="passive" title="Invoice preview">
         <div className="space-y-2 rounded-xl bg-white p-3 text-xs text-black shadow">
           {logoUrl ? (
             <Image
@@ -359,10 +316,11 @@ export default function OwnerSettingsSidebar({
           <div className="font-semibold text-black">Footer</div>
           <p>{invoiceFooter || "—"}</p>
         </div>
-      </SettingsSection>
+      </OwnerSettingsPanel>
 
-      <SettingsSection
+      <OwnerSettingsPanel
         id="email-activity"
+        tone="passive"
         title="Email activity"
         description="Recent transactional emails."
         action={
@@ -403,7 +361,7 @@ export default function OwnerSettingsSidebar({
             ))}
           </div>
         )}
-      </SettingsSection>
+      </OwnerSettingsPanel>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Bring OWNER / Settings surfaces into the Phase 3 panel hierarchy so settings read as a cohesive operational control center rather than a stack of equal-weight cards. 
- Emphasize branding and appearance as first-class system controls while preserving all existing branding functionality and boot behavior. 
- Do a controlled, non-breaking pass limited to owner/settings and branding-adjacent UI to improve visual hierarchy and action placement without changing APIs or schema.

### Description
- Add a reusable settings primitive module (`OwnerSettingsPanel`, `OwnerSettingsSectionIntro`, `OwnerSettingsStat`) that consumes existing `PANEL_VARIANTS` to expose `primary`/`secondary`/`passive` tones and unified header/body layout. 
- Refactor owner settings pieces (header, business, operations, scheduling, sidebar) to use the shared panel primitives and remove duplicated local wrapper styles so spacing, headings, and actions are consistent. 
- Promote branding into the system hierarchy by updating `BrandStudioSummaryCard` to use the primary panel tone and structured header/content treatment, and move the appearance mode into a dedicated appearance panel within the operations cluster. 
- Introduce structured section intros and a compact system summary panel to improve information density and establish a clear primary action (page-level save) with localized secondary actions where needed (hours/pricing/billing). 

### Testing
- Ran `npx tsc --noEmit`, which completed successfully (no TypeScript errors). 
- No API/schema changes were made so existing server routes and save flows remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d942df1d188328b908a98efc691d29)