### PR TITLE
Parts Phase 3: unify status & receiving UX, add trust signals, and improve inventory explainability

### DIFF
--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -1,5 +1,3 @@
-//app/parts/allocations/page.tsx
-
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
@@ -8,264 +6,70 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
-
 type Alloc = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
-type PartRow = DB["public"]["Tables"]["parts"]["Row"];
-type LocRow = DB["public"]["Tables"]["stock_locations"]["Row"];
-type WoLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
-type WoRow = DB["public"]["Tables"]["work_orders"]["Row"];
-
-function n(v: unknown): number {
-  const num = typeof v === "number" ? v : Number(v);
-  return Number.isFinite(num) ? num : 0;
-}
 
 async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
-  const { data: userRes } = await supabase.auth.getUser();
-  const uid = userRes.user?.id ?? null;
-  if (!uid) return "";
-
-  const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle();
-  if (profA?.shop_id) return String(profA.shop_id);
-
-  const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle();
-  return String(profB?.shop_id ?? "");
+  const { data: userRes } = await supabase.auth.getUser(); const uid = userRes.user?.id ?? null; if (!uid) return "";
+  const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle(); if (profA?.shop_id) return String(profA.shop_id);
+  const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle(); return String(profB?.shop_id ?? "");
 }
-
-type UiAlloc = {
-  alloc: Alloc;
-  partName: string;
-  partSku: string;
-  locCode: string;
-  locName: string;
-  woCustom: string;
-  woLineShort: string;
-};
 
 export default function AllocationsPage(): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
