### PR TITLE
Phase 8: add Decision Event Feed across key decision surfaces

### DIFF
--- a/app/portal/approvals/page.tsx
+++ b/app/portal/approvals/page.tsx
@@ -8,11 +8,13 @@ import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import DecisionTimeline, {
   type DecisionTimelineStage,
 } from "@/features/shared/components/ui/DecisionTimeline";
+import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
 import {
   formatDecisionStatus,
   getDecisionStatusView,
   resolveDecisionStatus,
 } from "@/features/shared/lib/decisionStatus";
+import { deriveEventsFromPortalApproval } from "@/features/shared/lib/decisionEvents";
 
 const COPPER = "#C57A4A";
 
@@ -36,6 +38,7 @@ type ApprovalLine = {
   hold_reason: string | null;
   work_order_id: string;
   created_at: string | null;
+  updated_at?: string | null;
 
   // joined
   work_orders: {
@@ -388,6 +391,18 @@ export default function PortalApprovalsPage() {
                           : "future",
                   },
                 ];
+                const decisionEvents = deriveEventsFromPortalApproval({
+                  line: {
+                    id: ln.id,
+                    description: ln.description,
+                    complaint: ln.complaint,
+                    created_at: ln.created_at,
+                    updated_at: ln.updated_at ?? null,
+                    approval_state: ln.approval_state,
+                    status: ln.status,
+                  },
+                  actorLabel: "Customer portal",
+                });
 
                 return (
                   <div key={ln.id} className={glass}>
@@ -431,6 +446,7 @@ export default function PortalApprovalsPage() {
 
                     <div className="px-4 py-4">
                       <DecisionTimeline stages={timelineStages} orientation="vertical" className="mb-3" />
+                      <DecisionEventFeed events={decisionEvents} compact className="mb-3" />
                       <div className="mb-2 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
                         <div>
                           <div className="text-[0.75rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -26,9 +26,11 @@ import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import DecisionTimeline, {
   type DecisionTimelineStage,
 } from "@/features/shared/components/ui/DecisionTimeline";
+import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import { cn } from "@shared/lib/utils";
 import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
+import { deriveEventsFromWorkOrder } from "@/features/shared/lib/decisionEvents";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -885,6 +887,15 @@ export default function WorkOrderIdClient(): JSX.Element {
       },
     ];
   }, [lines, wo?.status]);
