### PR TITLE
Refactor Shop Boost parts import into staged normalization/review pipeline

### DIFF
--- a/db/sql/2026-04-12_shop_boost_parts_staged_pipeline.sql
+++ b/db/sql/2026-04-12_shop_boost_parts_staged_pipeline.sql
@@ -1,0 +1,184 @@
+-- Shop Boost parts import staged pipeline (additive, non-breaking)
+-- Goal: keep messy competitor exports in raw/staging layers and only promote high-confidence matches.
+
+-- 1) Strengthen intake session metadata for import traceability.
+alter table public.shop_boost_intakes
+  add column if not exists source_system_guess text,
+  add column if not exists upload_status text,
+  add column if not exists import_counts jsonb default '{}'::jsonb,
+  add column if not exists parse_summary jsonb default '{}'::jsonb;
+
+-- 2) Extend raw source row storage without breaking existing readers.
+alter table public.shop_import_rows
+  add column if not exists shop_id uuid,
+  add column if not exists original_headers jsonb default '[]'::jsonb,
+  add column if not exists raw_payload jsonb default '{}'::jsonb,
+  add column if not exists parse_status text default 'pending',
+  add column if not exists parse_warnings jsonb default '[]'::jsonb;
+
+create index if not exists idx_shop_import_rows_shop_id on public.shop_import_rows(shop_id);
+create index if not exists idx_shop_import_rows_parse_status on public.shop_import_rows(parse_status);
+
+alter table public.shop_import_rows
+  drop constraint if exists shop_import_rows_shop_id_fkey;
+
+alter table public.shop_import_rows
+  add constraint shop_import_rows_shop_id_fkey
+  foreign key (shop_id)
+  references public.shops(id)
+  on delete cascade;
+
+-- Backfill shop_id from intake for older rows.
+update public.shop_import_rows r
+set shop_id = i.shop_id
+from public.shop_boost_intakes i
+where r.intake_id = i.id
+  and r.shop_id is null;
+
+-- 3) Normalized parts staging layer.
+create table if not exists public.shop_parts_import_staging (
+  id uuid primary key default gen_random_uuid(),
+  intake_id uuid not null references public.shop_boost_intakes(id) on delete cascade,
+  raw_row_id uuid references public.shop_import_rows(id) on delete set null,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  source_system text,
+  normalized_name text,
+  normalized_name_key text,
+  normalized_sku text,
+  normalized_part_number text,
+  normalized_brand text,
+  normalized_vendor text,
+  mapped_category text,
+  quantity_on_hand numeric(12,2),
+  cost numeric(12,2),
+  price numeric(12,2),
+  unit_of_measure text,
+  pack_info text,
+  source_confidence numeric(5,4),
+  status text not null default 'pending',
+  warnings jsonb not null default '[]'::jsonb,
+  raw_echo jsonb not null default '{}'::jsonb,
+  suggested_action text,
+  matched_part_id uuid references public.parts(id) on delete set null,
+  match_reason text,
+  auto_promote boolean not null default false,
+  promoted_at timestamptz,
+  reviewed_by uuid,
+  reviewed_at timestamptz,
+  review_notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_shop_parts_import_staging_intake on public.shop_parts_import_staging(intake_id);
+create index if not exists idx_shop_parts_import_staging_shop_status on public.shop_parts_import_staging(shop_id, status);
+create index if not exists idx_shop_parts_import_staging_part_number on public.shop_parts_import_staging(shop_id, normalized_part_number);
+create index if not exists idx_shop_parts_import_staging_sku on public.shop_parts_import_staging(shop_id, normalized_sku);
+
+-- 4) Candidate match layer for review queue.
+create table if not exists public.shop_parts_import_match_candidates (
+  id uuid primary key default gen_random_uuid(),
+  staging_row_id uuid not null references public.shop_parts_import_staging(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  candidate_part_id uuid references public.parts(id) on delete cascade,
+  confidence numeric(5,4) not null,
+  reason text,
+  rank integer not null default 1,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_shop_parts_import_match_candidates_staging on public.shop_parts_import_match_candidates(staging_row_id);
+create index if not exists idx_shop_parts_import_match_candidates_shop on public.shop_parts_import_match_candidates(shop_id);
+
+-- 5) Source alias/reference layer to preserve legacy identifiers.
+create table if not exists public.shop_parts_source_aliases (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  intake_id uuid references public.shop_boost_intakes(id) on delete set null,
+  raw_row_id uuid references public.shop_import_rows(id) on delete set null,
+  staging_row_id uuid references public.shop_parts_import_staging(id) on delete set null,
+  part_id uuid not null references public.parts(id) on delete cascade,
+  source_system text,
+  legacy_sku text,
+  legacy_part_number text,
+  legacy_label text,
+  vendor_alias text,
+  alias_type text not null default 'legacy_import',
+  source_hash text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, part_id, source_hash)
+);
+
+create index if not exists idx_shop_parts_source_aliases_shop_part on public.shop_parts_source_aliases(shop_id, part_id);
+create index if not exists idx_shop_parts_source_aliases_lookup on public.shop_parts_source_aliases(shop_id, legacy_part_number, legacy_sku);
+
+-- 6) RLS + scoped read access for shop users.
+alter table public.shop_parts_import_staging enable row level security;
+alter table public.shop_parts_import_match_candidates enable row level security;
+alter table public.shop_parts_source_aliases enable row level security;
+
+drop policy if exists "service-role-manage-shop-parts-import-staging" on public.shop_parts_import_staging;
+create policy "service-role-manage-shop-parts-import-staging"
+  on public.shop_parts_import_staging
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "service-role-manage-shop-parts-import-match-candidates" on public.shop_parts_import_match_candidates;
+create policy "service-role-manage-shop-parts-import-match-candidates"
+  on public.shop_parts_import_match_candidates
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "service-role-manage-shop-parts-source-aliases" on public.shop_parts_source_aliases;
+create policy "service-role-manage-shop-parts-source-aliases"
+  on public.shop_parts_source_aliases
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "shop-users-read-shop-parts-import-staging" on public.shop_parts_import_staging;
+create policy "shop-users-read-shop-parts-import-staging"
+  on public.shop_parts_import_staging
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = shop_parts_import_staging.shop_id
+    )
+  );
+
+drop policy if exists "shop-users-read-shop-parts-import-candidates" on public.shop_parts_import_match_candidates;
+create policy "shop-users-read-shop-parts-import-candidates"
+  on public.shop_parts_import_match_candidates
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = shop_parts_import_match_candidates.shop_id
+    )
+  );
+
+drop policy if exists "shop-users-read-shop-parts-source-aliases" on public.shop_parts_source_aliases;
+create policy "shop-users-read-shop-parts-source-aliases"
+  on public.shop_parts_source_aliases
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = shop_parts_source_aliases.shop_id
+    )
+  );

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -7,6 +7,7 @@ import {
   SHOP_BOOST_UPLOAD_DATASET_KEYS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
+import { runPartsImportPipeline, type PartsPipelineSummary } from "@/features/integrations/imports/runPartsImportPipeline";
 
 type DB = Database;
 
@@ -62,6 +63,7 @@ export type ShopBoostImportSummary = {
     menuSuggestions: number;
     inspectionSuggestions: number;
   };
+  partsPipeline?: PartsPipelineSummary;
 };
 
 type CsvRow = Record<string, string>;
