### PR TITLE
Phase 4: stabilize Parts surfaces and upgrade Parts dashboard command center

### DIFF
--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -7,11 +7,22 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type Alloc = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+type PartLite = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku">;
+type LocLite = Pick<DB["public"]["Tables"]["stock_locations"]["Row"], "id" | "code" | "name">;
+type WoLite = Pick<DB["public"]["Tables"]["work_orders"]["Row"], "id" | "custom_id">;
+type ReqItemLite = Pick<DB["public"]["Tables"]["part_request_items"]["Row"], "id" | "request_id" | "po_id">;
+type MoveLite = Pick<DB["public"]["Tables"]["stock_moves"]["Row"], "id" | "reference_kind" | "reference_id" | "reason">;
+
+type AllocationView = { a: Alloc; part?: PartLite; loc?: LocLite; wo?: WoLite | null; req?: ReqItemLite | null; move?: MoveLite | null };
 
 async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
-  const { data: userRes } = await supabase.auth.getUser(); const uid = userRes.user?.id ?? null; if (!uid) return "";
-  const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle(); if (profA?.shop_id) return String(profA.shop_id);
-  const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle(); return String(profB?.shop_id ?? "");
+  const { data: userRes } = await supabase.auth.getUser();
+  const uid = userRes.user?.id ?? null;
+  if (!uid) return "";
+  const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle();
+  if (profA?.shop_id) return String(profA.shop_id);
+  const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle();
+  return String(profB?.shop_id ?? "");
 }
 
 export default function AllocationsPage(): JSX.Element {
@@ -20,53 +31,105 @@ export default function AllocationsPage(): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [rows, setRows] = useState<any[]>([]);
+  const [rows, setRows] = useState<AllocationView[]>([]);
 
   useEffect(() => {
     void (async () => {
-      setLoading(true); setErr(null);
+      setLoading(true);
+      setErr(null);
       try {
-        const sid = await resolveShopId(supabase); setShopId(sid); if (!sid) { setRows([]); return; }
-        const { data: allocs, error } = await supabase.from("work_order_part_allocations").select("*").eq("shop_id", sid).order("created_at", { ascending: false }).limit(400);
+        const sid = await resolveShopId(supabase);
+        setShopId(sid);
+        if (!sid) {
+          setRows([]);
+          return;
+        }
+        const { data: allocs, error } = await supabase
+          .from("work_order_part_allocations")
+          .select("*")
+          .eq("shop_id", sid)
+          .order("created_at", { ascending: false })
+          .limit(400);
         if (error) throw error;
+
         const list = (allocs ?? []) as Alloc[];
         const partIds = [...new Set(list.map((a) => String(a.part_id)).filter(Boolean))];
         const locIds = [...new Set(list.map((a) => String(a.location_id)).filter(Boolean))];
         const woIds = [...new Set(list.map((a) => String(a.work_order_id ?? "")).filter(Boolean))];
         const reqItemIds = [...new Set(list.map((a) => String(a.source_request_item_id ?? "")).filter(Boolean))];
         const moveIds = [...new Set(list.map((a) => String(a.stock_move_id ?? "")).filter(Boolean))];
+
         const [parts, locs, wos, reqItems, moves] = await Promise.all([
-          partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as any[] }),
-          locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as any[] }),
-          woIds.length ? supabase.from("work_orders").select("id,custom_id").in("id", woIds) : Promise.resolve({ data: [] as any[] }),
-          reqItemIds.length ? supabase.from("part_request_items").select("id,request_id,po_id").in("id", reqItemIds) : Promise.resolve({ data: [] as any[] }),
-          moveIds.length ? supabase.from("stock_moves").select("id,reference_kind,reference_id,reason").in("id", moveIds) : Promise.resolve({ data: [] as any[] }),
+          partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as PartLite[] }),
+          locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as LocLite[] }),
+          woIds.length ? supabase.from("work_orders").select("id,custom_id").in("id", woIds) : Promise.resolve({ data: [] as WoLite[] }),
+          reqItemIds.length ? supabase.from("part_request_items").select("id,request_id,po_id").in("id", reqItemIds) : Promise.resolve({ data: [] as ReqItemLite[] }),
+          moveIds.length ? supabase.from("stock_moves").select("id,reference_kind,reference_id,reason").in("id", moveIds) : Promise.resolve({ data: [] as MoveLite[] }),
         ]);
