### PR TITLE
Polish operations dashboard layout density and visual quality

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -5,7 +5,7 @@ import DashboardViewSwitcher from "./DashboardViewSwitcher";
 import type { DashboardView } from "@/features/dashboard/lib/dashboard-views";
 
 export function DashboardShell({ children }: { children: ReactNode }) {
-  return <div className="mx-auto w-full max-w-[1580px] space-y-3 md:space-y-4">{children}</div>;
+  return <div className="mx-auto w-full max-w-[1580px] space-y-2.5 pt-1 md:space-y-3.5 md:pt-2">{children}</div>;
 }
 
 export function DashboardTopStrip({
@@ -23,7 +23,7 @@ export function DashboardTopStrip({
 }) {
   return (
     <section
-      className="sticky top-16 z-20 rounded-2xl border px-4 py-3 backdrop-blur-xl md:px-5"
+      className="relative z-10 rounded-2xl border px-4 py-3 backdrop-blur-xl md:px-5"
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 72%, transparent)",
         background:
@@ -62,21 +62,28 @@ export function DashboardTopStrip({
 export function MetricStrip({ items }: { items: Array<{ label: string; value: string; tone?: "default" | "accent" }> }) {
   return (
     <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
-      {items.map((item) => (
+      {items.map((item, index) => (
         <section
           key={item.label}
-          className="rounded-xl border p-3"
+          className="relative rounded-xl border px-3 py-2.5"
           style={{
-            borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 74%, transparent)",
-            background: "linear-gradient(155deg, rgba(15,23,42,0.88), rgba(2,6,23,0.72))",
+            borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 85%, transparent)",
+            background: "linear-gradient(155deg, rgba(15,23,42,0.96), rgba(2,6,23,0.88))",
+            boxShadow: "inset 0 1px 0 rgba(148,163,184,0.12)",
           }}
         >
-          <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{item.label}</div>
+          {index < items.length - 1 ? (
+            <span
+              className="pointer-events-none absolute right-0 top-2 hidden h-[calc(100%-1rem)] w-px lg:block"
+              style={{ background: "linear-gradient(to bottom, transparent, rgba(148,163,184,0.35), transparent)" }}
+            />
+          ) : null}
+          <div className="text-[10px] uppercase tracking-[0.14em] text-neutral-400">{item.label}</div>
           <div
             className={
               item.tone === "accent"
-                ? "mt-1.5 text-2xl font-semibold leading-none text-[var(--brand-accent,#E39A6E)]"
-                : "mt-1.5 text-2xl font-semibold leading-none text-white"
+                ? "mt-1 text-[1.85rem] font-semibold leading-none text-[var(--brand-accent,#E39A6E)]"
+                : "mt-1 text-[1.85rem] font-semibold leading-none text-white"
             }
           >
             {item.value}
@@ -102,13 +109,13 @@ export function DashboardPanel({
 }) {
   return (
     <section
-      className={`rounded-2xl border p-3.5 md:p-4 ${className ?? ""}`}
+      className={`rounded-2xl border p-3 md:p-3.5 ${className ?? ""}`}
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 78%, transparent)",
         background: "linear-gradient(155deg, rgba(2,6,23,0.9), rgba(10,15,28,0.78))",
       }}
     >
-      <header className="mb-3 flex items-start justify-between gap-2">
+      <header className="mb-2.5 flex items-start justify-between gap-2">
         <div>
           {eyebrow ? <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{eyebrow}</div> : null}
           <h2 className="text-sm font-semibold text-white md:text-base">{title}</h2>

--- a/app/dashboard/_components/OperationsCharts.tsx
+++ b/app/dashboard/_components/OperationsCharts.tsx
@@ -4,10 +4,16 @@ import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxi
 
 export function ShopLoadChart({ data }: { data: Array<{ label: string; count: number }> }) {
   return (
-    <div className="h-52 w-full">
+    <div className="h-56 w-full">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={{ top: 8, right: 4, bottom: 0, left: -20 }}>
-          <CartesianGrid stroke="rgba(148,163,184,0.14)" vertical={false} />
+          <defs>
+            <linearGradient id="shop-load-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="rgba(227,154,110,0.95)" />
+              <stop offset="100%" stopColor="rgba(193,102,59,0.45)" />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke="rgba(148,163,184,0.2)" strokeDasharray="3 3" vertical={false} />
           <XAxis dataKey="label" tick={{ fill: "#94A3B8", fontSize: 10 }} axisLine={false} tickLine={false} />
           <YAxis tick={{ fill: "#94A3B8", fontSize: 10 }} axisLine={false} tickLine={false} />
           <Tooltip
@@ -17,7 +23,7 @@ export function ShopLoadChart({ data }: { data: Array<{ label: string; count: nu
               borderRadius: "10px",
             }}
           />
-          <Bar dataKey="count" fill="rgba(193,102,59,0.78)" radius={[6, 6, 0, 0]} barSize={18} />
+          <Bar dataKey="count" fill="url(#shop-load-fill)" stroke="rgba(241,171,134,0.92)" strokeWidth={1.5} radius={[7, 7, 1, 1]} barSize={20} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { AlertTriangle, ArrowRight, TriangleAlert } from "lucide-react";
+import { ActivitySquare, AlertTriangle, ArrowRight, TriangleAlert } from "lucide-react";
 
 import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
 import { ActionRow, CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
@@ -8,6 +8,8 @@ import { ShopLoadChart } from "./OperationsCharts";
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
+  const hasTechnicianActivity = payload.technicianActivity.length > 0;
+  const hasLiveFlowData = payload.liveWork.length > 0 || payload.flowMix.length > 0;
 
   return (
     <DashboardShell>
@@ -31,16 +33,16 @@ export default async function OperationsDashboardView() {
         ]}
       />
 
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-12">
-        <DashboardPanel eyebrow="Row A" title="Active Job Summary" className="xl:col-span-4">
-          <div className="space-y-2">
+      <div className="grid grid-cols-1 gap-2.5 md:grid-cols-2 xl:grid-cols-12">
+        <DashboardPanel title="Active Job Summary" className="min-h-[270px] md:min-h-[288px] xl:col-span-4">
+          <div className="space-y-2.5">
             {payload.activeJobSummary.map((metric) => (
-              <div key={metric.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+              <div key={metric.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
                 <div className="flex items-center justify-between text-xs">
                   <span className="text-neutral-300">{metric.label}</span>
-                  <span className="font-semibold text-white">{metric.value}</span>
+                  <span className="text-sm font-semibold text-white">{metric.value}</span>
                 </div>
-                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-white/10">
                   <div
                     className="h-full rounded-full bg-[var(--brand-accent,#E39A6E)]"
                     style={{ width: `${metric.pct}%` }}
@@ -51,12 +53,11 @@ export default async function OperationsDashboardView() {
           </div>
         </DashboardPanel>
 
-        <DashboardPanel eyebrow="Row A" title="Live Shop Load" className="xl:col-span-5">
+        <DashboardPanel title="Live Shop Load" className="min-h-[270px] md:min-h-[288px] xl:col-span-5">
           <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
         </DashboardPanel>
 
         <DashboardPanel
-          eyebrow="Row A"
           title="Daily Summary"
           className="xl:col-span-3"
           action={<Link href="/dashboard/bookings" className="text-xs text-neutral-300 hover:text-white">Open</Link>}
@@ -64,31 +65,32 @@ export default async function OperationsDashboardView() {
           <CompactSignalList items={payload.dailySummary} />
         </DashboardPanel>
 
-        <DashboardPanel eyebrow="Row B" title="Technician Activity" className="xl:col-span-5">
-          <div className="space-y-2">
-            {payload.technicianActivity.map((tech) => (
-              <div key={tech.id} className="grid grid-cols-[minmax(0,1fr)_80px_64px] items-center gap-2 rounded-lg border border-white/10 bg-black/20 p-2.5">
-                <div className="min-w-0">
-                  <div className="truncate text-xs font-semibold text-white">{tech.name}</div>
-                  <div className="text-[11px] text-neutral-400">{tech.stage} · {tech.elapsed}</div>
-                  <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/10">
-                    <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
+        {hasTechnicianActivity ? (
+          <DashboardPanel title="Technician Activity" className="xl:col-span-5">
+            <div className="space-y-1.5">
+              {payload.technicianActivity.map((tech) => (
+                <div key={tech.id} className="grid grid-cols-[minmax(0,1fr)_76px_60px] items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-2.5 py-2">
+                  <div className="min-w-0">
+                    <div className="truncate text-xs font-semibold text-white">{tech.name}</div>
+                    <div className="text-[11px] text-neutral-400">{tech.stage} · {tech.elapsed}</div>
+                    <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/10">
+                      <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
+                    </div>
                   </div>
+                  <div className="text-right text-xs text-neutral-300">{tech.activeLines} lines</div>
+                  <button type="button" className="rounded-full border border-white/10 px-2 py-1 text-[10px] text-neutral-300">View</button>
                 </div>
-                <div className="text-right text-xs text-neutral-300">{tech.activeLines} lines</div>
-                <button type="button" className="rounded-full border border-white/10 px-2 py-1 text-[10px] text-neutral-300">View</button>
-              </div>
-            ))}
-          </div>
-        </DashboardPanel>
+              ))}
+            </div>
+          </DashboardPanel>
+        ) : null}
 
         <DashboardPanel
-          eyebrow="Row B"
           title="High Impact Alerts"
           className="xl:col-span-3"
           action={<Link href="/work-orders/board" className="text-xs text-neutral-300 hover:text-white">View all</Link>}
         >
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             {payload.alerts.map((alert) => (
               <div
                 key={alert.label}
@@ -108,44 +110,45 @@ export default async function OperationsDashboardView() {
           </div>
         </DashboardPanel>
 
-        <DashboardPanel eyebrow="Row B" title="Suggested Actions" className="xl:col-span-4">
+        <DashboardPanel title="Suggested Actions" className="xl:col-span-4">
           <ActionRow actions={payload.suggestedActions} />
         </DashboardPanel>
 
-        <DashboardPanel eyebrow="Row C" title="Technician / Flow Mix" className="xl:col-span-8">
-          <div className="grid gap-2 md:grid-cols-2">
-            <div className="space-y-2">
-              {payload.liveWork.map((item) => (
-                <div key={item.id} className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs">
-                  <div>
-                    <div className="font-semibold text-white">{item.label}</div>
-                    <div className="text-neutral-400">{item.stage}</div>
+        {hasLiveFlowData ? (
+          <DashboardPanel title="Technician / Flow Mix" className="xl:col-span-8">
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="space-y-1.5">
+                {payload.liveWork.map((item) => (
+                  <div key={item.id} className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-1.5 text-xs">
+                    <div>
+                      <div className="font-semibold text-white">{item.label}</div>
+                      <div className="text-neutral-400">{item.stage}</div>
+                    </div>
+                    <div className="rounded-full border border-white/10 px-2 py-0.5 text-neutral-300">P{item.priority}</div>
                   </div>
-                  <div className="rounded-full border border-white/10 px-2 py-0.5 text-neutral-300">P{item.priority}</div>
-                </div>
-              ))}
+                ))}
+              </div>
+              <div className="space-y-1.5">
+                {payload.flowMix.map((row) => (
+                  <div key={row.label} className="rounded-lg border border-white/10 bg-black/20 p-2">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-neutral-300">{row.label}</span>
+                      <span className="font-semibold text-white">{row.value}</span>
+                    </div>
+                    <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-white/10">
+                      <div
+                        className="h-full rounded-full bg-gradient-to-r from-[var(--brand-primary,#C1663B)] to-[var(--brand-accent,#E39A6E)]"
+                        style={{ width: `${Math.min(100, row.value * 12)}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-            <div className="space-y-2">
-              {payload.flowMix.map((row) => (
-                <div key={row.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="text-neutral-300">{row.label}</span>
-                    <span className="font-semibold text-white">{row.value}</span>
-                  </div>
-                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
-                    <div
-                      className="h-full rounded-full bg-gradient-to-r from-[var(--brand-primary,#C1663B)] to-[var(--brand-accent,#E39A6E)]"
-                      style={{ width: `${Math.min(100, row.value * 12)}%` }}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </DashboardPanel>
+          </DashboardPanel>
+        ) : null}
 
         <DashboardPanel
-          eyebrow="Row C"
           title="Revenue & Efficiency Snapshot"
           className="xl:col-span-4"
           action={<Link href="/dashboard/performance" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open <ArrowRight className="h-3 w-3" /></Link>}
@@ -167,16 +170,20 @@ export default async function OperationsDashboardView() {
       </div>
 
       {payload.sectionErrors.length > 0 ? (
-        <DashboardPanel eyebrow="Diagnostics" title="Section warnings">
-          <div className="space-y-1.5 text-xs text-amber-300">
+        <section className="rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-2.5">
+          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-300">
+            <ActivitySquare className="h-3.5 w-3.5" />
+            Section warnings
+          </div>
+          <div className="space-y-1 text-xs text-amber-200">
             {payload.sectionErrors.map((warning) => (
-              <div key={warning} className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-2">
-                <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
+              <div key={warning} className="flex items-start gap-2 rounded-md border border-amber-500/25 bg-black/20 px-2 py-1.5">
+                <AlertTriangle className="mt-0.5 h-3 w-3" />
                 <span>{warning}</span>
               </div>
             ))}
           </div>
-        </DashboardPanel>
+        </section>
       ) : null}
     </DashboardShell>
   );


### PR DESCRIPTION
### Motivation

- Prevent header overlap and make the top KPI strip reliably visible by ensuring dashboard content flows below the header. 
- Reduce wasted space and visual noise while strengthening hero panels so the dashboard reads like a compact command center. 
- Avoid rendering empty or dead panels and present lightweight empty / warning states instead of large blank containers. 
- Improve chart legibility and the KPI strip contrast to make operational signals clearer at-a-glance.

### Description

- Moved the operations top strip out of sticky positioning into the normal flow and tightened the shell spacing so content reliably starts below the header. (`app/dashboard/_components/DashboardPrimitives.tsx`).
- Refined the KPI strip with larger numeric typography, tighter label tracking, desktop separators, higher contrast, and slight background inset to increase command-center presence. (`app/dashboard/_components/DashboardPrimitives.tsx`).
- Increased hero panel prominence by adding minimum heights and denser internals for **Active Job Summary** and **Live Shop Load**, tightened paddings across panels, and removed dev eyebrow labels (`ROW A/B/C`). (`app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/DashboardPrimitives.tsx`).
- Added conditional rendering to avoid empty panels: hide `Technician Activity` when `payload.technicianActivity` is empty and hide `Technician / Flow Mix` when both `payload.liveWork` and `payload.flowMix` are empty. (`app/dashboard/_components/OperationsDashboardView.tsx`).
- Converted section warnings from a heavy panel into a compact alert strip style and reduced internal padding to make alerts feel like a system strip rather than a full panel. (`app/dashboard/_components/OperationsDashboardView.tsx`).
- Improved Live Shop Load chart visuals by increasing chart height, adding a gradient fill, thicker stroke, stronger grid contrast, and slightly larger bars for better visual weight. (`app/dashboard/_components/OperationsCharts.tsx`).
- Files changed: `app/dashboard/_components/DashboardPrimitives.tsx`, `app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/OperationsCharts.tsx`.

### Testing

- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully.
- No additional automated tests were modified or required for this polish pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf5169d488328a99e6e20fdbb5573)