@@ -138,28 +140,6 @@ function normalizeText(s: string | null | undefined): string {
     .replace(/[^a-z0-9]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-}
-
-function normalizePartToken(s: string | null | undefined): string {
-  return String(s ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "");
-}
-
-function buildNormalizedPartKey(args: {
-  partNumber: string | null;
-  sku: string | null;
-  name: string;
-  supplier: string | null;
-  category: string | null;
-}): string {
-  const partNo = normalizePartToken(args.partNumber);
-  const sku = normalizePartToken(args.sku);
-  const fallbackName = normalizeText(args.name);
-  const supplier = normalizeText(args.supplier);
-  const category = normalizeText(args.category);
-  return [partNo || "-", sku || "-", fallbackName || "-", supplier || "-", category || "-"].join("|");
 }
 
 function dateOnly(iso: string | null): string {
@@ -831,9 +811,6 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const conflictingCustomerPhones = new Set<string>();
   const vehiclesByVin = new Map<string, string>();
   const vehiclesByPlate = new Map<string, string>();
-  const partsByNumber = new Map<string, string>();
-  const partsBySku = new Map<string, string>();
-  const partsByNormalizedKey = new Map<string, string>();
   const staffByEmail = new Map<string, string>();
   const staffByName = new Map<string, string>();
 
@@ -893,36 +870,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     }
   }
 