-  const [shopId, setShopId] = useState<string>("");
-
-  const [loading, setLoading] = useState<boolean>(true);
+  const [shopId, setShopId] = useState("");
+  const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
-
-  const [search, setSearch] = useState<string>("");
-  const [rows, setRows] = useState<UiAlloc[]>([]);
+  const [search, setSearch] = useState("");
+  const [rows, setRows] = useState<any[]>([]);
 
   useEffect(() => {
     void (async () => {
-      setLoading(true);
-      setErr(null);
-
+      setLoading(true); setErr(null);
       try {
-        const sid = await resolveShopId(supabase);
-        setShopId(sid);
-
-        if (!sid) {
-          setRows([]);
-          setLoading(false);
-          return;
-        }
-
-        // allocations
-        const { data: allocs, error: aerr } = await supabase
-          .from("work_order_part_allocations")
-          .select("*")
-          .eq("shop_id", sid)
-          .order("created_at", { ascending: false })
-          .limit(400);
-
-        if (aerr) throw aerr;
-
-        const allocList = (allocs ?? []) as Alloc[];
-
-        const partIds = Array.from(
-          new Set(allocList.map((a) => a.part_id).filter((x): x is string => typeof x === "string" && x.length > 0)),
-        );
-        const locIds = Array.from(
-          new Set(
-            allocList.map((a) => a.location_id).filter((x): x is string => typeof x === "string" && x.length > 0),
-          ),
-        );
-        const lineIds = Array.from(
-          new Set(
-            allocList
-              .map((a) => a.work_order_line_id)
-              .filter((x): x is string => typeof x === "string" && x.length > 0),
-          ),
-        );
-
-        // parts + locations + lines + work orders (for custom_id)
-        const [partsRes, locsRes, linesRes] = await Promise.all([
-          partIds.length
-            ? supabase.from("parts").select("id, name, sku").in("id", partIds)
-            : Promise.resolve({ data: [] as unknown[] }),
-          locIds.length
-            ? supabase.from("stock_locations").select("id, code, name").in("id", locIds)
-            : Promise.resolve({ data: [] as unknown[] }),
-          lineIds.length
-            ? supabase.from("work_order_lines").select("id, work_order_id").in("id", lineIds)
-            : Promise.resolve({ data: [] as unknown[] }),
+        const sid = await resolveShopId(supabase); setShopId(sid); if (!sid) { setRows([]); return; }
+        const { data: allocs, error } = await supabase.from("work_order_part_allocations").select("*").eq("shop_id", sid).order("created_at", { ascending: false }).limit(400);
+        if (error) throw error;
+        const list = (allocs ?? []) as Alloc[];
+        const partIds = [...new Set(list.map((a) => String(a.part_id)).filter(Boolean))];
+        const locIds = [...new Set(list.map((a) => String(a.location_id)).filter(Boolean))];
+        const woIds = [...new Set(list.map((a) => String(a.work_order_id ?? "")).filter(Boolean))];
+        const reqItemIds = [...new Set(list.map((a) => String(a.source_request_item_id ?? "")).filter(Boolean))];
+        const moveIds = [...new Set(list.map((a) => String(a.stock_move_id ?? "")).filter(Boolean))];
+        const [parts, locs, wos, reqItems, moves] = await Promise.all([
+          partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as any[] }),
+          locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as any[] }),
+          woIds.length ? supabase.from("work_orders").select("id,custom_id").in("id", woIds) : Promise.resolve({ data: [] as any[] }),
+          reqItemIds.length ? supabase.from("part_request_items").select("id,request_id,po_id").in("id", reqItemIds) : Promise.resolve({ data: [] as any[] }),
+          moveIds.length ? supabase.from("stock_moves").select("id,reference_kind,reference_id,reason").in("id", moveIds) : Promise.resolve({ data: [] as any[] }),
         ]);
-
-        const partById = new Map<string, PartRow>();
-        ((partsRes.data ?? []) as PartRow[]).forEach((p) => partById.set(String(p.id), p));
-
-        const locById = new Map<string, LocRow>();
-        ((locsRes.data ?? []) as LocRow[]).forEach((l) => locById.set(String(l.id), l));
-
-        const lineById = new Map<string, WoLineRow>();
-        ((linesRes.data ?? []) as WoLineRow[]).forEach((l) => lineById.set(String(l.id), l));
-
-        const woIds = Array.from(
-          new Set(
-            ((linesRes.data ?? []) as WoLineRow[])
-              .map((l) => l.work_order_id)
-              .filter((x): x is string => typeof x === "string" && x.length > 0),
-          ),
-        );
-
-        const woById = new Map<string, WoRow>();
-        if (woIds.length) {
-          const { data: wos } = await supabase.from("work_orders").select("id, custom_id").in("id", woIds);
-          ((wos ?? []) as WoRow[]).forEach((w) => woById.set(String(w.id), w));
-        }
-
-        const ui: UiAlloc[] = allocList.map((a) => {
-          const p = partById.get(String(a.part_id));
-          const l = locById.get(String(a.location_id));
-          const line = a.work_order_line_id ? lineById.get(String(a.work_order_line_id)) : undefined;
-          const wo = line?.work_order_id ? woById.get(String(line.work_order_id)) : undefined;
-
-          return {
-            alloc: a,
-            partName: p?.name ? String(p.name) : String(a.part_id).slice(0, 8),
-            partSku: p?.sku ? String(p.sku) : "",
-            locCode: l?.code ? String(l.code) : "LOC",
-            locName: l?.name ? String(l.name) : "",
-            woCustom: wo?.custom_id ? String(wo.custom_id) : (line?.work_order_id ? String(line.work_order_id).slice(0, 8) : "—"),
-            woLineShort: a.work_order_line_id ? String(a.work_order_line_id).slice(0, 8) : "—",
-          };
-        });
-
-        setRows(ui);
-      } catch (e: unknown) {
-        setErr(e instanceof Error ? e.message : "Failed to load allocations.");
-      } finally {
-        setLoading(false);
-      }
+        const partBy: Record<string, any> = {}; (parts.data ?? []).forEach((x: any) => (partBy[String(x.id)] = x));
+        const locBy: Record<string, any> = {}; (locs.data ?? []).forEach((x: any) => (locBy[String(x.id)] = x));
+        const woBy: Record<string, any> = {}; (wos.data ?? []).forEach((x: any) => (woBy[String(x.id)] = x));
+        const reqBy: Record<string, any> = {}; (reqItems.data ?? []).forEach((x: any) => (reqBy[String(x.id)] = x));
+        const moveBy: Record<string, any> = {}; (moves.data ?? []).forEach((x: any) => (moveBy[String(x.id)] = x));
+        setRows(list.map((a) => ({ a, part: partBy[String(a.part_id)], loc: locBy[String(a.location_id)], wo: a.work_order_id ? woBy[String(a.work_order_id)] : null, req: a.source_request_item_id ? reqBy[String(a.source_request_item_id)] : null, move: a.stock_move_id ? moveBy[String(a.stock_move_id)] : null })));
+      } catch (e: any) { setErr(e.message ?? "Failed to load allocations."); }
+      finally { setLoading(false); }
     })();
   }, [supabase]);
 
   const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter((r) => {
-      const blob = [
-        r.woCustom,
-        r.woLineShort,
-        r.partName,
-        r.partSku,
-        r.locCode,
-        r.locName,
-        r.alloc.id ? String(r.alloc.id) : "",
-      ]
-        .join(" ")
-        .toLowerCase();
-      return blob.includes(q);
-    });
+    const q = search.trim().toLowerCase(); if (!q) return rows;
+    return rows.filter((r) => [r.part?.name, r.part?.sku, r.loc?.code, r.wo?.custom_id, r.a.work_order_id, r.req?.request_id, r.move?.reference_kind].join(" ").toLowerCase().includes(q));
   }, [rows, search]);
 
   return (
     <div className="p-6 space-y-4 text-white">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts</div>
-          <h1 className="text-2xl font-bold">Allocations</h1>
-          <div className="mt-1 text-sm text-neutral-400">
-            Inventory allocations created from request items / consume flows.
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <Link
-            href="/parts"
-            className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm text-neutral-100 hover:border-orange-500/60"
-          >
-            ← Parts
-          </Link>
-        </div>
-      </div>
-
-      <div className="rounded-2xl border border-white/10 bg-black/40 p-4 backdrop-blur-xl shadow-[0_18px_40px_rgba(0,0,0,0.9)]">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="text-xs text-neutral-500">
-            Showing <span className="text-neutral-200">{filtered.length}</span> allocations
-          </div>
-          <div className="w-full md:w-96">
-            <input
-              className="w-full rounded-xl border border-white/10 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500"
-              placeholder="Search WO#, part, SKU, location…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-          </div>
-        </div>
-      </div>
-
-      {loading ? (
-        <div className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-neutral-400">Loading…</div>
-      ) : err ? (
-        <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">{err}</div>
-      ) : !shopId ? (
-        <div className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-neutral-400">
-          No shop detected for this user.
-        </div>
-      ) : filtered.length === 0 ? (
-        <div className="rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-neutral-400">
-          No allocations found.
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40 backdrop-blur-xl shadow-[0_18px_40px_rgba(0,0,0,0.9)]">
-          <table className="w-full text-sm">
-            <thead className="bg-white/5 text-left text-neutral-400">
-              <tr>
-                <th className="p-3">WO</th>
-                <th className="p-3">WO Line</th>
-                <th className="p-3">Part</th>
-                <th className="p-3">Location</th>
-                <th className="p-3 text-right">Qty</th>
-                <th className="p-3">Created</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((r) => (
-                <tr key={String(r.alloc.id)} className="border-t border-white/10 hover:bg-white/5">
-                  <td className="p-3">
-                    <span className="font-mono text-xs text-neutral-200">{r.woCustom}</span>
-                  </td>
-                  <td className="p-3">
-                    <span className="font-mono text-xs text-neutral-200">{r.woLineShort}</span>
-                  </td>
-                  <td className="p-3">
-                    <div className="text-neutral-200">{r.partName}</div>
-                    {r.partSku ? <div className="text-xs text-neutral-500">{r.partSku}</div> : null}
-                  </td>
-                  <td className="p-3">
-                    <div className="text-neutral-200">
-                      {r.locCode} {r.locName ? `— ${r.locName}` : ""}
-                    </div>
-                  </td>
-                  <td className="p-3 text-right font-mono text-neutral-200">{n(r.alloc.qty)}</td>
-                  <td className="p-3 text-xs text-neutral-500">
-                    {r.alloc.created_at ? new Date(r.alloc.created_at).toLocaleString() : "—"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      <div className="flex items-center justify-between"><div><div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Audit Lens</div><h1 className="text-2xl font-bold">Allocations</h1><div className="text-sm text-neutral-400">What inventory was committed to jobs and where it came from.</div></div><Link href="/parts" className="rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm">Parts</Link></div>
+      <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-3"><input className="w-full rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm" placeholder="Search WO, part, source request, move kind..." value={search} onChange={(e) => setSearch(e.target.value)} /></div>
+      {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-4 text-sm text-red-200">{err}</div> : (
+        <div className="rounded-xl border border-white/10 bg-neutral-950/35 overflow-hidden">
+          <table className="w-full text-sm"><thead><tr className="text-left text-neutral-400"><th className="p-3">WO</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Upstream</th><th className="p-3">Created</th></tr></thead><tbody>
+            {filtered.map((r) => <tr key={String(r.a.id)} className="border-t border-white/10"><td className="p-3">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0,8)}</Link> : <span className="text-neutral-500">—</span>}</td><td className="p-3"><div>{r.part?.name ?? String(r.a.part_id).slice(0,8)}</div><div className="text-xs text-neutral-500">{r.part?.sku ?? ""}</div></td><td className="p-3">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td><td className="p-3 tabular-nums text-neutral-200">{r.a.qty}</td><td className="p-3 text-xs text-neutral-300">{r.req?.request_id ? <span>Request {String(r.req.request_id).slice(0,8)}</span> : <span className="text-neutral-500">No request link</span>}<div className="text-neutral-500">{r.move?.reference_kind ?? "—"} · {r.move?.reason ?? "—"}</div></td><td className="p-3 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td></tr>)}
+          </tbody></table>
         </div>
       )}
+      {!shopId ? <div className="text-xs text-neutral-500">No shop detected for this user.</div> : null}
     </div>
   );
 }

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -1,190 +1,93 @@
-// app/parts/movements/page.tsx
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
-
 type StockMove = DB["public"]["Tables"]["stock_moves"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type LocRow = DB["public"]["Tables"]["stock_locations"]["Row"];
 
-function n(v: unknown): number {
-  const num = typeof v === "number" ? v : Number(v);
-  return Number.isFinite(num) ? num : 0;
-}
+type RefContext = { workOrderId?: string | null; requestItemId?: string | null; sourceLabel: string };
 
+function n(v: unknown): number { const num = typeof v === "number" ? v : Number(v); return Number.isFinite(num) ? num : 0; }
 async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
   const { data: userRes } = await supabase.auth.getUser();
-  const uid = userRes.user?.id ?? null;
-  if (!uid) return "";
-
+  const uid = userRes.user?.id ?? null; if (!uid) return "";
   const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle();
   if (profA?.shop_id) return String(profA.shop_id);
-
   const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle();
   return String(profB?.shop_id ?? "");
 }
 
+function sourceLabel(kind: string | null, reason: string | null): string {
+  const k = String(kind ?? "").toLowerCase();
+  if (k === "purchase_order") return "PO receive";
+  if (k === "manual_receive") return "Manual receive";
+  if (k === "request_receive") return "Request receive";
+  if (k === "work_order") return "Work order";
+  if (k === "csv_import") return "Import receive";
+  if (reason === "consume" || reason === "wo_allocate") return "Allocation / consumption";
+  return k || String(reason ?? "movement");
+}
+
 export default function StockMovementsPage(): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
-  const [shopId, setShopId] = useState<string>("");
-
+  const [shopId, setShopId] = useState("");
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
-
   const [moves, setMoves] = useState<StockMove[]>([]);
   const [parts, setParts] = useState<Record<string, PartRow>>({});
   const [locs, setLocs] = useState<Record<string, LocRow>>({});
-
-  const card =
-    "metal-card rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 shadow-[0_18px_40px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+  const [ctxMap, setCtxMap] = useState<Record<string, RefContext>>({});
 
   const load = async () => {
-    setLoading(true);
-    setErr(null);
-
-    const sid = shopId || (await resolveShopId(supabase));
-    if (!sid) {
-      setLoading(false);
-      return;
-    }
-    if (!shopId) setShopId(sid);
-
-    const { data: mv, error: mvErr } = await supabase
+    setLoading(true); setErr(null);
+    const sid = shopId || (await resolveShopId(supabase)); if (!sid) return setLoading(false); if (!shopId) setShopId(sid);
+    const { data: mv, error } = await supabase
       .from("stock_moves")
-      .select("id, part_id, location_id, qty_change, reason, reference_kind, reference_id, created_at, created_by, shop_id")
-      .eq("shop_id", sid)
-      .order("created_at", { ascending: false })
-      .limit(200);
+      .select("id, part_id, location_id, qty_change, reason, reference_kind, reference_id, created_at, shop_id")
+      .eq("shop_id", sid).order("created_at", { ascending: false }).limit(200);
+    if (error) { setErr(error.message); return setLoading(false); }
+    const rows = (mv ?? []) as StockMove[]; setMoves(rows);
 
-    if (mvErr) {
-      setErr(mvErr.message);
-      setLoading(false);
-      return;
-    }
+    const partIds = [...new Set(rows.map((r) => String(r.part_id)).filter(Boolean))];
+    const locIds = [...new Set(rows.map((r) => String(r.location_id)).filter(Boolean))];
+    const requestItemRefs = [...new Set(rows.filter((r) => String(r.reference_kind ?? "") === "request_receive" && r.reference_id).map((r) => String(r.reference_id)))];
+    const stockMoveRefs = [...new Set(rows.filter((r) => String(r.reference_kind ?? "") === "work_order" && r.reference_id).map((r) => String(r.reference_id)))];
 
-    const rows = (mv ?? []) as StockMove[];
-    setMoves(rows);
-
-    const partIds = Array.from(new Set(rows.map((r) => String(r.part_id)).filter(Boolean)));
-    const locIds = Array.from(new Set(rows.map((r) => String(r.location_id)).filter(Boolean)));
-
-    if (partIds.length) {
-      const { data: pr, error: prErr } = await supabase.from("parts").select("*").in("id", partIds);
-      if (prErr) setErr(prErr.message);
-      const map: Record<string, PartRow> = {};
-      (pr ?? []).forEach((p) => (map[String((p as PartRow).id)] = p as PartRow));
-      setParts(map);
-    } else setParts({});
-
-    if (locIds.length) {
-      const { data: lr, error: lrErr } = await supabase.from("stock_locations").select("*").in("id", locIds);
-      if (lrErr) setErr(lrErr.message);
-      const map: Record<string, LocRow> = {};
-      (lr ?? []).forEach((l) => (map[String((l as LocRow).id)] = l as LocRow));
-      setLocs(map);
-    } else setLocs({});
-
+    const [pr, lr, reqItems, allocs] = await Promise.all([
+      partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as any[] }),
+      locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as any[] }),
+      requestItemRefs.length ? supabase.from("part_request_items").select("id,request_id,work_order_id").in("id", requestItemRefs) : Promise.resolve({ data: [] as any[] }),
+      stockMoveRefs.length ? supabase.from("work_order_part_allocations").select("stock_move_id,work_order_id,source_request_item_id").in("stock_move_id", stockMoveRefs) : Promise.resolve({ data: [] as any[] }),
+    ]);
+    const p: Record<string, PartRow> = {}; (pr.data ?? []).forEach((x: any) => (p[String(x.id)] = x)); setParts(p);
+    const l: Record<string, LocRow> = {}; (lr.data ?? []).forEach((x: any) => (l[String(x.id)] = x)); setLocs(l);
+    const c: Record<string, RefContext> = {};
+    (reqItems.data ?? []).forEach((r: any) => { c[String(r.id)] = { workOrderId: r.work_order_id ?? null, requestItemId: r.id, sourceLabel: "Request receive" }; });
+    (allocs.data ?? []).forEach((a: any) => { c[String(a.stock_move_id)] = { workOrderId: a.work_order_id ?? null, requestItemId: a.source_request_item_id ?? null, sourceLabel: "Allocation / consumption" }; });
+    setCtxMap(c);
     setLoading(false);
   };
 
