### PR TITLE
Phase 7: unify decision continuity statuses and timeline across inspections, quotes, approvals, and work orders

### DIFF
--- a/app/portal/approvals/page.tsx
+++ b/app/portal/approvals/page.tsx
@@ -4,6 +4,15 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Toaster, toast } from "sonner";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import DecisionTimeline, {
+  type DecisionTimelineStage,
+} from "@/features/shared/components/ui/DecisionTimeline";
+import {
+  formatDecisionStatus,
+  getDecisionStatusView,
+  resolveDecisionStatus,
+} from "@/features/shared/lib/decisionStatus";
 
 const COPPER = "#C57A4A";
 
@@ -73,16 +82,6 @@ function fmtDate(iso: string | null | undefined) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "—";
   return d.toLocaleString();
-}
-
-function statusLabel(s: string | null | undefined) {
-  return (s ?? "pending").replaceAll("_", " ");
-}
-
-function badgeTone(kind: "pending" | "approved" | "mixed") {
-  if (kind === "approved") return "border-emerald-400/40 bg-emerald-400/10 text-emerald-100";
-  if (kind === "mixed") return "border-amber-400/40 bg-amber-400/10 text-amber-100";
-  return "border-sky-400/40 bg-sky-400/10 text-sky-100";
 }
 
 async function readJson(res: Response): Promise<unknown> {
@@ -231,12 +230,12 @@ export default function PortalApprovalsPage() {
 
   const lineSummary = (ln: ApprovalLine) => {
     const items = Array.isArray(ln.part_request_items) ? ln.part_request_items : [];
-    if (items.length === 0) return { kind: "pending" as const, text: "No items" };
+    if (items.length === 0) return getDecisionStatusView("recommended");
 
     const approvedCount = items.filter((it) => Boolean(it.approved)).length;
-    if (approvedCount === 0) return { kind: "pending" as const, text: "Awaiting your approval" };
-    if (approvedCount === items.length) return { kind: "approved" as const, text: "All items approved" };
-    return { kind: "mixed" as const, text: `${approvedCount}/${items.length} approved` };
+    if (approvedCount === 0) return getDecisionStatusView("awaiting_approval");
+    if (approvedCount === items.length) return getDecisionStatusView("approved");
+    return getDecisionStatusView("in_progress");
   };
 
   const shell =
@@ -349,6 +348,46 @@ export default function PortalApprovalsPage() {
                 const title = (ln.description ?? ln.complaint ?? "Job").trim();
                 const summary = lineSummary(ln);
                 const items = Array.isArray(ln.part_request_items) ? ln.part_request_items : [];
+                const lineDecisionStatus = formatDecisionStatus({
+                  approvalState: ln.approval_state,
+                  workStatus: ln.status,
+                });
+                const timelineStages: DecisionTimelineStage[] = [
+                  { key: "inspection", label: "Inspection completed", state: "past" },
+                  { key: "recommendation", label: "Recommendation issued", state: "past" },
+                  {
+                    key: "approval",
+                    label: "Awaiting approval",
+                    state:
+                      resolveDecisionStatus({
+                        approvalState: ln.approval_state,
+                        workStatus: ln.status,
+                      }) === "awaiting_approval"
+                        ? "current"
+                        : resolveDecisionStatus({
+                              approvalState: ln.approval_state,
+                              workStatus: ln.status,
+                            }) === "approved"
+                          ? "past"
+                          : "future",
+                  },
+                  {
+                    key: "execution",
+                    label: "Work started",
+                    state:
+                      resolveDecisionStatus({
+                        approvalState: ln.approval_state,
+                        workStatus: ln.status,
+                      }) === "in_progress"
+                        ? "current"
+                        : resolveDecisionStatus({
+                              approvalState: ln.approval_state,
+                              workStatus: ln.status,
+                            }) === "completed"
+                          ? "past"
+                          : "future",
+                  },
+                ];
 
                 return (
                   <div key={ln.id} className={glass}>
@@ -356,14 +395,7 @@ export default function PortalApprovalsPage() {
                       <div className="min-w-0">
                         <div className="flex flex-wrap items-center gap-2">
                           <div className="truncate text-sm font-semibold text-neutral-100">{title}</div>
-                          <span
-                            className={cx(
-                              "inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.14em]",
-                              badgeTone(summary.kind),
-                            )}
-                          >
-                            {summary.text}
-                          </span>
+                          <StatusBadge variant={summary.variant}>{summary.label}</StatusBadge>
                         </div>
                         <div className="mt-2 text-xs text-neutral-300">
                           Decision needed: approve required parts so this work order can continue.
@@ -371,10 +403,10 @@ export default function PortalApprovalsPage() {
 
                         <div className="mt-1 flex flex-wrap items-center gap-2 text-[0.7rem] text-neutral-400">
                           <span className="rounded-full border border-white/10 bg-black/35 px-2 py-0.5">
-                            Status: {statusLabel(ln.status)}
+                            Work: {lineDecisionStatus.label}
                           </span>
                           <span className="rounded-full border border-white/10 bg-black/35 px-2 py-0.5">
-                            Approval: {statusLabel(ln.approval_state)}
+                            Approval: {formatDecisionStatus({ approvalState: ln.approval_state }).label}
                           </span>
                           {ln.hold_reason ? (
                             <span className="rounded-full border border-white/10 bg-black/35 px-2 py-0.5">
@@ -398,6 +430,7 @@ export default function PortalApprovalsPage() {
                     </div>
 
                     <div className="px-4 py-4">
+                      <DecisionTimeline stages={timelineStages} orientation="vertical" className="mb-3" />
                       <div className="mb-2 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
                         <div>
                           <div className="text-[0.75rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
@@ -450,7 +483,7 @@ export default function PortalApprovalsPage() {
                                             : "border-white/10 bg-black/40 text-neutral-300",
                                         )}
                                       >
-                                        {approved ? "Approved" : "Not approved"}
+                                        {approved ? "Approved" : "Awaiting approval"}
                                       </span>
                                     </div>
                                   </div>

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -23,8 +23,12 @@ import { JobCard } from "@/features/work-orders/components/JobCard";
 import { useWorkOrderActions } from "@/features/work-orders/hooks/useWorkOrderActions";
 import PageShell from "@/features/shared/components/PageShell";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import DecisionTimeline, {
+  type DecisionTimelineStage,
+} from "@/features/shared/components/ui/DecisionTimeline";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import { cn } from "@shared/lib/utils";
+import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -99,37 +103,6 @@ function extractInspectionTemplateId(ln: WorkOrderLineWithInspectionMeta): strin
 
 type TemplateSectionItem = { item: string; unit?: string | null };
 type TemplateSection = { title: string; items: TemplateSectionItem[] };
-
-/* ---------------------------- Badges ---------------------------- */
-
-type KnownStatus =
-  | "awaiting_approval"
-  | "awaiting"
-  | "queued"
-  | "in_progress"
-  | "on_hold"
-  | "planned"
-  | "new"
-  | "completed"
-  | "ready_to_invoice"
-  | "invoiced";
-
-const statusToBadgeVariant = (s: string | null | undefined) => {
-  const key = (s ?? "awaiting").toLowerCase().replaceAll(" ", "_") as KnownStatus;
-  const map: Record<KnownStatus, "neutral" | "info" | "active" | "warning" | "success"> = {
-    awaiting_approval: "info",
-    awaiting: "info",
-    queued: "active",
-    in_progress: "active",
-    on_hold: "warning",
-    planned: "neutral",
-    new: "neutral",
-    completed: "success",
-    ready_to_invoice: "success",
-    invoiced: "success",
-  };
-  return map[key] ?? "info";
-};
 
 // roles allowed to assign jobs
 const ASSIGN_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
@@ -862,6 +835,56 @@ export default function WorkOrderIdClient(): JSX.Element {
   );
 
   const hasAnyApprovalItems = approvalPending.length > 0 || approvalPendingQuotes.length > 0;
+  const decisionTimelineStages = useMemo<DecisionTimelineStage[]>(() => {
+    const hasRecommendedLines = lines.length > 0;
+    const hasAwaitingApproval = lines.some(
+      (line) =>
+        resolveDecisionStatus({
+          approvalState: line.approval_state,
+          workStatus: line.status,
+        }) === "awaiting_approval",
+    );
+    const hasDeclined = lines.some(
+      (line) =>
+        resolveDecisionStatus({
+          approvalState: line.approval_state,
+          workStatus: line.status,
+        }) === "declined",
+    );
+    const hasInProgress = lines.some(
+      (line) =>
+        resolveDecisionStatus({
+          approvalState: line.approval_state,
+          workStatus: line.status,
+        }) === "in_progress",
+    );
+    const isCompleted =
+      resolveDecisionStatus({ workStatus: wo?.status ?? null }) === "completed";
+
+    return [
+      { key: "inspection", label: "Inspection completed", state: "past" },
+      {
+        key: "recommendation",
+        label: "Recommendation issued",
+        state: hasRecommendedLines ? "past" : "future",
+      },
+      {
+        key: "approval",
+        label: hasDeclined ? "Declined" : "Awaiting approval",
+        state: hasAwaitingApproval ? "current" : hasDeclined || hasInProgress || isCompleted ? "past" : "future",
+      },
+      {
+        key: "execution",
+        label: "Work started",
+        state: hasInProgress ? "current" : isCompleted ? "past" : "future",
+      },
+      {
+        key: "completed",
+        label: "Completed",
+        state: isCompleted ? "current" : "future",
+      },
+    ];
+  }, [lines, wo?.status]);
 
   const sortedLines = useMemo(() => {
     const pr: Record<string, number> = {
@@ -1274,8 +1297,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                       Intake
                     </button>
 
-                  <StatusBadge variant={statusToBadgeVariant(wo.status)} size="md">
-                    {(wo.status ?? "awaiting").replaceAll("_", " ")}
+                  <StatusBadge
+                    variant={formatDecisionStatus({ workStatus: wo.status }).variant}
+                    size="md"
+                  >
+                    {formatDecisionStatus({ workStatus: wo.status }).label}
                   </StatusBadge>
 
                   {isWaiter && (
@@ -1286,6 +1312,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                 </div>
               </div>
           </section>
+
+          <DecisionTimeline stages={decisionTimelineStages} />
 
           {/* Vehicle & Customer */}
           <section className={cn(PANEL_VARIANTS.secondary, "p-4")}>
@@ -1425,8 +1453,13 @@ export default function WorkOrderIdClient(): JSX.Element {
                                 <div className="mt-0.5 text-[11px] text-muted-foreground">
                                   {String(ln.job_type ?? "job").replaceAll("_", " ")} •{" "}
                                   {typeof ln.labor_time === "number" ? `${ln.labor_time}h` : "—"} •
-                                  Status: {(ln.status ?? "awaiting").replaceAll("_", " ")} •
-                                  Approval: {(ln.approval_state ?? "pending").replaceAll("_", " ")}
+                                  Decision:{" "}
+                                  {
+                                    formatDecisionStatus({
+                                      approvalState: ln.approval_state,
+                                      workStatus: ln.status,
+                                    }).label
+                                  }
                                 </div>
 
                                 {isAwaitingPartsBase && (
@@ -1490,7 +1523,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                                 {typeof q.est_labor_hours === "number"
                                   ? `${q.est_labor_hours}h`
                                   : "—"}{" "}
-                                • Status: {(q.status ?? "pending_parts").replaceAll("_", " ")}
+                                • Decision: {formatDecisionStatus({ workStatus: q.status }).label}
                               </div>
                               {q.notes && (
                                 <div className="mt-1 text-[11px] text-muted-foreground">

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -20,6 +20,7 @@ import { Button } from "@shared/components/ui/Button";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import PhotoThumbnail from "@inspections/components/inspection/PhotoThumbnail";
+import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
 import { addWorkOrderLineFromSuggestion } from "@inspections/lib/inspection/addWorkOrderLine";
 import { cn } from "@shared/lib/utils";
@@ -990,6 +991,11 @@ export default function InspectionFindingsPage(): JSX.Element {
             ).toLowerCase() as InspectionItemStatus;
             const photos = row.item.photoUrls ?? [];
             const reviewed = row.item.findingReviewed === true;
+            const decisionStatus = formatDecisionStatus({
+              findingStatus: status,
+              hasEvidence: photos.length > 0,
+              isReviewed: reviewed,
+            });
             const laborHoursText = draftUi[key]?.laborHoursText ?? "";
             const partsText = draftUi[key]?.partsText ?? "";
             const isUploading = uploadingKey === key;
@@ -1009,17 +1015,17 @@ export default function InspectionFindingsPage(): JSX.Element {
                     </div>
                   </div>
                   <StatusBadge
-                    variant={status === "fail" ? "danger" : "warning"}
+                    variant={decisionStatus.variant}
                     className="px-3 py-1 text-[10px]"
                   >
-                    {status}
+                    {decisionStatus.label}
                   </StatusBadge>
                 </div>
 
                 <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
                   <div className={cn(PANEL_VARIANTS.secondary, "space-y-3 p-3")}>
                     <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
-                      Evidence and technician explanation
+                      Evidence
                     </div>
                     <label className="space-y-1">
                       <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
@@ -1080,7 +1086,7 @@ export default function InspectionFindingsPage(): JSX.Element {
 
                   <div className={cn(PANEL_VARIANTS.passive, "space-y-3 p-3")}>
                     <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-400">
-                      Recommendation and scope
+                      Recommendation
                     </div>
                     <label className="space-y-1">
                       <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
@@ -1186,6 +1192,9 @@ export default function InspectionFindingsPage(): JSX.Element {
                   >
                     Mark photo reviewed
                   </button>
+                </div>
+                <div className="mt-2 text-[11px] text-neutral-500">
+                  Action needed: mark reviewed so this recommendation can move to approval.
                 </div>
               </div>
             );

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -6,6 +6,11 @@ import { useParams, useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import QuoteApprovalActions from "@/features/portal/components/QuoteApprovalActions";
+import DecisionTimeline, {
+  type DecisionTimelineStage,
+} from "@/features/shared/components/ui/DecisionTimeline";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import {
   calculateTax,
   getTaxAmount,
@@ -84,10 +89,6 @@ function formatDate(value: string | null | undefined): string {
   const d = new Date(value);
   if (Number.isNaN(d.getTime())) return "—";
   return d.toLocaleString();
-}
-
-function labelize(v: string | null | undefined): string {
-  return (v ?? "").replaceAll("_", " ").trim() || "—";
 }
 
 function getShopProvinceCode(shop: ShopRow | null): ProvinceCode | null {
@@ -287,6 +288,32 @@ export default function QuotePageClient(): JSX.Element {
   const taxRes = provinceCode ? calculateTax(subtotal, provinceCode) : null;
   const taxAmount = taxRes ? getTaxAmount(taxRes) : 0;
   const grandTotal = subtotal + taxAmount;
+  const timelineStages: DecisionTimelineStage[] = [
+    { key: "inspection", label: "Inspection completed", state: "past" },
+    {
+      key: "recommendation",
+      label: "Recommendation issued",
+      state: lines.length > 0 ? "past" : "future",
+    },
+    {
+      key: "approval",
+      label: "Awaiting approval",
+      state: lines.some((line) => resolveDecisionStatus({ approvalState: line.approvalState }) === "awaiting_approval")
+        ? "current"
+        : lines.some((line) => resolveDecisionStatus({ approvalState: line.approvalState }) === "approved")
+          ? "past"
+          : "future",
+    },
+    {
+      key: "execution",
+      label: "Work started",
+      state: lines.some((line) => resolveDecisionStatus({ workStatus: line.status }) === "in_progress")
+        ? "current"
+        : lines.some((line) => resolveDecisionStatus({ workStatus: line.status }) === "completed")
+          ? "past"
+          : "future",
+    },
+  ];
 
   return (
     <div
@@ -334,6 +361,7 @@ export default function QuotePageClient(): JSX.Element {
               Review each recommendation with pricing context, then decide what should proceed.
             </p>
           </div>
+          <DecisionTimeline stages={timelineStages} className="mb-6" />
 
           <div className="mb-6 grid gap-4 sm:grid-cols-4">
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
@@ -386,8 +414,22 @@ export default function QuotePageClient(): JSX.Element {
 
                     <div className="text-right">
                       <div className="text-sm font-semibold text-white">{formatCurrency(line.totalAmount)}</div>
-                      <div className="mt-1 text-[11px] uppercase tracking-[0.18em] text-neutral-400">
-                        {labelize(line.approvalState)} • {labelize(line.status)}
+                      <div className="mt-1 flex justify-end">
+                        <StatusBadge
+                          variant={
+                            formatDecisionStatus({
+                              approvalState: line.approvalState,
+                              workStatus: line.status,
+                            }).variant
+                          }
+                        >
+                          {
+                            formatDecisionStatus({
+                              approvalState: line.approvalState,
+                              workStatus: line.status,
+                            }).label
+                          }
+                        </StatusBadge>
                       </div>
                     </div>
                   </div>

--- a/features/portal/components/QuoteApprovalActions.tsx
+++ b/features/portal/components/QuoteApprovalActions.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 
 type Decision = "approve" | "decline" | "defer";
 
@@ -16,21 +18,6 @@ type Props = {
   lines: LineLite[];
   onChanged?: () => void | Promise<void>;
 };
-
-function safeTrim(x: unknown): string {
-  return typeof x === "string" ? x.trim() : "";
-}
-
-function labelize(v: string | null | undefined): string {
-  return (v ?? "").replaceAll("_", " ").trim() || "—";
-}
-
-function pillClass(approval: string | null) {
-  const ap = safeTrim(approval).toLowerCase();
-  if (ap === "approved") return "border-emerald-400/50 bg-emerald-500/10 text-emerald-100";
-  if (ap === "declined") return "border-red-400/50 bg-red-500/10 text-red-100";
-  return "border-amber-400/40 bg-amber-500/10 text-amber-100";
-}
 
 export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: Props) {
   const [loadingLineId, setLoadingLineId] = useState<string | null>(null);
@@ -74,15 +61,19 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
   return (
     <div className="mt-6 space-y-3">
       <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
-        Decision actions
+        Approvals
       </div>
       <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-xs text-neutral-400">
-        For each recommendation, choose one clear action. Approve is the primary path when you want work to proceed.
+        For each recommendation: confirm the issue, review evidence, then choose Approve or Decline.
       </div>
 
       <div className="space-y-2">
         {lines.map((l) => {
           const ap = l.approval_state ?? "pending";
+          const decisionStatus = formatDecisionStatus({
+            approvalState: l.approval_state,
+            workStatus: l.status,
+          });
           const isBusy = loadingLineId === l.id;
 
           return (
@@ -97,14 +88,9 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
                       {l.description?.trim() || "Line item"}
                     </div>
 
-                    <span
-                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] ${pillClass(
-                        ap,
-                      )}`}
-                      title={`approval_state=${ap} status=${l.status ?? "null"}`}
-                    >
-                      {labelize(ap)} • {labelize(l.status)}
-                    </span>
+                    <StatusBadge variant={decisionStatus.variant}>
+                      {decisionStatus.label}
+                    </StatusBadge>
                   </div>
                 </div>
 

--- a/features/shared/components/ui/DecisionTimeline.tsx
+++ b/features/shared/components/ui/DecisionTimeline.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { cn } from "@shared/lib/utils";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+
+export type DecisionTimelineStage = {
+  key: string;
+  label: string;
+  description?: string;
+  state: "past" | "current" | "future";
+};
+
+type Props = {
+  stages: DecisionTimelineStage[];
+  orientation?: "horizontal" | "vertical";
+  className?: string;
+};
+
+function stageTone(state: DecisionTimelineStage["state"]): string {
+  if (state === "current") return "border-[var(--accent-copper-light)]/50 bg-[var(--accent-copper)]/12 text-[var(--accent-copper-light)]";
+  if (state === "past") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-200";
+  return "border-white/10 bg-black/30 text-neutral-500";
+}
+
+export default function DecisionTimeline({
+  stages,
+  orientation = "horizontal",
+  className,
+}: Props) {
+  if (!Array.isArray(stages) || stages.length === 0) return null;
+
+  const vertical = orientation === "vertical";
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-white/10 bg-black/25 p-3",
+        className,
+      )}
+    >
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+        Decision timeline
+      </div>
+      <ol
+        className={cn(
+          vertical ? "space-y-2" : "grid gap-2 md:grid-cols-4",
+        )}
+      >
+        {stages.map((stage) => (
+          <li key={stage.key} className={cn("rounded-xl border px-3 py-2", stageTone(stage.state))}>
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs font-semibold">{stage.label}</div>
+              <StatusBadge
+                size="sm"
+                variant={stage.state === "current" ? "active" : stage.state === "past" ? "success" : "neutral"}
+                className="px-2 py-0.5 text-[9px]"
+              >
+                {stage.state}
+              </StatusBadge>
+            </div>
+            {stage.description ? (
+              <div className="mt-1 text-[11px] text-neutral-400">{stage.description}</div>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/features/shared/lib/decisionStatus.ts
+++ b/features/shared/lib/decisionStatus.ts
@@ -1,0 +1,69 @@
+export type DecisionStatus =
+  | "needs_review"
+  | "evidence_added"
+  | "recommended"
+  | "awaiting_approval"
+  | "approved"
+  | "declined"
+  | "in_progress"
+  | "completed";
+
+export type DecisionStatusView = {
+  key: DecisionStatus;
+  label: string;
+  variant: "neutral" | "info" | "active" | "warning" | "success" | "danger";
+};
+
+const STATUS_VIEW: Record<DecisionStatus, DecisionStatusView> = {
+  needs_review: { key: "needs_review", label: "Needs review", variant: "warning" },
+  evidence_added: { key: "evidence_added", label: "Evidence added", variant: "info" },
+  recommended: { key: "recommended", label: "Recommended", variant: "active" },
+  awaiting_approval: { key: "awaiting_approval", label: "Awaiting approval", variant: "info" },
+  approved: { key: "approved", label: "Approved", variant: "success" },
+  declined: { key: "declined", label: "Declined", variant: "danger" },
+  in_progress: { key: "in_progress", label: "In progress", variant: "active" },
+  completed: { key: "completed", label: "Completed", variant: "success" },
+};
+
+function norm(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase().replaceAll(" ", "_");
+}
+
+export function getDecisionStatusView(status: DecisionStatus): DecisionStatusView {
+  return STATUS_VIEW[status];
+}
+
+export function resolveDecisionStatus(input: {
+  approvalState?: string | null;
+  workStatus?: string | null;
+  findingStatus?: string | null;
+  hasEvidence?: boolean;
+  isReviewed?: boolean;
+}): DecisionStatus {
+  const approval = norm(input.approvalState);
+  const workStatus = norm(input.workStatus);
+  const findingStatus = norm(input.findingStatus);
+
+  if (approval === "declined" || workStatus === "declined") return "declined";
+  if (workStatus === "completed" || workStatus === "ready_to_invoice" || workStatus === "invoiced") {
+    return "completed";
+  }
+  if (workStatus === "in_progress" || workStatus === "queued") return "in_progress";
+  if (approval === "approved") return "approved";
+  if (approval === "pending" || workStatus === "awaiting_approval" || workStatus === "waiting_for_approval") {
+    return "awaiting_approval";
+  }
+
+  if (findingStatus === "fail" || findingStatus === "recommend") {
+    if (input.hasEvidence) return "evidence_added";
+    if (input.isReviewed) return "recommended";
+    return "needs_review";
+  }
+
+  if (input.hasEvidence) return "evidence_added";
+  return "recommended";
+}
+
+export function formatDecisionStatus(input: Parameters<typeof resolveDecisionStatus>[0]): DecisionStatusView {
+  return STATUS_VIEW[resolveDecisionStatus(input)];
+}

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -5,6 +5,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 
 type DB = Database;
 
@@ -31,10 +33,6 @@ const INPUT_DARK =
 
 function safeTrim(x: unknown): string {
   return typeof x === "string" ? x.trim() : "";
-}
-
-function statusLabel(s: string | null | undefined): string {
-  return (s ?? "").replaceAll("_", " ").trim() || "—";
 }
 
 function queueAccent(waitingForParts: boolean): {
@@ -386,13 +384,16 @@ function ApprovalsList(): JSX.Element {
                       >
                         {w.waiting_for_parts ? "Waiting for parts" : "Quotes ready"}
                       </span>
+                      <StatusBadge variant={formatDecisionStatus({ workStatus: w.status }).variant}>
+                        {formatDecisionStatus({ workStatus: w.status }).label}
+                      </StatusBadge>
                     </div>
 
                     <div className="mt-3 text-base font-semibold text-white">
                       {w.shops?.name || "Shop"}
                     </div>
                     <div className="mt-1 text-sm text-neutral-300">
-                      {statusLabel(w.status)}
+                      {formatDecisionStatus({ workStatus: w.status }).label}
                       {typeof w.labor_hours === "number"
                         ? ` • ${w.labor_hours.toFixed(1)}h`
                         : ""}


### PR DESCRIPTION
### Motivation
- Introduce a shared, UI-only semantic layer so status wording and badge meaning are consistent across inspection findings, quote/recommendation, portal approvals, and work order detail.  
- Provide a lightweight, reusable timeline primitive so a decision’s lifecycle is visible without backend changes.  
- Keep the change non-breaking: no schema, API, or auth/RLS modifications and reuse the existing `StatusBadge` primitive.

### Description
- Added a canonical status normalization library at `features/shared/lib/decisionStatus.ts` exposing `resolveDecisionStatus` and `formatDecisionStatus` to map existing DB/app fields into the new semantic statuses.  
- Added a reusable `DecisionTimeline` component at `features/shared/components/ui/DecisionTimeline.tsx` supporting horizontal/vertical layouts and past/current/future stage states.  
- Replaced ad-hoc status text/tones with normalized views and `StatusBadge` usage in findings (`features/inspections/lib/inspection/findings/page.tsx`), portal quote page (`features/portal/app/quotes/[id]/QuotePageClient.tsx`), quote approval actions (`features/portal/components/QuoteApprovalActions.tsx`), portal approvals (`app/portal/approvals/page.tsx`), internal quote-review list (`features/work-orders/app/work-orders/quote-review/page.tsx`), and work-order detail (`app/work-orders/[id]/Client.tsx`).  
- Aligned copy and section labels to emphasize the decision lifecycle (Issue / Evidence / Recommendation / Action) and added selective timeline placements (quote header, per-job approval card, work order header) without changing business logic.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` which completed successfully.  
- Verified working tree and commit: `git status --short` is clean and the change is committed as `61f973b15a8b395cd1b33eac3759be96422385dd`.  
- No backend, API, schema, or auth tests were required or changed as part of this phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94bfea4fc83289fc9b2fcd425023d)