-  // Existing parts
-  {
-    const { data } = await supabase
-      .from("parts")
-      .select("id,part_number,sku,name,supplier,category,shop_id,normalized_part_key")
-      .eq("shop_id", shopId)
-      .limit(5000);
-
-    for (const r of data ?? []) {
-      const rec = r as unknown as Record<string, unknown>;
-      const partNumber = lower(String(rec.part_number ?? ""));
-      const sku = lower(String(rec.sku ?? ""));
-      const supplier = String(rec.supplier ?? "");
-      const category = String(rec.category ?? "");
-      const normalizedPartKeyRaw = String(rec.normalized_part_key ?? "").trim();
-      const normalizedPartKey =
-        normalizedPartKeyRaw ||
-        buildNormalizedPartKey({
-          partNumber: String(rec.part_number ?? ""),
-          sku: String(rec.sku ?? ""),
-          name: String(rec.name ?? ""),
-          supplier,
-          category,
-        });
-      const id = String(rec.id ?? "");
-      if (partNumber && id) partsByNumber.set(partNumber, id);
-      if (sku && id) partsBySku.set(sku, id);
-      if (id) partsByNormalizedKey.set(normalizedPartKey, id);
-    }
-  }
+  let partsPipelineSummary: PartsPipelineSummary | undefined;
 
   // 1) Import customers
   if (customersCsv) {
@@ -1084,98 +1032,15 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     }
   }
 
