### PR TITLE
Refine tablet dashboard density and keep desktop cockpit wider

### DIFF
--- a/app/dashboard/_components/DashboardPrimitives.tsx
+++ b/app/dashboard/_components/DashboardPrimitives.tsx
@@ -5,7 +5,7 @@ import DashboardViewSwitcher from "./DashboardViewSwitcher";
 import type { DashboardView } from "@/features/dashboard/lib/dashboard-views";
 
 export function DashboardShell({ children }: { children: ReactNode }) {
-  return <div className="mx-auto w-full max-w-[1580px] space-y-2.5 pt-1 md:space-y-3.5 md:pt-2">{children}</div>;
+  return <div className="mx-auto w-full max-w-[1640px] space-y-2 pt-0.5 md:space-y-2.5 md:pt-1">{children}</div>;
 }
 
 export function DashboardTopStrip({
@@ -23,7 +23,7 @@ export function DashboardTopStrip({
 }) {
   return (
     <section
-      className="relative z-10 rounded-2xl border px-4 py-3 backdrop-blur-xl md:px-5"
+      className="relative z-10 rounded-2xl border px-4 py-2.5 backdrop-blur-xl md:px-5 md:py-2"
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 72%, transparent)",
         background:
@@ -31,11 +31,11 @@ export function DashboardTopStrip({
         boxShadow: "0 16px 30px rgba(0,0,0,0.4)",
       }}
     >
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex flex-col gap-2.5 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <div className="text-[10px] uppercase tracking-[0.2em] text-neutral-500">{title}</div>
-          <h1 className="mt-1 text-xl font-semibold tracking-tight text-white md:text-2xl">{name}</h1>
-          <p className="mt-1 text-xs text-neutral-300 md:text-sm">{subtitle}</p>
+          <h1 className="mt-0.5 text-xl font-semibold tracking-tight text-white md:text-[1.7rem]">{name}</h1>
+          <p className="mt-0.5 text-xs text-neutral-300 md:text-sm">{subtitle}</p>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
@@ -73,11 +73,11 @@ export function MetricStrip({
   className?: string;
 }) {
   return (
-    <div className={`grid grid-cols-2 gap-2 lg:grid-cols-4 ${className ?? ""}`}>
+    <div className={`grid grid-cols-2 gap-1.5 lg:grid-cols-4 ${className ?? ""}`}>
       {items.map((item, index) => (
         <section
           key={item.label}
-          className="relative rounded-xl border px-3 py-2.5"
+          className="relative rounded-xl border px-3 py-2"
           style={{
             borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 85%, transparent)",
             background: "linear-gradient(155deg, rgba(15,23,42,0.96), rgba(2,6,23,0.88))",
@@ -134,13 +134,13 @@ export function DashboardPanel({
 }) {
   return (
     <section
-      className={`rounded-2xl border p-3 md:p-3.5 ${className ?? ""}`}
+      className={`rounded-2xl border p-3 md:p-3 ${className ?? ""}`}
       style={{
         borderColor: "color-mix(in srgb, var(--theme-card-border,#334155) 78%, transparent)",
         background: "linear-gradient(155deg, rgba(2,6,23,0.88), rgba(10,15,28,0.76))",
       }}
     >
-      <header className="mb-2.5 flex items-start justify-between gap-2">
+      <header className="mb-2 flex items-start justify-between gap-2">
         <div>
           {eyebrow ? <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{eyebrow}</div> : null}
           <h2 className="text-sm font-semibold text-white md:text-base">{title}</h2>

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -40,7 +40,7 @@ export default async function OperationsDashboardView() {
       />
 
       <MetricStrip
-        className="mb-0.5"
+        className="mb-0"
         items={[
           { label: "Active jobs", value: String(payload.topSummary.activeJobs) },
           {
@@ -65,8 +65,8 @@ export default async function OperationsDashboardView() {
         ]}
       />
 
-      <div className="grid gap-2 xl:grid-cols-[minmax(0,1.95fr)_minmax(300px,1fr)] 2xl:grid-cols-[minmax(0,2.08fr)_minmax(320px,1fr)]">
-        <section className="space-y-3">
+      <div className="grid gap-2 lg:grid-cols-[minmax(0,1.72fr)_minmax(276px,0.9fr)] xl:grid-cols-[minmax(0,1.92fr)_minmax(304px,0.96fr)] 2xl:grid-cols-[minmax(0,2.1fr)_minmax(340px,1fr)]">
+        <section className="space-y-2.5">
           {payload.sectionErrors.length > 0 ? (
             <section className="rounded-xl border border-amber-500/30 bg-gradient-to-r from-amber-500/15 via-amber-400/10 to-transparent px-3 py-2.5">
               <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-300">
@@ -90,19 +90,19 @@ export default async function OperationsDashboardView() {
           ) : null}
 
           <div
-            className="space-y-1.5 rounded-[22px] border border-white/5 p-2.5 md:p-3"
+            className="space-y-1.5 rounded-[22px] border border-white/5 p-2.5 md:p-2.5"
             style={{
               background: "linear-gradient(158deg, rgba(4,8,20,0.92), rgba(8,14,30,0.78) 48%, rgba(4,10,24,0.86))",
               boxShadow: "inset 0 1px 0 rgba(148,163,184,0.06), 0 16px 28px rgba(0,0,0,0.24)",
             }}
           >
-            <div className="grid gap-1.5 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
+            <div className="grid gap-1.5 md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)] xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]">
             <DashboardPanel
               title="Live Work Command Surface"
-              className="min-h-[330px] border-white/5 bg-[linear-gradient(155deg,rgba(7,13,28,0.9),rgba(8,14,30,0.78))]"
+              className="min-h-[300px] border-white/5 bg-[linear-gradient(155deg,rgba(7,13,28,0.9),rgba(8,14,30,0.78))]"
               action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open board <ArrowRight className="h-3 w-3" /></Link>}
             >
-              <div className="grid h-full gap-2.5 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+              <div className="grid h-full gap-2 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
                 <div className="space-y-0.5">
                   {payload.liveWork.length > 0 ? (
                     payload.liveWork.map((item) => (
@@ -158,8 +158,8 @@ export default async function OperationsDashboardView() {
               </div>
             </DashboardPanel>
 
-            <DashboardPanel title="Active Job Summary" className="min-h-[330px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
-              <div className="space-y-2.5">
+            <DashboardPanel title="Active Job Summary" className="min-h-[300px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
+              <div className="space-y-2">
                 {payload.activeJobSummary.map((metric) => (
                   <div key={metric.label} className="rounded-lg border border-white/5 bg-black/15 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
                     <div className="flex items-center justify-between text-xs">
@@ -178,8 +178,8 @@ export default async function OperationsDashboardView() {
             </DashboardPanel>
           </div>
 
-            <div className="grid gap-1.5 lg:grid-cols-[minmax(0,1.62fr)_minmax(248px,0.9fr)]">
-            <DashboardPanel title="Live Shop Load" className="min-h-[252px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
+            <div className="grid gap-1.5 md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)] xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]">
+            <DashboardPanel title="Live Shop Load" className="min-h-[236px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
               <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
             </DashboardPanel>
 
@@ -266,7 +266,7 @@ export default async function OperationsDashboardView() {
         </section>
 
         {hasRightRailSignals ? (
-          <aside className="space-y-2.5 xl:sticky xl:top-3 xl:self-start">
+          <aside className="space-y-2 lg:sticky lg:top-2.5 lg:self-start">
             <DashboardPanel
               title="High Impact Alerts"
               action={<Link href="/work-orders/board" className="text-xs text-neutral-300 hover:text-white">View all</Link>}

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -313,7 +313,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             "hidden shrink-0 overflow-hidden border-r backdrop-blur-xl transition-all duration-300 md:flex md:flex-col",
             HEADER_OFFSET_DESKTOP,
             sidebarOpen
-              ? "translate-x-0 border-r md:w-56 xl:w-60"
+              ? "translate-x-0 border-r md:w-52 lg:w-56 xl:w-60"
               : "pointer-events-none -translate-x-full md:w-0",
           )}
           style={{
@@ -328,7 +328,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               sidebarOpen ? "opacity-100" : "opacity-0",
             )}
           >
-            <div className="flex h-14 items-center justify-between border-b border-white/10 px-3 xl:px-4">
+            <div className="flex h-12 items-center justify-between border-b border-white/10 px-3 xl:px-4">
               <Link
                 href="/dashboard"
                 className="flex min-w-0 items-center gap-3 transition-colors hover:opacity-95"
@@ -366,7 +366,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
         <div className="flex min-h-screen min-w-0 flex-1 flex-col">
           <header
-            className="fixed inset-x-0 top-0 z-30 hidden h-14 items-center justify-between border-b px-3 backdrop-blur-xl md:flex lg:px-4"
+            className="fixed inset-x-0 top-0 z-30 hidden h-12 items-center justify-between border-b px-3 backdrop-blur-xl md:flex lg:px-4"
             style={{
               borderColor:
                 "color-mix(in srgb, var(--brand-primary, #C1663B) 30%, var(--metal-border-soft, rgba(148,163,184,0.3)))",
@@ -462,7 +462,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             </div>
           ) : null}
 
-          <main className="flex w-full min-w-0 flex-1 flex-col overflow-x-hidden px-3 pb-14 pt-16 md:px-5 md:pb-6 md:pt-20 lg:px-6 xl:px-8 2xl:px-10">
+          <main className="flex w-full min-w-0 flex-1 flex-col overflow-x-hidden px-3 pb-14 pt-16 md:px-4 md:pb-6 md:pt-16 lg:px-6 lg:pt-[4.25rem] xl:px-8 2xl:px-10">
             <TabsBridge tabsSubdued={chatOpen}>
               <div className="relative z-0 min-w-0">{children}</div>
             </TabsBridge>


### PR DESCRIPTION
### Motivation
- Align the dashboard tablet layout with the provided iPad composition so tablet behavior is the baseline for compact views. 
- Keep the right rail visible on tablet sizes and prevent desktop from collapsing to the same narrow column behavior. 
- Reduce vertical chrome and module padding to surface KPI content sooner and reclaim canvas width by slightly narrowing the left sidebar on tablet.

### Description
- Tightened the dashboard shell and top strip spacing and increased the dashboard `max-w` to `1640px` for a wider desktop canvas while reducing tablet/top chrome padding (`DashboardPrimitives.tsx`).
- Reduced metric strip gaps and panel paddings and tightened panel header spacing to improve vertical density (`DashboardPrimitives.tsx`).
- Updated the Operations grid breakpoints to keep a visible right rail at tablet widths and preserve a more expansive multi-column cockpit on desktop by adding explicit `lg`, `xl`, and `2xl` column recipes: `lg:grid-cols-[minmax(0,1.72fr)_minmax(276px,0.9fr)]`, `xl:grid-cols-[minmax(0,1.92fr)_minmax(304px,0.96fr)]`, and `2xl:grid-cols-[minmax(0,2.1fr)_minmax(340px,1fr)]` (`OperationsDashboardView.tsx`).
- Shifted internal command-center paired grids to engage earlier at `md` and expand at `xl` (e.g. `md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)]` and `xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]`) and reduced local min-heights (`OperationsDashboardView.tsx`).
- Moved right-rail sticky behavior from `xl` down to `lg` (`lg:sticky lg:top-2.5 lg:self-start`) so the rail remains visible on iPad/tablet widths (`OperationsDashboardView.tsx`).
- Narrowed the open sidebar widths to `md:w-52`, `lg:w-56`, `xl:w-60`, reduced sidebar/header chrome heights from `h-14` to `h-12`, and tightened main content padding/top offsets for earlier KPI visibility (`features/shared/components/AppShell.tsx`).

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc024e19408328b66bb582bae260b3)