### PR TITLE
Phase 9: add source/confidence and lightweight filtering to DecisionEventFeed

### DIFF
--- a/app/portal/approvals/page.tsx
+++ b/app/portal/approvals/page.tsx
@@ -446,7 +446,7 @@ export default function PortalApprovalsPage() {
 
                     <div className="px-4 py-4">
                       <DecisionTimeline stages={timelineStages} orientation="vertical" className="mb-3" />
-                      <DecisionEventFeed events={decisionEvents} compact className="mb-3" />
+                      <DecisionEventFeed events={decisionEvents} compact className="mb-3" maxVisible={4} />
                       <div className="mb-2 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
                         <div>
                           <div className="text-[0.75rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1325,7 +1325,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           </section>
 
           <DecisionTimeline stages={decisionTimelineStages} />
-          <DecisionEventFeed events={decisionEvents} />
+          <DecisionEventFeed events={decisionEvents} filter="all" maxVisible={6} />
 
           {/* Vehicle & Customer */}
           <section className={cn(PANEL_VARIANTS.secondary, "p-4")}>

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -992,7 +992,7 @@ export default function InspectionFindingsPage(): JSX.Element {
       description="Review failed and recommended findings before final submission."
     >
       <div className="mx-auto max-w-5xl space-y-4">
-        <DecisionEventFeed events={decisionEvents} compact />
+        <DecisionEventFeed events={decisionEvents} compact maxVisible={5} />
         {findings.length === 0 ? (
           <div className={cn(PANEL_VARIANTS.passive, "p-4 text-sm text-neutral-300")}>
             No failed or recommended findings to review.

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -394,7 +394,7 @@ export default function QuotePageClient(): JSX.Element {
             </p>
           </div>
           <DecisionTimeline stages={timelineStages} className="mb-6" />
-          <DecisionEventFeed events={decisionEvents} className="mb-6" compact />
+          <DecisionEventFeed events={decisionEvents} className="mb-6" compact maxVisible={5} />
 
           <div className="mb-6 grid gap-4 sm:grid-cols-4">
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">

--- a/features/shared/components/ui/DecisionEventFeed.tsx
+++ b/features/shared/components/ui/DecisionEventFeed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { format } from "date-fns";
+import { useMemo, useState } from "react";
 import { cn } from "@shared/lib/utils";
 import type { DecisionEvent } from "@/features/shared/lib/decisionEvents";
 
@@ -8,6 +9,8 @@ type DecisionEventFeedProps = {
   events: DecisionEvent[];
   compact?: boolean;
   className?: string;
+  filter?: "all" | "approvals" | "execution" | "evidence";
+  maxVisible?: number;
 };
 
 function formatEventTimestamp(timestamp: string | Date): string {
@@ -16,12 +19,60 @@ function formatEventTimestamp(timestamp: string | Date): string {
   return format(date, "PP p");
 }
 
+const FILTER_OPTIONS: Array<{
+  value: NonNullable<DecisionEventFeedProps["filter"]>;
+  label: string;
+}> = [
+  { value: "all", label: "All" },
+  { value: "approvals", label: "Approvals" },
+  { value: "execution", label: "Execution" },
+  { value: "evidence", label: "Evidence" },
+];
+
+function sourceLabel(source: DecisionEvent["source"]): string | null {
+  if (source === "approval") return "From approval";
+  if (source === "status") return "From status change";
+  if (source === "evidence") return "From evidence";
+  if (source === "system") return "From system";
+  return null;
+}
+
+function matchesFilter(event: DecisionEvent, filter: NonNullable<DecisionEventFeedProps["filter"]>): boolean {
+  if (filter === "all") return true;
+  if (filter === "approvals") {
+    return (
+      event.source === "approval" ||
+      event.type === "approved" ||
+      event.type === "declined" ||
+      event.type === "sent_for_approval"
+    );
+  }
+  if (filter === "execution") {
+    return event.type === "status_changed" || event.type === "work_started" || event.type === "completed";
+  }
+  return event.source === "evidence" || event.type === "evidence_added";
+}
+
 export default function DecisionEventFeed({
   events,
   compact = false,
   className,
+  filter = "all",
+  maxVisible = 5,
 }: DecisionEventFeedProps): JSX.Element | null {
   if (!Array.isArray(events) || events.length === 0) return null;
+
+  const [activeFilter, setActiveFilter] = useState<NonNullable<DecisionEventFeedProps["filter"]>>(filter);
+  const [expanded, setExpanded] = useState(false);
+  const showFilterControls = !compact && events.length > maxVisible;
+
+  const filteredEvents = useMemo(
+    () => events.filter((event) => matchesFilter(event, activeFilter)),
+    [events, activeFilter],
+  );
+
+  const visibleEvents = expanded ? filteredEvents : filteredEvents.slice(-Math.max(maxVisible, 1));
+  const hiddenCount = filteredEvents.length - visibleEvents.length;
 
   return (
     <div
@@ -32,8 +83,30 @@ export default function DecisionEventFeed({
       )}
     >
       <div className={cn("text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500", compact ? "mb-1.5" : "mb-2")}>Decision events</div>
+      {showFilterControls ? (
+        <div className="mb-2 flex flex-wrap gap-1">
+          {FILTER_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                setExpanded(false);
+                setActiveFilter(option.value);
+              }}
+              className={cn(
+                "rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] transition",
+                activeFilter === option.value
+                  ? "border-white/20 bg-white/10 text-neutral-200"
+                  : "border-white/10 bg-white/5 text-neutral-500 hover:text-neutral-300",
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
       <ol className={cn(compact ? "space-y-1.5" : "space-y-2")}>
-        {events.map((event) => (
+        {visibleEvents.map((event) => (
           <li
             key={event.id}
             className={cn(
@@ -42,11 +115,30 @@ export default function DecisionEventFeed({
             )}
           >
             <div className="flex items-center justify-between gap-2">
-              <p className={cn("font-medium text-neutral-100", compact ? "text-xs" : "text-sm")}>{event.label}</p>
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span
+                  className={cn(
+                    "inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-500/60",
+                    event.confidence === "medium" && "bg-neutral-500/45",
+                    event.confidence === "low" && "bg-neutral-500/30",
+                  )}
+                  title={
+                    event.confidence === "low"
+                      ? "Low confidence timestamp (fallback/system-derived)"
+                      : event.confidence === "medium"
+                        ? "Medium confidence timestamp (inferred transition)"
+                        : undefined
+                  }
+                />
+                <p className={cn("truncate font-medium text-neutral-100", compact ? "text-xs" : "text-sm")}>{event.label}</p>
+              </div>
               <time className="shrink-0 text-[10px] text-neutral-500">{formatEventTimestamp(event.timestamp)}</time>
             </div>
             {event.actor ? (
               <p className={cn("mt-1 text-neutral-400", compact ? "text-[11px]" : "text-xs")}>By {event.actor}</p>
+            ) : null}
+            {sourceLabel(event.source) ? (
+              <p className={cn("mt-0.5 text-neutral-500", compact ? "text-[10px]" : "text-[11px]")}>{sourceLabel(event.source)}</p>
             ) : null}
             {event.meta ? (
               <p className={cn("mt-0.5 text-neutral-500", compact ? "text-[10px]" : "text-[11px]")}>{event.meta}</p>
@@ -54,6 +146,15 @@ export default function DecisionEventFeed({
           </li>
         ))}
       </ol>
+      {!expanded && hiddenCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="mt-2 text-[11px] text-neutral-400 transition hover:text-neutral-200"
+        >
+          Show more history
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/features/shared/lib/decisionEvents.ts
+++ b/features/shared/lib/decisionEvents.ts
@@ -15,12 +15,17 @@ export type DecisionEvent = {
   actor?: string | null;
   label: string;
   meta?: string | null;
+  source?: "status" | "approval" | "evidence" | "system";
+  confidence?: "high" | "medium" | "low";
 };
 
 type EventDraft = Omit<DecisionEvent, "id" | "timestamp"> & {
   id?: string;
   timestamp: string | Date | null;
 };
+
+type DecisionEventSource = NonNullable<DecisionEvent["source"]>;
+type DecisionEventConfidence = NonNullable<DecisionEvent["confidence"]>;
 
 type MaybeDate = string | Date | null | undefined;
 
@@ -66,6 +71,11 @@ type PortalApprovalLineLike = {
   status?: string | null;
 };
 
+type TimestampCandidate = {
+  value: MaybeDate;
+  confidence: DecisionEventConfidence;
+};
+
 function norm(value: string | null | undefined): string {
   return (value ?? "").trim().toLowerCase().replaceAll(" ", "_");
 }
@@ -92,6 +102,18 @@ function coalesceTimestamp(...values: MaybeDate[]): string | Date | null {
   return null;
 }
 
+function coalesceTimestampWithConfidence(
+  ...values: TimestampCandidate[]
+): { timestamp: string | Date | null; confidence: DecisionEventConfidence } {
+  for (const value of values) {
+    const parsed = readableTimestamp(value.value);
+    if (parsed) {
+      return { timestamp: parsed, confidence: value.confidence };
+    }
+  }
+  return { timestamp: null, confidence: "low" };
+}
+
 function cleanText(value: string | null | undefined): string | null {
   const text = (value ?? "").trim();
   return text.length > 0 ? text : null;
@@ -100,6 +122,32 @@ function cleanText(value: string | null | undefined): string | null {
 function pushEvent(target: EventDraft[], event: EventDraft): void {
   if (!event.timestamp || Number.isNaN(toTime(event.timestamp))) return;
   target.push(event);
+}
+
+export function resolveEventSource(input: {
+  type: DecisionEventType;
+  source?: DecisionEventSource;
+}): DecisionEventSource {
+  if (input.source) return input.source;
+  if (input.type === "evidence_added") return "evidence";
+  if (input.type === "approved" || input.type === "declined" || input.type === "sent_for_approval") {
+    return "approval";
+  }
+  if (input.type === "status_changed" || input.type === "work_started" || input.type === "completed") {
+    return "status";
+  }
+  return "system";
+}
+
+export function resolveEventConfidence(input: {
+  type: DecisionEventType;
+  confidence?: DecisionEventConfidence;
+}): DecisionEventConfidence {
+  if (input.confidence) return input.confidence;
+  if (input.type === "work_started" || input.type === "completed" || input.type === "status_changed") {
+    return "medium";
+  }
+  return "low";
 }
 
 function finalizeEvents(events: EventDraft[]): DecisionEvent[] {
@@ -131,6 +179,8 @@ function finalizeEvents(events: EventDraft[]): DecisionEvent[] {
         label: event.label,
         actor,
         meta,
+        source: resolveEventSource({ type: event.type, source: event.source }),
+        confidence: resolveEventConfidence({ type: event.type, confidence: event.confidence }),
       },
     ];
   });
@@ -153,6 +203,8 @@ export function deriveEventsFromWorkOrder(input: {
       actor,
       label: "Recommendation created",
       meta: cleanText(wo.custom_id ? `Work order ${wo.custom_id}` : null),
+      source: "system",
+      confidence: "high",
     });
   }
 
@@ -164,36 +216,56 @@ export function deriveEventsFromWorkOrder(input: {
       actor,
       label: "Recommendation created",
       meta: lineMeta,
+      source: "system",
+      confidence: line.created_at ? "high" : "low",
     });
 
     const approval = norm(line.approval_state);
     if (approval === "pending") {
+      const approvalTimestamp = coalesceTimestampWithConfidence(
+        { value: line.updated_at, confidence: "low" },
+        { value: line.created_at, confidence: "high" },
+      );
       pushEvent(events, {
-        timestamp: coalesceTimestamp(line.updated_at, line.created_at),
+        timestamp: approvalTimestamp.timestamp,
         type: "sent_for_approval",
         actor,
         label: "Sent for approval",
         meta: lineMeta,
+        source: "approval",
+        confidence: approvalTimestamp.confidence,
       });
     }
 
     if (approval === "approved") {
+      const approvedTimestamp = coalesceTimestampWithConfidence(
+        { value: line.approved_at, confidence: "high" },
+        { value: line.updated_at, confidence: "low" },
+      );
       pushEvent(events, {
-        timestamp: coalesceTimestamp(line.approved_at, line.updated_at),
+        timestamp: approvedTimestamp.timestamp,
         type: "approved",
         actor,
         label: "Approved",
         meta: lineMeta,
+        source: "approval",
+        confidence: approvedTimestamp.confidence,
       });
     }
 
     if (approval === "declined") {
+      const declinedTimestamp = coalesceTimestampWithConfidence(
+        { value: line.declined_at, confidence: "high" },
+        { value: line.updated_at, confidence: "low" },
+      );
       pushEvent(events, {
-        timestamp: coalesceTimestamp(line.declined_at, line.updated_at),
+        timestamp: declinedTimestamp.timestamp,
         type: "declined",
         actor,
         label: "Declined",
         meta: lineMeta,
+        source: "approval",
+        confidence: declinedTimestamp.confidence,
       });
     }
 
@@ -205,6 +277,8 @@ export function deriveEventsFromWorkOrder(input: {
         actor,
         label: "Work started",
         meta: lineMeta,
+        source: "status",
+        confidence: "medium",
       });
     }
 
@@ -215,6 +289,8 @@ export function deriveEventsFromWorkOrder(input: {
         actor,
         label: "Work completed",
         meta: lineMeta,
+        source: "status",
+        confidence: "medium",
       });
     }
   }
@@ -227,6 +303,8 @@ export function deriveEventsFromWorkOrder(input: {
       actor,
       label: "Status updated",
       meta: cleanText(wo?.status ?? null),
+      source: "status",
+      confidence: "medium",
     });
 
     if (woStatus === "in_progress" || woStatus === "queued") {
@@ -235,6 +313,8 @@ export function deriveEventsFromWorkOrder(input: {
         type: "work_started",
         actor,
         label: "Work started",
+        source: "status",
+        confidence: "medium",
       });
     }
 
@@ -244,25 +324,39 @@ export function deriveEventsFromWorkOrder(input: {
         type: "completed",
         actor,
         label: "Work completed",
+        source: "status",
+        confidence: "medium",
       });
     }
   }
 
   if (norm(wo?.status) === "declined") {
+    const declinedTimestamp = coalesceTimestampWithConfidence(
+      { value: wo?.declined_at, confidence: "high" },
+      { value: wo?.updated_at, confidence: "low" },
+    );
     pushEvent(events, {
-      timestamp: coalesceTimestamp(wo?.declined_at, wo?.updated_at),
+      timestamp: declinedTimestamp.timestamp,
       type: "declined",
       actor,
       label: "Declined",
+      source: "approval",
+      confidence: declinedTimestamp.confidence,
     });
   }
 
   if (norm(wo?.status) === "approved") {
+    const approvedTimestamp = coalesceTimestampWithConfidence(
+      { value: wo?.approved_at, confidence: "high" },
+      { value: wo?.updated_at, confidence: "low" },
+    );
     pushEvent(events, {
-      timestamp: coalesceTimestamp(wo?.approved_at, wo?.updated_at),
+      timestamp: approvedTimestamp.timestamp,
       type: "approved",
       actor,
       label: "Approved",
+      source: "approval",
+      confidence: approvedTimestamp.confidence,
     });
   }
 
@@ -283,32 +377,50 @@ export function deriveEventsFromFindings(input: {
 
     const status = norm(finding.item.status);
     if (status === "fail" || status === "recommend") {
+      const recommendationTimestamp = coalesceTimestampWithConfidence(
+        { value: finding.item.estimateSubmittedAt, confidence: "high" },
+        { value: finding.item.estimateLastUpdatedAt, confidence: "low" },
+      );
       pushEvent(events, {
-        timestamp: coalesceTimestamp(finding.item.estimateSubmittedAt, finding.item.estimateLastUpdatedAt),
+        timestamp: recommendationTimestamp.timestamp,
         type: "recommendation_created",
         actor,
         label: "Recommendation created",
         meta,
+        source: "status",
+        confidence: recommendationTimestamp.confidence,
       });
     }
 
     if (Array.isArray(finding.item.photoUrls) && finding.item.photoUrls.length > 0) {
+      const evidenceTimestamp = coalesceTimestampWithConfidence(
+        { value: finding.item.estimateLastUpdatedAt, confidence: "medium" },
+        { value: input.sessionLastUpdated, confidence: "low" },
+      );
       pushEvent(events, {
-        timestamp: coalesceTimestamp(finding.item.estimateLastUpdatedAt, input.sessionLastUpdated),
+        timestamp: evidenceTimestamp.timestamp,
         type: "evidence_added",
         actor,
         label: "Photo evidence added",
         meta,
+        source: "evidence",
+        confidence: evidenceTimestamp.confidence,
       });
     }
 
     if (finding.item.findingReviewed) {
+      const sentForApprovalTimestamp = coalesceTimestampWithConfidence(
+        { value: finding.item.estimateLastUpdatedAt, confidence: "medium" },
+        { value: input.sessionLastUpdated, confidence: "low" },
+      );
       pushEvent(events, {
-        timestamp: coalesceTimestamp(finding.item.estimateLastUpdatedAt, input.sessionLastUpdated),
+        timestamp: sentForApprovalTimestamp.timestamp,
         type: "sent_for_approval",
         actor,
         label: "Sent for approval",
         meta,
+        source: "approval",
+        confidence: sentForApprovalTimestamp.confidence,
       });
     }
   }
@@ -343,6 +455,8 @@ export function deriveEventsFromPortalApproval(input: {
     actor,
     label: "Sent for approval",
     meta: lineTitle,
+    source: "approval",
+    confidence: "high",
   });
 
   const approval = norm(input.line.approval_state);
@@ -353,6 +467,8 @@ export function deriveEventsFromPortalApproval(input: {
       actor,
       label: "Approved",
       meta: lineTitle,
+      source: "approval",
+      confidence: "low",
     });
   } else if (approval === "declined") {
     pushEvent(events, {
@@ -361,6 +477,8 @@ export function deriveEventsFromPortalApproval(input: {
       actor,
       label: "Declined",
       meta: lineTitle,
+      source: "approval",
+      confidence: "low",
     });
   }
 
@@ -372,6 +490,8 @@ export function deriveEventsFromPortalApproval(input: {
       actor,
       label: "Status updated",
       meta: cleanText(input.line.status ?? null),
+      source: "status",
+      confidence: "medium",
     });
   }
 
@@ -382,6 +502,8 @@ export function deriveEventsFromPortalApproval(input: {
       actor,
       label: "Work started",
       meta: lineTitle,
+      source: "status",
+      confidence: "medium",
     });
   }
 
@@ -392,6 +514,8 @@ export function deriveEventsFromPortalApproval(input: {
       actor,
       label: "Work completed",
       meta: lineTitle,
+      source: "status",
+      confidence: "medium",
     });
   }
 

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -449,7 +449,7 @@ function ApprovalsList(): JSX.Element {
                     </div>
                   </div>
                 </div>
-                <DecisionEventFeed events={decisionEvents} compact className="mt-4" />
+                <DecisionEventFeed events={decisionEvents} compact className="mt-4" maxVisible={5} />
 
                 <div className="mt-4 flex flex-wrap gap-2">
                   <Link


### PR DESCRIPTION
### Motivation
- Improve explainability and trust by surfacing where decision events came from and how reliable their timestamps are without changing backend or schema.
- Keep the DecisionEvent feed lightweight and non-invasive while making high-value surfaces easier to audit and debug.
- Preserve existing UI hierarchy and compact/portal experiences while enabling optional local filtering for operator convenience.

### Description
- Extended the `DecisionEvent` model in `features/shared/lib/decisionEvents.ts` with optional `source?: "status" | "approval" | "evidence" | "system"` and `confidence?: "high" | "medium" | "low"` and added `resolveEventSource(...)` and `resolveEventConfidence(...)` helpers.
- Added timestamp provenance helpers and `coalesceTimestampWithConfidence(...)` to choose timestamps with an associated confidence level and updated all `deriveEventsFrom*` functions to populate `source` and `confidence` using explicit, inferred, and fallback rules.
- Enhanced the feed component `features/shared/components/ui/DecisionEventFeed.tsx` with a subtle confidence dot, optional source text (e.g., “From approval”), a lightweight in-component filter (`filter` prop) and deterministic history collapsing via `maxVisible` and a “Show more history” control.
- Applied feed usage updates across relevant surfaces while preserving compact behavior: `app/work-orders/[id]/Client.tsx`, `features/inspections/lib/inspection/findings/page.tsx`, `features/work-orders/app/work-orders/quote-review/page.tsx`, `features/portal/app/quotes/[id]/QuotePageClient.tsx`, and `app/portal/approvals/page.tsx`.

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` and it succeeded with no new errors.
- Verified there are no schema/API/auth changes and all feed behavior is derived from existing fields (no backend tests required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9516c72848328a41efa4650a8c3b4)