### PR TITLE
Refine Work Order cockpit: denser job rail and action-first focused panel

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -196,8 +196,10 @@ export default function WorkOrderIdClient(): JSX.Element {
   // ✅ prevents “logged out” banner flashing / sticking
   const [authChecked, setAuthChecked] = useState<boolean>(false);
 
-  const [showDetails, setShowDetails] = useTabState<boolean>("wo:showDetails", true);
+  const [showDetails, setShowDetails] = useTabState<boolean>("wo:showDetails", false);
   const [showFullHistory, setShowFullHistory] = useState(false);
+  const [showTimeline, setShowTimeline] = useState(false);
+  const [showApprovalSummary, setShowApprovalSummary] = useState(false);
 
   // ✅ focused job
   const [focusedJobId, setFocusedJobId] = useState<string | null>(null);
@@ -1297,9 +1299,9 @@ export default function WorkOrderIdClient(): JSX.Element {
         ) : !wo ? (
           <div className="mt-2 text-sm text-red-400">Work order not found.</div>
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-3">
           {/* Header */}
-          <section className={cn(PANEL_VARIANTS.primary, "p-3")}>
+          <section className={cn(PANEL_VARIANTS.primary, "p-2.5 sm:p-3")}>
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="space-y-1">
                   <h1 className="text-lg font-semibold text-foreground sm:text-xl">
@@ -1340,29 +1342,47 @@ export default function WorkOrderIdClient(): JSX.Element {
               </div>
           </section>
 
-          <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-            <DecisionTimeline stages={decisionTimelineStages} compact />
-            <div className={cn(PANEL_VARIANTS.secondary, "p-2.5")}>
-              <DecisionEventFeed
-                events={decisionEvents}
-                filter="all"
-                maxVisible={showFullHistory ? 12 : 3}
-                compact
-              />
-              {decisionEvents.length > 3 ? (
-                <button
-                  type="button"
-                  onClick={() => setShowFullHistory((prev) => !prev)}
-                  className="mt-2 text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:underline"
-                >
-                  {showFullHistory ? "Show recent only" : "View full history"}
-                </button>
-              ) : null}
-            </div>
+          <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}> 
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-2 text-left"
+              onClick={() => setShowTimeline((prev) => !prev)}
+              aria-expanded={showTimeline}
+            >
+              <span className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Decision timeline & recent events
+              </span>
+              <span className="text-[11px] font-medium text-[rgba(184,115,51,0.95)]">
+                {showTimeline ? "Hide" : "Show"}
+              </span>
+            </button>
+
+            {showTimeline ? (
+              <div className="mt-2 grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <DecisionTimeline stages={decisionTimelineStages} compact />
+                <div className={cn(PANEL_VARIANTS.passive, "p-2")}> 
+                  <DecisionEventFeed
+                    events={decisionEvents}
+                    filter="all"
+                    maxVisible={showFullHistory ? 10 : 3}
+                    compact
+                  />
+                  {decisionEvents.length > 3 ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowFullHistory((prev) => !prev)}
+                      className="mt-1.5 text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:underline"
+                    >
+                      {showFullHistory ? "Show recent only" : "View full history"}
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </section>
 
           {/* Vehicle & Customer */}
-          <section className={cn(PANEL_VARIANTS.secondary, "p-3")}>
+          <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}> 
             <div className="flex items-center justify-between gap-2">
               <h2 className="text-sm font-semibold text-foreground sm:text-base">
                 Vehicle &amp; Customer
@@ -1378,7 +1398,7 @@ export default function WorkOrderIdClient(): JSX.Element {
             </div>
 
             {showDetails && (
-              <div className="mt-2 grid gap-3 sm:grid-cols-2">
+              <div className="mt-2 grid gap-2.5 sm:grid-cols-2">
                 {/* Vehicle */}
                 <div className={cardInner}>
                   <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -1454,7 +1474,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           <section
             className={cn(
               PANEL_VARIANTS.secondary,
-              "p-3",
+              "p-2.5",
               hasAnyApprovalItems ? "cursor-pointer hover:border-sky-400/35" : "",
             )}
             onClick={hasAnyApprovalItems ? openQuoteReview : undefined}
@@ -1472,9 +1492,24 @@ export default function WorkOrderIdClient(): JSX.Element {
             }
             aria-label={hasAnyApprovalItems ? "Open quote review" : undefined}
           >
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  Approval queue
+                </div>
+                <button
+                  type="button"
+                  className="text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowApprovalSummary((prev) => !prev);
+                  }}
+                >
+                  {showApprovalSummary ? "Hide" : "Show"}
+                </button>
+              </div>
               {!hasAnyApprovalItems ? (
-                <p className="text-xs text-muted-foreground">No lines waiting for approval.</p>
-              ) : (
+                <p className="text-[11px] text-muted-foreground">Approval queue clear.</p>
+              ) : showApprovalSummary ? (
                 <>
                   {recentApprovalPending.length > 0 && (
                     <div className="space-y-2">
@@ -1614,11 +1649,15 @@ export default function WorkOrderIdClient(): JSX.Element {
                     </div>
                   )}
                 </>
+              ) : (
+                <div className="text-[11px] text-muted-foreground">
+                  {approvalPending.length + approvalPendingQuotes.length} item(s) awaiting decision.
+                </div>
               )}
           </section>
 
           {/* Workspace */}
-          <section className="grid gap-3 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] md:items-start md:gap-4">
+          <section className="grid gap-3 lg:grid-cols-[minmax(0,58fr)_minmax(0,42fr)] lg:items-start lg:gap-4">
             {/* Left: jobs list/cards */}
             <div className="space-y-2">
               {linesNeedingQuote.length > 0 && (
@@ -1635,36 +1674,6 @@ export default function WorkOrderIdClient(): JSX.Element {
                 </div>
               )}
 
-              {sortedLines.length > 0 && (
-                <div className="rounded-xl border border-white/10 bg-black/50 px-3 py-2">
-                  {(() => {
-                    const total = sortedLines.length;
-                    const done = sortedLines.filter((ln) => {
-                      const s = (ln.status ?? "").toLowerCase();
-                      return s === "completed" || s === "ready_to_invoice" || s === "invoiced";
-                    }).length;
-                    const pct = total ? Math.round((done / total) * 100) : 0;
-
-                    return (
-                      <>
-                        <div className="flex items-center justify-between gap-2 text-[11px] text-neutral-300">
-                          <span className="font-medium">
-                            Job progress: <span className="text-white">{done}/{total} done</span>
-                          </span>
-                          <span className="text-[10px] text-neutral-400">{pct}% complete</span>
-                        </div>
-                        <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-neutral-900">
-                          <div
-                            className="h-full rounded-full bg-[linear-gradient(90deg,_rgba(15,118,110,0.9),_rgba(16,185,129,0.9),_rgba(249,115,22,0.95))] transition-[width]"
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                      </>
-                    );
-                  })()}
-                </div>
-              )}
-
               {sortedLines.length === 0 ? (
                 <p className="text-sm text-muted-foreground">
                   No jobs added yet. Use the{" "}
@@ -1674,7 +1683,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                   actions in the focused panel to start building this work order.
                 </p>
               ) : (
-                <div className="max-h-[70vh] space-y-2 overflow-auto pr-1">
+                <div className="max-h-[72vh] space-y-1.5 overflow-auto pr-1">
                   {sortedLines.map((ln, idx) => {
                     const punchedIn = !!ln.punched_in_at && !ln.punched_out_at;
 
@@ -1774,7 +1783,7 @@ export default function WorkOrderIdClient(): JSX.Element {
             </div>
 
             {/* Right: focused job workspace pane */}
-            <div className="md:sticky md:top-4">
+            <div className="lg:sticky lg:top-20">
               {panelLineId ? (
                 <FocusedJobModal
                   key={panelLineId}

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -66,55 +66,80 @@ const CARD_SURFACE: Record<
   KnownStatus,
   {
     badgeVariant: "info" | "active" | "warning" | "success";
-    railClass: string;
     surfaceClass: string;
     label: string;
   }
 > = {
   awaiting: {
     badgeVariant: "info",
-    railClass: "bg-slate-400/80",
     surfaceClass:
       "bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.12),rgba(10,10,10,0.96))]",
     label: "Awaiting",
   },
   in_progress: {
     badgeVariant: "active",
-    railClass:
-      "bg-[linear-gradient(180deg,var(--accent-copper,#f97316),var(--accent-copper-light,#fdba74))]",
     surfaceClass:
       "bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),rgba(10,10,10,0.96))]",
     label: "In Progress",
   },
   on_hold: {
     badgeVariant: "warning",
-    railClass: "bg-amber-400/85",
     surfaceClass:
       "bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.14),rgba(10,10,10,0.96))]",
     label: "On Hold",
   },
   completed: {
     badgeVariant: "success",
-    railClass: "bg-emerald-400/85",
     surfaceClass:
       "bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(10,10,10,0.96))]",
     label: "Completed",
   },
   ready_to_invoice: {
     badgeVariant: "success",
-    railClass: "bg-emerald-400/85",
     surfaceClass:
       "bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(10,10,10,0.96))]",
     label: "Ready to Invoice",
   },
   invoiced: {
     badgeVariant: "success",
-    railClass: "bg-emerald-400/85",
     surfaceClass:
       "bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(10,10,10,0.96))]",
     label: "Invoiced",
   },
 };
+
+function statusRailTone(args: {
+  status: string | null;
+  holdReason: string | null;
+  approvalState: string | null;
+  reviewFlags: ReviewFlags;
+}): "healthy" | "needs" | "blocked" {
+  const status = norm(args.status);
+  const hold = norm(args.holdReason);
+  const approval = norm(args.approvalState);
+
+  if (
+    status === "on_hold" ||
+    status === "declined" ||
+    hold.includes("block") ||
+    hold.includes("part") ||
+    hold.includes("urgent")
+  ) {
+    return "blocked";
+  }
+
+  if (
+    approval === "pending" ||
+    args.reviewFlags.missingCause ||
+    args.reviewFlags.missingComplaint ||
+    args.reviewFlags.missingCorrection ||
+    args.reviewFlags.noParts
+  ) {
+    return "needs";
+  }
+
+  return "healthy";
+}
 
 function norm(s: unknown): string {
   return String(s ?? "").trim().toLowerCase();
@@ -196,7 +221,7 @@ function ReviewPill({
     <span
       title={title}
       className={cn(
-        "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]",
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.1em]",
         tone === "ok"
           ? "border-emerald-400/60 bg-emerald-400/10 text-emerald-100"
           : tone === "warn"
@@ -275,6 +300,12 @@ export function JobCard({
     partsCount: parts.length,
     reviewIssues,
   });
+  const railTone = statusRailTone({
+    status: line.status,
+    holdReason: line.hold_reason,
+    approvalState: line.approval_state,
+    reviewFlags,
+  });
 
   const createdLabel = line.created_at
     ? formatDistanceToNow(new Date(line.created_at), { addSuffix: true })
@@ -288,19 +319,43 @@ export function JobCard({
   void onDelete;
 
   return (
-    <Card
-      className={cn(
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+      className="outline-none"
+      aria-label={`Open job ${index + 1}: ${jobLabel}`}
+      aria-pressed={selected}
+    >
+      <Card
+        className={cn(
         "relative overflow-hidden p-0",
         "transition hover:-translate-y-[1px] hover:border-[color:var(--accent-copper-soft,#fdba74)]",
+        "focus-within:border-[color:var(--accent-copper-light,#fdba74)] focus-within:shadow-[0_0_0_1px_rgba(253,186,116,0.55),0_10px_30px_rgba(249,115,22,0.18)]",
         selected &&
-          "border-[color:var(--accent-copper-light,#fdba74)] shadow-[0_0_0_1px_rgba(253,186,116,0.7),0_10px_30px_rgba(249,115,22,0.22)]",
+          "scale-[1.01] border-[color:var(--accent-copper-light,#fdba74)] bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.2),rgba(10,10,10,0.96))] shadow-[0_0_0_1px_rgba(253,186,116,0.7),0_12px_34px_rgba(249,115,22,0.24)]",
         surfaceCfg.surfaceClass,
       )}
-    >
-      <div className={cn("absolute inset-y-0 left-0 w-1", surfaceCfg.railClass)} />
+      >
+        <div
+          className={cn(
+            "absolute inset-y-0 left-0 w-1",
+            railTone === "healthy"
+              ? "bg-emerald-400/90"
+              : railTone === "needs"
+                ? "bg-amber-400/90"
+                : "bg-red-400/90",
+          )}
+        />
 
-      <div className={cn("relative pl-6", compact ? "p-3.5" : "p-5")}>
-        <div className={cn("flex flex-col", compact ? "gap-2.5" : "gap-4")}>
+        <div className={cn("relative pl-5", compact ? "p-3" : "p-4")}>
+          <div className={cn("flex flex-col", compact ? "gap-2" : "gap-3")}>
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
@@ -315,13 +370,13 @@ export function JobCard({
                 ) : null}
               </div>
 
-              <div className={cn("flex items-start gap-3", compact ? "mt-2" : "mt-3")}>
+              <div className={cn("flex items-start gap-2.5", compact ? "mt-1.5" : "mt-2")}>
                 <div className={cn("flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-xs font-semibold text-neutral-200", compact ? "h-6 w-6" : "h-8 w-8")}>
                   {index + 1}
                 </div>
 
                 <div className="min-w-0">
-                  <h3 className={cn("font-semibold text-white", compact ? "text-sm sm:text-base" : "text-base sm:text-lg")}>
+                  <h3 className={cn("font-semibold text-white", compact ? "text-sm sm:text-[15px]" : "text-[15px] sm:text-base")}>
                     {jobLabel}
                   </h3>
                   <p className={cn("text-xs uppercase tracking-[0.16em] text-neutral-500", compact ? "mt-0.5" : "mt-1")}>
@@ -331,7 +386,7 @@ export function JobCard({
               </div>
             </div>
 
-            <div className={cn("flex flex-wrap items-center", compact ? "gap-1.5" : "gap-2")}>
+            <div className={cn("flex flex-wrap items-center", compact ? "gap-1" : "gap-1.5")}>
               <Button type="button" variant={selected ? "secondary" : "outline"} size="sm" onClick={onOpen}>
                 Open
               </Button>
@@ -378,27 +433,25 @@ export function JobCard({
             </div>
           </div>
 
-          <div className={cn("flex flex-wrap", compact ? "gap-1.5" : "gap-2")}>
-            <ReviewPill
-              tone={reviewFlags.missingComplaint ? "warn" : "ok"}
-              label={reviewFlags.missingComplaint ? "Complaint missing" : "Complaint ok"}
-              title="Complaint / description completeness"
-            />
-            <ReviewPill
-              tone={reviewFlags.missingCause ? "warn" : "ok"}
-              label={reviewFlags.missingCause ? "Cause missing" : "Cause ok"}
-              title="Cause completeness"
-            />
-            <ReviewPill
-              tone={reviewFlags.missingCorrection ? "warn" : "ok"}
-              label={reviewFlags.missingCorrection ? "Correction missing" : "Correction ok"}
-              title="Correction completeness"
-            />
-            <ReviewPill
-              tone={reviewFlags.noParts ? "warn" : "ok"}
-              label={reviewFlags.noParts ? "No parts" : "Parts added"}
-              title="Parts completeness"
-            />
+          <div className={cn("flex flex-wrap", compact ? "gap-1" : "gap-1.5")}>
+            {reviewFlags.missingComplaint ? (
+              <ReviewPill tone="warn" label="Complaint missing" title="Complaint / description completeness" />
+            ) : null}
+            {reviewFlags.missingCause ? (
+              <ReviewPill tone="warn" label="Cause missing" title="Cause completeness" />
+            ) : null}
+            {reviewFlags.missingCorrection ? (
+              <ReviewPill tone="warn" label="Correction missing" title="Correction completeness" />
+            ) : null}
+            {reviewFlags.noParts ? (
+              <ReviewPill tone="warn" label="No parts" title="Parts completeness" />
+            ) : null}
+            {norm(line.status) === "on_hold" ? (
+              <ReviewPill tone="warn" label="Blocked" title="Line currently blocked or on hold" />
+            ) : null}
+            {norm(line.approval_state) === "pending" ? (
+              <ReviewPill tone="info" label="Waiting approval" title="Waiting for approval decision" />
+            ) : null}
             {reviewFlags.otherIssues > 0 ? (
               <ReviewPill
                 tone="info"
@@ -410,7 +463,7 @@ export function JobCard({
 
           {!collapsed ? (
             <>
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-4">
                 <MetaTile label="Assigned Tech" value={assignedTech} />
                 <MetaTile label="Parts" value={String(parts.length)} />
                 <MetaTile
@@ -421,12 +474,12 @@ export function JobCard({
               </div>
 
               {canAssign && onAssign ? (
-                <div className="rounded-xl border border-white/10 bg-black/25 p-4">
+                <div className="rounded-xl border border-white/10 bg-black/25 p-3">
                   <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
                     Assign technician
                   </div>
 
-                  <div className="mt-3 flex flex-wrap gap-2">
+                  <div className="mt-2.5 flex flex-wrap gap-1.5">
                     {technicians.length === 0 ? (
                       <span className="text-sm text-neutral-400">
                         No technicians available.
@@ -458,8 +511,9 @@ export function JobCard({
             </>
           ) : null}
         </div>
-      </div>
-    </Card>
+        </div>
+      </Card>
+    </div>
   );
 }
 

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -47,16 +47,14 @@ const btnBase =
   "inline-flex items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition";
 const btnNeutral =
   btnBase + " border-white/10 bg-black/35 text-neutral-100 hover:bg-white/5";
-const btnWarn =
-  btnBase +
-  " border-amber-400/45 bg-amber-500/10 text-amber-100 hover:bg-amber-500/20";
-const btnDanger =
-  btnBase + " border-red-500/45 bg-red-500/10 text-red-100 hover:bg-red-500/20";
 const btnInfo =
   btnBase + " border-sky-500/45 bg-sky-500/10 text-sky-100 hover:bg-sky-500/20";
-const btnAccent =
+const btnPrimary =
   btnBase +
-  " border-[var(--accent-copper-soft)] bg-[var(--accent-copper-faint)] text-[var(--accent-copper-light)] hover:bg-[var(--accent-copper-soft)]/20";
+  " border-[var(--accent-copper-soft)] bg-[var(--accent-copper,#f97316)]/20 text-[var(--accent-copper-light)] shadow-[0_0_20px_rgba(249,115,22,0.2)] hover:bg-[var(--accent-copper,#f97316)]/30";
+const btnSecondary = btnInfo;
+const btnTertiary =
+  btnBase + " border-white/10 bg-black/25 text-neutral-200 hover:bg-white/5";
 
 type DB = Database;
 type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
@@ -528,6 +526,14 @@ export default function FocusedJobModal(props: {
     line?.status === "declined" ||
     (!!line?.approval_state && line.approval_state !== "approved");
   const isPanelVariant = variant === "panel";
+  const partsCount = allocs.length;
+  const laborDisplay =
+    typeof line?.labor_time === "number" ? `${line.labor_time.toFixed(1)} h` : "—";
+  const lineTotal = Number(
+    (line as unknown as { line_total?: number | null; total_price?: number | null })?.line_total ??
+      (line as unknown as { total_price?: number | null })?.total_price ??
+      0,
+  );
 
   if (!isOpen) return null;
 
@@ -558,6 +564,9 @@ export default function FocusedJobModal(props: {
                   WO #{workOrder.custom_id || workOrder.id?.slice(0, 8)}
                 </div>
               ) : null}
+              <div className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-500">
+                Selected job
+              </div>
             </div>
 
             <div className="flex items-center gap-2">
@@ -623,7 +632,7 @@ export default function FocusedJobModal(props: {
           ) : !line ? (
             <div className="text-sm text-neutral-300">No job found.</div>
           ) : (
-            <div className={isPanelVariant ? "grid gap-3 xl:grid-cols-[1.1fr_1fr]" : "space-y-4"}>
+            <div className={isPanelVariant ? "grid gap-3 xl:grid-cols-[1.05fr_1fr]" : "space-y-4"}>
               <div className="space-y-3">
               {mode === "tech" ? (
                 <SectionCard title="Operational actions">
@@ -647,7 +656,21 @@ export default function FocusedJobModal(props: {
                   <div className="mt-2 grid gap-2 sm:grid-cols-2">
                     <button
                       type="button"
-                      className={btnAccent}
+                      className={btnPrimary}
+                      onClick={async () => {
+                        if (!line?.id || busy) return;
+                        closeAllSubModals();
+                        await runJobPunchTransition(line.id, "start");
+                        await refresh();
+                      }}
+                      disabled={busy || line?.status === "in_progress" || line?.status === "completed"}
+                    >
+                      Start Job
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnPrimary}
                       onClick={() => {
                         closeAllSubModals();
                         setPrefillCause(line?.cause ?? "");
@@ -661,7 +684,7 @@ export default function FocusedJobModal(props: {
 
                     <button
                       type="button"
-                      className={btnWarn}
+                      className={btnSecondary}
                       onClick={() => {
                         closeAllSubModals();
                         setOpenHold(true);
@@ -673,7 +696,7 @@ export default function FocusedJobModal(props: {
 
                     <button
                       type="button"
-                      className={btnDanger}
+                      className={btnSecondary}
                       onClick={() => {
                         closeAllSubModals();
                         setOpenParts(true);
@@ -685,13 +708,52 @@ export default function FocusedJobModal(props: {
 
                     <button
                       type="button"
-                      className={btnInfo}
+                      className={btnSecondary}
                       onClick={() => {
                         closeAllSubModals();
                         setOpenAi(true);
                       }}
                     >
                       AI Assist
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnTertiary}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenPhoto(true);
+                      }}
+                      disabled={busy}
+                    >
+                      Add Photo
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnTertiary}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenChat(true);
+                      }}
+                    >
+                      Chat
+                    </button>
+
+                    <button
+                      type="button"
+                      className={btnTertiary}
+                      onClick={() => {
+                        if (!vehicle?.id) {
+                          toast.error("No vehicle linked to this work order yet.");
+                          return;
+                        }
+                        closeAllSubModals();
+                        setOpenVehicleHistory(true);
+                      }}
+                      disabled={busy || !vehicle?.id}
+                    >
+                      Vehicle History
                     </button>
                   </div>
 
@@ -710,7 +772,7 @@ export default function FocusedJobModal(props: {
               ) : null}
 
               <SectionCard title="Quick status">
-                <div className="grid gap-3 sm:grid-cols-2">
+                <div className="grid gap-2.5 sm:grid-cols-2">
                   <MetaStat
                     label="Start"
                     value={createdStart}
@@ -726,6 +788,20 @@ export default function FocusedJobModal(props: {
                   <MetaStat
                     label="Job type"
                     value={String(line.job_type ?? "—").replaceAll("_", " ")}
+                  />
+                  <MetaStat
+                    label="Assigned tech"
+                    value={line.assigned_tech_id ? `${line.assigned_tech_id.slice(0, 8)}…` : "Unassigned"}
+                  />
+                  <MetaStat label="Parts count" value={String(partsCount)} />
+                  <MetaStat label="Labor" value={laborDisplay} />
+                  <MetaStat
+                    label="Line total"
+                    value={new Intl.NumberFormat("en-CA", {
+                      style: "currency",
+                      currency: "CAD",
+                      maximumFractionDigits: 2,
+                    }).format(lineTotal)}
                   />
                 </div>
               </SectionCard>
@@ -768,74 +844,45 @@ export default function FocusedJobModal(props: {
                 </SectionCard>
               ) : null}
 
-              <SectionCard title="Actions">
-                <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                  {mode === "tech" ? (
-                    <>
-                      <button
-                        type="button"
-                        className={btnNeutral}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenPhoto(true);
-                        }}
-                        disabled={busy}
-                      >
-                        Add Photo
-                      </button>
+              {mode !== "tech" ? (
+                <SectionCard title="Actions">
+                  <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                    <button
+                      type="button"
+                      className={btnNeutral}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenChat(true);
+                      }}
+                    >
+                      Chat
+                    </button>
 
-                      <button
-                        type="button"
-                        className={btnNeutral}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenChat(true);
-                        }}
-                      >
-                        Chat
-                      </button>
+                    <button
+                      type="button"
+                      className={btnInfo}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenAi(true);
+                      }}
+                    >
+                      AI Assist
+                    </button>
 
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        type="button"
-                        className={btnNeutral}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenChat(true);
-                        }}
-                      >
-                        Chat
-                      </button>
-
-                      <button
-                        type="button"
-                        className={btnInfo}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenAi(true);
-                        }}
-                      >
-                        AI Assist
-                      </button>
-
-                      <button
-                        type="button"
-                        className={btnInfo}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenDtc(true);
-                        }}
-                        disabled={busy}
-                      >
-                        DTC Assist
-                      </button>
-
-                    </>
-                  )}
-                </div>
-              </SectionCard>
+                    <button
+                      type="button"
+                      className={btnInfo}
+                      onClick={() => {
+                        closeAllSubModals();
+                        setOpenDtc(true);
+                      }}
+                      disabled={busy}
+                    >
+                      DTC Assist
+                    </button>
+                  </div>
+                </SectionCard>
+              ) : null}
               </div>
 
               <div className="space-y-3">
@@ -849,23 +896,6 @@ export default function FocusedJobModal(props: {
                   className="w-full rounded-xl border border-white/10 bg-black/35 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-[var(--accent-copper-light)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]/60"
                   placeholder="Add notes for this job…"
                 />
-              </SectionCard>
-
-              <SectionCard title="History">
-                <button
-                  type="button"
-                  className={btnNeutral}
-                  onClick={() => {
-                    if (!vehicle?.id) {
-                      toast.error("No vehicle linked to this work order yet.");
-                      return;
-                    }
-                    setOpenVehicleHistory(true);
-                  }}
-                  disabled={busy || !vehicle?.id}
-                >
-                  Vehicle History
-                </button>
               </SectionCard>
 
               <SectionCard title="Parts used">


### PR DESCRIPTION
### Motivation

- Turn the Work Order page into a compact, desktop-grade operational cockpit with immediate access to job cards and a sticky, action-first focused panel. 
- Remove the large, passive containers that delayed access to the job navigator and compress low-priority informational areas to reduce vertical footprint. 
- Preserve all existing business logic, routes, and data flows while improving scan speed and control hierarchy.

### Description

- Compact the top band and make timeline/events and approval queue collapsible in `app/work-orders/[id]/Client.tsx` so the job rail appears sooner and vertical height is reduced. 
- Remove the prominent job progress wrapper above the job list and tune desktop split to approximately `58/42`, with the focused panel made sticky and given a larger top offset for desktop (`lg:sticky lg:top-20`). (file: `app/work-orders/[id]/Client.tsx`).
- Convert job cards into a denser left rail in `features/work-orders/components/JobCard.tsx` by adding a left-edge status accent (green/yellow/red) determined by job/hold/approval/review flags, tighter spacing/padding, a stronger selected state (border, subtle scale, shadow), compact review/issue pills, and keyboard-open handling (Enter/Space) while preserving the card-as-navigator model. (file: `features/work-orders/components/JobCard.tsx`).
- Reorder and compress the focused right-side panel in `features/work-orders/components/workorders/FocusedJobModal.tsx` to an action-first console: primary actions (`Start Job`, `Complete`) then secondary (`Hold`, `Request Parts`, `AI Assist`) and tertiary controls (`Add Photo`, `Chat`, `Vehicle History`), plus expanded quick-status metrics (assigned tech, parts count, labor, line total) while keeping notes/parts/AI suggestions and existing behavior intact; added `Start Job` implementation calling `runJobPunchTransition(line.id, "start")`. (file: `features/work-orders/components/workorders/FocusedJobModal.tsx`).
- Misc: tightened paddings/margins, reduced filler copy (approval summary default text), preserved modal fallback on small screens, and ensured the first active job is auto-selected for the desktop panel via existing query replace logic. Files changed: `app/work-orders/[id]/Client.tsx`, `features/work-orders/components/JobCard.tsx`, `features/work-orders/components/workorders/FocusedJobModal.tsx`.

### Testing

- Ran the TypeScript type check with `npx tsc --noEmit` and it passed successfully. 
- Ran the repository linter with `npm run -s lint` which reported pre-existing repo-wide lint errors unrelated to the touched files; these are not introduced by this change. 
- Confirmed a local commit was created with the message `Refine work order cockpit density and focused panel hierarchy` after the edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2586a44c8328af8ba6f7096e659a)