-  // 3) Import parts (name required)
+  // 3) Import parts (staged pipeline with review queue + safe promotion)
   if (partsCsv) {
-    const { rows } = parseCsv(partsCsv);
-
-    for (let i = 0; i < rows.length; i += 1) {
-      const row = rows[i];
-
-      const partNumber = pick(row, [/part number/, /^pn$/, /p\/n/, /part_no/]);
-      const sku = pick(row, [/sku/]);
-      const name =
-        pick(row, [/^name$/, /part name/, /description/]) ??
-        partNumber ??
-        sku ??
-        `Part ${i + 1}`;
-
-      const cost = parseMoney(pick(row, [/^cost$/, /unit cost/, /buy/]));
-      const price = parseMoney(pick(row, [/^price$/, /sell/, /retail/]));
-      const supplier = pick(row, [/supplier/, /vendor/]);
-      const category = pick(row, [/category/]);
-      const normalizedPartKey = buildNormalizedPartKey({
-        partNumber,
-        sku,
-        name,
-        supplier,
-        category,
-      });
-      const external_id = `import:${intakeId}:part:${sha1(normalizedPartKey).slice(0, 20)}`;
-
-      const existingId =
-        partsByNormalizedKey.get(normalizedPartKey) ||
-        (partNumber && partsByNumber.get(lower(partNumber))) ||
-        (sku && partsBySku.get(lower(sku)));
-
-      if (existingId) {
-        await supabase
-          .from("parts")
-          .update({
-            shop_id: shopId,
-            name,
-            part_number: partNumber ?? null,
-            sku: sku ?? null,
-            supplier: supplier ?? null,
-            category: category ?? null,
-            cost: cost ?? null,
-            price: price ?? null,
-            default_cost: cost ?? null,
-            default_price: price ?? null,
-            normalized_part_key: normalizedPartKey,
-            source_intake_id: intakeId,
-            external_id,
-            import_notes: JSON.stringify({
-              source: "shop_boost",
-              source_intake_id: intakeId,
-              normalized_part_key: normalizedPartKey,
-            }),
-          } as DB["public"]["Tables"]["parts"]["Update"])
-          .eq("id", existingId);
-        continue;
-      }
-
-      const { data: inserted } = await supabase
-        .from("parts")
-        .insert({
-          shop_id: shopId,
-          name,
-          part_number: partNumber ?? null,
-          sku: sku ?? null,
-          supplier: supplier ?? null,
-          category: category ?? null,
-          cost: cost ?? null,
-          price: price ?? null,
-          default_cost: cost ?? null,
-          default_price: price ?? null,
-          normalized_part_key: normalizedPartKey,
-          source_intake_id: intakeId,
-          external_id,
-          import_notes: JSON.stringify({
-            source: "shop_boost",
-            source_intake_id: intakeId,
-            normalized_part_key: normalizedPartKey,
-          }),
-        } as DB["public"]["Tables"]["parts"]["Insert"])
-        .select("id")
-        .limit(1);
-
-      const id = (inserted ?? [])[0]?.id as string | undefined;
-      if (id) {
-        if (partNumber) partsByNumber.set(lower(partNumber), id);
-        if (sku) partsBySku.set(lower(sku), id);
-        partsByNormalizedKey.set(normalizedPartKey, id);
-      }
-    }
+    partsPipelineSummary = await runPartsImportPipeline({
+      shopId,
+      intakeId,
+      partsCsv,
+      partsFilePath: intakeRow.parts_file_path ?? null,
+      sourceSystem: typeof intakeRow.source === "string" ? intakeRow.source : null,
+    });
   }
 
   // 4) Import staff -> staff_invite_suggestions (NO auth creation here)
@@ -1669,6 +1534,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
                 invoicesCustomerId: unresolvedInvoicesMissingCustomer.count ?? 0,
               },
             },
+            partsPipeline: partsPipelineSummary ?? null,
             shopBuildSummary,
           },
           shopBuildSummary,
@@ -1698,6 +1564,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         invoicesCustomerId: unresolvedInvoicesMissingCustomer.count ?? 0,
       },
     },
+    partsPipeline: partsPipelineSummary,
     shopBuildSummary,
   };
 }

