### PR TITLE
Refactor Work Order Operational Cockpit layout and focus priorities

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1618,29 +1618,11 @@ export default function WorkOrderIdClient(): JSX.Element {
           </section>
 
           {/* Workspace */}
-          <section
-            className={
-              showPanel
-                ? "grid gap-4 xl:grid-cols-[360px_minmax(0,1fr)]"
-                : "space-y-4"
-            }
-          >
+          <section className="grid gap-3 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] md:items-start md:gap-4">
             {/* Left: jobs list/cards */}
-            <div className="space-y-4">
-
-            {/* Jobs list */}
-            <section className={cn(PANEL_VARIANTS.primary, "p-3 sm:p-4", showPanel && "xl:sticky xl:top-4")}>
-              <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div className="space-y-1">
-                  <h2 className="text-sm font-semibold text-foreground sm:text-base">
-                    Job navigator
-                  </h2>
-                  <p className="text-[11px] text-muted-foreground">
-                    Select a job to keep controls and updates in the focused cockpit.
-                  </p>
-                </div>
-
-                {linesNeedingQuote.length > 0 && (
+            <div className="space-y-2">
+              {linesNeedingQuote.length > 0 && (
+                <div className="flex justify-end">
                   <button
                     type="button"
                     className="inline-flex items-center gap-1 rounded-full bg-blue-600 px-3 py-1.5 text-[11px] font-semibold text-white shadow-[0_0_18px_rgba(37,99,235,0.9)] hover:bg-blue-500 disabled:opacity-60"
@@ -1650,11 +1632,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                   >
                     ⚡ Quote all lines
                   </button>
-                )}
-              </div>
+                </div>
+              )}
 
               {sortedLines.length > 0 && (
-                <div className="mb-4 rounded-xl border border-white/10 bg-black/50 px-3 py-2.5">
+                <div className="rounded-xl border border-white/10 bg-black/50 px-3 py-2">
                   {(() => {
                     const total = sortedLines.length;
                     const done = sortedLines.filter((ln) => {
@@ -1731,78 +1713,69 @@ export default function WorkOrderIdClient(): JSX.Element {
                     });
 
                     return (
-                      <div key={ln.id} className="relative">
-                        <JobCard
-                          index={idx}
-                          line={ln}
-                          parts={partsForLine}
-                          technicians={assignables}
-                          canAssign={canAssign}
-                          isPunchedIn={punchedIn}
-                          onOpen={() => openFocusedJob(ln.id)}
-                          onAssign={
-                            canAssign
-                              ? async (techId: string) => {
-                                  try {
-                                    const res = await fetch("/api/work-orders/assign-line", {
-                                      method: "POST",
-                                      headers: { "Content-Type": "application/json" },
-                                      body: JSON.stringify({
-                                        work_order_line_id: ln.id,
-                                        tech_id: techId,
-                                      }),
-                                    });
+                      <JobCard
+                        key={ln.id}
+                        index={idx}
+                        line={ln}
+                        parts={partsForLine}
+                        technicians={assignables}
+                        canAssign={canAssign}
+                        isPunchedIn={punchedIn}
+                        onOpen={() => openFocusedJob(ln.id)}
+                        onAssign={
+                          canAssign
+                            ? async (techId: string) => {
+                                try {
+                                  const res = await fetch("/api/work-orders/assign-line", {
+                                    method: "POST",
+                                    headers: { "Content-Type": "application/json" },
+                                    body: JSON.stringify({
+                                      work_order_line_id: ln.id,
+                                      tech_id: techId,
+                                    }),
+                                  });
 
-                                    const json = await res.json().catch(() => ({}));
+                                  const json = await res.json().catch(() => ({}));
 
-                                    if (!res.ok) {
-                                      throw new Error(
-                                        typeof json?.error === "string"
-                                          ? json.error
-                                          : "Failed to assign technician."
-                                      );
-                                    }
-
-                                    toast.success("Technician assigned.");
-                                    await fetchAll();
-                                  } catch (e) {
-                                    const msg = e instanceof Error ? e.message : "Failed to assign technician.";
-                                    toast.error(msg);
+                                  if (!res.ok) {
+                                    throw new Error(
+                                      typeof json?.error === "string"
+                                        ? json.error
+                                        : "Failed to assign technician."
+                                    );
                                   }
+
+                                  toast.success("Technician assigned.");
+                                  await fetchAll();
+                                } catch (e) {
+                                  const msg = e instanceof Error ? e.message : "Failed to assign technician.";
+                                  toast.error(msg);
                                 }
-                              : undefined
-                          }
-                          onOpenInspection={
-                            ln.job_type === "inspection"
-                              ? () => void openInspectionForLine(ln)
-                              : undefined
-                          }
-                          onAddPart={() => setPartsLineId(ln.id)}
-                          reviewOk={reviewOk}
-                          reviewIssues={reviewIssuesByLine[ln.id] ?? []}
-                          canDelete={canDeleteLine}
-                          onDelete={() => openDeleteForLine(ln.id)}
-                          compact={showPanel}
-                          selected={panelLineId === ln.id}
-                        />
-                      </div>
+                              }
+                            : undefined
+                        }
+                        onOpenInspection={
+                          ln.job_type === "inspection"
+                            ? () => void openInspectionForLine(ln)
+                            : undefined
+                        }
+                        onAddPart={() => setPartsLineId(ln.id)}
+                        reviewOk={reviewOk}
+                        reviewIssues={reviewIssuesByLine[ln.id] ?? []}
+                        canDelete={canDeleteLine}
+                        onDelete={() => openDeleteForLine(ln.id)}
+                        compact={showPanel}
+                        selected={panelLineId === ln.id}
+                      />
                     );
                   })}
                 </div>
               )}
-            </section>
-
-            <section className={cn(PANEL_VARIANTS.passive, "p-3 text-sm text-muted-foreground")}>
-              <p>
-                Select a job card above to open the focused job panel with full editing, punch and
-                inspection controls.
-              </p>
-            </section>
             </div>
 
             {/* Right: focused job workspace pane */}
-            {showPanel && panelLineId ? (
-              <div className="self-start">
+            <div className="md:sticky md:top-4">
+              {panelLineId ? (
                 <FocusedJobModal
                   key={panelLineId}
                   isOpen={true}
@@ -1812,8 +1785,12 @@ export default function WorkOrderIdClient(): JSX.Element {
                   mode="tech"
                   variant="panel"
                 />
-              </div>
-            ) : null}
+              ) : (
+                <section className={cn(PANEL_VARIANTS.passive, "rounded-2xl p-4 text-sm text-muted-foreground")}>
+                  Select a job
+                </section>
+              )}
+            </div>
           </section>
 
         </div>

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -292,7 +292,8 @@ export function JobCard({
       className={cn(
         "relative overflow-hidden p-0",
         "transition hover:-translate-y-[1px] hover:border-[color:var(--accent-copper-soft,#fdba74)]",
-        selected && "border-[color:var(--accent-copper-soft,#fdba74)] shadow-[0_0_0_1px_rgba(253,186,116,0.4)]",
+        selected &&
+          "border-[color:var(--accent-copper-light,#fdba74)] shadow-[0_0_0_1px_rgba(253,186,116,0.7),0_10px_30px_rgba(249,115,22,0.22)]",
         surfaceCfg.surfaceClass,
       )}
     >

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -625,6 +625,90 @@ export default function FocusedJobModal(props: {
           ) : (
             <div className={isPanelVariant ? "grid gap-3 xl:grid-cols-[1.1fr_1fr]" : "space-y-4"}>
               <div className="space-y-3">
+              {mode === "tech" ? (
+                <SectionCard title="Operational actions">
+                  {line.status !== "completed" ? (
+                    <JobPunchButton
+                      lineId={line.id}
+                      punchedInAt={line.punched_in_at}
+                      punchedOutAt={line.punched_out_at}
+                      status={line.status as WorkflowStatus}
+                      onFinishRequested={() => {
+                        closeAllSubModals();
+                        setPrefillCause(line.cause ?? "");
+                        setPrefillCorrection(line.correction ?? "");
+                        setOpenComplete(true);
+                      }}
+                      onUpdated={refresh}
+                      disabled={completionBlocked}
+                    />
+                  ) : null}
+
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                    <button
+                      type="button"
+                      className={btnAccent}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setPrefillCause(line?.cause ?? "");
+                        setPrefillCorrection(line?.correction ?? "");
+                        setOpenComplete(true);
+                      }}
+                      disabled={completionBlocked}
+                    >
+                      Complete
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnWarn}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenHold(true);
+                      }}
+                      disabled={busy}
+                    >
+                      {line.status === "on_hold" ? "On Hold" : "Hold"}
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnDanger}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenParts(true);
+                      }}
+                      disabled={busy}
+                    >
+                      Request Parts
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnInfo}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenAi(true);
+                      }}
+                    >
+                      AI Assist
+                    </button>
+                  </div>
+
+                  {completionBlocked ? (
+                    <div className="mt-2 text-[11px] text-amber-300">
+                      {line.status === "awaiting_approval"
+                        ? "Awaiting approval — punching disabled"
+                        : line.status === "declined"
+                          ? "Declined — punching disabled"
+                          : line.approval_state && line.approval_state !== "approved"
+                            ? "Not approved — punching disabled"
+                            : ""}
+                    </div>
+                  ) : null}
+                </SectionCard>
+              ) : null}
+
               <SectionCard title="Quick status">
                 <div className="grid gap-3 sm:grid-cols-2">
                   <MetaStat
