### PR TITLE
Refactor key dashboard widgets into embedded module mode

### DIFF
--- a/features/assistant/components/SuggestedActionsPanel.tsx
+++ b/features/assistant/components/SuggestedActionsPanel.tsx
@@ -36,6 +36,7 @@ type Props = {
   maxItems?: number;
   collapsible?: boolean;
   hideDescription?: boolean;
+  embedded?: boolean;
 };
 
 export default function SuggestedActionsPanel({
@@ -47,6 +48,7 @@ export default function SuggestedActionsPanel({
   maxItems,
   collapsible = false,
   hideDescription = false,
+  embedded = false,
 }: Props) {
   const { loading, data, reload } = useSuggestedActions(true, context);
   const [expanded, setExpanded] = useState(defaultExpanded);
@@ -80,17 +82,22 @@ export default function SuggestedActionsPanel({
   } as const;
 
   return (
-    <section className={compact ? "border p-3" : "border p-5"} style={sectionStyle}>
+    <section
+      className={embedded ? (compact ? "space-y-3" : "space-y-4") : compact ? "border p-3" : "border p-5"}
+      style={embedded ? undefined : sectionStyle}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div
-            className="text-[11px] font-semibold uppercase tracking-[0.18em]"
-            style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
-          >
-            {title}
-          </div>
+          {!embedded ? (
+            <div
+              className="text-[11px] font-semibold uppercase tracking-[0.18em]"
+              style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
+            >
+              {title}
+            </div>
+          ) : null}
 
-          {!hideDescription && (
+          {!hideDescription && !embedded && (
             <div
               className={compact ? "mt-0.5 text-xs" : "mt-1 text-sm"}
               style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
@@ -155,7 +162,7 @@ export default function SuggestedActionsPanel({
             <div
               key={item.id}
               className={compact ? "border px-3 py-2.5" : "border p-4"}
-              style={itemStyle}
+              style={embedded ? undefined : itemStyle}
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">

--- a/features/dashboard/widgets/ShopPulseWidget.tsx
+++ b/features/dashboard/widgets/ShopPulseWidget.tsx
@@ -52,7 +52,13 @@ function MetricTile(props: {
   );
 }
 
-export default function ShopPulseWidget({ shopId }: { shopId: string | null }) {
+export default function ShopPulseWidget({
+  shopId,
+  embedded = false,
+}: {
+  shopId: string | null;
+  embedded?: boolean;
+}) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -120,20 +126,18 @@ export default function ShopPulseWidget({ shopId }: { shopId: string | null }) {
     };
   }, [rows]);
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Shop Pulse"
-      title="What needs attention right now"
-      subtitle="Fast operational summary from the live work board."
-      rightSlot={
-        <Link
-          href="/work-orders/board"
-          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:border-[color:var(--brand-accent)] hover:bg-black/45"
-        >
-          Open board →
-        </Link>
-      }
-    >
+  const content = (
+    <>
+      {embedded ? (
+        <div className="mb-2 flex justify-end">
+          <Link
+            href="/work-orders/board"
+            className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:border-[color:var(--brand-accent)] hover:bg-black/45"
+          >
+            Open board →
+          </Link>
+        </div>
+      ) : null}
       {loading ? (
         <div className="rounded-xl border border-white/10 bg-black/25 px-4 py-4 text-sm text-neutral-300">
           Loading AI pulse…
@@ -184,6 +188,26 @@ export default function ShopPulseWidget({ shopId }: { shopId: string | null }) {
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI · Shop Pulse"
+      title="What needs attention right now"
+      subtitle="Fast operational summary from the live work board."
+      rightSlot={
+        <Link
+          href="/work-orders/board"
+          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:border-[color:var(--brand-accent)] hover:bg-black/45"
+        >
+          Open board →
+        </Link>
+      }
+    >
+      {content}
     </DashboardWidgetShell>
   );
 }

--- a/features/dashboard/widgets/modules/AdvisorQueueWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/AdvisorQueueWidgetModule.tsx
@@ -10,6 +10,5 @@ export const advisorQueueWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: () => <AdvisorQueueWidget />,
+  render: () => <AdvisorQueueWidget embedded />,
 };

--- a/features/dashboard/widgets/modules/DailySummaryWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/DailySummaryWidgetModule.tsx
@@ -10,6 +10,5 @@ export const dailySummaryWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: () => <DailySummaryCard />,
+  render: () => <DailySummaryCard embedded />,
 };

--- a/features/dashboard/widgets/modules/ShopPulseWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ShopPulseWidgetModule.tsx
@@ -10,6 +10,5 @@ export const shopPulseWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: (context) => <ShopPulseWidget shopId={context.shopId} />,
+  render: (context) => <ShopPulseWidget shopId={context.shopId} embedded />,
 };

--- a/features/dashboard/widgets/modules/SuggestedActionsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/SuggestedActionsWidgetModule.tsx
@@ -10,7 +10,6 @@ export const suggestedActionsWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
   render: (_context, item) => (
     <SuggestedActionsPanel
       context={{ pageType: "dashboard", pageTitle: "Dashboard" }}
@@ -18,6 +17,7 @@ export const suggestedActionsWidgetModule: DashboardWidgetModule = {
       maxItems={item.h <= 4 ? 4 : 8}
       collapsible={false}
       hideDescription={item.h <= 3}
+      embedded
     />
   ),
 };

--- a/features/shared/components/DailySummaryCard.tsx
+++ b/features/shared/components/DailySummaryCard.tsx
@@ -9,34 +9,38 @@ function levelClasses(level: string): string {
   return "border-sky-500/30 bg-sky-500/10 text-sky-200";
 }
 
-export default function DailySummaryCard() {
+export default function DailySummaryCard({ embedded = false }: { embedded?: boolean }) {
   const { data, loading, error, reload } = useDailySummary(true);
 
-  return (
-    <section
-      className="border p-3 md:p-4"
-      style={{
+  const containerClassName = embedded ? "space-y-3" : "border p-3 md:p-4";
+  const containerStyle = embedded
+    ? undefined
+    : {
         borderColor: "var(--theme-card-border,#334155)",
         background: "var(--theme-card-bg,#111827)",
         borderRadius: "var(--theme-radius-xl,1rem)",
         boxShadow: "var(--theme-shadow-medium,0_18px_45px_rgba(0,0,0,0.45))",
-      }}
-    >
+      };
+
+  return (
+    <section className={containerClassName} style={containerStyle}>
       <div className="flex items-start justify-between gap-2">
-        <div>
-          <div
-            className="text-xs font-semibold uppercase tracking-[0.18em]"
-            style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
-          >
-            Daily Summary
+        {!embedded ? (
+          <div>
+            <div
+              className="text-xs font-semibold uppercase tracking-[0.18em]"
+              style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
+            >
+              Daily Summary
+            </div>
+            <div
+              className="mt-0.5 text-xs"
+              style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
+            >
+              Role-aware operational snapshot for today
+            </div>
           </div>
-          <div
-            className="mt-0.5 text-xs"
-            style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
-          >
-            Role-aware operational snapshot for today
-          </div>
-        </div>
+        ) : <div />}
 
         <button
           type="button"
@@ -73,7 +77,7 @@ export default function DailySummaryCard() {
       ) : (
         <>
           <div
-            className="mt-3 border p-3"
+            className="border p-3"
             style={{
               borderColor: "var(--theme-card-border,#334155)",
               background: "var(--theme-surface-2,#0B1220)",

--- a/features/work-orders/components/dashboard/AdvisorQueueWidget.tsx
+++ b/features/work-orders/components/dashboard/AdvisorQueueWidget.tsx
@@ -136,7 +136,7 @@ function BucketButton({
   );
 }
 
-export default function AdvisorQueueWidget(): JSX.Element {
+export default function AdvisorQueueWidget({ embedded = false }: { embedded?: boolean }): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
   
@@ -286,15 +286,19 @@ export default function AdvisorQueueWidget(): JSX.Element {
   if (isTech) return <></>;
 
   return (
-    <section className={PANEL + " overflow-hidden"}>
-      <div className="flex items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
+    <section className={embedded ? "space-y-4" : PANEL + " overflow-hidden"}>
+      <div className={embedded ? "flex items-center justify-end gap-2" : "flex items-center justify-between gap-3 border-b border-white/10 px-4 py-3"}>
         <div className="min-w-0">
-          <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
-            My advisor queue
-          </div>
-          <div className="mt-1 text-sm font-semibold text-white">
-            Only work orders assigned to you (last 30 days)
-          </div>
+          {!embedded ? (
+            <>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
+                My advisor queue
+              </div>
+              <div className="mt-1 text-sm font-semibold text-white">
+                Only work orders assigned to you (last 30 days)
+              </div>
+            </>
+          ) : null}
         </div>
 
         <div className="flex items-center gap-2">
@@ -320,7 +324,7 @@ export default function AdvisorQueueWidget(): JSX.Element {
       ) : err ? (
         <div className="px-4 py-5 text-sm text-red-200">{err}</div>
       ) : (
-        <div className="space-y-4 px-4 py-4">
+        <div className={embedded ? "space-y-4" : "space-y-4 px-4 py-4"}>
           <div className="grid gap-3 md:grid-cols-4">
             {(["awaiting", "in_progress", "on_hold", "ready_to_invoice"] as Bucket[]).map((b) => (
               <BucketButton


### PR DESCRIPTION
### Motivation
- The dashboard board provides the primary widget chrome but many high-impact widgets were rendering full internal shells, creating nested chrome, excess padding, and vertical bloat.  
- The intent is to change the rendering contract so high-impact widgets render as compact embedded modules for better density and scanability while preserving business logic and branding.  
- Keep changes incremental and non-breaking by adding an `embedded` rendering mode rather than creating a second widget system.  

### Description
- Add an `embedded` rendering mode and use it to remove duplicated inner shells/headers for four high-impact widgets so they render as compact modules: `Daily Summary`, `Shop Pulse`, `Suggested Actions`, and `Advisor Queue`.  
- Key technical changes: added `embedded?: boolean` props and conditional styling/structure to `DailySummaryCard`, `SuggestedActionsPanel`, `ShopPulseWidget`, and `AdvisorQueueWidget`, and updated their widget module entries to render the embedded variants where appropriate.  
- Files changed: `features/shared/components/DailySummaryCard.tsx`, `features/assistant/components/SuggestedActionsPanel.tsx`, `features/dashboard/widgets/ShopPulseWidget.tsx`, `features/work-orders/components/dashboard/AdvisorQueueWidget.tsx`, and the widget module entries under `features/dashboard/widgets/modules/*` for Daily Summary, Shop Pulse, Suggested Actions, and Advisor Queue.  
- Presentation changes are limited to removing/reducing nested chrome (card borders/background/shadow, repeated title/description blocks, and large inner padding) in embedded mode while preserving all data loading, error/fallback states, and CTAs (refresh/open links); non-priority widgets were left self-contained for a follow-up pass.  

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` — success (no type errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ceb77a488328ba0d2e5bfea53a12)