### PR TITLE
Refine dashboard cockpit persistence, density, and graceful widget failures

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -34,6 +34,7 @@ function isTechRole(role: string | null): boolean {
 export default function DashboardPage() {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestLayoutRef = useRef<DashboardWidgetLayout[] | undefined>(undefined);
 
   const [name, setName] = useState<string | null>(null);
   const [role, setRole] = useState<string | null>(null);
@@ -52,6 +53,7 @@ export default function DashboardPage() {
       if (!shopId) return;
 
       setLayout(nextLayout);
+      latestLayoutRef.current = nextLayout;
 
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
@@ -69,13 +71,39 @@ export default function DashboardPage() {
     [shopId, supabase, userId],
   );
 
+  const flushPendingLayoutSave = useCallback(() => {
+    if (!shopId || !latestLayoutRef.current) return;
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    void saveDashboardLayout({
+      supabase,
+      shopId,
+      userId,
+      layout: latestLayoutRef.current,
+    });
+  }, [shopId, supabase, userId]);
+
   useEffect(() => {
+    const flushOnVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        flushPendingLayoutSave();
+      }
+    };
+
+    window.addEventListener("pagehide", flushPendingLayoutSave);
+    document.addEventListener("visibilitychange", flushOnVisibility);
+
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
       }
+      window.removeEventListener("pagehide", flushPendingLayoutSave);
+      document.removeEventListener("visibilitychange", flushOnVisibility);
+      flushPendingLayoutSave();
     };
-  }, []);
+  }, [flushPendingLayoutSave]);
 
   useEffect(() => {
     void (async () => {
@@ -136,6 +164,7 @@ export default function DashboardPage() {
         ]);
 
         setLayout(loadedLayout);
+        latestLayoutRef.current = loadedLayout;
         setCounts({
           appointments: 0,
           workOrders: myJobs.error ? 0 : myJobs.count ?? 0,
@@ -163,6 +192,7 @@ export default function DashboardPage() {
       ]);
 
       setLayout(loadedLayout);
+      latestLayoutRef.current = loadedLayout;
       setCounts({
         appointments: appt.error ? 0 : appt.count ?? 0,
         workOrders: wo.error ? 0 : wo.count ?? 0,
@@ -175,9 +205,9 @@ export default function DashboardPage() {
   const displayName = name?.trim() || "there";
 
   return (
-    <div className="w-full space-y-5 xl:space-y-6">
+    <div className="w-full space-y-4 xl:space-y-5">
       <section
-        className="rounded-3xl border px-5 py-5 backdrop-blur-xl xl:px-7 xl:py-6"
+        className="rounded-2xl border px-5 py-4 backdrop-blur-xl xl:px-6 xl:py-5"
         style={{
           borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 72%, transparent)",
           background: "var(--dashboard-hero-bg, var(--dashboard-shell-bg))",
@@ -188,11 +218,11 @@ export default function DashboardPage() {
             <div className="text-[10px] uppercase tracking-[0.24em] text-neutral-400">
               Dashboard
             </div>
-            <h1 className="mt-2 text-3xl font-semibold text-white xl:text-4xl">
+            <h1 className="mt-1.5 text-3xl font-semibold text-white xl:text-4xl">
               Welcome back, {displayName} 👋
             </h1>
-            <p className="mt-2 max-w-3xl text-sm text-neutral-300 xl:text-[15px]">
-              Brand-aware widget dashboard with a stable default grid and responsive stacking.
+            <p className="mt-1.5 max-w-3xl text-sm text-neutral-300 xl:text-[15px]">
+              Command-center board with persistent layout, compact controls, and role-aware widget context.
             </p>
           </div>
 

--- a/features/dashboard/components/DashboardWidgetBoard.tsx
+++ b/features/dashboard/components/DashboardWidgetBoard.tsx
@@ -172,9 +172,9 @@ export default function DashboardWidgetBoard({
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <div
-        className="rounded-3xl border px-4 py-3"
+        className="rounded-2xl border px-4 py-3"
         style={{
           borderColor: "var(--theme-card-border,#334155)",
           background:
@@ -182,18 +182,18 @@ export default function DashboardWidgetBoard({
         }}
       >
         <div
-          className="text-[10px] font-semibold uppercase tracking-[0.2em]"
+          className="text-[10px] font-semibold uppercase tracking-[0.18em]"
           style={{ color: "var(--brand-accent,#E39A6E)" }}
         >
           Widget Layout
         </div>
         <div
-          className="mt-1 text-sm"
+          className="mt-1 text-xs sm:text-sm"
           style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
         >
-          Drag and resize widgets on desktop. Small screens keep simple stacked cards.
+          Board controls. Move, resize, and toggle widgets. Layout saves automatically.
         </div>
-        <div className="mt-3 flex flex-wrap gap-2">
+        <div className="mt-2.5 flex flex-wrap gap-1.5">
           {orderedWidgets.map(({ item, widget }) => {
             const enabled = item.hidden !== true;
 
@@ -202,7 +202,7 @@ export default function DashboardWidgetBoard({
                 key={item.id}
                 type="button"
                 onClick={() => handleWidgetVisibilityToggle(item.id)}
-                className="rounded-full border px-3 py-1.5 text-xs transition"
+                className="rounded-full border px-2.5 py-1 text-[11px] transition"
                 style={{
                   borderColor: enabled
                     ? "color-mix(in srgb, var(--brand-accent,#E39A6E) 60%, transparent)"
@@ -226,9 +226,13 @@ export default function DashboardWidgetBoard({
         <div className="space-y-4">
           {visibleWidgets.map(({ item, widget }) => (
             <div key={item.id}>
-              <DashboardWidgetShell title={widget.title} description={widget.description}>
-                {widget.render(context, item)}
-              </DashboardWidgetShell>
+              {widget.selfContained ? (
+                widget.render(context, item)
+              ) : (
+                <DashboardWidgetShell title={widget.title} description={widget.description}>
+                  {widget.render(context, item)}
+                </DashboardWidgetShell>
+              )}
             </div>
           ))}
         </div>
@@ -240,8 +244,8 @@ export default function DashboardWidgetBoard({
               width={Math.max(width, 320)}
               gridConfig={{
                 cols: DASHBOARD_GRID_COLUMNS,
-                rowHeight: 96,
-                margin: [16, 16],
+                rowHeight: 84,
+                margin: [12, 12],
                 containerPadding: [0, 0],
               }}
               dragConfig={{
@@ -265,14 +269,18 @@ export default function DashboardWidgetBoard({
                     >
                       Move
                     </button>
-                    <DashboardWidgetShell
-                      title={widget.title}
-                      description={widget.description}
-                      className="min-h-0"
-                      scrollClassName="pb-3"
-                    >
-                      {widget.render(context, item)}
-                    </DashboardWidgetShell>
+                    {widget.selfContained ? (
+                      <div className="h-full min-h-0">{widget.render(context, item)}</div>
+                    ) : (
+                      <DashboardWidgetShell
+                        title={widget.title}
+                        description={widget.description}
+                        className="min-h-0"
+                        scrollClassName="pb-2"
+                      >
+                        {widget.render(context, item)}
+                      </DashboardWidgetShell>
+                    )}
                   </div>
                 </div>
               ))}
@@ -281,9 +289,13 @@ export default function DashboardWidgetBoard({
             <div className="grid gap-4">
               {visibleWidgets.map(({ item, widget }) => (
                 <div key={item.id}>
-                  <DashboardWidgetShell title={widget.title} description={widget.description}>
-                    {widget.render(context, item)}
-                  </DashboardWidgetShell>
+                  {widget.selfContained ? (
+                    widget.render(context, item)
+                  ) : (
+                    <DashboardWidgetShell title={widget.title} description={widget.description}>
+                      {widget.render(context, item)}
+                    </DashboardWidgetShell>
+                  )}
                 </div>
               ))}
             </div>

--- a/features/dashboard/hooks/useTechnicianLoadMetrics.ts
+++ b/features/dashboard/hooks/useTechnicianLoadMetrics.ts
@@ -6,6 +6,7 @@ import {
   getTechnicianLoadMetrics,
   type TechnicianLoadMetricResult,
 } from "@shared/lib/stats/getTechnicianLoadMetrics";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 import { useVisibilityPolling } from "@/features/shared/hooks/useVisibilityPolling";
 
 type UseTechnicianLoadMetricsOptions = {
@@ -50,7 +51,9 @@ export function useTechnicianLoadMetrics(
       setMetrics(result);
     } catch (e) {
       hasLoadedRef.current = true;
-      setError(e instanceof Error ? e.message : "Failed to load technician load metrics.");
+      setError(
+        toDashboardFallbackMessage(e, "Data unavailable for technician metrics. Try refresh."),
+      );
       setMetrics(null);
     } finally {
       setLoading(false);

--- a/features/dashboard/lib/widget-fallback.ts
+++ b/features/dashboard/lib/widget-fallback.ts
@@ -1,0 +1,34 @@
+export function toDashboardFallbackMessage(
+  error: unknown,
+  fallback = "Data unavailable. Try refresh.",
+): string {
+  const raw =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : "";
+
+  const message = raw.toLowerCase();
+
+  if (!message) return fallback;
+
+  if (
+    message.includes("does not exist") ||
+    message.includes("relation") ||
+    message.includes("schema cache") ||
+    message.includes("column")
+  ) {
+    return "Needs setup. Data source is not ready.";
+  }
+
+  if (message.includes("timeout") || message.includes("timed out")) {
+    return "Data unavailable right now. Try refresh.";
+  }
+
+  if (message.includes("jwt") || message.includes("permission") || message.includes("not authorized")) {
+    return "Data unavailable for your access level.";
+  }
+
+  return fallback;
+}

--- a/features/dashboard/lib/widget-registry.tsx
+++ b/features/dashboard/lib/widget-registry.tsx
@@ -23,20 +23,20 @@ import type { DashboardWidgetModule } from "@/features/dashboard/types/widget";
 
 export const DASHBOARD_WIDGET_REGISTRY: DashboardWidgetModule[] = [
   statsOverviewWidgetModule,
-  dailySummaryWidgetModule,
   liveShopLoadWidgetModule,
+  dailySummaryWidgetModule,
+  workOrderBoardWidgetModule,
   suggestedActionsWidgetModule,
-  reportsPerformanceWidgetModule,
+  advisorQueueWidgetModule,
+  bookingsWidgetModule,
   shopPulseWidgetModule,
-  revenueWatchWidgetModule,
   techLoadWidgetModule,
   technicianPerformanceWidgetModule,
-  approvalRiskWidgetModule,
   waitingPartsWidgetModule,
+  approvalRiskWidgetModule,
+  revenueWatchWidgetModule,
   comebackRiskWidgetModule,
-  workOrderBoardWidgetModule,
-  bookingsWidgetModule,
-  advisorQueueWidgetModule,
+  reportsPerformanceWidgetModule,
   optimizationOpportunitiesWidgetModule,
 ];
 

--- a/features/dashboard/types/widget.ts
+++ b/features/dashboard/types/widget.ts
@@ -7,5 +7,6 @@ import type {
 } from "@/features/dashboard/types/layout";
 
 export interface DashboardWidgetModule extends DashboardWidgetDefinition {
+  selfContained?: boolean;
   render: (context: DashboardRenderContext, item: DashboardWidgetLayout) => ReactNode;
 }

--- a/features/dashboard/widgets/ApprovalRiskWidget.tsx
+++ b/features/dashboard/widgets/ApprovalRiskWidget.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 
 type DB = Database;
 type BoardRow = DB["public"]["Views"]["v_work_order_board_cards_shop"]["Row"];
@@ -42,7 +43,7 @@ export default function ApprovalRiskWidget({ shopId }: { shopId: string | null }
         if (!cancelled) setRows((data as BoardRow[]) ?? []);
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load approval risk.");
+          setError(toDashboardFallbackMessage(e, "Data unavailable. Try refresh."));
           setRows([]);
         }
       } finally {

--- a/features/dashboard/widgets/ComebackRiskWidget.tsx
+++ b/features/dashboard/widgets/ComebackRiskWidget.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 
 type DB = Database;
 type SnapshotRow = DB["public"]["Tables"]["shop_health_snapshots"]["Row"];
@@ -43,7 +44,7 @@ export default function ComebackRiskWidget({ shopId }: { shopId: string | null }
         if (!cancelled) setSnapshot((data as SnapshotRow | null) ?? null);
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load comeback risk.");
+          setError(toDashboardFallbackMessage(e, "Data unavailable. Try refresh."));
           setSnapshot(null);
         }
       } finally {

--- a/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
+++ b/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import OptimizationExecutionModal from "../../../components/optimization/OptimizationExecutionModal";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 import type {
   ExecutionPreview,
   OptimizationActionType,
@@ -350,7 +351,7 @@ export default function OptimizationOpportunitiesWidget({
         }
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load optimization opportunities");
+          setError(toDashboardFallbackMessage(e, "Data unavailable. Try refresh."));
         }
       } finally {
         if (!cancelled) setLoading(false);

--- a/features/dashboard/widgets/RevenueWatchWidget.tsx
+++ b/features/dashboard/widgets/RevenueWatchWidget.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 import { getShopStats } from "@shared/lib/stats/getShopStats";
 
 function money(n: number | null | undefined): string {
@@ -39,7 +40,7 @@ export default function RevenueWatchWidget({
         }
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load revenue watch.");
+          setError(toDashboardFallbackMessage(e, "Data unavailable. Try refresh."));
         }
       } finally {
         if (!cancelled) setLoading(false);

--- a/features/dashboard/widgets/ShopPulseWidget.tsx
+++ b/features/dashboard/widgets/ShopPulseWidget.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 import StatusBadge from "@shared/components/ui/StatusBadge";
 import { cn } from "@shared/lib/utils";
 
@@ -78,7 +79,7 @@ export default function ShopPulseWidget({ shopId }: { shopId: string | null }) {
         if (!cancelled) setRows((data as BoardRow[]) ?? []);
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load shop pulse.");
+          setError(toDashboardFallbackMessage(e, "Data unavailable. Try refresh."));
           setRows([]);
         }
       } finally {

--- a/features/dashboard/widgets/WaitingPartsWidget.tsx
+++ b/features/dashboard/widgets/WaitingPartsWidget.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 
 type DB = Database;
 type BoardRow = DB["public"]["Views"]["v_work_order_board_cards_shop"]["Row"];
@@ -41,7 +42,7 @@ export default function WaitingPartsWidget({ shopId }: { shopId: string | null }
         if (!cancelled) setRows((data as BoardRow[]) ?? []);
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load waiting parts.");
+          setError(toDashboardFallbackMessage(e, "Data unavailable. Try refresh."));
           setRows([]);
         }
       } finally {

--- a/features/dashboard/widgets/modules/AdvisorQueueWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/AdvisorQueueWidgetModule.tsx
@@ -7,8 +7,9 @@ export const advisorQueueWidgetModule: DashboardWidgetModule = {
   description: "Queue and approvals workload",
   roles: ["owner", "admin", "manager", "advisor"],
   defaultW: 4,
-  defaultH: 5,
+  defaultH: 4,
   minW: 3,
-  minH: 4,
+  minH: 3,
+  selfContained: true,
   render: () => <AdvisorQueueWidget />,
 };

--- a/features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx
@@ -6,9 +6,10 @@ export const approvalRiskWidgetModule: DashboardWidgetModule = {
   title: "Approval Risk",
   description: "Work awaiting decision",
   roles: ["owner", "admin", "manager", "advisor"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <ApprovalRiskWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/BookingsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/BookingsWidgetModule.tsx
@@ -7,8 +7,9 @@ export const bookingsWidgetModule: DashboardWidgetModule = {
   description: "Upcoming appointment activity",
   roles: ["owner", "admin", "manager", "advisor"],
   defaultW: 4,
-  defaultH: 5,
+  defaultH: 4,
   minW: 3,
-  minH: 4,
+  minH: 3,
+  selfContained: true,
   render: () => <BookingsWidget />,
 };

--- a/features/dashboard/widgets/modules/ComebackRiskWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ComebackRiskWidgetModule.tsx
@@ -6,9 +6,10 @@ export const comebackRiskWidgetModule: DashboardWidgetModule = {
   title: "Comeback Risk",
   description: "Potential return work alerts",
   roles: ["owner", "admin", "manager", "advisor"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <ComebackRiskWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/DailySummaryWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/DailySummaryWidgetModule.tsx
@@ -7,8 +7,9 @@ export const dailySummaryWidgetModule: DashboardWidgetModule = {
   description: "Role-aware operational snapshot",
   roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
   defaultW: 4,
-  defaultH: 5,
+  defaultH: 4,
   minW: 3,
-  minH: 4,
+  minH: 3,
+  selfContained: true,
   render: () => <DailySummaryCard />,
 };

--- a/features/dashboard/widgets/modules/LiveShopLoadWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/LiveShopLoadWidgetModule.tsx
@@ -6,9 +6,10 @@ export const liveShopLoadWidgetModule: DashboardWidgetModule = {
   title: "Live Shop Load",
   description: "Real-time active jobs, tech capacity, and utilization",
   roles: ["owner", "admin", "manager", "advisor", "parts"],
-  defaultW: 6,
-  defaultH: 3,
+  defaultW: 4,
+  defaultH: 4,
   minW: 4,
   minH: 3,
+  selfContained: true,
   render: (context) => <LiveShopLoadWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/OptimizationOpportunitiesWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/OptimizationOpportunitiesWidgetModule.tsx
@@ -7,8 +7,9 @@ export const optimizationOpportunitiesWidgetModule: DashboardWidgetModule = {
   description: "Pricing, inspection, and missed revenue opportunities",
   roles: ["owner", "admin", "manager"],
   defaultW: 6,
-  defaultH: 5,
+  defaultH: 4,
   minW: 3,
-  minH: 4,
+  minH: 3,
+  selfContained: true,
   render: (context) => <OptimizationOpportunitiesWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/ReportsPerformanceWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ReportsPerformanceWidgetModule.tsx
@@ -7,8 +7,9 @@ export const reportsPerformanceWidgetModule: DashboardWidgetModule = {
   description: "Revenue and team performance",
   roles: ["owner", "admin", "manager"],
   defaultW: 6,
-  defaultH: 6,
+  defaultH: 5,
   minW: 4,
   minH: 4,
+  selfContained: true,
   render: () => <ReportsPerformanceWidget />,
 };

--- a/features/dashboard/widgets/modules/RevenueWatchWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/RevenueWatchWidgetModule.tsx
@@ -6,9 +6,10 @@ export const revenueWatchWidgetModule: DashboardWidgetModule = {
   title: "Revenue Watch",
   description: "Financial watchpoints",
   roles: ["owner", "admin", "manager"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <RevenueWatchWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/ShopPulseWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ShopPulseWidgetModule.tsx
@@ -6,9 +6,10 @@ export const shopPulseWidgetModule: DashboardWidgetModule = {
   title: "Shop Pulse",
   description: "Current shop health snapshot",
   roles: ["owner", "admin", "manager"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <ShopPulseWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/StatsOverviewWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/StatsOverviewWidgetModule.tsx
@@ -8,7 +8,7 @@ function MetricCard({
   tone,
 }: {
   label: string;
-  value: number;
+  value: number | string;
   hint: string;
   tone: string;
 }) {
@@ -53,7 +53,7 @@ function StatsOverviewWidget({ context }: { context: DashboardRenderContext }) {
   const tech = isTechRole(context.role);
 
   return (
-    <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-4">
+    <div className="grid gap-2.5 md:grid-cols-2 2xl:grid-cols-4">
       <MetricCard
         label="Appointments"
         value={context.counts.appointments}
@@ -73,9 +73,9 @@ function StatsOverviewWidget({ context }: { context: DashboardRenderContext }) {
         tone={metricTone("partsRequests")}
       />
       <MetricCard
-        label="Role"
-        value={0}
-        hint={context.role ?? "—"}
+        label="My role"
+        value={(context.role ?? "Unknown").toUpperCase()}
+        hint="Role-aware dashboard context"
         tone="text-[color:var(--theme-text-primary,#ffffff)]"
       />
     </div>
@@ -87,8 +87,8 @@ export const statsOverviewWidgetModule: DashboardWidgetModule = {
   title: "Stats Overview",
   description: "Top counts and operational context",
   roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
-  defaultW: 6,
-  defaultH: 4,
+  defaultW: 8,
+  defaultH: 3,
   minW: 4,
   minH: 3,
   render: (context) => <StatsOverviewWidget context={context} />,

--- a/features/dashboard/widgets/modules/SuggestedActionsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/SuggestedActionsWidgetModule.tsx
@@ -7,9 +7,10 @@ export const suggestedActionsWidgetModule: DashboardWidgetModule = {
   description: "Highest-value next steps",
   roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
   defaultW: 4,
-  defaultH: 5,
+  defaultH: 4,
   minW: 3,
-  minH: 4,
+  minH: 3,
+  selfContained: true,
   render: (_context, item) => (
     <SuggestedActionsPanel
       context={{ pageType: "dashboard", pageTitle: "Dashboard" }}

--- a/features/dashboard/widgets/modules/TechLoadWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/TechLoadWidgetModule.tsx
@@ -6,9 +6,10 @@ export const techLoadWidgetModule: DashboardWidgetModule = {
   title: "Technician Load",
   description: "Current active jobs and load balance",
   roles: ["owner", "admin", "manager", "advisor", "parts"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <TechLoadWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/TechnicianPerformanceWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/TechnicianPerformanceWidgetModule.tsx
@@ -6,9 +6,10 @@ export const technicianPerformanceWidgetModule: DashboardWidgetModule = {
   title: "Technician Performance",
   description: "Completed jobs and average duration today",
   roles: ["owner", "admin", "manager", "advisor", "parts"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <TechnicianPerformanceWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx
@@ -6,9 +6,10 @@ export const waitingPartsWidgetModule: DashboardWidgetModule = {
   title: "Waiting Parts",
   description: "Blocked by parts availability",
   roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
-  defaultW: 3,
+  defaultW: 4,
   defaultH: 4,
   minW: 3,
   minH: 3,
+  selfContained: true,
   render: (context) => <WaitingPartsWidget shopId={context.shopId} />,
 };

--- a/features/dashboard/widgets/modules/WorkOrderBoardWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/WorkOrderBoardWidgetModule.tsx
@@ -6,9 +6,10 @@ export const workOrderBoardWidgetModule: DashboardWidgetModule = {
   title: "Work Order Board",
   description: "Live workboard snapshot",
   roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
-  defaultW: 6,
-  defaultH: 6,
-  minW: 4,
+  defaultW: 8,
+  defaultH: 5,
+  minW: 5,
   minH: 4,
+  selfContained: true,
   render: () => <WorkOrderBoardWidget />,
 };


### PR DESCRIPTION
### Motivation
- Ensure user dashboard personalization (visibility, placement, sizing) persists reliably across navigation and tab/page lifecycle events by fixing lost debounced saves. 
- Improve operational cockpit density, scanability, and hierarchy while preserving the existing dark-brand widget system and role behavior. 
- Prevent raw DB/query errors from surfacing to users by providing concise, operational fallback messages for failing widgets.

### Description
- Persist/flush: store the latest layout in a ref and add `flushPendingLayoutSave()` invoked on `pagehide`, `visibilitychange(hidden)`, and component unmount so pending debounced saves are not lost (changes in `app/dashboard/page.tsx`).
- Board density/layout: reduce grid vertical footprint (`rowHeight` 96 → 84, `margin` 16 → 12), tighten control strip spacing and hero padding, and reorder/adjust widget defaults to favor a cockpit flow (changes in `features/dashboard/components/DashboardWidgetBoard.tsx` and `features/dashboard/lib/widget-registry.tsx` and many `features/dashboard/widgets/modules/*` updates). 
- Self-contained modules: introduce `selfContained?: boolean` on `DashboardWidgetModule` and render those modules directly (no forced nested shell) to eliminate card-inside-card visual noise (changes in `features/dashboard/types/widget.ts` and `features/dashboard/components/DashboardWidgetBoard.tsx` and module files). 
- Graceful failure handling: add `toDashboardFallbackMessage` to normalize backend errors into user-friendly states and wire it into key widgets and the technician metrics hook (`features/dashboard/lib/widget-fallback.ts`, `features/dashboard/widgets/*`, and `features/dashboard/hooks/useTechnicianLoadMetrics.ts`).

### Testing
- Type-check: ran `npx tsc --noEmit` and the TypeScript build passed successfully. 
- No DB schema/migration changes were introduced and no automated integration tests were modified in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b85466f08328a57b62680abfc848)