### PR TITLE
Refactor dashboard into curated Operations and Performance command centers

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -5,7 +5,7 @@ import DashboardViewSwitcher from "./DashboardViewSwitcher";
 import type { DashboardView } from "@/features/dashboard/lib/dashboard-views";
 
 export function DashboardShell({ children }: { children: ReactNode }) {
-  return <div className="w-full space-y-4 xl:space-y-5">{children}</div>;
+  return <div className="mx-auto w-full max-w-[1580px] space-y-3 md:space-y-4">{children}</div>;
 }
 
 export function DashboardTopStrip({
@@ -14,50 +14,44 @@ export function DashboardTopStrip({
   subtitle,
   name,
   actions,
-  summary,
 }: {
   view: DashboardView;
   title: string;
   subtitle: string;
   name: string;
-  actions: Array<{ label: string; href: string }>;
-  summary: Array<{ label: string; value: string }>;
+  actions: Array<{ label: string; href: string; tone?: "primary" | "secondary" }>;
 }) {
   return (
     <section
-      className="rounded-2xl border px-5 py-4 backdrop-blur-xl xl:px-6 xl:py-5"
+      className="sticky top-16 z-20 rounded-2xl border px-4 py-3 backdrop-blur-xl md:px-5"
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 72%, transparent)",
-        background: "var(--dashboard-hero-bg, var(--dashboard-shell-bg))",
+        background:
+          "linear-gradient(135deg, rgba(2,6,23,0.82), color-mix(in srgb, var(--brand-secondary,#0f172a) 72%, rgba(0,0,0,0.9)))",
+        boxShadow: "0 16px 30px rgba(0,0,0,0.4)",
       }}
     >
-      <div className="flex flex-col gap-4 xl:gap-5">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
-          <div>
-            <div className="text-[10px] uppercase tracking-[0.24em] text-neutral-400">{title}</div>
-            <h1 className="mt-1.5 text-3xl font-semibold text-white xl:text-4xl">Welcome back, {name}</h1>
-            <p className="mt-1.5 max-w-3xl text-sm text-neutral-300 xl:text-[15px]">{subtitle}</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <DashboardViewSwitcher currentView={view} />
-            {actions.map((action) => (
-              <Link
-                key={action.href}
-                href={action.href}
-                className="rounded-full border border-white/10 bg-black/25 px-4 py-2 text-sm font-medium text-neutral-200 transition hover:bg-black/40"
-              >
-                {action.label}
-              </Link>
-            ))}
-          </div>
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.2em] text-neutral-500">{title}</div>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight text-white md:text-2xl">{name}</h1>
+          <p className="mt-1 text-xs text-neutral-300 md:text-sm">{subtitle}</p>
         </div>
 
