### PR TITLE
Polish Operations/Performance dashboard surfaces and fix part status warning

### DIFF
--- a/app/dashboard/_components/DashboardViewSwitcher.tsx
+++ b/app/dashboard/_components/DashboardViewSwitcher.tsx
@@ -19,10 +19,7 @@ const DASHBOARD_VIEW_ROUTE: Record<DashboardView, string> = {
 
 export default function DashboardViewSwitcher({ currentView }: Props) {
   return (
-    <nav
-      className="inline-flex rounded-full border border-white/10 bg-black/20 p-1"
-      aria-label="Dashboard view"
-    >
+    <nav className="inline-flex items-center gap-1.5 rounded-lg border border-white/5 bg-black/15 px-1.5 py-1" aria-label="Dashboard view">
       {(Object.keys(DASHBOARD_VIEW_LABEL) as DashboardView[]).map((view) => {
         const active = view === currentView;
 
@@ -34,14 +31,15 @@ export default function DashboardViewSwitcher({ currentView }: Props) {
               window.localStorage.setItem(DASHBOARD_LAST_VIEW_KEY, view);
             }}
             aria-current={active ? "page" : undefined}
-            className="rounded-full px-3 py-1.5 text-xs font-semibold transition"
+            className="rounded-md px-3 py-1.5 text-xs font-semibold transition"
             style={{
               color: active
                 ? "var(--theme-text-primary,#F8FAFC)"
                 : "var(--theme-text-secondary,#94A3B8)",
               background: active
-                ? "color-mix(in srgb, var(--brand-accent,#E39A6E) 24%, transparent)"
+                ? "color-mix(in srgb, var(--brand-accent,#E39A6E) 16%, rgba(2,6,23,0.35))"
                 : "transparent",
+              boxShadow: active ? "inset 0 -1px 0 color-mix(in srgb, var(--brand-accent,#E39A6E) 70%, transparent)" : "none",
             }}
           >
             {view === "operations" ? "Operations" : "Performance"}

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -5,6 +5,15 @@ import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOp
 import { ActionRow, CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
 import { ShopLoadChart } from "./OperationsCharts";
 
+function EmbeddedEmptyState({ label, detail }: { label: string; detail: string }) {
+  return (
+    <div className="rounded-lg border border-white/5 bg-black/15 px-3 py-2.5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-400">{label}</div>
+      <div className="mt-1 text-xs text-neutral-500">{detail}</div>
+    </div>
+  );
+}
+
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
@@ -74,16 +83,16 @@ export default async function OperationsDashboardView() {
           ) : null}
 
           <div
-            className="space-y-2 rounded-[22px] border border-white/10 p-2.5 md:p-3"
+            className="space-y-1.5 rounded-[22px] border border-white/5 p-2.5 md:p-3"
             style={{
-              background: "linear-gradient(160deg, rgba(4,8,20,0.9), rgba(8,14,30,0.72) 45%, rgba(4,10,24,0.8))",
-              boxShadow: "inset 0 1px 0 rgba(148,163,184,0.1), 0 20px 40px rgba(0,0,0,0.28)",
+              background: "linear-gradient(158deg, rgba(4,8,20,0.92), rgba(8,14,30,0.78) 48%, rgba(4,10,24,0.86))",
+              boxShadow: "inset 0 1px 0 rgba(148,163,184,0.06), 0 16px 28px rgba(0,0,0,0.24)",
             }}
           >
-            <div className="grid gap-2 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
+            <div className="grid gap-1.5 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
             <DashboardPanel
               title="Live Work Command Surface"
-              className="min-h-[330px] border-white/10 bg-[linear-gradient(155deg,rgba(9,16,34,0.92),rgba(8,14,29,0.82))]"
+              className="min-h-[330px] border-white/5 bg-[linear-gradient(155deg,rgba(7,13,28,0.9),rgba(8,14,30,0.78))]"
               action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open board <ArrowRight className="h-3 w-3" /></Link>}
             >
               <div className="grid h-full gap-2.5 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
@@ -106,7 +115,10 @@ export default async function OperationsDashboardView() {
                       </Link>
                     ))
                   ) : (
-                    <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs text-neutral-400">No active jobs currently in motion.</div>
+                    <EmbeddedEmptyState
+                      label="Live work idle"
+                      detail="No active jobs are currently in motion."
+                    />
                   )}
                 </div>
                 <div className="space-y-1">
@@ -130,13 +142,16 @@ export default async function OperationsDashboardView() {
                       </Link>
                     ))
                   ) : (
-                    <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs text-neutral-400">Flow mix will populate as stages progress.</div>
+                    <EmbeddedEmptyState
+                      label="Flow signal pending"
+                      detail="Stage mix will appear as work transitions through the board."
+                    />
                   )}
                 </div>
               </div>
             </DashboardPanel>
 
