### PR TITLE
Embed selected dashboard widgets and reduce inner chrome for denser board

### DIFF
--- a/features/dashboard/widgets/ApprovalRiskWidget.tsx
+++ b/features/dashboard/widgets/ApprovalRiskWidget.tsx
@@ -16,7 +16,13 @@ function hoursInState(seconds: number | null | undefined): number {
   return s / 3600;
 }
 
-export default function ApprovalRiskWidget({ shopId }: { shopId: string | null }) {
+export default function ApprovalRiskWidget({
+  shopId,
+  embedded = false,
+}: {
+  shopId: string | null;
+  embedded?: boolean;
+}) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [rows, setRows] = useState<BoardRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -58,21 +64,8 @@ export default function ApprovalRiskWidget({ shopId }: { shopId: string | null }
 
   const aged = useMemo(() => rows.filter((r) => hoursInState(r.time_in_stage_seconds) >= 24), [rows]);
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Approval Risk"
-      title="Quotes and approvals aging"
-      subtitle="Work orders waiting too long for customer or fleet approval."
-      rightSlot={
-        <Link
-          href="/work-orders/view"
-          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
-        >
-          Open queue →
-        </Link>
-      }
-      compact
-    >
+  const content = (
+    <>
       {loading ? (
         <div className="text-sm text-neutral-300">Loading approval risk…</div>
       ) : error ? (
@@ -99,7 +92,7 @@ export default function ApprovalRiskWidget({ shopId }: { shopId: string | null }
               <Link
                 key={row.work_order_id}
                 href={`/work-orders/${row.work_order_id}`}
-                className="block rounded-xl border border-white/10 bg-black/25 px-3 py-3 transition hover:bg-black/35"
+                className="block rounded-xl border border-white/10 bg-black/25 px-3 py-2.5 transition hover:bg-black/35"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -121,6 +114,27 @@ export default function ApprovalRiskWidget({ shopId }: { shopId: string | null }
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI · Approval Risk"
+      title="Quotes and approvals aging"
+      subtitle="Work orders waiting too long for customer or fleet approval."
+      rightSlot={
+        <Link
+          href="/work-orders/view"
+          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
+        >
+          Open queue →
+        </Link>
+      }
+      compact
+    >
+      {content}
     </DashboardWidgetShell>
   );
 }

--- a/features/dashboard/widgets/ComebackRiskWidget.tsx
+++ b/features/dashboard/widgets/ComebackRiskWidget.tsx
@@ -18,7 +18,13 @@ function getString(v: unknown): string | null {
   return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
 }
 
-export default function ComebackRiskWidget({ shopId }: { shopId: string | null }) {
+export default function ComebackRiskWidget({
+  shopId,
+  embedded = false,
+}: {
+  shopId: string | null;
+  embedded?: boolean;
+}) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -76,21 +82,8 @@ export default function ComebackRiskWidget({ shopId }: { shopId: string | null }
           ? "border-[color:color-mix(in_srgb,var(--brand-accent)_48%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent)_15%,transparent)] text-[color:var(--brand-accent)]"
           : "border-[color:color-mix(in_srgb,var(--brand-secondary)_68%,white_18%)] bg-[color:color-mix(in_srgb,var(--brand-secondary)_76%,black)] text-[color:var(--theme-text-secondary)]";
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Comeback Risk"
-      title="Quality risk watch"
-      subtitle="Uses the latest shop health snapshot as a quick comeback-risk indicator."
-      rightSlot={
-        <Link
-          href="/dashboard/owner/reports?tab=health"
-          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
-        >
-          Open health →
-        </Link>
-      }
-      compact
-    >
+  const content = (
+    <>
       {loading ? (
         <div className="text-sm text-neutral-300">Loading comeback risk…</div>
       ) : error ? (
@@ -127,6 +120,27 @@ export default function ComebackRiskWidget({ shopId }: { shopId: string | null }
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI · Comeback Risk"
+      title="Quality risk watch"
+      subtitle="Uses the latest shop health snapshot as a quick comeback-risk indicator."
+      rightSlot={
+        <Link
+          href="/dashboard/owner/reports?tab=health"
+          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
+        >
+          Open health →
+        </Link>
+      }
+      compact
+    >
+      {content}
     </DashboardWidgetShell>
   );
 }

--- a/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
+++ b/features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx
@@ -708,7 +708,7 @@ export default function OptimizationOpportunitiesWidget({
             </div>
           </div>
         ) : (
-          <div className="grid gap-3">
+          <div className="grid gap-2.5">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <button
                 type="button"
@@ -725,9 +725,6 @@ export default function OptimizationOpportunitiesWidget({
               >
                 {showRecentChanges ? "Hide recent changes" : "Recent changes"}
               </button>
-            </div>
-            <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-[11px] text-neutral-400">
-              Suggestions are advisory only. Confirm with your team before changing menu pricing or inspection templates.
             </div>
             {recommendedNext.length > 0 ? (
               <div className="rounded-xl border border-[color:var(--brand-primary)]/30 bg-[color:color-mix(in_srgb,var(--brand-primary)_12%,transparent)] px-3 py-2.5">
@@ -818,7 +815,7 @@ export default function OptimizationOpportunitiesWidget({
                 <div
                   key={opportunity.id}
                   className={[
-                    "rounded-2xl px-4 py-3 transition-all duration-500",
+                    "rounded-2xl px-3 py-2.5 transition-all duration-500",
                     isApplied
                       ? "border border-emerald-500/35 bg-[color:color-mix(in_srgb,rgba(16,185,129,0.18)_55%,black)]"
                       : isDismissed
@@ -892,7 +889,7 @@ export default function OptimizationOpportunitiesWidget({
                         </details>
                       ) : null}
 
-                      <div className="mt-3 rounded-xl border border-white/10 bg-black/25 p-2.5 text-[11px] text-neutral-300">
+                      <div className="mt-2 rounded-lg border border-white/10 bg-black/20 p-2 text-[11px] text-neutral-300">
                         <div className="font-semibold uppercase tracking-[0.12em] text-neutral-200">Why recommended</div>
                         <ul className="mt-1.5 space-y-1">
                           {whyThisMatters.slice(0, 3).map((item) => (
@@ -918,7 +915,7 @@ export default function OptimizationOpportunitiesWidget({
                     <div className="mt-2 text-xs text-neutral-400">Hidden from active recommendations.</div>
                   )}
 
-                  <div className="mt-3 flex flex-wrap gap-2">
+                  <div className="mt-2.5 flex flex-wrap gap-2">
                     <button
                       type="button"
                       onClick={() => void openExecutionModal(opportunity)}
@@ -948,9 +945,9 @@ export default function OptimizationOpportunitiesWidget({
             })}
 
             {groups.length > 0 ? (
-              <div className="grid gap-2 rounded-xl border border-white/10 bg-black/15 p-2.5">
+              <div className="grid gap-2">
                 {groups.map((group) => (
-                  <div key={`${group.type}:${group.groupKey}`} className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+                  <div key={`${group.type}:${group.groupKey}`} className="rounded-lg border border-white/10 bg-black/15 px-3 py-2">
                     <div className="text-xs font-semibold text-neutral-100">{groupLabel(group)} Optimization</div>
                     <div className="mt-1 text-[11px] text-neutral-400">
                       {group.opportunities.length} opportunities ·

--- a/features/dashboard/widgets/RevenueWatchWidget.tsx
+++ b/features/dashboard/widgets/RevenueWatchWidget.tsx
@@ -14,9 +14,11 @@ function money(n: number | null | undefined): string {
 export default function RevenueWatchWidget({
   shopId,
   goal = 10000,
+  embedded = false,
 }: {
   shopId: string | null;
   goal?: number;
+  embedded?: boolean;
 }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -54,21 +56,8 @@ export default function RevenueWatchWidget({
 
   const pct = goal > 0 ? Math.max(0, Math.min(100, Math.round((revenue / goal) * 100))) : 0;
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Revenue Watch"
-      title="Current month pace"
-      subtitle="Fast monthly revenue and profit pulse."
-      rightSlot={
-        <Link
-          href="/dashboard/owner/reports"
-          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
-        >
-          Open reports →
-        </Link>
-      }
-      compact
-    >
+  const content = (
+    <>
       {loading ? (
         <div className="text-sm text-neutral-300">Loading revenue watch…</div>
       ) : error ? (
@@ -100,6 +89,27 @@ export default function RevenueWatchWidget({
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI · Revenue Watch"
+      title="Current month pace"
+      subtitle="Fast monthly revenue and profit pulse."
+      rightSlot={
+        <Link
+          href="/dashboard/owner/reports"
+          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
+        >
+          Open reports →
+        </Link>
+      }
+      compact
+    >
+      {content}
     </DashboardWidgetShell>
   );
 }

--- a/features/dashboard/widgets/TechLoadWidget.tsx
+++ b/features/dashboard/widgets/TechLoadWidget.tsx
@@ -42,7 +42,13 @@ function toneClasses(tone: "high" | "balanced" | "low"): { pill: string; bar: st
   };
 }
 
-export default function TechLoadWidget({ shopId }: { shopId: string | null }) {
+export default function TechLoadWidget({
+  shopId,
+  embedded = false,
+}: {
+  shopId: string | null;
+  embedded?: boolean;
+}) {
   const { metrics, loading, error } = useTechnicianLoadMetrics(shopId, {
     enabled: true,
     pollMs: 30_000,
@@ -65,13 +71,8 @@ export default function TechLoadWidget({ shopId }: { shopId: string | null }) {
     };
   }, [rows]);
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Technician Load"
-      title="Technician Load"
-      subtitle="Today in shop timezone: utilization, active jobs, and active vs idle balance."
-      compact
-    >
+  const content = (
+    <>
       {loading ? (
         <div className="text-sm text-neutral-300">Loading technician load…</div>
       ) : error ? (
@@ -157,6 +158,19 @@ export default function TechLoadWidget({ shopId }: { shopId: string | null }) {
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI · Technician Load"
+      title="Technician Load"
+      subtitle="Today in shop timezone: utilization, active jobs, and active vs idle balance."
+      compact
+    >
+      {content}
     </DashboardWidgetShell>
   );
 }

--- a/features/dashboard/widgets/WaitingPartsWidget.tsx
+++ b/features/dashboard/widgets/WaitingPartsWidget.tsx
@@ -16,7 +16,13 @@ function hoursInState(seconds: number | null | undefined): number {
   return s / 3600;
 }
 
-export default function WaitingPartsWidget({ shopId }: { shopId: string | null }) {
+export default function WaitingPartsWidget({
+  shopId,
+  embedded = false,
+}: {
+  shopId: string | null;
+  embedded?: boolean;
+}) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [rows, setRows] = useState<BoardRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -56,21 +62,8 @@ export default function WaitingPartsWidget({ shopId }: { shopId: string | null }
 
   const longWait = useMemo(() => rows.filter((r) => hoursInState(r.time_in_stage_seconds) >= 48), [rows]);
 
-  return (
-    <DashboardWidgetShell
-      eyebrow="AI · Parts Attention"
-      title="Jobs blocked by parts"
-      subtitle="Jobs waiting on parts requests or incomplete receiving."
-      rightSlot={
-        <Link
-          href="/parts/requests"
-          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
-        >
-          Open parts →
-        </Link>
-      }
-      compact
-    >
+  const content = (
+    <>
       {loading ? (
         <div className="text-sm text-neutral-300">Loading parts blockers…</div>
       ) : error ? (
@@ -97,7 +90,7 @@ export default function WaitingPartsWidget({ shopId }: { shopId: string | null }
               <Link
                 key={row.work_order_id}
                 href={`/work-orders/${row.work_order_id}`}
-                className="block rounded-xl border border-white/10 bg-black/25 px-3 py-3 transition hover:bg-black/35"
+                className="block rounded-xl border border-white/10 bg-black/25 px-3 py-2.5 transition hover:bg-black/35"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -121,6 +114,27 @@ export default function WaitingPartsWidget({ shopId }: { shopId: string | null }
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI · Parts Attention"
+      title="Jobs blocked by parts"
+      subtitle="Jobs waiting on parts requests or incomplete receiving."
+      rightSlot={
+        <Link
+          href="/parts/requests"
+          className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-xs font-semibold text-neutral-200 transition hover:bg-black/45"
+        >
+          Open parts →
+        </Link>
+      }
+      compact
+    >
+      {content}
     </DashboardWidgetShell>
   );
 }

--- a/features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx
@@ -10,6 +10,5 @@ export const approvalRiskWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: (context) => <ApprovalRiskWidget shopId={context.shopId} />,
+  render: (context) => <ApprovalRiskWidget shopId={context.shopId} embedded />,
 };

--- a/features/dashboard/widgets/modules/ComebackRiskWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ComebackRiskWidgetModule.tsx
@@ -10,6 +10,5 @@ export const comebackRiskWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: (context) => <ComebackRiskWidget shopId={context.shopId} />,
+  render: (context) => <ComebackRiskWidget shopId={context.shopId} embedded />,
 };

--- a/features/dashboard/widgets/modules/RevenueWatchWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/RevenueWatchWidgetModule.tsx
@@ -10,6 +10,5 @@ export const revenueWatchWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: (context) => <RevenueWatchWidget shopId={context.shopId} />,
+  render: (context) => <RevenueWatchWidget shopId={context.shopId} embedded />,
 };

--- a/features/dashboard/widgets/modules/TechLoadWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/TechLoadWidgetModule.tsx
@@ -10,6 +10,5 @@ export const techLoadWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: (context) => <TechLoadWidget shopId={context.shopId} />,
+  render: (context) => <TechLoadWidget shopId={context.shopId} embedded />,
 };

--- a/features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx
@@ -10,6 +10,5 @@ export const waitingPartsWidgetModule: DashboardWidgetModule = {
   defaultH: 4,
   minW: 3,
   minH: 3,
-  selfContained: true,
-  render: (context) => <WaitingPartsWidget shopId={context.shopId} />,
+  render: (context) => <WaitingPartsWidget shopId={context.shopId} embedded />,
 };


### PR DESCRIPTION
### Motivation
- Make the dashboard feel like a single command surface by reducing nested widget chrome and density for medium-size widgets.
- Target a focused, non-breaking conversion for specific widgets so the board shell becomes the primary chrome while preserving all business/data logic and persistence.
- Keep the change small and reversible: do not alter dashboard architecture, layout persistence, or core data flows.

### Description
- Converted these widgets to support an `embedded` mode and return only their inner content when embedded: `TechLoadWidget`, `ApprovalRiskWidget`, `WaitingPartsWidget`, `ComebackRiskWidget`, and `RevenueWatchWidget`.
- Updated widget modules to render the widgets in embedded mode (removed nested self-contained shells) by passing `embedded` from the module render path: changed module render calls to use e.g. `<TechLoadWidget shopId={context.shopId} embedded />`.
- Performed a targeted density/chrome reduction in `OptimizationOpportunitiesWidget` without changing its architecture by tightening gaps (`gap-3` → `gap-2.5`), reducing card paddings, removing a duplicated advisory strip, and simplifying some nested shells to be lighter.
- Files changed: `features/dashboard/widgets/TechLoadWidget.tsx`, `features/dashboard/widgets/ApprovalRiskWidget.tsx`, `features/dashboard/widgets/WaitingPartsWidget.tsx`, `features/dashboard/widgets/ComebackRiskWidget.tsx`, `features/dashboard/widgets/RevenueWatchWidget.tsx`, `features/dashboard/widgets/OptimizationOpportunitiesWidget.tsx`, `features/dashboard/widgets/modules/TechLoadWidgetModule.tsx`, `features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx`, `features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx`, `features/dashboard/widgets/modules/ComebackRiskWidgetModule.tsx`, `features/dashboard/widgets/modules/RevenueWatchWidgetModule.tsx`.
- Preserved behaviors: loading states, fallback/error messages, actions/links, role-aware behavior, and all data logic; the Work Order Board was intentionally deferred from embedded conversion.

### Testing
- Ran the required TypeScript validation with `npx tsc --noEmit` and it passed.  
- No additional automated tests were added or modified for this focused UI density pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d2aad5248328ac04776b3b2ef32f)