@@ -684,78 +768,10 @@ export default function FocusedJobModal(props: {
                 </SectionCard>
               ) : null}
 
-              {mode === "tech" && line.status !== "completed" ? (
-                <SectionCard title="Punch controls">
-                  <JobPunchButton
-                    lineId={line.id}
-                    punchedInAt={line.punched_in_at}
-                    punchedOutAt={line.punched_out_at}
-                    status={line.status as WorkflowStatus}
-                    onFinishRequested={() => {
-                      closeAllSubModals();
-                      setPrefillCause(line.cause ?? "");
-                      setPrefillCorrection(line.correction ?? "");
-                      setOpenComplete(true);
-                    }}
-                    onUpdated={refresh}
-                    disabled={completionBlocked}
-                  />
-                  {completionBlocked ? (
-                    <div className="mt-2 text-[11px] text-amber-300">
-                      {line.status === "awaiting_approval"
-                        ? "Awaiting approval — punching disabled"
-                        : line.status === "declined"
-                          ? "Declined — punching disabled"
-                          : line.approval_state && line.approval_state !== "approved"
-                            ? "Not approved — punching disabled"
-                            : ""}
-                    </div>
-                  ) : null}
-                </SectionCard>
-              ) : null}
-
               <SectionCard title="Actions">
                 <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
                   {mode === "tech" ? (
                     <>
-                      <button
-                        type="button"
-                        className={btnAccent}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setPrefillCause(line?.cause ?? "");
-                          setPrefillCorrection(line?.correction ?? "");
-                          setOpenComplete(true);
-                        }}
-                        disabled={completionBlocked}
-                      >
-                        Complete
-                      </button>
-
-                      <button
-                        type="button"
-                        className={btnDanger}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenParts(true);
-                        }}
-                        disabled={busy}
-                      >
-                        Request Parts
-                      </button>
-
-                      <button
-                        type="button"
-                        className={btnWarn}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenHold(true);
-                        }}
-                        disabled={busy}
-                      >
-                        {line.status === "on_hold" ? "On Hold" : "Hold"}
-                      </button>
-
                       <button
                         type="button"
                         className={btnNeutral}