--- a/features/integrations/imports/runPartsImportPipeline.ts
+++ b/features/integrations/imports/runPartsImportPipeline.ts
@@ -1,0 +1,471 @@
+import { createHash } from "crypto";
+
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type CsvRow = Record<string, string>;
+
+type PartsPipelineArgs = {
+  shopId: string;
+  intakeId: string;
+  partsCsv: string;
+  partsFilePath: string | null;
+  sourceSystem: string | null;
+};
+
+export type PartsPipelineSummary = {
+  rawRows: number;
+  normalizedRows: number;
+  matchedRows: number;
+  ambiguousRows: number;
+  promotedRows: number;
+  rejectedRows: number;
+};
+
+type ParsedPart = {
+  row: CsvRow;
+  rowNumber: number;
+  name: string;
+  sku: string | null;
+  partNumber: string | null;
+  brand: string | null;
+  vendor: string | null;
+  category: string | null;
+  quantityOnHand: number | null;
+  cost: number | null;
+  price: number | null;
+  uom: string | null;
+  warnings: string[];
+  parseClean: boolean;
+};
+
+function norm(s: string): string {
+  return (s ?? "").trim();
+}
+
+function lower(s: string): string {
+  return norm(s).toLowerCase();
+}
+
+function normalizeToken(s: string | null | undefined): string {
+  return String(s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function normalizeText(s: string | null | undefined): string {
+  return String(s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function parseCsv(csv: string): { header: string[]; rows: CsvRow[] } {
+  const lines = csv
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length);
+
+  if (lines.length < 2) return { header: [], rows: [] };
+
+  const splitLine = (line: string): string[] => {
+    const out: string[] = [];
+    let cur = "";
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line[i];
+      if (ch === '"') {
+        inQuotes = !inQuotes;
+        continue;
+      }
+      if (ch === "," && !inQuotes) {
+        out.push(cur);
+        cur = "";
+        continue;
+      }
+      cur += ch;
+    }
+
+    out.push(cur);
+    return out.map((s) => s.trim());
+  };
+
+  const header = splitLine(lines[0]).map((h) => h.trim());
+  const rows: CsvRow[] = [];
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const cols = splitLine(lines[i]);
+    const rec: CsvRow = {};
+    for (let c = 0; c < header.length; c += 1) {
+      const key = header[c] || `col_${c + 1}`;
+      rec[key] = cols[c] ?? "";
+    }
+    rows.push(rec);
+  }
+
+  return { header, rows };
+}
+
+function pick(row: CsvRow, patterns: RegExp[]): string | null {
+  const keys = Object.keys(row);
+  for (const k of keys) {
+    const nk = lower(k);
+    if (patterns.some((p) => p.test(nk))) {
+      const v = norm(row[k] ?? "");
+      if (v) return v;
+    }
+  }
+  return null;
+}
+
+function parseMoney(v: string | null): number | null {
+  const s = (v ?? "").trim();
+  if (!s) return null;
+
+  const cleaned = s.replace(/[^0-9,.\-]/g, "");
+  if (!cleaned) return null;
+
+  if (cleaned.includes(",") && cleaned.includes(".")) {
+    const n = Number(cleaned.replace(/,/g, ""));
+    return Number.isFinite(n) ? n : null;
+  }
+
+  if (cleaned.includes(",") && !cleaned.includes(".")) {
+    const n = Number(cleaned.replace(",", "."));
+    return Number.isFinite(n) ? n : null;
+  }
+
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseIntSafe(v: string | null): number | null {
+  if (!v) return null;
+  const n = Number(String(v).replace(/[^0-9\-]/g, ""));
+  return Number.isFinite(n) ? n : null;
+}
+
+function normalizePartRow(row: CsvRow, rowNumber: number): ParsedPart {
+  const partNumber = pick(row, [/part number/, /^pn$/, /p\/n/, /part_no/, /part #/]);
+  const sku = pick(row, [/^sku$/, /item sku/, /stock code/]);
+  const name =
+    pick(row, [/^name$/, /part name/, /description/, /item name/, /product/]) ??
+    partNumber ??
+    sku ??
+    `Part ${rowNumber}`;
+
+  const cost = parseMoney(pick(row, [/^cost$/, /unit cost/, /buy/, /acq/])) ?? null;
+  const price = parseMoney(pick(row, [/^price$/, /sell/, /retail/, /list/])) ?? null;
+  const quantityOnHand = parseIntSafe(pick(row, [/qty/, /quantity/, /on hand/, /stock/])) ?? null;
+
+  const warnings: string[] = [];
+  if (!name) warnings.push("missing_name");
+  if (!partNumber && !sku) warnings.push("missing_part_number_and_sku");
+
+  return {
+    row,
+    rowNumber,
+    name,
+    sku,
+    partNumber,
+    brand: pick(row, [/brand/, /manufacturer/]),
+    vendor: pick(row, [/vendor/, /supplier/]),
+    category: pick(row, [/category/, /class/]),
+    quantityOnHand,
+    cost,
+    price,
+    uom: pick(row, [/uom/, /unit/, /pack/, /case/]),
+    warnings,
+    parseClean: warnings.length === 0,
+  };
+}
+
+export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<PartsPipelineSummary> {
+  const supabase = createAdminSupabase() as any;
+  const { shopId, intakeId, partsCsv, partsFilePath, sourceSystem } = args;
+
+  const { header, rows } = parseCsv(partsCsv);
+  if (rows.length === 0) {
+    return {
+      rawRows: 0,
+      normalizedRows: 0,
+      matchedRows: 0,
+      ambiguousRows: 0,
+      promotedRows: 0,
+      rejectedRows: 0,
+    };
+  }
+
+  const existingPartsRows =
+    (
+      await supabase
+        .from("parts")
+        .select("id,name,part_number,sku,supplier,category,shop_id")
+        .eq("shop_id", shopId)
+        .limit(5000)
+    ).data ?? [];
+
+  const partsByPartNo = new Map<string, { id: string; row: any }>();
+  const partsBySku = new Map<string, { id: string; row: any }>();
+  const partsByName = new Map<string, Array<{ id: string; row: any }>>();
+
+  for (const p of existingPartsRows) {
+    const partNo = normalizeToken(p.part_number);
+    const sku = normalizeToken(p.sku);
+    const name = normalizeText(p.name);
+    if (partNo) partsByPartNo.set(partNo, { id: p.id, row: p });
+    if (sku) partsBySku.set(sku, { id: p.id, row: p });
+    if (name) {
+      const prev = partsByName.get(name) ?? [];
+      prev.push({ id: p.id, row: p });
+      partsByName.set(name, prev);
+    }
+  }
+
+  const computedFileId = createHash("sha1")
+    .update(`${intakeId}|parts|${partsFilePath ?? "none"}`)
+    .digest("hex")
+    .slice(0, 32);
+
+  const { data: existingFile } = partsFilePath
+    ? await supabase
+        .from("shop_import_files")
+        .select("id")
+        .eq("intake_id", intakeId)
+        .eq("kind", "parts")
+        .eq("storage_path", partsFilePath)
+        .maybeSingle()
+    : { data: null };
+
+  const effectiveFileId = partsFilePath ? existingFile?.id ?? computedFileId : null;
+
+  if (!existingFile?.id && partsFilePath) {
+    await supabase.from("shop_import_files").insert({
+      id: effectiveFileId,
+      intake_id: intakeId,
+      kind: "parts",
+      storage_path: partsFilePath,
+      original_filename: partsFilePath.split("/").pop() ?? null,
+      parsed_row_count: rows.length,
+      status: "parsed",
+    });
+  }
+
+  const rawInsertPayload = rows.map((row, idx) => ({
+    intake_id: intakeId,
+    file_id: effectiveFileId,
+    row_number: idx + 1,
+    entity_type: "parts",
+    raw: row,
+    normalized: {},
+    errors: [],
+    shop_id: shopId,
+    original_headers: header,
+    raw_payload: row,
+    parse_status: "parsed",
+    parse_warnings: [],
+  }));
+
+  const { data: rawRowsInserted } = await supabase
+    .from("shop_import_rows")
+    .insert(rawInsertPayload)
+    .select("id,row_number,raw");
+
+  const parsedRows = rows.map((row, idx) => normalizePartRow(row, idx + 1));
+
+  const stagingRowsPayload = parsedRows.map((p, idx) => {
+    const rawRowId = rawRowsInserted?.[idx]?.id ?? null;
+    const normalizedPartNo = normalizeToken(p.partNumber);
+    const normalizedSku = normalizeToken(p.sku);
+    const normalizedName = normalizeText(p.name);
+
+    const exactPartMatch = normalizedPartNo ? partsByPartNo.get(normalizedPartNo) : null;
+    const exactSkuMatch = normalizedSku ? partsBySku.get(normalizedSku) : null;
+    const nameMatches = normalizedName ? partsByName.get(normalizedName) ?? [] : [];
+
+    let status = "pending";
+    let matchConfidence = 0;
+    let suggestedAction = "review";
+    let matchedPartId: string | null = null;
+    let matchReason: string | null = null;
+
+    if (exactPartMatch) {
+      status = "matched";
+      matchConfidence = 0.99;
+      suggestedAction = "merge_existing";
+      matchedPartId = exactPartMatch.id;
+      matchReason = "exact_part_number";
+    } else if (exactSkuMatch) {
+      status = "ambiguous";
+      matchConfidence = 0.85;
+      suggestedAction = "review";
+      matchedPartId = exactSkuMatch.id;
+      matchReason = "exact_sku_without_part_number";
+    } else if (nameMatches.length === 1) {
+      status = "ambiguous";
+      matchConfidence = 0.65;
+      suggestedAction = "review";
+      matchedPartId = nameMatches[0].id;
+      matchReason = "name_similarity_only";
+    } else if (nameMatches.length > 1) {
+      status = "ambiguous";
+      matchConfidence = 0.45;
+      suggestedAction = "review";
+      matchReason = "multiple_name_candidates";
+    } else {
+      status = "ambiguous";
+      matchConfidence = p.partNumber ? 0.7 : 0.4;
+      suggestedAction = p.partNumber ? "create_new_part_review" : "review";
+      matchReason = p.partNumber ? "new_part_number_candidate" : "insufficient_identity";
+    }
+
+    const autoPromote =
+      status === "matched" &&
+      matchReason === "exact_part_number" &&
+      p.parseClean &&
+      !!matchedPartId;
+
+    return {
+      intake_id: intakeId,
+      raw_row_id: rawRowId,
+      shop_id: shopId,
+      source_system: sourceSystem,
+      normalized_name: p.name,
+      normalized_name_key: normalizedName || null,
+      normalized_sku: normalizedSku || null,
+      normalized_part_number: normalizedPartNo || null,
+      normalized_brand: normalizeText(p.brand) || null,
+      normalized_vendor: normalizeText(p.vendor) || null,
+      mapped_category: normalizeText(p.category) || null,
+      quantity_on_hand: p.quantityOnHand,
+      cost: p.cost,
+      price: p.price,
+      unit_of_measure: p.uom,
+      pack_info: null,
+      source_confidence: matchConfidence,
+      status: autoPromote ? "approved" : status,
+      warnings: p.warnings,
+      raw_echo: {
+        partNumber: p.partNumber,
+        sku: p.sku,
+        name: p.name,
+        brand: p.brand,
+        vendor: p.vendor,
+        category: p.category,
+      },
+      suggested_action: autoPromote ? "auto_promote" : suggestedAction,
+      matched_part_id: matchedPartId,
+      match_reason: matchReason,
+      auto_promote: autoPromote,
+    };
+  });
+
+  const { data: insertedStagingRows } = await supabase
+    .from("shop_parts_import_staging")
+    .insert(stagingRowsPayload)
+    .select("id,raw_row_id,normalized_name,normalized_part_number,normalized_sku,status,matched_part_id,match_reason");
+
+  let promotedRows = 0;
+  let matchedRows = 0;
+  let ambiguousRows = 0;
+
+  for (const staged of insertedStagingRows ?? []) {
+    const shouldAutoPromote = staged.status === "approved" && staged.matched_part_id;
+
+    if (staged.status === "matched" || staged.status === "approved") matchedRows += 1;
+    if (staged.status === "ambiguous" || staged.status === "pending") ambiguousRows += 1;
+
+    if (!shouldAutoPromote) {
+      const candidates: Array<{ candidatePartId: string; confidence: number; reason: string }> = [];
+      if (staged.matched_part_id) {
+        candidates.push({
+          candidatePartId: staged.matched_part_id,
+          confidence: staged.match_reason === "exact_sku_without_part_number" ? 0.85 : 0.65,
+          reason: staged.match_reason ?? "candidate",
+        });
+      }
+
+      await supabase.from("shop_parts_import_match_candidates").insert(
+        candidates.map((c) => ({
+          staging_row_id: staged.id,
+          shop_id: shopId,
+          candidate_part_id: c.candidatePartId,
+          confidence: c.confidence,
+          reason: c.reason,
+          rank: 1,
+        })),
+      );
+
+      continue;
+    }
+
+    promotedRows += 1;
+    const sourceHash = createHash("sha1")
+      .update(`${intakeId}|${staged.raw_row_id ?? "none"}|${staged.normalized_part_number ?? ""}|${staged.normalized_sku ?? ""}`)
+      .digest("hex")
+      .slice(0, 20);
+
+    await supabase
+      .from("parts")
+      .update({
+        source_intake_id: intakeId,
+        import_notes: JSON.stringify({
+          source: "shop_boost",
+          intake_id: intakeId,
+          import_mode: "staged_auto_promote_exact_part_number",
+        }),
+      })
+      .eq("id", staged.matched_part_id);
+
+    await supabase.from("shop_parts_source_aliases").upsert(
+      {
+        shop_id: shopId,
+        intake_id: intakeId,
+        raw_row_id: staged.raw_row_id,
+        staging_row_id: staged.id,
+        part_id: staged.matched_part_id,
+        source_system: sourceSystem,
+        legacy_sku: staged.normalized_sku,
+        legacy_part_number: staged.normalized_part_number,
+        legacy_label: staged.normalized_name,
+        alias_type: "legacy_import",
+        source_hash: sourceHash,
+      },
+      { onConflict: "shop_id,part_id,source_hash" },
+    );
+
+    await supabase
+      .from("shop_parts_import_staging")
+      .update({ status: "promoted", promoted_at: new Date().toISOString() })
+      .eq("id", staged.id);
+  }
+
+  await supabase
+    .from("shop_boost_intakes")
+    .update({
+      intake_basics: {
+        partsImportPipeline: {
+          rawRows: rows.length,
+          normalizedRows: stagingRowsPayload.length,
+          matchedRows,
+          ambiguousRows,
+          promotedRows,
+          rejectedRows: 0,
+        },
+      },
+    })
+    .eq("id", intakeId)
+    .eq("shop_id", shopId);
+
+  return {
+    rawRows: rows.length,
+    normalizedRows: stagingRowsPayload.length,
+    matchedRows,
+    ambiguousRows,
+    promotedRows,
+    rejectedRows: 0,
+  };
+}


### PR DESCRIPTION
### Motivation
- Prevent messy competitor parts CSV rows from being written directly into live `parts` and inventory tables by introducing a safe staged import workflow. 
- Preserve raw uploaded data and maintain full traceability from source file/row through normalization, matching, review, and promotion. 
- Make the parts onboarding flow incremental and non-breaking while giving reviewers control over ambiguous matches. 

### Description
- Replaced inline direct upsert logic for parts in `features/integrations/imports/runFullImport.ts` with a dedicated staged pipeline call to `runPartsImportPipeline` (new): `features/integrations/imports/runPartsImportPipeline.ts`. 
- Added an additive SQL migration `db/sql/2026-04-12_shop_boost_parts_staged_pipeline.sql` that extends `shop_boost_intakes` and `shop_import_rows` and creates the staging tables `shop_parts_import_staging`, `shop_parts_import_match_candidates`, and `shop_parts_source_aliases` with indexes, FKs and RLS policies. 
- Implemented normalization + matching heuristics that score candidate matches, persist raw rows and staging rows, create candidate records for ambiguous rows, and auto-promote only high-confidence exact part-number matches while creating source alias records for traceability. 
- Wired pipeline summary into intake metadata and the import summary payload so intake records record pipeline counts and outcomes. 

### Testing
- Ran `npx tsc --noEmit` and it completed successfully, confirming TypeScript types compile. 
- Ran `npm run -s lint` which failed due to pre-existing repository-wide lint errors not introduced by this change. 
- Verified the new migration SQL is added at `db/sql/2026-04-12_shop_boost_parts_staged_pipeline.sql` and the staged pipeline implementation is at `features/integrations/imports/runPartsImportPipeline.ts` for review and deployment testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc143792048328af12d39c8ea1ff9c)