### PR TITLE
Refactor Operations dashboard into fixed cockpit grid layout

### DIFF
--- a/features/dashboard/components/DashboardWidgetBoard.tsx
+++ b/features/dashboard/components/DashboardWidgetBoard.tsx
@@ -141,32 +141,45 @@ export default function DashboardWidgetBoard({
   const renderWidget = (
     item: DashboardWidgetLayout,
     widget: DashboardWidgetModule,
-    emphasis: "dominant" | "normal" = "normal",
+    options?: {
+      emphasis?: "dominant" | "normal";
+      compact?: boolean;
+      className?: string;
+    },
   ) => {
+    const emphasis = options?.emphasis ?? "normal";
+    const compact = options?.compact ?? false;
+    const className = options?.className ?? "";
+
     const heightClass = item.id === "work_order_board"
-      ? item.h >= 6
-        ? "min-h-[28rem]"
-        : "min-h-[24rem]"
-      : item.h >= 5
-        ? "min-h-[17rem]"
-        : item.h >= 4
-          ? "min-h-[14.5rem]"
-          : "min-h-[12.5rem]";
+      ? "h-full min-h-[26rem]"
+      : compact
+        ? "h-full min-h-[9.5rem]"
+        : item.h >= 5
+          ? "min-h-[17rem]"
+          : item.h >= 4
+            ? "min-h-[14.5rem]"
+            : "min-h-[12.5rem]";
     const emphasisClass = emphasis === "dominant" ? "ring-1 ring-[var(--brand-accent,#E39A6E)]/35" : "";
+    const compactDensityClass = compact
+      ? "[&_p]:hidden [&_.pfq-widget-shell]:pr-0 [&_.pfq-widget-shell]:text-[12px] [&_.pfq-widget-shell]:leading-snug"
+      : "";
+    const renderItem = compact ? { ...item, h: Math.min(item.h, 3) } : item;
 
     return (
-      <div key={item.id} className={`h-full min-h-0 ${heightClass}`}>
-        <div className={`h-full min-h-0 ${emphasisClass}`}>
+      <div key={item.id} className={`min-h-0 ${heightClass} ${className}`}>
+        <div className={`h-full min-h-0 ${emphasisClass} ${compactDensityClass}`}>
           {widget.selfContained ? (
-            <div className="h-full min-h-0">{widget.render(context, item)}</div>
+            <div className="h-full min-h-0">{widget.render(context, renderItem)}</div>
           ) : (
             <DashboardWidgetShell
               title={widget.title}
-              description={widget.description}
+              description={compact ? undefined : widget.description}
+              compact={compact}
               className="min-h-0"
               scrollClassName="pb-2"
             >
-              {widget.render(context, item)}
+              {widget.render(context, renderItem)}
             </DashboardWidgetShell>
           )}
         </div>
@@ -310,46 +323,32 @@ export default function DashboardWidgetBoard({
       ) : null}
 
       {view === "operations" ? (
-        <>
-          <section className="space-y-2">
-            <header>
-              <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Live Awareness</h2>
-            </header>
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              {operationTopIds
-                .map((id) => visibleById.get(id))
-                .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
-                .map(({ item, widget }) => renderWidget(item, widget))}
-            </div>
-          </section>
+        <section className="grid gap-3 xl:h-[calc(100vh-16.5rem)] xl:grid-rows-[auto_minmax(0,1fr)_auto]">
+          <div className="grid gap-3 md:grid-cols-3">
+            {operationTopIds
+              .map((id) => visibleById.get(id))
+              .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
+              .map(({ item, widget }) => renderWidget(item, widget, { compact: true }))}
+          </div>
 
-          <section className="grid gap-4 xl:grid-cols-[1.7fr_1fr]">
-            <div className="space-y-2">
-              <header>
-                <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Immediate Action</h2>
-              </header>
-              <div>
-                {(() => {
-                  const board = visibleById.get("work_order_board");
-                  if (!board) return null;
-                  return renderWidget(board.item, board.widget, "dominant");
-                })()}
-              </div>
-            </div>
+          <div className="min-h-0">
+            {(() => {
+              const board = visibleById.get("work_order_board");
+              if (!board) return null;
+              return renderWidget(board.item, board.widget, {
+                emphasis: "dominant",
+                className: "h-full",
+              });
+            })()}
+          </div>
 
-            <div className="space-y-2">
-              <header>
-                <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Throughput & Blockers</h2>
-              </header>
-              <div className="grid gap-3">
-                {operationSideIds
-                  .map((id) => visibleById.get(id))
-                  .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
-                  .map(({ item, widget }) => renderWidget(item, widget))}
-              </div>
-            </div>
-          </section>
-        </>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {operationSideIds
+              .map((id) => visibleById.get(id))
+              .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
+              .map(({ item, widget }) => renderWidget(item, widget, { compact: true }))}
+          </div>
+        </section>
       ) : (
         <>
           <section className="space-y-2">

--- a/features/dashboard/components/DashboardWidgetShell.tsx
+++ b/features/dashboard/components/DashboardWidgetShell.tsx
@@ -41,7 +41,7 @@ export default function DashboardWidgetShell({
     <Card
       className={cn(
         "h-full min-h-0 overflow-hidden",
-        compact ? "px-4 py-4" : "px-5 py-5",
+        compact ? "px-3.5 py-3.5" : "px-5 py-5",
         className,
       )}
     >
@@ -54,11 +54,11 @@ export default function DashboardWidgetShell({
               </div>
             ) : null}
 
-            <h2 className="mt-1 text-[17px] font-semibold leading-tight text-white sm:text-[19px]">
+            <h2 className={cn("mt-1 font-semibold leading-tight text-white", compact ? "text-[14px] sm:text-[15px]" : "text-[17px] sm:text-[19px]")}>
               {title}
             </h2>
 
-            {bodyText ? (
+            {bodyText && !compact ? (
               <p className="mt-1 max-w-2xl text-[12px] leading-relaxed text-neutral-300 sm:text-[13px]">
                 {bodyText}
               </p>
@@ -90,7 +90,7 @@ export default function DashboardWidgetShell({
           </div>
         </div>
 
-        <div className={cn("mt-3 min-h-0 flex-1 overflow-hidden", contentClassName)}>
+        <div className={cn(compact ? "mt-2 min-h-0 flex-1 overflow-hidden" : "mt-3 min-h-0 flex-1 overflow-hidden", contentClassName)}>
           <div
             className={cn(
               "pfq-widget-shell h-full min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain pr-1",


### PR DESCRIPTION
### Motivation
- The operations dashboard still read as a long vertical stack of independent cards and scrolled too much, so the intent is to provide a fixed, non-scrolling cockpit layout with a compact signal bar, a visually dominant work board, and compact operational panels.

### Description
- Reworked the `view === "operations"` flow in `DashboardWidgetBoard` to a fixed three-row grid using `xl:grid-rows-[auto_minmax(0,1fr)_auto]` and `xl:h-[calc(100vh-16.5rem)]`, replacing the old stacked section headers (`Live Awareness`, `Immediate Action`, `Throughput & Blockers`).
- Introduced `renderWidget(..., options)` with `compact` and `emphasis` flags and mapped widgets explicitly into top (`daily_summary`, `shop_pulse`, `suggested_actions`), main (`work_order_board`), and bottom (`advisor_queue`, `tech_load`, `approval_risk`, `waiting_parts`, `live_shop_load`) zones so top/bottom widgets render in compact mode while preserving widget logic and role filtering.
- Passed `compact` into `DashboardWidgetShell` and tightened compact styling (reduced padding, smaller title typography, suppressed descriptive/body text, and denser content spacing) to support signal-style and quick-glance panels.
- Files changed: `features/dashboard/components/DashboardWidgetBoard.tsx` and `features/dashboard/components/DashboardWidgetShell.tsx`.

### Testing
- Ran type-check: `npx tsc --noEmit`, which completed successfully with no new errors.
- No other automated tests were modified or executed as part of this layout-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7dcad3288328b01e47850a9db788)