-        const partBy: Record<string, any> = {}; (parts.data ?? []).forEach((x: any) => (partBy[String(x.id)] = x));
-        const locBy: Record<string, any> = {}; (locs.data ?? []).forEach((x: any) => (locBy[String(x.id)] = x));
-        const woBy: Record<string, any> = {}; (wos.data ?? []).forEach((x: any) => (woBy[String(x.id)] = x));
-        const reqBy: Record<string, any> = {}; (reqItems.data ?? []).forEach((x: any) => (reqBy[String(x.id)] = x));
-        const moveBy: Record<string, any> = {}; (moves.data ?? []).forEach((x: any) => (moveBy[String(x.id)] = x));
-        setRows(list.map((a) => ({ a, part: partBy[String(a.part_id)], loc: locBy[String(a.location_id)], wo: a.work_order_id ? woBy[String(a.work_order_id)] : null, req: a.source_request_item_id ? reqBy[String(a.source_request_item_id)] : null, move: a.stock_move_id ? moveBy[String(a.stock_move_id)] : null })));
-      } catch (e: any) { setErr(e.message ?? "Failed to load allocations."); }
-      finally { setLoading(false); }
+
+        const partBy: Record<string, PartLite> = {}; (parts.data ?? []).forEach((x) => (partBy[String(x.id)] = x));
+        const locBy: Record<string, LocLite> = {}; (locs.data ?? []).forEach((x) => (locBy[String(x.id)] = x));
+        const woBy: Record<string, WoLite> = {}; (wos.data ?? []).forEach((x) => (woBy[String(x.id)] = x));
+        const reqBy: Record<string, ReqItemLite> = {}; (reqItems.data ?? []).forEach((x) => (reqBy[String(x.id)] = x));
+        const moveBy: Record<string, MoveLite> = {}; (moves.data ?? []).forEach((x) => (moveBy[String(x.id)] = x));
+
+        setRows(list.map((a) => ({
+          a,
+          part: partBy[String(a.part_id)],
+          loc: locBy[String(a.location_id)],
+          wo: a.work_order_id ? woBy[String(a.work_order_id)] ?? null : null,
+          req: a.source_request_item_id ? reqBy[String(a.source_request_item_id)] ?? null : null,
+          move: a.stock_move_id ? moveBy[String(a.stock_move_id)] ?? null : null,
+        })));
+      } catch (e: unknown) {
+        setErr(e instanceof Error ? e.message : "Failed to load allocations.");
+      } finally {
+        setLoading(false);
+      }
     })();
   }, [supabase]);
 
   const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase(); if (!q) return rows;
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
     return rows.filter((r) => [r.part?.name, r.part?.sku, r.loc?.code, r.wo?.custom_id, r.a.work_order_id, r.req?.request_id, r.move?.reference_kind].join(" ").toLowerCase().includes(q));
   }, [rows, search]);
 
   return (
-    <div className="p-6 space-y-4 text-white">
-      <div className="flex items-center justify-between"><div><div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Audit Lens</div><h1 className="text-2xl font-bold">Allocations</h1><div className="text-sm text-neutral-400">What inventory was committed to jobs and where it came from.</div></div><Link href="/parts" className="rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm">Parts</Link></div>
-      <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-3"><input className="w-full rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm" placeholder="Search WO, part, source request, move kind..." value={search} onChange={(e) => setSearch(e.target.value)} /></div>
+    <div className="space-y-4 p-6 text-white">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Traceability</div>
+          <h1 className="text-2xl font-bold">Allocations</h1>
+          <div className="text-sm text-neutral-400">Track inventory committed to work orders with upstream request and stock move context.</div>
+        </div>
+        <Link href="/parts" className="rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm">Parts</Link>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-3">
+        <input className="w-full rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm" placeholder="Search WO, part, source request, move kind..." value={search} onChange={(e) => setSearch(e.target.value)} />
+      </div>
+
       {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-4 text-sm text-red-200">{err}</div> : (
-        <div className="rounded-xl border border-white/10 bg-neutral-950/35 overflow-hidden">
-          <table className="w-full text-sm"><thead><tr className="text-left text-neutral-400"><th className="p-3">WO</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Upstream</th><th className="p-3">Created</th></tr></thead><tbody>
-            {filtered.map((r) => <tr key={String(r.a.id)} className="border-t border-white/10"><td className="p-3">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0,8)}</Link> : <span className="text-neutral-500">—</span>}</td><td className="p-3"><div>{r.part?.name ?? String(r.a.part_id).slice(0,8)}</div><div className="text-xs text-neutral-500">{r.part?.sku ?? ""}</div></td><td className="p-3">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td><td className="p-3 tabular-nums text-neutral-200">{r.a.qty}</td><td className="p-3 text-xs text-neutral-300">{r.req?.request_id ? <span>Request {String(r.req.request_id).slice(0,8)}</span> : <span className="text-neutral-500">No request link</span>}<div className="text-neutral-500">{r.move?.reference_kind ?? "—"} · {r.move?.reason ?? "—"}</div></td><td className="p-3 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td></tr>)}
-          </tbody></table>
+        <div className="overflow-hidden rounded-xl border border-white/10 bg-neutral-950/35">
+          <table className="w-full text-sm">
+            <thead><tr className="text-left text-neutral-400"><th className="p-3">WO</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Upstream trace</th><th className="p-3">Created</th></tr></thead>
+            <tbody>
+              {filtered.map((r) => (
+                <tr key={String(r.a.id)} className="border-t border-white/10 align-top">
+                  <td className="p-3">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0, 8)}</Link> : <span className="text-neutral-500">—</span>}</td>
+                  <td className="p-3"><div>{r.part?.name ?? String(r.a.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{r.part?.sku ?? ""}</div></td>
+                  <td className="p-3">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td>
+                  <td className="p-3 tabular-nums text-neutral-200">{r.a.qty}</td>
+                  <td className="p-3 text-xs text-neutral-300">
+                    {r.req?.request_id ? <span className="rounded border border-white/10 px-2 py-0.5">Req {String(r.req.request_id).slice(0, 8)}</span> : <span className="text-neutral-500">No request link</span>}
+                    <div className="mt-1 text-neutral-500">{r.move?.reference_kind ?? "—"} · {r.move?.reason ?? "—"}</div>
+                  </td>
+                  <td className="p-3 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
       {!shopId ? <div className="text-xs text-neutral-500">No shop detected for this user.</div> : null}

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -6,6 +6,12 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
 import Link from "next/link";
+import {
+  buildPartTrustMeta,
+  trustBadgeTone,
+  trustLevelLabel,
+  type PartTrustMeta,
+} from "@/features/parts/lib/trust-signals";
 
 /* ----------------------------- Types ----------------------------- */
 
@@ -25,11 +31,7 @@ type StagingRow = {
   source_system: string | null;
   status: string | null;
 };
-type TrustLevel = "high" | "review" | "low";
-type TrustMeta = {
-  level: TrustLevel;
-  reasons: string[];
-};
+type TrustMeta = PartTrustMeta;
 
 // app-side view of the enum
 type StockMoveReason = "receive" | "adjust" | "consume" | "transfer";
@@ -430,35 +432,23 @@ export default function InventoryPage(): JSX.Element {
 
         const nextTrust: Record<string, TrustMeta> = {};
         partRows.forEach((p) => {
-          const reasons: string[] = [];
+          const extended = p as Part & { import_confidence?: number | null };
           const aliases = aliasByPart.get(p.id) ?? [];
           const stagingRows = stagingByPart.get(p.id) ?? [];
-
-          const hasSku = typeof p.sku === "string" && p.sku.trim().length > 0;
-          const hasPartNumber =
-            typeof p.part_number === "string" && p.part_number.trim().length > 0;
-          const hasIdentityKey =
-            typeof p.normalized_part_key === "string" && p.normalized_part_key.trim().length > 0;
-
-          if (!hasSku) reasons.push("Missing SKU");
-          if (!hasPartNumber) reasons.push("Missing part #");
-          if (!hasIdentityKey && !hasSku && !hasPartNumber) reasons.push("Weak identity");
-
-          if (aliases.length > 0) reasons.push("Alias-linked import");
-          if (stagingRows.length > 0) reasons.push("Imported lineage");
-          if (typeof p.source_intake_id === "string" && p.source_intake_id.trim()) {
-            reasons.push("Staged intake source");
-          }
-
-          const hasAmbiguousImport = stagingRows.some((s) => {
-            const status = String(s.status ?? "").toLowerCase();
-            return status === "pending" || status === "review";
+          nextTrust[p.id] = buildPartTrustMeta({
+            sku: p.sku,
+            partNumber: p.part_number,
+            normalizedPartKey: p.normalized_part_key,
+            sourceIntakeId: p.source_intake_id,
+            aliasCount: aliases.length,
+            pendingStagingCount: stagingRows.length,
+            ambiguousCandidateCount: stagingRows.some((s) =>
+              ["pending", "review", "ambiguous"].includes(String(s.status ?? "").toLowerCase()),
+            )
+              ? 1
+              : 0,
+            importConfidence: extended.import_confidence,
           });
-          if (hasAmbiguousImport) reasons.push("Ambiguous import");
-
-          const low = reasons.some((r) => r === "Weak identity" || r === "Ambiguous import");
-          const review = reasons.length > 0;
-          nextTrust[p.id] = { level: low ? "low" : review ? "review" : "high", reasons };
         });
 
         setTrustByPartId(nextTrust);
@@ -868,15 +858,6 @@ export default function InventoryPage(): JSX.Element {
                   const total = onHand[p.id] ?? 0;
                   const onHandPill = total > 0 ? pillOk : pillZero;
                   const trust = trustByPartId[p.id] ?? { level: "high", reasons: [] as string[] };
-                  const trustBadge =
-                    trust.level === "low"
-                      ? "border-red-500/30 bg-red-950/30 text-red-200"
-                      : trust.level === "review"
-                        ? "border-amber-500/35 bg-amber-950/30 text-amber-200"
-                        : "border-emerald-500/30 bg-emerald-950/25 text-emerald-200";
-                  const trustLabel =
-                    trust.level === "low" ? "Low trust" : trust.level === "review" ? "Review" : "High";
-
                   return (
                     <tr key={p.id} className="border-t border-white/10">
                       <td className="p-3">
@@ -888,8 +869,8 @@ export default function InventoryPage(): JSX.Element {
                       <td className="p-3">{p.sku ?? "—"}</td>
                       <td className="p-3">{p.category ?? "—"}</td>
                       <td className="p-3">
-                        <div className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold ${trustBadge}`}>
-                          {trustLabel}
+                        <div className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold ${trustBadgeTone(trust.level)}`}>
+                          {trustLevelLabel(trust.level)}
                         </div>
                         {trust.reasons.length > 0 ? (
                           <div className="mt-1 line-clamp-2 text-xs text-neutral-400">

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -7,15 +7,18 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type StockMove = DB["public"]["Tables"]["stock_moves"]["Row"];
-type PartRow = DB["public"]["Tables"]["parts"]["Row"];
-type LocRow = DB["public"]["Tables"]["stock_locations"]["Row"];
+type PartLite = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku">;
+type LocLite = Pick<DB["public"]["Tables"]["stock_locations"]["Row"], "id" | "code" | "name">;
+type RequestItemLite = Pick<DB["public"]["Tables"]["part_request_items"]["Row"], "id" | "work_order_id">;
+type AllocationLite = Pick<DB["public"]["Tables"]["work_order_part_allocations"]["Row"], "stock_move_id" | "work_order_id" | "source_request_item_id">;
 
 type RefContext = { workOrderId?: string | null; requestItemId?: string | null; sourceLabel: string };
 
 function n(v: unknown): number { const num = typeof v === "number" ? v : Number(v); return Number.isFinite(num) ? num : 0; }
 async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
   const { data: userRes } = await supabase.auth.getUser();
-  const uid = userRes.user?.id ?? null; if (!uid) return "";
+  const uid = userRes.user?.id ?? null;
+  if (!uid) return "";
   const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle();
   if (profA?.shop_id) return String(profA.shop_id);
   const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle();
@@ -27,8 +30,8 @@ function sourceLabel(kind: string | null, reason: string | null): string {
   if (k === "purchase_order") return "PO receive";
   if (k === "manual_receive") return "Manual receive";
   if (k === "request_receive") return "Request receive";
-  if (k === "work_order") return "Work order";
-  if (k === "csv_import") return "Import receive";
+  if (k === "work_order") return "WO allocation";
+  if (k === "csv_import") return "CSV import";
   if (reason === "consume" || reason === "wo_allocate") return "Allocation / consumption";
   return k || String(reason ?? "movement");
 }
@@ -39,19 +42,32 @@ export default function StockMovementsPage(): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [moves, setMoves] = useState<StockMove[]>([]);
-  const [parts, setParts] = useState<Record<string, PartRow>>({});
-  const [locs, setLocs] = useState<Record<string, LocRow>>({});
+  const [parts, setParts] = useState<Record<string, PartLite>>({});
+  const [locs, setLocs] = useState<Record<string, LocLite>>({});
   const [ctxMap, setCtxMap] = useState<Record<string, RefContext>>({});
 
   const load = async () => {
-    setLoading(true); setErr(null);
-    const sid = shopId || (await resolveShopId(supabase)); if (!sid) return setLoading(false); if (!shopId) setShopId(sid);
+    setLoading(true);
+    setErr(null);
+    const sid = shopId || (await resolveShopId(supabase));
+    if (!sid) return setLoading(false);
+    if (!shopId) setShopId(sid);
+
     const { data: mv, error } = await supabase
       .from("stock_moves")
       .select("id, part_id, location_id, qty_change, reason, reference_kind, reference_id, created_at, shop_id")
-      .eq("shop_id", sid).order("created_at", { ascending: false }).limit(200);
-    if (error) { setErr(error.message); return setLoading(false); }
-    const rows = (mv ?? []) as StockMove[]; setMoves(rows);
+      .eq("shop_id", sid)
+      .order("created_at", { ascending: false })
+      .limit(200);
+
+    if (error) {
+      setErr(error.message);
+      setLoading(false);
+      return;
+    }
+
+    const rows = (mv ?? []) as StockMove[];
+    setMoves(rows);
 
     const partIds = [...new Set(rows.map((r) => String(r.part_id)).filter(Boolean))];
     const locIds = [...new Set(rows.map((r) => String(r.location_id)).filter(Boolean))];
@@ -59,35 +75,78 @@ export default function StockMovementsPage(): JSX.Element {
     const stockMoveRefs = [...new Set(rows.filter((r) => String(r.reference_kind ?? "") === "work_order" && r.reference_id).map((r) => String(r.reference_id)))];
 
     const [pr, lr, reqItems, allocs] = await Promise.all([
-      partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as any[] }),
-      locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as any[] }),
-      requestItemRefs.length ? supabase.from("part_request_items").select("id,request_id,work_order_id").in("id", requestItemRefs) : Promise.resolve({ data: [] as any[] }),
-      stockMoveRefs.length ? supabase.from("work_order_part_allocations").select("stock_move_id,work_order_id,source_request_item_id").in("stock_move_id", stockMoveRefs) : Promise.resolve({ data: [] as any[] }),
+      partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as PartLite[] }),
+      locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as LocLite[] }),
+      requestItemRefs.length ? supabase.from("part_request_items").select("id,work_order_id").in("id", requestItemRefs) : Promise.resolve({ data: [] as RequestItemLite[] }),
+      stockMoveRefs.length ? supabase.from("work_order_part_allocations").select("stock_move_id,work_order_id,source_request_item_id").in("stock_move_id", stockMoveRefs) : Promise.resolve({ data: [] as AllocationLite[] }),
     ]);
-    const p: Record<string, PartRow> = {}; (pr.data ?? []).forEach((x: any) => (p[String(x.id)] = x)); setParts(p);
-    const l: Record<string, LocRow> = {}; (lr.data ?? []).forEach((x: any) => (l[String(x.id)] = x)); setLocs(l);
-    const c: Record<string, RefContext> = {};
-    (reqItems.data ?? []).forEach((r: any) => { c[String(r.id)] = { workOrderId: r.work_order_id ?? null, requestItemId: r.id, sourceLabel: "Request receive" }; });
-    (allocs.data ?? []).forEach((a: any) => { c[String(a.stock_move_id)] = { workOrderId: a.work_order_id ?? null, requestItemId: a.source_request_item_id ?? null, sourceLabel: "Allocation / consumption" }; });
-    setCtxMap(c);
+
+    const partMap: Record<string, PartLite> = {};
+    (pr.data ?? []).forEach((x) => (partMap[String(x.id)] = x));
+    setParts(partMap);
+
+    const locMap: Record<string, LocLite> = {};
+    (lr.data ?? []).forEach((x) => (locMap[String(x.id)] = x));
+    setLocs(locMap);
+
+    const context: Record<string, RefContext> = {};
+    (reqItems.data ?? []).forEach((r) => {
+      context[String(r.id)] = { workOrderId: r.work_order_id ?? null, requestItemId: String(r.id), sourceLabel: "Request receive" };
+    });
+    (allocs.data ?? []).forEach((a) => {
+      context[String(a.stock_move_id)] = { workOrderId: a.work_order_id ?? null, requestItemId: a.source_request_item_id ?? null, sourceLabel: "WO allocation" };
+    });
+    setCtxMap(context);
     setLoading(false);
   };
 
   useEffect(() => { void load(); }, []);
 
   return (
-    <div className="p-6 space-y-4 text-white">
-      <div className="flex items-start justify-between"><div><div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Audit Lens</div><h1 className="text-2xl font-bold">Stock Movements</h1><div className="text-sm text-neutral-400">Inventory change ledger with source context.</div></div><button onClick={() => void load()} className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm">Refresh</button></div>
+    <div className="space-y-4 p-6 text-white">
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Traceability</div>
+          <h1 className="text-2xl font-bold">Stock movements</h1>
+          <div className="text-sm text-neutral-400">Ledger with direct source links for PO, request receive, and WO allocation context.</div>
+        </div>
+        <button onClick={() => void load()} className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm">Refresh</button>
+      </div>
+
       {err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
       {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : (
-        <div className="rounded-xl border border-white/10 bg-neutral-950/35 overflow-hidden">
-          <table className="w-full text-sm"><thead><tr className="text-left text-neutral-400"><th className="p-3">Time</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Source</th><th className="p-3">Trace</th></tr></thead><tbody>
-            {moves.map((m) => {
-              const part = parts[String(m.part_id)]; const loc = locs[String(m.location_id)]; const qty = n(m.qty_change);
-              const refId = String(m.reference_id ?? ""); const ctx = ctxMap[refId] ?? ctxMap[String(m.id)] ?? null;
-              return <tr key={String(m.id)} className="border-t border-white/10"><td className="p-3 text-neutral-300">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td><td className="p-3"><div>{part?.name ?? String(m.part_id).slice(0,8)}</div><div className="text-xs text-neutral-500">{part?.sku ?? ""}</div></td><td className="p-3">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td><td className={`p-3 font-semibold ${qty >= 0 ? "text-emerald-300" : "text-rose-300"}`}>{qty}</td><td className="p-3"><div>{sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{String(m.reason)}</div></td><td className="p-3 text-xs">{ctx?.workOrderId ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(ctx.workOrderId)}`}>WO {ctx.workOrderId.slice(0,8)}</Link> : <span className="text-neutral-500">No WO</span>} {ctx?.requestItemId ? <span className="ml-2 text-neutral-400">ReqItem {ctx.requestItemId.slice(0,8)}</span> : null}</td></tr>;
-            })}
-          </tbody></table>
+        <div className="overflow-hidden rounded-xl border border-white/10 bg-neutral-950/35">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-neutral-400">
+                <th className="p-3">Time</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Source</th><th className="p-3">Trace links</th>
+              </tr>
+            </thead>
+            <tbody>
+              {moves.map((m) => {
+                const part = parts[String(m.part_id)];
+                const loc = locs[String(m.location_id)];
+                const qty = n(m.qty_change);
+                const refId = String(m.reference_id ?? "");
+                const ctx = ctxMap[refId] ?? ctxMap[String(m.id)] ?? null;
+                return (
+                  <tr key={String(m.id)} className="border-t border-white/10 align-top">
+                    <td className="p-3 text-xs text-neutral-400">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td>
+                    <td className="p-3"><div>{part?.name ?? String(m.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{part?.sku ?? ""}</div></td>
+                    <td className="p-3">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td>
+                    <td className="p-3"><span className={`inline-flex rounded-full border px-2 py-0.5 text-xs ${qty >= 0 ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-200" : "border-rose-500/30 bg-rose-950/20 text-rose-200"}`}>{qty >= 0 ? "+" : ""}{qty}</span></td>
+                    <td className="p-3"><div>{ctx?.sourceLabel ?? sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{String(m.reason ?? "—").replaceAll("_", " ")}</div></td>
+                    <td className="p-3 text-xs">
+                      <div className="flex flex-wrap gap-2">
+                        {ctx?.workOrderId ? <Link className="rounded border border-white/10 px-2 py-0.5 text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(ctx.workOrderId)}`}>WO {ctx.workOrderId.slice(0, 8)}</Link> : <span className="text-neutral-500">No WO</span>}
+                        {ctx?.requestItemId ? <span className="rounded border border-white/10 px-2 py-0.5 text-neutral-300">Req item {ctx.requestItemId.slice(0, 8)}</span> : null}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
         </div>
       )}
     </div>

--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -12,98 +12,45 @@ type DB = Database;
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type StockMoveRow = DB["public"]["Tables"]["stock_moves"]["Row"];
 type RequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
+type TrustExtendedPart = {
+  part_number?: string | null;
+  normalized_part_key?: string | null;
+  import_confidence?: number | null;
+};
 
-// ---------- UI helpers ----------
+type RecentMove = Pick<StockMoveRow, "id" | "created_at" | "reason" | "qty_change" | "part_id" | "reference_kind" | "reference_id">;
+type TrustSummary = { lowTrust: number; reviewStaging: number; ambiguousCandidates: number };
 
-function Sparkline({
-  points,
-  width = 120,
-  height = 28,
-}: {
-  points: number[];
-  width?: number;
-  height?: number;
-}) {
-  if (!points.length) {
-    return (
-      <svg width={width} height={height} aria-hidden>
-        <line
-          x1="0"
-          x2={width}
-          y1={height / 2}
-          y2={height / 2}
-          stroke="currentColor"
-          opacity={0.2}
-        />
-      </svg>
-    );
-  }
+function Sparkline({ points, width = 120, height = 28 }: { points: number[]; width?: number; height?: number }) {
+  if (!points.length) return <svg width={width} height={height} aria-hidden><line x1="0" x2={width} y1={height / 2} y2={height / 2} stroke="currentColor" opacity={0.2} /></svg>;
   const min = Math.min(...points);
   const max = Math.max(...points);
   const range = max - min || 1;
   const stepX = width / Math.max(1, points.length - 1);
-  const path = points
-    .map((v, i) => {
-      const x = i * stepX;
-      const y = height - ((v - min) / range) * height;
-      return `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
-    })
-    .join(" ");
-  return (
-    <svg width={width} height={height} aria-hidden>
-      <path d={path} fill="none" stroke="currentColor" />
-    </svg>
-  );
+  const path = points.map((v, i) => `${i === 0 ? "M" : "L"} ${(i * stepX).toFixed(2)} ${(height - ((v - min) / range) * height).toFixed(2)}`).join(" ");
+  return <svg width={width} height={height} aria-hidden><path d={path} fill="none" stroke="currentColor" /></svg>;
 }
 
-// shared card primitives (mirrors main dashboard look)
-function OverviewCard({
-  title,
-  value,
-  href,
-}: {
-  title: string;
-  value: React.ReactNode;
-  href?: string;
-}) {
+function OverviewCard({ title, value, href, hint }: { title: string; value: React.ReactNode; href?: string; hint?: string }) {
   const content = (
-    <div className="group relative overflow-hidden rounded-xl border border-white/10 bg-white/[0.04] px-4 py-4 shadow-card backdrop-blur-md transition hover:border-accent hover:shadow-glow">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),transparent_60%)] opacity-0 transition-opacity group-hover:opacity-100" />
-      <div className="relative">
-        <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
-          {title}
-        </p>
-        <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
-      </div>
+    <div className="group relative overflow-hidden rounded-xl border border-white/10 bg-white/[0.04] px-4 py-4 shadow-card backdrop-blur-md transition hover:border-sky-400/50 hover:shadow-glow">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.14),transparent_58%)] opacity-0 transition-opacity group-hover:opacity-100" />
+      <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">{title}</p>
+      <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
+      {hint ? <div className="mt-1 text-xs text-neutral-500">{hint}</div> : null}
     </div>
   );
-
-  if (href) {
-    return (
-      <Link href={href} className="block">
-        {content}
-      </Link>
-    );
-  }
-  return content;
+  return href ? <Link href={href} className="block">{content}</Link> : content;
 }
 
-function QuickButton({
-  href,
-  children,
-  accent,
-}: {
-  href: string;
-  children: React.ReactNode;
-  accent?: boolean;
-}) {
+function ActionButton({ href, children, emphasis }: { href: string; children: React.ReactNode; emphasis?: boolean }) {
   return (
     <Link
       href={href}
-      className={`inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm text-white shadow-sm backdrop-blur-md transition ${
-        accent
-          ? "border-sky-500/40 bg-white/[0.03] hover:bg-sky-900/20 hover:border-sky-400"
-          : "border-neutral-700 bg-white/[0.02] hover:bg-neutral-800/80"
+      className={`inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium text-white transition ${
+        emphasis
+          ? "border-sky-400/45 bg-sky-950/35 hover:border-sky-300 hover:bg-sky-900/30"
+          : "border-white/10 bg-white/[0.03] hover:bg-white/[0.08]"
       }`}
     >
       {children}
@@ -111,262 +58,213 @@ function QuickButton({
   );
 }
 
-// ---------- Page ----------
+function moveTone(qty: number): string {
+  if (qty > 0) return "text-emerald-200 bg-emerald-950/20 border-emerald-500/25";
+  if (qty < 0) return "text-rose-200 bg-rose-950/20 border-rose-500/25";
+  return "text-neutral-300 bg-white/[0.03] border-white/10";
+}
+
+function sourceLabel(kind: string | null, reason: string | null): string {
+  const key = String(kind ?? "").toLowerCase();
+  if (key === "purchase_order") return "PO receive";
+  if (key === "request_receive") return "Request receive";
+  if (key === "manual_receive") return "Manual receive";
+  if (key === "work_order") return "Work order allocation";
+  return String(reason ?? (key || "movement")).replaceAll("_", " ");
+}
+
 export default function PartsDashboardPage(): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [loading, setLoading] = useState(true);
-
-  // KPIs
-  const [skuTotal, setSkuTotal] = useState<number>(0);
-  const [skuNewThis7d, setSkuNewThis7d] = useState<number>(0);
-
-  const [moves7dCount, setMoves7dCount] = useState<number>(0);
+  const [skuTotal, setSkuTotal] = useState(0);
+  const [skuNewThis7d, setSkuNewThis7d] = useState(0);
+  const [moves7dCount, setMoves7dCount] = useState(0);
   const [moves30Spark, setMoves30Spark] = useState<number[]>([]);
-
-  const [openRequestsCount, setOpenRequestsCount] = useState<number | null>(
-    null,
-  );
-
-  // Recent moves (list)
-  const [recentMoves, setRecentMoves] = useState<
-    Pick<
-      StockMoveRow,
-      "id" | "created_at" | "reason" | "qty_change" | "part_id"
-    >[]
-  >([]);
+  const [openRequestsCount, setOpenRequestsCount] = useState<number | null>(null);
+  const [openPoCount, setOpenPoCount] = useState<number | null>(null);
+  const [receiveQueueCount, setReceiveQueueCount] = useState<number | null>(null);
+  const [trustSummary, setTrustSummary] = useState<TrustSummary>({ lowTrust: 0, reviewStaging: 0, ambiguousCandidates: 0 });
+  const [partNameById, setPartNameById] = useState<Record<string, { name: string | null; sku: string | null }>>({});
+  const [recentMoves, setRecentMoves] = useState<RecentMove[]>([]);
 
   useEffect(() => {
-    (async () => {
+    void (async () => {
       setLoading(true);
-
       const now = new Date();
       const d7Ago = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
       const d30Ago = new Date(now.getTime() - 30 * 24 * 3600 * 1000);
 
-      // -------- parts (for SKUs + 7d new) --------
-      const { data: parts, error: perr } = await supabase
-        .from("parts")
-        .select("id, created_at");
+      const [partsRes, movesRes, openReqRes, openPoRes, receiveQueueRes, stagingRes, candidateRes] = await Promise.all([
+        supabase.from("parts").select("id, created_at, sku, part_number, normalized_part_key, import_confidence, source_intake_id"),
+        supabase
+          .from("stock_moves")
+          .select("id, part_id, qty_change, reason, created_at, reference_kind, reference_id")
+          .gte("created_at", d30Ago.toISOString())
+          .order("created_at", { ascending: true }),
+        supabase.from("part_requests").select("id", { count: "exact", head: true }).in("status", ["requested", "quoted", "approved"] as RequestRow["status"][]),
+        supabase.from("purchase_orders").select("id", { count: "exact", head: true }).in("status", ["draft", "sent", "partially_received"]),
+        supabase.from("part_request_items").select("qty_approved, qty_received").gt("qty_approved", 0),
+        supabase.from("shop_parts_import_staging").select("status"),
+        supabase.from("shop_parts_import_match_candidates").select("staging_id, candidate_part_id"),
+      ]);
 
-      if (perr) {
-        // eslint-disable-next-line no-console
-        console.error("[parts] load failed:", perr);
-      }
-      const partsRows = (parts ?? []) as Pick<
-        PartRow,
-        "id" | "created_at"
-      >[];
+      const partsRows = (partsRes.data ?? []) as Array<Pick<PartRow, "id" | "created_at" | "sku"> & TrustExtendedPart>;
 
       setSkuTotal(partsRows.length);
+      setSkuNewThis7d(partsRows.filter((p) => !!p.created_at && new Date(p.created_at) >= d7Ago && new Date(p.created_at) < now).length);
 
-      const createdInLast7 = partsRows.filter((p) => {
-        const ts = p.created_at ? new Date(p.created_at) : null;
-        return !!ts && ts >= d7Ago && ts < now;
-      }).length;
-      setSkuNewThis7d(createdInLast7);
-
-      // -------- stock_moves (for 7d count + 30d sparkline + list) --------
-      const { data: moves, error: merr } = await supabase
-        .from("stock_moves")
-        .select("id, part_id, qty_change, reason, created_at")
-        .gte("created_at", d30Ago.toISOString())
-        .order("created_at", { ascending: true });
-
-      if (merr) {
-        // eslint-disable-next-line no-console
-        console.error("[stock_moves] load failed:", merr);
+      const lowTrust = partsRows.filter((p) => !p.sku?.trim() || !p.part_number?.trim() || !p.normalized_part_key?.trim() || (typeof p.import_confidence === "number" && p.import_confidence < 0.75)).length;
+      const reviewStaging = (stagingRes.data ?? []).filter((s) => ["pending", "review", "ambiguous"].includes(String(s.status ?? "").toLowerCase())).length;
+      const candidateCounts: Record<string, number> = {};
+      for (const row of candidateRes.data ?? []) {
+        const key = String(row.staging_id ?? row.candidate_part_id ?? "");
+        if (!key) continue;
+        candidateCounts[key] = (candidateCounts[key] ?? 0) + 1;
       }
+      const ambiguousCandidates = Object.values(candidateCounts).filter((count) => count > 1).length;
+      setTrustSummary({ lowTrust, reviewStaging, ambiguousCandidates });
 
-      const mv = (moves ?? []) as Pick<
-        StockMoveRow,
-        "id" | "part_id" | "qty_change" | "reason" | "created_at"
-      >[];
-
-      // 7d moves count
-      setMoves7dCount(
-        mv.filter((m) => new Date(m.created_at) >= d7Ago).length,
-      );
-
-      // 30-day sparkline (daily net qty_change)
-      const days = 30;
-      const buckets = Array<number>(days).fill(0);
+      const mv = (movesRes.data ?? []) as RecentMove[];
+      setMoves7dCount(mv.filter((m) => new Date(String(m.created_at)) >= d7Ago).length);
+      const buckets = Array<number>(30).fill(0);
       for (const m of mv) {
-        const dt = new Date(m.created_at);
-        const idx = Math.min(
-          days - 1,
-          Math.max(
-            0,
-            Math.floor(
-              (dt.getTime() - d30Ago.getTime()) / (24 * 3600 * 1000),
-            ),
-          ),
-        );
+        const dt = new Date(String(m.created_at));
+        const idx = Math.min(29, Math.max(0, Math.floor((dt.getTime() - d30Ago.getTime()) / (24 * 3600 * 1000))));
         buckets[idx] += Number(m.qty_change ?? 0);
       }
       setMoves30Spark(buckets);
-
-      // Recent list (latest 10, descending)
-      const recent = [...mv]
-        .sort(
-          (a, b) =>
-            new Date(b.created_at).getTime() -
-            new Date(a.created_at).getTime(),
-        )
-        .slice(0, 10);
+      const recent = [...mv].sort((a, b) => new Date(String(b.created_at)).getTime() - new Date(String(a.created_at)).getTime()).slice(0, 12);
       setRecentMoves(recent);
 
-      // -------- open parts requests count --------
-      const {
-        count: openCount,
-        error: rerr,
-      } = await supabase
-        .from("part_requests")
-        .select("id", { count: "exact", head: true })
-        .in("status", ["requested", "quoted", "approved"] as RequestRow["status"][]);
-
-      if (rerr) {
-        // eslint-disable-next-line no-console
-        console.error("[part_requests] count failed:", rerr);
-        setOpenRequestsCount(0);
+      const partIds = [...new Set(recent.map((x) => String(x.part_id ?? "")).filter(Boolean))];
+      if (partIds.length) {
+        const partInfo = await supabase.from("parts").select("id, name, sku").in("id", partIds);
+        const map: Record<string, { name: string | null; sku: string | null }> = {};
+        for (const p of partInfo.data ?? []) map[String(p.id)] = { name: p.name ?? null, sku: p.sku ?? null };
+        setPartNameById(map);
       } else {
-        setOpenRequestsCount(openCount ?? 0);
+        setPartNameById({});
       }
 
+      setOpenRequestsCount(openReqRes.count ?? 0);
+      setOpenPoCount(openPoRes.count ?? 0);
+      const receiveQueue = (receiveQueueRes.data ?? []).filter((r) => Number(r.qty_received ?? 0) < Number(r.qty_approved ?? 0)).length;
+      setReceiveQueueCount(receiveQueue);
       setLoading(false);
     })();
   }, [supabase]);
 
-  const skuTotalDisplay = loading ? "…" : skuTotal.toLocaleString();
-  const newSkuDisplay = loading ? "…" : String(skuNewThis7d);
-  const moves7dDisplay = loading ? "…" : moves7dCount.toLocaleString();
-  const openReqDisplay =
-    openRequestsCount === null || loading
-      ? "…"
-      : openRequestsCount.toLocaleString();
+  const openReqDisplay = openRequestsCount == null || loading ? "…" : openRequestsCount.toLocaleString();
   const hasOpenRequests = (openRequestsCount ?? 0) > 0;
 
   return (
-    <div className="relative space-y-6 p-5 text-white fade-in md:space-y-7 md:p-6">
-      {/* soft gradient background for this page */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.08),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.92),#020617_70%)]"
-      />
+    <div className="relative space-y-5 p-5 text-white fade-in md:space-y-6 md:p-6">
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.09),transparent_54%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.9),#020617_72%)]" />
 
-      {/* welcome panel */}
       <section className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-5 shadow-card backdrop-blur-md">
-        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(120deg,rgba(56,189,248,0.14),transparent_45%)]" />
-        <div>
-          <div className="text-[10px] uppercase tracking-[0.2em] text-neutral-400">Parts command center</div>
-          <h1 className="mt-1 text-2xl font-semibold text-white md:text-3xl">Parts dashboard</h1>
-          <p className="mt-2 max-w-2xl text-sm text-neutral-300">
-            Overview of your catalog, movement, and open requests.
-          </p>
+        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(130deg,rgba(56,189,248,0.13),rgba(15,23,42,0.02)_45%,transparent_70%)]" />
+        <div className="relative flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.2em] text-neutral-400">Parts command center</div>
+            <h1 className="mt-1 text-2xl font-semibold md:text-3xl">Start your parts day with clear signals</h1>
+            <p className="mt-2 max-w-2xl text-sm text-neutral-300">Prioritize open requests, receiving, and recent movement from one operational surface.</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <ActionButton href="/parts/requests" emphasis>Open requests</ActionButton>
+            <ActionButton href="/parts/receiving">Receiving inbox</ActionButton>
+          </div>
         </div>
       </section>
 
-      <SuggestedActionsPanel
-        context={{
-          pageType: "parts_dashboard",
-          pageTitle: "Parts Dashboard",
-        }}
-        title="Suggested Actions for Parts"
-        description="Inventory insights, restocking suggestions, request follow-ups, and procurement optimization"
-       compact collapsible defaultExpanded={false} maxItems={3} hideDescription />
-
-      {/* overview cards */}
-      <section className="grid gap-3 md:grid-cols-4">
-        <OverviewCard
-          title="SKUs in catalog"
-          value={skuTotalDisplay}
-          href="/parts/inventory"
-        />
-        <OverviewCard
-          title="New SKUs (7 days)"
-          value={newSkuDisplay}
-          href="/parts/inventory"
-        />
-        <OverviewCard
-          title="Stock moves (7 days)"
-          value={moves7dDisplay}
-          href="/parts/inventory"
-        />
-        <OverviewCard
-          title="Open parts requests"
-          value={openReqDisplay}
-          href="/parts/requests"
-        />
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <OverviewCard title="SKUs in catalog" value={loading ? "…" : skuTotal.toLocaleString()} href="/parts/inventory" />
+        <OverviewCard title="New SKUs (7d)" value={loading ? "…" : skuNewThis7d} href="/parts/inventory" />
+        <OverviewCard title="Stock moves (7d)" value={loading ? "…" : moves7dCount.toLocaleString()} hint="Receive, adjust, consume" href="/parts/movements" />
+        <OverviewCard title="Open part requests" value={openReqDisplay} href="/parts/requests" />
       </section>
 
-      {hasOpenRequests && (
-        <section className="rounded-xl border border-sky-500/30 bg-sky-950/20 px-4 py-3 shadow-[0_0_24px_rgba(14,116,144,0.22)]">
+      <section className="grid gap-3 lg:grid-cols-[1.5fr_1fr]">
+        <div className="rounded-xl border border-sky-500/30 bg-sky-950/20 px-4 py-3 shadow-[0_0_24px_rgba(14,116,144,0.18)]">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
-              <div className="text-[10px] uppercase tracking-[0.18em] text-sky-200/80">Bottleneck signal</div>
-              <p className="text-sm text-sky-100">
-                You have <span className="font-semibold">{openReqDisplay}</span> open parts request{openRequestsCount === 1 ? "" : "s"} awaiting action.
-              </p>
+              <div className="text-[10px] uppercase tracking-[0.18em] text-sky-200/80">Operational bottleneck</div>
+              <p className="text-sm text-sky-100">{hasOpenRequests ? <>You have <span className="font-semibold">{openReqDisplay}</span> open parts request{openRequestsCount === 1 ? "" : "s"} pending fulfillment flow.</> : "No open parts request bottlenecks right now."}</p>
             </div>
-            <Link href="/parts/requests" className="rounded-full border border-sky-300/60 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-sky-100 hover:bg-sky-900/35">
-              Open requests
-            </Link>
+            <ActionButton href="/parts/requests" emphasis>{hasOpenRequests ? "Resolve request queue" : "Review requests"}</ActionButton>
           </div>
-        </section>
-      )}
+        </div>
 
-      {/* quick actions */}
-      <section className="space-y-2">
-        <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">Quick actions</h2>
-        <div className="flex flex-wrap gap-2">
-          <QuickButton href="/parts/po" accent>
-            Create PO
-          </QuickButton>
-          <QuickButton href="/parts/inventory">Inventory</QuickButton>
-          <QuickButton href="/parts/receive">Scan to receive</QuickButton>
-          <QuickButton href="/parts/requests">Requests</QuickButton>
-          <QuickButton href="/parts/vendors">Vendors</QuickButton>
+        <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-400">Primary actions</div>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <ActionButton href="/parts/po" emphasis>Create PO</ActionButton>
+            <ActionButton href="/parts/requests">Open requests</ActionButton>
+            <ActionButton href="/parts/receiving">Receiving inbox</ActionButton>
+            <ActionButton href="/parts/receive">Scan to receive</ActionButton>
+            <ActionButton href="/parts/inventory">Inventory</ActionButton>
+            <ActionButton href="/parts/po/receive">Purchase orders</ActionButton>
+          </div>
         </div>
       </section>
 
-      {/* recent moves */}
+      <section className="grid gap-3 xl:grid-cols-[1.2fr_1fr]">
+        <SuggestedActionsPanel
+          context={{ pageType: "parts_dashboard", pageTitle: "Parts Dashboard" }}
+          title="Urgent suggested actions"
+          description="Compact triage queue for procurement and receiving"
+          compact
+          collapsible
+          defaultExpanded
+          maxItems={5}
+          hideDescription
+        />
+
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4 shadow-card backdrop-blur-md">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-neutral-300">Operational insights</h2>
+              <p className="text-xs text-neutral-500">Live queues and catalog trust posture.</p>
+            </div>
+            <Sparkline points={moves30Spark} />
+          </div>
+          <div className="mt-3 grid gap-2 text-sm">
+            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Receive queue</span><span className="font-semibold">{loading ? "…" : (receiveQueueCount ?? 0).toLocaleString()}</span></div>
+            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Open purchase orders</span><span className="font-semibold">{loading ? "…" : (openPoCount ?? 0).toLocaleString()}</span></div>
+            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Low-trust catalog records</span><span className="font-semibold text-rose-200">{loading ? "…" : trustSummary.lowTrust.toLocaleString()}</span></div>
+            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Review-needed imports</span><span className="font-semibold text-sky-200">{loading ? "…" : trustSummary.reviewStaging.toLocaleString()}</span></div>
+            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Ambiguous match candidates</span><span className="font-semibold text-sky-200">{loading ? "…" : trustSummary.ambiguousCandidates.toLocaleString()}</span></div>
+          </div>
+        </div>
+      </section>
+
       <section className="rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-4 shadow-card backdrop-blur-md">
         <div className="mb-2 flex items-center justify-between gap-4">
           <div>
             <h2 className="text-lg font-semibold">Recent stock moves</h2>
-            <p className="text-xs text-neutral-400">
-              Last 30 days of inventory activity.
-            </p>
+            <p className="text-xs text-neutral-400">Most recent inventory movement with source traceability.</p>
           </div>
-          <Sparkline points={moves30Spark} />
+          <Link href="/parts/movements" className="text-xs uppercase tracking-[0.14em] text-sky-300 hover:text-sky-200">View ledger</Link>
         </div>
 
         {loading ? (
           <div className="text-sm text-neutral-400">Loading…</div>
         ) : recentMoves.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-neutral-700 bg-black/20 px-3 py-4 text-sm text-neutral-400">
-            No recent moves in the last 30 days. Once receiving, adjustments, or issues post, movement will appear here.
-          </div>
+          <div className="rounded-lg border border-dashed border-neutral-700 bg-black/20 px-3 py-4 text-sm text-neutral-400">No recent moves in the last 30 days.</div>
         ) : (
           <ul className="divide-y divide-neutral-800 text-sm">
-            {recentMoves.map((m) => (
-              <li
-                key={m.id}
-                className="flex items-center justify-between py-2"
-              >
-                <div className="min-w-0">
-                  <div className="font-medium">
-                    {String(m.reason ?? "move").replaceAll("_", " ")}
+            {recentMoves.map((m) => {
+              const qty = Number(m.qty_change ?? 0);
+              const part = partNameById[String(m.part_id)] ?? null;
+              return (
+                <li key={m.id} className="flex flex-wrap items-center justify-between gap-3 py-2.5">
+                  <div className="min-w-0">
+                    <div className="font-medium text-neutral-100">{part?.name ?? String(m.reason ?? "move").replaceAll("_", " ")}</div>
+                    <div className="text-xs text-neutral-500">{part?.sku ? `${part.sku} · ` : ""}{sourceLabel(m.reference_kind ?? null, m.reason ?? null)} · {new Date(String(m.created_at)).toLocaleString()}</div>
                   </div>
-                  <div className="text-xs text-neutral-500">
-                    {new Date(m.created_at as string).toLocaleString()}
-                  </div>
-                </div>
-                <div className="pl-3 font-semibold">
-                  {Number(m.qty_change ?? 0) >= 0 ? "+" : ""}
-                  {Number(m.qty_change ?? 0)}
-                </div>
-              </li>
-            ))}
+                  <div className={`inline-flex min-w-[72px] items-center justify-center rounded-full border px-2 py-1 text-xs font-semibold ${moveTone(qty)}`}>{qty >= 0 ? "+" : ""}{qty}</div>
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>

--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -668,7 +668,7 @@ export default function PoReceivePage(): JSX.Element {
                             <span className="text-[11px] text-neutral-400">{receiveProgressLabel(recvState)}</span>
                             {trust ? <span className={`rounded-full border px-2 py-0.5 text-[10px] ${trustBadgeTone(trust.level)}`}>{trust.level}</span> : null}
                           </div>
-                          {trust && trust.reasons.length > 0 ? <div className="text-[11px] text-amber-200">{trust.reasons.slice(0, 1).join(" · ")}</div> : null}
+                          {trust && trust.reasons.length > 0 ? <div className="text-[11px] text-sky-200">{trust.reasons.slice(0, 1).join(" · ")}</div> : null}
                         </td>
                         <td className="p-3 font-mono">{ordered}</td>
                         <td className="p-3 font-mono">{received}</td>

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -362,7 +362,7 @@ export default function ReceivePage(): JSX.Element {
             {lastTrust ? (
               <div className="mt-1 text-xs">
                 <span className={`inline-flex rounded-full border px-2 py-1 ${trustBadgeTone(lastTrust.level)}`}>Trust: {lastTrust.level}</span>
-                {lastTrust.reasons.length > 0 ? <span className="ml-2 text-amber-200">{lastTrust.reasons.slice(0, 2).join(" · ")}</span> : null}
+                {lastTrust.reasons.length > 0 ? <span className="ml-2 text-sky-200">{lastTrust.reasons.slice(0, 2).join(" · ")}</span> : null}
               </div>
             ) : null}
           </div>

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -11,7 +11,13 @@ import {
   toItemFlowDisplay,
   toReceiveProgressDisplay,
 } from "@/features/parts/lib/status-display";
-import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
+import {
+  buildPartTrustMeta,
+  trustBadgeTone,
+  trustReasonTone,
+  type PartTrustMeta,
+} from "@/features/parts/lib/trust-signals";
+import type { ReceiveDrawerItem } from "@/features/parts/components/ReceiveDrawer";
 
 type DB = Database;
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
@@ -69,7 +75,7 @@ export default function ReceivingInboxPage(): JSX.Element {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [nowTs, setNowTs] = useState<number>(Date.now());
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  const [drawerItem, setDrawerItem] = useState<any>(null);
+  const [drawerItem, setDrawerItem] = useState<ReceiveDrawerItem | null>(null);
 
   const load = async (pageToLoad = page) => {
     setLoading(true);
@@ -136,7 +142,7 @@ export default function ReceivingInboxPage(): JSX.Element {
     if (requestIds.length) {
       const { data: reqRows } = await supabase.from("part_requests").select("id, work_order_id").in("id", requestIds);
       const woByReq: Record<string, string | null> = {};
-      (reqRows ?? []).forEach((r: any) => (woByReq[r.id] = r.work_order_id));
+      (reqRows ?? []).forEach((r) => (woByReq[String(r.id)] = r.work_order_id ?? null));
       setItems((prev) => prev.map((it) => ({ ...it, work_order_id: woByReq[it.request_id] ?? null })));
     }
 
@@ -162,16 +168,16 @@ export default function ReceivingInboxPage(): JSX.Element {
       setPartsMap(pMap);
 
       const aliasCount: Record<string, number> = {};
-      (aliasRes.data ?? []).forEach((r: any) => (aliasCount[String(r.part_id)] = (aliasCount[String(r.part_id)] ?? 0) + 1));
+      (aliasRes.data ?? []).forEach((r) => (aliasCount[String(r.part_id)] = (aliasCount[String(r.part_id)] ?? 0) + 1));
       const pendingCount: Record<string, number> = {};
-      (stagingRes.data ?? []).forEach((r: any) => {
+      (stagingRes.data ?? []).forEach((r) => {
         const st = String(r.status ?? "").toLowerCase();
         if (st === "pending" || st === "review" || st === "ambiguous") {
           pendingCount[String(r.matched_part_id)] = (pendingCount[String(r.matched_part_id)] ?? 0) + 1;
         }
       });
       const candCount: Record<string, number> = {};
-      (candRes.data ?? []).forEach((r: any) => {
+      (candRes.data ?? []).forEach((r) => {
         const id = String(r.candidate_part_id);
         candCount[id] = (candCount[id] ?? 0) + 1;
       });
@@ -179,12 +185,13 @@ export default function ReceivingInboxPage(): JSX.Element {
       const tMap: Record<string, PartTrustMeta> = {};
       for (const pid of partIds) {
         const p = pMap[pid];
+        const extended = p as PartRow & { import_confidence?: number | null };
         tMap[pid] = buildPartTrustMeta({
           sku: p?.sku,
-          partNumber: (p as any)?.part_number ?? null,
-          normalizedPartKey: (p as any)?.normalized_part_key ?? null,
-          sourceIntakeId: (p as any)?.source_intake_id ?? null,
-          importConfidence: (p as any)?.import_confidence ?? null,
+          partNumber: p?.part_number ?? null,
+          normalizedPartKey: p?.normalized_part_key ?? null,
+          sourceIntakeId: p?.source_intake_id ?? null,
+          importConfidence: extended?.import_confidence ?? null,
           aliasCount: aliasCount[pid] ?? 0,
           ambiguousCandidateCount: (candCount[pid] ?? 0) > 1 ? candCount[pid] : 0,
           pendingStagingCount: pendingCount[pid] ?? 0,
@@ -264,7 +271,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                     <td className="p-3">
                       <div className="font-semibold">{p?.name ? String(p.name) : it.description}</div>
                       <div className="text-[11px] text-neutral-500">{p?.sku ? `${p.sku} • ` : ""}{itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}</div>
-                      {trust && trust.reasons.length > 0 ? <div className="mt-1 text-[11px] text-amber-200">{trust.reasons.slice(0,2).join(" · ")}</div> : null}
+                      {trust && trust.reasons.length > 0 ? <div className={`mt-1 text-[11px] ${trustReasonTone(trust.level)}`}>{trust.reasons.slice(0,2).join(" · ")}</div> : null}
                     </td>
                     <td className="p-3"><span className="inline-flex rounded-full border border-white/10 bg-black/40 px-2 py-1 text-xs">{receiveProgressLabel(recvState)}</span>{trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trust.level}</span> : null}</td>
                     <td className="p-3 tabular-nums">{it.qty_received} / {it.qty_approved} <span className="text-neutral-500">({it.qty_remaining} rem)</span></td>

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1176,13 +1176,13 @@ if (!lineId || !isUuid(lineId)) {
                               Job:{" "}
                               <span className="text-neutral-300">{jobText}</span>
                               {isFallbackLinked ? (
-                                <span className="ml-2 text-amber-300">
+                                <span className="ml-2 text-sky-200">
                                   (using only work order line)
                                 </span>
                               ) : null}
                             </div>
                           ) : !hasValidLineId ? (
-                            <div className="mt-1 text-xs text-amber-300">
+                            <div className="mt-1 text-xs text-sky-200">
                               This request is not linked to a valid work order line yet.
                             </div>
                           ) : null}
@@ -1369,7 +1369,7 @@ if (!lineId || !isUuid(lineId)) {
                                           </div>
                                         ) : null}
                                         {trustMeta && trustMeta.reasons.length > 0 ? (
-                                          <div className="text-[11px] text-amber-200">
+                                          <div className="text-[11px] text-sky-200">
                                             {trustMeta.reasons.slice(0, 2).join(" · ")}
                                           </div>
                                         ) : null}

--- a/features/parts/components/ReceiveDrawer.tsx
+++ b/features/parts/components/ReceiveDrawer.tsx
@@ -2,6 +2,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { itemFlowLabel, toItemFlowDisplay } from "@/features/parts/lib/status-display";
+import { trustBadgeTone } from "@/features/parts/lib/trust-signals";
 
 type Option = { value: string; label: string };
 
@@ -287,11 +289,13 @@ export default function ReceiveDrawer(props: {
                   </div>
                   <div>
                     <span className="text-neutral-500">Status:</span>{" "}
-                    <span className="text-neutral-200">{item.status ?? "—"}</span>
+                    <span className="text-neutral-200">
+                      {itemFlowLabel(toItemFlowDisplay({ rawStatus: item.status, qtyApproved: item.qty_approved, qtyReceived: item.qty_received }))}
+                    </span>
                   </div>
                 </div>
                 {Array.isArray(item.trust_reasons) && item.trust_reasons.length > 0 ? (
-                  <div className="rounded-lg border border-amber-500/30 bg-amber-950/20 px-2 py-1 text-[11px] text-amber-200">
+                  <div className={`rounded-lg border px-2 py-1 text-[11px] ${trustBadgeTone("review")}`}>
                     Trust review: {item.trust_reasons.slice(0, 2).join(" · ")}
                   </div>
                 ) : null}

--- a/features/parts/lib/trust-signals.ts
+++ b/features/parts/lib/trust-signals.ts
@@ -40,6 +40,18 @@ export function buildPartTrustMeta(input: {
 
 export function trustBadgeTone(level: PartTrustLevel): string {
   if (level === "low") return "border-rose-500/30 bg-rose-950/25 text-rose-200";
-  if (level === "review") return "border-amber-500/30 bg-amber-950/20 text-amber-200";
+  if (level === "review") return "border-sky-500/30 bg-sky-950/20 text-sky-200";
   return "border-emerald-500/30 bg-emerald-950/20 text-emerald-200";
+}
+
+export function trustLevelLabel(level: PartTrustLevel): string {
+  if (level === "low") return "Low trust";
+  if (level === "review") return "Needs review";
+  return "High trust";
+}
+
+export function trustReasonTone(level: PartTrustLevel): string {
+  if (level === "low") return "text-rose-200";
+  if (level === "review") return "text-sky-200";
+  return "text-neutral-300";
 }


### PR DESCRIPTION
### Motivation
- Finish Parts stabilization by making trust signals consistent, removing warm/brown visual drift, and reducing risky `any` usage in recently touched Parts UI code.
- Reshape the Parts dashboard into a compact, operational command-center so parts staff see KPIs, queues, and actions first.
- Improve traceability for movements and allocations so stock activity links cleanly back to requests, POs, and work orders.

### Description
- Reworked the Parts dashboard (`app/parts/page.tsx`) into a command-center hierarchy with a cool-neutral hero, KPI strip, primary action rail, compact bottleneck signal, urgent suggestions, operational insights (receive queue / open PO / trust summary), and an improved recent moves panel with clearer source labels and toned qty pills.
- Standardized trust helpers in `features/parts/lib/trust-signals.ts` by adding label/tone helpers and switching the "review" tone to a cool/sky treatment, and then reused those helpers across inventory and receiving surfaces to eliminate inconsistent badge behavior and warm/copper accents.
- Updated receiving/receive drawer and inventory pages to use canonical status/trust presentation and safer typings (e.g., `ReceiveDrawer` item typing, parts trust mapping), and replaced several high-risk `any` usages with narrower types or mapped records to improve type safety without a large refactor.
- Improved movements and allocations pages (`app/parts/movements/page.tsx`, `app/parts/allocations/page.tsx`) to surface richer trace context (request item, work order, allocation) and applied typed light-weight record shapes to make rows easier to scan and link out to related context.
- Minor stylistic cleanups across touched files to remove remaining brown/copper overlays and align to cool neutral/sky accents (including `app/parts/receive/page.tsx`, `app/parts/po/[id]/receive/page.tsx`, `app/parts/requests/[id]/page.tsx`, and `features/parts/components/ReceiveDrawer.tsx`).
- Files touched (key): `app/parts/page.tsx`, `app/parts/inventory/page.tsx`, `app/parts/receiving/page.tsx`, `app/parts/receive/page.tsx`, `app/parts/movements/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/po/[id]/receive/page.tsx`, `app/parts/requests/[id]/page.tsx`, `features/parts/lib/trust-signals.ts`, `features/parts/components/ReceiveDrawer.tsx`.

### Testing
- Ran TypeScript typecheck with `npx tsc --noEmit` and it completed successfully (no errors).
- Ran ESLint for the touched files and received only warnings (no errors) which were accepted as scoped, incremental technical debt for later follow-up.
- Visual/UX validation: inspected the modified UI component markup and class names to ensure cooler glass/sky accents replaced brown/copper treatments on affected Parts surfaces.
- No DB migrations or RPC write-path changes were made, so no database testing or migrations were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4963f3588328b6e92fefbd0f4102)