@@ -779,31 +795,6 @@ export default function FocusedJobModal(props: {
                         Chat
                       </button>
 
-                      <button
-                        type="button"
-                        className={btnInfo}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenAi(true);
-                        }}
-                      >
-                        AI Assist
-                      </button>
-
-                      <button
-                        type="button"
-                        className={btnNeutral}
-                        onClick={() => {
-                          if (!vehicle?.id) {
-                            toast.error("No vehicle linked to this work order yet.");
-                            return;
-                          }
-                          setOpenVehicleHistory(true);
-                        }}
-                        disabled={busy || !vehicle?.id}
-                      >
-                        Vehicle History
-                      </button>
                     </>
                   ) : (
                     <>
@@ -841,20 +832,6 @@ export default function FocusedJobModal(props: {
                         DTC Assist
                       </button>
 
-                      <button
-                        type="button"
-                        className={btnNeutral}
-                        onClick={() => {
-                          if (!vehicle?.id) {
-                            toast.error("No vehicle linked to this work order yet.");
-                            return;
-                          }
-                          setOpenVehicleHistory(true);
-                        }}
-                        disabled={busy || !vehicle?.id}
-                      >
-                        Vehicle History
-                      </button>
                     </>
                   )}
                 </div>
@@ -862,6 +839,35 @@ export default function FocusedJobModal(props: {
               </div>
 
               <div className="space-y-3">
+              <SectionCard title="Tech notes">
+                <textarea
+                  rows={3}
+                  value={techNotes}
+                  onChange={(e) => setTechNotes(e.target.value)}
+                  onBlur={saveNotes}
+                  disabled={savingNotes}
+                  className="w-full rounded-xl border border-white/10 bg-black/35 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-[var(--accent-copper-light)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]/60"
+                  placeholder="Add notes for this job…"
+                />
+              </SectionCard>
+
+              <SectionCard title="History">
+                <button
+                  type="button"
+                  className={btnNeutral}
+                  onClick={() => {
+                    if (!vehicle?.id) {
+                      toast.error("No vehicle linked to this work order yet.");
+                      return;
+                    }
+                    setOpenVehicleHistory(true);
+                  }}
+                  disabled={busy || !vehicle?.id}
+                >
+                  Vehicle History
+                </button>
+              </SectionCard>
+
               <SectionCard title="Parts used">
                 {allocsLoading ? (
                   <div className="text-sm text-neutral-300">Loading…</div>
@@ -900,18 +906,6 @@ export default function FocusedJobModal(props: {
                     </ul>
                   </div>
                 )}
-              </SectionCard>
-
-              <SectionCard title="Tech notes">
-                <textarea
-                  rows={3}
-                  value={techNotes}
-                  onChange={(e) => setTechNotes(e.target.value)}
-                  onBlur={saveNotes}
-                  disabled={savingNotes}
-                  className="w-full rounded-xl border border-white/10 bg-black/35 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-[var(--accent-copper-light)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]/60"
-                  placeholder="Add notes for this job…"
-                />
               </SectionCard>
 
               <SectionCard title="AI suggested repairs">


### PR DESCRIPTION
### Motivation
- Restore the correct operational mental model by making job cards the primary surface and the focused job panel the secondary, denser and faster to scan. 
- Remove the misleading “job navigator” wrapper and reduce vertical noise while keeping existing data flows and behaviors intact. 

### Description
- Replace the old job navigator container with a direct rendering of `JobCard` items and convert the workspace to a two-column responsive grid (`md+` uses a 60/40 split via `3fr/2fr`, mobile stacks). 
- Make the focus panel sticky and conditional: it only renders the focused panel when a job is selected and otherwise shows the empty state text `Select a job`. 
- Move operational controls to the top of the focused panel by adding an `Operational actions` section containing start/complete/hold controls, `Request Parts`, and `AI Assist`, and move notes/history/parts lower to reduce vertical noise. 
- Strengthen selected job visual state on `JobCard` and remove unnecessary nested wrapper elements around cards to simplify the layout and improve rendering density.
- Files changed: `app/work-orders/[id]/Client.tsx`, `features/work-orders/components/JobCard.tsx`, `features/work-orders/components/workorders/FocusedJobModal.tsx`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build check completed successfully. 
- No automated unit tests were changed by this UI-only refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1f8ed480832881e3521e401323f6)