### PR TITLE
Micro-polish dashboard: density, affordance, and severity signaling

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -63,7 +63,13 @@ export function MetricStrip({
   items,
   className,
 }: {
-  items: Array<{ label: string; value: string; tone?: "default" | "accent" }>;
+  items: Array<{
+    label: string;
+    value: string;
+    tone?: "default" | "accent";
+    indicator?: "red" | "amber" | "accent";
+    pulse?: boolean;
+  }>;
   className?: string;
 }) {
   return (
@@ -84,7 +90,20 @@ export function MetricStrip({
               style={{ background: "linear-gradient(to bottom, transparent, rgba(148,163,184,0.35), transparent)" }}
             />
           ) : null}
-          <div className="text-[10px] uppercase tracking-[0.14em] text-neutral-400">{item.label}</div>
+          <div className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.14em] text-neutral-400">
+            <span>{item.label}</span>
+            {item.indicator ? (
+              <span
+                className={`inline-block h-1.5 w-1.5 rounded-full ${
+                  item.indicator === "red"
+                    ? "bg-red-400/90 shadow-[0_0_8px_rgba(248,113,113,0.45)]"
+                    : item.indicator === "amber"
+                      ? "bg-amber-300/90 shadow-[0_0_7px_rgba(245,158,11,0.35)]"
+                      : "bg-[var(--brand-accent,#E39A6E)]/90 shadow-[0_0_7px_rgba(227,154,110,0.35)]"
+                } ${item.pulse ? "animate-pulse" : ""}`}
+              />
+            ) : null}
+          </div>
           <div
             className={
               item.tone === "accent"

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -14,6 +14,12 @@ function EmbeddedEmptyState({ label, detail }: { label: string; detail: string }
   );
 }
 
+function getCountSeverity(count: number): "neutral" | "amber" | "red" {
+  if (count > 50) return "red";
+  if (count > 20) return "amber";
+  return "neutral";
+}
+
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
@@ -52,9 +58,25 @@ export default async function OperationsDashboardView() {
         className="mb-0.5"
         items={[
           { label: "Active jobs", value: String(payload.topSummary.activeJobs) },
-          { label: "Blocked", value: String(payload.topSummary.blockedJobs), tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default" },
-          { label: "Approvals", value: String(payload.topSummary.waitingApprovals), tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default" },
-          { label: "Waiting parts", value: String(payload.topSummary.waitingParts), tone: payload.topSummary.waitingParts > 0 ? "accent" : "default" },
+          {
+            label: "Blocked",
+            value: String(payload.topSummary.blockedJobs),
+            tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default",
+            indicator: payload.topSummary.blockedJobs > 0 ? "red" : undefined,
+            pulse: payload.topSummary.blockedJobs > 0,
+          },
+          {
+            label: "Approvals",
+            value: String(payload.topSummary.waitingApprovals),
+            tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
+            indicator: payload.topSummary.waitingApprovals > 0 ? "accent" : undefined,
+          },
+          {
+            label: "Waiting parts",
+            value: String(payload.topSummary.waitingParts),
+            tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
+            indicator: payload.topSummary.waitingParts > 0 ? "amber" : undefined,
+          },
         ]}
       />
 
@@ -96,16 +118,16 @@ export default async function OperationsDashboardView() {
               action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open board <ArrowRight className="h-3 w-3" /></Link>}
             >
               <div className="grid h-full gap-2.5 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-                <div className="space-y-1">
+                <div className="space-y-0.5">
                   {payload.liveWork.length > 0 ? (
                     payload.liveWork.map((item) => (
                       <Link
                         key={item.id}
                         href={`/work-orders/${item.id}`}
-                        className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/25 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/60 hover:bg-black/45 hover:shadow-[0_0_0_1px_rgba(227,154,110,0.2),0_8px_20px_rgba(0,0,0,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                        className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/25 px-2.5 py-[0.32rem] text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/60 hover:bg-black/45 hover:shadow-[0_0_0_1px_rgba(227,154,110,0.2),0_8px_20px_rgba(0,0,0,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                       >
                         <div>
-                          <div className="font-bold tracking-wide text-white">{item.label}</div>
+                          <div className="font-extrabold tracking-wide text-white/95">{item.label}</div>
                           <div className="text-neutral-400">{item.stage}</div>
                         </div>
                         <div className="flex items-center gap-1.5">
@@ -268,7 +290,7 @@ export default async function OperationsDashboardView() {
                   <Link
                     key={alert.label}
                     href={alertHrefByLabel[alert.label] ?? "/work-orders/board"}
-                    className="group block rounded-lg border p-2 transition hover:-translate-y-px hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                    className="group block rounded-lg border p-2 transition hover:-translate-y-0.5 hover:brightness-[1.14] hover:shadow-[0_0_0_1px_rgba(248,113,113,0.26),0_12px_24px_rgba(0,0,0,0.36)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                     style={{
                       borderColor: alert.tone === "critical" ? "rgba(248,113,113,0.7)" : alert.tone === "warning" ? "rgba(251,191,36,0.48)" : "rgba(148,163,184,0.25)",
                       background: alert.tone === "critical" ? "linear-gradient(120deg, rgba(127,29,29,0.48), rgba(69,10,10,0.24))" : alert.tone === "warning" ? "rgba(120,53,15,0.24)" : "rgba(15,23,42,0.5)",
@@ -280,7 +302,7 @@ export default async function OperationsDashboardView() {
                         {alert.tone === "critical" ? <TriangleAlert className="h-3.5 w-3.5 text-red-300" /> : <AlertTriangle className="h-3.5 w-3.5 text-amber-300" />}
                         {alert.label}
                       </span>
-                      <ChevronRight className="h-3.5 w-3.5 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                      <ChevronRight className="h-3.5 w-3.5 text-neutral-400 transition duration-200 group-hover:translate-x-1 group-hover:scale-110 group-hover:text-[var(--brand-accent,#E39A6E)]" />
                     </div>
                     <div className="mt-1 text-[11px] text-neutral-300">{alert.detail}</div>
                   </Link>
@@ -293,17 +315,37 @@ export default async function OperationsDashboardView() {
             <DashboardPanel title="Action Rail" eyebrow="Urgency" className="border-amber-300/30 bg-[linear-gradient(150deg,rgba(36,22,8,0.42),rgba(8,11,24,0.84))]">
               <div className="space-y-1.5">
                 {payload.blockerStack.map((blocker) => (
-                  <Link
-                    key={blocker.label}
-                    href={blockerHrefByLabel[blocker.label] ?? "/work-orders/board"}
-                    className="group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
-                  >
-                    <span className="text-neutral-300">{blocker.label}</span>
-                    <span className={blocker.tone === "accent" ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]" : "inline-flex items-center gap-1 font-semibold text-white"}>
-                      {blocker.value}
-                      <ChevronRight className="h-3 w-3 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                    </span>
-                  </Link>
+                  (() => {
+                    const count = Number.parseInt(blocker.value, 10);
+                    const severity = Number.isFinite(count) ? getCountSeverity(count) : "neutral";
+                    const valueClass =
+                      severity === "red"
+                        ? "inline-flex items-center gap-1 font-semibold text-red-300"
+                        : severity === "amber"
+                          ? "inline-flex items-center gap-1 font-semibold text-amber-300"
+                          : blocker.tone === "accent"
+                            ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]"
+                            : "inline-flex items-center gap-1 font-semibold text-white";
+                    const rowClass =
+                      severity === "red"
+                        ? "group flex items-center justify-between rounded-lg border border-red-400/35 bg-red-950/20 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-red-300/60 hover:bg-red-950/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300/50"
+                        : severity === "amber"
+                          ? "group flex items-center justify-between rounded-lg border border-amber-300/30 bg-amber-950/10 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-amber-300/55 hover:bg-amber-950/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/45"
+                          : "group flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-black/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60";
+                    return (
+                      <Link
+                        key={blocker.label}
+                        href={blockerHrefByLabel[blocker.label] ?? "/work-orders/board"}
+                        className={rowClass}
+                      >
+                        <span className="text-neutral-300">{blocker.label}</span>
+                        <span className={valueClass}>
+                          {blocker.value}
+                          <ChevronRight className="h-3 w-3 text-neutral-500 transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                        </span>
+                      </Link>
+                    );
+                  })()
                 ))}
               </div>
             </DashboardPanel>

--- a/app/dashboard/_components/PerformanceDashboardView.tsx
+++ b/app/dashboard/_components/PerformanceDashboardView.tsx
@@ -23,6 +23,15 @@ function EmbeddedEmptyState({
   );
 }
 
+function riskHrefForLabel(label: string): string {
+  const normalized = label.toLowerCase();
+  if (normalized.includes("comeback") || normalized.includes("warranty")) return "/work-orders/board?stage=comeback";
+  if (normalized.includes("on-hold") || normalized.includes("on hold") || normalized.includes("blocked")) return "/work-orders/board?stage=on_hold";
+  if (normalized.includes("approval")) return "/work-orders/board?stage=awaiting_approval";
+  if (normalized.includes("parts")) return "/parts/requests";
+  return "/dashboard/owner/reports";
+}
+
 export default async function PerformanceDashboardView() {
   const payload = await getPerformanceDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
@@ -111,17 +120,21 @@ export default async function PerformanceDashboardView() {
                 <CompactSignalList items={payload.businessSignals} />
                 <div className="mt-3 space-y-1.5">
                   {payload.optimizationSummary.map((item) => (
-                    <div
+                    <Link
                       key={item.label}
-                      className="rounded-lg border px-2.5 py-2"
+                      href={riskHrefForLabel(item.label)}
+                      className="group flex items-start justify-between gap-2 rounded-lg border px-2.5 py-2 transition hover:-translate-y-0.5 hover:brightness-110 hover:shadow-[0_0_0_1px_rgba(148,163,184,0.18),0_10px_18px_rgba(0,0,0,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                       style={{
                         borderColor: item.tone === "critical" ? "rgba(239,68,68,0.35)" : item.tone === "warning" ? "rgba(245,158,11,0.35)" : "rgba(148,163,184,0.25)",
                         background: item.tone === "critical" ? "rgba(127,29,29,0.16)" : item.tone === "warning" ? "rgba(120,53,15,0.15)" : "rgba(15,23,42,0.42)",
                       }}
                     >
-                      <div className="text-xs font-semibold text-white">{item.label}</div>
-                      <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
-                    </div>
+                      <div>
+                        <div className="text-xs font-semibold text-white">{item.label}</div>
+                        <div className="mt-1 text-[11px] text-neutral-300">{item.detail}</div>
+                      </div>
+                      <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-neutral-400 transition duration-200 group-hover:translate-x-1 group-hover:scale-110 group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                    </Link>
                   ))}
                 </div>
               </>


### PR DESCRIPTION
### Motivation
- Make the Operations and Performance dashboards faster to scan by tightening list density and increasing key-label contrast. 
- Improve click affordance for high-impact alerts so they clearly read as “act now” without changing layout or routing. 
- Surface numeric severity on count-based action rows and KPIs with subtle visual cues so operators can triage at a glance. 

### Description
- Tightened Live Work list density in `app/dashboard/_components/OperationsDashboardView.tsx` by reducing vertical stacking from `space-y-1` to `space-y-0.5` and row padding from `py-1.5` to `py-[0.32rem]`, and increased job-id emphasis with `font-extrabold text-white/95` for faster scanning. 
- Strengthened High Impact Alerts hover affordance by increasing lift and glow (`hover:-translate-y-0.5`, brighter hover/shadow) and making the chevron more visible and animated on hover in `OperationsDashboardView.tsx`. 
- Added numeric severity thresholds via `getCountSeverity` in `OperationsDashboardView.tsx` and applied severity-aware styling to Action Rail rows so counts `>20` render amber and counts `>50` render red with subtle row/border/value treatments. 
- Enhanced KPI strip by extending `MetricStrip` in `app/dashboard/_components/DashboardPrimitives.tsx` to accept `indicator` and `pulse` flags and render tiny, subtle dots (red/amber/accent) next to KPI labels, then wired blocked/approvals/waiting-parts indicators in the Operations view. 
- Made Performance risk items actionable by adding `riskHrefForLabel` and converting Optimization / Revenue Risk Signal rows into `Link` rows with the same hover + chevron affordance used for alerts in `app/dashboard/_components/PerformanceDashboardView.tsx`. 
- No layout structure, routing, or data-fetch changes were made; only interaction, density, and visual signaling were adjusted across `OperationsDashboardView.tsx`, `PerformanceDashboardView.tsx`, and `DashboardPrimitives.tsx`.

### Testing
- Ran type-checking with `npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd0985b308328a367b948d3443565)