+  const decisionEvents = useMemo(
+    () =>
+      deriveEventsFromWorkOrder({
+        workOrder: wo,
+        lines,
+        actorLabel: "Service team",
+      }),
+    [wo, lines],
+  );
 
   const sortedLines = useMemo(() => {
     const pr: Record<string, number> = {
@@ -1314,6 +1325,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           </section>
 
           <DecisionTimeline stages={decisionTimelineStages} />
+          <DecisionEventFeed events={decisionEvents} />
 
           {/* Vehicle & Customer */}
           <section className={cn(PANEL_VARIANTS.secondary, "p-4")}>

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -18,9 +18,11 @@ import type {
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import PhotoThumbnail from "@inspections/components/inspection/PhotoThumbnail";
 import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
+import { deriveEventsFromFindings } from "@/features/shared/lib/decisionEvents";
 import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
 import { addWorkOrderLineFromSuggestion } from "@inspections/lib/inspection/addWorkOrderLine";
 import { cn } from "@shared/lib/utils";
@@ -396,6 +398,18 @@ export default function InspectionFindingsPage(): JSX.Element {
   const findings = useMemo(
     () => (session ? collectFindings(session) : []),
     [session],
+  );
+  const decisionEvents = useMemo(
+    () =>
+      deriveEventsFromFindings({
+        findings: findings.map((row) => ({
+          sectionTitle: row.sectionTitle,
+          item: row.item,
+        })),
+        sessionLastUpdated: session?.lastUpdated ?? null,
+        actorLabel: "Technician",
+      }),
+    [findings, session?.lastUpdated],
   );
 
   useEffect(() => {
@@ -978,6 +992,7 @@ export default function InspectionFindingsPage(): JSX.Element {
       description="Review failed and recommended findings before final submission."
     >
       <div className="mx-auto max-w-5xl space-y-4">
+        <DecisionEventFeed events={decisionEvents} compact />
         {findings.length === 0 ? (
           <div className={cn(PANEL_VARIANTS.passive, "p-4 text-sm text-neutral-300")}>
             No failed or recommended findings to review.

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -9,8 +9,10 @@ import QuoteApprovalActions from "@/features/portal/components/QuoteApprovalActi
 import DecisionTimeline, {
   type DecisionTimelineStage,
 } from "@/features/shared/components/ui/DecisionTimeline";
+import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
+import { deriveEventsFromQuote } from "@/features/shared/lib/decisionEvents";
 import {
   calculateTax,
   getTaxAmount,
@@ -31,7 +33,16 @@ type ParamsShape = Record<string, string | string[] | undefined>;
 
 type QuoteLineRow = Pick<
   WorkOrderLineRow,
-  "id" | "description" | "complaint" | "labor_time" | "price_estimate" | "line_no" | "approval_state" | "status"
+  | "id"
+  | "description"
+  | "complaint"
+  | "labor_time"
+  | "price_estimate"
+  | "line_no"
+  | "approval_state"
+  | "status"
+  | "created_at"
+  | "updated_at"
 >;
 
 type AllocationWithPart = Pick<
@@ -52,6 +63,8 @@ type LineView = {
   totalAmount: number;
   approvalState: "pending" | "approved" | "declined" | null;
   status: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
   parts: Array<{
     name: string;
     qty: number;
@@ -183,7 +196,7 @@ export default function QuotePageClient(): JSX.Element {
 
     const { data: lineRowsRaw, error: lineErr } = await supabase
       .from("work_order_lines")
-      .select("id, description, complaint, labor_time, price_estimate, line_no, approval_state, status")
+      .select("id, description, complaint, labor_time, price_estimate, line_no, approval_state, status, created_at, updated_at")
       .eq("work_order_id", workOrderId)
       .order("line_no", { ascending: true });
 
@@ -254,6 +267,8 @@ export default function QuotePageClient(): JSX.Element {
             ? line.approval_state
             : null,
         status: line.status,
+        createdAt: line.created_at ?? null,
+        updatedAt: line.updated_at ?? null,
         parts,
       };
     });
@@ -314,6 +329,23 @@ export default function QuotePageClient(): JSX.Element {
           : "future",
     },
   ];
+  const decisionEvents = useMemo(
+    () =>
+      deriveEventsFromQuote({
+        workOrder,
+        lines: lines.map((line) => ({
+          id: line.id,
+          line_no: line.lineNo,
+          description: line.title,
+          approval_state: line.approvalState,
+          status: line.status,
+          created_at: line.createdAt,
+          updated_at: line.updatedAt,
+        })),
+        actorLabel: "Shop team",
+      }),
+    [workOrder, lines],
+  );
 
   return (
     <div
@@ -362,6 +394,7 @@ export default function QuotePageClient(): JSX.Element {
             </p>
           </div>
           <DecisionTimeline stages={timelineStages} className="mb-6" />
+          <DecisionEventFeed events={decisionEvents} className="mb-6" compact />
 
           <div className="mb-6 grid gap-4 sm:grid-cols-4">
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">

--- a/features/shared/components/ui/DecisionEventFeed.tsx
+++ b/features/shared/components/ui/DecisionEventFeed.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { format } from "date-fns";
+import { cn } from "@shared/lib/utils";
+import type { DecisionEvent } from "@/features/shared/lib/decisionEvents";
+
+type DecisionEventFeedProps = {
+  events: DecisionEvent[];
+  compact?: boolean;
+  className?: string;
+};
+
+function formatEventTimestamp(timestamp: string | Date): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "—";
+  return format(date, "PP p");
+}
+
+export default function DecisionEventFeed({
+  events,
+  compact = false,
+  className,
+}: DecisionEventFeedProps): JSX.Element | null {
+  if (!Array.isArray(events) || events.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-white/10 bg-black/20",
+        compact ? "p-2.5" : "p-3",
+        className,
+      )}
+    >
+      <div className={cn("text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500", compact ? "mb-1.5" : "mb-2")}>Decision events</div>
+      <ol className={cn(compact ? "space-y-1.5" : "space-y-2")}>
+        {events.map((event) => (
+          <li
+            key={event.id}
+            className={cn(
+              "rounded-xl border border-white/10 bg-black/25",
+              compact ? "px-2.5 py-2" : "px-3 py-2.5",
+            )}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <p className={cn("font-medium text-neutral-100", compact ? "text-xs" : "text-sm")}>{event.label}</p>
+              <time className="shrink-0 text-[10px] text-neutral-500">{formatEventTimestamp(event.timestamp)}</time>
+            </div>
+            {event.actor ? (
+              <p className={cn("mt-1 text-neutral-400", compact ? "text-[11px]" : "text-xs")}>By {event.actor}</p>
+            ) : null}
+            {event.meta ? (
+              <p className={cn("mt-0.5 text-neutral-500", compact ? "text-[10px]" : "text-[11px]")}>{event.meta}</p>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/features/shared/lib/decisionEvents.ts
+++ b/features/shared/lib/decisionEvents.ts
@@ -1,0 +1,399 @@
+export type DecisionEventType =
+  | "evidence_added"
+  | "recommendation_created"
+  | "sent_for_approval"
+  | "approved"
+  | "declined"
+  | "status_changed"
+  | "work_started"
+  | "completed";
+
+export type DecisionEvent = {
+  id: string;
+  timestamp: string | Date;
+  type: DecisionEventType;
+  actor?: string | null;
+  label: string;
+  meta?: string | null;
+};
+
+type EventDraft = Omit<DecisionEvent, "id" | "timestamp"> & {
+  id?: string;
+  timestamp: string | Date | null;
+};
+
+type MaybeDate = string | Date | null | undefined;
+
+type WorkOrderLike = {
+  id?: string | null;
+  custom_id?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  approved_at?: string | null;
+  declined_at?: string | null;
+  status?: string | null;
+};
+
+type WorkOrderLineLike = {
+  id?: string | null;
+  line_no?: number | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  approved_at?: string | null;
+  declined_at?: string | null;
+  approval_state?: string | null;
+  status?: string | null;
+  description?: string | null;
+};
+
+type FindingItemLike = {
+  item?: string | null;
+  name?: string | null;
+  status?: string | null;
+  findingReviewed?: boolean;
+  photoUrls?: string[];
+  estimateSubmittedAt?: string | null;
+  estimateLastUpdatedAt?: string | null;
+};
+
+type PortalApprovalLineLike = {
+  id?: string;
+  description?: string | null;
+  complaint?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  approval_state?: string | null;
+  status?: string | null;
+};
+
+function norm(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase().replaceAll(" ", "_");
+}
+
+function toTime(value: MaybeDate): number {
+  if (!value) return Number.NaN;
+  const stamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(stamp) ? stamp : Number.NaN;
+}
+
+function readableTimestamp(value: MaybeDate): string | Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return value;
+}
+
+function coalesceTimestamp(...values: MaybeDate[]): string | Date | null {
+  for (const value of values) {
+    const parsed = readableTimestamp(value);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function cleanText(value: string | null | undefined): string | null {
+  const text = (value ?? "").trim();
+  return text.length > 0 ? text : null;
+}
+
+function pushEvent(target: EventDraft[], event: EventDraft): void {
+  if (!event.timestamp || Number.isNaN(toTime(event.timestamp))) return;
+  target.push(event);
+}
+
+function finalizeEvents(events: EventDraft[]): DecisionEvent[] {
+  const sorted = [...events].sort((a, b) => toTime(a.timestamp) - toTime(b.timestamp));
+  const seen = new Set<string>();
+
+  return sorted.flatMap((event, index) => {
+    const timestamp = readableTimestamp(event.timestamp);
+    if (!timestamp) return [];
+
+    const actor = cleanText(event.actor ?? null);
+    const meta = cleanText(event.meta ?? null);
+    const key = [
+      toTime(timestamp),
+      event.type,
+      event.label,
+      actor ?? "",
+      meta ?? "",
+    ].join("|");
+
+    if (seen.has(key)) return [];
+    seen.add(key);
+
+    return [
+      {
+        id: event.id ?? `${event.type}-${index}`,
+        timestamp,
+        type: event.type,
+        label: event.label,
+        actor,
+        meta,
+      },
+    ];
+  });
+}
+
+export function deriveEventsFromWorkOrder(input: {
+  workOrder?: WorkOrderLike | null;
+  lines?: WorkOrderLineLike[] | null;
+  actorLabel?: string | null;
+}): DecisionEvent[] {
+  const events: EventDraft[] = [];
+  const lines = Array.isArray(input.lines) ? input.lines : [];
+  const actor = cleanText(input.actorLabel ?? null);
+
+  const wo = input.workOrder;
+  if (wo?.created_at) {
+    pushEvent(events, {
+      timestamp: wo.created_at,
+      type: "recommendation_created",
+      actor,
+      label: "Recommendation created",
+      meta: cleanText(wo.custom_id ? `Work order ${wo.custom_id}` : null),
+    });
+  }
+
+  for (const line of lines) {
+    const lineMeta = line.line_no ? `Line #${line.line_no}` : cleanText(line.description) ?? null;
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(line.created_at),
+      type: "recommendation_created",
+      actor,
+      label: "Recommendation created",
+      meta: lineMeta,
+    });
+
+    const approval = norm(line.approval_state);
+    if (approval === "pending") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(line.updated_at, line.created_at),
+        type: "sent_for_approval",
+        actor,
+        label: "Sent for approval",
+        meta: lineMeta,
+      });
+    }
+
+    if (approval === "approved") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(line.approved_at, line.updated_at),
+        type: "approved",
+        actor,
+        label: "Approved",
+        meta: lineMeta,
+      });
+    }
+
+    if (approval === "declined") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(line.declined_at, line.updated_at),
+        type: "declined",
+        actor,
+        label: "Declined",
+        meta: lineMeta,
+      });
+    }
+
+    const lineStatus = norm(line.status);
+    if (lineStatus === "in_progress" || lineStatus === "queued") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(line.updated_at),
+        type: "work_started",
+        actor,
+        label: "Work started",
+        meta: lineMeta,
+      });
+    }
+
+    if (lineStatus === "completed" || lineStatus === "ready_to_invoice" || lineStatus === "invoiced") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(line.updated_at),
+        type: "completed",
+        actor,
+        label: "Work completed",
+        meta: lineMeta,
+      });
+    }
+  }
+
+  const woStatus = norm(wo?.status);
+  if (woStatus) {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(wo?.updated_at),
+      type: "status_changed",
+      actor,
+      label: "Status updated",
+      meta: cleanText(wo?.status ?? null),
+    });
+
+    if (woStatus === "in_progress" || woStatus === "queued") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(wo?.updated_at),
+        type: "work_started",
+        actor,
+        label: "Work started",
+      });
+    }
+
+    if (woStatus === "completed" || woStatus === "ready_to_invoice" || woStatus === "invoiced") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(wo?.updated_at),
+        type: "completed",
+        actor,
+        label: "Work completed",
+      });
+    }
+  }
+
+  if (norm(wo?.status) === "declined") {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(wo?.declined_at, wo?.updated_at),
+      type: "declined",
+      actor,
+      label: "Declined",
+    });
+  }
+
+  if (norm(wo?.status) === "approved") {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(wo?.approved_at, wo?.updated_at),
+      type: "approved",
+      actor,
+      label: "Approved",
+    });
+  }
+
+  return finalizeEvents(events);
+}
+
+export function deriveEventsFromFindings(input: {
+  findings: Array<{ sectionTitle?: string | null; item: FindingItemLike }>;
+  sessionLastUpdated?: string | null;
+  actorLabel?: string | null;
+}): DecisionEvent[] {
+  const events: EventDraft[] = [];
+  const actor = cleanText(input.actorLabel ?? null);
+
+  for (const finding of input.findings) {
+    const itemLabel = cleanText(finding.item.item ?? finding.item.name ?? null) ?? "Finding";
+    const meta = cleanText(finding.sectionTitle ? `${finding.sectionTitle} • ${itemLabel}` : itemLabel);
+
+    const status = norm(finding.item.status);
+    if (status === "fail" || status === "recommend") {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(finding.item.estimateSubmittedAt, finding.item.estimateLastUpdatedAt),
+        type: "recommendation_created",
+        actor,
+        label: "Recommendation created",
+        meta,
+      });
+    }
+
+    if (Array.isArray(finding.item.photoUrls) && finding.item.photoUrls.length > 0) {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(finding.item.estimateLastUpdatedAt, input.sessionLastUpdated),
+        type: "evidence_added",
+        actor,
+        label: "Photo evidence added",
+        meta,
+      });
+    }
+
+    if (finding.item.findingReviewed) {
+      pushEvent(events, {
+        timestamp: coalesceTimestamp(finding.item.estimateLastUpdatedAt, input.sessionLastUpdated),
+        type: "sent_for_approval",
+        actor,
+        label: "Sent for approval",
+        meta,
+      });
+    }
+  }
+
+  return finalizeEvents(events);
+}
+
+export function deriveEventsFromQuote(input: {
+  workOrder?: WorkOrderLike | null;
+  lines?: WorkOrderLineLike[] | null;
+  actorLabel?: string | null;
+}): DecisionEvent[] {
+  return deriveEventsFromWorkOrder({
+    workOrder: input.workOrder,
+    lines: input.lines,
+    actorLabel: input.actorLabel,
+  });
+}
+
+export function deriveEventsFromPortalApproval(input: {
+  line: PortalApprovalLineLike;
+  actorLabel?: string | null;
+}): DecisionEvent[] {
+  const actor = cleanText(input.actorLabel ?? null);
+  const lineTitle = cleanText(input.line.description ?? input.line.complaint ?? null);
+
+  const events: EventDraft[] = [];
+
+  pushEvent(events, {
+    timestamp: coalesceTimestamp(input.line.created_at),
+    type: "sent_for_approval",
+    actor,
+    label: "Sent for approval",
+    meta: lineTitle,
+  });
+
+  const approval = norm(input.line.approval_state);
+  if (approval === "approved") {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(input.line.updated_at),
+      type: "approved",
+      actor,
+      label: "Approved",
+      meta: lineTitle,
+    });
+  } else if (approval === "declined") {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(input.line.updated_at),
+      type: "declined",
+      actor,
+      label: "Declined",
+      meta: lineTitle,
+    });
+  }
+
+  const status = norm(input.line.status);
+  if (status) {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(input.line.updated_at),
+      type: "status_changed",
+      actor,
+      label: "Status updated",
+      meta: cleanText(input.line.status ?? null),
+    });
+  }
+
+  if (status === "in_progress" || status === "queued") {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(input.line.updated_at),
+      type: "work_started",
+      actor,
+      label: "Work started",
+      meta: lineTitle,
+    });
+  }
+
+  if (status === "completed" || status === "ready_to_invoice" || status === "invoiced") {
+    pushEvent(events, {
+      timestamp: coalesceTimestamp(input.line.updated_at),
+      type: "completed",
+      actor,
+      label: "Work completed",
+      meta: lineTitle,
+    });
+  }
+
+  return finalizeEvents(events);
+}

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -7,6 +7,8 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
+import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
+import { deriveEventsFromQuote } from "@/features/shared/lib/decisionEvents";
 
 type DB = Database;
 
