### PR TITLE
Refine operations dashboard cohesion, hierarchy, and urgency affordances

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -151,26 +151,29 @@ export function CompactSignalList({
 
 export function ActionRow({ actions }: { actions: Array<{ label: string; href: string; tone?: "primary" | "neutral"; detail?: string }> }) {
   return (
-    <div className="space-y-2">
+    <div className="space-y-1.5">
       {actions.map((action) => (
         <Link
           key={`${action.href}-${action.label}`}
           href={action.href}
-          className="group block rounded-lg border border-white/10 bg-black/20 p-2.5 transition hover:border-white/20 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+          className="group block rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
         >
           <div className="flex items-center justify-between gap-2">
             <div className="text-xs font-semibold text-white">{action.label}</div>
-            <span
-              className={
-                action.tone === "primary"
-                  ? "rounded-full border border-[var(--accent-copper-soft)]/80 bg-[var(--accent-copper)]/15 px-2.5 py-1 text-[10px] font-semibold text-[var(--accent-copper-light)]"
-                  : "rounded-full border border-white/10 px-2.5 py-1 text-[10px] font-semibold text-neutral-200"
-              }
-            >
-              Open
-            </span>
+            <div className="inline-flex items-center gap-1.5">
+              <span
+                className={
+                  action.tone === "primary"
+                    ? "rounded-full border border-[var(--accent-copper-soft)]/80 bg-[var(--accent-copper)]/15 px-2.5 py-0.5 text-[10px] font-semibold text-[var(--accent-copper-light)]"
+                    : "rounded-full border border-white/10 px-2.5 py-0.5 text-[10px] font-semibold text-neutral-200"
+                }
+              >
+                Open
+              </span>
+              <span className="text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]">→</span>
+            </div>
           </div>
-          {action.detail ? <div className="mt-1 text-[11px] text-neutral-400">{action.detail}</div> : null}
+          {action.detail ? <div className="mt-0.5 text-[11px] text-neutral-400">{action.detail}</div> : null}
         </Link>
       ))}
     </div>

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -48,12 +48,41 @@ export default async function OperationsDashboardView() {
         ]}
       />
 
-      <div className="grid gap-3 xl:grid-cols-[minmax(0,1.85fr)_minmax(292px,1fr)] 2xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+      <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)] 2xl:grid-cols-[minmax(0,2.08fr)_minmax(320px,1fr)]">
         <section className="space-y-3">
-          <div className="grid gap-3 lg:grid-cols-[minmax(0,1.45fr)_minmax(260px,1fr)]">
+          {payload.sectionErrors.length > 0 ? (
+            <section className="rounded-xl border border-amber-500/30 bg-gradient-to-r from-amber-500/15 via-amber-400/10 to-transparent px-3 py-2.5">
+              <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-300">
+                <ActivitySquare className="h-3.5 w-3.5" />
+                Section warnings
+              </div>
+              <div className="space-y-1 text-xs text-amber-200">
+                {payload.sectionErrors.map((warning) => (
+                  <Link
+                    key={warning}
+                    href="/dashboard/operations"
+                    className="group flex items-start gap-2 rounded-md border border-amber-500/30 bg-black/25 px-2 py-1.5 transition hover:bg-black/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/60"
+                  >
+                    <AlertTriangle className="mt-0.5 h-3 w-3" />
+                    <span className="flex-1">{warning}</span>
+                    <ChevronRight className="mt-0.5 h-3 w-3 text-amber-200/70 transition group-hover:text-amber-100" />
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          <div
+            className="space-y-2 rounded-[22px] border border-white/10 p-2.5 md:p-3"
+            style={{
+              background: "linear-gradient(160deg, rgba(3,7,18,0.82), rgba(6,11,24,0.55) 45%, rgba(2,6,23,0.7))",
+              boxShadow: "inset 0 1px 0 rgba(148,163,184,0.08), 0 20px 40px rgba(0,0,0,0.28)",
+            }}
+          >
+            <div className="grid gap-2 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
             <DashboardPanel
               title="Live Work Command Surface"
-              className="min-h-[316px]"
+              className="min-h-[330px] border-white/15"
               action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open board <ArrowRight className="h-3 w-3" /></Link>}
             >
               <div className="grid h-full gap-2.5 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
@@ -106,13 +135,13 @@ export default async function OperationsDashboardView() {
               </div>
             </DashboardPanel>
 
-            <DashboardPanel title="Active Job Summary" className="min-h-[316px]">
+            <DashboardPanel title="Active Job Summary" className="min-h-[330px] border-white/10 bg-[linear-gradient(155deg,rgba(2,6,23,0.82),rgba(8,12,24,0.68))]">
               <div className="space-y-2.5">
                 {payload.activeJobSummary.map((metric) => (
-                  <div key={metric.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
+                  <div key={metric.label} className="rounded-lg border border-white/10 bg-black/15 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
                     <div className="flex items-center justify-between text-xs">
-                      <span className="text-neutral-300">{metric.label}</span>
-                      <span className="text-sm font-semibold text-white">{metric.value}</span>
+                      <span className="text-neutral-400">{metric.label}</span>
+                      <span className="text-[13px] font-semibold text-neutral-100">{metric.value}</span>
                     </div>
                     <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-white/10">
                       <div
@@ -126,13 +155,14 @@ export default async function OperationsDashboardView() {
             </DashboardPanel>
           </div>
 
-          <div className="grid gap-3 lg:grid-cols-[minmax(0,1.4fr)_minmax(260px,1fr)]">
-            <DashboardPanel title="Live Shop Load" className="min-h-[274px]">
+            <div className="grid gap-2 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
+            <DashboardPanel title="Live Shop Load" className="min-h-[252px] border-white/10">
               <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
             </DashboardPanel>
 
             <DashboardPanel
               title="Daily Summary"
+              className="border-white/10"
               action={<Link href="/dashboard/bookings" className="text-xs text-neutral-300 hover:text-white">Open</Link>}
             >
               <div className="space-y-1.5">
@@ -161,6 +191,7 @@ export default async function OperationsDashboardView() {
                 })}
               </div>
             </DashboardPanel>
+          </div>
           </div>
 
           {hasTechnicianActivity ? (
@@ -217,7 +248,7 @@ export default async function OperationsDashboardView() {
                   <Link
                     key={blocker.label}
                     href={blockerHrefByLabel[blocker.label] ?? "/work-orders/board"}
-                    className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs transition hover:border-white/20 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                    className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-1.5 text-xs transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                   >
                     <span className="text-neutral-300">{blocker.label}</span>
                     <span className={blocker.tone === "accent" ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]" : "inline-flex items-center gap-1 font-semibold text-white"}>
@@ -238,10 +269,11 @@ export default async function OperationsDashboardView() {
                   <Link
                     key={alert.label}
                     href={alertHrefByLabel[alert.label] ?? "/work-orders/board"}
-                    className="group block rounded-lg border p-2 transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                    className="group block rounded-lg border p-2 transition hover:-translate-y-px hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                     style={{
-                      borderColor: alert.tone === "critical" ? "rgba(239,68,68,0.4)" : alert.tone === "warning" ? "rgba(245,158,11,0.38)" : "rgba(148,163,184,0.25)",
-                      background: alert.tone === "critical" ? "rgba(127,29,29,0.18)" : alert.tone === "warning" ? "rgba(120,53,15,0.18)" : "rgba(15,23,42,0.5)",
+                      borderColor: alert.tone === "critical" ? "rgba(248,113,113,0.62)" : alert.tone === "warning" ? "rgba(251,191,36,0.42)" : "rgba(148,163,184,0.25)",
+                      background: alert.tone === "critical" ? "linear-gradient(120deg, rgba(127,29,29,0.36), rgba(69,10,10,0.2))" : alert.tone === "warning" ? "rgba(120,53,15,0.2)" : "rgba(15,23,42,0.5)",
+                      boxShadow: alert.tone === "critical" ? "0 0 0 1px rgba(239,68,68,0.15), inset 0 1px 0 rgba(254,202,202,0.15)" : undefined,
                     }}
                   >
                     <div className="flex items-center justify-between gap-2 text-xs font-semibold text-white">
@@ -249,7 +281,7 @@ export default async function OperationsDashboardView() {
                         {alert.tone === "critical" ? <TriangleAlert className="h-3.5 w-3.5 text-red-300" /> : <AlertTriangle className="h-3.5 w-3.5 text-amber-300" />}
                         {alert.label}
                       </span>
-                      <ChevronRight className="h-3.5 w-3.5 text-neutral-500 transition group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                      <ChevronRight className="h-3.5 w-3.5 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
                     </div>
                     <div className="mt-1 text-[11px] text-neutral-300">{alert.detail}</div>
                   </Link>
@@ -263,28 +295,6 @@ export default async function OperationsDashboardView() {
           </aside>
         ) : null}
       </div>
-
-      {payload.sectionErrors.length > 0 ? (
-        <section className="rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-2.5">
-          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-300">
-            <ActivitySquare className="h-3.5 w-3.5" />
-            Section warnings
-          </div>
-          <div className="space-y-1 text-xs text-amber-200">
-            {payload.sectionErrors.map((warning) => (
-              <Link
-                key={warning}
-                href="/dashboard/operations"
-                className="group flex items-start gap-2 rounded-md border border-amber-500/25 bg-black/20 px-2 py-1.5 transition hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/60"
-              >
-                <AlertTriangle className="mt-0.5 h-3 w-3" />
-                <span className="flex-1">{warning}</span>
-                <ChevronRight className="mt-0.5 h-3 w-3 text-amber-200/70 transition group-hover:text-amber-100" />
-              </Link>
-            ))}
-          </div>
-        </section>
-      ) : null}
     </DashboardShell>
   );
 }


### PR DESCRIPTION
### Motivation
- The left operations area (Live Work, Active Job Summary, Live Shop Load, Daily Summary) read as isolated cards and needed to feel like one connected operational surface. 
- Live Work must be visually dominant so operators scan it first while related visualizations should read as part of the same system. 
- Alerts and section warnings were not prominent enough for urgent issues and action rows lacked tighter density and click affordances. 
- Changes must be layout/visual only with no route, data fetching, or orchestration changes. 

### Description
- Grouped the primary operations panels into a shared command plane using a subtle rounded container, unified background gradient, tighter internal gaps, and asymmetric column spans to remove the “card grid” feel; file changed: `app/dashboard/_components/OperationsDashboardView.tsx`. 
- Increased prominence of `Live Work Command Surface` by expanding left-lane share and minimum height and softened `Active Job Summary` emphasis via lighter typography and internal surface treatment. 
- Integrated `Live Shop Load` into the same command plane and aligned column geometry so the chart reads as a visualization of Live Work rather than a separate card. 
- Moved `Section Warnings` from the bottom of the page to directly under the KPI strip for immediate visibility, and kept each warning as a full-row clickable `Link`. 
- Elevated alert urgency by increasing critical contrast, adding subtle hover motion (`-translate-y-px` and chevron motion), stronger critical box-shadow, and ensuring each alert row is a full-link with a clear directional affordance. 
- Tightened the Action Rail and suggested-actions rows (reduced padding, increased density, added inline arrow cue) and confirmed full-row click targets remain intact; file changed: `app/dashboard/_components/DashboardPrimitives.tsx`. 

### Testing
- Ran type-checking with `npx tsc --noEmit` and it passed. 
- Ran lint with `npm run lint` and it failed due to pre-existing repository-wide lint errors that are outside the scope of these visual/layout changes. 
- No runtime data fetching or route-level changes were introduced so data/performance patterns remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc228e56c8328830214e967b06bcc)