-        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-          {summary.map((item) => (
-            <div key={item.label} className="rounded-xl border border-white/10 bg-black/30 px-3 py-2.5">
-              <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{item.label}</div>
-              <div className="mt-1 text-xl font-semibold text-white">{item.value}</div>
-            </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <DashboardViewSwitcher currentView={view} />
+          {actions.map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              className={
+                action.tone === "primary"
+                  ? "rounded-full border border-[var(--accent-copper-soft)]/80 bg-[var(--accent-copper)]/20 px-3.5 py-1.5 text-xs font-semibold text-[var(--accent-copper-light)] transition hover:bg-[var(--accent-copper)] hover:text-black"
+                  : "rounded-full border border-white/10 bg-black/25 px-3.5 py-1.5 text-xs font-semibold text-neutral-100 transition hover:bg-black/40"
+              }
+            >
+              {action.label}
+            </Link>
           ))}
         </div>
       </div>
@@ -65,28 +59,61 @@ export function DashboardTopStrip({
   );
 }
 
-export function DashboardSectionShell({
+export function MetricStrip({ items }: { items: Array<{ label: string; value: string; tone?: "default" | "accent" }> }) {
+  return (
+    <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+      {items.map((item) => (
+        <section
+          key={item.label}
+          className="rounded-xl border p-3"
+          style={{
+            borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 74%, transparent)",
+            background: "linear-gradient(155deg, rgba(15,23,42,0.88), rgba(2,6,23,0.72))",
+          }}
+        >
+          <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{item.label}</div>
+          <div
+            className={
+              item.tone === "accent"
+                ? "mt-1.5 text-2xl font-semibold leading-none text-[var(--brand-accent,#E39A6E)]"
+                : "mt-1.5 text-2xl font-semibold leading-none text-white"
+            }
+          >
+            {item.value}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardPanel({
+  eyebrow,
   title,
-  description,
+  action,
   children,
   className,
 }: {
+  eyebrow?: string;
   title: string;
-  description?: string;
+  action?: ReactNode;
   children: ReactNode;
   className?: string;
 }) {
   return (
     <section
-      className={`rounded-2xl border p-4 ${className ?? ""}`}
+      className={`rounded-2xl border p-3.5 md:p-4 ${className ?? ""}`}
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 78%, transparent)",
-        background: "color-mix(in srgb, var(--theme-card-bg,#111827) 88%, black)",
+        background: "linear-gradient(155deg, rgba(2,6,23,0.9), rgba(10,15,28,0.78))",
       }}
     >
-      <header className="mb-3">
-        <h2 className="text-sm font-semibold text-white md:text-base">{title}</h2>
-        {description ? <p className="mt-1 text-xs text-neutral-400">{description}</p> : null}
+      <header className="mb-3 flex items-start justify-between gap-2">
+        <div>
+          {eyebrow ? <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{eyebrow}</div> : null}
+          <h2 className="text-sm font-semibold text-white md:text-base">{title}</h2>
+        </div>
+        {action}
       </header>
       {children}
     </section>
@@ -103,10 +130,10 @@ export function CompactSignalList({
       {items.map((item) => (
         <div
           key={`${item.label}-${item.value}`}
-          className="flex items-center justify-between rounded-lg border border-white/10 bg-black/25 px-2.5 py-2 text-xs"
+          className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs"
         >
           <span className="text-neutral-300">{item.label}</span>
-          <span className={item.tone === "accent" ? "font-semibold text-[color:var(--brand-accent)]" : "font-semibold text-white"}>
+          <span className={item.tone === "accent" ? "font-semibold text-[var(--brand-accent,#E39A6E)]" : "font-semibold text-white"}>
             {item.value}
           </span>
         </div>
@@ -115,21 +142,26 @@ export function CompactSignalList({
   );
 }
 
-export function ActionRow({ actions }: { actions: Array<{ label: string; href: string; tone?: "primary" | "neutral" }> }) {
+export function ActionRow({ actions }: { actions: Array<{ label: string; href: string; tone?: "primary" | "neutral"; detail?: string }> }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="space-y-2">
       {actions.map((action) => (
-        <Link
-          key={`${action.href}-${action.label}`}
-          href={action.href}
-          className={
-            action.tone === "primary"
-              ? "rounded-full border border-[var(--accent-copper-soft)]/70 bg-[var(--accent-copper)]/15 px-3 py-1.5 text-xs font-semibold text-[var(--accent-copper-light)] transition hover:bg-[var(--accent-copper)] hover:text-black"
-              : "rounded-full border border-white/10 bg-black/25 px-3 py-1.5 text-xs font-semibold text-neutral-200 transition hover:bg-black/40"
-          }
-        >
-          {action.label}
-        </Link>
+        <div key={`${action.href}-${action.label}`} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-xs font-semibold text-white">{action.label}</div>
+            <Link
+              href={action.href}
+              className={
+                action.tone === "primary"
+                  ? "rounded-full border border-[var(--accent-copper-soft)]/80 bg-[var(--accent-copper)]/15 px-2.5 py-1 text-[10px] font-semibold text-[var(--accent-copper-light)]"
+                  : "rounded-full border border-white/10 px-2.5 py-1 text-[10px] font-semibold text-neutral-200"
+              }
+            >
+              Open
+            </Link>
+          </div>
+          {action.detail ? <div className="mt-1 text-[11px] text-neutral-400">{action.detail}</div> : null}
+        </div>
       ))}
     </div>
   );

--- a/app/dashboard/_components/OperationsCharts.tsx
+++ b/app/dashboard/_components/OperationsCharts.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+export function ShopLoadChart({ data }: { data: Array<{ label: string; count: number }> }) {
+  return (
+    <div className="h-52 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: -20 }}>
+          <CartesianGrid stroke="rgba(148,163,184,0.14)" vertical={false} />
+          <XAxis dataKey="label" tick={{ fill: "#94A3B8", fontSize: 10 }} axisLine={false} tickLine={false} />
+          <YAxis tick={{ fill: "#94A3B8", fontSize: 10 }} axisLine={false} tickLine={false} />
+          <Tooltip
+            contentStyle={{
+              background: "#050b18",
+              border: "1px solid rgba(148,163,184,0.25)",
+              borderRadius: "10px",
+            }}
+          />
+          <Bar dataKey="count" fill="rgba(193,102,59,0.78)" radius={[6, 6, 0, 0]} barSize={18} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -1,84 +1,183 @@
-import { AlertTriangle } from "lucide-react";
+import Link from "next/link";
+import { AlertTriangle, ArrowRight, TriangleAlert } from "lucide-react";
 
-import {
-  ActionRow,
-  CompactSignalList,
-  DashboardSectionShell,
-  DashboardShell,
-  DashboardTopStrip,
-} from "./DashboardPrimitives";
 import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+import { ActionRow, CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
+import { ShopLoadChart } from "./OperationsCharts";
 
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
-  const displayName = payload.identity.fullName?.trim() || "there";
+  const displayName = payload.identity.fullName?.trim() || "Operator";
 
   return (
     <DashboardShell>
       <DashboardTopStrip
         view="operations"
         title="Operations Dashboard"
-        name={displayName}
-        subtitle="Live command center for blockers, active jobs, and immediate next actions."
+        name={`Welcome back, ${displayName}`}
+        subtitle="Live command center for active jobs, bottlenecks, and immediate dispatch actions."
         actions={[
-          { label: "Create work order", href: "/work-orders/create" },
-          { label: "Dispatch", href: "/dashboard/manager/dispatch" },
-        ]}
-        summary={[
-          { label: "Active jobs", value: String(payload.topSummary.activeJobs) },
-          { label: "Blocked", value: String(payload.topSummary.blockedJobs) },
-          { label: "Approvals", value: String(payload.topSummary.waitingApprovals) },
-          { label: "Waiting parts", value: String(payload.topSummary.waitingParts) },
+          { label: "Create work order", href: "/work-orders/create", tone: "primary" },
+          { label: "Dispatch", href: "/dashboard/manager/dispatch", tone: "secondary" },
         ]}
       />
 
-      <div className="grid gap-4 xl:grid-cols-12">
-        <div className="space-y-4 xl:col-span-8">
-          <DashboardSectionShell title="Live Work / Active Jobs" description="Current board flow and priority stack.">
+      <MetricStrip
+        items={[
+          { label: "Active jobs", value: String(payload.topSummary.activeJobs) },
+          { label: "Blocked", value: String(payload.topSummary.blockedJobs), tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default" },
+          { label: "Approvals", value: String(payload.topSummary.waitingApprovals), tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default" },
+          { label: "Waiting parts", value: String(payload.topSummary.waitingParts), tone: payload.topSummary.waitingParts > 0 ? "accent" : "default" },
+        ]}
+      />
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-12">
+        <DashboardPanel eyebrow="Row A" title="Active Job Summary" className="xl:col-span-4">
+          <div className="space-y-2">
+            {payload.activeJobSummary.map((metric) => (
+              <div key={metric.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-neutral-300">{metric.label}</span>
+                  <span className="font-semibold text-white">{metric.value}</span>
+                </div>
+                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full rounded-full bg-[var(--brand-accent,#E39A6E)]"
+                    style={{ width: `${metric.pct}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </DashboardPanel>
+
+        <DashboardPanel eyebrow="Row A" title="Live Shop Load" className="xl:col-span-5">
+          <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
+        </DashboardPanel>
+
+        <DashboardPanel
+          eyebrow="Row A"
+          title="Daily Summary"
+          className="xl:col-span-3"
+          action={<Link href="/dashboard/bookings" className="text-xs text-neutral-300 hover:text-white">Open</Link>}
+        >
+          <CompactSignalList items={payload.dailySummary} />
+        </DashboardPanel>
+
+        <DashboardPanel eyebrow="Row B" title="Technician Activity" className="xl:col-span-5">
+          <div className="space-y-2">
+            {payload.technicianActivity.map((tech) => (
+              <div key={tech.id} className="grid grid-cols-[minmax(0,1fr)_80px_64px] items-center gap-2 rounded-lg border border-white/10 bg-black/20 p-2.5">
+                <div className="min-w-0">
+                  <div className="truncate text-xs font-semibold text-white">{tech.name}</div>
+                  <div className="text-[11px] text-neutral-400">{tech.stage} · {tech.elapsed}</div>
+                  <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/10">
+                    <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
+                  </div>
+                </div>
+                <div className="text-right text-xs text-neutral-300">{tech.activeLines} lines</div>
+                <button type="button" className="rounded-full border border-white/10 px-2 py-1 text-[10px] text-neutral-300">View</button>
+              </div>
+            ))}
+          </div>
+        </DashboardPanel>
+
+        <DashboardPanel
+          eyebrow="Row B"
+          title="High Impact Alerts"
+          className="xl:col-span-3"
+          action={<Link href="/work-orders/board" className="text-xs text-neutral-300 hover:text-white">View all</Link>}
+        >
+          <div className="space-y-2">
+            {payload.alerts.map((alert) => (
+              <div
+                key={alert.label}
+                className="rounded-lg border p-2"
+                style={{
+                  borderColor: alert.tone === "critical" ? "rgba(239,68,68,0.4)" : alert.tone === "warning" ? "rgba(245,158,11,0.38)" : "rgba(148,163,184,0.25)",
+                  background: alert.tone === "critical" ? "rgba(127,29,29,0.18)" : alert.tone === "warning" ? "rgba(120,53,15,0.18)" : "rgba(15,23,42,0.5)",
+                }}
+              >
+                <div className="flex items-center gap-2 text-xs font-semibold text-white">
+                  {alert.tone === "critical" ? <TriangleAlert className="h-3.5 w-3.5 text-red-300" /> : <AlertTriangle className="h-3.5 w-3.5 text-amber-300" />}
+                  {alert.label}
+                </div>
+                <div className="mt-1 text-[11px] text-neutral-300">{alert.detail}</div>
+              </div>
+            ))}
+          </div>
+        </DashboardPanel>
+
+        <DashboardPanel eyebrow="Row B" title="Suggested Actions" className="xl:col-span-4">
+          <ActionRow actions={payload.suggestedActions} />
+        </DashboardPanel>
+
+        <DashboardPanel eyebrow="Row C" title="Technician / Flow Mix" className="xl:col-span-8">
+          <div className="grid gap-2 md:grid-cols-2">
             <div className="space-y-2">
               {payload.liveWork.map((item) => (
-                <div key={item.id} className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-xs">
+                <div key={item.id} className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs">
                   <div>
                     <div className="font-semibold text-white">{item.label}</div>
                     <div className="text-neutral-400">{item.stage}</div>
-                  </div>
-                  <div className={item.risk === "danger" ? "text-[color:var(--brand-accent)]" : "text-neutral-300"}>
-                    {item.risk}
                   </div>
                   <div className="rounded-full border border-white/10 px-2 py-0.5 text-neutral-300">P{item.priority}</div>
                 </div>
               ))}
             </div>
-          </DashboardSectionShell>
-
-          <DashboardSectionShell title="Technician Activity / Current Flow" description="Team-level active line pressure.">
-            <CompactSignalList items={payload.technicianFlow} />
-          </DashboardSectionShell>
-        </div>
-
-        <div className="space-y-4 xl:col-span-4">
-          <DashboardSectionShell title="Blocker Stack" description="Approvals, waiting parts, and on-hold pressure.">
-            <CompactSignalList items={payload.blockerStack} />
-          </DashboardSectionShell>
-
-          <DashboardSectionShell title="Suggested Actions" description="Highest-leverage operational actions right now.">
-            <ActionRow actions={payload.suggestedActions} />
-          </DashboardSectionShell>
-
-          {payload.sectionErrors.length > 0 ? (
-            <DashboardSectionShell title="Section Warnings">
-              <div className="space-y-1.5 text-xs text-amber-300">
-                {payload.sectionErrors.map((warning) => (
-                  <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
-                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
-                    <span>{warning}</span>
+            <div className="space-y-2">
+              {payload.flowMix.map((row) => (
+                <div key={row.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-neutral-300">{row.label}</span>
+                    <span className="font-semibold text-white">{row.value}</span>
                   </div>
-                ))}
-              </div>
-            </DashboardSectionShell>
-          ) : null}
-        </div>
+                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-[var(--brand-primary,#C1663B)] to-[var(--brand-accent,#E39A6E)]"
+                      style={{ width: `${Math.min(100, row.value * 12)}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </DashboardPanel>
+
+        <DashboardPanel
+          eyebrow="Row C"
+          title="Revenue & Efficiency Snapshot"
+          className="xl:col-span-4"
+          action={<Link href="/dashboard/performance" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open <ArrowRight className="h-3 w-3" /></Link>}
+        >
+          <div className="space-y-2">
+            <div className="rounded-lg border border-white/10 bg-black/25 p-2.5">
+              <div className="text-[10px] uppercase tracking-[0.15em] text-neutral-500">Revenue (MTD)</div>
+              <div className="mt-1 text-xl font-semibold text-white">${payload.revenueEfficiency.revenue.toLocaleString()}</div>
+            </div>
+            <CompactSignalList
+              items={[
+                { label: "Profit", value: `$${payload.revenueEfficiency.profit.toLocaleString()}` },
+                { label: "Efficiency", value: `${payload.revenueEfficiency.efficiencyPct}%` },
+                { label: "Active lines", value: String(payload.revenueEfficiency.completedLines) },
+              ]}
+            />
+          </div>
+        </DashboardPanel>
       </div>
+
+      {payload.sectionErrors.length > 0 ? (
+        <DashboardPanel eyebrow="Diagnostics" title="Section warnings">
+          <div className="space-y-1.5 text-xs text-amber-300">
+            {payload.sectionErrors.map((warning) => (
+              <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
+                <span>{warning}</span>
+              </div>
+            ))}
+          </div>
+        </DashboardPanel>
+      ) : null}
     </DashboardShell>
   );
 }

--- a/app/dashboard/_components/PerformanceDashboardView.tsx
+++ b/app/dashboard/_components/PerformanceDashboardView.tsx
@@ -1,70 +1,105 @@
+import Link from "next/link";
 import { AlertTriangle } from "lucide-react";
 
-import {
-  CompactSignalList,
-  DashboardSectionShell,
-  DashboardShell,
-  DashboardTopStrip,
-} from "./DashboardPrimitives";
-import PerformanceTrendPanel from "./PerformanceTrendPanel";
 import { getPerformanceDashboardPayload } from "@/features/dashboard/server/getPerformanceDashboardPayload";
+import { CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
+import PerformanceTrendPanel, { MiniSparkline } from "./PerformanceTrendPanel";
 
 export default async function PerformanceDashboardView() {
   const payload = await getPerformanceDashboardPayload();
-  const displayName = payload.identity.fullName?.trim() || "there";
+  const displayName = payload.identity.fullName?.trim() || "Operator";
 
   return (
     <DashboardShell>
       <DashboardTopStrip
         view="performance"
         title="Performance Dashboard"
-        name={displayName}
-        subtitle="Business review view for KPI trajectory, technician output, and optimization risk."
+        name={`Executive review, ${displayName}`}
+        subtitle="Revenue, margin, and operational performance with compact optimization risk tracking."
         actions={[
-          { label: "Full reports", href: "/dashboard/owner/reports" },
-          { label: "Revenue view", href: "/dashboard/owner/reports/technicians" },
-        ]}
-        summary={[
-          { label: "Revenue", value: `$${payload.kpis.revenue.toLocaleString()}` },
-          { label: "Profit", value: `$${payload.kpis.profit.toLocaleString()}` },
-          { label: "Jobs", value: String(payload.kpis.jobs) },
-          { label: "Efficiency", value: `${payload.kpis.efficiencyPct}%` },
+          { label: "Full reports", href: "/dashboard/owner/reports", tone: "primary" },
+          { label: "Revenue detail", href: "/dashboard/owner/reports/technicians", tone: "secondary" },
         ]}
       />
 
-      <div className="grid gap-4 xl:grid-cols-12">
-        <div className="space-y-4 xl:col-span-8">
-          <DashboardSectionShell
-            title="Trend / Performance Charts"
-            description="Last 6 months of revenue and profit, sourced from a single finance range payload."
-          >
-            <PerformanceTrendPanel data={payload.trend} />
-          </DashboardSectionShell>
+      <MetricStrip
+        items={[
+          { label: "Revenue", value: `$${payload.kpis.revenue.toLocaleString()}` },
+          { label: "Profit", value: `$${payload.kpis.profit.toLocaleString()}` },
+          { label: "Jobs", value: String(payload.kpis.jobs) },
+          { label: "Efficiency", value: `${payload.kpis.efficiencyPct}%`, tone: payload.kpis.efficiencyPct < 25 ? "accent" : "default" },
+        ]}
+      />
 
-          <DashboardSectionShell title="Technician / Throughput Performance" description="Completed-line output during the current month.">
-            <CompactSignalList items={payload.technicianPerformance} />
-          </DashboardSectionShell>
-        </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-12">
+        <DashboardPanel eyebrow="Row A" title="Trend / Performance Charts" className="xl:col-span-8">
+          <PerformanceTrendPanel data={payload.trend} />
+        </DashboardPanel>
 
-        <div className="space-y-4 xl:col-span-4">
-          <DashboardSectionShell title="Optimization / Revenue Risk Signals" description="Potential margin pressure and comeback risk signals.">
-            <CompactSignalList items={payload.businessSignals} />
-          </DashboardSectionShell>
-
-          {payload.sectionErrors.length > 0 ? (
-            <DashboardSectionShell title="Section Warnings">
-              <div className="space-y-1.5 text-xs text-amber-300">
-                {payload.sectionErrors.map((warning) => (
-                  <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
-                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
-                    <span>{warning}</span>
-                  </div>
-                ))}
+        <DashboardPanel eyebrow="Row A" title="Optimization / Revenue Risk Signals" className="xl:col-span-4">
+          <CompactSignalList items={payload.businessSignals} />
+          <div className="mt-3 space-y-1.5">
+            {payload.optimizationSummary.map((item) => (
+              <div
+                key={item.label}
+                className="rounded-lg border px-2.5 py-2"
+                style={{
+                  borderColor: item.tone === "critical" ? "rgba(239,68,68,0.35)" : item.tone === "warning" ? "rgba(245,158,11,0.35)" : "rgba(148,163,184,0.25)",
+                  background: item.tone === "critical" ? "rgba(127,29,29,0.16)" : item.tone === "warning" ? "rgba(120,53,15,0.15)" : "rgba(15,23,42,0.42)",
+                }}
+              >
+                <div className="text-xs font-semibold text-white">{item.label}</div>
+                <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
               </div>
-            </DashboardSectionShell>
-          ) : null}
-        </div>
+            ))}
+          </div>
+        </DashboardPanel>
+
+        <DashboardPanel eyebrow="Row B" title="Technician / Throughput Performance" className="xl:col-span-4">
+          <div className="space-y-2">
+            {payload.technicianPerformance.map((tech) => (
+              <div key={tech.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-semibold text-white">{tech.label}</span>
+                  <span className="text-neutral-300">{tech.completed} completed</span>
+                </div>
+                <div className="mt-1 text-[11px] text-neutral-400">{tech.pace}</div>
+                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                  <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </DashboardPanel>
+
+        <DashboardPanel eyebrow="Row B" title="Revenue Watch" className="xl:col-span-4">
+          <CompactSignalList items={payload.revenueWatch} />
+          <MiniSparkline data={payload.trend} dataKey="revenue" />
+        </DashboardPanel>
+
+        <DashboardPanel
+          eyebrow="Row B"
+          title="Business Risk / Opportunity"
+          className="xl:col-span-4"
+          action={<Link href="/dashboard/operations" className="text-xs text-neutral-300 hover:text-white">Operations view</Link>}
+        >
+          <CompactSignalList items={payload.businessSignals} />
+          <MiniSparkline data={payload.trend} dataKey="profit" />
+        </DashboardPanel>
       </div>
+
+      {payload.sectionErrors.length > 0 ? (
+        <DashboardPanel eyebrow="Diagnostics" title="Section warnings">
+          <div className="space-y-1.5 text-xs text-amber-300">
+            {payload.sectionErrors.map((warning) => (
+              <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
+                <span>{warning}</span>
+              </div>
+            ))}
+          </div>
+        </DashboardPanel>
+      ) : null}
     </DashboardShell>
   );
 }

--- a/app/dashboard/_components/PerformanceTrendPanel.tsx
+++ b/app/dashboard/_components/PerformanceTrendPanel.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 type TrendPoint = {
   label: string;
@@ -9,24 +19,36 @@ type TrendPoint = {
   profit: number;
 };
 
+export function MiniSparkline({ data, dataKey }: { data: TrendPoint[]; dataKey: "revenue" | "profit" | "jobs" }) {
+  return (
+    <div className="h-16 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+          <Area type="monotone" dataKey={dataKey} stroke="var(--brand-accent,#E39A6E)" fill="rgba(227,154,110,0.2)" strokeWidth={2} />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
 export default function PerformanceTrendPanel({ data }: { data: TrendPoint[] }) {
   return (
-    <div className="h-[250px] w-full">
+    <div className="h-[250px] w-full lg:h-[290px]">
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: -18 }}>
-          <CartesianGrid stroke="rgba(148, 163, 184, 0.12)" vertical={false} />
+        <ComposedChart data={data} margin={{ top: 8, right: 12, bottom: 0, left: -12 }}>
+          <CartesianGrid stroke="rgba(148,163,184,0.15)" vertical={false} />
           <XAxis dataKey="label" tick={{ fill: "#94A3B8", fontSize: 11 }} axisLine={false} tickLine={false} />
           <YAxis tick={{ fill: "#94A3B8", fontSize: 11 }} axisLine={false} tickLine={false} />
           <Tooltip
             contentStyle={{
-              background: "#0b1220",
-              border: "1px solid rgba(148, 163, 184, 0.2)",
+              background: "#050b18",
+              border: "1px solid rgba(148, 163, 184, 0.25)",
               borderRadius: "10px",
             }}
           />
-          <Bar dataKey="revenue" fill="var(--brand-primary,#C1663B)" radius={[5, 5, 0, 0]} />
-          <Bar dataKey="profit" fill="var(--brand-accent,#E39A6E)" radius={[5, 5, 0, 0]} />
-        </BarChart>
+          <Area type="monotone" dataKey="profit" fill="rgba(227,154,110,0.18)" stroke="rgba(227,154,110,0.9)" strokeWidth={2} />
+          <Bar dataKey="revenue" fill="rgba(193,102,59,0.75)" radius={[6, 6, 0, 0]} barSize={18} />
+        </ComposedChart>
       </ResponsiveContainer>
     </div>
   );

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -1,10 +1,17 @@
+import { endOfDay, startOfDay, startOfMonth } from "date-fns";
+
 import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
 
 const CLOSED_PART_STATUSES = ["fulfilled", "rejected", "cancelled"] as const;
+const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
 
 type OpSignal = { label: string; value: string; tone?: "default" | "accent" };
-
-type OpAction = { label: string; href: string; tone?: "primary" | "neutral" };
+type OpAction = {
+  label: string;
+  href: string;
+  tone?: "primary" | "neutral";
+  detail?: string;
+};
 
 export type OperationsDashboardPayload = {
   identity: Awaited<ReturnType<typeof getDashboardIdentity>>;
@@ -14,6 +21,9 @@ export type OperationsDashboardPayload = {
     waitingApprovals: number;
     waitingParts: number;
   };
+  activeJobSummary: Array<{ label: string; value: number; pct: number }>;
+  liveShopLoad: Array<{ label: string; count: number; pct: number }>;
+  dailySummary: OpSignal[];
   liveWork: Array<{
     id: string;
     label: string;
@@ -21,15 +31,45 @@ export type OperationsDashboardPayload = {
     risk: string;
     priority: number;
   }>;
-  technicianFlow: OpSignal[];
+  technicianActivity: Array<{
+    id: string;
+    name: string;
+    activeLines: number;
+    stage: string;
+    elapsed: string;
+    utilizationPct: number;
+  }>;
   blockerStack: OpSignal[];
+  alerts: Array<{ label: string; detail: string; tone: "critical" | "warning" | "info" }>;
   suggestedActions: OpAction[];
+  flowMix: Array<{ label: string; value: number }>;
+  revenueEfficiency: {
+    revenue: number;
+    profit: number;
+    completedLines: number;
+    efficiencyPct: number;
+  };
   sectionErrors: string[];
   fetchAudit: string[];
 };
 
 function stageLabel(stage: string | null | undefined): string {
   return (stage ?? "in_progress").replaceAll("_", " ");
+}
+
+function asPct(value: number, total: number): number {
+  if (!total) return 0;
+  return Math.max(0, Math.min(100, Math.round((value / total) * 100)));
+}
+
+function elapsedLabel(updatedAt: string | null): string {
+  if (!updatedAt) return "--";
+  const diffMs = Date.now() - new Date(updatedAt).getTime();
+  if (!Number.isFinite(diffMs) || diffMs < 0) return "--";
+  const mins = Math.round(diffMs / (1000 * 60));
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ${mins % 60}m`;
 }
 
 export async function getOperationsDashboardPayload(): Promise<OperationsDashboardPayload> {
@@ -42,10 +82,21 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       waitingApprovals: 0,
       waitingParts: 0,
     },
+    activeJobSummary: [],
+    liveShopLoad: [],
+    dailySummary: [],
     liveWork: [],
-    technicianFlow: [],
+    technicianActivity: [],
     blockerStack: [],
+    alerts: [],
     suggestedActions: [],
+    flowMix: [],
+    revenueEfficiency: {
+      revenue: 0,
+      profit: 0,
+      completedLines: 0,
+      efficiencyPct: 0,
+    },
     sectionErrors: [],
     fetchAudit: [],
   };
@@ -56,14 +107,25 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   }
 
   const supabase = createDashboardServerClient();
+  const todayStart = startOfDay(new Date()).toISOString();
+  const todayEnd = endOfDay(new Date()).toISOString();
+  const monthStart = startOfMonth(new Date()).toISOString();
 
-  const [boardResult, approvalsResult, partsResult, techProfilesResult, activeLinesResult] = await Promise.all([
+  const [
+    boardResult,
+    approvalsResult,
+    partsResult,
+    techProfilesResult,
+    activeLinesResult,
+    invoicesMonthResult,
+    bookingsTodayResult,
+  ] = await Promise.all([
     supabase
       .from("v_work_order_board_cards_shop")
       .select("work_order_id,custom_id,display_name,overall_stage,risk_level,priority")
       .eq("shop_id", identity.shopId)
       .order("activity_at", { ascending: false })
-      .limit(14),
+      .limit(48),
     supabase
       .from("work_order_lines")
       .select("id", { count: "exact", head: true })
@@ -74,7 +136,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       .select("id,status", { count: "exact" })
       .eq("shop_id", identity.shopId)
       .not("status", "in", `(${CLOSED_PART_STATUSES.map((status) => `'${status}'`).join(",")})`)
-      .limit(80),
+      .limit(120),
     supabase
       .from("profiles")
       .select("id,full_name")
@@ -82,24 +144,63 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       .in("role", ["tech", "mechanic", "technician"]),
     supabase
       .from("work_order_lines")
-      .select("assigned_tech_id,status")
+      .select("assigned_tech_id,status,updated_at")
       .eq("shop_id", identity.shopId)
-      .not("status", "in", "('completed','ready_to_invoice','invoiced')")
+      .not("status", "in", `(${CLOSED_LINE_STATUSES.map((status) => `'${status}'`).join(",")})`)
       .not("assigned_tech_id", "is", null)
-      .limit(200),
+      .order("updated_at", { ascending: false })
+      .limit(400),
+    supabase
+      .from("invoices")
+      .select("total,labor_cost,created_at")
+      .eq("shop_id", identity.shopId)
+      .gte("created_at", monthStart),
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", identity.shopId)
+      .gte("created_at", todayStart)
+      .lte("created_at", todayEnd),
   ]);
+
+  const boardRows = boardResult.error ? [] : boardResult.data ?? [];
+  const activeBoardRows = boardRows.filter((row) => row.overall_stage !== "completed");
 
   if (boardResult.error) {
     payload.sectionErrors.push(`Live work section: ${boardResult.error.message}`);
   } else {
-    const rows = boardResult.data ?? [];
-    const blocked = rows.filter(
+    payload.topSummary.activeJobs = activeBoardRows.length;
+    payload.topSummary.blockedJobs = activeBoardRows.filter(
       (row) => row.overall_stage === "waiting_parts" || row.overall_stage === "on_hold",
     ).length;
 
-    payload.topSummary.activeJobs = rows.filter((row) => row.overall_stage !== "completed").length;
-    payload.topSummary.blockedJobs = blocked;
-    payload.liveWork = rows.slice(0, 8).map((row) => ({
+    const stageCounts = new Map<string, number>();
+    activeBoardRows.forEach((row) => {
+      const key = stageLabel(row.overall_stage);
+      stageCounts.set(key, (stageCounts.get(key) ?? 0) + 1);
+    });
+
+    const total = activeBoardRows.length;
+    payload.liveShopLoad = [...stageCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([label, count]) => ({ label, count, pct: asPct(count, total) }));
+
+    const awaiting = stageCounts.get("awaiting approval") ?? 0;
+    const inProgress = stageCounts.get("in progress") ?? 0;
+    const waitingParts = stageCounts.get("waiting parts") ?? 0;
+    payload.activeJobSummary = [
+      { label: "Awaiting", value: awaiting, pct: asPct(awaiting, total) },
+      { label: "In progress", value: inProgress, pct: asPct(inProgress, total) },
+      { label: "Waiting parts", value: waitingParts, pct: asPct(waitingParts, total) },
+      {
+        label: "Tech coverage",
+        value: Math.min(total, (techProfilesResult.data ?? []).length),
+        pct: asPct(Math.min(total, (techProfilesResult.data ?? []).length), Math.max(total, 1)),
+      },
+    ];
+
+    payload.liveWork = activeBoardRows.slice(0, 7).map((row) => ({
       id: row.work_order_id,
       label: row.custom_id ?? row.display_name ?? row.work_order_id.slice(0, 8),
       stage: stageLabel(row.overall_stage),
@@ -107,7 +208,10 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       priority: row.priority ?? 3,
     }));
 
-    payload.fetchAudit.push("Consolidated work-order board query now powers active jobs, live queue, and blocker counts.");
+    payload.flowMix = payload.liveShopLoad.slice(0, 4).map((entry) => ({
+      label: entry.label,
+      value: entry.count,
+    }));
   }
 
   if (approvalsResult.error) {
@@ -119,46 +223,162 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   if (partsResult.error) {
     payload.sectionErrors.push(`Parts blocker section: ${partsResult.error.message}`);
   } else {
-    const pendingParts = partsResult.data ?? [];
-    payload.topSummary.waitingParts = partsResult.count ?? pendingParts.length;
-    payload.blockerStack.push({ label: "Approvals pending", value: String(payload.topSummary.waitingApprovals), tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default" });
-    payload.blockerStack.push({ label: "Waiting parts", value: String(payload.topSummary.waitingParts), tone: payload.topSummary.waitingParts > 0 ? "accent" : "default" });
-    payload.blockerStack.push({ label: "On hold / blocked", value: String(payload.topSummary.blockedJobs), tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default" });
+    payload.topSummary.waitingParts = partsResult.count ?? (partsResult.data ?? []).length;
   }
 
+  payload.blockerStack = [
+    {
+      label: "Approvals pending",
+      value: String(payload.topSummary.waitingApprovals),
+      tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
+    },
+    {
+      label: "Waiting parts",
+      value: String(payload.topSummary.waitingParts),
+      tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
+    },
+    {
+      label: "On hold / blocked",
+      value: String(payload.topSummary.blockedJobs),
+      tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default",
+    },
+  ];
+
+  if (bookingsTodayResult.error) {
+    payload.sectionErrors.push(`Daily summary section: ${bookingsTodayResult.error.message}`);
+  }
+
+  payload.dailySummary = [
+    { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
+    { label: "Approval queue", value: String(payload.topSummary.waitingApprovals), tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default" },
+    { label: "Parts waiting", value: String(payload.topSummary.waitingParts), tone: payload.topSummary.waitingParts > 0 ? "accent" : "default" },
+    { label: "Active board", value: String(payload.topSummary.activeJobs) },
+  ];
+
   if (techProfilesResult.error || activeLinesResult.error) {
-    payload.sectionErrors.push("Technician flow section is degraded due to query failures.");
+    payload.sectionErrors.push("Technician activity section is degraded due to query failures.");
   } else {
     const techs = techProfilesResult.data ?? [];
     const activeLines = activeLinesResult.data ?? [];
-    const counts = new Map<string, number>();
+    const counts = new Map<string, { activeLines: number; latestStatus: string; lastUpdated: string | null }>();
+
     activeLines.forEach((line) => {
       if (!line.assigned_tech_id) return;
-      counts.set(line.assigned_tech_id, (counts.get(line.assigned_tech_id) ?? 0) + 1);
+      const previous = counts.get(line.assigned_tech_id);
+      counts.set(line.assigned_tech_id, {
+        activeLines: (previous?.activeLines ?? 0) + 1,
+        latestStatus: previous?.latestStatus ?? stageLabel(line.status),
+        lastUpdated: previous?.lastUpdated ?? line.updated_at,
+      });
     });
 
-    payload.technicianFlow = techs
-      .map((tech) => ({
-        label: tech.full_name ?? "Unassigned tech",
-        value: `${counts.get(tech.id) ?? 0} active lines`,
-      }))
-      .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))
-      .slice(0, 5);
+    const maxLines = Math.max(1, ...[...counts.values()].map((entry) => entry.activeLines));
+    payload.technicianActivity = techs
+      .map((tech) => {
+        const activity = counts.get(tech.id);
+        return {
+          id: tech.id,
+          name: tech.full_name ?? "Unassigned tech",
+          activeLines: activity?.activeLines ?? 0,
+          stage: activity?.latestStatus ?? "idle",
+          elapsed: elapsedLabel(activity?.lastUpdated ?? null),
+          utilizationPct: asPct(activity?.activeLines ?? 0, maxLines),
+        };
+      })
+      .sort((a, b) => b.activeLines - a.activeLines)
+      .slice(0, 6);
   }
+
+  payload.alerts = [
+    payload.topSummary.blockedJobs > 0
+      ? {
+          label: "Blocked jobs climbing",
+          detail: `${payload.topSummary.blockedJobs} jobs currently in blocked stages.`,
+          tone: "critical",
+        }
+      : {
+          label: "Blocker pressure stable",
+          detail: "No blocked stage spike detected.",
+          tone: "info",
+        },
+    payload.topSummary.waitingApprovals > 3
+      ? {
+          label: "Approval queue aging",
+          detail: `${payload.topSummary.waitingApprovals} approvals need advisor follow-up.`,
+          tone: "warning",
+        }
+      : {
+          label: "Approval queue healthy",
+          detail: "Approval queue is below action threshold.",
+          tone: "info",
+        },
+    payload.topSummary.waitingParts > 0
+      ? {
+          label: "Parts constraints active",
+          detail: `${payload.topSummary.waitingParts} open part requests still unresolved.`,
+          tone: "warning",
+        }
+      : {
+          label: "No parts constraints",
+          detail: "Parts flow is currently clear.",
+          tone: "info",
+        },
+  ];
 
   payload.suggestedActions = [
     payload.topSummary.waitingApprovals > 0
-      ? { label: "Clear approval queue", href: "/work-orders/board?stage=awaiting_approval", tone: "primary" }
-      : { label: "Review active board", href: "/work-orders/board", tone: "neutral" },
+      ? {
+          label: "Clear approval queue",
+          href: "/work-orders/board?stage=awaiting_approval",
+          tone: "primary",
+          detail: "Prioritize pending approvals to free advisor handoffs.",
+        }
+      : {
+          label: "Review active board",
+          href: "/work-orders/board",
+          tone: "neutral",
+          detail: "No immediate queue pressure detected.",
+        },
     payload.topSummary.waitingParts > 0
-      ? { label: "Resolve waiting parts", href: "/dashboard/operations?focus=parts", tone: "primary" }
-      : { label: "Create work order", href: "/work-orders/create", tone: "neutral" },
-    { label: "Open dispatch view", href: "/dashboard/manager/dispatch", tone: "neutral" },
+      ? {
+          label: "Resolve waiting parts",
+          href: "/dashboard/operations?focus=parts",
+          tone: "primary",
+          detail: "Parts backlog is blocking active jobs.",
+        }
+      : {
+          label: "Create work order",
+          href: "/work-orders/create",
+          tone: "neutral",
+          detail: "Keep bay utilization steady with next intake.",
+        },
+    {
+      label: "Open dispatch view",
+      href: "/dashboard/manager/dispatch",
+      tone: "neutral",
+      detail: "Review technician assignment and bay balancing.",
+    },
   ];
 
-  if (payload.sectionErrors.length === 0) {
-    payload.fetchAudit.push("No per-widget client bootstrap fetches remain on first paint for operations.");
+  if (invoicesMonthResult.error) {
+    payload.sectionErrors.push(`Revenue snapshot section: ${invoicesMonthResult.error.message}`);
+  } else {
+    const invoices = invoicesMonthResult.data ?? [];
+    const revenue = invoices.reduce((sum, invoice) => sum + Number(invoice.total ?? 0), 0);
+    const profit = invoices.reduce(
+      (sum, invoice) => sum + Number(invoice.total ?? 0) - Number(invoice.labor_cost ?? 0),
+      0,
+    );
+
+    payload.revenueEfficiency = {
+      revenue: Math.round(revenue),
+      profit: Math.round(profit),
+      completedLines: payload.technicianActivity.reduce((sum, tech) => sum + tech.activeLines, 0),
+      efficiencyPct: revenue > 0 ? Math.round((profit / revenue) * 100) : 0,
+    };
   }
+
+  payload.fetchAudit.push("Operations dashboard now renders from one server payload with composed panel data.");
 
   return payload;
 }

--- a/features/dashboard/server/getPerformanceDashboardPayload.ts
+++ b/features/dashboard/server/getPerformanceDashboardPayload.ts
@@ -24,14 +24,21 @@ export type PerformanceDashboardPayload = {
     efficiencyPct: number;
   };
   trend: TrendPoint[];
-  technicianPerformance: PerfSignal[];
+  technicianPerformance: Array<{ label: string; completed: number; pace: string; utilizationPct: number }>;
   businessSignals: PerfSignal[];
+  revenueWatch: Array<{ label: string; value: string; tone?: "default" | "accent" }>;
+  optimizationSummary: Array<{ label: string; detail: string; tone: "critical" | "warning" | "info" }>;
   sectionErrors: string[];
   fetchAudit: string[];
 };
 
 function asMoney(value: number): number {
   return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+function pct(delta: number, baseline: number): number {
+  if (!baseline) return 0;
+  return Math.round((delta / baseline) * 100);
 }
 
 export async function getPerformanceDashboardPayload(): Promise<PerformanceDashboardPayload> {
@@ -42,6 +49,8 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
     trend: [],
     technicianPerformance: [],
     businessSignals: [],
+    revenueWatch: [],
+    optimizationSummary: [],
     sectionErrors: [],
     fetchAudit: [],
   };
@@ -80,12 +89,12 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
       .gte("updated_at", startOfMonth(new Date()).toISOString())
       .in("status", ["completed", "ready_to_invoice", "invoiced"])
       .not("assigned_tech_id", "is", null)
-      .limit(400),
+      .limit(500),
     supabase
       .from("v_work_order_board_cards_shop")
       .select("risk_level,overall_stage")
       .eq("shop_id", identity.shopId)
-      .limit(100),
+      .limit(140),
   ]);
 
   if (invoiceResult.error || expenseResult.error) {
@@ -133,12 +142,30 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
     }));
 
     const latest = payload.trend[payload.trend.length - 1];
+    const previous = payload.trend[payload.trend.length - 2];
     payload.kpis.revenue = latest?.revenue ?? 0;
     payload.kpis.profit = latest?.profit ?? 0;
     payload.kpis.jobs = latest?.jobs ?? 0;
     payload.kpis.efficiencyPct = payload.kpis.revenue > 0 ? Math.round((payload.kpis.profit / payload.kpis.revenue) * 100) : 0;
 
-    payload.fetchAudit.push("Single finance range query now feeds KPI strip and trend chart data.");
+    const revenueDelta = (latest?.revenue ?? 0) - (previous?.revenue ?? 0);
+    const jobsDelta = (latest?.jobs ?? 0) - (previous?.jobs ?? 0);
+    payload.revenueWatch = [
+      {
+        label: "Revenue vs last month",
+        value: `${revenueDelta >= 0 ? "+" : ""}${pct(revenueDelta, previous?.revenue ?? 0)}%`,
+        tone: revenueDelta < 0 ? "accent" : "default",
+      },
+      {
+        label: "Jobs pace",
+        value: `${jobsDelta >= 0 ? "+" : ""}${jobsDelta}`,
+        tone: jobsDelta < 0 ? "accent" : "default",
+      },
+      {
+        label: "Current margin",
+        value: `${payload.kpis.efficiencyPct}%`,
+      },
+    ];
   }
 
   if (techProfilesResult.error || completedLinesResult.error) {
@@ -153,12 +180,18 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
       byTech.set(row.assigned_tech_id, (byTech.get(row.assigned_tech_id) ?? 0) + 1);
     });
 
+    const maxCompleted = Math.max(1, ...[...byTech.values()]);
     payload.technicianPerformance = techs
-      .map((tech) => ({
-        label: tech.full_name ?? "Unassigned tech",
-        value: `${byTech.get(tech.id) ?? 0} completed`,
-      }))
-      .sort((a, b) => Number.parseInt(b.value, 10) - Number.parseInt(a.value, 10))
+      .map((tech) => {
+        const completedCount = byTech.get(tech.id) ?? 0;
+        return {
+          label: tech.full_name ?? "Unassigned tech",
+          completed: completedCount,
+          pace: completedCount >= Math.ceil(maxCompleted * 0.75) ? "On pace" : "Watch",
+          utilizationPct: Math.round((completedCount / maxCompleted) * 100),
+        };
+      })
+      .sort((a, b) => b.completed - a.completed)
       .slice(0, 6);
   }
 
@@ -176,11 +209,45 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
       { label: "Warning queue", value: String(warnRisk), tone: warnRisk > 0 ? "accent" : "default" },
       { label: "On-hold revenue", value: String(onHold), tone: onHold > 0 ? "accent" : "default" },
     ];
+
+    payload.optimizationSummary = [
+      highRisk > 0
+        ? {
+            label: "Comeback exposure",
+            detail: `${highRisk} high-risk jobs require immediate QA review.`,
+            tone: "critical",
+          }
+        : {
+            label: "Comeback exposure",
+            detail: "No critical comeback concentration detected.",
+            tone: "info",
+          },
+      warnRisk > 0
+        ? {
+            label: "Margin pressure",
+            detail: `${warnRisk} jobs are in warning tier for margin.`,
+            tone: "warning",
+          }
+        : {
+            label: "Margin pressure",
+            detail: "Warning-tier margin pressure is currently low.",
+            tone: "info",
+          },
+      onHold > 0
+        ? {
+            label: "On-hold revenue",
+            detail: `${onHold} jobs are stalled and carrying deferred revenue.`,
+            tone: "warning",
+          }
+        : {
+            label: "On-hold revenue",
+            detail: "No material on-hold revenue risk right now.",
+            tone: "info",
+          },
+    ];
   }
 
-  if (payload.sectionErrors.length === 0) {
-    payload.fetchAudit.push("Removed first-paint widget fan-out; performance view hydrates only interactive chart chrome.");
-  }
+  payload.fetchAudit.push("Performance dashboard now ships a single curated payload with finance, throughput, and risk sections.");
 
   return payload;
 }


### PR DESCRIPTION
### Motivation
- Replace the old widget-board composition with a hand-composed, purpose-driven command center to improve scanability, hierarchy, and visual density for Operations and Performance views. 
- Consolidate first-paint data to server-curated payloads so panels hydrate quickly with a single payload instead of many independent widget bootstraps. 
- Preserve existing business logic, shop scoping, and role-aware visibility while reducing nested card chrome and duplicated shells. 

### Description
- Introduced lightweight, page-focused primitives and layout: `DashboardTopStrip`, `MetricStrip`, `DashboardPanel`, `DashboardShell`, `CompactSignalList`, and `ActionRow`, and moved dashboard pages to explicit page compositions for Operations and Performance (files updated: `app/dashboard/_components/DashboardPrimitives.tsx`, `app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/PerformanceDashboardView.tsx`).
- Built purpose-built visual panels and charts: added `ShopLoadChart` for operations and upgraded `PerformanceTrendPanel` with composed chart and a `MiniSparkline` helper (files added/updated: `app/dashboard/_components/OperationsCharts.tsx`, `app/dashboard/_components/PerformanceTrendPanel.tsx`).
- Expanded server-side orchestration to return curated payloads per view (stage/load summaries, daily snapshots, technician activity/utilization, alerts/actions, revenue/efficiency, trend buckets, revenue watch, and optimization summaries) while keeping `shop_id` scoping (files updated: `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/dashboard/server/getPerformanceDashboardPayload.ts`).
- Replaced widget-board rendering for these routes with explicit multi-row, multi-column grid composition tuned for desktop/tablet density and responsive reflow (routes unaffected: `/dashboard/operations`, `/dashboard/performance`).

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed without errors. 
- Ran targeted linting with `npx eslint` against the modified dashboard components and server payload files, and no new lint errors remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf0b2bf54832893161d4360ffe284)