@@ -19,7 +21,7 @@ type Profile = DB["public"]["Tables"]["profiles"]["Row"];
 type WorkOrderWithMeta = WorkOrder & {
   shops?: Pick<Shop, "name"> | null;
   work_order_lines?: Array<
-    Pick<Line, "id" | "status" | "approval_state" | "labor_time">
+    Pick<Line, "id" | "status" | "approval_state" | "labor_time" | "line_no" | "description" | "created_at" | "updated_at">
   >;
   work_order_quote_lines?: Array<Pick<QuoteLine, "id" | "stage">>;
   labor_hours?: number | null;
@@ -124,7 +126,7 @@ function ApprovalsList(): JSX.Element {
         `
         *,
         shops(name),
-        work_order_lines(id,status,approval_state,labor_time),
+        work_order_lines(id,status,approval_state,labor_time,line_no,description,created_at,updated_at),
         work_order_quote_lines(id,stage)
       `,
       )
@@ -362,6 +364,11 @@ function ApprovalsList(): JSX.Element {
           const woHref = `/work-orders/${w.id}`;
           const accent = queueAccent(Boolean(w.waiting_for_parts));
           const progressValue = w.waiting_for_parts ? 45 : 78;
+          const decisionEvents = deriveEventsFromQuote({
+            workOrder: w,
+            lines: w.work_order_lines ?? [],
+            actorLabel: "Service advisor",
+          });
 
           return (
             <div
@@ -442,6 +449,7 @@ function ApprovalsList(): JSX.Element {
                     </div>
                   </div>
                 </div>
+                <DecisionEventFeed events={decisionEvents} compact className="mt-4" />
 
                 <div className="mt-4 flex flex-wrap gap-2">
                   <Link


### PR DESCRIPTION
### Motivation
- Provide lightweight, visible system memory that answers “what happened, in what order, and who did it” across decision surfaces without changing backend contracts or behavior.
- Extend the Phase 7 decision continuity stack so StatusBadge (current) + DecisionTimeline (lifecycle) + DecisionEventFeed (history) feel like one non-disruptive system.

### Description
- Added a shared UI primitive `DecisionEventFeed` (`features/shared/components/ui/DecisionEventFeed.tsx`) that renders a quiet, chronological event list with a compact mode and neutral styling.
- Added conservative event-derivation helpers (`features/shared/lib/decisionEvents.ts`) including `deriveEventsFromWorkOrder`, `deriveEventsFromFindings`, `deriveEventsFromQuote`, and `deriveEventsFromPortalApproval` that produce `DecisionEvent[]` using only existing fields (`created_at`, `updated_at`, `approved_at`, `declined_at`, `photoUrls`, `finding` metadata, `status`, `approval_state`, etc.) and that dedupe and sort by timestamp.
- Integrated the feed into targeted surfaces: Work Order detail (`app/work-orders/[id]/Client.tsx`), Inspection findings (`features/inspections/lib/inspection/findings/page.tsx`), Internal quote review cards (`features/work-orders/app/work-orders/quote-review/page.tsx`), Portal quote detail (`features/portal/app/quotes/[id]/QuotePageClient.tsx`), and Portal approvals cards (`app/portal/approvals/page.tsx`).
- Kept visual hierarchy and branding intact by reusing existing panel/Card primitives and Phase 7 language; the feed is secondary to timeline and primary actions and is purely UI/derivation only (no DB, API, auth, or workflow changes).

### Testing
- Ran TypeScript check with `npx tsc --noEmit` and it passed successfully.
- No schema/migration, API contract, or auth changes were made so no backend tests were required. 
- Manual visual verification was limited in this environment; UI integration is intentionally non-invasive and placed in compact mode on dense surfaces to avoid clutter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94f6c64b8832899bd40275138e803)