### PR TITLE
Polish dashboard command surfaces and hierarchy clarity

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -59,9 +59,15 @@ export function DashboardTopStrip({
   );
 }
 
-export function MetricStrip({ items }: { items: Array<{ label: string; value: string; tone?: "default" | "accent" }> }) {
+export function MetricStrip({
+  items,
+  className,
+}: {
+  items: Array<{ label: string; value: string; tone?: "default" | "accent" }>;
+  className?: string;
+}) {
   return (
-    <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+    <div className={`grid grid-cols-2 gap-2 lg:grid-cols-4 ${className ?? ""}`}>
       {items.map((item, index) => (
         <section
           key={item.label}
@@ -112,7 +118,7 @@ export function DashboardPanel({
       className={`rounded-2xl border p-3 md:p-3.5 ${className ?? ""}`}
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 78%, transparent)",
-        background: "linear-gradient(155deg, rgba(2,6,23,0.9), rgba(10,15,28,0.78))",
+        background: "linear-gradient(155deg, rgba(2,6,23,0.88), rgba(10,15,28,0.76))",
       }}
     >
       <header className="mb-2.5 flex items-start justify-between gap-2">
@@ -149,14 +155,24 @@ export function CompactSignalList({
   );
 }
 
-export function ActionRow({ actions }: { actions: Array<{ label: string; href: string; tone?: "primary" | "neutral"; detail?: string }> }) {
+export function ActionRow({
+  actions,
+  emphasis = "default",
+}: {
+  actions: Array<{ label: string; href: string; tone?: "primary" | "neutral"; detail?: string }>;
+  emphasis?: "default" | "subtle";
+}) {
   return (
     <div className="space-y-1.5">
       {actions.map((action) => (
         <Link
           key={`${action.href}-${action.label}`}
           href={action.href}
-          className="group block rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+          className={`group block rounded-lg border px-2.5 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60 ${
+            emphasis === "subtle"
+              ? "border-white/5 bg-black/15 hover:border-white/15 hover:bg-black/25"
+              : "border-white/10 bg-black/20 hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40"
+          }`}
         >
           <div className="flex items-center justify-between gap-2">
             <div className="text-xs font-semibold text-white">{action.label}</div>

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -40,6 +40,7 @@ export default async function OperationsDashboardView() {
       />
 
       <MetricStrip
+        className="mb-0.5"
         items={[
           { label: "Active jobs", value: String(payload.topSummary.activeJobs) },
           { label: "Blocked", value: String(payload.topSummary.blockedJobs), tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default" },
@@ -48,7 +49,7 @@ export default async function OperationsDashboardView() {
         ]}
       />
 
-      <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)] 2xl:grid-cols-[minmax(0,2.08fr)_minmax(320px,1fr)]">
+      <div className="grid gap-2 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)] 2xl:grid-cols-[minmax(0,2.08fr)_minmax(320px,1fr)]">
         <section className="space-y-3">
           {payload.sectionErrors.length > 0 ? (
             <section className="rounded-xl border border-amber-500/30 bg-gradient-to-r from-amber-500/15 via-amber-400/10 to-transparent px-3 py-2.5">
@@ -75,32 +76,32 @@ export default async function OperationsDashboardView() {
           <div
             className="space-y-2 rounded-[22px] border border-white/10 p-2.5 md:p-3"
             style={{
-              background: "linear-gradient(160deg, rgba(3,7,18,0.82), rgba(6,11,24,0.55) 45%, rgba(2,6,23,0.7))",
-              boxShadow: "inset 0 1px 0 rgba(148,163,184,0.08), 0 20px 40px rgba(0,0,0,0.28)",
+              background: "linear-gradient(160deg, rgba(4,8,20,0.9), rgba(8,14,30,0.72) 45%, rgba(4,10,24,0.8))",
+              boxShadow: "inset 0 1px 0 rgba(148,163,184,0.1), 0 20px 40px rgba(0,0,0,0.28)",
             }}
           >
             <div className="grid gap-2 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
             <DashboardPanel
               title="Live Work Command Surface"
-              className="min-h-[330px] border-white/15"
+              className="min-h-[330px] border-white/10 bg-[linear-gradient(155deg,rgba(9,16,34,0.92),rgba(8,14,29,0.82))]"
               action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open board <ArrowRight className="h-3 w-3" /></Link>}
             >
               <div className="grid h-full gap-2.5 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-                <div className="space-y-1.5">
+                <div className="space-y-1">
                   {payload.liveWork.length > 0 ? (
                     payload.liveWork.map((item) => (
                       <Link
                         key={item.id}
                         href={`/work-orders/${item.id}`}
-                        className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                        className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/25 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/60 hover:bg-black/45 hover:shadow-[0_0_0_1px_rgba(227,154,110,0.2),0_8px_20px_rgba(0,0,0,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                       >
                         <div>
-                          <div className="font-semibold text-white">{item.label}</div>
+                          <div className="font-bold tracking-wide text-white">{item.label}</div>
                           <div className="text-neutral-400">{item.stage}</div>
                         </div>
                         <div className="flex items-center gap-1.5">
-                          <div className="rounded-full border border-white/10 px-2 py-0.5 text-neutral-300">P{item.priority}</div>
-                          <ChevronRight className="h-3.5 w-3.5 text-neutral-500 transition group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                          <div className="rounded-full border border-white/10 px-2 py-0.5 text-neutral-200">P{item.priority}</div>
+                          <ChevronRight className="h-3.5 w-3.5 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
                         </div>
                       </Link>
                     ))
@@ -108,13 +109,13 @@ export default async function OperationsDashboardView() {
                     <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs text-neutral-400">No active jobs currently in motion.</div>
                   )}
                 </div>
-                <div className="space-y-1.5">
+                <div className="space-y-1">
                   {payload.flowMix.length > 0 ? (
                     payload.flowMix.map((row) => (
                       <Link
                         key={row.label}
                         href={`/work-orders/board?stage=${encodeURIComponent(row.label.toLowerCase().replaceAll(" ", "_"))}`}
-                        className="group block rounded-lg border border-white/10 bg-black/20 p-2 transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                        className="group block rounded-lg border border-white/8 bg-black/20 p-2 transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                       >
                         <div className="flex items-center justify-between text-xs">
                           <span className="text-neutral-300">{row.label}</span>
@@ -135,10 +136,10 @@ export default async function OperationsDashboardView() {
               </div>
             </DashboardPanel>
 
-            <DashboardPanel title="Active Job Summary" className="min-h-[330px] border-white/10 bg-[linear-gradient(155deg,rgba(2,6,23,0.82),rgba(8,12,24,0.68))]">
+            <DashboardPanel title="Active Job Summary" className="min-h-[330px] border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
               <div className="space-y-2.5">
                 {payload.activeJobSummary.map((metric) => (
-                  <div key={metric.label} className="rounded-lg border border-white/10 bg-black/15 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
+                  <div key={metric.label} className="rounded-lg border border-white/5 bg-black/15 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-neutral-400">{metric.label}</span>
                       <span className="text-[13px] font-semibold text-neutral-100">{metric.value}</span>
@@ -156,13 +157,13 @@ export default async function OperationsDashboardView() {
           </div>
 
             <div className="grid gap-2 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
-            <DashboardPanel title="Live Shop Load" className="min-h-[252px] border-white/10">
+            <DashboardPanel title="Live Shop Load" className="min-h-[252px] border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
               <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
             </DashboardPanel>
 
             <DashboardPanel
               title="Daily Summary"
-              className="border-white/10"
+              className="border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]"
               action={<Link href="/dashboard/bookings" className="text-xs text-neutral-300 hover:text-white">Open</Link>}
             >
               <div className="space-y-1.5">
@@ -179,12 +180,12 @@ export default async function OperationsDashboardView() {
                     <Link
                       key={`${item.label}-${item.value}`}
                       href={href}
-                      className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs transition hover:border-white/20 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                      className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                     >
                       <span className="text-neutral-300">{item.label}</span>
                       <span className={item.tone === "accent" ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]" : "inline-flex items-center gap-1 font-semibold text-white"}>
                         {item.value}
-                        <ChevronRight className="h-3 w-3 text-neutral-500 transition group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                        <ChevronRight className="h-3 w-3 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
                       </span>
                     </Link>
                   );
@@ -241,28 +242,11 @@ export default async function OperationsDashboardView() {
         </section>
 
         {hasRightRailSignals ? (
-          <aside className="space-y-3 xl:sticky xl:top-3 xl:self-start">
-            <DashboardPanel title="Action Rail" eyebrow="Urgency">
-              <div className="space-y-1.5">
-                {payload.blockerStack.map((blocker) => (
-                  <Link
-                    key={blocker.label}
-                    href={blockerHrefByLabel[blocker.label] ?? "/work-orders/board"}
-                    className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-1.5 text-xs transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
-                  >
-                    <span className="text-neutral-300">{blocker.label}</span>
-                    <span className={blocker.tone === "accent" ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]" : "inline-flex items-center gap-1 font-semibold text-white"}>
-                      {blocker.value}
-                      <ChevronRight className="h-3 w-3 text-neutral-500 transition group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                    </span>
-                  </Link>
-                ))}
-              </div>
-            </DashboardPanel>
-
+          <aside className="space-y-2.5 xl:sticky xl:top-3 xl:self-start">
             <DashboardPanel
               title="High Impact Alerts"
               action={<Link href="/work-orders/board" className="text-xs text-neutral-300 hover:text-white">View all</Link>}
+              className="border-red-400/45 bg-[linear-gradient(150deg,rgba(32,10,10,0.64),rgba(12,9,16,0.86))] shadow-[0_0_0_1px_rgba(239,68,68,0.12)]"
             >
               <div className="space-y-1.5">
                 {payload.alerts.map((alert) => (
@@ -271,9 +255,9 @@ export default async function OperationsDashboardView() {
                     href={alertHrefByLabel[alert.label] ?? "/work-orders/board"}
                     className="group block rounded-lg border p-2 transition hover:-translate-y-px hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                     style={{
-                      borderColor: alert.tone === "critical" ? "rgba(248,113,113,0.62)" : alert.tone === "warning" ? "rgba(251,191,36,0.42)" : "rgba(148,163,184,0.25)",
-                      background: alert.tone === "critical" ? "linear-gradient(120deg, rgba(127,29,29,0.36), rgba(69,10,10,0.2))" : alert.tone === "warning" ? "rgba(120,53,15,0.2)" : "rgba(15,23,42,0.5)",
-                      boxShadow: alert.tone === "critical" ? "0 0 0 1px rgba(239,68,68,0.15), inset 0 1px 0 rgba(254,202,202,0.15)" : undefined,
+                      borderColor: alert.tone === "critical" ? "rgba(248,113,113,0.7)" : alert.tone === "warning" ? "rgba(251,191,36,0.48)" : "rgba(148,163,184,0.25)",
+                      background: alert.tone === "critical" ? "linear-gradient(120deg, rgba(127,29,29,0.48), rgba(69,10,10,0.24))" : alert.tone === "warning" ? "rgba(120,53,15,0.24)" : "rgba(15,23,42,0.5)",
+                      boxShadow: alert.tone === "critical" ? "0 0 0 1px rgba(239,68,68,0.2), inset 0 1px 0 rgba(254,202,202,0.18)" : undefined,
                     }}
                   >
                     <div className="flex items-center justify-between gap-2 text-xs font-semibold text-white">
@@ -289,8 +273,30 @@ export default async function OperationsDashboardView() {
               </div>
             </DashboardPanel>
 
-            <DashboardPanel title="Suggested Actions">
-              <ActionRow actions={payload.suggestedActions} />
+            <div className="h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+
+            <DashboardPanel title="Action Rail" eyebrow="Urgency" className="border-amber-300/30 bg-[linear-gradient(150deg,rgba(36,22,8,0.42),rgba(8,11,24,0.84))]">
+              <div className="space-y-1.5">
+                {payload.blockerStack.map((blocker) => (
+                  <Link
+                    key={blocker.label}
+                    href={blockerHrefByLabel[blocker.label] ?? "/work-orders/board"}
+                    className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                  >
+                    <span className="text-neutral-300">{blocker.label}</span>
+                    <span className={blocker.tone === "accent" ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]" : "inline-flex items-center gap-1 font-semibold text-white"}>
+                      {blocker.value}
+                      <ChevronRight className="h-3 w-3 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </DashboardPanel>
+
+            <div className="h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+
+            <DashboardPanel title="Suggested Actions" className="border-white/10 bg-[linear-gradient(150deg,rgba(2,6,23,0.7),rgba(7,10,18,0.6))]">
+              <ActionRow actions={payload.suggestedActions} emphasis="subtle" />
             </DashboardPanel>
           </aside>
         ) : null}

--- a/app/dashboard/_components/PerformanceDashboardView.tsx
+++ b/app/dashboard/_components/PerformanceDashboardView.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ChevronRight } from "lucide-react";
 
 import { getPerformanceDashboardPayload } from "@/features/dashboard/server/getPerformanceDashboardPayload";
 import { CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
@@ -23,6 +23,7 @@ export default async function PerformanceDashboardView() {
       />
 
       <MetricStrip
+        className="mb-0.5"
         items={[
           { label: "Revenue", value: `$${payload.kpis.revenue.toLocaleString()}` },
           { label: "Profit", value: `$${payload.kpis.profit.toLocaleString()}` },
@@ -31,61 +32,73 @@ export default async function PerformanceDashboardView() {
         ]}
       />
 
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-12">
-        <DashboardPanel eyebrow="Row A" title="Trend / Performance Charts" className="xl:col-span-8">
-          <PerformanceTrendPanel data={payload.trend} />
-        </DashboardPanel>
+      <div
+        className="grid gap-2 rounded-[22px] border border-white/10 p-2.5 md:p-3 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)]"
+        style={{
+          background: "linear-gradient(160deg, rgba(4,8,20,0.9), rgba(8,14,30,0.72) 45%, rgba(4,10,24,0.8))",
+          boxShadow: "inset 0 1px 0 rgba(148,163,184,0.1), 0 20px 40px rgba(0,0,0,0.28)",
+        }}
+      >
+        <section className="space-y-2">
+          <DashboardPanel eyebrow="Primary" title="Trend / Performance Charts" className="border-white/10 min-h-[338px] bg-[linear-gradient(155deg,rgba(9,16,34,0.92),rgba(8,14,29,0.82))]">
+            <PerformanceTrendPanel data={payload.trend} />
+          </DashboardPanel>
 
-        <DashboardPanel eyebrow="Row A" title="Optimization / Revenue Risk Signals" className="xl:col-span-4">
-          <CompactSignalList items={payload.businessSignals} />
-          <div className="mt-3 space-y-1.5">
-            {payload.optimizationSummary.map((item) => (
-              <div
-                key={item.label}
-                className="rounded-lg border px-2.5 py-2"
-                style={{
-                  borderColor: item.tone === "critical" ? "rgba(239,68,68,0.35)" : item.tone === "warning" ? "rgba(245,158,11,0.35)" : "rgba(148,163,184,0.25)",
-                  background: item.tone === "critical" ? "rgba(127,29,29,0.16)" : item.tone === "warning" ? "rgba(120,53,15,0.15)" : "rgba(15,23,42,0.42)",
-                }}
-              >
-                <div className="text-xs font-semibold text-white">{item.label}</div>
-                <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
+          <div className="grid gap-2 md:grid-cols-2">
+            <DashboardPanel eyebrow="Support" title="Technician / Throughput Performance" className="border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
+              <div className="space-y-1.5">
+                {payload.technicianPerformance.map((tech) => (
+                  <div key={tech.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="font-semibold text-white">{tech.label}</span>
+                      <span className="text-neutral-300">{tech.completed} completed</span>
+                    </div>
+                    <div className="mt-1 text-[11px] text-neutral-400">{tech.pace}</div>
+                    <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                      <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
+                    </div>
+                  </div>
+                ))}
               </div>
-            ))}
+            </DashboardPanel>
+
+            <DashboardPanel eyebrow="Support" title="Revenue Watch" className="border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
+              <CompactSignalList items={payload.revenueWatch} />
+              <MiniSparkline data={payload.trend} dataKey="revenue" />
+            </DashboardPanel>
           </div>
-        </DashboardPanel>
+        </section>
 
-        <DashboardPanel eyebrow="Row B" title="Technician / Throughput Performance" className="xl:col-span-4">
-          <div className="space-y-2">
-            {payload.technicianPerformance.map((tech) => (
-              <div key={tech.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
-                <div className="flex items-center justify-between text-xs">
-                  <span className="font-semibold text-white">{tech.label}</span>
-                  <span className="text-neutral-300">{tech.completed} completed</span>
+        <aside className="space-y-2.5">
+          <DashboardPanel eyebrow="Risk Rail" title="Optimization / Revenue Risk Signals" className="border-amber-300/30 bg-[linear-gradient(150deg,rgba(36,22,8,0.42),rgba(8,11,24,0.84))]">
+            <CompactSignalList items={payload.businessSignals} />
+            <div className="mt-3 space-y-1.5">
+              {payload.optimizationSummary.map((item) => (
+                <div
+                  key={item.label}
+                  className="rounded-lg border px-2.5 py-2"
+                  style={{
+                    borderColor: item.tone === "critical" ? "rgba(239,68,68,0.35)" : item.tone === "warning" ? "rgba(245,158,11,0.35)" : "rgba(148,163,184,0.25)",
+                    background: item.tone === "critical" ? "rgba(127,29,29,0.16)" : item.tone === "warning" ? "rgba(120,53,15,0.15)" : "rgba(15,23,42,0.42)",
+                  }}
+                >
+                  <div className="text-xs font-semibold text-white">{item.label}</div>
+                  <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
                 </div>
-                <div className="mt-1 text-[11px] text-neutral-400">{tech.pace}</div>
-                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
-                  <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
-                </div>
-              </div>
-            ))}
-          </div>
-        </DashboardPanel>
+              ))}
+            </div>
+          </DashboardPanel>
 
-        <DashboardPanel eyebrow="Row B" title="Revenue Watch" className="xl:col-span-4">
-          <CompactSignalList items={payload.revenueWatch} />
-          <MiniSparkline data={payload.trend} dataKey="revenue" />
-        </DashboardPanel>
-
-        <DashboardPanel
-          eyebrow="Row B"
-          title="Business Risk / Opportunity"
-          className="xl:col-span-4"
-          action={<Link href="/dashboard/operations" className="text-xs text-neutral-300 hover:text-white">Operations view</Link>}
-        >
-          <CompactSignalList items={payload.businessSignals} />
-          <MiniSparkline data={payload.trend} dataKey="profit" />
-        </DashboardPanel>
+          <DashboardPanel
+            eyebrow="Opportunity"
+            title="Business Risk / Opportunity"
+            className="border-white/10 bg-[linear-gradient(155deg,rgba(2,6,23,0.7),rgba(7,10,18,0.6))]"
+            action={<Link href="/dashboard/operations" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Operations view <ChevronRight className="h-3 w-3" /></Link>}
+          >
+            <CompactSignalList items={payload.businessSignals} />
+            <MiniSparkline data={payload.trend} dataKey="profit" />
+          </DashboardPanel>
+        </aside>
       </div>
 
       {payload.sectionErrors.length > 0 ? (


### PR DESCRIPTION
### Motivation
- Make the operations dashboard read as a single continuous command surface by softening internal panel seams, relying more on spacing and tone, and reducing inner border contrast.
- Give the Live Work area stronger visual authority so operators can scan and act quickly by increasing contrast, tightening row density/padding, and emphasizing hover/interaction.
- Clarify right-rail urgency so users can instantly parse critical alerts vs actions vs suggestions and align the Performance dashboard to the same cockpit system language.

### Description
- Extended primitives in `app/dashboard/_components/DashboardPrimitives.tsx`: added `MetricStrip` `className` support, softened `DashboardPanel` background tone, and added an `ActionRow` `emphasis` mode to support subtle/passive action styling.
- Polished the operations surface in `app/dashboard/_components/OperationsDashboardView.tsx`: reduced vertical gaps, unified the command-plane background, tightened Live Work rows (`space-y-1`, reduced row padding), increased job label weight, strengthened row hover/interaction (lift, glow, chevrons), and harmonized inner card tones.
- Reworked the right rail ordering and visuals: separated `High Impact Alerts` (highest contrast red/orange treatment), `Action Rail` (medium emphasis), and `Suggested Actions` (lowest/passive) with subtle separators and adjusted backgrounds for clear hierarchy.
- Aligned `app/dashboard/_components/PerformanceDashboardView.tsx` to the same visual system by grouping cards into a cohesive surface, elevating the trend panel as the dominant zone, and treating risk/optimization panels as a right rail with matching spacing and tones.
- Files changed: `app/dashboard/_components/DashboardPrimitives.tsx`, `app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/PerformanceDashboardView.tsx`.

### Testing
- Ran `npx tsc --noEmit` and type checking passed successfully.
- Ran `npm run lint -- app/dashboard/_components/DashboardPrimitives.tsx app/dashboard/_components/OperationsDashboardView.tsx app/dashboard/_components/PerformanceDashboardView.tsx` which completed but reported pre-existing repo-wide lint errors/warnings outside this change set (no new lint issues were introduced by these edits).
- No route, data-fetching, or architectural changes were made, and visual-only adjustments were confined to the three files listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc5183da083288608f44ee65f1f98)