-  useEffect(() => {
-    void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useEffect(() => { void load(); }, []);
 
   return (
     <div className="p-6 space-y-4 text-white">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-neutral-400">Parts</div>
-          <h1 className="text-2xl font-bold" style={{ fontFamily: "var(--font-blackops), system-ui" }}>
-            Stock Movements
-          </h1>
-          <div className="text-sm text-neutral-400">Immutable inventory ledger (stock_moves).</div>
-        </div>
-        <button
-          onClick={() => void load()}
-          className="rounded-full border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 px-4 py-2 text-sm text-neutral-100 hover:border-[color:var(--accent-copper,#f97316)]/70 hover:bg-black/70"
-        >
-          Refresh
-        </button>
-      </div>
-
-      {err ? (
-        <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">
-          {err}
-        </div>
-      ) : null}
-
-      {loading ? (
-        <div className={`${card} p-4 text-sm text-neutral-400`}>Loading…</div>
-      ) : moves.length === 0 ? (
-        <div className={`${card} p-4 text-sm text-neutral-400`}>No movements.</div>
-      ) : (
-        <div className={`${card} overflow-hidden`}>
-          <div className="border-b border-white/10 bg-gradient-to-r from-black/80 via-slate-950/80 to-black/80 px-4 py-3">
-            <div className="text-xs font-medium uppercase tracking-[0.18em] text-neutral-400">
-              Latest movements
-            </div>
-          </div>
-
-          <div className="overflow-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-neutral-400">
-                  <th className="p-3">Time</th>
-                  <th className="p-3">Part</th>
-                  <th className="p-3">Location</th>
-                  <th className="p-3">Qty</th>
-                  <th className="p-3">Reason</th>
-                  <th className="p-3">Ref</th>
-                </tr>
-              </thead>
-              <tbody>
-                {moves.map((m) => {
-                  const part = parts[String(m.part_id)];
-                  const loc = locs[String(m.location_id)];
-                  const qty = n(m.qty_change);
-                  const t = m.created_at ? new Date(m.created_at).toLocaleString() : "—";
-
-                  return (
-                    <tr key={String(m.id)} className="border-t border-white/10">
-                      <td className="p-3 whitespace-nowrap text-neutral-300">{t}</td>
-                      <td className="p-3">
-                        <div className="font-semibold text-neutral-100">
-                          {part?.name ? String(part.name) : String(m.part_id).slice(0, 8)}
-                        </div>
-                        <div className="text-[11px] text-neutral-500">
-                          {part?.sku ? String(part.sku) + " • " : ""}
-                          {String(m.part_id).slice(0, 8)}
-                        </div>
-                      </td>
-                      <td className="p-3">
-                        <div className="font-semibold text-neutral-100">{loc?.code ? String(loc.code) : "LOC"}</div>
-                        <div className="text-[11px] text-neutral-500">{loc?.name ? String(loc.name) : String(m.location_id).slice(0, 8)}</div>
-                      </td>
-                      <td className="p-3 tabular-nums font-semibold">
-                        <span className={qty >= 0 ? "text-emerald-300" : "text-red-300"}>{qty}</span>
-                      </td>
-                      <td className="p-3">{String(m.reason ?? "")}</td>
-                      <td className="p-3 text-[11px] text-neutral-400">
-                        {String(m.reference_kind ?? "—")}
-                        {m.reference_id ? " • " + String(m.reference_id).slice(0, 8) : ""}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="border-t border-white/10 px-4 py-3 text-[11px] text-neutral-500">
-            This is your source of truth. part_stock is a snapshot maintained by triggers on stock_moves.
-          </div>
+      <div className="flex items-start justify-between"><div><div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Audit Lens</div><h1 className="text-2xl font-bold">Stock Movements</h1><div className="text-sm text-neutral-400">Inventory change ledger with source context.</div></div><button onClick={() => void load()} className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm">Refresh</button></div>
+      {err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
+      {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : (
+        <div className="rounded-xl border border-white/10 bg-neutral-950/35 overflow-hidden">
+          <table className="w-full text-sm"><thead><tr className="text-left text-neutral-400"><th className="p-3">Time</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Source</th><th className="p-3">Trace</th></tr></thead><tbody>
+            {moves.map((m) => {
+              const part = parts[String(m.part_id)]; const loc = locs[String(m.location_id)]; const qty = n(m.qty_change);
+              const refId = String(m.reference_id ?? ""); const ctx = ctxMap[refId] ?? ctxMap[String(m.id)] ?? null;
+              return <tr key={String(m.id)} className="border-t border-white/10"><td className="p-3 text-neutral-300">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td><td className="p-3"><div>{part?.name ?? String(m.part_id).slice(0,8)}</div><div className="text-xs text-neutral-500">{part?.sku ?? ""}</div></td><td className="p-3">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td><td className={`p-3 font-semibold ${qty >= 0 ? "text-emerald-300" : "text-rose-300"}`}>{qty}</td><td className="p-3"><div>{sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{String(m.reason)}</div></td><td className="p-3 text-xs">{ctx?.workOrderId ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(ctx.workOrderId)}`}>WO {ctx.workOrderId.slice(0,8)}</Link> : <span className="text-neutral-500">No WO</span>} {ctx?.requestItemId ? <span className="ml-2 text-neutral-400">ReqItem {ctx.requestItemId.slice(0,8)}</span> : null}</td></tr>;
+            })}
+          </tbody></table>
         </div>
       )}
     </div>

--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -8,6 +8,8 @@ import { useParams, useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveScannedCode } from "@/features/parts/server/scanActions";
+import { receiveProgressLabel, toReceiveProgressDisplay } from "@/features/parts/lib/status-display";
+import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
 
 type QuaggaResult = { codeResult?: { code?: string | null } | null };
 
@@ -120,6 +122,7 @@ export default function PoReceivePage(): JSX.Element {
   const [lines, setLines] = useState<PurchaseOrderLine[]>([]);
   const [locs, setLocs] = useState<StockLoc[]>([]);
   const [parts, setParts] = useState<PartRow[]>([]);
+  const [trustByPartId, setTrustByPartId] = useState<Record<string, PartTrustMeta>>({});
 
   const [selectedLoc, setSelectedLoc] = useState<string>("");
   const [qty, setQty] = useState<number>(1);
@@ -196,13 +199,46 @@ export default function PoReceivePage(): JSX.Element {
         if (sid) {
           const { data: partRows, error: partErr } = await supabase
             .from("parts")
-            .select("id, name, sku, category")
+            .select("*")
             .eq("shop_id", sid)
             .order("name", { ascending: true })
             .limit(700);
 
           if (partErr) throw partErr;
-          setParts((partRows ?? []) as PartRow[]);
+          const partList = (partRows ?? []) as PartRow[];
+          setParts(partList);
+          const partIds = partList.map((p) => String(p.id));
+          const [aliasRes, stagingRes, candRes] = await Promise.all([
+            supabase.from("shop_parts_source_aliases").select("part_id").in("part_id", partIds).eq("shop_id", sid),
+            supabase.from("shop_parts_import_staging").select("matched_part_id,status").in("matched_part_id", partIds).eq("shop_id", sid),
+            supabase.from("shop_parts_import_match_candidates").select("candidate_part_id").in("candidate_part_id", partIds).eq("shop_id", sid),
+          ]);
+          const aliasCount: Record<string, number> = {};
+          (aliasRes.data ?? []).forEach((r: any) => (aliasCount[String(r.part_id)] = (aliasCount[String(r.part_id)] ?? 0) + 1));
+          const stagingCount: Record<string, number> = {};
+          (stagingRes.data ?? []).forEach((r: any) => {
+            const st = String(r.status ?? "").toLowerCase();
+            if (st === "pending" || st === "review" || st === "ambiguous") {
+              stagingCount[String(r.matched_part_id)] = (stagingCount[String(r.matched_part_id)] ?? 0) + 1;
+            }
+          });
+          const candCount: Record<string, number> = {};
+          (candRes.data ?? []).forEach((r: any) => (candCount[String(r.candidate_part_id)] = (candCount[String(r.candidate_part_id)] ?? 0) + 1));
+          const trustMap: Record<string, PartTrustMeta> = {};
+          partList.forEach((p: any) => {
+            const id = String(p.id);
+            trustMap[id] = buildPartTrustMeta({
+              sku: p.sku,
+              partNumber: p.part_number ?? null,
+              normalizedPartKey: p.normalized_part_key ?? null,
+              sourceIntakeId: p.source_intake_id ?? null,
+              importConfidence: p.import_confidence ?? null,
+              aliasCount: aliasCount[id] ?? 0,
+              pendingStagingCount: stagingCount[id] ?? 0,
+              ambiguousCandidateCount: (candCount[id] ?? 0) > 1 ? candCount[id] : 0,
+            });
+          });
+          setTrustByPartId(trustMap);
         } else {
           setParts([]);
         }
@@ -618,6 +654,8 @@ export default function PoReceivePage(): JSX.Element {
                     const ordered = n(ln.qty);
                     const received = n(ln.received_qty);
                     const rem = Math.max(0, ordered - received);
+                    const trust = ln.part_id ? trustByPartId[String(ln.part_id)] : null;
+                    const recvState = toReceiveProgressDisplay({ qtyApproved: ordered, qtyReceived: received });
 
                     return (
                       <tr key={String(ln.id)} className="border-t border-white/5 hover:bg-white/5">
@@ -626,6 +664,11 @@ export default function PoReceivePage(): JSX.Element {
                             {ln.part_id ? String(ln.part_id).slice(0, 8) : "—"}
                           </div>
                           <div className="text-xs text-neutral-500">{ln.description ?? "—"}</div>
+                          <div className="mt-1 flex items-center gap-2">
+                            <span className="text-[11px] text-neutral-400">{receiveProgressLabel(recvState)}</span>
+                            {trust ? <span className={`rounded-full border px-2 py-0.5 text-[10px] ${trustBadgeTone(trust.level)}`}>{trust.level}</span> : null}
+                          </div>
+                          {trust && trust.reasons.length > 0 ? <div className="text-[11px] text-amber-200">{trust.reasons.slice(0, 1).join(" · ")}</div> : null}
                         </td>
                         <td className="p-3 font-mono">{ordered}</td>
                         <td className="p-3 font-mono">{received}</td>

--- a/app/parts/po/receive/page.tsx
+++ b/app/parts/po/receive/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { receiveProgressLabel } from "@/features/parts/lib/status-display";
 
 type DB = Database;
 
@@ -75,14 +76,12 @@ export default function ReceiveFromPOPage(): JSX.Element {
           >
             Receive from PO
           </h1>
-          <div className="text-sm text-neutral-400">
-            Receive from PO: items tied to this purchase order.
-          </div>
+          <div className="text-sm text-neutral-400">PO lens into the shared receiving workflow.</div>
         </div>
 
         <button
           onClick={() => void load()}
-          className="rounded-full border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 px-4 py-2 text-sm text-neutral-100 hover:border-[color:var(--accent-copper,#f97316)]/70 hover:bg-black/70"
+          className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm text-neutral-100 hover:bg-white/5"
         >
           Refresh
         </button>
@@ -162,7 +161,7 @@ export default function ReceiveFromPOPage(): JSX.Element {
                       <td className="p-3">
                         <Link
                           href={`/parts/po/${encodeURIComponent(id)}/receive`}
-                          className="inline-flex items-center justify-center rounded-full border border-[color:var(--accent-copper,#f97316)]/80 bg-gradient-to-r from-black/80 via-[color:var(--accent-copper,#f97316)]/15 to-black/80 px-4 py-2 text-sm font-semibold text-neutral-50 hover:border-[color:var(--accent-copper-light,#fed7aa)]"
+                          className="inline-flex items-center justify-center rounded-lg border border-sky-500/35 bg-neutral-950/20 px-4 py-2 text-sm font-semibold text-sky-200 hover:bg-sky-900/20"
                         >
                           Open receive →
                         </Link>
@@ -175,7 +174,7 @@ export default function ReceiveFromPOPage(): JSX.Element {
           </div>
 
           <div className="border-t border-white/10 px-4 py-3 text-[11px] text-neutral-500">
-            Tip: Receiving from a PO updates inventory and increments PO line received_qty (FIFO) until complete.
+            Tip: Shared receive language: {receiveProgressLabel("partial")} and {receiveProgressLabel("received")} apply across Inbox, PO, and Scan.
           </div>
         </div>
       )}

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -7,6 +7,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveScannedCode } from "@/features/parts/server/scanActions";
 import Link from "next/link";
+import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
 
 type QuaggaResult = { codeResult?: { code?: string | null } | null };
 
@@ -66,6 +67,7 @@ export default function ReceivePage(): JSX.Element {
   const [qty, setQty] = useState<number>(1);
 
   const [lastResult, setLastResult] = useState<ReceiveResult | null>(null);
+  const [lastTrust, setLastTrust] = useState<PartTrustMeta | null>(null);
   const [busy, setBusy] = useState(false);
 
   const onDetectedRef = useRef<QuaggaDetectedHandler | null>(null);
@@ -186,6 +188,20 @@ export default function ReceivePage(): JSX.Element {
         window.setTimeout(() => setLastScan(""), 1200);
         return;
       }
+      const { data: partRow } = await supabase
+        .from("parts")
+        .select("id, sku, part_number, normalized_part_key, source_intake_id, import_confidence")
+        .eq("id", part_id)
+        .maybeSingle();
+      setLastTrust(
+        buildPartTrustMeta({
+          sku: (partRow as any)?.sku ?? null,
+          partNumber: (partRow as any)?.part_number ?? null,
+          normalizedPartKey: (partRow as any)?.normalized_part_key ?? null,
+          sourceIntakeId: (partRow as any)?.source_intake_id ?? null,
+          importConfidence: (partRow as any)?.import_confidence ?? null,
+        }),
+      );
 
       setBusy(true);
       try {
@@ -342,6 +358,12 @@ export default function ReceivePage(): JSX.Element {
               <pre className="mt-2 max-h-64 overflow-auto rounded border border-neutral-800 bg-black/60 p-2 text-xs text-neutral-200">
                 {JSON.stringify(lastResult.result ?? {}, null, 2)}
               </pre>
+            ) : null}
+            {lastTrust ? (
+              <div className="mt-1 text-xs">
+                <span className={`inline-flex rounded-full border px-2 py-1 ${trustBadgeTone(lastTrust.level)}`}>Trust: {lastTrust.level}</span>
+                {lastTrust.reasons.length > 0 ? <span className="ml-2 text-amber-200">{lastTrust.reasons.slice(0, 2).join(" · ")}</span> : null}
+              </div>
             ) : null}
           </div>
         )}

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -1,4 +1,3 @@
-// app/parts/receiving/page.tsx
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
@@ -6,10 +5,15 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { itemFlowLabel, toItemFlowDisplay } from "@/features/parts/lib/status-display";
+import {
+  itemFlowLabel,
+  receiveProgressLabel,
+  toItemFlowDisplay,
+  toReceiveProgressDisplay,
+} from "@/features/parts/lib/status-display";
+import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
 
 type DB = Database;
-
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
 type PurchaseOrder = DB["public"]["Tables"]["purchase_orders"]["Row"];
 type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
@@ -18,7 +22,6 @@ type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type InboxItem = {
   id: string;
   created_at: string | null;
-  shop_id: string | null;
   request_id: string;
   part_id: string | null;
   description: string;
@@ -26,6 +29,7 @@ type InboxItem = {
   qty_approved: number;
   qty_received: number;
   qty_remaining: number;
+  qty_allocated: number;
   po_id: string | null;
   work_order_id: string | null;
 };
@@ -39,139 +43,87 @@ async function resolveShopId(supabase: ReturnType<typeof createClientComponentCl
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
   if (!uid) return "";
-
-  const { data: profA } = await supabase
-    .from("profiles")
-    .select("shop_id")
-    .eq("user_id", uid)
-    .maybeSingle();
+  const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle();
   if (profA?.shop_id) return String(profA.shop_id);
-
-  const { data: profB } = await supabase
-    .from("profiles")
-    .select("shop_id")
-    .eq("id", uid)
-    .maybeSingle();
-
+  const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle();
   return String(profB?.shop_id ?? "");
 }
 
-const ReceiveDrawer = dynamic(() => import("@/features/parts/components/ReceiveDrawer"), {
-  ssr: false,
-});
-
-type DrawerItem = {
-  id: string;
-  created_at?: string | null;
-  request_id?: string | null;
-  part_id?: string | null;
-  description?: string | null;
-  status?: string | null;
-  qty_approved?: number | null;
-  qty_received?: number | null;
-  qty_remaining?: number | null;
-  part_name?: string | null;
-  sku?: string | null;
-};
+const ReceiveDrawer = dynamic(() => import("@/features/parts/components/ReceiveDrawer"), { ssr: false });
 
 export default function ReceivingInboxPage(): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
-
   const [shopId, setShopId] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(true);
   const [err, setErr] = useState<string | null>(null);
-
   const [locs, setLocs] = useState<StockLoc[]>([]);
   const [selectedLoc, setSelectedLoc] = useState<string>("");
-
   const [pos, setPOs] = useState<PurchaseOrder[]>([]);
   const [selectedPo, setSelectedPo] = useState<string>("");
-
   const [items, setItems] = useState<InboxItem[]>([]);
   const [partsMap, setPartsMap] = useState<Record<string, PartRow>>({});
-  const [poMap, setPoMap] = useState<Record<string, PurchaseOrder>>({});
+  const [trustByPartId, setTrustByPartId] = useState<Record<string, PartTrustMeta>>({});
   const [page, setPage] = useState(1);
   const pageSize = 100;
   const [totalCount, setTotalCount] = useState(0);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [nowTs, setNowTs] = useState<number>(Date.now());
-
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  const [drawerItem, setDrawerItem] = useState<DrawerItem | null>(null);
+  const [drawerItem, setDrawerItem] = useState<any>(null);
 
   const load = async (pageToLoad = page) => {
     setLoading(true);
     setErr(null);
-
     const sid = shopId || (await resolveShopId(supabase));
-    if (!sid) {
-      setLoading(false);
-      return;
-    }
+    if (!sid) return setLoading(false);
     if (!shopId) setShopId(sid);
 
     const [locRes, poRes] = await Promise.all([
       supabase.from("stock_locations").select("*").eq("shop_id", sid).order("code"),
-      supabase
-        .from("purchase_orders")
-        .select("*")
-        .eq("shop_id", sid)
-        .order("created_at", { ascending: false })
-        .limit(50),
+      supabase.from("purchase_orders").select("*").eq("shop_id", sid).order("created_at", { ascending: false }).limit(50),
     ]);
-
-    if (locRes.error) setErr(locRes.error.message);
-    if (poRes.error) setErr(poRes.error.message);
 
     const locRows = (locRes.data ?? []) as StockLoc[];
     setLocs(locRows);
-
     const main = locRows.find((l) => (l.code ?? "").toUpperCase() === "MAIN");
     if (!selectedLoc && main?.id) setSelectedLoc(String(main.id));
-
     setPOs((poRes.data ?? []) as PurchaseOrder[]);
 
     const from = (pageToLoad - 1) * pageSize;
     const to = from + pageSize - 1;
-
-    const [{ data: priRows, error: priErr }, { count: rawCount, error: cntErr }] = await Promise.all([
+    const [{ data: priRows, error: priErr }, { count: rawCount }] = await Promise.all([
       supabase
-      .from("part_request_items")
-      .select("id, created_at, shop_id, request_id, part_id, description, status, qty_approved, qty_received, po_id")
-      .eq("shop_id", sid)
-      .order("created_at", { ascending: true })
-      .order("id", { ascending: true })
-      .range(from, to),
+        .from("part_request_items")
+        .select("id, created_at, request_id, part_id, description, status, qty_approved, qty_received, qty_consumed, po_id")
+        .eq("shop_id", sid)
+        .order("created_at", { ascending: true })
+        .range(from, to),
       supabase.from("part_request_items").select("id", { count: "exact", head: true }).eq("shop_id", sid),
     ]);
 
     if (priErr) {
       setErr(priErr.message);
-      setItems([]);
-      setLoading(false);
-      return;
+      return setLoading(false);
     }
-    if (cntErr) setErr(cntErr.message);
     setTotalCount(rawCount ?? 0);
 
     const normalized: InboxItem[] = (priRows ?? [])
       .map((r) => {
-        const approved = n((r as PartRequestItemRow).qty_approved);
-        const received = n((r as PartRequestItemRow).qty_received);
-        const remaining = Math.max(0, approved - received);
-
+        const row = r as PartRequestItemRow;
+        const approved = n(row.qty_approved);
+        const received = n(row.qty_received);
         return {
-          id: String((r as PartRequestItemRow).id),
-          created_at: (r as PartRequestItemRow).created_at ?? null,
-          shop_id: (r as PartRequestItemRow).shop_id ?? null,
-          request_id: String((r as PartRequestItemRow).request_id),
-          part_id: ((r as PartRequestItemRow).part_id as string | null) ?? null,
-          description: String((r as PartRequestItemRow).description ?? ""),
-          status: String((r as PartRequestItemRow).status ?? ""),
+          id: String(row.id),
+          created_at: row.created_at ?? null,
+          request_id: String(row.request_id),
+          part_id: row.part_id ?? null,
+          description: String(row.description ?? ""),
+          status: String(row.status ?? ""),
           qty_approved: approved,
           qty_received: received,
-          qty_remaining: remaining,
-          po_id: ((r as PartRequestItemRow) as { po_id?: string | null }).po_id ?? null,
+          qty_remaining: Math.max(0, approved - received),
+          qty_allocated: n(row.qty_consumed),
+          po_id: row.po_id ?? null,
           work_order_id: null,
         };
       })
@@ -180,50 +132,68 @@ export default function ReceivingInboxPage(): JSX.Element {
     setItems(normalized);
     setLastUpdated(new Date());
 
-    const requestIds = Array.from(new Set(normalized.map((x) => x.request_id)));
+    const requestIds = [...new Set(normalized.map((x) => x.request_id))];
     if (requestIds.length) {
-      const { data: reqRows } = await supabase
-        .from("part_requests")
-        .select("id, work_order_id")
-        .in("id", requestIds);
-      const workOrderByRequest: Record<string, string | null> = {};
-      (reqRows ?? []).forEach((r) => {
-        const row = r as { id: string; work_order_id: string | null };
-        workOrderByRequest[row.id] = row.work_order_id;
-      });
-      setItems((prev) =>
-        prev.map((it) => ({
-          ...it,
-          work_order_id: workOrderByRequest[it.request_id] ?? null,
-        })),
-      );
+      const { data: reqRows } = await supabase.from("part_requests").select("id, work_order_id").in("id", requestIds);
+      const woByReq: Record<string, string | null> = {};
+      (reqRows ?? []).forEach((r: any) => (woByReq[r.id] = r.work_order_id));
+      setItems((prev) => prev.map((it) => ({ ...it, work_order_id: woByReq[it.request_id] ?? null })));
     }
 
-    const partIds = Array.from(new Set(normalized.map((x) => x.part_id).filter(Boolean))) as string[];
+    const partIds = [...new Set(normalized.map((x) => x.part_id).filter(Boolean))] as string[];
     if (partIds.length) {
-      const { data: partRows, error: pErr } = await supabase.from("parts").select("*").in("id", partIds);
-      if (pErr) setErr(pErr.message);
+      const [partRes, aliasRes, stagingRes, candRes] = await Promise.all([
+        supabase.from("parts").select("*").in("id", partIds),
+        supabase.from("shop_parts_source_aliases").select("part_id").in("part_id", partIds).eq("shop_id", sid),
+        supabase
+          .from("shop_parts_import_staging")
+          .select("matched_part_id, status")
+          .in("matched_part_id", partIds)
+          .eq("shop_id", sid),
+        supabase
+          .from("shop_parts_import_match_candidates")
+          .select("staging_id, candidate_part_id")
+          .in("candidate_part_id", partIds)
+          .eq("shop_id", sid),
+      ]);
 
-      const map: Record<string, PartRow> = {};
-      (partRows ?? []).forEach((p) => {
-        map[String((p as PartRow).id)] = p as PartRow;
+      const pMap: Record<string, PartRow> = {};
+      (partRes.data ?? []).forEach((p) => (pMap[String((p as PartRow).id)] = p as PartRow));
+      setPartsMap(pMap);
+
+      const aliasCount: Record<string, number> = {};
+      (aliasRes.data ?? []).forEach((r: any) => (aliasCount[String(r.part_id)] = (aliasCount[String(r.part_id)] ?? 0) + 1));
+      const pendingCount: Record<string, number> = {};
+      (stagingRes.data ?? []).forEach((r: any) => {
+        const st = String(r.status ?? "").toLowerCase();
+        if (st === "pending" || st === "review" || st === "ambiguous") {
+          pendingCount[String(r.matched_part_id)] = (pendingCount[String(r.matched_part_id)] ?? 0) + 1;
+        }
       });
-      setPartsMap(map);
+      const candCount: Record<string, number> = {};
+      (candRes.data ?? []).forEach((r: any) => {
+        const id = String(r.candidate_part_id);
+        candCount[id] = (candCount[id] ?? 0) + 1;
+      });
+
+      const tMap: Record<string, PartTrustMeta> = {};
+      for (const pid of partIds) {
+        const p = pMap[pid];
+        tMap[pid] = buildPartTrustMeta({
+          sku: p?.sku,
+          partNumber: (p as any)?.part_number ?? null,
+          normalizedPartKey: (p as any)?.normalized_part_key ?? null,
+          sourceIntakeId: (p as any)?.source_intake_id ?? null,
+          importConfidence: (p as any)?.import_confidence ?? null,
+          aliasCount: aliasCount[pid] ?? 0,
+          ambiguousCandidateCount: (candCount[pid] ?? 0) > 1 ? candCount[pid] : 0,
+          pendingStagingCount: pendingCount[pid] ?? 0,
+        });
+      }
+      setTrustByPartId(tMap);
     } else {
       setPartsMap({});
-    }
-
-    const poIds = Array.from(new Set(normalized.map((x) => x.po_id).filter(Boolean))) as string[];
-    if (poIds.length) {
-      const { data: poRows } = await supabase.from("purchase_orders").select("*").in("id", poIds);
-      const map: Record<string, PurchaseOrder> = {};
-      (poRows ?? []).forEach((row) => {
-        const po = row as PurchaseOrder;
-        map[String(po.id)] = po;
-      });
-      setPoMap(map);
-    } else {
-      setPoMap({});
+      setTrustByPartId({});
     }
 
     setLoading(false);
@@ -231,15 +201,12 @@ export default function ReceivingInboxPage(): JSX.Element {
 
   useEffect(() => {
     void load(page);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
 
-  // any drawer receive triggers refresh via event
   useEffect(() => {
     const handler = () => void load(page);
     window.addEventListener("parts:received", handler as EventListener);
     return () => window.removeEventListener("parts:received", handler as EventListener);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
 
   useEffect(() => {
@@ -247,253 +214,73 @@ export default function ReceivingInboxPage(): JSX.Element {
     return () => window.clearInterval(t);
   }, []);
 
-  const openDrawerFor = (it: InboxItem) => {
-    const p = it.part_id ? partsMap[it.part_id] : null;
-
-    setDrawerItem({
-      id: it.id,
-      created_at: it.created_at,
-      request_id: it.request_id,
-      part_id: it.part_id,
-      description: it.description,
-      status: it.status,
-      qty_approved: it.qty_approved,
-      qty_received: it.qty_received,
-      qty_remaining: it.qty_remaining,
-      part_name: p?.name ? String(p.name) : null,
-      sku: p?.sku ? String(p.sku) : null,
-    });
-
-    setDrawerOpen(true);
-  };
-
-  const card =
-    "metal-card rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 shadow-[0_18px_40px_rgba(0,0,0,0.95)] backdrop-blur-xl";
-
-  const locOptions = locs.map((l) => ({
-    value: String(l.id),
-    label: `${String(l.code ?? "LOC")} — ${String(l.name ?? "")}`,
-  }));
-
-  const poOptions = pos.map((po) => ({
-    value: String(po.id),
-    label: `${String(po.id).slice(0, 8)} • ${String(po.status ?? "draft")}`,
-  }));
+  const locOptions = locs.map((l) => ({ value: String(l.id), label: `${l.code ?? "LOC"} — ${l.name ?? ""}` }));
+  const poOptions = pos.map((po) => ({ value: String(po.id), label: `${String(po.id).slice(0, 8)} • ${String(po.status ?? "draft")}` }));
 
   return (
     <div className="p-6 space-y-4 text-white">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-neutral-400">Parts</div>
-          <h1 className="text-2xl font-bold" style={{ fontFamily: "var(--font-blackops), system-ui" }}>
-            Receiving Inbox
-          </h1>
-          <div className="text-sm text-neutral-400">Receiving Inbox: all pending request items.</div>
-          <div className="mt-1 text-xs text-neutral-500">Use this queue for operational receiving across all work orders.</div>
+          <div className="text-[11px] uppercase tracking-[0.22em] text-neutral-400">Parts · Receiving Lens</div>
+          <h1 className="text-2xl font-bold">Receiving Inbox</h1>
+          <div className="text-sm text-neutral-400">Shared receive flow for request items with consistent status and trust context.</div>
         </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <Link
-            href="/assistant?pageType=receiving_inbox&pageTitle=Receiving%20Inbox"
-            className="rounded-full border border-[color:var(--accent-copper,#f97316)]/80 bg-gradient-to-r from-black/80 via-[color:var(--accent-copper,#f97316)]/15 to-black/80 px-4 py-2 text-sm font-semibold text-neutral-50 hover:border-[color:var(--accent-copper-light,#fed7aa)]"
-          >
-            Ask Assistant
-          </Link>
-          <button
-            onClick={() => void load(page)}
-            className="rounded-full border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 px-4 py-2 text-sm text-neutral-100 hover:border-[color:var(--accent-copper,#f97316)]/70 hover:bg-black/70"
-          >
-            Refresh
-          </button>
-        </div>
+        <button onClick={() => void load(page)} className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm hover:bg-white/5">Refresh</button>
       </div>
 
       <div className="text-xs text-neutral-500">
-        Last updated: <span className="text-neutral-300">{lastUpdated ? lastUpdated.toLocaleTimeString() : "—"}</span>
-        {" · "}
-        {lastUpdated && nowTs - lastUpdated.getTime() > 120000 ? (
-          <span className="text-amber-300">stale</span>
-        ) : (
-          <span className="text-emerald-300">fresh</span>
-        )}
+        Last updated <span className="text-neutral-300">{lastUpdated ? lastUpdated.toLocaleTimeString() : "—"}</span> · {lastUpdated && nowTs - lastUpdated.getTime() > 120000 ? <span className="text-amber-300">stale</span> : <span className="text-emerald-300">fresh</span>}
       </div>
 
-      {/* Controls */}
-      <div className={`${card} p-4`}>
+      <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4">
         <div className="grid gap-3 md:grid-cols-3">
-          <div>
-            <div className="mb-1 text-xs text-neutral-400">Location</div>
-            <select
-              className="w-full rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-2 text-sm text-white"
-              value={selectedLoc}
-              onChange={(e) => setSelectedLoc(e.target.value)}
-            >
-              {locs.map((l) => (
-                <option key={String(l.id)} value={String(l.id)}>
-                  {String(l.code ?? "LOC")} — {String(l.name ?? "")}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div>
-            <div className="mb-1 text-xs text-neutral-400">PO (optional)</div>
-            <select
-              className="w-full rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-2 text-sm text-white"
-              value={selectedPo}
-              onChange={(e) => setSelectedPo(e.target.value)}
-            >
-              <option value="">— none —</option>
-              {pos.map((po) => (
-                <option key={String(po.id)} value={String(po.id)}>
-                  {String(po.id).slice(0, 8)} • {String(po.status ?? "draft")}
-                </option>
-              ))}
-            </select>
-            <div className="mt-1 text-[11px] text-neutral-500">
-              If selected, we attribute receiving to that PO via the RPC.
-            </div>
-          </div>
-
-          <div className="flex items-end">
-            <div className="text-[11px] text-neutral-500">
-              Showing items where <span className="text-neutral-200">qty_received &lt; qty_approved</span>.
-            </div>
-          </div>
+          <select className="rounded-lg border border-white/10 bg-neutral-950/40 p-2" value={selectedLoc} onChange={(e) => setSelectedLoc(e.target.value)}>
+            {locs.map((l) => <option key={String(l.id)} value={String(l.id)}>{l.code ?? "LOC"} — {l.name ?? ""}</option>)}
+          </select>
+          <select className="rounded-lg border border-white/10 bg-neutral-950/40 p-2" value={selectedPo} onChange={(e) => setSelectedPo(e.target.value)}>
+            <option value="">PO optional</option>
+            {pos.map((po) => <option key={String(po.id)} value={String(po.id)}>{String(po.id).slice(0, 8)} • {String(po.status ?? "draft")}</option>)}
+          </select>
+          <div className="text-xs text-neutral-500 flex items-center">Rows where remaining qty is greater than zero.</div>
         </div>
       </div>
 
-      {err ? (
-        <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div>
+      {err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
+      {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : null}
+
+      {!loading && items.length > 0 ? (
+        <div className="rounded-xl border border-white/10 bg-neutral-950/35 overflow-hidden">
+          <div className="border-b border-white/10 px-4 py-3 text-xs text-neutral-500">{items.length} of {totalCount} rows loaded · page {page}</div>
+          <table className="w-full text-sm">
+            <thead><tr className="text-left text-neutral-400"><th className="p-3">Part / Context</th><th className="p-3">Receive state</th><th className="p-3">Qty</th><th className="p-3"/></tr></thead>
+            <tbody>
+              {items.map((it) => {
+                const p = it.part_id ? partsMap[it.part_id] : null;
+                const trust = it.part_id ? trustByPartId[it.part_id] : undefined;
+                const itemState = toItemFlowDisplay({ rawStatus: it.status, qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
+                const recvState = toReceiveProgressDisplay({ qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
+                return (
+                  <tr key={it.id} className="border-t border-white/10">
+                    <td className="p-3">
+                      <div className="font-semibold">{p?.name ? String(p.name) : it.description}</div>
+                      <div className="text-[11px] text-neutral-500">{p?.sku ? `${p.sku} • ` : ""}{itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}</div>
+                      {trust && trust.reasons.length > 0 ? <div className="mt-1 text-[11px] text-amber-200">{trust.reasons.slice(0,2).join(" · ")}</div> : null}
+                    </td>
+                    <td className="p-3"><span className="inline-flex rounded-full border border-white/10 bg-black/40 px-2 py-1 text-xs">{receiveProgressLabel(recvState)}</span>{trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trust.level}</span> : null}</td>
+                    <td className="p-3 tabular-nums">{it.qty_received} / {it.qty_approved} <span className="text-neutral-500">({it.qty_remaining} rem)</span></td>
+                    <td className="p-3"><button onClick={() => {setDrawerItem({ ...it, part_name: p?.name ?? null, sku: p?.sku ?? null, trust_reasons: trust?.reasons ?? [] }); setDrawerOpen(true);}} className="rounded-lg border border-sky-500/35 px-3 py-1 text-sky-200">Receive</button></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <div className="flex justify-between border-t border-white/10 p-3 text-xs"><button className="rounded border border-white/10 px-2 py-1" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Previous</button><button className="rounded border border-white/10 px-2 py-1" disabled={items.length < pageSize} onClick={() => setPage((p) => p + 1)}>Next</button></div>
+        </div>
       ) : null}
 
-      {loading ? (
-        <div className={`${card} p-4 text-sm text-neutral-400`}>Loading…</div>
-      ) : items.length === 0 ? (
-        <div className={`${card} p-4 text-sm text-neutral-400`}>No outstanding receive items.</div>
-      ) : (
-        <div className={`${card} overflow-hidden`}>
-          <div className="border-b border-white/10 bg-gradient-to-r from-black/80 via-slate-950/80 to-black/80 px-4 py-3">
-            <div className="text-xs font-medium uppercase tracking-[0.18em] text-neutral-400">Outstanding items</div>
-            <div className="mt-1 text-[11px] text-neutral-500">
-              Showing {items.length} of {totalCount} loaded rows (page {page}).
-            </div>
-          </div>
+      {!loading && items.length === 0 ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">No outstanding receive items.</div> : null}
 
-          <div className="overflow-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-neutral-400">
-                  <th className="p-3">Part</th>
-                  <th className="p-3">Approved</th>
-                  <th className="p-3">Received</th>
-                  <th className="p-3">Remaining</th>
-                  <th className="p-3"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((it) => {
-                  const p = it.part_id ? partsMap[it.part_id] : null;
-                  const sku = (p?.sku as string | null) ?? null;
-                  const po = it.po_id ? poMap[it.po_id] : null;
-                  const itemState = toItemFlowDisplay({
-                    rawStatus: it.status,
-                    qtyApproved: it.qty_approved,
-                    qtyReceived: it.qty_received,
-                  });
-
-                  return (
-                    <tr key={it.id} className="border-t border-white/10">
-                      <td className="p-3">
-                        <div className="font-semibold text-neutral-100">{p?.name ? String(p.name) : it.description}</div>
-                        <div className="text-[11px] text-neutral-500">
-                          {sku ? `${sku} • ` : ""}
-                          {it.part_id ? String(it.part_id).slice(0, 8) : "no part_id"} • {itemFlowLabel(itemState)}
-                          {" • "}
-                          WO:{" "}
-                          {it.work_order_id ? (
-                            <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>
-                              → Open WO {it.work_order_id.slice(0, 8)}
-                            </Link>
-                          ) : (
-                            <span className="text-neutral-300">—</span>
-                          )}
-                          {" • "}
-                          {po ? (
-                            <Link className="text-neutral-200 hover:text-white" href={`/parts/po/${encodeURIComponent(String(po.id))}`}>
-                              → Open PO {String(po.id).slice(0, 8)}
-                            </Link>
-                          ) : (
-                            <span className="text-neutral-400">No PO</span>
-                          )}
-                        </div>
-                        {it.work_order_id ? (
-                          <div className="mt-1 text-[11px] text-neutral-500">
-                            <Link className="text-neutral-200 hover:text-white" href={`/parts/requests/${encodeURIComponent(it.work_order_id)}`}>
-                              → View Request Flow
-                            </Link>
-                          </div>
-                        ) : null}
-                      </td>
-                      <td className="p-3 tabular-nums">{it.qty_approved}</td>
-                      <td className="p-3 tabular-nums">{it.qty_received}</td>
-                      <td className="p-3 tabular-nums">{it.qty_remaining}</td>
-                      <td className="p-3">
-                        <button
-                          onClick={() => openDrawerFor(it)}
-                          className="rounded-full border border-[color:var(--accent-copper,#f97316)]/80 bg-gradient-to-r from-black/80 via-[color:var(--accent-copper,#f97316)]/15 to-black/80 px-4 py-2 text-sm font-semibold text-neutral-50 hover:border-[color:var(--accent-copper-light,#fed7aa)]"
-                        >
-                          → Receive
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="border-t border-white/10 px-4 py-3 text-[11px] text-neutral-500">
-            Notes: This flow calls <span className="text-neutral-200">receive_part_request_item</span> RPC and refreshes automatically via{" "}
-            <span className="text-neutral-200">parts:received</span>.
-          </div>
-
-          <div className="flex items-center justify-between border-t border-white/10 px-4 py-3 text-xs">
-            <button
-              type="button"
-              className="rounded border border-white/10 px-2 py-1 disabled:opacity-50"
-              disabled={page <= 1}
-              onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-            >
-              Previous
-            </button>
-            <button
-              type="button"
-              className="rounded border border-white/10 px-2 py-1 disabled:opacity-50"
-              disabled={items.length < pageSize}
-              onClick={() => setPage((prev) => prev + 1)}
-            >
-              Next
-            </button>
-          </div>
-        </div>
-      )}
-
-      <ReceiveDrawer
-        open={drawerOpen}
-        item={drawerItem}
-        onClose={() => {
-          setDrawerOpen(false);
-          setDrawerItem(null);
-          void load();
-        }}
-        locations={locOptions}
-        defaultLocationId={selectedLoc || locOptions[0]?.value || ""}
-        purchaseOrders={poOptions}
-        defaultPoId={selectedPo ? selectedPo : ""}
-        lockLocation={false}
-        lockPo={false}
-      />
+      <ReceiveDrawer open={drawerOpen} item={drawerItem} onClose={() => { setDrawerOpen(false); setDrawerItem(null); void load(); }} locations={locOptions} defaultLocationId={selectedLoc || locOptions[0]?.value || ""} purchaseOrders={poOptions} defaultPoId={selectedPo || ""} />
     </div>
   );
 }

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
   toItemFlowDisplay,
   toRequestFlowDisplay,
 } from "@/features/parts/lib/status-display";
+import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
 
 type DB = Database;
 
@@ -72,6 +73,7 @@ type DrawerItem = {
   qty_remaining?: number | null;
   part_name?: string | null;
   sku?: string | null;
+  trust_reasons?: string[];
 };
 
 function isNonEmptyString(v: unknown): v is string {
@@ -168,6 +170,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   );
   const [requests, setRequests] = useState<RequestUi[]>([]);
   const [parts, setParts] = useState<PartRow[]>([]);
+  const [trustByPartId, setTrustByPartId] = useState<Record<string, PartTrustMeta>>({});
   const [locations, setLocations] = useState<LocationRow[]>([]);
   const [defaultLocationId, setDefaultLocationId] = useState<string>("");
 
@@ -422,7 +425,19 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
             .limit(500),
         ]);
 
-      setParts((ps ?? []) as PartRow[]);
+      const partRows = (ps ?? []) as PartRow[];
+      setParts(partRows);
+      const trustMap: Record<string, PartTrustMeta> = {};
+      partRows.forEach((p: any) => {
+        trustMap[String(p.id)] = buildPartTrustMeta({
+          sku: p.sku ?? null,
+          partNumber: p.part_number ?? null,
+          normalizedPartKey: p.normalized_part_key ?? null,
+          sourceIntakeId: p.source_intake_id ?? null,
+          importConfidence: p.import_confidence ?? null,
+        });
+      });
+      setTrustByPartId(trustMap);
 
       const locList = (locs ?? []) as LocationRow[];
       setLocations(locList);
@@ -447,6 +462,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
         setSelectedPo("");
     } else {
       setParts([]);
+      setTrustByPartId({});
       setLocations([]);
       setDefaultLocationId("");
       setPOs([]);
@@ -659,6 +675,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       qty_remaining: remaining,
       part_name: part?.name ? String(part.name) : null,
       sku: part?.sku ? String(part.sku) : null,
+      trust_reasons: partId ? (trustByPartId[partId]?.reasons ?? []) : [],
     });
     setRecvOpen(true);
   }
@@ -1245,6 +1262,7 @@ if (!lineId || !isUuid(lineId)) {
                                 const effectivePartId = (it.part_id ??
                                   it.ui_part_id ??
                                   null) as string | null;
+                                const trustMeta = effectivePartId ? trustByPartId[effectivePartId] : null;
                                 const canReceive =
                                   !!effectivePartId &&
                                   approved > 0 &&
@@ -1343,6 +1361,16 @@ if (!lineId || !isUuid(lineId)) {
                                             <span className="text-neutral-200">
                                               {remaining}
                                             </span>
+                                            {trustMeta ? (
+                                              <span className={`ml-2 inline-flex rounded-full border px-2 py-0.5 ${trustBadgeTone(trustMeta.level)}`}>
+                                                {trustMeta.level}
+                                              </span>
+                                            ) : null}
+                                          </div>
+                                        ) : null}
+                                        {trustMeta && trustMeta.reasons.length > 0 ? (
+                                          <div className="text-[11px] text-amber-200">
+                                            {trustMeta.reasons.slice(0, 2).join(" · ")}
                                           </div>
                                         ) : null}
                                       </div>

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -170,7 +170,7 @@ export default function PartsRequestsPage(): JSX.Element {
     if (requestIds.length) {
       const { data: items, error: itemsErr } = await supabase
         .from("part_request_items")
-        .select("request_id, description, part_id, qty, quoted_price")
+        .select("request_id, description, part_id, qty, quoted_price, status, qty_approved, qty_received, qty_consumed")
         .in("request_id", requestIds);
 
       if (itemsErr) {
@@ -198,10 +198,11 @@ export default function PartsRequestsPage(): JSX.Element {
 
           (itemStatesByRequest[row.request_id] ||= []).push(
             toItemFlowDisplay({
-              rawStatus: null,
+              rawStatus: (row as { status?: string | null }).status ?? null,
               qty: row.qty,
-              qtyApproved: row.qty,
-              qtyReceived: 0,
+              qtyApproved: (row as { qty_approved?: unknown }).qty_approved ?? row.qty,
+              qtyReceived: (row as { qty_received?: unknown }).qty_received ?? 0,
+              qtyAllocated: (row as { qty_consumed?: unknown }).qty_consumed ?? 0,
             }),
           );
         });

--- a/features/parts/components/ReceiveDrawer.tsx
+++ b/features/parts/components/ReceiveDrawer.tsx
@@ -19,6 +19,7 @@ export type ReceiveDrawerItem = {
 
   part_name?: string | null;
   sku?: string | null;
+  trust_reasons?: string[];
 };
 
 type ReceiveResult =
@@ -289,6 +290,11 @@ export default function ReceiveDrawer(props: {
                     <span className="text-neutral-200">{item.status ?? "—"}</span>
                   </div>
                 </div>
+                {Array.isArray(item.trust_reasons) && item.trust_reasons.length > 0 ? (
+                  <div className="rounded-lg border border-amber-500/30 bg-amber-950/20 px-2 py-1 text-[11px] text-amber-200">
+                    Trust review: {item.trust_reasons.slice(0, 2).join(" · ")}
+                  </div>
+                ) : null}
               </div>
             </div>
           ) : (

--- a/features/parts/lib/status-display.ts
+++ b/features/parts/lib/status-display.ts
@@ -6,6 +6,17 @@ export type ItemFlowDisplay =
   | "received"
   | "consumed";
 
+export type ReceiveProgressDisplay = "not_received" | "partial" | "received" | "allocated";
+
+export const REQUEST_STATUS_CANONICAL: RequestFlowDisplay[] = ["pending", "in_progress", "ready", "complete"];
+export const ITEM_STATUS_CANONICAL: ItemFlowDisplay[] = [
+  "requested",
+  "ordered",
+  "partially_received",
+  "received",
+  "consumed",
+];
+
 function asNum(v: unknown): number {
   const n = typeof v === "number" ? v : Number(v);
   return Number.isFinite(n) ? n : 0;
@@ -14,7 +25,7 @@ function asNum(v: unknown): number {
 export function requestFlowLabel(status: RequestFlowDisplay): string {
   if (status === "pending") return "Pending";
   if (status === "in_progress") return "In Progress";
-  if (status === "ready") return "Ready";
+  if (status === "ready") return "Ready to Allocate";
   return "Complete";
 }
 
@@ -22,6 +33,31 @@ export function itemFlowLabel(status: ItemFlowDisplay): string {
   if (status === "partially_received") return "Partially Received";
   if (status === "consumed") return "Allocated / Consumed";
   return status.charAt(0).toUpperCase() + status.slice(1).replace("_", " ");
+}
+
+export function receiveProgressLabel(status: ReceiveProgressDisplay): string {
+  if (status === "not_received") return "Awaiting Receive";
+  if (status === "partial") return "Partially Received";
+  if (status === "allocated") return "Allocated";
+  return "Received";
+}
+
+export function toReceiveProgressDisplay(input: {
+  qty?: unknown;
+  qtyApproved?: unknown;
+  qtyReceived?: unknown;
+  qtyAllocated?: unknown;
+}): ReceiveProgressDisplay {
+  const qty = asNum(input.qty);
+  const approved = asNum(input.qtyApproved);
+  const received = asNum(input.qtyReceived);
+  const allocated = asNum(input.qtyAllocated);
+  const target = approved > 0 ? approved : qty;
+
+  if (target > 0 && allocated >= target) return "allocated";
+  if (target > 0 && received >= target) return "received";
+  if (received > 0) return "partial";
+  return "not_received";
 }
 
 export function toItemFlowDisplay(input: {
@@ -32,17 +68,23 @@ export function toItemFlowDisplay(input: {
   qtyAllocated?: unknown;
 }): ItemFlowDisplay {
   const status = String(input.rawStatus ?? "").toLowerCase();
-  const qty = asNum(input.qty);
-  const approved = asNum(input.qtyApproved);
-  const received = asNum(input.qtyReceived);
-  const allocated = asNum(input.qtyAllocated);
-  const target = approved > 0 ? approved : qty;
+  const receiveState = toReceiveProgressDisplay(input);
 
-  if (allocated > 0 && target > 0 && allocated >= target) return "consumed";
+  if (receiveState === "allocated") return "consumed";
   if (status === "fulfilled") return "consumed";
-  if (received > 0 && target > 0 && received >= target) return "received";
-  if (received > 0 && target > 0 && received < target) return "partially_received";
-  if (status.includes("ordered") || status === "approved" || status === "reserved") return "ordered";
+  if (receiveState === "received") return "received";
+  if (receiveState === "partial") return "partially_received";
+
+  if (
+    status.includes("ordered") ||
+    status === "approved" ||
+    status === "reserved" ||
+    status === "picking" ||
+    status === "picked"
+  ) {
+    return "ordered";
+  }
+
   return "requested";
 }
 

--- a/features/parts/lib/trust-signals.ts
+++ b/features/parts/lib/trust-signals.ts
@@ -1,0 +1,45 @@
+export type PartTrustLevel = "high" | "review" | "low";
+
+export type PartTrustMeta = {
+  level: PartTrustLevel;
+  reasons: string[];
+};
+
+export function buildPartTrustMeta(input: {
+  sku?: string | null;
+  partNumber?: string | null;
+  normalizedPartKey?: string | null;
+  sourceIntakeId?: string | null;
+  aliasCount?: number;
+  ambiguousCandidateCount?: number;
+  pendingStagingCount?: number;
+  importConfidence?: number | null;
+}): PartTrustMeta {
+  const reasons: string[] = [];
+
+  if (!input.sku?.trim()) reasons.push("Missing SKU");
+  if (!input.partNumber?.trim()) reasons.push("Missing part number");
+  if (!input.normalizedPartKey?.trim()) reasons.push("Weak identity");
+  if ((input.aliasCount ?? 0) > 0) reasons.push("Alias-backed import");
+  if ((input.pendingStagingCount ?? 0) > 0) reasons.push("Staging not finalized");
+  if ((input.ambiguousCandidateCount ?? 0) > 0) reasons.push("Ambiguous import lineage");
+  if (typeof input.importConfidence === "number" && input.importConfidence < 0.75) {
+    reasons.push("Low import confidence");
+  }
+  if (input.sourceIntakeId?.trim() && reasons.length === 0) reasons.push("Imported record");
+
+  const low = reasons.some((r) =>
+    ["Weak identity", "Ambiguous import lineage", "Low import confidence"].includes(r),
+  );
+
+  return {
+    level: low ? "low" : reasons.length > 0 ? "review" : "high",
+    reasons,
+  };
+}
+
+export function trustBadgeTone(level: PartTrustLevel): string {
+  if (level === "low") return "border-rose-500/30 bg-rose-950/25 text-rose-200";
+  if (level === "review") return "border-amber-500/30 bg-amber-950/20 text-amber-200";
+  return "border-emerald-500/30 bg-emerald-950/20 text-emerald-200";
+}


### PR DESCRIPTION
### Motivation
- Make Parts behave as a single operational surface by tightening status semantics, unifying receive interactions, surfacing import/trust quality at point-of-action, and improving inventory auditability without risky schema changes. 
- Provide operators clear, consistent language and compact trust signals where they take action so receiving, allocation, and movement trails are explainable in day-to-day workflows.

### Description
- Introduced a small canonical status/receive contract and helpers in `features/parts/lib/status-display.ts` (request/item/receive progression + label helpers) and migrated pages to use those helpers for consistent badges and filters. 
- Unified the receive UX so Inbox/PO/Scan share behavior and language by enhancing `ReceiveDrawer` (now surfaces compact trust reasons) and wiring all receive lenses to the same flow; touched pages: `app/parts/receiving/page.tsx`, `app/parts/po/receive/page.tsx`, `app/parts/po/[id]/receive/page.tsx`, and `app/parts/receive/page.tsx`. 
- Added a lightweight derived trust system in `features/parts/lib/trust-signals.ts` (no schema changes): `buildPartTrustMeta` computes `level` and `reasons` from existing fields (`sku`, `part_number`, `normalized_part_key`, `source_intake_id`, alias/staging/candidate counts, `import_confidence`) and UI helpers like `trustBadgeTone` used across inbox, request detail, PO lines, scan results, and the receive drawer. 
- Improved explainability in ledger surfaces by adding source labeling and context traces: `app/parts/movements/page.tsx` now maps `reference_kind`/`reason` to friendly source labels and links to related WO/request-item when available, and `app/parts/allocations/page.tsx` shows upstream request/move context for allocations. 
- Visual/UX normalization: neutralized remaining copper-heavy accents on touched receive pages, applied consistent dark/glass cockpit card styles and restrained sky accent tokens across the modified surfaces. 
- Files changed: `features/parts/lib/status-display.ts`, `features/parts/components/ReceiveDrawer.tsx`, `features/parts/lib/trust-signals.ts` (new), `app/parts/receiving/page.tsx`, `app/parts/receive/page.tsx`, `app/parts/po/receive/page.tsx`, `app/parts/po/[id]/receive/page.tsx`, `app/parts/requests/page.tsx`, `app/parts/requests/[id]/page.tsx`, `app/parts/movements/page.tsx`, `app/parts/allocations/page.tsx`.
- No DB migrations were added; trust logic is read-only and derived from existing columns and auxiliary import tables.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it passed (no type errors). 
- Ran targeted linting on touched files with `npx eslint` (touched files); the run completed with warnings only (no errors) primarily about `any` usages and some `react-hooks/exhaustive-deps` warnings in updated pages. 
- No automated unit/integration tests were added for this pass; changes are incremental and non-destructive and rely on existing server RPCs and APIs for writes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc44f7212c8328b82ddc4271b54e71)