### PR TITLE
Finalize launch hardening: RBAC, labor backfill, offline queue, and mobile UX

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 // ⬇️ If you ALREADY have a helper like this somewhere else, import that instead:
 // import { createRouteHandlerClient } from "@/features/shared/lib/supabase/server";
@@ -81,11 +82,8 @@ export async function POST(req: Request) {
     }
 
     const callerShopId = callerProfile.shop_id;
-    const callerRole = callerProfile.role ?? "mechanic";
-
-    // optionally: only allow certain roles to create users
-    const ALLOWED_CREATORS = new Set(["owner", "admin", "manager"]);
-    if (!ALLOWED_CREATORS.has(callerRole)) {
+    const actor = getActorCapabilities({ role: callerProfile.role });
+    if (!actor.isKnownRole || !actor.canManageUsers) {
       return NextResponse.json(
         { error: "You do not have permission to create users." },
         { status: 403 }

--- a/app/api/maintenance/history/backfill/route.ts
+++ b/app/api/maintenance/history/backfill/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { backfillMaintenanceHistorySignals } from "@/features/maintenance/server/backfillMaintenanceHistorySignals";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -29,8 +30,8 @@ export async function POST() {
     return NextResponse.json({ error: "Unable to resolve shop context" }, { status: 400 });
   }
 
-  const role = String(profile.role ?? "").toLowerCase();
-  if (!["owner", "admin", "manager"].includes(role)) {
+  const actor = getActorCapabilities({ role: profile.role });
+  if (!actor.isKnownRole || !actor.canViewShopWideData) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/app/api/portal/bookings/[id]/route.ts
+++ b/app/api/portal/bookings/[id]/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
-
-const STAFF_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 
 type PatchBody = {
   status?: "pending" | "confirmed" | "cancelled" | "completed";
@@ -34,7 +33,8 @@ async function getAuthedContext(supabase: ReturnType<typeof createRouteHandlerCl
     return { error: NextResponse.json({ error: "Profile/shop not found" }, { status: 403 }) };
   }
 
-  if (!STAFF_ROLES.has(String(profile.role ?? ""))) {
+  const actor = getActorCapabilities({ role: profile.role });
+  if (!actor.isKnownRole || !actor.canManageScheduling) {
     return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
   }
 

--- a/app/api/portal/bookings/route.ts
+++ b/app/api/portal/bookings/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 export const runtime = "nodejs";
 
@@ -64,19 +65,8 @@ export async function GET(req: Request): Promise<Response> {
     return bad("Profile / shop not found", 403);
   }
 
-  const staffRoles = [
-    "owner",
-    "admin",
-    "manager",
-    "advisor",
-    "mechanic",
-    "parts",
-  ] as const;
-
-  if (
-    !profile.role ||
-    !staffRoles.includes(profile.role as (typeof staffRoles)[number])
-  ) {
+  const actor = getActorCapabilities({ role: profile.role });
+  if (!actor.isKnownRole || (!actor.canManageScheduling && !actor.canViewShopWideData)) {
     return bad("Not allowed", 403);
   }
 

--- a/app/api/settings/hours/route.ts
+++ b/app/api/settings/hours/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -93,7 +94,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    if (profile.role !== "owner" && profile.role !== "admin") {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || (actor.canonicalRole !== "owner" && actor.canonicalRole !== "admin")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/settings/time-off/route.ts
+++ b/app/api/settings/time-off/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -94,7 +95,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    if (profile.role !== "owner" && profile.role !== "admin") {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || (actor.canonicalRole !== "owner" && actor.canonicalRole !== "admin")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -164,7 +166,8 @@ export async function DELETE(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    if (profile.role !== "owner" && profile.role !== "admin") {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || (actor.canonicalRole !== "owner" && actor.canonicalRole !== "admin")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/work-orders/quotes/[id]/authorize/route.ts
+++ b/app/api/work-orders/quotes/[id]/authorize/route.ts
@@ -4,6 +4,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database, TablesInsert } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 export const runtime = "nodejs";
 
@@ -14,6 +15,29 @@ export async function POST(req: NextRequest) {
   const supabase = createRouteHandlerClient<DB>({ cookies });
 
   try {
+    const {
+      data: { user },
+      error: authErr,
+    } = await supabase.auth.getUser();
+    if (authErr || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("shop_id, role")
+      .eq("id", user.id)
+      .single();
+
+    if (profileErr || !profile?.shop_id) {
+      return NextResponse.json({ error: "Unable to resolve actor profile" }, { status: 403 });
+    }
+
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canAuthorizeQuotes) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     // Extract `[id]` from the pathname .../quotes/<id>/authorize
     const segments = req.nextUrl.pathname.split("/").filter(Boolean);
     const id = segments[segments.length - 2]; // the segment before "authorize"
@@ -35,6 +59,9 @@ export async function POST(req: NextRequest) {
 
     if (!q.shop_id) {
       return NextResponse.json({ error: "Quote line is missing shop_id" }, { status: 400 });
+    }
+    if (q.shop_id !== profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     // 2) Turn it into a punchable job line

--- a/db/sql/2026-04-10_work_order_labor_segments_backfill.sql
+++ b/db/sql/2026-04-10_work_order_labor_segments_backfill.sql
@@ -1,0 +1,44 @@
+-- Backfill trustworthy historical labor segments from legacy line punches.
+-- Safe rules:
+-- 1) Only lines with assigned_tech_id, punched_in_at and punched_out_at.
+-- 2) Require punch-out after punch-in.
+-- 3) Skip lines that already have any segment history.
+-- 4) Keep shop/work-order lineage intact.
+
+insert into public.work_order_line_labor_segments (
+  shop_id,
+  work_order_id,
+  work_order_line_id,
+  technician_id,
+  started_at,
+  ended_at,
+  source,
+  created_by,
+  metadata
+)
+select
+  wol.shop_id,
+  wol.work_order_id,
+  wol.id as work_order_line_id,
+  wol.assigned_tech_id as technician_id,
+  wol.punched_in_at as started_at,
+  wol.punched_out_at as ended_at,
+  'legacy_line_backfill'::text as source,
+  wol.assigned_tech_id as created_by,
+  jsonb_build_object(
+    'backfill', true,
+    'from', 'work_order_lines',
+    'backfilled_at', now()
+  ) as metadata
+from public.work_order_lines wol
+where wol.shop_id is not null
+  and wol.work_order_id is not null
+  and wol.assigned_tech_id is not null
+  and wol.punched_in_at is not null
+  and wol.punched_out_at is not null
+  and wol.punched_out_at > wol.punched_in_at
+  and not exists (
+    select 1
+    from public.work_order_line_labor_segments seg
+    where seg.work_order_line_id = wol.id
+  );

--- a/features/inspections/lib/inspection/save.ts
+++ b/features/inspections/lib/inspection/save.ts
@@ -1,5 +1,50 @@
 // features/inspections/lib/inspection/save.ts
+"use client";
+
 import type { InspectionSession } from "@inspections/lib/inspection/types";
+import {
+  runMutationWithOfflineQueue,
+  replayQueuedMutations,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+
+const ACTION_SAVE_INSPECTION = "inspection:save-session";
+
+async function postInspectionSave(payload: {
+  workOrderLineId: string;
+  session: InspectionSession;
+}) {
+  const res = await fetch("/api/inspections/save", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const j = await res.json().catch(() => ({}));
+    throw new Error(j?.error || "Save failed");
+  }
+}
+
+export async function replayQueuedInspectionSaves(): Promise<void> {
+  await replayQueuedMutations({
+    handlers: {
+      [ACTION_SAVE_INSPECTION]: async (mutation: PendingMutation) => {
+        const payload = mutation.payload as
+          | { workOrderLineId?: string; session?: InspectionSession }
+          | undefined;
+        if (!payload?.workOrderLineId || !payload.session) {
+          return { conflicted: "Inspection save mutation is missing payload data." };
+        }
+        await postInspectionSave({
+          workOrderLineId: payload.workOrderLineId,
+          session: payload.session,
+        });
+      },
+    },
+  });
+}
 
 export async function saveInspectionSession(
   session: InspectionSession,
@@ -9,15 +54,20 @@ export async function saveInspectionSession(
     throw new Error("Missing workOrderLineId");
   }
 
-  const res = await fetch("/api/inspections/save", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify({ workOrderLineId, session }),
+  const payload = { workOrderLineId, session };
+  const mutationId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${workOrderLineId}:${Date.now()}`;
+
+  await runMutationWithOfflineQueue({
+    clientMutationId: mutationId,
+    actionType: ACTION_SAVE_INSPECTION,
+    payload,
+    runner: () => postInspectionSave(payload),
   });
 
-  if (!res.ok) {
-    const j = await res.json().catch(() => ({}));
-    throw new Error(j?.error || "Save failed");
+  if (typeof navigator !== "undefined" && navigator.onLine) {
+    await replayQueuedInspectionSaves();
   }
 }

--- a/features/mobile/components/MobileShiftTracker.tsx
+++ b/features/mobile/components/MobileShiftTracker.tsx
@@ -4,6 +4,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { formatDistanceToNow } from "date-fns";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  runMutationWithOfflineQueue,
+  getOfflineSyncSummary,
+  replayQueuedMutations,
+  subscribeOfflineMutations,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
 
 type DB = Database;
 
@@ -34,24 +41,90 @@ export default function MobileShiftTracker({ userId }: Props) {
   const [mode, setMode] = useState<Mode>("none");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [syncSummary, setSyncSummary] = useState(() => getOfflineSyncSummary());
+
+  const refreshOfflineSummary = useCallback(() => {
+    setSyncSummary(getOfflineSyncSummary());
+  }, []);
+
+  useEffect(() => {
+    return subscribeOfflineMutations(refreshOfflineSummary);
+  }, [refreshOfflineSummary]);
 
   const insertPunch = useCallback(
     async (sid: string, event: PunchEventType) => {
-      const { error } = await supabase.from("punch_events").insert({
-        shift_id: sid,
-        user_id: userId,
-        profile_id: userId,
-        event_type: event,
-        timestamp: new Date().toISOString(),
-      });
+      const timestamp = new Date().toISOString();
+      const mutationId =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `${sid}:${event}:${Date.now()}`;
 
-      if (error) {
+      try {
+        const result = await runMutationWithOfflineQueue({
+          clientMutationId: mutationId,
+          actionType: "shift:punch-event",
+          payload: {
+            shift_id: sid,
+            user_id: userId,
+            profile_id: userId,
+            event_type: event,
+            timestamp,
+          },
+          runner: async () => {
+            const { error } = await supabase.from("punch_events").insert({
+              shift_id: sid,
+              user_id: userId,
+              profile_id: userId,
+              event_type: event,
+              timestamp,
+            });
+            if (error) throw error;
+          },
+        });
+        if (result.queued) {
+          setErr("Punch event queued for sync once connection is restored.");
+        }
+      } catch (error) {
+        const e = error as { code?: string; message?: string };
         console.error("[MobileShiftTracker] insertPunch failed:", error);
-        setErr(`${error.code ?? "punch_error"}: ${error.message}`);
+        setErr(`${e.code ?? "punch_error"}: ${e.message ?? "Failed to record punch event"}`);
       }
     },
     [supabase, userId],
   );
+
+  const replayOfflineMutations = useCallback(async () => {
+    const result = await replayQueuedMutations({
+      handlers: {
+        "shift:punch-event": async (mutation: PendingMutation) => {
+          const payload = mutation.payload as
+            | {
+                shift_id?: string;
+                user_id?: string;
+                profile_id?: string;
+                event_type?: PunchEventType;
+                timestamp?: string;
+              }
+            | undefined;
+          if (!payload?.shift_id || !payload?.user_id || !payload?.event_type || !payload?.timestamp) {
+            return { conflicted: "Queued shift punch payload is incomplete." };
+          }
+          const { error } = await supabase.from("punch_events").insert({
+            shift_id: payload.shift_id,
+            user_id: payload.user_id,
+            profile_id: payload.profile_id ?? payload.user_id,
+            event_type: payload.event_type,
+            timestamp: payload.timestamp,
+          });
+          if (error) throw error;
+        },
+      },
+    });
+
+    if (result.failed > 0) {
+      setErr(`${result.failed} queued punch event(s) still failing to sync.`);
+    }
+  }, [supabase]);
 
   const punchOutActiveJobsForShiftEnd = useCallback(async () => {
     if (!userId) return;
@@ -151,6 +224,16 @@ export default function MobileShiftTracker({ userId }: Props) {
   useEffect(() => {
     void loadOpenShift();
   }, [loadOpenShift]);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    if (navigator.onLine) {
+      void replayOfflineMutations();
+    }
+    const onOnline = () => void replayOfflineMutations();
+    window.addEventListener("online", onOnline);
+    return () => window.removeEventListener("online", onOnline);
+  }, [replayOfflineMutations]);
 
   const startShift = useCallback(async () => {
     if (busy || !userId) return;
@@ -300,6 +383,15 @@ export default function MobileShiftTracker({ userId }: Props) {
           {niceStatus}
         </span>
       </div>
+      {(syncSummary.queued > 0 ||
+        syncSummary.failed > 0 ||
+        syncSummary.syncing > 0 ||
+        syncSummary.conflicted > 0) && (
+        <div className="rounded-md border border-amber-400/35 bg-amber-500/10 px-2 py-1 text-[0.65rem] text-amber-100">
+          Sync queue • Pending {syncSummary.queued + syncSummary.syncing} • Failed{" "}
+          {syncSummary.failed} • Conflicted {syncSummary.conflicted}
+        </div>
+      )}
 
       {err && (
         <div className="rounded-md border border-red-500/40 bg-red-950/70 px-2 py-1 text-[0.65rem] text-red-200">

--- a/features/shared/lib/stats/getTechLeaderboard.ts
+++ b/features/shared/lib/stats/getTechLeaderboard.ts
@@ -51,6 +51,12 @@ type WorkOrderLineSlim = {
   punchable: boolean | null;
 };
 
+type LaborSegmentSlim = {
+  technician_id: string | null;
+  started_at: string;
+  ended_at: string | null;
+};
+
 export type TechLeaderboardRow = {
   techId: string;
   name: string;
@@ -102,6 +108,24 @@ function chunk<T>(arr: T[], size: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
   return out;
+}
+
+function getOverlapHours(
+  startedAt: string | null | undefined,
+  endedAt: string | null | undefined,
+  rangeStartIso: string,
+  rangeEndIso: string,
+): number {
+  if (!startedAt) return 0;
+  const startMs = new Date(startedAt).getTime();
+  if (!Number.isFinite(startMs)) return 0;
+  const endMs = endedAt ? new Date(endedAt).getTime() : new Date().getTime();
+  if (!Number.isFinite(endMs)) return 0;
+  const windowStart = new Date(rangeStartIso).getTime();
+  const windowEnd = new Date(rangeEndIso).getTime();
+  const overlapMs = Math.min(endMs, windowEnd) - Math.max(startMs, windowStart);
+  if (overlapMs <= 0) return 0;
+  return overlapMs / (1000 * 60 * 60);
 }
 
 export async function getTechLeaderboard(
@@ -164,8 +188,8 @@ export async function getTechLeaderboard(
     return { shop_id: shopId, start: startIso, end: endIso, rows: [] };
   }
 
-  // 2) Invoices + timecards in range
-  const [invoicesRes, timecardsRes] = await Promise.all([
+  // 2) Invoices + labor segments in range (timecards kept as fallback)
+  const [invoicesRes, timecardsRes, segmentsRes] = await Promise.all([
     supabase
       .from("invoices")
       .select("id, tech_id, shop_id, work_order_id, total, labor_cost, created_at")
@@ -181,13 +205,22 @@ export async function getTechLeaderboard(
       .in("user_id", techIds)
       .gte("clock_in", startIso)
       .lt("clock_in", endExclusiveIso),
+    supabase
+      .from("work_order_line_labor_segments")
+      .select("technician_id, started_at, ended_at")
+      .eq("shop_id", shopId)
+      .in("technician_id", techIds)
+      .lt("started_at", endExclusiveIso)
+      .or(`ended_at.gte.${startIso},ended_at.is.null`),
   ]);
 
   if (invoicesRes.error) throw invoicesRes.error;
   if (timecardsRes.error) throw timecardsRes.error;
+  if (segmentsRes.error) throw segmentsRes.error;
 
   const invoices: InvoiceSlim[] = (invoicesRes.data as InvoiceSlim[]) ?? [];
   const timecards: TimecardSlim[] = (timecardsRes.data as TimecardSlim[]) ?? [];
+  const segments: LaborSegmentSlim[] = (segmentsRes.data as LaborSegmentSlim[]) ?? [];
 
   // 3) Seed rows so techs show even with 0 activity
   const byTech = new Map<string, TechLeaderboardRow>();
@@ -232,15 +265,25 @@ export async function getTechLeaderboard(
     }
   }
 
-  // 5) Aggregate clocked hours from payroll timecards
+  // 5) Aggregate clocked hours from labor segments (source of truth)
+  for (const seg of segments) {
+    const techId = seg.technician_id;
+    if (!techId) continue;
+    const row = byTech.get(techId);
+    if (!row) continue;
+    row.clockedHours += getOverlapHours(seg.started_at, seg.ended_at, startIso, endExclusiveIso);
+  }
+
+  // Compatibility fallback for historical windows where no segments were created yet.
   for (const tc of timecards) {
     const techId = tc.user_id;
     if (!techId) continue;
 
     const row = byTech.get(techId);
     if (!row) continue;
-
-    row.clockedHours += safeNum(tc.hours_worked);
+    if (row.clockedHours <= 0) {
+      row.clockedHours += safeNum(tc.hours_worked);
+    }
   }
 
   // 6) Billed hours = sum(work_order_lines.labor_time) for invoiced work orders

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -27,6 +27,10 @@ import { useTabState } from "@/features/shared/hooks/useTabState";
 import { JobCard } from "@/features/work-orders/mobile/MobileJobCard";
 import MobileFocusedJob from "@/features/work-orders/mobile/MobileFocusedJob";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
+import {
+  getOfflineSyncSummary,
+  subscribeOfflineMutations,
+} from "@/features/shared/lib/offline/mutations";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -243,6 +247,7 @@ export default function MobileWorkOrderClient({
     true,
   );
   const [warnedMissing, setWarnedMissing] = useState(false);
+  const [offlineSummary, setOfflineSummary] = useState(() => getOfflineSyncSummary());
 
   // mobile focused job view
   const [focusedJobId, setFocusedJobId] = useState<string | null>(null);
@@ -316,6 +321,11 @@ export default function MobileWorkOrderClient({
       sub?.subscription?.unsubscribe?.();
     };
   }, [routeId, setCurrentUserId, setUserId, setShopId]);
+
+  useEffect(() => {
+    const refresh = () => setOfflineSummary(getOfflineSyncSummary());
+    return subscribeOfflineMutations(refresh);
+  }, []);
 
   /* ---------------------- FETCH ---------------------- */
   const fetchAll = useCallback(
@@ -713,6 +723,13 @@ export default function MobileWorkOrderClient({
       }).length,
     [lines],
   );
+  const nextActionText = useMemo(() => {
+    if (approvalPending.length > 0) return "Review pending approvals before starting new labor actions.";
+    if (inProgressCount > 0) return "Continue active job punches and close blockers first.";
+    if (awaitingPartsCount > 0) return "Check parts holds and release next ready line.";
+    if (unassignedCount > 0) return "Assign the next unassigned line to keep throughput moving.";
+    return "Open a line to run inspection, notes, or punch actions.";
+  }, [approvalPending.length, awaitingPartsCount, inProgressCount, unassignedCount]);
 
   /* ----------------------- line & quote actions ----------------------- */
 
@@ -934,6 +951,15 @@ export default function MobileWorkOrderClient({
           {viewError}
         </div>
       )}
+      {(offlineSummary.queued > 0 ||
+        offlineSummary.syncing > 0 ||
+        offlineSummary.failed > 0 ||
+        offlineSummary.conflicted > 0) && (
+        <div className="metal-panel metal-panel--card rounded-2xl border border-amber-500/35 px-3 py-2 text-xs text-amber-100">
+          Sync queue: pending {offlineSummary.queued + offlineSummary.syncing} • failed{" "}
+          {offlineSummary.failed} • conflicted {offlineSummary.conflicted}
+        </div>
+      )}
 
       {loading ? (
         <div className="grid gap-4">
@@ -962,6 +988,12 @@ export default function MobileWorkOrderClient({
               <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">Unassigned</div>
               <div className="mt-1 text-base font-semibold text-neutral-200">{unassignedCount}</div>
             </div>
+          </div>
+          <div className="metal-card rounded-xl border border-[var(--metal-border-soft)] bg-black/35 px-3 py-2 text-xs text-neutral-200">
+            <span className="font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper-light)]">
+              Next action
+            </span>
+            <div className="mt-1">{nextActionText}</div>
           </div>
 
           {/* Header card */}


### PR DESCRIPTION
### Motivation
- Close remaining high-risk RBAC holes on launch-critical mutating and settings routes without changing auth/RLS model. 
- Ensure time-tracking uses labor segments as the primary truth for launch paths while providing a safe historical backfill for trustworthy legacy punches. 
- Strengthen offline reliability for key technician mobile mutations (shift/punch, inspection saves) and make sync state visible in-field. 

### Description
- RBAC: replaced ad-hoc role-array checks with canonical capability checks via `getActorCapabilities` on targeted, high-risk endpoints and added missing actor + tenant guardrails for quote authorization; routes updated include settings (hours, time-off), admin create-user, portal bookings (list/patch/delete), maintenance history backfill trigger, and quote authorize. 
- Time-tracking: added a conservative SQL backfill `db/sql/2026-04-10_work_order_labor_segments_backfill.sql` that only inserts labor segments for lines with `assigned_tech_id`, `punched_in_at` and `punched_out_at` and no existing segments, and updated `getTechLeaderboard` to prefer `work_order_line_labor_segments` for clocked hours with payroll timecards as compatibility fallback. 
- Offline: wired inspection progress saves into the offline queue/replay (new handlers in `features/inspections/lib/inspection/save.ts`) and added queued/replay support for shift/punch events in `MobileShiftTracker` using the existing offline queue runner. 
- Mobile UX: surfaced offline sync queue summary and clearer “Next action” guidance in mobile work-order detail and showed sync health in the mobile shift tracker to reduce field ambiguity. 
- Files changed (key): `app/api/settings/hours/route.ts`, `app/api/settings/time-off/route.ts`, `app/api/admin/create-user/route.ts`, `app/api/portal/bookings/route.ts`, `app/api/portal/bookings/[id]/route.ts`, `app/api/maintenance/history/backfill/route.ts`, `app/api/work-orders/quotes/[id]/authorize/route.ts`, `features/shared/lib/stats/getTechLeaderboard.ts`, `db/sql/2026-04-10_work_order_labor_segments_backfill.sql`, `features/inspections/lib/inspection/save.ts`, `features/mobile/components/MobileShiftTracker.tsx`, `features/work-orders/mobile/MobileWorkOrderClient.tsx`. 

### Testing
- Ran `npx tsc --noEmit` and the type-check passed with no new TypeScript errors. 
- No additional automated unit/integration tests were added in this pass; manual runtime validation surface coverage was limited to code review and TypeScript build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97c47160483288dea3b9550393b83)