### PR TITLE
Add per-tech labor segments and segment-backed active labor flows

### DIFF
--- a/app/api/scheduling/punches/route.ts
+++ b/app/api/scheduling/punches/route.ts
@@ -124,12 +124,11 @@ export async function POST(req: NextRequest) {
 
   if (body.event_type === "end_shift" && shift.user_id) {
     const { data: activeJobPunches, error: activeJobsErr } = await admin
-      .from("work_order_lines")
+      .from("work_order_line_labor_segments")
       .select("id")
       .eq("shop_id", a.me.shop_id)
-      .eq("assigned_tech_id", shift.user_id)
-      .not("punched_in_at", "is", null)
-      .is("punched_out_at", null);
+      .eq("technician_id", shift.user_id)
+      .is("ended_at", null);
 
     if (activeJobsErr) {
       return NextResponse.json({ error: activeJobsErr.message }, { status: 500 });

--- a/app/api/time/shift/end/route.ts
+++ b/app/api/time/shift/end/route.ts
@@ -22,11 +22,10 @@ export async function POST() {
   const admin = createAdminSupabase();
 
   const { data: activeJobs, error: activeJobsErr } = await admin
-    .from("work_order_lines")
+    .from("work_order_line_labor_segments")
     .select("id")
-    .eq("assigned_tech_id", user.id)
-    .not("punched_in_at", "is", null)
-    .is("punched_out_at", null)
+    .eq("technician_id", user.id)
+    .is("ended_at", null)
     .limit(2);
 
   if (activeJobsErr) return NextResponse.json({ error: activeJobsErr.message }, { status: 500 });

--- a/db/sql/2026-04-10_work_order_line_labor_segments.sql
+++ b/db/sql/2026-04-10_work_order_line_labor_segments.sql
@@ -1,0 +1,98 @@
+-- Add per-technician labor segments for work-order lines.
+-- This is additive and preserves existing work_order_lines punch fields as compatibility mirrors.
+
+create extension if not exists btree_gist;
+
+create table if not exists public.work_order_line_labor_segments (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  work_order_id uuid not null references public.work_orders(id) on delete cascade,
+  work_order_line_id uuid not null references public.work_order_lines(id) on delete cascade,
+  technician_id uuid not null references public.profiles(id) on delete cascade,
+  created_by uuid null references public.profiles(id) on delete set null,
+  source text not null default 'job_punch',
+  pause_reason text null,
+  started_at timestamptz not null,
+  ended_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint work_order_line_labor_segments_time_order_chk
+    check (ended_at is null or ended_at >= started_at)
+);
+
+create index if not exists idx_wolls_shop on public.work_order_line_labor_segments(shop_id);
+create index if not exists idx_wolls_line on public.work_order_line_labor_segments(work_order_line_id);
+create index if not exists idx_wolls_tech_start on public.work_order_line_labor_segments(technician_id, started_at);
+create index if not exists idx_wolls_active_tech on public.work_order_line_labor_segments(technician_id) where ended_at is null;
+
+-- Strong DB guardrail: at most one active segment per technician.
+create unique index if not exists uq_wolls_active_by_tech
+  on public.work_order_line_labor_segments(technician_id)
+  where ended_at is null;
+
+-- Strong DB guardrail: no overlapping segment windows per technician.
+alter table public.work_order_line_labor_segments
+  drop constraint if exists ex_wolls_no_overlap;
+
+alter table public.work_order_line_labor_segments
+  add constraint ex_wolls_no_overlap
+  exclude using gist (
+    technician_id with =,
+    tstzrange(started_at, coalesce(ended_at, 'infinity'::timestamptz), '[)') with &&
+  );
+
+create or replace function public.set_work_order_line_labor_segments_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_wolls_updated_at on public.work_order_line_labor_segments;
+create trigger trg_wolls_updated_at
+before update on public.work_order_line_labor_segments
+for each row
+execute function public.set_work_order_line_labor_segments_updated_at();
+
+alter table public.work_order_line_labor_segments enable row level security;
+
+drop policy if exists wolls_shop_select on public.work_order_line_labor_segments;
+create policy wolls_shop_select
+on public.work_order_line_labor_segments
+for select to authenticated
+using (shop_id = public.current_shop_id());
+
+drop policy if exists wolls_shop_insert on public.work_order_line_labor_segments;
+create policy wolls_shop_insert
+on public.work_order_line_labor_segments
+for insert to authenticated
+with check (shop_id = public.current_shop_id());
+
+drop policy if exists wolls_shop_update on public.work_order_line_labor_segments;
+create policy wolls_shop_update
+on public.work_order_line_labor_segments
+for update to authenticated
+using (shop_id = public.current_shop_id())
+with check (shop_id = public.current_shop_id());
+
+drop policy if exists wolls_shop_delete on public.work_order_line_labor_segments;
+create policy wolls_shop_delete
+on public.work_order_line_labor_segments
+for delete to authenticated
+using (shop_id = public.current_shop_id());
+
+create or replace view public.v_work_order_line_labor_rollups as
+select
+  ls.shop_id,
+  ls.work_order_id,
+  ls.work_order_line_id,
+  count(*) filter (where ls.ended_at is null) as active_segment_count,
+  count(distinct ls.technician_id) filter (where ls.ended_at is null) as active_tech_count,
+  min(ls.started_at) as first_started_at,
+  max(ls.ended_at) as last_ended_at,
+  sum(extract(epoch from (coalesce(ls.ended_at, now()) - ls.started_at)))::bigint as worked_seconds
+from public.work_order_line_labor_segments ls
+group by ls.shop_id, ls.work_order_id, ls.work_order_line_id;

--- a/features/agent/tools/getShopCurrentStatus.ts
+++ b/features/agent/tools/getShopCurrentStatus.ts
@@ -24,6 +24,11 @@ type Row = {
   work_orders: WorkOrderRef;
 };
 
+type ActiveSegmentRow = {
+  work_order_line_id: string | null;
+  technician_id: string | null;
+};
+
 type ProfileRow = {
   id: string;
   full_name: string | null;
@@ -36,7 +41,11 @@ function getWorkOrder(workOrder: WorkOrderRef) {
 export async function runGetShopCurrentStatus(_: object, ctx: ToolContext) {
   const supabase = getServerSupabase();
 
-  const [{ data: lines, error: linesError }, { data: profiles, error: profilesError }] =
+  const [
+    { data: lines, error: linesError },
+    { data: profiles, error: profilesError },
+    { data: activeSegments, error: activeSegmentsError },
+  ] =
     await Promise.all([
       supabase
         .from("work_order_lines")
@@ -64,12 +73,19 @@ export async function runGetShopCurrentStatus(_: object, ctx: ToolContext) {
         .from("profiles")
         .select("id, full_name")
         .eq("shop_id", ctx.shopId),
+      supabase
+        .from("work_order_line_labor_segments")
+        .select("work_order_line_id, technician_id")
+        .eq("shop_id", ctx.shopId)
+        .is("ended_at", null),
     ]);
 
   if (linesError) throw new Error(linesError.message);
   if (profilesError) throw new Error(profilesError.message);
+  if (activeSegmentsError) throw new Error(activeSegmentsError.message);
 
   const rows = (lines ?? []) as unknown as Row[];
+  const segments = (activeSegments ?? []) as ActiveSegmentRow[];
   const people = (profiles ?? []) as ProfileRow[];
 
   const profileMap = new Map<string, string>();
@@ -77,6 +93,14 @@ export async function runGetShopCurrentStatus(_: object, ctx: ToolContext) {
     if (profile.id) {
       profileMap.set(profile.id, profile.full_name ?? profile.id);
     }
+  }
+
+  const activeTechByLineId = new Map<string, string[]>();
+  for (const segment of segments) {
+    if (!segment.work_order_line_id || !segment.technician_id) continue;
+    const techs = activeTechByLineId.get(segment.work_order_line_id) ?? [];
+    techs.push(segment.technician_id);
+    activeTechByLineId.set(segment.work_order_line_id, techs);
   }
 
   const grouped = new Map<
@@ -89,11 +113,8 @@ export async function runGetShopCurrentStatus(_: object, ctx: ToolContext) {
   >();
 
   for (const row of rows) {
-    const techKey = row.assigned_tech_id ?? "unassigned";
-    const techName =
-      techKey === "unassigned"
-        ? "Unassigned"
-        : profileMap.get(techKey) ?? techKey;
+    const activeTechIds = activeTechByLineId.get(row.id) ?? [];
+    const groupingTechIds = activeTechIds.length > 0 ? activeTechIds : [row.assigned_tech_id ?? "unassigned"];
 
     const wo = getWorkOrder(row.work_orders);
     const woId = wo?.id ?? row.id;
@@ -102,17 +123,22 @@ export async function runGetShopCurrentStatus(_: object, ctx: ToolContext) {
     const lineLabel =
       row.description ?? row.complaint ?? row.status ?? "Active job";
 
-    if (!grouped.has(techName)) {
-      grouped.set(techName, []);
-    }
+    for (const techId of groupingTechIds) {
+      const techName =
+        techId === "unassigned"
+          ? "Unassigned"
+          : profileMap.get(techId) ?? techId;
 
-    grouped.get(techName)!.push({
-      id: woId,
-      href: row.assigned_tech_id
-        ? `/work-orders/${woId}/focused-job/${row.id}`
-        : `/work-orders/${woId}`,
-      label: `${woLabel} • ${lineLabel}`,
-    });
+      if (!grouped.has(techName)) {
+        grouped.set(techName, []);
+      }
+
+      grouped.get(techName)!.push({
+        id: woId,
+        href: techId !== "unassigned" ? `/work-orders/${woId}/focused-job/${row.id}` : `/work-orders/${woId}`,
+        label: `${woLabel} • ${lineLabel}`,
+      });
+    }
   }
 
   const techSections = Array.from(grouped.entries()).map(([tech, jobs]) => ({

--- a/features/agent/tools/getTechCurrentWork.ts
+++ b/features/agent/tools/getTechCurrentWork.ts
@@ -101,6 +101,19 @@ export async function runGetTechCurrentWork(rawInput: Input, ctx: ToolContext) {
   if (error) throw new Error(error.message);
 
   const rows = (data ?? []) as unknown as Row[];
+  const lineIds = rows.map((row) => row.id);
+
+  const { data: activeSegments } =
+    lineIds.length === 0
+      ? { data: [] as Array<{ work_order_line_id: string }> }
+      : await supabase
+          .from("work_order_line_labor_segments")
+          .select("work_order_line_id")
+          .eq("shop_id", ctx.shopId)
+          .is("ended_at", null)
+          .in("work_order_line_id", lineIds);
+
+  const activeLineIds = new Set((activeSegments ?? []).map((segment) => segment.work_order_line_id));
 
   if (rows.length === 0) {
     return {
@@ -127,6 +140,7 @@ export async function runGetTechCurrentWork(rawInput: Input, ctx: ToolContext) {
           : `/mobile/jobs/${row.id}`,
         label:
           `${wo?.custom_id ? `WO #${wo.custom_id}` : "Job"} • ` +
+          `${activeLineIds.has(row.id) ? "active_now" : "queued"} • ` +
           `${row.status ?? "unknown"} • ` +
           `${row.description ?? row.complaint ?? "No description"}`,
       };

--- a/features/shared/components/ui/PunchController.tsx
+++ b/features/shared/components/ui/PunchController.tsx
@@ -128,18 +128,17 @@ export default function PunchController(): JSX.Element {
   }
 
   async function countActiveJobsForTech(uid: string): Promise<number> {
-    const { data: activeLines, error: listErr } = await supabase
-      .from("work_order_lines")
+    const { data: activeSegments, error: listErr } = await supabase
+      .from("work_order_line_labor_segments")
       .select("id")
-      .eq("assigned_tech_id", uid)
-      .not("punched_in_at", "is", null)
-      .is("punched_out_at", null);
+      .eq("technician_id", uid)
+      .is("ended_at", null);
 
     if (listErr) {
       throw new Error(listErr.message);
     }
 
-    return activeLines?.length ?? 0;
+    return activeSegments?.length ?? 0;
   }
 
   async function insertPunch(

--- a/features/shared/lib/stats/getTechnicianLoadMetricsCore.ts
+++ b/features/shared/lib/stats/getTechnicianLoadMetricsCore.ts
@@ -33,6 +33,10 @@ type LineLite = Pick<
 >;
 
 type ShopTimezoneLite = Pick<DB["public"]["Tables"]["shops"]["Row"], "timezone">;
+type LaborSegmentLite = Pick<
+  DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"],
+  "work_order_line_id" | "technician_id" | "started_at" | "ended_at"
+>;
 
 export type TechnicianIdleBreakdown = {
   availableIdleSeconds: number;
@@ -229,7 +233,7 @@ export async function getTechnicianLoadMetricsWithClient(
     };
   }
 
-  const [linesRes, shiftsRes] = await Promise.all([
+  const [linesRes, shiftsRes, segmentsRes] = await Promise.all([
     supabase
       .from("work_order_lines")
       .select("id, shop_id, work_order_id, assigned_tech_id, punched_in_at, punched_out_at, labor_time")
@@ -244,13 +248,22 @@ export async function getTechnicianLoadMetricsWithClient(
       .in("user_id", techIds)
       .lt("start_time", dayEndIso)
       .or(`end_time.is.null,end_time.gte.${dayStartIso}`),
+    supabase
+      .from("work_order_line_labor_segments")
+      .select("work_order_line_id, technician_id, started_at, ended_at")
+      .eq("shop_id", shopId)
+      .in("technician_id", techIds)
+      .lt("started_at", dayEndIso)
+      .or(`ended_at.is.null,ended_at.gte.${dayStartIso}`),
   ]);
 
   if (linesRes.error) throw linesRes.error;
   if (shiftsRes.error) throw shiftsRes.error;
+  if (segmentsRes.error) throw segmentsRes.error;
 
   const lines = (linesRes.data as LineLite[] | null) ?? [];
   const shifts = (shiftsRes.data as ShiftLite[] | null) ?? [];
+  const laborSegments = (segmentsRes.data as LaborSegmentLite[] | null) ?? [];
   const shiftIds = shifts.map((s) => s.id).filter(Boolean);
 
   let punches: PunchLite[] = [];
@@ -300,52 +313,53 @@ export async function getTechnicianLoadMetricsWithClient(
   );
 
   const durationTotals = new Map<string, { totalSeconds: number; count: number }>();
+  const activeLineIdsByTech = new Map<string, Set<string>>();
+  const lineDurationByTech = new Map<string, Map<string, number>>();
 
-  for (const line of lines) {
-    const techId = line.assigned_tech_id;
+  for (const segment of laborSegments) {
+    const techId = segment.technician_id;
     if (!techId) continue;
+
     const row = rowsByTech.get(techId);
     if (!row) continue;
 
-    const activeSeconds = clampOverlapSeconds(
-      line.punched_in_at,
-      line.punched_out_at,
+    const segSeconds = clampOverlapSeconds(
+      segment.started_at,
+      segment.ended_at,
       dayStartMs,
       dayEndMs,
       nowMs,
     );
+    row.activeSecondsToday += segSeconds;
 
-    row.activeSecondsToday += activeSeconds;
-
-    if (line.punched_in_at && !line.punched_out_at) {
-      row.currentActiveJobs += 1;
+    if (!segment.ended_at && segment.work_order_line_id) {
+      const activeSet = activeLineIdsByTech.get(techId) ?? new Set<string>();
+      activeSet.add(segment.work_order_line_id);
+      activeLineIdsByTech.set(techId, activeSet);
     }
 
-    if (line.punched_in_at && line.punched_out_at) {
-      const outMs = new Date(line.punched_out_at).getTime();
-      const inMs = new Date(line.punched_in_at).getTime();
-
-      if (
-        outMs >= dayStartMs &&
-        outMs < dayEndMs &&
-        Number.isFinite(inMs) &&
-        Number.isFinite(outMs) &&
-        outMs > inMs
-      ) {
-        row.completedJobsToday += 1;
-
-        const item = durationTotals.get(techId) ?? { totalSeconds: 0, count: 0 };
-        item.totalSeconds += clampOverlapSeconds(
-          line.punched_in_at,
-          line.punched_out_at,
-          dayStartMs,
-          dayEndMs,
-          nowMs,
-        );
-        item.count += 1;
-        durationTotals.set(techId, item);
-      }
+    if (segment.work_order_line_id) {
+      const byLine = lineDurationByTech.get(techId) ?? new Map<string, number>();
+      byLine.set(segment.work_order_line_id, (byLine.get(segment.work_order_line_id) ?? 0) + segSeconds);
+      lineDurationByTech.set(techId, byLine);
     }
+
+    if (!segment.ended_at) continue;
+
+    const endedMs = new Date(segment.ended_at).getTime();
+    if (!Number.isFinite(endedMs) || endedMs < dayStartMs || endedMs >= dayEndMs) continue;
+
+    row.completedJobsToday += 1;
+    const item = durationTotals.get(techId) ?? { totalSeconds: 0, count: 0 };
+    item.totalSeconds += segSeconds;
+    item.count += 1;
+    durationTotals.set(techId, item);
+  }
+
+  for (const [techId, activeLineIds] of activeLineIdsByTech.entries()) {
+    const row = rowsByTech.get(techId);
+    if (!row) continue;
+    row.currentActiveJobs = activeLineIds.size;
   }
 
   const punchesByShiftId = new Map<string, PunchLite[]>();
@@ -379,7 +393,6 @@ export async function getTechnicianLoadMetricsWithClient(
 
     const netShiftSeconds = Math.max(0, shiftSeconds - breakSeconds);
     row.shiftSecondsToday += netShiftSeconds;
-    row.workedSecondsToday = row.shiftSecondsToday;
   }
 
   for (const line of lines) {
@@ -387,12 +400,9 @@ export async function getTechnicianLoadMetricsWithClient(
     if (!techId) continue;
     const row = rowsByTech.get(techId);
     if (!row) continue;
-    if (!line.punched_in_at || !line.punched_out_at) continue;
 
-    const outMs = new Date(line.punched_out_at).getTime();
-    const inMs = new Date(line.punched_in_at).getTime();
-    if (!Number.isFinite(inMs) || !Number.isFinite(outMs) || outMs <= inMs) continue;
-    if (outMs < dayStartMs || outMs >= dayEndMs) continue;
+    const actualSeconds = lineDurationByTech.get(techId)?.get(line.id) ?? 0;
+    if (actualSeconds <= 0) continue;
 
     row.expectedActualSummary.eligibleCompletedJobs += 1;
 
@@ -403,15 +413,6 @@ export async function getTechnicianLoadMetricsWithClient(
     if (expectedSecondsRaw <= 0) continue;
 
     row.expectedActualSummary.expectedDataAvailable = true;
-    const actualSeconds = clampOverlapSeconds(
-      line.punched_in_at,
-      line.punched_out_at,
-      dayStartMs,
-      dayEndMs,
-      nowMs,
-    );
-
-    if (actualSeconds <= 0) continue;
 
     const varianceSeconds = actualSeconds - expectedSecondsRaw;
     const efficiencyPct = toPercent(expectedSecondsRaw, actualSeconds);
@@ -419,7 +420,7 @@ export async function getTechnicianLoadMetricsWithClient(
     row.completedJobVariance.push({
       lineId: line.id,
       workOrderId: line.work_order_id ?? null,
-      completedAtIso: line.punched_out_at,
+      completedAtIso: line.punched_out_at ?? line.punched_in_at ?? dayEndIso,
       expectedSeconds: expectedSecondsRaw,
       actualActiveSeconds: actualSeconds,
       varianceSeconds,
@@ -428,6 +429,7 @@ export async function getTechnicianLoadMetricsWithClient(
   }
 
   for (const row of rowsByTech.values()) {
+    row.workedSecondsToday = row.activeSecondsToday;
     const totals = durationTotals.get(row.techId);
     row.avgJobDurationSeconds =
       totals && totals.count > 0 ? Math.round(totals.totalSeconds / totals.count) : 0;

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -14821,6 +14821,108 @@ export type Database = {
           },
         ]
       }
+      work_order_line_labor_segments: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          ended_at: string | null
+          id: string
+          pause_reason: string | null
+          shop_id: string
+          source: string
+          started_at: string
+          technician_id: string
+          updated_at: string
+          work_order_id: string
+          work_order_line_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          ended_at?: string | null
+          id?: string
+          pause_reason?: string | null
+          shop_id: string
+          source?: string
+          started_at: string
+          technician_id: string
+          updated_at?: string
+          work_order_id: string
+          work_order_line_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          ended_at?: string | null
+          id?: string
+          pause_reason?: string | null
+          shop_id?: string
+          source?: string
+          started_at?: string
+          technician_id?: string
+          updated_at?: string
+          work_order_id?: string
+          work_order_line_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "work_order_line_labor_segments_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_technician_id_fkey"
+            columns: ["technician_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "work_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_line_id_fkey"
+            columns: ["work_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "v_quote_queue"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_line_id_fkey"
+            columns: ["work_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "v_vehicle_service_history"
+            referencedColumns: ["work_order_line_id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_line_id_fkey"
+            columns: ["work_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_lines"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       work_order_lines: {
         Row: {
           approval_at: string | null

--- a/features/work-orders/components/ActiveJobWidget.tsx
+++ b/features/work-orders/components/ActiveJobWidget.tsx
@@ -47,14 +47,27 @@ export function ActiveJobWidget(): JSX.Element {
         return;
       }
 
-      // 🔍 Find the current user's active punched-in line
+      const { data: activeSegment, error: activeSegmentErr } = await supabase
+        .from("work_order_line_labor_segments")
+        .select("work_order_line_id")
+        .eq("technician_id", user.id)
+        .is("ended_at", null)
+        .order("started_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (activeSegmentErr) throw activeSegmentErr;
+
+      if (!activeSegment?.work_order_line_id) {
+        setState({ line: null, workOrder: null, vehicle: null });
+        setLoading(false);
+        return;
+      }
+
       const { data: line, error: lineErr } = await supabase
         .from("work_order_lines")
         .select("*")
-        .eq("assigned_tech_id", user.id)
-        .not("punched_in_at", "is", null)
-        .is("punched_out_at", null)
-        .order("punched_in_at", { ascending: false })
+        .eq("id", activeSegment.work_order_line_id)
         .maybeSingle<WorkOrderLine>();
 
       if (lineErr) throw lineErr;

--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -5,6 +5,11 @@ import {
   getWorkOrderLineTransitionError,
   normalizeWorkOrderLineStatus,
 } from "@/features/work-orders/lib/line-status";
+import {
+  closeActiveLaborSegments,
+  startLaborSegment,
+  syncLinePunchMirrorFromSegments,
+} from "@/features/work-orders/server/laborSegments";
 
 type DB = Database;
 
@@ -150,7 +155,7 @@ export async function applyJobPunchTransition({
       );
     }
 
-    const lineTechId = line.assigned_tech_id ?? technicianId;
+    const lineTechId = technicianId;
 
     let openShiftQ = supabase
       .from("tech_shifts")
@@ -197,17 +202,23 @@ export async function applyJobPunchTransition({
     }
 
     if (!allowConcurrentJobPunches) {
-      const { data: activeJobRows, error: activeJobsErr } = await supabase
-        .from("work_order_lines")
+      let activeSegmentQuery = supabase
+        .from("work_order_line_labor_segments")
         .select("id")
-        .eq("assigned_tech_id", lineTechId)
-        .not("punched_in_at", "is", null)
-        .is("punched_out_at", null)
-        .neq("id", lineId);
+        .eq("technician_id", lineTechId)
+        .is("ended_at", null)
+        .neq("work_order_line_id", lineId)
+        .limit(1);
 
-      if (activeJobsErr) return err(400, activeJobsErr.message);
+      if (line.shop_id) {
+        activeSegmentQuery = activeSegmentQuery.eq("shop_id", line.shop_id);
+      }
 
-      if ((activeJobRows?.length ?? 0) > 0) {
+      const { data: activeSegments, error: activeSegmentErr } = await activeSegmentQuery;
+
+      if (activeSegmentErr) return err(400, activeSegmentErr.message);
+
+      if ((activeSegments?.length ?? 0) > 0) {
         return err(
           409,
           "Technician already has an active job punch. Complete/pause it first or retry with allowConcurrentJobPunches=true.",
@@ -218,6 +229,10 @@ export async function applyJobPunchTransition({
     const now = new Date().toISOString();
     const shouldResetPunchClock =
       action === "start" || status === "on_hold" || Boolean(line.punched_out_at);
+
+    if (!line.shop_id || !line.work_order_id) {
+      return err(409, "Cannot start labor segment until line has shop_id and work_order_id.");
+    }
 
     const { error: updateErr } = await supabase
       .from("work_order_lines")
@@ -235,6 +250,32 @@ export async function applyJobPunchTransition({
       .single();
 
     if (updateErr) return err(400, updateErr.message);
+
+    const { error: segmentErr } = await startLaborSegment({
+      supabase,
+      shopId: line.shop_id,
+      workOrderId: line.work_order_id,
+      workOrderLineId: lineId,
+      technicianId: lineTechId,
+      actorId: technicianId,
+      startedAtIso: now,
+      source: action === "start" ? "job_start" : "job_resume",
+    });
+
+    if (segmentErr) {
+      const message = segmentErr.message.toLowerCase();
+      if (message.includes("uq_wolls_active_by_tech") || message.includes("ex_wolls_no_overlap")) {
+        return err(409, "Technician already has overlapping active labor. Pause/finish current job first.");
+      }
+      return err(400, segmentErr.message);
+    }
+
+    const { error: syncErr } = await syncLinePunchMirrorFromSegments({
+      supabase,
+      workOrderLineId: lineId,
+    });
+
+    if (syncErr) return err(400, syncErr.message);
 
     await supabase.from("activity_logs").insert({
       entity_type: "work_order_line",
@@ -272,6 +313,19 @@ export async function applyJobPunchTransition({
 
     if (updateErr) return err(400, updateErr.message);
 
+    const pauseTechId = technicianId;
+    const { error: closeErr } = await closeActiveLaborSegments({
+      supabase,
+      workOrderLineId: lineId,
+      technicianId: pauseTechId,
+      endedAtIso: now,
+    });
+
+    if (closeErr) return err(400, closeErr.message);
+
+    const { error: syncErr } = await syncLinePunchMirrorFromSegments({ supabase, workOrderLineId: lineId });
+    if (syncErr) return err(400, syncErr.message);
+
     await supabase.from("activity_logs").insert({
       entity_type: "work_order_line",
       entity_id: lineId,
@@ -307,6 +361,19 @@ export async function applyJobPunchTransition({
   }
 
   const nowIso = new Date().toISOString();
+
+  const finishTechId = technicianId;
+  const { error: closeErr } = await closeActiveLaborSegments({
+    supabase,
+    workOrderLineId: lineId,
+    technicianId: finishTechId,
+    endedAtIso: nowIso,
+  });
+
+  if (closeErr) return err(400, closeErr.message);
+
+  const { error: syncErr } = await syncLinePunchMirrorFromSegments({ supabase, workOrderLineId: lineId });
+  if (syncErr) return err(400, syncErr.message);
 
   const updatePayload: DB["public"]["Tables"]["work_order_lines"]["Update"] = {
     status: "completed",

--- a/features/work-orders/server/laborSegments.ts
+++ b/features/work-orders/server/laborSegments.ts
@@ -1,0 +1,113 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+type LaborSegmentRow = DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
+
+type LaborSegmentInsert = DB["public"]["Tables"]["work_order_line_labor_segments"]["Insert"];
+
+export async function startLaborSegment(params: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+  workOrderLineId: string;
+  technicianId: string;
+  actorId: string;
+  startedAtIso: string;
+  source?: string;
+}) {
+  const payload: LaborSegmentInsert = {
+    shop_id: params.shopId,
+    work_order_id: params.workOrderId,
+    work_order_line_id: params.workOrderLineId,
+    technician_id: params.technicianId,
+    created_by: params.actorId,
+    started_at: params.startedAtIso,
+    source: params.source ?? "job_punch",
+  };
+
+  const { error } = await params.supabase.from("work_order_line_labor_segments").insert(payload);
+  return { error };
+}
+
+export async function closeActiveLaborSegments(params: {
+  supabase: SupabaseClient<DB>;
+  workOrderLineId?: string;
+  technicianId?: string;
+  endedAtIso: string;
+}) {
+  let query = params.supabase
+    .from("work_order_line_labor_segments")
+    .update({ ended_at: params.endedAtIso })
+    .is("ended_at", null);
+
+  if (params.workOrderLineId) {
+    query = query.eq("work_order_line_id", params.workOrderLineId);
+  }
+  if (params.technicianId) {
+    query = query.eq("technician_id", params.technicianId);
+  }
+
+  const { error } = await query;
+  return { error };
+}
+
+export async function getActiveLaborSegmentsByTechnician(params: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  technicianId: string;
+}) {
+  const { data, error } = await params.supabase
+    .from("work_order_line_labor_segments")
+    .select("id, work_order_line_id, started_at")
+    .eq("shop_id", params.shopId)
+    .eq("technician_id", params.technicianId)
+    .is("ended_at", null)
+    .order("started_at", { ascending: true });
+
+  return { data, error };
+}
+
+export async function syncLinePunchMirrorFromSegments(params: {
+  supabase: SupabaseClient<DB>;
+  workOrderLineId: string;
+}) {
+  const { data: segments, error: segErr } = await params.supabase
+    .from("work_order_line_labor_segments")
+    .select("started_at, ended_at")
+    .eq("work_order_line_id", params.workOrderLineId)
+    .order("started_at", { ascending: true });
+
+  if (segErr) return { error: segErr };
+
+  const rows = (segments ?? []) as Pick<LaborSegmentRow, "started_at" | "ended_at">[];
+  if (rows.length === 0) {
+    const { error } = await params.supabase
+      .from("work_order_lines")
+      .update({ punched_in_at: null, punched_out_at: null })
+      .eq("id", params.workOrderLineId);
+    return { error };
+  }
+
+  const earliestStartedAt = rows[0]?.started_at ?? null;
+  const hasOpenSegment = rows.some((segment) => !segment.ended_at);
+
+  let latestEndedAt: string | null = null;
+  for (const segment of rows) {
+    if (!segment.ended_at) continue;
+    if (!latestEndedAt || new Date(segment.ended_at).getTime() > new Date(latestEndedAt).getTime()) {
+      latestEndedAt = segment.ended_at;
+    }
+  }
+
+  const { error } = await params.supabase
+    .from("work_order_lines")
+    .update({
+      punched_in_at: earliestStartedAt,
+      punched_out_at: hasOpenSegment ? null : latestEndedAt,
+    })
+    .eq("id", params.workOrderLineId);
+
+  return { error };
+}

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -12401,6 +12401,108 @@ export type Database = {
           },
         ]
       }
+      work_order_line_labor_segments: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          ended_at: string | null
+          id: string
+          pause_reason: string | null
+          shop_id: string
+          source: string
+          started_at: string
+          technician_id: string
+          updated_at: string
+          work_order_id: string
+          work_order_line_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          ended_at?: string | null
+          id?: string
+          pause_reason?: string | null
+          shop_id: string
+          source?: string
+          started_at: string
+          technician_id: string
+          updated_at?: string
+          work_order_id: string
+          work_order_line_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          ended_at?: string | null
+          id?: string
+          pause_reason?: string | null
+          shop_id?: string
+          source?: string
+          started_at?: string
+          technician_id?: string
+          updated_at?: string
+          work_order_id?: string
+          work_order_line_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "work_order_line_labor_segments_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_technician_id_fkey"
+            columns: ["technician_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "work_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_line_id_fkey"
+            columns: ["work_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "v_quote_queue"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_line_id_fkey"
+            columns: ["work_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "v_vehicle_service_history"
+            referencedColumns: ["work_order_line_id"]
+          },
+          {
+            foreignKeyName: "work_order_line_labor_segments_work_order_line_id_fkey"
+            columns: ["work_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_lines"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       work_order_lines: {
         Row: {
           approval_at: string | null


### PR DESCRIPTION
### Motivation
- Introduce a true per-technician worked-time model so worked time is audit-grade and no longer relies on single line-level punch fields.
- Preserve existing workflows by keeping `work_order_lines.punched_in_at`/`punched_out_at` as compatibility mirrors during the transition.
- Enforce server-authoritative punch lifecycle and reduce overlap risk with the strongest safe DB and server guards while remaining additive and non-breaking.

### Description
- Added an additive SQL migration `db/sql/2026-04-10_work_order_line_labor_segments.sql` which creates `work_order_line_labor_segments` with indexes, RLS, a partial-unique index and an exclusion constraint to prevent overlapping active segments, plus a rollup view for worked-time reporting.
- Implemented server helpers in `features/work-orders/server/laborSegments.ts` to start/close segments and to sync the legacy line-level punch mirror (`syncLinePunchMirrorFromSegments`).
- Wired punch lifecycle to segments in `features/work-orders/server/applyJobPunchTransition.ts` so start/resume creates a segment, pause/finish close segments, and the line-level fields are updated as mirrors; added guards to prevent overlapping active segments and to require shift open when starting segments.
- Updated high-value surfaces and flows to read segment truth: shift-end endpoints (`app/api/time/shift/end/route.ts`, `app/api/scheduling/punches/route.ts`), active job UI (`features/work-orders/components/ActiveJobWidget.tsx`), punch controller (`features/shared/components/ui/PunchController.tsx`), agent tools (`features/agent/tools/getShopCurrentStatus.ts`, `features/agent/tools/getTechCurrentWork.ts`), technician metrics (`features/shared/lib/stats/getTechnicianLoadMetricsCore.ts`), and regenerated Supabase types to include the new table.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` which completed with no type errors.
- No additional automated unit tests were modified or added in this change; the migration and behavioral validations are additive and intended to be exercised by integration/DB migration runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d975dc051c832881cea16bacb28c5f)