### PR TITLE
Refine dashboard responsive command-center spans

### DIFF
--- a/features/dashboard/components/DashboardWidgetBoard.tsx
+++ b/features/dashboard/components/DashboardWidgetBoard.tsx
@@ -7,6 +7,13 @@ import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidge
 import { buildDefaultDashboardLayout } from "@/features/dashboard/lib/defaultLayout";
 import { normalizeDashboardLayout } from "@/features/dashboard/lib/dashboard-layouts";
 import {
+  DASHBOARD_WIDGET_RESPONSIVE_META,
+  getDashboardViewport,
+  getDashboardZoneColumns,
+  getWidgetSpanForViewport,
+  type DashboardViewport,
+} from "@/features/dashboard/lib/dashboard-responsive-layout";
+import {
   getWidgetsForView,
   type DashboardView,
 } from "@/features/dashboard/lib/dashboard-views";
@@ -57,7 +64,21 @@ export default function DashboardWidgetBoard({
 
   const [layout, setLayout] = useState<DashboardWidgetLayout[]>(computedInitialLayout);
   const [controlsOpen, setControlsOpen] = useState(false);
+  const [viewport, setViewport] = useState<DashboardViewport>("desktop");
+  const [screenWidth, setScreenWidth] = useState(1536);
   const prevSerializedRef = useRef<string>(JSON.stringify(computedInitialLayout));
+
+  useEffect(() => {
+    const syncViewport = () => {
+      const width = window.innerWidth;
+      setScreenWidth(width);
+      setViewport(getDashboardViewport(width));
+    };
+
+    syncViewport();
+    window.addEventListener("resize", syncViewport);
+    return () => window.removeEventListener("resize", syncViewport);
+  }, []);
 
   useEffect(() => {
     const serialized = JSON.stringify(computedInitialLayout);
@@ -138,6 +159,9 @@ export default function DashboardWidgetBoard({
     );
   };
 
+  const zoneColumns = getDashboardZoneColumns(screenWidth);
+  const isCompactDensity = viewport !== "desktop";
+
   const renderWidget = (
     item: DashboardWidgetLayout,
     widget: DashboardWidgetModule,
@@ -150,24 +174,25 @@ export default function DashboardWidgetBoard({
     const emphasis = options?.emphasis ?? "normal";
     const compact = options?.compact ?? false;
     const className = options?.className ?? "";
+    const meta = DASHBOARD_WIDGET_RESPONSIVE_META[item.id];
 
-    const heightClass = item.id === "work_order_board"
-      ? "h-full min-h-[26rem]"
-      : compact
-        ? "h-full min-h-[9.5rem]"
-        : item.h >= 5
-          ? "min-h-[17rem]"
-          : item.h >= 4
-            ? "min-h-[14.5rem]"
-            : "min-h-[12.5rem]";
-    const emphasisClass = emphasis === "dominant" ? "ring-1 ring-[var(--brand-accent,#E39A6E)]/35" : "";
+    const emphasisClass =
+      emphasis === "dominant" ? "ring-1 ring-[var(--brand-accent,#E39A6E)]/35" : "";
     const compactDensityClass = compact
       ? "[&_p]:hidden [&_.pfq-widget-shell]:pr-0 [&_.pfq-widget-shell]:text-[12px] [&_.pfq-widget-shell]:leading-snug"
       : "";
     const renderItem = compact ? { ...item, h: Math.min(item.h, 3) } : item;
+    const minHeight = compact ? meta.compactMinHeightRem : meta.preferredMinHeightRem;
 
     return (
-      <div key={item.id} className={`min-h-0 ${heightClass} ${className}`}>
+      <div
+        key={item.id}
+        className={`min-h-0 ${className}`}
+        style={{
+          gridColumn: `span ${getWidgetSpanForViewport(item.id, viewport, zoneColumns)} / span ${getWidgetSpanForViewport(item.id, viewport, zoneColumns)}`,
+          minHeight: `${minHeight}rem`,
+        }}
+      >
         <div className={`h-full min-h-0 ${emphasisClass} ${compactDensityClass}`}>
           {widget.selfContained ? (
             <div className="h-full min-h-0">{widget.render(context, renderItem)}</div>
@@ -187,30 +212,34 @@ export default function DashboardWidgetBoard({
     );
   };
 
-  const operationTopIds: DashboardWidgetId[] = [
-    "daily_summary",
-    "shop_pulse",
-    "suggested_actions",
-  ];
-  const operationSideIds: DashboardWidgetId[] = [
-    "advisor_queue",
-    "tech_load",
-    "approval_risk",
-    "waiting_parts",
-    "live_shop_load",
-  ];
+  const operationTopIds: DashboardWidgetId[] = ["daily_summary", "shop_pulse", "suggested_actions"];
+  const operationPrimaryIds: DashboardWidgetId[] = ["work_order_board"];
+  const operationSecondaryIds: DashboardWidgetId[] = ["approval_risk", "waiting_parts"];
+  const operationBusinessIds: DashboardWidgetId[] = ["advisor_queue", "tech_load", "live_shop_load"];
 
-  const performanceTopIds: DashboardWidgetId[] = [
-    "stats_overview",
-    "revenue_watch",
-    "reports_performance",
-  ];
-  const performanceBottomIds: DashboardWidgetId[] = [
-    "tech_performance",
-    "bookings",
-    "optimization_opportunities",
-    "comeback_risk",
-  ];
+  const performanceTopIds: DashboardWidgetId[] = ["stats_overview", "revenue_watch", "reports_performance"];
+  const performancePrimaryIds: DashboardWidgetId[] = ["tech_performance", "optimization_opportunities"];
+  const performanceSecondaryIds: DashboardWidgetId[] = ["comeback_risk"];
+  const performanceBusinessIds: DashboardWidgetId[] = ["bookings"];
+
+  const renderZone = (ids: DashboardWidgetId[], options?: { compact?: boolean; emphasis?: "dominant" | "normal" }) => (
+    <div
+      className="grid gap-3"
+      style={{
+        gridTemplateColumns: `repeat(${zoneColumns}, minmax(0, 1fr))`,
+      }}
+    >
+      {ids
+        .map((id) => visibleById.get(id))
+        .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
+        .map(({ item, widget }) =>
+          renderWidget(item, widget, {
+            compact: options?.compact ?? isCompactDensity,
+            emphasis: options?.emphasis,
+          }),
+        )}
+    </div>
+  );
 
   return (
     <div className="space-y-4">
@@ -323,58 +352,19 @@ export default function DashboardWidgetBoard({
       ) : null}
 
       {view === "operations" ? (
-        <section className="grid gap-3 xl:h-[calc(100vh-16.5rem)] xl:grid-rows-[auto_minmax(0,1fr)_auto]">
-          <div className="grid gap-3 md:grid-cols-3">
-            {operationTopIds
-              .map((id) => visibleById.get(id))
-              .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
-              .map(({ item, widget }) => renderWidget(item, widget, { compact: true }))}
-          </div>
-
-          <div className="min-h-0">
-            {(() => {
-              const board = visibleById.get("work_order_board");
-              if (!board) return null;
-              return renderWidget(board.item, board.widget, {
-                emphasis: "dominant",
-                className: "h-full",
-              });
-            })()}
-          </div>
-
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            {operationSideIds
-              .map((id) => visibleById.get(id))
-              .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
-              .map(({ item, widget }) => renderWidget(item, widget, { compact: true }))}
-          </div>
+        <section className="space-y-3">
+          {renderZone(operationTopIds, { compact: true })}
+          {renderZone(operationPrimaryIds, { emphasis: "dominant" })}
+          {renderZone(operationSecondaryIds, { compact: true })}
+          {renderZone(operationBusinessIds)}
         </section>
       ) : (
-        <>
-          <section className="space-y-2">
-            <header>
-              <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Business Snapshot</h2>
-            </header>
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              {performanceTopIds
-                .map((id) => visibleById.get(id))
-                .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
-                .map(({ item, widget }) => renderWidget(item, widget))}
-            </div>
-          </section>
-
-          <section className="space-y-2">
-            <header>
-              <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Trends & Optimization</h2>
-            </header>
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              {performanceBottomIds
-                .map((id) => visibleById.get(id))
-                .filter((entry): entry is { item: DashboardWidgetLayout; widget: DashboardWidgetModule } => Boolean(entry))
-                .map(({ item, widget }) => renderWidget(item, widget))}
-            </div>
-          </section>
-        </>
+        <section className="space-y-3">
+          {renderZone(performanceTopIds, { compact: true })}
+          {renderZone(performancePrimaryIds)}
+          {renderZone(performanceSecondaryIds)}
+          {renderZone(performanceBusinessIds)}
+        </section>
       )}
     </div>
   );

--- a/features/dashboard/lib/dashboard-responsive-layout.ts
+++ b/features/dashboard/lib/dashboard-responsive-layout.ts
@@ -1,0 +1,61 @@
+import type { DashboardWidgetId } from "@/features/dashboard/types/layout";
+
+export type DashboardViewport = "mobile" | "tablet" | "laptop" | "desktop";
+export type DashboardModuleMode = "signal" | "standard" | "feature";
+
+export type DashboardResponsiveSpan = {
+  desktop: number;
+  laptop: number;
+  tablet: number;
+  mobile: number;
+};
+
+export type DashboardWidgetResponsiveMeta = {
+  mode: DashboardModuleMode;
+  span: DashboardResponsiveSpan;
+  preferredMinHeightRem: number;
+  compactMinHeightRem: number;
+};
+
+export const DASHBOARD_WIDGET_RESPONSIVE_META: Record<DashboardWidgetId, DashboardWidgetResponsiveMeta> = {
+  daily_summary: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11, compactMinHeightRem: 9.5 },
+  shop_pulse: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11, compactMinHeightRem: 9.5 },
+  suggested_actions: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11, compactMinHeightRem: 9.5 },
+  work_order_board: { mode: "feature", span: { desktop: 2, laptop: 2, tablet: 2, mobile: 1 }, preferredMinHeightRem: 24, compactMinHeightRem: 20 },
+  advisor_queue: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
+  tech_load: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
+  approval_risk: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12, compactMinHeightRem: 9.5 },
+  waiting_parts: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12, compactMinHeightRem: 9.5 },
+  live_shop_load: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
+  stats_overview: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },
+  revenue_watch: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },
+  reports_performance: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },
+  tech_performance: { mode: "feature", span: { desktop: 2, laptop: 2, tablet: 2, mobile: 1 }, preferredMinHeightRem: 15, compactMinHeightRem: 12 },
+  bookings: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
+  optimization_opportunities: { mode: "feature", span: { desktop: 2, laptop: 2, tablet: 2, mobile: 1 }, preferredMinHeightRem: 15, compactMinHeightRem: 12 },
+  comeback_risk: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
+};
+
+export function getDashboardViewport(width: number): DashboardViewport {
+  if (width < 640) return "mobile";
+  if (width < 1200) return "tablet";
+  if (width < 1536) return "laptop";
+  return "desktop";
+}
+
+export function getDashboardZoneColumns(width: number): number {
+  if (width < 640) return 1;
+  if (width < 900) return 2;
+  if (width < 1200) return 2;
+  if (width < 1360) return 2;
+  return 3;
+}
+
+export function getWidgetSpanForViewport(
+  id: DashboardWidgetId,
+  viewport: DashboardViewport,
+  zoneColumns: number,
+): number {
+  const span = DASHBOARD_WIDGET_RESPONSIVE_META[id].span[viewport];
+  return Math.max(1, Math.min(zoneColumns, span));
+}

--- a/features/dashboard/types/layout.ts
+++ b/features/dashboard/types/layout.ts
@@ -22,6 +22,20 @@ export type DashboardCountState = {
   partsRequests: number;
 };
 
+export type DashboardViewportSpans = {
+  desktop: number;
+  laptop: number;
+  tablet: number;
+  mobile: number;
+};
+
+export type DashboardWidgetLayoutMeta = {
+  mode: "signal" | "standard" | "feature";
+  span: DashboardViewportSpans;
+  preferredMinHeightRem: number;
+  compactMinHeightRem: number;
+};
+
 export type DashboardWidgetLayout = {
   id: DashboardWidgetId;
   x: number;
@@ -40,6 +54,7 @@ export type DashboardLayoutItem = DashboardWidgetLayout & {
   minH?: number;
   maxW?: number;
   maxH?: number;
+  responsive?: DashboardWidgetLayoutMeta;
 };
 
 export type DashboardRenderContext = {
@@ -59,4 +74,5 @@ export type DashboardWidgetDefinition = {
   minH: number;
   maxW?: number;
   maxH?: number;
+  responsive?: DashboardWidgetLayoutMeta;
 };


### PR DESCRIPTION
### Motivation
- Preserve the dashboard "command-center" cockpit and zone hierarchy across desktop, laptop, and tablet while preventing arbitrary vertical stacking except on true mobile widths.
- Provide explicit per-widget responsive metadata (mode + per-breakpoint span + preferred/compact min heights) so modules compress predictably across breakpoints.
- Keep all existing data loading, registry, visibility, and layout persistence behavior intact while improving density and readabilty.

### Description
- Added a new responsive layout module `features/dashboard/lib/dashboard-responsive-layout.ts` that defines viewport breakpoints, zone column rules, and per-widget responsive metadata for all dashboard widgets.
- Updated the renderer in `features/dashboard/components/DashboardWidgetBoard.tsx` to detect viewport size, compute zone column counts, and apply `gridColumn` spans and density-aware `minHeight` from the widget responsive meta while preserving the four-zone cockpit structure (top/primary/secondary/business).
- Extended dashboard layout/types in `features/dashboard/types/layout.ts` to support responsive metadata on legacy layout items and widget definitions without changing persisted layout semantics.
- Preserved existing APIs and behaviors: widget registry usage, role-aware filtering, data fetching, and layout save/load flows remain unchanged.

### Testing
- Ran TypeScript verification with `npx tsc --noEmit` and it completed successfully with no new type errors.
- Confirmed the changes compile and the updated `DashboardWidgetBoard` file and new responsive module are present in the build output; no automated UI tests were added in this change.
- Files changed: `features/dashboard/components/DashboardWidgetBoard.tsx`, `features/dashboard/lib/dashboard-responsive-layout.ts` (new), and `features/dashboard/types/layout.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8245ae7483288314eaabcf6cb048)