### PR TITLE
Phase 6: tighten findings-to-approval trust surfaces

### DIFF
--- a/app/portal/approvals/page.tsx
+++ b/app/portal/approvals/page.tsx
@@ -365,6 +365,9 @@ export default function PortalApprovalsPage() {
                             {summary.text}
                           </span>
                         </div>
+                        <div className="mt-2 text-xs text-neutral-300">
+                          Decision needed: approve required parts so this work order can continue.
+                        </div>
 
                         <div className="mt-1 flex flex-wrap items-center gap-2 text-[0.7rem] text-neutral-400">
                           <span className="rounded-full border border-white/10 bg-black/35 px-2 py-0.5">
@@ -395,12 +398,17 @@ export default function PortalApprovalsPage() {
                     </div>
 
                     <div className="px-4 py-4">
-                      <div className="mb-2 flex items-center justify-between gap-2">
-                        <div className="text-[0.75rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                          Parts
+                      <div className="mb-2 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
+                        <div>
+                          <div className="text-[0.75rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+                            Evidence-backed recommendation
+                          </div>
+                          <div className="text-[0.7rem] text-neutral-500">
+                            Review pricing and approve each required part. This is the action step for this job.
+                          </div>
                         </div>
-                        <div className="text-[0.7rem] text-neutral-500">
-                          Approve each item to move the job forward.
+                        <div className="text-[0.68rem] text-neutral-400">
+                          Primary action: <span className="text-neutral-200">Approve</span>
                         </div>
                       </div>
 
@@ -465,12 +473,10 @@ export default function PortalApprovalsPage() {
                                         type="button"
                                         onClick={() => void approveItem(it.id)}
                                         disabled={isBusy}
-                                        className="inline-flex items-center rounded-full border border-white/12 bg-black/45 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-neutral-100 transition hover:bg-black/70 active:scale-95 disabled:opacity-60"
+                                        className="inline-flex items-center rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-emerald-100 transition hover:bg-emerald-500/20 active:scale-95 disabled:opacity-60"
                                         title="Approve item"
                                       >
-                                        <span style={{ color: COPPER }}>
-                                          {isBusy ? "..." : "Approve"}
-                                        </span>
+                                        {isBusy ? "..." : "Approve"}
                                       </button>
                                     ) : (
                                       <button

--- a/features/inspections/components/inspection/PhotoThumbnail.tsx
+++ b/features/inspections/components/inspection/PhotoThumbnail.tsx
@@ -9,16 +9,19 @@ interface PhotoThumbnailProps {
 
 const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({ url, onRemove }) => {
   return (
-    <div className="relative w-24 h-24 m-1 rounded overflow-hidden border border-gray-600 shadow">
+    <div className="group relative m-1 w-28 overflow-hidden rounded-xl border border-white/15 bg-black/45 shadow-[0_10px_25px_rgba(0,0,0,0.45)]">
       <img
         src={url}
-        alt="Inspection"
-        className="object-cover w-full h-full rounded"
+        alt="Inspection evidence"
+        className="h-24 w-full object-cover transition duration-200 group-hover:scale-[1.02]"
       />
+      <div className="border-t border-white/10 bg-black/55 px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-neutral-300">
+        Evidence photo
+      </div>
       {onRemove && (
         <button
           onClick={onRemove}
-          className="absolute top-0 right-0 bg-red-600 text-white rounded-bl px-1 text-xs hover:bg-red-700"
+          className="absolute right-1 top-1 rounded-md border border-red-400/40 bg-black/70 px-1.5 py-0.5 text-[10px] text-red-100 hover:bg-red-500/25"
         >
           ✕
         </button>

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -1002,7 +1002,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
-                      {row.sectionTitle}
+                      Decision unit • {row.sectionTitle}
                     </div>
                     <div className="text-lg font-semibold text-neutral-100">
                       {itemLabel}
@@ -1016,25 +1016,74 @@ export default function InspectionFindingsPage(): JSX.Element {
                   </StatusBadge>
                 </div>
 
-                <div className="mt-4 grid gap-4 md:grid-cols-2">
-                  <label className="space-y-1">
+                <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+                  <div className={cn(PANEL_VARIANTS.secondary, "space-y-3 p-3")}>
                     <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
-                      Note
+                      Evidence and technician explanation
                     </div>
-                    <textarea
-                      className="min-h-[110px] w-full rounded-xl border border-white/10 bg-black/40 p-3 text-sm text-white outline-none"
-                      value={String(row.item.notes ?? "")}
-                      onChange={(e) =>
-                        updateFinding(row.sectionIndex, row.itemIndex, {
-                          notes: e.target.value,
-                        })
-                      }
-                    />
-                  </label>
-
-                  <div className="space-y-3">
                     <label className="space-y-1">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                        Technician notes
+                      </div>
+                      <textarea
+                        className="min-h-[110px] w-full rounded-xl border border-white/10 bg-black/40 p-3 text-sm text-white outline-none"
+                        value={String(row.item.notes ?? "")}
+                        onChange={(e) =>
+                          updateFinding(row.sectionIndex, row.itemIndex, {
+                            notes: e.target.value,
+                          })
+                        }
+                      />
+                    </label>
+                    <div>
+                      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-neutral-300">
+                        <span className="rounded-full border border-white/10 px-3 py-1">
+                          Visual proof: {photos.length} photo{photos.length === 1 ? "" : "s"}
+                        </span>
+
+                        <input
+                          ref={(el) => {
+                            fileInputRefs.current[key] = el;
+                          }}
+                          type="file"
+                          accept="image/*"
+                          className="hidden"
+                          onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            void handleUploadPhoto(row, file);
+                          }}
+                        />
+
+                        <button
+                          type="button"
+                          className="rounded-full border border-white/10 px-3 py-1 hover:bg-white/5 disabled:opacity-60"
+                          onClick={() => fileInputRefs.current[key]?.click()}
+                          disabled={isUploading}
+                        >
+                          {isUploading ? "Uploading photo..." : "Add photo evidence"}
+                        </button>
+                      </div>
+                      {photos.length > 0 ? (
+                        <div className="flex gap-2 overflow-x-auto pb-1">
+                          {photos.map((url, i) => (
+                            <PhotoThumbnail key={`${url}-${i}`} url={url} />
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-white/10 bg-black/25 p-3 text-xs text-neutral-500">
+                          Add at least one photo for stronger customer approval confidence.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className={cn(PANEL_VARIANTS.passive, "space-y-3 p-3")}>
+                    <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
+                      Recommendation and scope
+                    </div>
+                    <label className="space-y-1">
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
                         Labor hours
                       </div>
                       <input
@@ -1084,8 +1133,8 @@ export default function InspectionFindingsPage(): JSX.Element {
                     </label>
 
                     <label className="space-y-1">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
-                        Parts
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                        Parts and quantities
                       </div>
                       <textarea
                         className="min-h-[110px] w-full rounded-xl border border-white/10 bg-black/40 p-3 text-sm text-white outline-none"
@@ -1106,31 +1155,12 @@ export default function InspectionFindingsPage(): JSX.Element {
                 </div>
 
                 <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-neutral-300">
-                  <span className="rounded-full border border-white/10 px-3 py-1">
-                    Photos: {photos.length}
-                  </span>
-
-                  <input
-                    ref={(el) => {
-                      fileInputRefs.current[key] = el;
-                    }}
-                    type="file"
-                    accept="image/*"
-                    className="hidden"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (!file) return;
-                      void handleUploadPhoto(row, file);
-                    }}
-                  />
-
                   <button
                     type="button"
-                    className="rounded-full border border-white/10 px-3 py-1 hover:bg-white/5 disabled:opacity-60"
-                    onClick={() => fileInputRefs.current[key]?.click()}
-                    disabled={isUploading}
+                    className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-emerald-200 hover:bg-emerald-500/20"
+                    onClick={() => markReviewed(row)}
                   >
-                    {isUploading ? "Uploading photo..." : "Add photo"}
+                    {reviewed ? "Reviewed" : "Mark reviewed"}
                   </button>
 
                   <button
@@ -1156,23 +1186,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                   >
                     Mark photo reviewed
                   </button>
-
-                  <button
-                    type="button"
-                    className="rounded-full border border-emerald-500/30 px-3 py-1 text-emerald-200 hover:bg-emerald-500/10"
-                    onClick={() => markReviewed(row)}
-                  >
-                    {reviewed ? "Reviewed" : "Mark reviewed"}
-                  </button>
                 </div>
-
-                {photos.length > 0 && (
-                  <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
-                    {photos.map((url, i) => (
-                      <PhotoThumbnail key={`${url}-${i}`} url={url} />
-                    ))}
-                  </div>
-                )}
               </div>
             );
           })

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -331,7 +331,7 @@ export default function QuotePageClient(): JSX.Element {
               {titleLabel}
             </h1>
             <p className="text-xs text-neutral-400 sm:text-sm">
-              Review your quote with parts, labor, and totals.
+              Review each recommendation with pricing context, then decide what should proceed.
             </p>
           </div>
 
@@ -371,11 +371,16 @@ export default function QuotePageClient(): JSX.Element {
                 <div key={line.id} className="rounded-2xl border border-white/10 bg-black/40 px-4 py-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
+                      <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">
+                        Recommendation
+                      </div>
                       <div className="text-sm font-semibold text-white">
                         {line.lineNo ? `#${line.lineNo} • ` : ""}{line.title}
                       </div>
                       {line.complaint ? (
-                        <div className="mt-1 text-xs text-neutral-400">{line.complaint}</div>
+                        <div className="mt-1 rounded-lg border border-white/10 bg-black/30 px-2.5 py-1.5 text-xs text-neutral-300">
+                          <span className="text-neutral-500">Issue observed:</span> {line.complaint}
+                        </div>
                       ) : null}
                     </div>
 
@@ -389,7 +394,7 @@ export default function QuotePageClient(): JSX.Element {
 
                   <div className="mt-4 grid gap-3 sm:grid-cols-3">
                     <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Labor</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Labor evidence</div>
                       <div className="mt-1 text-sm font-medium text-white">{formatCurrency(line.laborAmount)}</div>
                       <div className="mt-1 text-xs text-neutral-400">{line.laborHours.toFixed(1)} hr</div>
                     </div>
@@ -401,7 +406,7 @@ export default function QuotePageClient(): JSX.Element {
                     </div>
 
                     <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Line total</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Decision total</div>
                       <div className="mt-1 text-sm font-medium text-white">{formatCurrency(line.totalAmount)}</div>
                     </div>
                   </div>

--- a/features/portal/components/QuoteApprovalActions.tsx
+++ b/features/portal/components/QuoteApprovalActions.tsx
@@ -74,7 +74,10 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
   return (
     <div className="mt-6 space-y-3">
       <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
-        Quote decisions
+        Decision actions
+      </div>
+      <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-xs text-neutral-400">
+        For each recommendation, choose one clear action. Approve is the primary path when you want work to proceed.
       </div>
 
       <div className="space-y-2">
@@ -110,7 +113,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
                     type="button"
                     onClick={() => void runDecision(l.id, "approve")}
                     disabled={!!loadingLineId || ap === "approved"}
-                    className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/10 px-4 py-1.5 text-xs font-semibold text-emerald-100 transition hover:bg-emerald-500/20 disabled:opacity-50"
+                    className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-100 transition hover:bg-emerald-500/25 disabled:opacity-50"
                   >
                     {isBusy ? "Saving..." : ap === "approved" ? "Approved" : "Approve"}
                   </button>
@@ -119,7 +122,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
                     type="button"
                     onClick={() => void runDecision(l.id, "decline")}
                     disabled={!!loadingLineId || ap === "declined"}
-                    className="inline-flex items-center justify-center rounded-full border border-red-400/70 bg-red-500/10 px-4 py-1.5 text-xs font-semibold text-red-100 transition hover:bg-red-500/20 disabled:opacity-50"
+                    className="inline-flex items-center justify-center rounded-full border border-white/20 bg-black/45 px-4 py-1.5 text-xs font-semibold text-neutral-100 transition hover:bg-black/65 disabled:opacity-50"
                   >
                     {isBusy ? "Saving..." : ap === "declined" ? "Declined" : "Decline"}
                   </button>
@@ -128,7 +131,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
                     type="button"
                     onClick={() => void runDecision(l.id, "defer")}
                     disabled={!!loadingLineId || ap === "pending"}
-                    className="inline-flex items-center justify-center rounded-full border border-amber-300/60 bg-amber-500/10 px-4 py-1.5 text-xs font-semibold text-amber-100 transition hover:bg-amber-500/20 disabled:opacity-50"
+                    className="inline-flex items-center justify-center rounded-full border border-white/15 bg-transparent px-3 py-1.5 text-[11px] font-medium text-neutral-300 transition hover:bg-white/5 disabled:opacity-50"
                   >
                     {isBusy ? "Saving..." : "Defer"}
                   </button>


### PR DESCRIPTION
### Motivation
- Improve the decision-first UX across inspection findings → evidence → quote/approval so recommendations read as evidence-backed decision units. 
- Strengthen customer/fleet-facing trust signals and make the primary action (`Approve`) visually dominant without changing business logic or APIs.

### Description
- Reframed findings into explicit decision units and split each finding into `Evidence` (secondary panel) and `Recommendation/Scope` (passive panel) in `features/inspections/lib/inspection/findings/page.tsx` to improve hierarchy and scanability. 
- Normalized the shared evidence thumbnail in `features/inspections/components/inspection/PhotoThumbnail.tsx` to present media as structured proof blocks with clearer labeling and calmer controls. 
- Emphasized primary decision language and action framing in the portal approvals list at `app/portal/approvals/page.tsx` so each job row clearly indicates the decision needed and the primary action. 
- Tuned quote review wording and line labels in `features/portal/app/quotes/[id]/QuotePageClient.tsx` and reweighted the decision controls in `features/portal/components/QuoteApprovalActions.tsx` so `Approve` is the obvious primary path while keeping decline/defer quieter.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` which passed. 
- No schema, API, role, or RLS changes were made and no additional automated tests were required for this UI-only refinement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94995e8388328b505163b199cfee7)