-            <DashboardPanel title="Active Job Summary" className="min-h-[330px] border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
+            <DashboardPanel title="Active Job Summary" className="min-h-[330px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
               <div className="space-y-2.5">
                 {payload.activeJobSummary.map((metric) => (
                   <div key={metric.label} className="rounded-lg border border-white/5 bg-black/15 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
@@ -156,14 +171,14 @@ export default async function OperationsDashboardView() {
             </DashboardPanel>
           </div>
 
-            <div className="grid gap-2 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
-            <DashboardPanel title="Live Shop Load" className="min-h-[252px] border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
+            <div className="grid gap-1.5 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
+            <DashboardPanel title="Live Shop Load" className="min-h-[252px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
               <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
             </DashboardPanel>
 
             <DashboardPanel
               title="Daily Summary"
-              className="border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]"
+              className="border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]"
               action={<Link href="/dashboard/bookings" className="text-xs text-neutral-300 hover:text-white">Open</Link>}
             >
               <div className="space-y-1.5">

--- a/app/dashboard/_components/PerformanceDashboardView.tsx
+++ b/app/dashboard/_components/PerformanceDashboardView.tsx
@@ -5,6 +5,24 @@ import { getPerformanceDashboardPayload } from "@/features/dashboard/server/getP
 import { CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
 import PerformanceTrendPanel, { MiniSparkline } from "./PerformanceTrendPanel";
 
+function EmbeddedEmptyState({
+  label,
+  detail,
+  hint,
+}: {
+  label: string;
+  detail: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/5 bg-black/15 px-3 py-2.5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-400">{label}</div>
+      <div className="mt-1 text-xs text-neutral-500">{detail}</div>
+      {hint ? <div className="mt-1.5 text-[11px] text-neutral-500">{hint}</div> : null}
+    </div>
+  );
+}
+
 export default async function PerformanceDashboardView() {
   const payload = await getPerformanceDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
@@ -33,61 +51,89 @@ export default async function PerformanceDashboardView() {
       />
 
       <div
-        className="grid gap-2 rounded-[22px] border border-white/10 p-2.5 md:p-3 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)]"
+        className="grid gap-2 rounded-[22px] border border-white/5 p-2.5 md:p-3 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)]"
         style={{
-          background: "linear-gradient(160deg, rgba(4,8,20,0.9), rgba(8,14,30,0.72) 45%, rgba(4,10,24,0.8))",
-          boxShadow: "inset 0 1px 0 rgba(148,163,184,0.1), 0 20px 40px rgba(0,0,0,0.28)",
+          background: "linear-gradient(158deg, rgba(4,8,20,0.92), rgba(8,14,30,0.78) 48%, rgba(4,10,24,0.86))",
+          boxShadow: "inset 0 1px 0 rgba(148,163,184,0.06), 0 16px 28px rgba(0,0,0,0.24)",
         }}
       >
-        <section className="space-y-2">
-          <DashboardPanel eyebrow="Primary" title="Trend / Performance Charts" className="border-white/10 min-h-[338px] bg-[linear-gradient(155deg,rgba(9,16,34,0.92),rgba(8,14,29,0.82))]">
+        <section className="space-y-1.5">
+          <DashboardPanel eyebrow="Primary" title="Trend / Performance Charts" className="border-white/5 min-h-[338px] bg-[linear-gradient(155deg,rgba(7,13,28,0.9),rgba(8,14,30,0.78))]">
             <PerformanceTrendPanel data={payload.trend} />
           </DashboardPanel>
 
-          <div className="grid gap-2 md:grid-cols-2">
-            <DashboardPanel eyebrow="Support" title="Technician / Throughput Performance" className="border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
-              <div className="space-y-1.5">
-                {payload.technicianPerformance.map((tech) => (
-                  <div key={tech.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="font-semibold text-white">{tech.label}</span>
-                      <span className="text-neutral-300">{tech.completed} completed</span>
+          <div className="grid gap-1.5 md:grid-cols-2">
+            <DashboardPanel eyebrow="Support" title="Technician / Throughput Performance" className="border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
+              {payload.technicianPerformance.length > 0 ? (
+                <div className="space-y-1.5">
+                  {payload.technicianPerformance.map((tech) => (
+                    <div key={tech.label} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="font-semibold text-white">{tech.label}</span>
+                        <span className="text-neutral-300">{tech.completed} completed</span>
+                      </div>
+                      <div className="mt-1 text-[11px] text-neutral-400">{tech.pace}</div>
+                      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                        <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
+                      </div>
                     </div>
-                    <div className="mt-1 text-[11px] text-neutral-400">{tech.pace}</div>
-                    <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
-                      <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
-                    </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              ) : (
+                <EmbeddedEmptyState
+                  label="Throughput standby"
+                  detail="Technician throughput data will appear after completed line activity is recorded."
+                  hint="Tip: closing current jobs will start this signal."
+                />
+              )}
             </DashboardPanel>
 
-            <DashboardPanel eyebrow="Support" title="Revenue Watch" className="border-white/5 bg-[linear-gradient(155deg,rgba(6,11,24,0.8),rgba(9,14,28,0.7))]">
-              <CompactSignalList items={payload.revenueWatch} />
-              <MiniSparkline data={payload.trend} dataKey="revenue" />
+            <DashboardPanel eyebrow="Support" title="Revenue Watch" className="border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
+              {payload.revenueWatch.length > 0 ? (
+                <>
+                  <CompactSignalList items={payload.revenueWatch} />
+                  <MiniSparkline data={payload.trend} dataKey="revenue" />
+                </>
+              ) : (
+                <EmbeddedEmptyState
+                  label="Revenue watch idle"
+                  detail="Monthly revenue comparisons will populate as billing periods close."
+                />
+              )}
             </DashboardPanel>
           </div>
         </section>
 
-        <aside className="space-y-2.5">
+        <aside className="space-y-2.5 xl:sticky xl:top-3 xl:self-start">
           <DashboardPanel eyebrow="Risk Rail" title="Optimization / Revenue Risk Signals" className="border-amber-300/30 bg-[linear-gradient(150deg,rgba(36,22,8,0.42),rgba(8,11,24,0.84))]">
-            <CompactSignalList items={payload.businessSignals} />
-            <div className="mt-3 space-y-1.5">
-              {payload.optimizationSummary.map((item) => (
-                <div
-                  key={item.label}
-                  className="rounded-lg border px-2.5 py-2"
-                  style={{
-                    borderColor: item.tone === "critical" ? "rgba(239,68,68,0.35)" : item.tone === "warning" ? "rgba(245,158,11,0.35)" : "rgba(148,163,184,0.25)",
-                    background: item.tone === "critical" ? "rgba(127,29,29,0.16)" : item.tone === "warning" ? "rgba(120,53,15,0.15)" : "rgba(15,23,42,0.42)",
-                  }}
-                >
-                  <div className="text-xs font-semibold text-white">{item.label}</div>
-                  <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
+            {payload.businessSignals.length > 0 ? (
+              <>
+                <CompactSignalList items={payload.businessSignals} />
+                <div className="mt-3 space-y-1.5">
+                  {payload.optimizationSummary.map((item) => (
+                    <div
+                      key={item.label}
+                      className="rounded-lg border px-2.5 py-2"
+                      style={{
+                        borderColor: item.tone === "critical" ? "rgba(239,68,68,0.35)" : item.tone === "warning" ? "rgba(245,158,11,0.35)" : "rgba(148,163,184,0.25)",
+                        background: item.tone === "critical" ? "rgba(127,29,29,0.16)" : item.tone === "warning" ? "rgba(120,53,15,0.15)" : "rgba(15,23,42,0.42)",
+                      }}
+                    >
+                      <div className="text-xs font-semibold text-white">{item.label}</div>
+                      <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
+              </>
+            ) : (
+              <EmbeddedEmptyState
+                label="Risk rail stable"
+                detail="Optimization and risk indicators will publish as board risk signals are detected."
+              />
+            )}
           </DashboardPanel>
+
+          <div className="h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
           <DashboardPanel
             eyebrow="Opportunity"
@@ -95,8 +141,17 @@ export default async function PerformanceDashboardView() {
             className="border-white/10 bg-[linear-gradient(155deg,rgba(2,6,23,0.7),rgba(7,10,18,0.6))]"
             action={<Link href="/dashboard/operations" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Operations view <ChevronRight className="h-3 w-3" /></Link>}
           >
-            <CompactSignalList items={payload.businessSignals} />
-            <MiniSparkline data={payload.trend} dataKey="profit" />
+            {payload.businessSignals.length > 0 ? (
+              <>
+                <CompactSignalList items={payload.businessSignals} />
+                <MiniSparkline data={payload.trend} dataKey="profit" />
+              </>
+            ) : (
+              <EmbeddedEmptyState
+                label="Opportunity feed waiting"
+                detail="Business opportunities will appear once trend and risk data reaches signal thresholds."
+              />
+            )}
           </DashboardPanel>
         </aside>
       </div>

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -2,7 +2,7 @@ import { endOfDay, startOfDay, startOfMonth } from "date-fns";
 
 import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
 
-const CLOSED_PART_STATUSES = ["fulfilled", "rejected", "cancelled"] as const;
+const OPEN_PART_STATUSES = ["requested", "quoted", "approved"] as const;
 const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
 
 type OpSignal = { label: string; value: string; tone?: "default" | "accent" };
@@ -135,7 +135,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       .from("part_requests")
       .select("id,status", { count: "exact" })
       .eq("shop_id", identity.shopId)
-      .not("status", "in", `(${CLOSED_PART_STATUSES.map((status) => `'${status}'`).join(",")})`)
+      .in("status", OPEN_PART_STATUSES as unknown as string[])
       .limit(120),
     supabase
       .from("profiles")

--- a/features/shared/components/tabs/TabsBar.tsx
+++ b/features/shared/components/tabs/TabsBar.tsx
@@ -16,9 +16,11 @@ export default function TabsBar() {
     useTabs();
 
   const pathname = usePathname() || "/";
+  const isDashboardRoute =
+    pathname === "/dashboard" || pathname.startsWith("/dashboard/");
 
-  // ❌ Never show tabs on auth routes
-  if (AUTH_ROUTES.has(pathname)) {
+  // ❌ Never show tabs on auth routes or polished dashboard surfaces
+  if (AUTH_ROUTES.has(pathname) || isDashboardRoute) {
     return null;
   }
 


### PR DESCRIPTION
### Motivation
- Remove workspace/tab chrome that makes the dashboard feel like a dev workspace and tighten the product navigation for Operations/Performance.
- Soften panel seams and unify background/spacing so the Operations command plane reads as a single continuous surface while preserving layout.
- Bring the Performance view into the same visual family as Operations so it reads as an executive mode of the same cockpit.
- Ensure empty/low-data areas feel intentional and fix the surfaced enum warning coming from part request status filtering at the source.

### Description
- Suppress the workspace-style tabs bar on dashboard routes so developer tab chrome (including close controls) is not shown on `/dashboard` surfaces; file: `features/shared/components/tabs/TabsBar.tsx`.
- Refined the Operations/Performance switch visuals to a subtler product navigation treatment (softer pill, lower-contrast active state); file: `app/dashboard/_components/DashboardViewSwitcher.tsx`.
- Soften internal seams, lower border contrast, tighten spacing and unify gradients across the Operations command plane while preserving all composition and column structure; file: `app/dashboard/_components/OperationsDashboardView.tsx`.
- Align Performance visual language to Operations (matching surface continuity, right-rail behavior, density and spacing) without changing layout or data orchestration; file: `app/dashboard/_components/PerformanceDashboardView.tsx`.
- Add compact, unobtrusive embedded empty states (label + subtle supporting text + optional hint) for low-data panels in both Operations and Performance (examples: Live Work, Flow mix, Technician/Throughput Performance, Revenue Watch, Risk / Opportunity rails); files: `app/dashboard/_components/OperationsDashboardView.tsx` and `app/dashboard/_components/PerformanceDashboardView.tsx`.
- Fix the invalid-part-status warning at the source by changing the parts query to include canonical open statuses instead of excluding closed literals (use `requested`, `quoted`, `approved`); file: `features/dashboard/server/getOperationsDashboardPayload.ts` (replaced closed-status exclusion with `OPEN_PART_STATUSES`).
- Files changed: `features/shared/components/tabs/TabsBar.tsx`, `app/dashboard/_components/DashboardViewSwitcher.tsx`, `app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/PerformanceDashboardView.tsx`, `features/dashboard/server/getOperationsDashboardPayload.ts`.

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript types; result: success.
- Ran `npx eslint` targeting the modified dashboard files (`app/dashboard/_components/DashboardViewSwitcher.tsx`, `app/dashboard/_components/OperationsDashboardView.tsx`, `app/dashboard/_components/PerformanceDashboardView.tsx`, `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/shared/components/tabs/TabsBar.tsx`); result: success for the scoped files.
- Ran the full repository lint `npm run lint`; result: failed due to pre-existing repo-wide lint errors unrelated to this change (no lint errors were introduced by this patch).

If you want, I can tighten any of the copy for empty states, further reduce contrast, or run additional focused checks on other dashboard variants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcb07ac008328a075220a1c18c125)