### PR TITLE
Consolidate dashboard into server-orchestrated operations and performance surfaces

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -1,0 +1,136 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import DashboardViewSwitcher from "./DashboardViewSwitcher";
+import type { DashboardView } from "@/features/dashboard/lib/dashboard-views";
+
+export function DashboardShell({ children }: { children: ReactNode }) {
+  return <div className="w-full space-y-4 xl:space-y-5">{children}</div>;
+}
+
+export function DashboardTopStrip({
+  view,
+  title,
+  subtitle,
+  name,
+  actions,
+  summary,
+}: {
+  view: DashboardView;
+  title: string;
+  subtitle: string;
+  name: string;
+  actions: Array<{ label: string; href: string }>;
+  summary: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <section
+      className="rounded-2xl border px-5 py-4 backdrop-blur-xl xl:px-6 xl:py-5"
+      style={{
+        borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 72%, transparent)",
+        background: "var(--dashboard-hero-bg, var(--dashboard-shell-bg))",
+      }}
+    >
+      <div className="flex flex-col gap-4 xl:gap-5">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.24em] text-neutral-400">{title}</div>
+            <h1 className="mt-1.5 text-3xl font-semibold text-white xl:text-4xl">Welcome back, {name}</h1>
+            <p className="mt-1.5 max-w-3xl text-sm text-neutral-300 xl:text-[15px]">{subtitle}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <DashboardViewSwitcher currentView={view} />
+            {actions.map((action) => (
+              <Link
+                key={action.href}
+                href={action.href}
+                className="rounded-full border border-white/10 bg-black/25 px-4 py-2 text-sm font-medium text-neutral-200 transition hover:bg-black/40"
+              >
+                {action.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+          {summary.map((item) => (
+            <div key={item.label} className="rounded-xl border border-white/10 bg-black/30 px-3 py-2.5">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{item.label}</div>
+              <div className="mt-1 text-xl font-semibold text-white">{item.value}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function DashboardSectionShell({
+  title,
+  description,
+  children,
+  className,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={`rounded-2xl border p-4 ${className ?? ""}`}
+      style={{
+        borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 78%, transparent)",
+        background: "color-mix(in srgb, var(--theme-card-bg,#111827) 88%, black)",
+      }}
+    >
+      <header className="mb-3">
+        <h2 className="text-sm font-semibold text-white md:text-base">{title}</h2>
+        {description ? <p className="mt-1 text-xs text-neutral-400">{description}</p> : null}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+export function CompactSignalList({
+  items,
+}: {
+  items: Array<{ label: string; value: string; tone?: "default" | "accent" }>;
+}) {
+  return (
+    <div className="space-y-1.5">
+      {items.map((item) => (
+        <div
+          key={`${item.label}-${item.value}`}
+          className="flex items-center justify-between rounded-lg border border-white/10 bg-black/25 px-2.5 py-2 text-xs"
+        >
+          <span className="text-neutral-300">{item.label}</span>
+          <span className={item.tone === "accent" ? "font-semibold text-[color:var(--brand-accent)]" : "font-semibold text-white"}>
+            {item.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ActionRow({ actions }: { actions: Array<{ label: string; href: string; tone?: "primary" | "neutral" }> }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {actions.map((action) => (
+        <Link
+          key={`${action.href}-${action.label}`}
+          href={action.href}
+          className={
+            action.tone === "primary"
+              ? "rounded-full border border-[var(--accent-copper-soft)]/70 bg-[var(--accent-copper)]/15 px-3 py-1.5 text-xs font-semibold text-[var(--accent-copper-light)] transition hover:bg-[var(--accent-copper)] hover:text-black"
+              : "rounded-full border border-white/10 bg-black/25 px-3 py-1.5 text-xs font-semibold text-neutral-200 transition hover:bg-black/40"
+          }
+        >
+          {action.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -1,0 +1,84 @@
+import { AlertTriangle } from "lucide-react";
+
+import {
+  ActionRow,
+  CompactSignalList,
+  DashboardSectionShell,
+  DashboardShell,
+  DashboardTopStrip,
+} from "./DashboardPrimitives";
+import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+
+export default async function OperationsDashboardView() {
+  const payload = await getOperationsDashboardPayload();
+  const displayName = payload.identity.fullName?.trim() || "there";
+
+  return (
+    <DashboardShell>
+      <DashboardTopStrip
+        view="operations"
+        title="Operations Dashboard"
+        name={displayName}
+        subtitle="Live command center for blockers, active jobs, and immediate next actions."
+        actions={[
+          { label: "Create work order", href: "/work-orders/create" },
+          { label: "Dispatch", href: "/dashboard/manager/dispatch" },
+        ]}
+        summary={[
+          { label: "Active jobs", value: String(payload.topSummary.activeJobs) },
+          { label: "Blocked", value: String(payload.topSummary.blockedJobs) },
+          { label: "Approvals", value: String(payload.topSummary.waitingApprovals) },
+          { label: "Waiting parts", value: String(payload.topSummary.waitingParts) },
+        ]}
+      />
+
+      <div className="grid gap-4 xl:grid-cols-12">
+        <div className="space-y-4 xl:col-span-8">
+          <DashboardSectionShell title="Live Work / Active Jobs" description="Current board flow and priority stack.">
+            <div className="space-y-2">
+              {payload.liveWork.map((item) => (
+                <div key={item.id} className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-xs">
+                  <div>
+                    <div className="font-semibold text-white">{item.label}</div>
+                    <div className="text-neutral-400">{item.stage}</div>
+                  </div>
+                  <div className={item.risk === "danger" ? "text-[color:var(--brand-accent)]" : "text-neutral-300"}>
+                    {item.risk}
+                  </div>
+                  <div className="rounded-full border border-white/10 px-2 py-0.5 text-neutral-300">P{item.priority}</div>
+                </div>
+              ))}
+            </div>
+          </DashboardSectionShell>
+
+          <DashboardSectionShell title="Technician Activity / Current Flow" description="Team-level active line pressure.">
+            <CompactSignalList items={payload.technicianFlow} />
+          </DashboardSectionShell>
+        </div>
+
+        <div className="space-y-4 xl:col-span-4">
+          <DashboardSectionShell title="Blocker Stack" description="Approvals, waiting parts, and on-hold pressure.">
+            <CompactSignalList items={payload.blockerStack} />
+          </DashboardSectionShell>
+
+          <DashboardSectionShell title="Suggested Actions" description="Highest-leverage operational actions right now.">
+            <ActionRow actions={payload.suggestedActions} />
+          </DashboardSectionShell>
+
+          {payload.sectionErrors.length > 0 ? (
+            <DashboardSectionShell title="Section Warnings">
+              <div className="space-y-1.5 text-xs text-amber-300">
+                {payload.sectionErrors.map((warning) => (
+                  <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
+                    <span>{warning}</span>
+                  </div>
+                ))}
+              </div>
+            </DashboardSectionShell>
+          ) : null}
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/app/dashboard/_components/PerformanceDashboardView.tsx
+++ b/app/dashboard/_components/PerformanceDashboardView.tsx
@@ -1,0 +1,70 @@
+import { AlertTriangle } from "lucide-react";
+
+import {
+  CompactSignalList,
+  DashboardSectionShell,
+  DashboardShell,
+  DashboardTopStrip,
+} from "./DashboardPrimitives";
+import PerformanceTrendPanel from "./PerformanceTrendPanel";
+import { getPerformanceDashboardPayload } from "@/features/dashboard/server/getPerformanceDashboardPayload";
+
+export default async function PerformanceDashboardView() {
+  const payload = await getPerformanceDashboardPayload();
+  const displayName = payload.identity.fullName?.trim() || "there";
+
+  return (
+    <DashboardShell>
+      <DashboardTopStrip
+        view="performance"
+        title="Performance Dashboard"
+        name={displayName}
+        subtitle="Business review view for KPI trajectory, technician output, and optimization risk."
+        actions={[
+          { label: "Full reports", href: "/dashboard/owner/reports" },
+          { label: "Revenue view", href: "/dashboard/owner/reports/technicians" },
+        ]}
+        summary={[
+          { label: "Revenue", value: `$${payload.kpis.revenue.toLocaleString()}` },
+          { label: "Profit", value: `$${payload.kpis.profit.toLocaleString()}` },
+          { label: "Jobs", value: String(payload.kpis.jobs) },
+          { label: "Efficiency", value: `${payload.kpis.efficiencyPct}%` },
+        ]}
+      />
+
+      <div className="grid gap-4 xl:grid-cols-12">
+        <div className="space-y-4 xl:col-span-8">
+          <DashboardSectionShell
+            title="Trend / Performance Charts"
+            description="Last 6 months of revenue and profit, sourced from a single finance range payload."
+          >
+            <PerformanceTrendPanel data={payload.trend} />
+          </DashboardSectionShell>
+
+          <DashboardSectionShell title="Technician / Throughput Performance" description="Completed-line output during the current month.">
+            <CompactSignalList items={payload.technicianPerformance} />
+          </DashboardSectionShell>
+        </div>
+
+        <div className="space-y-4 xl:col-span-4">
+          <DashboardSectionShell title="Optimization / Revenue Risk Signals" description="Potential margin pressure and comeback risk signals.">
+            <CompactSignalList items={payload.businessSignals} />
+          </DashboardSectionShell>
+
+          {payload.sectionErrors.length > 0 ? (
+            <DashboardSectionShell title="Section Warnings">
+              <div className="space-y-1.5 text-xs text-amber-300">
+                {payload.sectionErrors.map((warning) => (
+                  <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
+                    <span>{warning}</span>
+                  </div>
+                ))}
+              </div>
+            </DashboardSectionShell>
+          ) : null}
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/app/dashboard/_components/PerformanceTrendPanel.tsx
+++ b/app/dashboard/_components/PerformanceTrendPanel.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+type TrendPoint = {
+  label: string;
+  revenue: number;
+  jobs: number;
+  profit: number;
+};
+
+export default function PerformanceTrendPanel({ data }: { data: TrendPoint[] }) {
+  return (
+    <div className="h-[250px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: -18 }}>
+          <CartesianGrid stroke="rgba(148, 163, 184, 0.12)" vertical={false} />
+          <XAxis dataKey="label" tick={{ fill: "#94A3B8", fontSize: 11 }} axisLine={false} tickLine={false} />
+          <YAxis tick={{ fill: "#94A3B8", fontSize: 11 }} axisLine={false} tickLine={false} />
+          <Tooltip
+            contentStyle={{
+              background: "#0b1220",
+              border: "1px solid rgba(148, 163, 184, 0.2)",
+              borderRadius: "10px",
+            }}
+          />
+          <Bar dataKey="revenue" fill="var(--brand-primary,#C1663B)" radius={[5, 5, 0, 0]} />
+          <Bar dataKey="profit" fill="var(--brand-accent,#E39A6E)" radius={[5, 5, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/dashboard/operations/page.tsx
+++ b/app/dashboard/operations/page.tsx
@@ -1,5 +1,5 @@
-import CuratedDashboardPage from "../_components/CuratedDashboardPage";
+import OperationsDashboardView from "../_components/OperationsDashboardView";
 
 export default function OperationsDashboardPage() {
-  return <CuratedDashboardPage view="operations" />;
+  return <OperationsDashboardView />;
 }

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -1,5 +1,5 @@
-import CuratedDashboardPage from "../_components/CuratedDashboardPage";
+import PerformanceDashboardView from "../_components/PerformanceDashboardView";
 
 export default function PerformanceDashboardPage() {
-  return <CuratedDashboardPage view="performance" />;
+  return <PerformanceDashboardView />;
 }

--- a/features/dashboard/server/dashboard-shell-data.ts
+++ b/features/dashboard/server/dashboard-shell-data.ts
@@ -1,0 +1,40 @@
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+import type { Database } from "@shared/types/types/supabase";
+
+export type DashboardIdentity = {
+  userId: string | null;
+  shopId: string | null;
+  role: string | null;
+  fullName: string | null;
+};
+
+export async function getDashboardIdentity(): Promise<DashboardIdentity> {
+  const supabase = createServerComponentClient<Database>({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const userId = session?.user?.id ?? null;
+  if (!userId) {
+    return { userId: null, shopId: null, role: null, fullName: null };
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name, role, shop_id")
+    .eq("id", userId)
+    .maybeSingle();
+
+  return {
+    userId,
+    shopId: profile?.shop_id ?? null,
+    role: profile?.role ?? null,
+    fullName: profile?.full_name ?? null,
+  };
+}
+
+export function createDashboardServerClient() {
+  return createServerComponentClient<Database>({ cookies });
+}

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -1,0 +1,164 @@
+import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
+
+const CLOSED_PART_STATUSES = ["fulfilled", "rejected", "cancelled"] as const;
+
+type OpSignal = { label: string; value: string; tone?: "default" | "accent" };
+
+type OpAction = { label: string; href: string; tone?: "primary" | "neutral" };
+
+export type OperationsDashboardPayload = {
+  identity: Awaited<ReturnType<typeof getDashboardIdentity>>;
+  topSummary: {
+    activeJobs: number;
+    blockedJobs: number;
+    waitingApprovals: number;
+    waitingParts: number;
+  };
+  liveWork: Array<{
+    id: string;
+    label: string;
+    stage: string;
+    risk: string;
+    priority: number;
+  }>;
+  technicianFlow: OpSignal[];
+  blockerStack: OpSignal[];
+  suggestedActions: OpAction[];
+  sectionErrors: string[];
+  fetchAudit: string[];
+};
+
+function stageLabel(stage: string | null | undefined): string {
+  return (stage ?? "in_progress").replaceAll("_", " ");
+}
+
+export async function getOperationsDashboardPayload(): Promise<OperationsDashboardPayload> {
+  const identity = await getDashboardIdentity();
+  const payload: OperationsDashboardPayload = {
+    identity,
+    topSummary: {
+      activeJobs: 0,
+      blockedJobs: 0,
+      waitingApprovals: 0,
+      waitingParts: 0,
+    },
+    liveWork: [],
+    technicianFlow: [],
+    blockerStack: [],
+    suggestedActions: [],
+    sectionErrors: [],
+    fetchAudit: [],
+  };
+
+  if (!identity.shopId) {
+    payload.sectionErrors.push("No shop context found for this user.");
+    return payload;
+  }
+
+  const supabase = createDashboardServerClient();
+
+  const [boardResult, approvalsResult, partsResult, techProfilesResult, activeLinesResult] = await Promise.all([
+    supabase
+      .from("v_work_order_board_cards_shop")
+      .select("work_order_id,custom_id,display_name,overall_stage,risk_level,priority")
+      .eq("shop_id", identity.shopId)
+      .order("activity_at", { ascending: false })
+      .limit(14),
+    supabase
+      .from("work_order_lines")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", identity.shopId)
+      .in("approval_state", ["requested", "pending", "awaiting_approval"]),
+    supabase
+      .from("part_requests")
+      .select("id,status", { count: "exact" })
+      .eq("shop_id", identity.shopId)
+      .not("status", "in", `(${CLOSED_PART_STATUSES.map((status) => `'${status}'`).join(",")})`)
+      .limit(80),
+    supabase
+      .from("profiles")
+      .select("id,full_name")
+      .eq("shop_id", identity.shopId)
+      .in("role", ["tech", "mechanic", "technician"]),
+    supabase
+      .from("work_order_lines")
+      .select("assigned_tech_id,status")
+      .eq("shop_id", identity.shopId)
+      .not("status", "in", "('completed','ready_to_invoice','invoiced')")
+      .not("assigned_tech_id", "is", null)
+      .limit(200),
+  ]);
+
+  if (boardResult.error) {
+    payload.sectionErrors.push(`Live work section: ${boardResult.error.message}`);
+  } else {
+    const rows = boardResult.data ?? [];
+    const blocked = rows.filter(
+      (row) => row.overall_stage === "waiting_parts" || row.overall_stage === "on_hold",
+    ).length;
+
+    payload.topSummary.activeJobs = rows.filter((row) => row.overall_stage !== "completed").length;
+    payload.topSummary.blockedJobs = blocked;
+    payload.liveWork = rows.slice(0, 8).map((row) => ({
+      id: row.work_order_id,
+      label: row.custom_id ?? row.display_name ?? row.work_order_id.slice(0, 8),
+      stage: stageLabel(row.overall_stage),
+      risk: row.risk_level ?? "none",
+      priority: row.priority ?? 3,
+    }));
+
+    payload.fetchAudit.push("Consolidated work-order board query now powers active jobs, live queue, and blocker counts.");
+  }
+
+  if (approvalsResult.error) {
+    payload.sectionErrors.push(`Approvals section: ${approvalsResult.error.message}`);
+  } else {
+    payload.topSummary.waitingApprovals = approvalsResult.count ?? 0;
+  }
+
+  if (partsResult.error) {
+    payload.sectionErrors.push(`Parts blocker section: ${partsResult.error.message}`);
+  } else {
+    const pendingParts = partsResult.data ?? [];
+    payload.topSummary.waitingParts = partsResult.count ?? pendingParts.length;
+    payload.blockerStack.push({ label: "Approvals pending", value: String(payload.topSummary.waitingApprovals), tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default" });
+    payload.blockerStack.push({ label: "Waiting parts", value: String(payload.topSummary.waitingParts), tone: payload.topSummary.waitingParts > 0 ? "accent" : "default" });
+    payload.blockerStack.push({ label: "On hold / blocked", value: String(payload.topSummary.blockedJobs), tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default" });
+  }
+
+  if (techProfilesResult.error || activeLinesResult.error) {
+    payload.sectionErrors.push("Technician flow section is degraded due to query failures.");
+  } else {
+    const techs = techProfilesResult.data ?? [];
+    const activeLines = activeLinesResult.data ?? [];
+    const counts = new Map<string, number>();
+    activeLines.forEach((line) => {
+      if (!line.assigned_tech_id) return;
+      counts.set(line.assigned_tech_id, (counts.get(line.assigned_tech_id) ?? 0) + 1);
+    });
+
+    payload.technicianFlow = techs
+      .map((tech) => ({
+        label: tech.full_name ?? "Unassigned tech",
+        value: `${counts.get(tech.id) ?? 0} active lines`,
+      }))
+      .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))
+      .slice(0, 5);
+  }
+
+  payload.suggestedActions = [
+    payload.topSummary.waitingApprovals > 0
+      ? { label: "Clear approval queue", href: "/work-orders/board?stage=awaiting_approval", tone: "primary" }
+      : { label: "Review active board", href: "/work-orders/board", tone: "neutral" },
+    payload.topSummary.waitingParts > 0
+      ? { label: "Resolve waiting parts", href: "/dashboard/operations?focus=parts", tone: "primary" }
+      : { label: "Create work order", href: "/work-orders/create", tone: "neutral" },
+    { label: "Open dispatch view", href: "/dashboard/manager/dispatch", tone: "neutral" },
+  ];
+
+  if (payload.sectionErrors.length === 0) {
+    payload.fetchAudit.push("No per-widget client bootstrap fetches remain on first paint for operations.");
+  }
+
+  return payload;
+}

--- a/features/dashboard/server/getPerformanceDashboardPayload.ts
+++ b/features/dashboard/server/getPerformanceDashboardPayload.ts
@@ -1,0 +1,186 @@
+import { endOfMonth, format, startOfMonth, subMonths } from "date-fns";
+
+import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
+
+type TrendPoint = {
+  label: string;
+  revenue: number;
+  jobs: number;
+  profit: number;
+};
+
+type PerfSignal = {
+  label: string;
+  value: string;
+  tone?: "default" | "accent";
+};
+
+export type PerformanceDashboardPayload = {
+  identity: Awaited<ReturnType<typeof getDashboardIdentity>>;
+  kpis: {
+    revenue: number;
+    profit: number;
+    jobs: number;
+    efficiencyPct: number;
+  };
+  trend: TrendPoint[];
+  technicianPerformance: PerfSignal[];
+  businessSignals: PerfSignal[];
+  sectionErrors: string[];
+  fetchAudit: string[];
+};
+
+function asMoney(value: number): number {
+  return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+export async function getPerformanceDashboardPayload(): Promise<PerformanceDashboardPayload> {
+  const identity = await getDashboardIdentity();
+  const payload: PerformanceDashboardPayload = {
+    identity,
+    kpis: { revenue: 0, profit: 0, jobs: 0, efficiencyPct: 0 },
+    trend: [],
+    technicianPerformance: [],
+    businessSignals: [],
+    sectionErrors: [],
+    fetchAudit: [],
+  };
+
+  if (!identity.shopId) {
+    payload.sectionErrors.push("No shop context found for this user.");
+    return payload;
+  }
+
+  const supabase = createDashboardServerClient();
+  const rangeStart = startOfMonth(subMonths(new Date(), 5)).toISOString();
+  const rangeEnd = endOfMonth(new Date()).toISOString();
+
+  const [invoiceResult, expenseResult, techProfilesResult, completedLinesResult, comebackRiskResult] = await Promise.all([
+    supabase
+      .from("invoices")
+      .select("id,total,labor_cost,created_at")
+      .eq("shop_id", identity.shopId)
+      .gte("created_at", rangeStart)
+      .lte("created_at", rangeEnd),
+    supabase
+      .from("expenses")
+      .select("amount,created_at")
+      .eq("shop_id", identity.shopId)
+      .gte("created_at", rangeStart)
+      .lte("created_at", rangeEnd),
+    supabase
+      .from("profiles")
+      .select("id,full_name")
+      .eq("shop_id", identity.shopId)
+      .in("role", ["tech", "mechanic", "technician"]),
+    supabase
+      .from("work_order_lines")
+      .select("assigned_tech_id,status,updated_at")
+      .eq("shop_id", identity.shopId)
+      .gte("updated_at", startOfMonth(new Date()).toISOString())
+      .in("status", ["completed", "ready_to_invoice", "invoiced"])
+      .not("assigned_tech_id", "is", null)
+      .limit(400),
+    supabase
+      .from("v_work_order_board_cards_shop")
+      .select("risk_level,overall_stage")
+      .eq("shop_id", identity.shopId)
+      .limit(100),
+  ]);
+
+  if (invoiceResult.error || expenseResult.error) {
+    payload.sectionErrors.push("Finance trend section is degraded due to invoice/expense query failures.");
+  } else {
+    const invoices = invoiceResult.data ?? [];
+    const expenses = expenseResult.data ?? [];
+
+    const monthBuckets = new Map<string, TrendPoint>();
+    for (let i = 5; i >= 0; i -= 1) {
+      const monthDate = subMonths(new Date(), i);
+      const key = format(monthDate, "yyyy-MM");
+      monthBuckets.set(key, {
+        label: format(monthDate, "MMM"),
+        revenue: 0,
+        jobs: 0,
+        profit: 0,
+      });
+    }
+
+    invoices.forEach((invoice) => {
+      const key = format(new Date(invoice.created_at ?? new Date()), "yyyy-MM");
+      const bucket = monthBuckets.get(key);
+      if (!bucket) return;
+
+      const total = Number(invoice.total ?? 0);
+      const labor = Number(invoice.labor_cost ?? 0);
+      bucket.revenue += total;
+      bucket.jobs += 1;
+      bucket.profit += total - labor;
+    });
+
+    expenses.forEach((expense) => {
+      const key = format(new Date(expense.created_at ?? new Date()), "yyyy-MM");
+      const bucket = monthBuckets.get(key);
+      if (!bucket) return;
+
+      bucket.profit -= Number(expense.amount ?? 0);
+    });
+
+    payload.trend = [...monthBuckets.values()].map((bucket) => ({
+      ...bucket,
+      revenue: asMoney(bucket.revenue),
+      profit: asMoney(bucket.profit),
+    }));
+
+    const latest = payload.trend[payload.trend.length - 1];
+    payload.kpis.revenue = latest?.revenue ?? 0;
+    payload.kpis.profit = latest?.profit ?? 0;
+    payload.kpis.jobs = latest?.jobs ?? 0;
+    payload.kpis.efficiencyPct = payload.kpis.revenue > 0 ? Math.round((payload.kpis.profit / payload.kpis.revenue) * 100) : 0;
+
+    payload.fetchAudit.push("Single finance range query now feeds KPI strip and trend chart data.");
+  }
+
+  if (techProfilesResult.error || completedLinesResult.error) {
+    payload.sectionErrors.push("Technician performance section is degraded due to work-order line query failures.");
+  } else {
+    const techs = techProfilesResult.data ?? [];
+    const completed = completedLinesResult.data ?? [];
+    const byTech = new Map<string, number>();
+
+    completed.forEach((row) => {
+      if (!row.assigned_tech_id) return;
+      byTech.set(row.assigned_tech_id, (byTech.get(row.assigned_tech_id) ?? 0) + 1);
+    });
+
+    payload.technicianPerformance = techs
+      .map((tech) => ({
+        label: tech.full_name ?? "Unassigned tech",
+        value: `${byTech.get(tech.id) ?? 0} completed`,
+      }))
+      .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))
+      .slice(0, 6);
+  }
+
+  if (comebackRiskResult.error) {
+    payload.sectionErrors.push("Business signals section is degraded due to board risk query failures.");
+  } else {
+    const riskRows = comebackRiskResult.data ?? [];
+    const highRisk = riskRows.filter((row) => row.risk_level === "danger").length;
+    const warnRisk = riskRows.filter((row) => row.risk_level === "warn").length;
+    const onHold = riskRows.filter((row) => row.overall_stage === "on_hold").length;
+
+    payload.businessSignals = [
+      { label: "Comeback risk", value: String(highRisk), tone: highRisk > 0 ? "accent" : "default" },
+      { label: "Margin watch", value: `${payload.kpis.efficiencyPct}%` },
+      { label: "Warning queue", value: String(warnRisk), tone: warnRisk > 0 ? "accent" : "default" },
+      { label: "On-hold revenue", value: String(onHold), tone: onHold > 0 ? "accent" : "default" },
+    ];
+  }
+
+  if (payload.sectionErrors.length === 0) {
+    payload.fetchAudit.push("Removed first-paint widget fan-out; performance view hydrates only interactive chart chrome.");
+  }
+
+  return payload;
+}


### PR DESCRIPTION
### Motivation
- Replace the prior widget-first dashboard fan-out with two curated, view-first dashboards (Operations and Performance) to improve first-paint UX and perceived load speed. 
- Reduce nested shell/card chrome and stop per-widget client bootstrap fetches on first paint to lower hydration cost and duplicate reads. 
- Preserve existing auth/RLS/business logic while making the primary dashboards feel like a premium operational cockpit and analytical review surface.

### Description
- Added server-side orchestrators `getOperationsDashboardPayload` and `getPerformanceDashboardPayload` to produce single, consolidated payloads per view and consolidated duplicate reads (files: `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/dashboard/server/getPerformanceDashboardPayload.ts`).
- Introduced a small set of lightweight presentational primitives and view components to enforce hierarchy and reduce chrome: `DashboardPrimitives`, `OperationsDashboardView`, `PerformanceDashboardView`, and `PerformanceTrendPanel` (files: `app/dashboard/_components/DashboardPrimitives.tsx`, `app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/PerformanceDashboardView.tsx`, `app/dashboard/_components/PerformanceTrendPanel.tsx`).
- Added a shared server identity/bootstrap helper `dashboard-shell-data` for consistent shop/user context without changing auth/RLS behavior (file: `features/dashboard/server/dashboard-shell-data.ts`).
- Switched the operations/performance routes to render the new view-first pages instead of the widget-board-first composition (files updated: `app/dashboard/operations/page.tsx`, `app/dashboard/performance/page.tsx`).
- Kept the existing widget registry and board code in the repo for compatibility, but it no longer drives first-paint composition for these two primary dashboards; charts hydrate only as a narrow client island (`PerformanceTrendPanel`) to minimize client work.

### Testing
- Ran `npx tsc --noEmit` which completed successfully and shows the TypeScript build is clean. 
- Ran `pnpm lint` which reported pre-existing repository lint errors unrelated to this refactor; no lint failures were introduced by these changes that block the refactor. 
- Manual code inspection and local type checks were used to verify the new server payload shapes feed the presentational modules and that both routes render the consolidated views.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae435d5108328afd765ccb07abbb3)