### PR TITLE
Phase 10: Add evidence-grounded explainability layer for optimization & decision flows

### DIFF
--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -696,7 +696,18 @@ export default function ShopBoostOnboardingPage() {
                           className="rounded-md border border-sky-300/20 bg-black/25 p-2 text-xs"
                         >
                           <p className="font-medium text-sky-100">{action.title}</p>
-                          <p className="mt-0.5 text-sky-100/80">{action.summary}</p>
+                          <p className="mt-0.5 text-sky-100/80">{action.explanationSummary ?? action.summary}</p>
+                          {action.expectedOutcome ? (
+                            <p className="mt-1 text-[11px] text-sky-100/70">Expected outcome: {action.expectedOutcome}</p>
+                          ) : null}
+                          {action.riskIfIgnored ? (
+                            <p className="mt-1 text-[11px] text-sky-100/65">If deferred: {action.riskIfIgnored}</p>
+                          ) : null}
+                          {action.isStoryWorthy ? (
+                            <span className="mt-1 inline-flex rounded-full border border-sky-300/35 bg-sky-400/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-sky-100">
+                              Story-worthy ops signal
+                            </span>
+                          ) : null}
                           <div className="mt-2 flex flex-wrap gap-2">
                             <button
                               type="button"

--- a/components/optimization/OptimizationExecutionModal.tsx
+++ b/components/optimization/OptimizationExecutionModal.tsx
@@ -97,7 +97,7 @@ export default function OptimizationExecutionModal({
         <div className="mt-3 space-y-3 text-sm">
           <section className="rounded-xl border border-white/10 bg-black/30 p-3">
             <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-200">Summary</div>
-            <p className="mt-1 text-neutral-300">{opportunity.summary}</p>
+            <p className="mt-1 text-neutral-300">{opportunity.explanation?.operational.summary ?? opportunity.summary}</p>
           </section>
 
           <section className="rounded-xl border border-white/10 bg-black/30 p-3">
@@ -112,11 +112,22 @@ export default function OptimizationExecutionModal({
           <section className="rounded-xl border border-white/10 bg-black/30 p-3">
             <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-200">Why this matters</div>
             <ul className="mt-1.5 space-y-1 text-xs text-neutral-300">
-              {opportunity.reasoning.map((item) => (
+              {(opportunity.explanation?.operational.bullets ?? opportunity.reasoning).map((item) => (
                 <li key={item}>• {item}</li>
               ))}
             </ul>
           </section>
+          {opportunity.explanation?.operational.evidence?.length ? (
+            <section className="rounded-xl border border-white/10 bg-black/30 p-3">
+              <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-200">What supports this</div>
+              <ul className="mt-1.5 space-y-1 text-xs text-neutral-300">
+                {opportunity.explanation.operational.evidence.slice(0, 4).map((item) => (
+                  <li key={`${item.label}:${item.value ?? ""}`}>• {item.label}{item.value != null ? `: ${item.value}` : ""}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
           <section className="rounded-xl border border-white/10 bg-black/30 p-3">
             <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-200">Expected impact</div>
             <div className="mt-1 text-xs text-neutral-300">
@@ -127,6 +138,12 @@ export default function OptimizationExecutionModal({
               {opportunity.impactLabel ??
                 (typeof opportunity.estimatedValue === "number" ? `+$${Math.round(opportunity.estimatedValue)}/month` : "Potential impact detected")}
             </div>
+            {opportunity.explanation?.operational.riskIfIgnored ? (
+              <div className="mt-1 text-xs text-neutral-400">If deferred: {opportunity.explanation.operational.riskIfIgnored}</div>
+            ) : null}
+            {opportunity.explanation?.story?.isStoryWorthy ? (
+              <div className="mt-1 text-xs text-sky-200">Story-worthy angle: {opportunity.explanation.story.angle ?? "Operational trust proof"}</div>
+            ) : null}
           </section>
 
           <section className="rounded-xl border border-white/10 bg-black/30 p-3">

--- a/features/agent/server/getOpsNotifications.ts
+++ b/features/agent/server/getOpsNotifications.ts
@@ -444,11 +444,17 @@ export async function getOpsNotifications(
       .slice(0, 3);
 
     for (const item of selected) {
+      const explanation = item.explanation?.operational;
       notifications.push({
         level: item.priorityBand === "critical" ? "urgent" : "warning",
         code: toOptimizationCode(item.type),
         title: item.title,
-        message: item.summary,
+        message: [
+          explanation?.summary ?? item.summary,
+          explanation?.riskIfIgnored ? `If deferred: ${explanation.riskIfIgnored}` : null,
+        ]
+          .filter(Boolean)
+          .join(" "),
         href: optimizationHref(item),
         entityType: "optimization_opportunity",
         entityId: item.id,

--- a/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
+++ b/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
@@ -91,7 +91,7 @@ function formatEstimatedImpact(value: number | undefined): string {
 }
 
 function getWhyThisMatters(opportunity: OptimizationOpportunity): string[] {
-  const entries = opportunity.reasoning.slice(0, 5);
+  const entries = opportunity.explanation?.operational.bullets ?? opportunity.reasoning.slice(0, 5);
   if (entries.length === 0) return [opportunity.sourceBasis];
   return entries;
 }
@@ -810,6 +810,8 @@ export default function OptimizationOpportunitiesWidget({
               const isApplied = actionState === "applied";
               const isDismissed = actionState === "dismissed";
               const whyThisMatters = getWhyThisMatters(opportunity);
+              const explanation = opportunity.explanation?.operational;
+              const story = opportunity.explanation?.story;
 
               return (
                 <div
@@ -862,8 +864,13 @@ export default function OptimizationOpportunitiesWidget({
 
                   {!isDismissed ? (
                     <>
-                      <div className="mt-1 text-xs text-neutral-300">{opportunity.summary}</div>
+                      <div className="mt-1 text-xs text-neutral-300">{explanation?.summary ?? opportunity.summary}</div>
                       <div className="mt-2 text-[11px] text-neutral-400">Suggested action: {opportunity.suggestedAction}</div>
+                      {story?.isStoryWorthy ? (
+                        <div className="mt-1 inline-flex rounded-full border border-sky-300/35 bg-sky-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-sky-200">
+                          Ops + Story signal
+                        </div>
+                      ) : null}
                       {opportunity.whyNow ? (
                         <div className="mt-1 text-[11px] text-[color:var(--brand-primary)]">Why now: {opportunity.whyNow}</div>
                       ) : null}
@@ -885,12 +892,25 @@ export default function OptimizationOpportunitiesWidget({
                       ) : null}
 
                       <div className="mt-3 rounded-xl border border-white/10 bg-black/25 p-2.5 text-[11px] text-neutral-300">
-                        <div className="font-semibold uppercase tracking-[0.12em] text-neutral-200">Why this matters:</div>
+                        <div className="font-semibold uppercase tracking-[0.12em] text-neutral-200">Why recommended</div>
                         <ul className="mt-1.5 space-y-1">
                           {whyThisMatters.slice(0, 3).map((item) => (
                             <li key={item}>• {item}</li>
                           ))}
                         </ul>
+                        {explanation?.evidence?.length ? (
+                          <div className="mt-2">
+                            <div className="font-semibold uppercase tracking-[0.12em] text-neutral-200">What supports this</div>
+                            <ul className="mt-1 space-y-1 text-neutral-400">
+                              {explanation.evidence.slice(0, 3).map((evidence) => (
+                                <li key={`${evidence.label}:${evidence.value ?? ""}`}>• {evidence.label}{evidence.value != null ? `: ${evidence.value}` : ""}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ) : null}
+                        {explanation?.riskIfIgnored ? (
+                          <div className="mt-2 text-neutral-400">What happens if deferred: {explanation.riskIfIgnored}</div>
+                        ) : null}
                       </div>
                     </>
                   ) : (

--- a/features/optimization/lib/buildInsightExplanation.ts
+++ b/features/optimization/lib/buildInsightExplanation.ts
@@ -1,0 +1,145 @@
+import type {
+  EvidenceItem,
+  OptimizationOpportunity,
+  StoryOpportunityExplanation,
+  UnifiedInsightExplanation,
+} from "@/features/optimization/types";
+
+function toNum(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toPct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function compactEvidence(items: Array<EvidenceItem | null>): EvidenceItem[] {
+  return items.filter((item): item is EvidenceItem => item !== null);
+}
+
+function pricingEvidence(opportunity: OptimizationOpportunity): EvidenceItem[] {
+  const meta = opportunity.meta ?? {};
+  const jobs = toNum(meta.jobsAnalyzed);
+  const recommendedPrice = toNum(meta.recommendedPrice);
+  const underpricedOutliers = toNum(meta.underpricedOutliers);
+  const overpricedOutliers = toNum(meta.overpricedOutliers);
+
+  return compactEvidence([
+    jobs ? { label: "Jobs analyzed", value: jobs, kind: "metric" } : null,
+    recommendedPrice ? { label: "Median recommended price", value: `$${recommendedPrice.toFixed(2)}`, kind: "comparison" } : null,
+    underpricedOutliers != null
+      ? { label: "Underpriced outliers", value: underpricedOutliers, kind: "pattern" }
+      : null,
+    overpricedOutliers != null
+      ? { label: "Overpriced outliers", value: overpricedOutliers, kind: "pattern" }
+      : null,
+  ]);
+}
+
+function coverageEvidence(opportunity: OptimizationOpportunity): EvidenceItem[] {
+  const meta = opportunity.meta ?? {};
+  const jobs = toNum(meta.jobs);
+  const coverageRate = toNum(meta.coverageRate);
+  const linkedRate = toNum(meta.inspectionLinkedRate);
+
+  return compactEvidence([
+    jobs ? { label: "Jobs mapped", value: jobs, kind: "metric" } : null,
+    coverageRate != null ? { label: "Inspection linkage", value: toPct(coverageRate), kind: "status" } : null,
+    linkedRate != null ? { label: "Template link rate", value: toPct(linkedRate), kind: "comparison" } : null,
+  ]);
+}
+
+function revenueEvidence(opportunity: OptimizationOpportunity): EvidenceItem[] {
+  const meta = opportunity.meta ?? {};
+  const sourceFamilyCount = toNum(meta.sourceFamilyCount);
+  const pairCount = toNum(meta.pairCount);
+  const missingCount = toNum(meta.missingCount) ?? toNum(meta.missingCapturedRecommendations);
+  const findings = toNum(meta.flaggedFindings);
+
+  return compactEvidence([
+    sourceFamilyCount ? { label: "Anchor-family jobs", value: sourceFamilyCount, kind: "metric" } : null,
+    pairCount ? { label: "Companion captures", value: pairCount, kind: "pattern" } : null,
+    missingCount != null ? { label: "Likely misses", value: missingCount, kind: "comparison" } : null,
+    findings ? { label: "Flagged findings reviewed", value: findings, kind: "event" } : null,
+  ]);
+}
+
+function toStorySignal(opportunity: OptimizationOpportunity): StoryOpportunityExplanation {
+  const meta = opportunity.meta ?? {};
+  if (opportunity.type === "inspection_coverage_gap") {
+    const coverageRate = toNum(meta.coverageRate) ?? 1;
+    const jobs = toNum(meta.jobs) ?? 0;
+    const isStrongSignal = opportunity.confidence >= 0.68 && coverageRate <= 0.45 && jobs >= 10;
+
+    if (!isStrongSignal) {
+      return { isStoryWorthy: false };
+    }
+
+    return {
+      isStoryWorthy: true,
+      angle: "Consistent inspection proof builds customer trust before approvals",
+      whyStoryWorthy: [
+        `Repeat service family shows only ${toPct(coverageRate)} inspection linkage`,
+        "Closing the gap creates stronger maintenance education moments",
+      ],
+      suggestedAudience: "Vehicle owners and fleet coordinators",
+      suggestedFormat: "trust_proof",
+    };
+  }
+
+  if (opportunity.type === "missed_revenue" && opportunity.id.includes("inspection-finding-gaps")) {
+    const findingMisses = toNum(meta.missingCapturedRecommendations) ?? 0;
+    const flagged = toNum(meta.flaggedFindings) ?? 0;
+
+    if (opportunity.confidence >= 0.72 && flagged >= 10 && findingMisses >= 4) {
+      return {
+        isStoryWorthy: true,
+        angle: "Safety findings converted into transparent repair decisions",
+        whyStoryWorthy: [
+          `${findingMisses} flagged findings lacked matching service lines`,
+          "Strong before/after education opportunity when findings are documented",
+        ],
+        suggestedAudience: "Safety-focused customers",
+        suggestedFormat: "educational",
+      };
+    }
+  }
+
+  return { isStoryWorthy: false };
+}
+
+export function buildInsightExplanation(opportunity: OptimizationOpportunity): UnifiedInsightExplanation {
+  const evidence =
+    opportunity.type === "pricing_normalization"
+      ? pricingEvidence(opportunity)
+      : opportunity.type === "inspection_coverage_gap"
+        ? coverageEvidence(opportunity)
+        : revenueEvidence(opportunity);
+
+  const riskIfIgnored =
+    opportunity.type === "pricing_normalization"
+      ? "Quote variance can erode margin consistency and customer trust in similar repairs."
+      : opportunity.type === "inspection_coverage_gap"
+        ? "Low inspection linkage can weaken approval confidence and reduce trust-proof evidence."
+        : "Missed companion recommendations can suppress captured revenue and leave needed work undocumented.";
+
+  const expectedOutcome =
+    opportunity.type === "pricing_normalization"
+      ? "More predictable estimates and tighter gross-margin control."
+      : opportunity.type === "inspection_coverage_gap"
+        ? "Higher inspection-backed approval quality with clearer advisor conversations."
+        : "Improved average RO value from consistently captured related work.";
+
+  return {
+    operational: {
+      summary: opportunity.summary,
+      bullets: opportunity.reasoning.slice(0, 4),
+      evidence,
+      riskIfIgnored,
+      expectedOutcome,
+      confidenceNote: opportunity.confidenceLabel ?? `${Math.round(opportunity.confidence * 100)}% confidence signal`,
+    },
+    story: toStorySignal(opportunity),
+  };
+}

--- a/features/optimization/server/buildOptimizationOpportunities.ts
+++ b/features/optimization/server/buildOptimizationOpportunities.ts
@@ -6,6 +6,7 @@ import type {
   OptimizationImpactLevel,
   OptimizationOpportunity,
 } from "@/features/optimization/types";
+import { buildInsightExplanation } from "@/features/optimization/lib/buildInsightExplanation";
 
 type DB = Database;
 
@@ -975,6 +976,7 @@ export async function buildOptimizationOpportunities(
       whyNow: computeWhyNow(opportunity),
       confidenceLabel: computeConfidenceLabel(opportunity),
       impactLabel: computeImpactLabel(opportunity),
+      explanation: buildInsightExplanation(opportunity),
     };
   });
 

--- a/features/optimization/server/selectOnboardingRecommendedActions.ts
+++ b/features/optimization/server/selectOnboardingRecommendedActions.ts
@@ -13,6 +13,10 @@ export type OnboardingOptimizationAction = {
   estimatedValue?: number;
   href: string;
   plannerGoal: string;
+  explanationSummary?: string;
+  expectedOutcome?: string | null;
+  riskIfIgnored?: string | null;
+  isStoryWorthy?: boolean;
 };
 
 function toMenuItemPath(menuItemId?: string): string {
@@ -40,13 +44,14 @@ function toActionHref(opportunity: OptimizationOpportunity): string {
 }
 
 function toPlannerGoal(opportunity: OptimizationOpportunity): string {
+  const explanation = opportunity.explanation?.operational;
   if (opportunity.type === "pricing_normalization") {
-    return `Standardize pricing: ${opportunity.title}. ${opportunity.summary}`;
+    return `Standardize pricing: ${opportunity.title}. ${explanation?.summary ?? opportunity.summary}`;
   }
   if (opportunity.type === "inspection_coverage_gap") {
-    return `Improve inspection coverage: ${opportunity.title}. ${opportunity.summary}`;
+    return `Improve inspection coverage: ${opportunity.title}. ${explanation?.summary ?? opportunity.summary}`;
   }
-  return `Review missed-revenue opportunity: ${opportunity.title}. ${opportunity.summary}`;
+  return `Review missed-revenue opportunity: ${opportunity.title}. ${explanation?.summary ?? opportunity.summary}`;
 }
 
 function rankOpportunity(opportunity: OptimizationOpportunity): number {
@@ -90,5 +95,9 @@ export function selectTopOnboardingOptimizationActions(
     estimatedValue: opportunity.estimatedValue,
     href: toActionHref(opportunity),
     plannerGoal: toPlannerGoal(opportunity),
+    explanationSummary: opportunity.explanation?.operational.summary,
+    expectedOutcome: opportunity.explanation?.operational.expectedOutcome ?? null,
+    riskIfIgnored: opportunity.explanation?.operational.riskIfIgnored ?? null,
+    isStoryWorthy: Boolean(opportunity.explanation?.story?.isStoryWorthy),
   }));
 }

--- a/features/optimization/types.ts
+++ b/features/optimization/types.ts
@@ -1,3 +1,32 @@
+export type EvidenceItem = {
+  label: string;
+  value?: string | number | null;
+  detail?: string | null;
+  kind?: "metric" | "event" | "status" | "comparison" | "pattern" | "media";
+};
+
+export type OperationalExplanation = {
+  summary: string;
+  bullets: string[];
+  evidence?: EvidenceItem[];
+  riskIfIgnored?: string | null;
+  expectedOutcome?: string | null;
+  confidenceNote?: string | null;
+};
+
+export type StoryOpportunityExplanation = {
+  isStoryWorthy: boolean;
+  angle?: string | null;
+  whyStoryWorthy?: string[];
+  suggestedAudience?: string | null;
+  suggestedFormat?: "before_after" | "educational" | "trust_proof" | "repair_story" | "maintenance_tip" | null;
+};
+
+export type UnifiedInsightExplanation = {
+  operational: OperationalExplanation;
+  story?: StoryOpportunityExplanation | null;
+};
+
 export type OptimizationType =
   | "pricing_normalization"
   | "inspection_coverage_gap"
@@ -38,6 +67,7 @@ export type OptimizationOpportunity = {
     menuItemId?: string;
     inspectionTemplateId?: string;
   };
+  explanation?: UnifiedInsightExplanation;
   meta?: Record<string, unknown>;
 };
 

--- a/features/shared/quote/QuoteLineCard.tsx
+++ b/features/shared/quote/QuoteLineCard.tsx
@@ -41,6 +41,9 @@ export function QuoteLineCard(props: {
   onDefer?: () => void;
 
   footerNote?: string | null; // optional tiny footer line
+  whyRecommended?: string[];
+  supportingEvidence?: string[];
+  deferredConsequence?: string | null;
 }) {
   const {
     title,
@@ -56,6 +59,9 @@ export function QuoteLineCard(props: {
     onDecline,
     onDefer,
     footerNote,
+    whyRecommended = [],
+    supportingEvidence = [],
+    deferredConsequence,
   } = props;
 
   const total = partsTotal + laborTotal;
@@ -120,6 +126,35 @@ export function QuoteLineCard(props: {
           </div>
           <div className={codeBox}>{safeTrim(recommendedText) || "—"}</div>
         </div>
+
+
+        {(whyRecommended.length > 0 || supportingEvidence.length > 0 || deferredConsequence) ? (
+          <div className="mt-4 rounded-xl border border-white/10 bg-black/55 px-4 py-3 text-sm text-neutral-200">
+            {whyRecommended.length > 0 ? (
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">Why recommended</div>
+                <ul className="mt-1 space-y-1 text-xs text-neutral-300">
+                  {whyRecommended.slice(0, 3).map((item) => (
+                    <li key={item}>• {item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {supportingEvidence.length > 0 ? (
+              <div className="mt-2">
+                <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">What supports this</div>
+                <ul className="mt-1 space-y-1 text-xs text-neutral-400">
+                  {supportingEvidence.slice(0, 3).map((item) => (
+                    <li key={item}>• {item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {deferredConsequence ? (
+              <div className="mt-2 text-xs text-neutral-400">What happens if deferred: {deferredConsequence}</div>
+            ) : null}
+          </div>
+        ) : null}
 
         {/* Cost */}
         <div className="mt-4">

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -967,6 +967,23 @@ export default function QuoteReviewView(props: {
                       safeTrim(l.description) ||
                       "—";
 
+                    const whyRecommended = [
+                      safeTrim(l.correction) ? "Corrective action maps directly to the identified issue." : "Recommendation is tied to the current finding.",
+                      laborHours > 0 ? `Labor time estimate recorded at ${laborHours.toFixed(2)}h.` : null,
+                      partsAmt > 0 ? `Parts are already scoped (${fmt(partsAmt)}).` : null,
+                    ].filter((item): item is string => Boolean(item));
+
+                    const supportingEvidence = [
+                      safeTrim(l.cause) ? `Finding detail: ${safeTrim(l.cause)}` : null,
+                      safeTrim(l.status) ? `Line status: ${statusLabel(l.status)}` : null,
+                      safeTrim(l.approval_state) ? `Decision state: ${statusLabel(l.approval_state)}` : null,
+                    ].filter((item): item is string => Boolean(item));
+
+                    const deferredConsequence =
+                      ap === "approved"
+                        ? null
+                        : "Deferring may keep the original issue active and can delay full work-order completion.";
+
                     return (
                       <div key={l.id} className={`${padX} py-4`}>
                         <div className="rounded-[24px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(197,122,74,0.10),rgba(0,0,0,0.88)_42%,rgba(2,6,23,0.96)_100%)] p-3 shadow-[0_24px_70px_rgba(0,0,0,0.65)]">
@@ -984,6 +1001,9 @@ export default function QuoteReviewView(props: {
                             onDecline={() => void setDecision(l.id, "decline")}
                             onDefer={() => void setDecision(l.id, "defer")}
                             footerNote={`approval_state=${l.approval_state ?? "null"} • status=${l.status ?? "null"}`}
+                            whyRecommended={whyRecommended}
+                            supportingEvidence={supportingEvidence}
+                            deferredConsequence={deferredConsequence}
                           />
                         </div>
 


### PR DESCRIPTION
### Motivation
- Provide a conservative, evidence-backed “why” layer so optimization opportunities and decision surfaces explain themselves using existing shop signals (pricing variance, inspection linkage, missed-revenue/finding gaps). 
- Surface actionable context (evidence, risk if deferred, expected outcome) to make recommendations more trustworthy and operator-grade without changing schema, auth, or business logic. 
- Add a lightweight story-signal bridge that flags rare, high-confidence operational insights as possible story opportunities (conservative, rule-based). 

### Description
- Added shared types in `features/optimization/types.ts`: `EvidenceItem`, `OperationalExplanation`, `StoryOpportunityExplanation`, and `UnifiedInsightExplanation`, and attached `explanation?: UnifiedInsightExplanation` to `OptimizationOpportunity`. 
- Implemented `buildInsightExplanation` in `features/optimization/lib/buildInsightExplanation.ts` to derive operational bullets, evidence rows, risk/outcome text, and a conservative story-worthy signal exclusively from existing `opportunity.meta` and engine signals. 
- Injected explanation output into the final shaping step in `features/optimization/server/buildOptimizationOpportunities.ts` via `explanation: buildInsightExplanation(opportunity)`. 
- Enriched UIs and flows to render compact explainability: updated optimization dashboard widget (`features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx`) and execution modal (`components/optimization/OptimizationExecutionModal.tsx`) to show `Why recommended`, `What supports this`, `If deferred`, and optional story badge. 
- Propagated explanation into onboarding/planner handoff by extending `OnboardingOptimizationAction` and using `explanation?.operational.summary` in `features/optimization/server/selectOnboardingRecommendedActions.ts` and rendering in `app/onboarding/shop-boost/page.tsx`. 
- Added explanation-aware ops notifications in `features/agent/server/getOpsNotifications.ts` to include summary + deferred-risk text. 
- Touched decision surfaces: added compact per-line explainability props to `QuoteLineCard` (`features/shared/quote/QuoteLineCard.tsx`) and compute/pass grounded line-level `whyRecommended` / `supportingEvidence` / `deferredConsequence` in `features/work-orders/quote-review/QuoteReviewView.tsx` without changing approval flows. 

### Testing
- Ran TypeScript validation: `npx tsc --noEmit`, which completed successfully (environment printed a non-blocking npm env warning but no type errors). 
- No runtime or automated unit tests were changed; changes were additive and typed to minimize regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9533f3b588328bb5a6ccc92cfe494)