### PR TITLE
Introduce shared RBAC capability matrix and apply to high-risk routes

### DIFF
--- a/app/api/admin/staff-invite-candidates/[id]/create-user/route.ts
+++ b/app/api/admin/staff-invite-candidates/[id]/create-user/route.ts
@@ -8,10 +8,9 @@ import {
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
 import { sendUserInviteEmail } from "@/features/email/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager"]);
 
 const INVITE_STATUS = {
   pending: "pending",
@@ -75,8 +74,8 @@ export async function POST(req: NextRequest, context: unknown) {
       );
     }
 
-    const callerRole = String(me.role ?? "").toLowerCase();
-    if (!ADMIN_ROLES.has(callerRole)) {
+    const actor = getActorCapabilities({ role: me.role });
+    if (!actor.canManageUsers) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/admin/staff-invite-candidates/[id]/resend-invite/route.ts
+++ b/app/api/admin/staff-invite-candidates/[id]/resend-invite/route.ts
@@ -8,10 +8,9 @@ import {
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
 import { sendUserInviteEmail } from "@/features/email/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager"]);
 
 const INVITE_STATUS = {
   pending: "pending",
@@ -64,8 +63,8 @@ export async function POST(req: NextRequest, context: unknown) {
       );
     }
 
-    const callerRole = String(me.role ?? "").toLowerCase();
-    if (!ADMIN_ROLES.has(callerRole)) {
+    const actor = getActorCapabilities({ role: me.role });
+    if (!actor.canManageUsers) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/admin/staff-invite-candidates/route.ts
+++ b/app/api/admin/staff-invite-candidates/route.ts
@@ -4,9 +4,9 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 const MAX_ROWS = 500;
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager"]);
 
 // ✅ Canonical invite statuses (status is TEXT)
 const INVITE_STATUS = {
@@ -42,8 +42,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
   }
 
-  const role = String(me.role ?? "").toLowerCase();
-  if (!ADMIN_ROLES.has(role)) {
+  const actor = getActorCapabilities({ role: me.role });
+  if (!actor.canManageUsers) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -5,10 +5,9 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager"]);
 
 type CallerProfile = Pick<
   DB["public"]["Tables"]["profiles"]["Row"],
@@ -50,8 +49,8 @@ async function getCaller(): Promise<CallerResult> {
     };
   }
 
-  const role = String(me.role ?? "").toLowerCase();
-  if (!ADMIN_ROLES.has(role)) {
+  const actor = getActorCapabilities({ role: me.role });
+  if (!actor.canManageUsers) {
     return {
       ok: false,
       res: NextResponse.json({ error: "Forbidden" }, { status: 403 }),

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -4,9 +4,9 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 const MAX_ROWS = 500;
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager"]);
 
 export async function GET(req: Request) {
   const supabaseUser = createServerSupabaseRoute();
@@ -32,8 +32,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
   }
 
-  const role = String(me.role ?? "").toLowerCase();
-  if (!ADMIN_ROLES.has(role)) {
+  const actor = getActorCapabilities({ role: me.role });
+  if (!actor.canManageUsers) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/app/api/fleet/service-requests/convert-to-work-order/route.ts
+++ b/app/api/fleet/service-requests/convert-to-work-order/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -23,6 +24,14 @@ export async function POST(req: NextRequest) {
     }
 
     const serviceRequestId = body.serviceRequestId;
+    const {
+      data: { user },
+      error: userErr,
+    } = await supabase.auth.getUser();
+
+    if (userErr || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
     // Load the service request (fleet-scoped row; RLS enforces membership)
     const { data: sr, error: srError } = await supabase
@@ -47,6 +56,25 @@ export async function POST(req: NextRequest) {
         { error: "Service request not found." },
         { status: 404 },
       );
+    }
+
+    const [{ data: profile }, { data: fleetMember }] = await Promise.all([
+      supabase.from("profiles").select("role").eq("id", user.id).maybeSingle(),
+      supabase
+        .from("fleet_members")
+        .select("role")
+        .eq("fleet_id", sr.fleet_id)
+        .eq("user_id", user.id)
+        .maybeSingle(),
+    ]);
+
+    const actorCaps = getActorCapabilities({
+      role: profile?.role,
+      fleetRole: fleetMember?.role,
+    });
+
+    if (!actorCaps.canManageFleetApprovals) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     if (sr.work_order_id) {

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -4,7 +4,7 @@ import type { Database } from "@shared/types/types/supabase";
 import { runPostSendPersistence, sendQuoteReadyEmail } from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { canSendQuotes } from "@/features/shared/lib/rbac";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -166,7 +166,8 @@ export async function POST(req: Request) {
     if (meErr || !me) {
       return NextResponse.json({ ok: false, trace, error: "Unable to load actor profile" }, { status: 403 });
     }
-    if (!canSendQuotes(me.role)) {
+    const actorCaps = getActorCapabilities({ role: me.role });
+    if (!actorCaps.isKnownRole || !actorCaps.canAuthorizeQuotes) {
       return NextResponse.json({ ok: false, trace, error: "Forbidden" }, { status: 403 });
     }
     if (!me.shop_id || me.shop_id !== wo.shop_id) {

--- a/app/api/scheduling/assigned-work-order-lines/route.ts
+++ b/app/api/scheduling/assigned-work-order-lines/route.ts
@@ -4,18 +4,13 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -44,7 +39,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/assigned-work-orders/route.ts
+++ b/app/api/scheduling/assigned-work-orders/route.ts
@@ -4,18 +4,13 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -44,7 +39,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/context/route.ts
+++ b/app/api/scheduling/context/route.ts
@@ -4,8 +4,7 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 export async function GET() {
   const supabase = createServerSupabaseRoute();
@@ -31,7 +30,9 @@ export async function GET() {
     );
   }
 
-  const canEditAll = ADMIN_ROLES.has(String(me.role ?? "").toLowerCase());
+  const canEditAll = getActorCapabilities({
+    role: me.role,
+  }).canManageScheduling;
 
   let users: Array<{
     id: string;

--- a/app/api/scheduling/punches/[id]/route.ts
+++ b/app/api/scheduling/punches/[id]/route.ts
@@ -4,20 +4,15 @@ import {
   createAdminSupabase,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 function isIsoDate(v: unknown): v is string {
   if (typeof v !== "string" || v.length < 10) return false;
@@ -72,7 +67,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/punches/route.ts
+++ b/app/api/scheduling/punches/route.ts
@@ -4,20 +4,15 @@ import {
   createAdminSupabase,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 function isIsoDate(v: unknown): v is string {
   if (typeof v !== "string" || v.length < 10) return false;
@@ -72,7 +67,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/sessions/[id]/route.ts
+++ b/app/api/scheduling/sessions/[id]/route.ts
@@ -4,20 +4,15 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -47,7 +42,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/sessions/route.ts
+++ b/app/api/scheduling/sessions/route.ts
@@ -4,20 +4,15 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -47,7 +42,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/shifts/[id]/route.ts
+++ b/app/api/scheduling/shifts/[id]/route.ts
@@ -4,20 +4,15 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -47,7 +42,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/scheduling/shifts/route.ts
+++ b/app/api/scheduling/shifts/route.ts
@@ -4,20 +4,15 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 
 type Caller = {
   id: string;
   role: string | null;
   shop_id: string | null;
 };
-
-function safeRole(v: unknown): string {
-  return String(v ?? "").toLowerCase();
-}
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -47,7 +42,8 @@ async function authz() {
     };
   }
 
-  const isAdmin = ADMIN_ROLES.has(safeRole(me.role));
+  const actor = getActorCapabilities({ role: me.role });
+  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
   return { ok: true as const, me, isAdmin };
 }
 

--- a/app/api/settings/pricing-valid-days/route.ts
+++ b/app/api/settings/pricing-valid-days/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -28,7 +29,8 @@ async function verifyOwnerPin(req: NextRequest) {
     .eq("id", user.id)
     .maybeSingle();
 
-  if (!profile || profile.role !== "owner") return { ok: false };
+  const actor = getActorCapabilities({ role: profile?.role });
+  if (!profile || actor.canonicalRole !== "owner") return { ok: false };
 
   if (!profile.owner_pin_hash || pin !== profile.owner_pin_hash) {
     return { ok: false };

--- a/app/api/settings/update/route.ts
+++ b/app/api/settings/update/route.ts
@@ -3,10 +3,9 @@ import { NextResponse } from "next/server";
 import { cookies as nextCookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 const COOKIE_NAME = "pfq_owner_pin_shop";
-
-const ADMIN_ROLES = new Set(["owner", "admin", "manager"]);
 
 // Whitelist fields that can be updated from Settings
 const ALLOWED_FIELDS = new Set([
@@ -97,8 +96,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const role = String(profile.role ?? "").toLowerCase();
-    if (!ADMIN_ROLES.has(role)) {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canManageBranding) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/work-orders/add-line/route.ts
+++ b/app/api/work-orders/add-line/route.ts
@@ -3,7 +3,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { canMutateWorkOrders } from "@/features/shared/lib/rbac";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { createClient, type PostgrestError } from "@supabase/supabase-js";
 import type { Database, TablesInsert } from "@shared/types/types/supabase";
 
@@ -193,7 +193,8 @@ export async function POST(req: Request) {
     if (meErr || !me) {
       return NextResponse.json({ error: "Unable to load actor profile" }, { status: 403 });
     }
-    if (!canMutateWorkOrders(me.role)) {
+    const actorCaps = getActorCapabilities({ role: me.role });
+    if (!actorCaps.isKnownRole || !actorCaps.canManageWorkOrders) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     if (me.shop_id !== wo.shop_id) {

--- a/app/api/work-orders/lines/update-from-inspection/route.ts
+++ b/app/api/work-orders/lines/update-from-inspection/route.ts
@@ -6,7 +6,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { canMutateWorkOrders } from "@/features/shared/lib/rbac";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { createClient, type PostgrestError } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { maybeRefreshPricingSnapshotForLine } from "@/features/work-orders/server/maybeRefreshPricingSnapshotForLine";
@@ -123,7 +123,8 @@ export async function POST(req: Request) {
     if (meErr || !me) {
       return NextResponse.json({ error: "Unable to load actor profile" }, { status: 403 });
     }
-    if (!canMutateWorkOrders(me.role)) {
+    const actorCaps = getActorCapabilities({ role: me.role });
+    if (!actorCaps.isKnownRole || !actorCaps.canManageWorkOrders) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     if (!me.shop_id || me.shop_id !== (line as { shop_id?: string | null }).shop_id) {

--- a/app/dashboard/owner/payments/page.tsx
+++ b/app/dashboard/owner/payments/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -15,8 +16,6 @@ type ProfileScope = {
 };
 
 type PaymentRow = DB["public"]["Tables"]["payments"]["Row"];
-
-const ADMIN_ROLES = new Set(["owner", "admin", "manager"]);
 
 function fmtMoney(cents: number | null, currency: string | null): string {
   const c = typeof cents === "number" ? cents : 0;
@@ -85,10 +84,10 @@ export default function OwnerPaymentsPage() {
         return;
       }
 
-      const role = String(me?.role ?? "").toLowerCase();
       const sId = me?.shop_id ?? null;
+      const actor = getActorCapabilities({ role: me?.role });
 
-      if (!sId || !ADMIN_ROLES.has(role)) {
+      if (!sId || !actor.canManageBilling) {
         if (!cancelled) {
           setForbidden("Forbidden.");
           setLoading(false);

--- a/app/mobile/work-orders/page.tsx
+++ b/app/mobile/work-orders/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { format } from "date-fns";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { canonicalizeRole } from "@/features/shared/lib/rbac";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -146,8 +146,8 @@ export default function MobileWorkOrdersListPage() {
       .eq("id", auth.user.id)
       .maybeSingle();
 
-    const role = canonicalizeRole(me?.role ?? null);
-    const canView = ["owner", "admin", "manager", "advisor", "service", "mechanic", "lead_hand"].includes(role);
+    const actor = getActorCapabilities({ role: me?.role ?? null });
+    const canView = actor.canManageWorkOrders;
     if (!canView) {
       setForbidden(true);
       setRows([]);

--- a/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
@@ -8,6 +8,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -89,8 +90,6 @@ type TabKey = "shifts" | "sessions";
 
 // Admins can view/edit all staff in shop.
 // Everyone else can still view their own shifts/sessions.
-const ADMIN_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
-
 /* ---------------------------------------------------------------------- */
 /* Theme tokens (burnt copper / metallic / glass)                          */
 /* ---------------------------------------------------------------------- */
@@ -322,8 +321,7 @@ export default function SchedulingClient(): JSX.Element {
     useState<boolean>(false);
 
   const isAdmin = useMemo(() => {
-    const r = (me?.role ?? "").toLowerCase();
-    return ADMIN_ROLES.has(r);
+    return getActorCapabilities({ role: me?.role }).canManageScheduling;
   }, [me?.role]);
 
   const canEditAll = isAdmin;
@@ -355,7 +353,9 @@ export default function SchedulingClient(): JSX.Element {
           setCurrentShopId(ctx.shopId);
           setUsers(ctx.users ?? []);
           // If not admin, force selection to self.
-          const admin = ADMIN_ROLES.has((ctx.me.role ?? "").toLowerCase());
+          const admin = getActorCapabilities({
+            role: ctx.me.role,
+          }).canManageScheduling;
           if (!admin) setUserId(ctx.me.id);
           setLoading(false);
           return;
@@ -399,7 +399,9 @@ export default function SchedulingClient(): JSX.Element {
         setMe(prof);
         setCurrentShopId(prof.shop_id);
 
-        const admin = ADMIN_ROLES.has((prof.role ?? "").toLowerCase());
+        const admin = getActorCapabilities({
+          role: prof.role,
+        }).canManageScheduling;
         if (!admin) {
           setUsers([prof]);
           setUserId(prof.id);

--- a/features/shared/lib/rbac.ts
+++ b/features/shared/lib/rbac.ts
@@ -32,6 +32,140 @@ const ROLE_ALIASES: Record<string, CanonicalRole> = {
   customer: "customer",
 };
 
+export type FleetRoleTier = "none" | "viewer" | "approver" | "manager";
+
+export type ActorCapabilities = {
+  canManageUsers: boolean;
+  canAuthorizeQuotes: boolean;
+  canEditPricing: boolean;
+  canManageWorkOrders: boolean;
+  canRunInspections: boolean;
+  canViewShopWideData: boolean;
+  canManageScheduling: boolean;
+  canManageFleetApprovals: boolean;
+  canViewFleetOnlyData: boolean;
+  canManageBranding: boolean;
+  canManageBilling: boolean;
+  canOverrideOperationalState: boolean;
+};
+
+type RoleCapabilityMap = Record<CanonicalRole, ActorCapabilities>;
+
+const NONE: ActorCapabilities = {
+  canManageUsers: false,
+  canAuthorizeQuotes: false,
+  canEditPricing: false,
+  canManageWorkOrders: false,
+  canRunInspections: false,
+  canViewShopWideData: false,
+  canManageScheduling: false,
+  canManageFleetApprovals: false,
+  canViewFleetOnlyData: false,
+  canManageBranding: false,
+  canManageBilling: false,
+  canOverrideOperationalState: false,
+};
+
+const CAPABILITY_MATRIX: RoleCapabilityMap = {
+  owner: {
+    ...NONE,
+    canManageUsers: true,
+    canAuthorizeQuotes: true,
+    canEditPricing: true,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+    canViewShopWideData: true,
+    canManageScheduling: true,
+    canManageBranding: true,
+    canManageBilling: true,
+    canOverrideOperationalState: true,
+  },
+  admin: {
+    ...NONE,
+    canManageUsers: true,
+    canAuthorizeQuotes: true,
+    canEditPricing: true,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+    canViewShopWideData: true,
+    canManageScheduling: true,
+    canManageBranding: true,
+    canManageBilling: true,
+    canOverrideOperationalState: true,
+  },
+  manager: {
+    ...NONE,
+    canManageUsers: true,
+    canAuthorizeQuotes: true,
+    canEditPricing: true,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+    canViewShopWideData: true,
+    canManageScheduling: true,
+    canManageBranding: true,
+    canManageBilling: true,
+  },
+  advisor: {
+    ...NONE,
+    canAuthorizeQuotes: true,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+    canViewShopWideData: true,
+    canManageScheduling: true,
+  },
+  service: {
+    ...NONE,
+    canAuthorizeQuotes: true,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+  },
+  parts: {
+    ...NONE,
+    canViewShopWideData: true,
+  },
+  mechanic: {
+    ...NONE,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+  },
+  lead_hand: {
+    ...NONE,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+    canViewShopWideData: true,
+    canManageScheduling: true,
+  },
+  fleet_manager: {
+    ...NONE,
+    canManageFleetApprovals: true,
+    canViewFleetOnlyData: true,
+  },
+  dispatcher: {
+    ...NONE,
+    canManageFleetApprovals: true,
+    canViewFleetOnlyData: true,
+  },
+  driver: {
+    ...NONE,
+    canViewFleetOnlyData: true,
+  },
+  customer: { ...NONE },
+  unknown: { ...NONE },
+};
+
+const FLEET_ROLE_ALIASES: Record<string, FleetRoleTier> = {
+  viewer: "viewer",
+  driver: "viewer",
+  member: "viewer",
+  user: "viewer",
+  approver: "approver",
+  dispatcher: "approver",
+  admin: "manager",
+  manager: "manager",
+  fleet_manager: "manager",
+  owner: "manager",
+};
+
 export function canonicalizeRole(role: string | null | undefined): CanonicalRole {
   const key = String(role ?? "").trim().toLowerCase();
   return ROLE_ALIASES[key] ?? "unknown";
@@ -45,21 +179,49 @@ export function hasAnyRole(
 }
 
 export function isAdminRole(role: string | null | undefined): boolean {
-  return hasAnyRole(role, ["owner", "admin", "manager"]);
+  return getActorCapabilities({ role }).canManageUsers;
 }
 
 export function canMutateWorkOrders(role: string | null | undefined): boolean {
-  return hasAnyRole(role, [
-    "owner",
-    "admin",
-    "manager",
-    "advisor",
-    "service",
-    "mechanic",
-    "lead_hand",
-  ]);
+  return getActorCapabilities({ role }).canManageWorkOrders;
 }
 
 export function canSendQuotes(role: string | null | undefined): boolean {
-  return hasAnyRole(role, ["owner", "admin", "manager", "advisor", "service"]);
+  return getActorCapabilities({ role }).canAuthorizeQuotes;
+}
+
+export function resolveFleetRoleTier(role: string | null | undefined): FleetRoleTier {
+  const key = String(role ?? "").trim().toLowerCase();
+  return FLEET_ROLE_ALIASES[key] ?? "none";
+}
+
+export function getActorCapabilities(input: {
+  role: string | null | undefined;
+  fleetRole?: string | null | undefined;
+}): ActorCapabilities & {
+  canonicalRole: CanonicalRole;
+  fleetRoleTier: FleetRoleTier;
+  isKnownRole: boolean;
+} {
+  const canonicalRole = canonicalizeRole(input.role);
+  const fleetRoleTier = resolveFleetRoleTier(input.fleetRole);
+  const roleCaps = CAPABILITY_MATRIX[canonicalRole];
+  const isKnownRole = canonicalRole !== "unknown";
+
+  const fleetCaps: Partial<ActorCapabilities> =
+    fleetRoleTier === "manager"
+      ? { canManageFleetApprovals: true, canViewFleetOnlyData: true }
+      : fleetRoleTier === "approver"
+        ? { canManageFleetApprovals: true, canViewFleetOnlyData: true }
+        : fleetRoleTier === "viewer"
+          ? { canViewFleetOnlyData: true }
+          : {};
+
+  return {
+    ...roleCaps,
+    ...fleetCaps,
+    canonicalRole,
+    fleetRoleTier,
+    isKnownRole,
+  };
 }

--- a/features/work-orders/lib/capabilities.ts
+++ b/features/work-orders/lib/capabilities.ts
@@ -1,11 +1,12 @@
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
 export function capabilities(role: string | null) {
-  const r = (role || "").toLowerCase();
-  const staff = ["owner", "admin", "manager", "advisor", "tech"];
+  const actor = getActorCapabilities({ role });
   return {
-    canView: true,
-    canEditWoMeta: ["owner", "admin", "manager", "advisor"].includes(r),
-    canTechOps: ["tech", "manager"].includes(r),
-    canAddJobs: staff.includes(r),
-    canGenerateQuote: staff.includes(r),
+    canView: actor.canManageWorkOrders || actor.canViewShopWideData,
+    canEditWoMeta: actor.canManageWorkOrders,
+    canTechOps: actor.canRunInspections,
+    canAddJobs: actor.canManageWorkOrders,
+    canGenerateQuote: actor.canAuthorizeQuotes,
   } as const;
 }


### PR DESCRIPTION
### Motivation
- Provide a single, reusable capability model so permissions are explicit, consistent, and scalable across server routes and UI without redesigning auth or RLS. 
- Normalize scattered role-alias logic (tech/lead/owner/fleet variants) to reduce drift and make future expansions safe and incremental. 
- Harden next-highest-risk routes and selected high-value UI surfaces by routing authorization through a shared resolver.

### Description
- Added a canonical capability model and resolver in `features/shared/lib/rbac.ts` including `ActorCapabilities`, fleet-tier normalization, `ROLE_ALIASES`, and `getActorCapabilities({ role, fleetRole })` that returns `canonicalRole`, `fleetRoleTier`, and `isKnownRole` in addition to boolean capability flags. 
- Rewrote existing helpers to flow through the capability model by updating `isAdminRole`, `canMutateWorkOrders`, and `canSendQuotes` to use `getActorCapabilities`. 
- Enforced capability checks on high-risk server routes and flows (quote send, work-order mutations, admin/staff management, scheduling endpoints, settings updates, fleet convert-to-work-order) by replacing ad-hoc role-set checks with `getActorCapabilities(...).<capability>` checks. 
- Replaced targeted UI role-array gating with capability checks for scheduling admin surfaces, owner payments, and mobile work-orders, and updated the local work-order capability helper to consume the shared capabilities source-of-truth. 
- Kept change surface constrained: no auth/session redesign, no RLS or DB schema changes, and unknown roles are explicitly handled (`isKnownRole=false`) to reduce accidental elevation.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully. 
- Verified modified server routes now call `getActorCapabilities(...)` and return `403` for callers that lack the required capability during the authorization checks. 
- Performed a targeted inspection of the changed UI files to ensure gating now references shared capabilities instead of scattered role lists. 
- No automated backend integration tests were added in this phase; only type-check and static verifications were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d973a47a008328b03d8d8b8f6b5ceb)