### PR TITLE
Harden RBAC, add safe labor-segment backfill, and improve mobile/offline UX

### DIFF
--- a/app/api/admin/reset-user-password/route.ts
+++ b/app/api/admin/reset-user-password/route.ts
@@ -1,7 +1,10 @@
 // app/api/admin/reset-user-password/route.ts
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 function mustEnv(name: string) {
   const v = process.env[name];
@@ -10,6 +13,31 @@ function mustEnv(name: string) {
 }
 
 export async function POST(req: Request) {
+  const authClient = createRouteHandlerClient<Database>({ cookies });
+  const {
+    data: { user: callerUser },
+    error: callerAuthError,
+  } = await authClient.auth.getUser();
+
+  if (callerAuthError || !callerUser) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: callerProfile, error: callerProfileError } = await authClient
+    .from("profiles")
+    .select("id, role, shop_id")
+    .eq("id", callerUser.id)
+    .maybeSingle();
+
+  if (callerProfileError || !callerProfile?.shop_id) {
+    return NextResponse.json({ error: "Unable to resolve caller profile" }, { status: 400 });
+  }
+
+  const actor = getActorCapabilities({ role: callerProfile.role });
+  if (!actor.isKnownRole || !actor.canManageUsers) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const { username, password } = (await req.json()) as {
     username?: string;
     password?: string;
@@ -23,15 +51,19 @@ export async function POST(req: Request) {
     mustEnv("SUPABASE_SERVICE_ROLE_KEY")
   );
 
-  // find user by username in profiles
+  // find user by username in profiles scoped to the caller shop
   const { data: profile, error: profileErr } = await supabase
     .from("profiles")
-    .select("id")
+    .select("id, shop_id")
     .eq("username", username.toLowerCase())
     .maybeSingle();
 
   if (profileErr || !profile) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  if (profile.shop_id !== callerProfile.shop_id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const { error: updateErr } = await supabase.auth.admin.updateUserById(profile.id, {

--- a/app/api/organizations/create/route.ts
+++ b/app/api/organizations/create/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -12,7 +13,6 @@ type CreateOrgBody = {
   name?: string;
 };
 
-const ALLOWED_ROLES = new Set(["owner", "admin"]);
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -54,8 +54,8 @@ export async function POST(req: Request) {
       );
     }
 
-    const role = String(profile.role ?? "").toLowerCase();
-    if (!ALLOWED_ROLES.has(role)) {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canManageBilling) {
       return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/shop/owner-pin/set/route.ts
+++ b/app/api/shop/owner-pin/set/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import bcrypt from "bcryptjs";
 import type { Database } from "@shared/types/types/supabase";
 import { getRouteHandlerCookies, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -61,7 +62,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    if (profile.role !== "owner" && profile.role !== "admin") {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canOverrideOperationalState) {
       return NextResponse.json({ error: "Only owner/admin can set PIN" }, { status: 403 });
     }
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -7,6 +7,7 @@ import Stripe from "stripe";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -31,7 +32,6 @@ type ShopScope = Pick<
   "id" | "email" | "shop_name" | "name" | "stripe_customer_id"
 >;
 
-const ALLOWED_ROLES = new Set(["owner", "admin", "manager"]);
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -146,8 +146,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "No shop found for this account." }, { status: 400 });
     }
 
-    const role = String(profile.role ?? "").trim().toLowerCase();
-    if (!ALLOWED_ROLES.has(role)) {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canManageBilling) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/stripe/connect/onboard/route.ts
+++ b/app/api/stripe/connect/onboard/route.ts
@@ -7,6 +7,7 @@ import Stripe from "stripe";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -20,7 +21,6 @@ type ShopScope = Pick<
   "id" | "country" | "timezone" | "shop_name" | "name" | "stripe_account_id"
 >;
 
-const ALLOWED_ROLES = new Set(["owner", "admin", "manager"]);
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -81,8 +81,8 @@ export async function POST() {
       return NextResponse.json({ error: "No shop found for this account." }, { status: 400 });
     }
 
-    const role = String(profile.role ?? "").trim().toLowerCase();
-    if (!ALLOWED_ROLES.has(role)) {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canManageBilling) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -7,6 +7,7 @@ import Stripe from "stripe";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -20,7 +21,6 @@ type ShopScope = Pick<
   "id" | "email" | "shop_name" | "name" | "stripe_customer_id"
 >;
 
-const ALLOWED_ROLES = new Set(["owner", "admin", "manager"]);
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -104,8 +104,8 @@ export async function POST() {
       return NextResponse.json({ error: "No shop found for this account." }, { status: 400 });
     }
 
-    const role = String(profile.role ?? "").trim().toLowerCase();
-    if (!ALLOWED_ROLES.has(role)) {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canManageBilling) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/time/labor-segments/backfill/route.ts
+++ b/app/api/time/labor-segments/backfill/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type DB = Database;
+
+type LegacyPunchLine = Pick<
+  DB["public"]["Tables"]["work_order_lines"]["Row"],
+  "id" | "shop_id" | "work_order_id" | "assigned_tech_id" | "punched_in_at" | "punched_out_at"
+>;
+
+function mustEnv(name: string) {
+  const value = process.env[name];
+  if (!value || !value.trim()) throw new Error(`Missing env ${name}`);
+  return value;
+}
+
+export async function POST() {
+  const supabase = createRouteHandlerClient<DB>({ cookies });
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, shop_id, role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json(
+      { ok: false, error: profileError?.message ?? "Unable to resolve profile" },
+      { status: 400 },
+    );
+  }
+
+  const actor = getActorCapabilities({ role: profile.role });
+  if (!actor.isKnownRole || !actor.canManageScheduling) {
+    return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+  }
+
+  const admin = createClient<DB>(mustEnv("NEXT_PUBLIC_SUPABASE_URL"), mustEnv("SUPABASE_SERVICE_ROLE_KEY"));
+
+  const { data: legacyLines, error: linesError } = await admin
+    .from("work_order_lines")
+    .select("id, shop_id, work_order_id, assigned_tech_id, punched_in_at, punched_out_at")
+    .eq("shop_id", profile.shop_id)
+    .not("assigned_tech_id", "is", null)
+    .not("punched_in_at", "is", null)
+    .not("punched_out_at", "is", null);
+
+  if (linesError) {
+    return NextResponse.json({ ok: false, error: linesError.message }, { status: 500 });
+  }
+
+  const rows = (legacyLines ?? []) as LegacyPunchLine[];
+  if (!rows.length) {
+    return NextResponse.json({ ok: true, inserted: 0, skippedExisting: 0, skippedAmbiguous: 0 });
+  }
+
+  const lineIds = rows.map((row) => row.id);
+
+  const { data: existingSegments, error: segmentError } = await admin
+    .from("work_order_line_labor_segments")
+    .select("work_order_line_id")
+    .in("work_order_line_id", lineIds);
+
+  if (segmentError) {
+    return NextResponse.json({ ok: false, error: segmentError.message }, { status: 500 });
+  }
+
+  const existingSet = new Set((existingSegments ?? []).map((segment) => segment.work_order_line_id));
+
+  const payload: DB["public"]["Tables"]["work_order_line_labor_segments"]["Insert"][] = [];
+  let skippedExisting = 0;
+  let skippedAmbiguous = 0;
+
+  for (const line of rows) {
+    if (existingSet.has(line.id)) {
+      skippedExisting += 1;
+      continue;
+    }
+
+    const start = line.punched_in_at ? new Date(line.punched_in_at).getTime() : Number.NaN;
+    const end = line.punched_out_at ? new Date(line.punched_out_at).getTime() : Number.NaN;
+
+    if (
+      !line.shop_id ||
+      !line.work_order_id ||
+      !line.assigned_tech_id ||
+      !Number.isFinite(start) ||
+      !Number.isFinite(end) ||
+      end <= start
+    ) {
+      skippedAmbiguous += 1;
+      continue;
+    }
+
+    payload.push({
+      shop_id: line.shop_id,
+      work_order_id: line.work_order_id,
+      work_order_line_id: line.id,
+      technician_id: line.assigned_tech_id,
+      started_at: line.punched_in_at as string,
+      ended_at: line.punched_out_at as string,
+      source: "legacy_line_backfill",
+      created_by: user.id,
+    });
+  }
+
+  if (!payload.length) {
+    return NextResponse.json({
+      ok: true,
+      inserted: 0,
+      skippedExisting,
+      skippedAmbiguous,
+    });
+  }
+
+  const { error: insertError } = await admin.from("work_order_line_labor_segments").insert(payload);
+
+  if (insertError) {
+    return NextResponse.json({ ok: false, error: insertError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    inserted: payload.length,
+    skippedExisting,
+    skippedAmbiguous,
+  });
+}

--- a/app/mobile/tech/queue/page.tsx
+++ b/app/mobile/tech/queue/page.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import SuggestedActionsPanel from "@/features/assistant/components/SuggestedActionsPanel";
+import { getOfflineSyncSummary, subscribeOfflineMutations } from "@/features/shared/lib/offline/mutations";
 
 type DB = Database;
 type Line = DB["public"]["Tables"]["work_order_lines"]["Row"];
@@ -66,6 +67,13 @@ function cleanText(v: string | null | undefined): string {
   return String(v ?? "").trim().replace(/\s+/g, " ");
 }
 
+function nextActionLabel(status: RollupStatus): string {
+  if (status === "in_progress") return "Resume focused job";
+  if (status === "on_hold") return "Review hold reason + resume";
+  if (status === "awaiting") return "Start line when bay is free";
+  return "Review completion notes";
+}
+
 function formatVehicle(v: VehiclePick | null | undefined): string | null {
   if (!v) return null;
 
@@ -107,6 +115,14 @@ export default function MobileTechQueuePage() {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState<RollupStatus | null>(null);
+  const [syncSummary, setSyncSummary] = useState(() => getOfflineSyncSummary());
+
+
+  useEffect(() => {
+    const refresh = () => setSyncSummary(getOfflineSyncSummary());
+    refresh();
+    return subscribeOfflineMutations(refresh);
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -334,6 +350,11 @@ export default function MobileTechQueuePage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 pb-8 pt-4">
+        {(syncSummary.queued > 0 || syncSummary.syncing > 0 || syncSummary.failed > 0 || syncSummary.conflicted > 0) && (
+          <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+            Sync status: pending {syncSummary.queued + syncSummary.syncing} • failed {syncSummary.failed} • conflicted {syncSummary.conflicted}
+          </div>
+        )}
         {/* HERO (match MobileTechHome vibe) */}
         <section className="metal-panel metal-panel--hero rounded-2xl border border-[var(--metal-border-soft)] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.85)]">
           <div className="space-y-1">
@@ -467,6 +488,10 @@ export default function MobileTechQueuePage() {
 
                     <div className="mt-1 truncate text-[0.75rem] text-neutral-400">
                       {vehicleLabel ? vehicleLabel : "—"}
+                    </div>
+
+                    <div className="mt-2 text-[0.65rem] uppercase tracking-[0.12em] text-amber-200/90">
+                      Next action: {nextActionLabel(bucket)}
                     </div>
 
                     <div className="mt-2 flex flex-wrap gap-1">

--- a/features/inspections/components/inspection/SaveInspectionButton.tsx
+++ b/features/inspections/components/inspection/SaveInspectionButton.tsx
@@ -2,10 +2,12 @@
 
 "use client";
 
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { saveInspectionSession } from "@inspections/lib/inspection/save";
 import type { InspectionSession } from "@inspections/lib/inspection/types";
 import { Button } from "@shared/components/ui/Button";
+import { getOfflineSyncSummary, subscribeOfflineMutations } from "@/features/shared/lib/offline/mutations";
 
 type Props = {
   session: InspectionSession;
@@ -19,11 +21,31 @@ function errorMessage(err: unknown): string {
 }
 
 export function SaveInspectionButton({ session, workOrderLineId }: Props) {
+  const [syncSummary, setSyncSummary] = useState(() => getOfflineSyncSummary());
+
+  useEffect(() => {
+    const refresh = () => setSyncSummary(getOfflineSyncSummary());
+    const unsub = subscribeOfflineMutations(refresh);
+    const onOnline = () => void refresh();
+    window.addEventListener("online", onOnline);
+    refresh();
+    return () => {
+      unsub();
+      window.removeEventListener("online", onOnline);
+    };
+  }, []);
+
   const handleSave = async (): Promise<void> => {
     try {
       if (!workOrderLineId) throw new Error("Missing workOrderLineId");
-      await saveInspectionSession(session, workOrderLineId);
-      toast.success("Inspection saved.");
+      const result = await saveInspectionSession(session, workOrderLineId);
+      if (result.conflicted) {
+        toast.error("Inspection save conflicted. Review sync queue status.");
+      } else if (result.queued) {
+        toast.warning("Inspection save queued and will sync when online.");
+      } else {
+        toast.success("Inspection saved.");
+      }
     } catch (error: unknown) {
       // eslint-disable-next-line no-console
       console.error("Save error:", error);
@@ -32,14 +54,21 @@ export function SaveInspectionButton({ session, workOrderLineId }: Props) {
   };
 
   return (
-    <Button
-      onClick={handleSave}
-      type="button"
-      variant="outline"
-      size="sm"
-      className="font-medium border-[rgba(184,115,51,0.75)] text-[11px] tracking-[0.16em] uppercase"
-    >
-      Save Progress
-    </Button>
+    <div className="flex flex-col items-start gap-1">
+      <Button
+        onClick={handleSave}
+        type="button"
+        variant="outline"
+        size="sm"
+        className="font-medium border-[rgba(184,115,51,0.75)] text-[11px] tracking-[0.16em] uppercase"
+      >
+        Save Progress
+      </Button>
+      {(syncSummary.queued > 0 || syncSummary.syncing > 0 || syncSummary.failed > 0 || syncSummary.conflicted > 0) && (
+        <p className="text-[10px] text-neutral-400">
+          Sync queue: pending {syncSummary.queued + syncSummary.syncing} • failed {syncSummary.failed} • conflicted {syncSummary.conflicted}
+        </p>
+      )}
+    </div>
   );
 }

--- a/features/inspections/lib/inspection/save.ts
+++ b/features/inspections/lib/inspection/save.ts
@@ -49,7 +49,7 @@ export async function replayQueuedInspectionSaves(): Promise<void> {
 export async function saveInspectionSession(
   session: InspectionSession,
   workOrderLineId: string
-): Promise<void> {
+): Promise<{ queued: boolean; conflicted: boolean }> {
   if (!workOrderLineId) {
     throw new Error("Missing workOrderLineId");
   }
@@ -60,7 +60,7 @@ export async function saveInspectionSession(
       ? crypto.randomUUID()
       : `${workOrderLineId}:${Date.now()}`;
 
-  await runMutationWithOfflineQueue({
+  const result = await runMutationWithOfflineQueue({
     clientMutationId: mutationId,
     actionType: ACTION_SAVE_INSPECTION,
     payload,
@@ -70,4 +70,6 @@ export async function saveInspectionSession(
   if (typeof navigator !== "undefined" && navigator.onLine) {
     await replayQueuedInspectionSaves();
   }
+
+  return result;
 }

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -41,7 +41,9 @@ type Props = {
 
 type ShiftStatus = "none" | "active" | "break" | "lunch" | "ended";
 
-type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"] & {
+  active_segment_started_at?: string | null;
+};
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 
@@ -201,28 +203,64 @@ export function MobileTechHome({
 
       setLoadingCurrentJob(true);
       try {
-        const { data, error } = await supabase
-          .from("work_order_lines")
-          .select(
-            "id, work_order_id, description, complaint, job_type, punched_in_at, punched_out_at, assigned_tech_id",
-          )
-          .eq("assigned_tech_id", uid)
-          .not("punched_in_at", "is", null)
-          .is("punched_out_at", null)
-          .order("punched_in_at", { ascending: false })
-          .limit(1)
-          .maybeSingle();
+        const { data: activeSegments, error: segmentError } = await supabase
+          .from("work_order_line_labor_segments")
+          .select("work_order_line_id, started_at")
+          .eq("technician_id", uid)
+          .is("ended_at", null)
+          .order("started_at", { ascending: false })
+          .limit(1);
 
-        if (error) {
-          // eslint-disable-next-line no-console
-          console.error("[MobileTechHome] current job load error:", error);
-          setCurrentJob(null);
-          setCurrentJobWorkOrder(null);
-          setCurrentJobVehicle(null);
-          return;
+        const activeLineId = activeSegments?.[0]?.work_order_line_id ?? null;
+
+        let line: WorkOrderLine | null = null;
+
+        if (activeLineId) {
+          const { data: activeLine, error } = await supabase
+            .from("work_order_lines")
+            .select(
+              "id, work_order_id, description, complaint, job_type, punched_in_at, punched_out_at, assigned_tech_id",
+            )
+            .eq("id", activeLineId)
+            .maybeSingle();
+
+          if (error) {
+            console.error("[MobileTechHome] current job active-line load error:", error);
+          } else if (activeLine) {
+            line = {
+              ...(activeLine as WorkOrderLine),
+              active_segment_started_at: activeSegments?.[0]?.started_at ?? null,
+            };
+          }
         }
 
-        const line = (data as WorkOrderLine | null) ?? null;
+        if (!line) {
+          const { data, error } = await supabase
+            .from("work_order_lines")
+            .select(
+              "id, work_order_id, description, complaint, job_type, punched_in_at, punched_out_at, assigned_tech_id",
+            )
+            .eq("assigned_tech_id", uid)
+            .not("punched_in_at", "is", null)
+            .is("punched_out_at", null)
+            .order("punched_in_at", { ascending: false })
+            .limit(1)
+            .maybeSingle();
+
+          if (error) {
+            console.error("[MobileTechHome] current job fallback load error:", error);
+            setCurrentJob(null);
+            setCurrentJobWorkOrder(null);
+            setCurrentJobVehicle(null);
+            return;
+          }
+
+          line = (data as WorkOrderLine | null) ?? null;
+        }
+
+        if (segmentError) {
+          console.error("[MobileTechHome] active segment load error:", segmentError);
+        }
         setCurrentJob(line);
 
         if (!line?.work_order_id) {

--- a/features/tech/components/TechPerformanceTiles.tsx
+++ b/features/tech/components/TechPerformanceTiles.tsx
@@ -103,13 +103,23 @@ export default function TechPerformanceTiles({
 
         // Optional fallback: assigned jobs count (if not passed in)
         if (typeof assignedJobsCount !== "number") {
-          const { count } = await supabase
-            .from("work_order_lines")
-            .select("id", { count: "exact", head: true })
-            .eq("assigned_tech_id", user.id)
-            .is("punched_out_at", null);
+          const { data: activeSegments, error: activeSegmentError } = await supabase
+            .from("work_order_line_labor_segments")
+            .select("work_order_line_id")
+            .eq("technician_id", user.id)
+            .is("ended_at", null);
 
-          setAssignedFallback(count ?? 0);
+          if (activeSegmentError) {
+            const { count } = await supabase
+              .from("work_order_lines")
+              .select("id", { count: "exact", head: true })
+              .eq("assigned_tech_id", user.id)
+              .is("punched_out_at", null);
+            setAssignedFallback(count ?? 0);
+          } else {
+            const uniqueActiveLines = new Set((activeSegments ?? []).map((row) => row.work_order_line_id));
+            setAssignedFallback(uniqueActiveLines.size);
+          }
         }
       } finally {
         setLoading(false);


### PR DESCRIPTION
### Motivation
- Close remaining launch-critical RBAC gaps on mutating routes (admin/settings/billing/fleet) by moving away from ad-hoc role arrays to the canonical capability matrix.  
- Prevent split truths in time-tracking by providing a safe, conservative historical backfill for labor segments from trustworthy legacy line punches.  
- Extend offline/replay UX and visibility for technician-critical flows (inspections, shift/punches, focused job queue) so mobile field flows behave reliably under poor connectivity.  
- Keep changes non-breaking, avoid schema churn, and preserve existing tenant/shop scoping rules.

### Description
- Replaced ad-hoc role checks with capability-based guards (`getActorCapabilities`) on launch-critical mutation paths: `admin/reset-user-password`, `organizations/create`, `shop/owner-pin/set`, and Stripe billing routes (`portal`, `connect/onboard`, `checkout`).  
- Added a safe server endpoint `POST /api/time/labor-segments/backfill` that uses the service-role key to insert labor segments from legacy `work_order_lines` only when rows are unambiguous, already have no segments, and are scoped to the caller's shop; reports inserted / skipped counts.  
- Switched high-value technician readers toward segment truth: `MobileTechHome` now resolves active current job from open `work_order_line_labor_segments` first with a legacy punched-in fallback; `TechPerformanceTiles` counts unique open segments as the primary assigned-job fallback.  
- Improved offline/replay UX: `saveInspectionSession` now returns queued/conflicted outcomes from `runMutationWithOfflineQueue` and `SaveInspectionButton` surfaces queue state and shows distinct toasts for queued/conflicted/synced cases.  
- Improved mobile queue UX: `app/mobile/tech/queue/page.tsx` now shows a sync-state banner (pending/failed/conflicted) and a concise “Next action” label per line status to reduce action ambiguity in the field.  
- Kept all changes focused and non-breaking; no RLS, auth redesign, or schema changes were introduced.

### Testing
- Ran type check: `npx tsc --noEmit` — result: success (no new TypeScript errors).  
- Verified the following manual / automated safety checks in code during the pass: capability checks were applied where legacy role arrays previously gated mutating behavior; backfill endpoint enforces shop scoping and skips ambiguous records; offline queue handlers surfaced states to UI components.  

Files changed (high level): `app/api/admin/reset-user-password/route.ts`, `app/api/organizations/create/route.ts`, `app/api/shop/owner-pin/set/route.ts`, `app/api/stripe/*` billing routes, new `app/api/time/labor-segments/backfill/route.ts`, `features/mobile/dashboard/MobileTechHome.tsx`, `features/tech/components/TechPerformanceTiles.tsx`, `features/inspections/lib/inspection/save.ts`, `features/inspections/components/inspection/SaveInspectionButton.tsx`, `app/mobile/tech/queue/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a37d456c8328ac900601dd4b17ca)