### PR TITLE
Polish dashboard deep-links, tab strip, and top navbar interactions

### DIFF
--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -26,21 +26,6 @@ export default async function OperationsDashboardView() {
   const hasTechnicianActivity = payload.technicianActivity.length > 0;
   const hasRightRailSignals = payload.blockerStack.length > 0 || payload.alerts.length > 0 || payload.suggestedActions.length > 0;
 
-  const alertHrefByLabel: Record<string, string> = {
-    "Blocked jobs climbing": "/work-orders/board?stage=on_hold",
-    "Approval queue aging": "/work-orders/board?stage=awaiting_approval",
-    "Parts constraints active": "/parts/requests",
-    "Blocker pressure stable": "/work-orders/board",
-    "Approval queue healthy": "/work-orders/board?stage=awaiting_approval",
-    "No parts constraints": "/parts/requests",
-  };
-
-  const blockerHrefByLabel: Record<string, string> = {
-    "Approvals pending": "/work-orders/board?stage=awaiting_approval",
-    "Waiting parts": "/parts/requests",
-    "On hold / blocked": "/work-orders/board?stage=on_hold",
-  };
-
   return (
     <DashboardShell>
       <DashboardTopStrip
@@ -206,7 +191,9 @@ export default async function OperationsDashboardView() {
               <div className="space-y-1.5">
                 {payload.dailySummary.map((item) => {
                   const href =
-                    item.label === "Today's bookings"
+                    item.href
+                      ? item.href
+                      : item.label === "Today's bookings"
                       ? "/dashboard/bookings"
                       : item.label === "Approval queue"
                         ? "/work-orders/board?stage=awaiting_approval"
@@ -289,7 +276,7 @@ export default async function OperationsDashboardView() {
                 {payload.alerts.map((alert) => (
                   <Link
                     key={alert.label}
-                    href={alertHrefByLabel[alert.label] ?? "/work-orders/board"}
+                    href={alert.href}
                     className="group block rounded-lg border p-2 transition hover:-translate-y-0.5 hover:brightness-[1.14] hover:shadow-[0_0_0_1px_rgba(248,113,113,0.26),0_12px_24px_rgba(0,0,0,0.36)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                     style={{
                       borderColor: alert.tone === "critical" ? "rgba(248,113,113,0.7)" : alert.tone === "warning" ? "rgba(251,191,36,0.48)" : "rgba(148,163,184,0.25)",
@@ -335,7 +322,7 @@ export default async function OperationsDashboardView() {
                     return (
                       <Link
                         key={blocker.label}
-                        href={blockerHrefByLabel[blocker.label] ?? "/work-orders/board"}
+                        href={blocker.href ?? "/work-orders/board"}
                         className={rowClass}
                       >
                         <span className="text-neutral-300">{blocker.label}</span>

--- a/features/assistant/components/AskAssistantEntry.tsx
+++ b/features/assistant/components/AskAssistantEntry.tsx
@@ -185,21 +185,17 @@ export default function AskAssistantEntry({
           type="button"
           title={assistantLabel}
           onClick={() => setOpen(true)}
-          className="inline-flex items-center gap-1 rounded-md border border-white/10 bg-black/60 px-2.5 py-1.5 text-xs text-neutral-100 shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:text-white hover:bg-black/80"
+          className="inline-flex h-8 items-center justify-center rounded-md border border-slate-400/20 bg-slate-950/70 px-2.5 text-xs font-medium text-slate-100 shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)]/60 hover:bg-slate-900/80 hover:text-white"
         >
-          <span aria-hidden>✨</span>
-          <span className="hidden lg:inline">Assistant</span>
-          <span className="lg:hidden">Assistant</span>
+          <span>Assistant</span>
         </button>
 
         <Link
           href={plannerHref}
           title={plannerLabel}
-          className="inline-flex items-center gap-1 rounded-md border border-white/10 bg-black/60 px-2.5 py-1.5 text-xs text-neutral-100 shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:text-white hover:bg-black/80"
+          className="inline-flex h-8 items-center justify-center rounded-md border border-slate-400/20 bg-slate-950/70 px-2.5 text-xs font-medium text-slate-100 shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)]/60 hover:bg-slate-900/80 hover:text-white"
         >
-          <span aria-hidden>⚡</span>
-          <span className="hidden lg:inline">Planner</span>
-          <span className="lg:hidden">Planner</span>
+          <span>Planner</span>
         </Link>
 
         <Dialog open={open} onOpenChange={setOpen}>

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -5,7 +5,13 @@ import { createDashboardServerClient, getDashboardIdentity } from "@/features/da
 const OPEN_PART_STATUSES = ["requested", "quoted", "approved"] as const;
 const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
 
-type OpSignal = { label: string; value: string; tone?: "default" | "accent" };
+type OpSignal = {
+  label: string;
+  value: string;
+  tone?: "default" | "accent";
+  href?: string;
+  targetKind?: "item" | "filtered";
+};
 type OpAction = {
   label: string;
   href: string;
@@ -40,7 +46,13 @@ export type OperationsDashboardPayload = {
     utilizationPct: number;
   }>;
   blockerStack: OpSignal[];
-  alerts: Array<{ label: string; detail: string; tone: "critical" | "warning" | "info" }>;
+  alerts: Array<{
+    label: string;
+    detail: string;
+    tone: "critical" | "warning" | "info";
+    href: string;
+    targetKind: "item" | "filtered";
+  }>;
   suggestedActions: OpAction[];
   flowMix: Array<{ label: string; value: number }>;
   revenueEfficiency: {
@@ -128,12 +140,12 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       .limit(48),
     supabase
       .from("work_order_lines")
-      .select("id", { count: "exact", head: true })
+      .select("id,work_order_id,status,updated_at", { count: "exact" })
       .eq("shop_id", identity.shopId)
       .in("approval_state", ["requested", "pending", "awaiting_approval"]),
     supabase
       .from("part_requests")
-      .select("id,status", { count: "exact" })
+      .select("id,status,work_order_id,job_id,created_at", { count: "exact" })
       .eq("shop_id", identity.shopId)
       .in("status", OPEN_PART_STATUSES as unknown as string[])
       .limit(120),
@@ -165,6 +177,10 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
 
   const boardRows = boardResult.error ? [] : boardResult.data ?? [];
   const activeBoardRows = boardRows.filter((row) => row.overall_stage !== "completed");
+  const mostRecentBlockedWorkOrderId =
+    activeBoardRows.find(
+      (row) => row.overall_stage === "waiting_parts" || row.overall_stage === "on_hold",
+    )?.work_order_id ?? null;
 
   if (boardResult.error) {
     payload.sectionErrors.push(`Live work section: ${boardResult.error.message}`);
@@ -226,21 +242,64 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     payload.topSummary.waitingParts = partsResult.count ?? (partsResult.data ?? []).length;
   }
 
+  const recentApprovalLine = approvalsResult.error
+    ? null
+    : (approvalsResult.data ?? [])
+        .filter((row) => !!row.work_order_id)
+        .sort(
+          (a, b) =>
+            new Date(b.updated_at ?? 0).getTime() - new Date(a.updated_at ?? 0).getTime(),
+        )[0] ?? null;
+  const approvalTargetHref = recentApprovalLine?.work_order_id
+    ? `/work-orders/${recentApprovalLine.work_order_id}`
+    : "/work-orders/board?stage=awaiting_approval";
+  const approvalTargetKind: "item" | "filtered" = recentApprovalLine?.work_order_id
+    ? "item"
+    : "filtered";
+
+  const recentPartsRequest = partsResult.error
+    ? null
+    : (partsResult.data ?? [])
+        .filter((row) => !!row.work_order_id)
+        .sort(
+          (a, b) =>
+            new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+        )[0] ?? null;
+  const waitingPartsTargetHref = recentPartsRequest?.work_order_id
+    ? `/work-orders/${recentPartsRequest.work_order_id}`
+    : "/parts/requests?status=requested,quoted,approved";
+  const waitingPartsTargetKind: "item" | "filtered" = recentPartsRequest?.work_order_id
+    ? "item"
+    : "filtered";
+
+  const blockedTargetHref = mostRecentBlockedWorkOrderId
+    ? `/work-orders/${mostRecentBlockedWorkOrderId}`
+    : "/work-orders/board?stage=on_hold";
+  const blockedTargetKind: "item" | "filtered" = mostRecentBlockedWorkOrderId
+    ? "item"
+    : "filtered";
+
   payload.blockerStack = [
     {
       label: "Approvals pending",
       value: String(payload.topSummary.waitingApprovals),
       tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
+      href: approvalTargetHref,
+      targetKind: approvalTargetKind,
     },
     {
       label: "Waiting parts",
       value: String(payload.topSummary.waitingParts),
       tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
+      href: waitingPartsTargetHref,
+      targetKind: waitingPartsTargetKind,
     },
     {
       label: "On hold / blocked",
       value: String(payload.topSummary.blockedJobs),
       tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default",
+      href: blockedTargetHref,
+      targetKind: blockedTargetKind,
     },
   ];
 
@@ -250,8 +309,20 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
 
   payload.dailySummary = [
     { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
-    { label: "Approval queue", value: String(payload.topSummary.waitingApprovals), tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default" },
-    { label: "Parts waiting", value: String(payload.topSummary.waitingParts), tone: payload.topSummary.waitingParts > 0 ? "accent" : "default" },
+    {
+      label: "Approval queue",
+      value: String(payload.topSummary.waitingApprovals),
+      tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
+      href: approvalTargetHref,
+      targetKind: approvalTargetKind,
+    },
+    {
+      label: "Parts waiting",
+      value: String(payload.topSummary.waitingParts),
+      tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
+      href: waitingPartsTargetHref,
+      targetKind: waitingPartsTargetKind,
+    },
     { label: "Active board", value: String(payload.topSummary.activeJobs) },
   ];
 
@@ -295,33 +366,45 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           label: "Blocked jobs climbing",
           detail: `${payload.topSummary.blockedJobs} jobs currently in blocked stages.`,
           tone: "critical",
+          href: blockedTargetHref,
+          targetKind: blockedTargetKind,
         }
       : {
           label: "Blocker pressure stable",
           detail: "No blocked stage spike detected.",
           tone: "info",
+          href: "/work-orders/board?stage=on_hold",
+          targetKind: "filtered",
         },
     payload.topSummary.waitingApprovals > 3
       ? {
           label: "Approval queue aging",
           detail: `${payload.topSummary.waitingApprovals} approvals need advisor follow-up.`,
           tone: "warning",
+          href: approvalTargetHref,
+          targetKind: approvalTargetKind,
         }
       : {
           label: "Approval queue healthy",
           detail: "Approval queue is below action threshold.",
           tone: "info",
+          href: "/work-orders/board?stage=awaiting_approval",
+          targetKind: "filtered",
         },
     payload.topSummary.waitingParts > 0
       ? {
           label: "Parts constraints active",
           detail: `${payload.topSummary.waitingParts} open part requests still unresolved.`,
           tone: "warning",
+          href: waitingPartsTargetHref,
+          targetKind: waitingPartsTargetKind,
         }
       : {
           label: "No parts constraints",
           detail: "Parts flow is currently clear.",
           tone: "info",
+          href: "/parts/requests?status=requested,quoted,approved",
+          targetKind: "filtered",
         },
   ];
 
@@ -329,7 +412,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     payload.topSummary.waitingApprovals > 0
       ? {
           label: "Clear approval queue",
-          href: "/work-orders/board?stage=awaiting_approval",
+          href: approvalTargetHref,
           tone: "primary",
           detail: "Prioritize pending approvals to free advisor handoffs.",
         }
@@ -342,7 +425,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     payload.topSummary.waitingParts > 0
       ? {
           label: "Resolve waiting parts",
-          href: "/dashboard/operations?focus=parts",
+          href: waitingPartsTargetHref,
           tone: "primary",
           detail: "Parts backlog is blocking active jobs.",
         }

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -46,12 +46,12 @@ const ActionButton = ({
     type="button"
     onClick={onClick}
     title={title}
-    className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1.5 text-xs shadow-sm backdrop-blur-md transition"
+    className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-2.5 text-xs font-medium shadow-sm backdrop-blur-md transition-colors"
     style={{
-      borderColor: "rgba(255,255,255,0.10)",
+      borderColor: "rgba(148,163,184,0.22)",
       background:
-        "linear-gradient(135deg, rgba(0,0,0,0.55), color-mix(in srgb, var(--brand-secondary, #0F172A) 42%, black))",
-      color: "#f5f5f5",
+        "linear-gradient(145deg, rgba(2,6,23,0.82), color-mix(in srgb, var(--brand-secondary, #0F172A) 58%, rgba(0,0,0,0.92)))",
+      color: "rgb(226,232,240)",
     }}
   >
     {children}
@@ -105,8 +105,6 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const isAppRoute =
     !isPortalRoute &&
     !NON_APP_ROUTES.some((p) => pathname === p || pathname.startsWith(p + "/"));
-
-  const isTech = (userRole ?? "").toLowerCase() === "tech";
 
   const canSeeAgentConsole =
     !!userRole &&
@@ -408,7 +406,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               ) : null}
 
               <ActionButton onClick={() => setChatOpen(true)} title="Messages">
-                💬 <span className="hidden lg:inline">Messages</span>
+                <span>Messages</span>
               </ActionButton>
 
               {userId ? (
@@ -416,16 +414,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                   onClick={() => setAgentDialogOpen(true)}
                   title="Submit a request to ProFixIQ Agent"
                 >
-                  🤖 <span className="hidden lg:inline">Agent Request</span>
-                </ActionButton>
-              ) : null}
-
-              {!isTech ? (
-                <ActionButton
-                  onClick={() => router.push("/agent/planner")}
-                  title="AI Planner"
-                >
-                  ⚡ <span className="hidden lg:inline">AI Planner</span>
+                  <span>Agent Request</span>
                 </ActionButton>
               ) : null}
 
@@ -436,7 +425,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                   onClick={() => router.push("/agent")}
                   title="ProFixIQ Agent Console"
                 >
-                  🧠 <span className="hidden lg:inline">Agent</span>
+                  <span>Agent Console</span>
                 </ActionButton>
               ) : null}
 

--- a/features/shared/components/tabs/TabsBar.tsx
+++ b/features/shared/components/tabs/TabsBar.tsx
@@ -30,17 +30,18 @@ export default function TabsBar() {
     <div
       className="
         sticky top-0 z-30
-        -mt-2
+        -mt-1
         w-full min-w-0
-        border-b border-neutral-800
-        bg-neutral-950/80 backdrop-blur-md
-        px-2
+        border-b border-slate-700/40
+        bg-[linear-gradient(180deg,rgba(2,6,23,0.88),rgba(2,6,23,0.72))]
+        backdrop-blur-xl
+        px-2.5
       "
     >
       <div className="flex min-w-0 items-center gap-2 py-1.5">
         {/* Tabs scroller */}
         <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden [&::-webkit-scrollbar]:hidden">
-          <div className="flex w-max items-center gap-2">
+          <div className="flex w-max items-center gap-1.5">
             <AnimatePresence initial={false}>
               {safeTabs.map((t) => {
                 const active = t.href === activeHref;
@@ -54,29 +55,36 @@ export default function TabsBar() {
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0, scale: 0.95 }}
                     className={`
-                      group inline-flex items-center gap-2 rounded-md border
-                      px-3 py-1 text-sm transition
+                      group inline-flex h-8 items-center gap-1.5 rounded-md border
+                      px-2.5 text-[12px] transition-colors
                       ${
                         active
-                          ? "border-orange-500 bg-neutral-800 text-white"
-                          : "border-neutral-700 bg-neutral-900/60 text-neutral-300 hover:bg-neutral-900"
+                          ? "border-[var(--brand-accent,#E39A6E)]/55 bg-[linear-gradient(140deg,rgba(30,41,59,0.75),rgba(15,23,42,0.95))] text-white shadow-[inset_0_1px_0_rgba(148,163,184,0.22),0_8px_24px_rgba(0,0,0,0.35)]"
+                          : "border-slate-600/40 bg-slate-900/45 text-slate-300 hover:border-slate-500/60 hover:bg-slate-900/70 hover:text-slate-100"
                       }
                     `}
                   >
                     <button
                       type="button"
                       onClick={() => activateTab(t.href)}
-                      className="flex items-center gap-1 max-w-[220px]"
+                      className="flex max-w-[220px] items-center gap-1.5"
                     >
-                      <span className="truncate">{t.title}</span>
-                      {pinned && <span aria-label="Pinned tab">📌</span>}
+                      <span className="truncate leading-none">{t.title}</span>
+                      {pinned && (
+                        <span
+                          aria-label="Default dashboard tab"
+                          className="rounded-sm border border-slate-500/45 px-1 py-[1px] text-[9px] uppercase tracking-[0.12em] text-slate-300"
+                        >
+                          Base
+                        </span>
+                      )}
                     </button>
 
                     {!pinned && (
                       <button
                         type="button"
                         onClick={() => closeTab(t.href)}
-                        className="rounded px-1 text-xs text-neutral-400 hover:text-white"
+                        className="inline-flex h-4 w-4 items-center justify-center rounded text-[11px] leading-none text-slate-400 transition hover:bg-slate-700/55 hover:text-slate-100"
                         aria-label="Close tab"
                       >
                         ✕
@@ -100,14 +108,14 @@ export default function TabsBar() {
           <button
             type="button"
             onClick={() => closeOthers(activeHref)}
-            className="rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-900 hover:text-white"
+            className="inline-flex h-7 items-center rounded-md border border-slate-600/40 px-2 text-[11px] text-slate-300 transition hover:border-slate-500/60 hover:bg-slate-900/80 hover:text-slate-100"
           >
             Close others
           </button>
           <button
             type="button"
             onClick={closeAll}
-            className="rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-900 hover:text-white"
+            className="inline-flex h-7 items-center rounded-md border border-slate-600/40 px-2 text-[11px] text-slate-300 transition hover:border-slate-500/60 hover:bg-slate-900/80 hover:text-slate-100"
           >
             Close all
           </button>


### PR DESCRIPTION
### Motivation
- Make dashboard alerts/actions deep-link to the exact item when possible and refine UI chrome to feel more premium without changing data flows or routing shape.
- Preserve current backend sources and fallback behavior while improving directness of action and visual hierarchy for tabs and header controls.

### Description
- Server: extended `OperationsDashboardPayload` to include link metadata (`href`, `targetKind`) and compute item-aware targets for approvals, parts, and blocked work orders in `features/dashboard/server/getOperationsDashboardPayload.ts`.
- UI: wired High Impact Alerts, Action Rail, Suggested Actions, and Daily Summary rows to use server-provided `href` so full-row clicks deep-link to the most relevant work order when available in `app/dashboard/_components/OperationsDashboardView.tsx`.
- Tabs: redesigned the tabs strip for a slimmer, more premium look with tighter spacing, clearer active state, improved close button sizing/alignment, and a compact pinned/default indicator in `features/shared/components/tabs/TabsBar.tsx`.
- Top navbar: removed duplicate Planner entry and emoji clutter, unified action sizing/padding, and aligned Assistant/Planner header controls to the calmer style in `features/shared/components/AppShell.tsx` and `features/assistant/components/AskAssistantEntry.tsx`.
- Files changed: `features/dashboard/server/getOperationsDashboardPayload.ts`, `app/dashboard/_components/OperationsDashboardView.tsx`, `features/shared/components/tabs/TabsBar.tsx`, `features/shared/components/AppShell.tsx`, `features/assistant/components/AskAssistantEntry.tsx`.
- Which alert/action types now deep-link directly: `Blocked jobs climbing` (to a concrete blocked work order when one exists), `Approval queue aging` (to most recent approval work order when available), `Parts constraints active` (to the related work order when a parts request includes `work_order_id`), `Approvals pending` / `Waiting parts` / `On hold / blocked` (Action Rail entries use computed `href`).
- Which still go to filtered index/list pages and why: healthy/stable informational variants and any rows that are aggregate-only (no `work_order_id` found) intentionally fall back to filtered pages such as `/work-orders/board?stage=awaiting_approval`, `/work-orders/board?stage=on_hold`, or `/parts/requests?status=requested,quoted,approved` because there is no single-item target in the source data.

### Testing
- Ran TypeScript type check with `npx tsc --noEmit` and it succeeded. 
- No other automated tests were modified or required for this UI/interaction polish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd2321c7c8328aa87852a9cec3d3a)