### PR TITLE
Inbox: stronger overlay dominance and refined dashboard tabs

### DIFF
--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -11,7 +11,12 @@ type DB = Database;
 type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
 type ConversationRow = DB["public"]["Tables"]["conversations"]["Row"];
 
-type Participant = { id: string; full_name: string | null; avatar_url?: string | null; role?: string | null };
+type Participant = {
+  id: string;
+  full_name: string | null;
+  avatar_url?: string | null;
+  role?: string | null;
+};
 type ConversationPayload = {
   conversation: ConversationRow;
   latest_message: MessageRow | null;
@@ -19,23 +24,67 @@ type ConversationPayload = {
   unread_count: number;
 };
 
-type Props = { open: boolean; onClose: () => void; seedConversationId?: string | null };
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  seedConversationId?: string | null;
+};
 
-type ComposeContext = { context_type: string | null; context_id: string | null; deep_link: string | null; context_label: string };
+type ComposeContext = {
+  context_type: string | null;
+  context_id: string | null;
+  deep_link: string | null;
+  context_label: string;
+};
 
 function inferContext(pathname: string): ComposeContext {
   const match = (re: RegExp) => pathname.match(re)?.[1] ?? null;
   const workOrderId = match(/^\/work-orders\/([^/]+)/);
-  if (workOrderId) return { context_type: "work_order", context_id: workOrderId, deep_link: `/work-orders/${workOrderId}`, context_label: `Work Order ${workOrderId.slice(0, 8)}` };
+  if (workOrderId)
+    return {
+      context_type: "work_order",
+      context_id: workOrderId,
+      deep_link: `/work-orders/${workOrderId}`,
+      context_label: `Work Order ${workOrderId.slice(0, 8)}`,
+    };
   const inspectionId = match(/^\/inspections\/([^/]+)/);
-  if (inspectionId) return { context_type: "inspection", context_id: inspectionId, deep_link: `/inspections/${inspectionId}`, context_label: `Inspection ${inspectionId.slice(0, 8)}` };
+  if (inspectionId)
+    return {
+      context_type: "inspection",
+      context_id: inspectionId,
+      deep_link: `/inspections/${inspectionId}`,
+      context_label: `Inspection ${inspectionId.slice(0, 8)}`,
+    };
   const bookingId = match(/^\/dashboard\/(?:advisor\/)?bookings\/([^/]+)/);
-  if (bookingId) return { context_type: "booking", context_id: bookingId, deep_link: `/dashboard/bookings/${bookingId}`, context_label: `Booking ${bookingId.slice(0, 8)}` };
+  if (bookingId)
+    return {
+      context_type: "booking",
+      context_id: bookingId,
+      deep_link: `/dashboard/bookings/${bookingId}`,
+      context_label: `Booking ${bookingId.slice(0, 8)}`,
+    };
   const customerId = match(/^\/customers\/([^/]+)/);
-  if (customerId) return { context_type: "customer", context_id: customerId, deep_link: `/customers/${customerId}`, context_label: `Customer ${customerId.slice(0, 8)}` };
+  if (customerId)
+    return {
+      context_type: "customer",
+      context_id: customerId,
+      deep_link: `/customers/${customerId}`,
+      context_label: `Customer ${customerId.slice(0, 8)}`,
+    };
   const vehicleId = match(/^\/vehicles\/([^/]+)/);
-  if (vehicleId) return { context_type: "vehicle", context_id: vehicleId, deep_link: `/vehicles/${vehicleId}`, context_label: `Vehicle ${vehicleId.slice(0, 8)}` };
-  return { context_type: null, context_id: null, deep_link: null, context_label: "General" };
+  if (vehicleId)
+    return {
+      context_type: "vehicle",
+      context_id: vehicleId,
+      deep_link: `/vehicles/${vehicleId}`,
+      context_label: `Vehicle ${vehicleId.slice(0, 8)}`,
+    };
+  return {
+    context_type: null,
+    context_id: null,
+    deep_link: null,
+    context_label: "General",
+  };
 }
 
 function contextHref(conversation: ConversationRow): string | null {
@@ -50,12 +99,18 @@ function contextHref(conversation: ConversationRow): string | null {
   return null;
 }
 
-export default function InboxModal({ open, onClose, seedConversationId = null }: Props): JSX.Element | null {
+export default function InboxModal({
+  open,
+  onClose,
+  seedConversationId = null,
+}: Props): JSX.Element | null {
   const pathname = usePathname() ?? "/dashboard";
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [me, setMe] = useState<string | null>(null);
   const [rows, setRows] = useState<ConversationPayload[]>([]);
-  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(
+    null,
+  );
   const [messages, setMessages] = useState<MessageRow[]>([]);
   const [users, setUsers] = useState<Participant[]>([]);
   const [search, setSearch] = useState("");
@@ -72,7 +127,9 @@ export default function InboxModal({ open, onClose, seedConversationId = null }:
     if (!res.ok) return;
     const data = (await res.json()) as ConversationPayload[];
     setRows(data);
-    setActiveConversationId((curr) => curr ?? seedConversationId ?? data[0]?.conversation.id ?? null);
+    setActiveConversationId(
+      (curr) => curr ?? seedConversationId ?? data[0]?.conversation.id ?? null,
+    );
   }, [seedConversationId]);
 
   useEffect(() => {
@@ -81,35 +138,79 @@ export default function InboxModal({ open, onClose, seedConversationId = null }:
     void loadConversations();
     void fetch("/api/chat/users", { credentials: "include" })
       .then((r) => r.json())
-      .then((json) => setUsers((Array.isArray(json?.users) ? json.users : []).map((u: any) => ({ ...u, avatar_url: u.avatar_url ?? null }))));
+      .then((json) =>
+        setUsers(
+          (Array.isArray(json?.users) ? json.users : []).map((u: any) => ({
+            ...u,
+            avatar_url: u.avatar_url ?? null,
+          })),
+        ),
+      );
   }, [open, supabase, loadConversations]);
 
   useEffect(() => {
     if (!open || !activeConversationId) return;
-    void fetch("/api/chat/get-messages", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ conversationId: activeConversationId }) })
+    void fetch("/api/chat/get-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId: activeConversationId }),
+    })
       .then((r) => r.json())
       .then((data) => {
         setMessages(Array.isArray(data) ? data : []);
-        void fetch("/api/chat/mark-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ conversationId: activeConversationId }) });
+        void fetch("/api/chat/mark-read", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ conversationId: activeConversationId }),
+        });
       });
   }, [open, activeConversationId]);
 
   useEffect(() => {
     if (!open || !activeConversationId) return;
-    const ch = supabase.channel(`inbox-${activeConversationId}`).on("postgres_changes", { event: "INSERT", schema: "public", table: "messages", filter: `conversation_id=eq.${activeConversationId}` }, (payload) => {
-      const message = payload.new as MessageRow;
-      setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
-      void loadConversations();
-    }).subscribe();
-    return () => { supabase.removeChannel(ch); };
+    const ch = supabase
+      .channel(`inbox-${activeConversationId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `conversation_id=eq.${activeConversationId}`,
+        },
+        (payload) => {
+          const message = payload.new as MessageRow;
+          setMessages((prev) =>
+            prev.some((m) => m.id === message.id) ? prev : [...prev, message],
+          );
+          void loadConversations();
+        },
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(ch);
+    };
   }, [open, activeConversationId, supabase, loadConversations]);
 
-  const activeConversation = rows.find((x) => x.conversation.id === activeConversationId) ?? null;
+  useEffect(() => {
+    if (!open) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
+  const activeConversation =
+    rows.find((x) => x.conversation.id === activeConversationId) ?? null;
 
   const visibleRows = rows.filter((row) => {
     const term = search.toLowerCase().trim();
     if (!term) return true;
-    const participantNames = row.participants.map((p) => p.full_name ?? "").join(" ").toLowerCase();
+    const participantNames = row.participants
+      .map((p) => p.full_name ?? "")
+      .join(" ")
+      .toLowerCase();
     const preview = (row.latest_message?.content ?? "").toLowerCase();
     return participantNames.includes(term) || preview.includes(term);
   });
@@ -134,7 +235,10 @@ export default function InboxModal({ open, onClose, seedConversationId = null }:
             participant_ids: selectedRecipients,
             context_type: useContext ? context.context_type : null,
             context_id: useContext ? context.context_id : null,
-            title: useContext && context.context_label !== "General" ? context.context_label : null,
+            title:
+              useContext && context.context_label !== "General"
+                ? context.context_label
+                : null,
             is_broadcast: selectedRecipients.length > 3,
           }),
         });
@@ -147,28 +251,71 @@ export default function InboxModal({ open, onClose, seedConversationId = null }:
       const res = await fetch("/api/chat/send-message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ conversationId, senderId: me, content, metadata: { deep_link: useContext ? context.deep_link : null, context_type: context.context_type, context_id: context.context_id } }),
+        body: JSON.stringify({
+          conversationId,
+          senderId: me,
+          content,
+          metadata: {
+            deep_link: useContext ? context.deep_link : null,
+            context_type: context.context_type,
+            context_id: context.context_id,
+          },
+        }),
       });
       if (res.ok) setCompose("");
     } finally {
       setSending(false);
     }
-  }, [compose, sending, me, activeConversationId, selectedRecipients, useContext, context, loadConversations]);
+  }, [
+    compose,
+    sending,
+    me,
+    activeConversationId,
+    selectedRecipients,
+    useContext,
+    context,
+    loadConversations,
+  ]);
 
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[140] bg-black/65 backdrop-blur-sm" onClick={onClose}>
-      <div className="absolute right-0 top-0 h-full w-full max-w-[1200px] border-l border-[var(--metal-border-soft)] bg-[var(--theme-app-bg,#070b12)] p-3 md:p-4" onClick={(e) => e.stopPropagation()}>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="font-blackops text-sm uppercase tracking-[0.18em] text-[var(--accent-copper-soft)]">Inbox</h2>
-          <button type="button" onClick={onClose} className="rounded border border-[var(--metal-border-soft)] px-2 py-1 text-xs text-neutral-200">Close</button>
+    <div
+      className="fixed inset-0 z-[220] bg-black/82 backdrop-blur-md"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Inbox"
+    >
+      <div
+        className="absolute inset-2 right-2 h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] rounded-2xl border border-[var(--metal-border-soft)] bg-[var(--theme-app-bg,#070b12)]/95 p-2.5 shadow-[0_30px_100px_rgba(0,0,0,0.82)] md:inset-4 md:right-4 md:h-[calc(100vh-2rem)] md:w-[min(1320px,calc(100vw-2rem))] md:p-3"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-2.5 flex items-center justify-between border-b border-[var(--metal-border-soft)]/80 px-1 pb-2">
+          <div>
+            <p className="font-blackops text-sm uppercase tracking-[0.2em] text-[var(--accent-copper-soft)]">
+              Inbox
+            </p>
+            <p className="text-[11px] text-neutral-500">Shop communication center</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-[var(--metal-border-soft)] bg-black/40 px-2 py-1 text-[11px] text-neutral-200 transition hover:bg-white/10"
+          >
+            Close
+          </button>
         </div>
 
-        <div className="grid h-[calc(100vh-90px)] grid-cols-1 gap-3 md:grid-cols-[320px_1fr] xl:grid-cols-[300px_1fr_280px]">
-          <aside className="flex min-h-0 flex-col rounded-xl border border-[var(--metal-border-soft)] bg-black/35">
-            <div className="border-b border-[var(--metal-border-soft)] p-2">
-              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search inbox" className="w-full rounded border border-[var(--metal-border-soft)] bg-black/60 px-2 py-1.5 text-xs" />
+        <div className="grid h-[calc(100%-3.25rem)] grid-cols-1 gap-2.5 md:grid-cols-[290px_1fr] xl:grid-cols-[280px_1fr_230px]">
+          <aside className="flex min-h-0 flex-col rounded-xl border border-[var(--metal-border-soft)]/80 bg-black/35">
+            <div className="border-b border-[var(--metal-border-soft)]/70 p-2">
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search inbox"
+                className="h-8 w-full rounded border border-[var(--metal-border-soft)] bg-black/60 px-2 text-xs"
+              />
             </div>
             <div className="min-h-0 flex-1 overflow-auto">
               {visibleRows.map((row) => {
@@ -179,31 +326,69 @@ export default function InboxModal({ open, onClose, seedConversationId = null }:
                   (mineExcluded.map((p) => p.full_name).filter(Boolean).join(", ") ||
                     `Thread ${row.conversation.id.slice(0, 6)}`);
                 return (
-                  <button key={row.conversation.id} type="button" onClick={() => setActiveConversationId(row.conversation.id)} className={`flex w-full items-start gap-2 border-b border-[var(--metal-border-soft)]/50 px-2 py-2 text-left hover:bg-white/5 ${activeConversationId === row.conversation.id ? "bg-white/10" : ""}`}>
-                    <UserAvatar name={primary?.full_name} avatarUrl={primary?.avatar_url} size="sm" />
+                  <button
+                    key={row.conversation.id}
+                    type="button"
+                    onClick={() => setActiveConversationId(row.conversation.id)}
+                    className={`flex w-full items-start gap-2 border-b border-[var(--metal-border-soft)]/35 px-2 py-1.5 text-left transition hover:bg-white/5 ${
+                      activeConversationId === row.conversation.id
+                        ? "bg-white/10 ring-1 ring-[var(--accent-copper-soft)]/35"
+                        : ""
+                    }`}
+                  >
+                    <UserAvatar
+                      name={primary?.full_name}
+                      avatarUrl={primary?.avatar_url}
+                      size="sm"
+                    />
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-semibold text-neutral-100">{title}</p>
-                      <p className="truncate text-[11px] text-neutral-400">{row.latest_message?.content ?? "No messages"}</p>
+                      <p className="truncate text-[11px] font-semibold text-neutral-100">
+                        {title}
+                      </p>
+                      <p className="truncate text-[10px] text-neutral-400">
+                        {row.latest_message?.content ?? "No messages"}
+                      </p>
                     </div>
-                    {row.unread_count > 0 ? <span className="rounded-full bg-[var(--accent-copper-soft)] px-1.5 py-0.5 text-[10px] font-bold text-black">{row.unread_count}</span> : null}
+                    {row.unread_count > 0 ? (
+                      <span className="rounded-full bg-[var(--accent-copper-soft)] px-1.5 py-0.5 text-[9px] font-bold text-black">
+                        {row.unread_count}
+                      </span>
+                    ) : null}
                   </button>
                 );
               })}
             </div>
           </aside>
 
-          <section className="flex min-h-0 flex-col rounded-xl border border-[var(--metal-border-soft)] bg-black/30">
-            <div className="border-b border-[var(--metal-border-soft)] px-3 py-2 text-xs text-neutral-200">
-              {activeConversation ? (activeConversation.conversation.title ?? "Thread") : "New message"}
+          <section className="flex min-h-0 flex-col rounded-xl border border-[var(--metal-border-soft)]/80 bg-black/30">
+            <div className="border-b border-[var(--metal-border-soft)]/70 px-3 py-1.5 text-xs font-medium text-neutral-200">
+              {activeConversation
+                ? activeConversation.conversation.title ?? "Thread"
+                : "New message"}
             </div>
-            <div className="min-h-0 flex-1 space-y-2 overflow-auto p-3">
+            <div className="min-h-0 flex-1 space-y-1.5 overflow-auto p-2.5">
               {messages.map((m) => {
                 const mine = m.sender_id === me;
                 const sender = users.find((u) => u.id === m.sender_id);
                 return (
-                  <div key={m.id} className={`flex gap-2 ${mine ? "justify-end" : "justify-start"}`}>
-                    {!mine ? <UserAvatar name={sender?.full_name} avatarUrl={sender?.avatar_url} size="sm" /> : null}
-                    <div className={`max-w-[75%] rounded-lg border px-3 py-2 text-xs ${mine ? "border-orange-500/40 bg-orange-500/20 text-orange-50" : "border-[var(--metal-border-soft)] bg-black/50 text-neutral-100"}`}>
+                  <div
+                    key={m.id}
+                    className={`flex gap-1.5 ${mine ? "justify-end" : "justify-start"}`}
+                  >
+                    {!mine ? (
+                      <UserAvatar
+                        name={sender?.full_name}
+                        avatarUrl={sender?.avatar_url}
+                        size="sm"
+                      />
+                    ) : null}
+                    <div
+                      className={`max-w-[78%] rounded-lg border px-2.5 py-1.5 text-xs leading-relaxed ${
+                        mine
+                          ? "border-orange-500/35 bg-orange-500/18 text-orange-50"
+                          : "border-[var(--metal-border-soft)] bg-black/55 text-neutral-100"
+                      }`}
+                    >
                       {m.content}
                     </div>
                   </div>
@@ -211,48 +396,118 @@ export default function InboxModal({ open, onClose, seedConversationId = null }:
               })}
             </div>
             {!activeConversationId ? (
-              <div className="space-y-2 border-t border-[var(--metal-border-soft)] p-3 text-xs">
+              <div className="space-y-2 border-t border-[var(--metal-border-soft)]/70 p-2.5 text-xs">
                 <div className="flex gap-2">
-                  <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} className="rounded border border-[var(--metal-border-soft)] bg-black/60 px-2 py-1">
-                    <option value="all">All roles</option><option value="tech">Tech</option><option value="advisor">Advisor</option><option value="parts">Parts</option><option value="manager">Manager</option>
+                  <select
+                    value={roleFilter}
+                    onChange={(e) => setRoleFilter(e.target.value)}
+                    className="h-8 rounded border border-[var(--metal-border-soft)] bg-black/60 px-2 py-1"
+                  >
+                    <option value="all">All roles</option>
+                    <option value="tech">Tech</option>
+                    <option value="advisor">Advisor</option>
+                    <option value="parts">Parts</option>
+                    <option value="manager">Manager</option>
                   </select>
-                  <button type="button" className="rounded border border-[var(--metal-border-soft)] px-2 py-1" onClick={() => setSelectedRecipients(recipientOptions.map((u) => u.id))}>Select all</button>
+                  <button
+                    type="button"
+                    className="h-8 rounded border border-[var(--metal-border-soft)] px-2"
+                    onClick={() =>
+                      setSelectedRecipients(recipientOptions.map((u) => u.id))
+                    }
+                  >
+                    Select all
+                  </button>
                 </div>
-                <div className="max-h-24 overflow-auto rounded border border-[var(--metal-border-soft)] p-2">
+                <div className="max-h-20 overflow-auto rounded border border-[var(--metal-border-soft)] p-2">
                   {recipientOptions.map((u) => (
                     <label key={u.id} className="mb-1 flex items-center gap-2">
-                      <input type="checkbox" checked={selectedRecipients.includes(u.id)} onChange={(e) => setSelectedRecipients((prev) => e.target.checked ? [...prev, u.id] : prev.filter((id) => id !== u.id))} />
-                      <UserAvatar name={u.full_name} avatarUrl={u.avatar_url} size="sm" />
+                      <input
+                        type="checkbox"
+                        checked={selectedRecipients.includes(u.id)}
+                        onChange={(e) =>
+                          setSelectedRecipients((prev) =>
+                            e.target.checked
+                              ? [...prev, u.id]
+                              : prev.filter((id) => id !== u.id),
+                          )
+                        }
+                      />
+                      <UserAvatar
+                        name={u.full_name}
+                        avatarUrl={u.avatar_url}
+                        size="sm"
+                      />
                       <span>{u.full_name ?? u.id.slice(0, 6)}</span>
                     </label>
                   ))}
                 </div>
-                {context.context_type ? <label className="flex items-center gap-2"><input type="checkbox" checked={useContext} onChange={(e) => setUseContext(e.target.checked)} /> Attach {context.context_label}</label> : null}
+                {context.context_type ? (
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={useContext}
+                      onChange={(e) => setUseContext(e.target.checked)}
+                    />
+                    Attach {context.context_label}
+                  </label>
+                ) : null}
               </div>
             ) : null}
-            <div className="flex gap-2 border-t border-[var(--metal-border-soft)] p-3">
-              <textarea value={compose} onChange={(e) => setCompose(e.target.value)} placeholder={activeConversationId ? "Reply…" : "Compose…"} className="h-16 flex-1 rounded border border-[var(--metal-border-soft)] bg-black/60 px-2 py-1.5 text-xs" />
-              <button type="button" onClick={() => void sendMessage()} disabled={sending || (!activeConversationId && selectedRecipients.length === 0)} className="rounded bg-[var(--accent-copper-soft)] px-3 py-2 text-xs font-semibold text-black disabled:opacity-60">{sending ? "Sending" : "Send"}</button>
+            <div className="flex gap-2 border-t border-[var(--metal-border-soft)]/70 p-2.5">
+              <textarea
+                value={compose}
+                onChange={(e) => setCompose(e.target.value)}
+                placeholder={activeConversationId ? "Reply…" : "Compose…"}
+                className="h-14 flex-1 rounded border border-[var(--metal-border-soft)] bg-black/60 px-2 py-1.5 text-xs"
+              />
+              <button
+                type="button"
+                onClick={() => void sendMessage()}
+                disabled={sending || (!activeConversationId && selectedRecipients.length === 0)}
+                className="h-14 rounded bg-[var(--accent-copper-soft)] px-3 py-2 text-xs font-semibold text-black disabled:opacity-60"
+              >
+                {sending ? "Sending" : "Send"}
+              </button>
             </div>
           </section>
 
-          <aside className="hidden rounded-xl border border-[var(--metal-border-soft)] bg-black/35 p-3 text-xs text-neutral-300 xl:block">
-            <h3 className="mb-2 text-[11px] uppercase tracking-[0.14em] text-neutral-400">Context</h3>
+          <aside className="hidden rounded-xl border border-[var(--metal-border-soft)]/80 bg-black/35 p-2.5 text-xs text-neutral-300 xl:block">
+            <h3 className="mb-2 text-[10px] uppercase tracking-[0.14em] text-neutral-400">
+              Context
+            </h3>
             {activeConversation ? (
               <>
-                <p className="mb-1 text-neutral-100">Type: {activeConversation.conversation.context_type ?? "general"}</p>
-                <p className="mb-3 text-neutral-400">ID: {activeConversation.conversation.context_id ?? "—"}</p>
-                {contextHref(activeConversation.conversation) ? (
-                  <Link href={contextHref(activeConversation.conversation) ?? "#"} className="inline-flex rounded border border-[var(--accent-copper-soft)] px-2 py-1 text-[var(--accent-copper-soft)] hover:bg-orange-500/10">Open linked record</Link>
+                <p className="mb-1 text-neutral-100">
+                  Type: {activeConversation.conversation.context_type ?? "general"}
+                </p>
+                {activeConversation.conversation.context_id ? (
+                  <p className="mb-3 text-neutral-400">
+                    ID: {activeConversation.conversation.context_id}
+                  </p>
                 ) : (
-                  <p className="text-neutral-500">No direct deep-link route available yet.</p>
+                  <div className="mb-3 rounded border border-[var(--metal-border-soft)]/70 bg-black/40 p-2 text-[11px] text-neutral-400">
+                    General thread with no linked record.
+                  </div>
+                )}
+                {contextHref(activeConversation.conversation) ? (
+                  <Link
+                    href={contextHref(activeConversation.conversation) ?? "#"}
+                    className="inline-flex rounded border border-[var(--accent-copper-soft)] px-2 py-1 text-[11px] text-[var(--accent-copper-soft)] hover:bg-orange-500/10"
+                  >
+                    Open linked record
+                  </Link>
+                ) : (
+                  <p className="text-[11px] text-neutral-500">
+                    No direct deep-link route available.
+                  </p>
                 )}
               </>
             ) : (
-              <>
-                <p className="mb-2">Compose mode uses your current page context when available.</p>
-                <p className="text-neutral-400">Current: {context.context_label}</p>
-              </>
+              <div className="rounded border border-[var(--metal-border-soft)]/70 bg-black/40 p-2 text-[11px] text-neutral-400">
+                <p className="mb-1 text-neutral-200">No thread selected.</p>
+                <p>Compose mode uses current page context when available.</p>
+              </div>
             )}
           </aside>
         </div>

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -302,7 +302,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <>
-      <div className="flex min-h-screen overflow-x-hidden text-foreground">
+      <div
+        className={cn(
+          "flex min-h-screen overflow-x-hidden text-foreground transition-[filter,opacity] duration-200",
+          chatOpen && "pointer-events-none opacity-70 blur-[1.5px] saturate-75",
+        )}
+      >
         <aside
           className={cn(
             "hidden shrink-0 overflow-hidden border-r backdrop-blur-xl transition-all duration-300 md:flex md:flex-col",
@@ -361,7 +366,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
         <div className="flex min-h-screen min-w-0 flex-1 flex-col">
           <header
-            className="fixed inset-x-0 top-0 z-40 hidden h-14 items-center justify-between border-b px-3 backdrop-blur-xl md:flex lg:px-4"
+            className="fixed inset-x-0 top-0 z-30 hidden h-14 items-center justify-between border-b px-3 backdrop-blur-xl md:flex lg:px-4"
             style={{
               borderColor:
                 "color-mix(in srgb, var(--brand-primary, #C1663B) 30%, var(--metal-border-soft, rgba(148,163,184,0.3)))",
@@ -444,7 +449,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           {punchOpen && userId ? (
             <div
               ref={punchRef}
-              className="fixed right-6 top-20 z-50 hidden w-72 rounded-xl border p-3 backdrop-blur-xl md:block"
+              className="fixed right-6 top-20 z-30 hidden w-72 rounded-xl border p-3 backdrop-blur-xl md:block"
               style={{
                 borderColor: "var(--metal-border-soft, rgba(148,163,184,0.3))",
                 background:
@@ -458,13 +463,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           ) : null}
 
           <main className="flex w-full min-w-0 flex-1 flex-col overflow-x-hidden px-3 pb-14 pt-16 md:px-5 md:pb-6 md:pt-20 lg:px-6 xl:px-8 2xl:px-10">
-            <TabsBridge>
+            <TabsBridge tabsSubdued={chatOpen}>
               <div className="relative z-0 min-w-0">{children}</div>
             </TabsBridge>
           </main>
 
           <nav
-            className="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
+            className="fixed inset-x-0 bottom-0 z-30 border-t pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
             style={{
               borderColor: "var(--metal-border-soft, rgba(148,163,184,0.3))",
               background:

--- a/features/shared/components/tabs/TabsBar.tsx
+++ b/features/shared/components/tabs/TabsBar.tsx
@@ -2,6 +2,7 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import { usePathname } from "next/navigation";
+import { cn } from "@/features/shared/utils/cn";
 import { useTabs } from "./TabsProvider";
 
 const AUTH_ROUTES = new Set([
@@ -11,7 +12,11 @@ const AUTH_ROUTES = new Set([
   "/reset-password",
 ]);
 
-export default function TabsBar() {
+type TabsBarProps = {
+  subdued?: boolean;
+};
+
+export default function TabsBar({ subdued = false }: TabsBarProps) {
   const { tabs, activeHref, activateTab, closeTab, closeOthers, closeAll } =
     useTabs();
 
@@ -28,20 +33,16 @@ export default function TabsBar() {
 
   return (
     <div
-      className="
-        sticky top-0 z-30
-        -mt-1
-        w-full min-w-0
-        border-b border-slate-700/40
-        bg-[linear-gradient(180deg,rgba(2,6,23,0.88),rgba(2,6,23,0.72))]
-        backdrop-blur-xl
-        px-2.5
-      "
+      aria-hidden={subdued}
+      className={cn(
+        "sticky top-0 z-20 -mt-1 w-full min-w-0 border-b px-2 transition-all duration-200",
+        "border-slate-700/30 bg-[linear-gradient(180deg,rgba(2,6,23,0.84),rgba(2,6,23,0.68))] backdrop-blur-lg",
+        subdued && "pointer-events-none opacity-25 saturate-50",
+      )}
     >
-      <div className="flex min-w-0 items-center gap-2 py-1.5">
-        {/* Tabs scroller */}
+      <div className="flex min-w-0 items-center gap-1.5 py-1">
         <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden [&::-webkit-scrollbar]:hidden">
-          <div className="flex w-max items-center gap-1.5">
+          <div className="flex w-max items-center gap-1">
             <AnimatePresence initial={false}>
               {safeTabs.map((t) => {
                 const active = t.href === activeHref;
@@ -51,29 +52,26 @@ export default function TabsBar() {
                   <motion.div
                     key={t.href}
                     layout
-                    initial={{ opacity: 0, scale: 0.95 }}
+                    initial={{ opacity: 0, scale: 0.97 }}
                     animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.95 }}
-                    className={`
-                      group inline-flex h-8 items-center gap-1.5 rounded-md border
-                      px-2.5 text-[12px] transition-colors
-                      ${
-                        active
-                          ? "border-[var(--brand-accent,#E39A6E)]/55 bg-[linear-gradient(140deg,rgba(30,41,59,0.75),rgba(15,23,42,0.95))] text-white shadow-[inset_0_1px_0_rgba(148,163,184,0.22),0_8px_24px_rgba(0,0,0,0.35)]"
-                          : "border-slate-600/40 bg-slate-900/45 text-slate-300 hover:border-slate-500/60 hover:bg-slate-900/70 hover:text-slate-100"
-                      }
-                    `}
+                    exit={{ opacity: 0, scale: 0.97 }}
+                    className={cn(
+                      "group inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors",
+                      active
+                        ? "border-[var(--brand-accent,#E39A6E)]/45 bg-[linear-gradient(140deg,rgba(30,41,59,0.55),rgba(15,23,42,0.86))] text-slate-100 shadow-[inset_0_1px_0_rgba(148,163,184,0.16)]"
+                        : "border-slate-700/40 bg-slate-950/50 text-slate-400 hover:border-slate-600/50 hover:bg-slate-900/60 hover:text-slate-200",
+                    )}
                   >
                     <button
                       type="button"
                       onClick={() => activateTab(t.href)}
-                      className="flex max-w-[220px] items-center gap-1.5"
+                      className="flex max-w-[200px] items-center gap-1"
                     >
                       <span className="truncate leading-none">{t.title}</span>
                       {pinned && (
                         <span
                           aria-label="Default dashboard tab"
-                          className="rounded-sm border border-slate-500/45 px-1 py-[1px] text-[9px] uppercase tracking-[0.12em] text-slate-300"
+                          className="rounded-sm border border-slate-500/35 px-1 py-px text-[8px] uppercase tracking-[0.1em] text-slate-300"
                         >
                           Base
                         </span>
@@ -84,7 +82,7 @@ export default function TabsBar() {
                       <button
                         type="button"
                         onClick={() => closeTab(t.href)}
-                        className="inline-flex h-4 w-4 items-center justify-center rounded text-[11px] leading-none text-slate-400 transition hover:bg-slate-700/55 hover:text-slate-100"
+                        className="inline-flex h-3.5 w-3.5 items-center justify-center rounded text-[10px] leading-none text-slate-500 transition hover:bg-slate-700/45 hover:text-slate-100"
                         aria-label="Close tab"
                       >
                         ✕
@@ -96,26 +94,23 @@ export default function TabsBar() {
             </AnimatePresence>
 
             {safeTabs.length === 0 && (
-              <div className="px-2 py-1 text-xs text-neutral-500">
-                No tabs yet
-              </div>
+              <div className="px-2 py-1 text-xs text-neutral-500">No tabs yet</div>
             )}
           </div>
         </div>
 
-        {/* Controls */}
-        <div className="ml-2 flex shrink-0 items-center gap-2">
+        <div className="ml-1.5 flex shrink-0 items-center gap-1.5">
           <button
             type="button"
             onClick={() => closeOthers(activeHref)}
-            className="inline-flex h-7 items-center rounded-md border border-slate-600/40 px-2 text-[11px] text-slate-300 transition hover:border-slate-500/60 hover:bg-slate-900/80 hover:text-slate-100"
+            className="inline-flex h-6 items-center rounded border border-slate-700/45 px-1.5 text-[10px] text-slate-400 transition hover:border-slate-600/55 hover:bg-slate-900/75 hover:text-slate-200"
           >
             Close others
           </button>
           <button
             type="button"
             onClick={closeAll}
-            className="inline-flex h-7 items-center rounded-md border border-slate-600/40 px-2 text-[11px] text-slate-300 transition hover:border-slate-500/60 hover:bg-slate-900/80 hover:text-slate-100"
+            className="inline-flex h-6 items-center rounded border border-slate-700/45 px-1.5 text-[10px] text-slate-400 transition hover:border-slate-600/55 hover:bg-slate-900/75 hover:text-slate-200"
           >
             Close all
           </button>

--- a/features/shared/components/tabs/TabsBridge.tsx
+++ b/features/shared/components/tabs/TabsBridge.tsx
@@ -31,8 +31,10 @@ export function useTabsScopedStorageKey(subkey: string) {
 
 export default function TabsBridge({
   children,
+  tabsSubdued = false,
 }: {
   children: React.ReactNode;
+  tabsSubdued?: boolean;
 }) {
   const session = useSession();
   const userId = session?.user?.id ?? null;
@@ -193,7 +195,7 @@ export default function TabsBridge({
   return (
     <TabsProvider userId={userId ?? undefined}>
       {/* No tab bar on the mobile companion routes */}
-      {!isMobileRoute && <TabsBar />}
+      {!isMobileRoute && <TabsBar subdued={tabsSubdued} />}
       {children}
     </TabsProvider>
   );


### PR DESCRIPTION
### Motivation
- The Inbox overlay visually competed with persistent shell chrome (header, nav, and dashboard tabs), making it feel like a page instead of a dominant modal layer.  
- Tab chips were visually heavy and noisy, reducing focus on the active thread and increasing background distraction when Inbox is open.  
- Make minimal, incremental changes focused on layering, visual hierarchy, and density without touching message data flow or read/unread logic.

### Description
- Make the app shell visually inactive while Inbox is open by adding a conditional class to `AppShell` that applies `pointer-events-none`, reduced `opacity`, blur and reduced saturation when `chatOpen` is true, and lower z for header/punch/mobile nav so Inbox sits unambiguously above everything (`features/shared/components/AppShell.tsx`).
- Add a `tabsSubdued` prop to the tabs bridge and wire it from the shell so tabs can render in an inert/dimmed state while Inbox is open (`features/shared/components/tabs/TabsBridge.tsx`).
- Redesign `TabsBar` for a calmer strip: reduce tab chip height/padding, simplify borders, flatten inactive tabs, tighten spacing, reduce close/control button sizes, and support the subdued/inert visual state (`features/shared/components/tabs/TabsBar.tsx`).
- Strengthen the Inbox overlay in `InboxModal` by raising z-index, darkening the scrim and backdrop blur, applying dialog semantics (`role="dialog"`, `aria-modal`), locking body scroll when open, and stopping propagation on the dialog shell so clicks are trapped to the overlay; also tighten paddings, compact thread rows and composer, refine selected row styling, and narrow/smartly render the context rail for general threads (`features/chat/components/InboxModal.tsx`).
- Files changed: `features/shared/components/AppShell.tsx`, `features/shared/components/tabs/TabsBridge.tsx`, `features/shared/components/tabs/TabsBar.tsx`, and `features/chat/components/InboxModal.tsx`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully.  
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe459363c8328ad80cc8559958bfc)