### PR TITLE
Admin Phase 1: canonical admin landing, role-guarded admin pages/APIs, and Stripe hardening

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -3,14 +3,9 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
-
-// ⬇️ If you ALREADY have a helper like this somewhere else, import that instead:
-// import { createRouteHandlerClient } from "@/features/shared/lib/supabase/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs"; // <-- this is the common one
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type Body = {
   username: string;
@@ -47,51 +42,14 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Temporary password is required." }, { status: 400 });
     }
 
-    // 1) get the caller (the shop admin creating the user)
-    const cookieStore = cookies();
-    const userScopedSupabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageUsers",
+      allowRoles: ["owner", "admin"],
+    });
+    if (!access.ok) return access.response;
 
-    const {
-      data: { user: caller },
-    } = await userScopedSupabase.auth.getUser();
-
-    if (!caller) {
-      return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
-    }
-
-    // 2) get caller's profile to know their shop + role
-    const { data: callerProfile, error: callerProfileErr } = await userScopedSupabase
-      .from("profiles")
-      .select("shop_id, role")
-      .eq("id", caller.id)
-      .maybeSingle();
-
-    if (callerProfileErr) {
-      return NextResponse.json(
-        { error: `Failed to load caller profile: ${callerProfileErr.message}` },
-        { status: 500 }
-      );
-    }
-
-    if (!callerProfile?.shop_id) {
-      // tenant-safe: you can't create users if you're not in a shop
-      return NextResponse.json(
-        { error: "Your profile has no shop_id. Cannot create user for a shop." },
-        { status: 403 }
-      );
-    }
-
-    const callerShopId = callerProfile.shop_id;
-    const actor = getActorCapabilities({ role: callerProfile.role });
-    if (!actor.isKnownRole || !actor.canManageUsers) {
-      return NextResponse.json(
-        { error: "You do not have permission to create users." },
-        { status: 403 }
-      );
-    }
-
-    // 3) we now have the shop_id we MUST use
-    const effectiveShopId = callerShopId;
+    // Always force the creator's shop_id to preserve tenant boundaries.
+    const effectiveShopId = access.profile.shop_id;
 
     // 4) build service client to actually create auth user
     const url = mustEnv("NEXT_PUBLIC_SUPABASE_URL");

--- a/app/api/admin/staff-invite-candidates/route.ts
+++ b/app/api/admin/staff-invite-candidates/route.ts
@@ -1,10 +1,7 @@
 // app/api/admin/staff-invite-candidates/route.ts
 import { NextResponse } from "next/server";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const MAX_ROWS = 500;
 
@@ -17,35 +14,16 @@ const INVITE_STATUS = {
 } as const;
 
 export async function GET(req: Request) {
-  const supabaseUser = createServerSupabaseRoute();
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
+
   const { searchParams } = new URL(req.url);
   const q = searchParams.get("q")?.trim() ?? "";
 
   const status = (searchParams.get("status")?.trim() ?? INVITE_STATUS.pending).toLowerCase();
-
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabaseUser.auth.getUser();
-
-  if (userErr || !user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
-  const { data: me, error: meErr } = await supabaseUser
-    .from("profiles")
-    .select("id, role, shop_id")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (meErr || !me || !me.shop_id) {
-    return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
-  }
-
-  const actor = getActorCapabilities({ role: me.role });
-  if (!actor.canManageUsers) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
 
   const admin = createAdminSupabase();
 
@@ -54,7 +32,7 @@ export async function GET(req: Request) {
     .select(
       "id, shop_id, intake_id, full_name, email, phone, username, role, source, confidence, notes, status, created_at, updated_at, created_user_id, created_profile_id, error",
     )
-    .eq("shop_id", me.shop_id)
+     .eq("shop_id", access.profile.shop_id)
     .order("created_at", { ascending: false })
     .limit(MAX_ROWS);
 

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,64 +1,10 @@
 // app/api/admin/users/[id]/route.ts
 import { NextResponse, type NextRequest } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
-
-type CallerProfile = Pick<
-  DB["public"]["Tables"]["profiles"]["Row"],
-  "id" | "role" | "shop_id"
->;
-
-type CallerOk = { ok: true; me: CallerProfile };
-type CallerBad = { ok: false; res: NextResponse };
-type CallerResult = CallerOk | CallerBad;
-
-async function getCaller(): Promise<CallerResult> {
-  const supabase = createServerSupabaseRoute();
-
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabase.auth.getUser();
-
-  if (userErr || !user) {
-    return {
-      ok: false,
-      res: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
-    };
-  }
-
-  const { data: me, error: meErr } = await supabase
-    .from("profiles")
-    .select("id, role, shop_id")
-    .eq("id", user.id)
-    .maybeSingle<CallerProfile>();
-
-  if (meErr || !me || !me.shop_id) {
-    return {
-      ok: false,
-      res: NextResponse.json(
-        { error: "Profile not found or missing shop" },
-        { status: 403 },
-      ),
-    };
-  }
-
-  const actor = getActorCapabilities({ role: me.role });
-  if (!actor.canManageUsers) {
-    return {
-      ok: false,
-      res: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
-    };
-  }
-
-  return { ok: true, me };
-}
 
 type TargetCheckOk = { ok: true };
 type TargetCheckBad = { ok: false; message: string };
@@ -86,12 +32,12 @@ async function assertTargetInSameShop(
 
 type PutBody = {
   full_name?: string | null;
+  phone?: string | null;
   role?: DB["public"]["Enums"]["user_role_enum"] | null;
 };
 
 type RouteContext = { params: { id: string } };
 
-// ✅ PUT /api/admin/users/:id
 export async function PUT(req: NextRequest, context: unknown) {
   const { params } = context as RouteContext;
   const id = params?.id;
@@ -100,8 +46,11 @@ export async function PUT(req: NextRequest, context: unknown) {
     return NextResponse.json({ error: "Missing user id" }, { status: 400 });
   }
 
-  const caller = await getCaller();
-  if (!caller.ok) return caller.res;
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
 
   const body = (await req.json().catch(() => null)) as PutBody | null;
 
@@ -109,19 +58,20 @@ export async function PUT(req: NextRequest, context: unknown) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  if (body.full_name === undefined && body.role === undefined) {
+  if (body.full_name === undefined && body.role === undefined && body.phone === undefined) {
     return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
   }
 
   const admin = createAdminSupabase();
 
-  const check = await assertTargetInSameShop(admin, caller.me.shop_id!, id);
+  const check = await assertTargetInSameShop(admin, access.profile.shop_id!, id);
   if (!check.ok) {
     return NextResponse.json({ error: check.message }, { status: 403 });
   }
 
   const update: Partial<DB["public"]["Tables"]["profiles"]["Update"]> = {
     ...(body.full_name !== undefined ? { full_name: body.full_name } : {}),
+    ...(body.phone !== undefined ? { phone: body.phone } : {}),
     ...(body.role !== undefined ? { role: body.role } : {}),
   };
 
@@ -134,7 +84,6 @@ export async function PUT(req: NextRequest, context: unknown) {
   return NextResponse.json({ ok: true });
 }
 
-// ✅ DELETE /api/admin/users/:id
 export async function DELETE(_req: NextRequest, context: unknown) {
   const { params } = context as RouteContext;
   const id = params?.id;
@@ -143,17 +92,19 @@ export async function DELETE(_req: NextRequest, context: unknown) {
     return NextResponse.json({ error: "Missing user id" }, { status: 400 });
   }
 
-  const caller = await getCaller();
-  if (!caller.ok) return caller.res;
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
 
   const admin = createAdminSupabase();
 
-  const check = await assertTargetInSameShop(admin, caller.me.shop_id!, id);
+  const check = await assertTargetInSameShop(admin, access.profile.shop_id!, id);
   if (!check.ok) {
     return NextResponse.json({ error: check.message }, { status: 403 });
   }
 
-  // Delete profile row first
   const { error: profileErr } = await admin
     .from("profiles")
     .delete()
@@ -163,7 +114,6 @@ export async function DELETE(_req: NextRequest, context: unknown) {
     return NextResponse.json({ error: profileErr.message }, { status: 500 });
   }
 
-  // Delete auth user
   const { error: authErr } = await admin.auth.admin.deleteUser(id);
 
   if (authErr) {

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,48 +1,26 @@
 // app/api/admin/users/route.ts
 import { NextResponse } from "next/server";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const MAX_ROWS = 500;
 
 export async function GET(req: Request) {
-  const supabaseUser = createServerSupabaseRoute();
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
+
   const { searchParams } = new URL(req.url);
   const q = searchParams.get("q")?.trim() ?? "";
-
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabaseUser.auth.getUser();
-
-  if (userErr || !user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
-  const { data: me, error: meErr } = await supabaseUser
-    .from("profiles")
-    .select("id, role, shop_id")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (meErr || !me || !me.shop_id) {
-    return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
-  }
-
-  const actor = getActorCapabilities({ role: me.role });
-  if (!actor.canManageUsers) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
 
   const admin = createAdminSupabase();
 
   let query = admin
     .from("profiles")
     .select("id, full_name, email, phone, role, created_at, shop_id")
-    .eq("shop_id", me.shop_id)
+    .eq("shop_id", access.profile.shop_id)
     .order("created_at", { ascending: false })
     .limit(MAX_ROWS);
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -2,12 +2,9 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import Stripe from "stripe";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-
 import type { Database } from "@shared/types/types/supabase";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
 
@@ -22,16 +19,10 @@ type CheckoutPayload = {
   applyFoundingDiscount?: boolean;
 };
 
-type ProfileScope = Pick<
-  DB["public"]["Tables"]["profiles"]["Row"],
-  "id" | "role" | "shop_id"
->;
-
 type ShopScope = Pick<
   DB["public"]["Tables"]["shops"]["Row"],
   "id" | "email" | "shop_name" | "name" | "stripe_customer_id"
 >;
-
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -86,7 +77,7 @@ async function resolvePriceId(stripe: Stripe, input: string): Promise<string | n
 
 async function createCustomerIfMissing(
   stripe: Stripe,
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: any,
   shop: ShopScope,
 ): Promise<string> {
   const existing = (shop.stripe_customer_id ?? "").trim();
@@ -121,43 +112,21 @@ export async function POST(req: Request) {
       apiVersion: "2022-11-15",
     });
 
-    const supabase = createRouteHandlerClient<DB>({ cookies });
-
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select("id, role, shop_id")
-      .eq("id", user.id)
-      .maybeSingle<ProfileScope>();
-
-    if (profileError) {
-      return NextResponse.json({ error: profileError.message }, { status: 500 });
-    }
-
-    if (!profile?.shop_id) {
-      return NextResponse.json({ error: "No shop found for this account." }, { status: 400 });
-    }
-
-    const actor = getActorCapabilities({ role: profile.role });
-    if (!actor.isKnownRole || !actor.canManageBilling) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBilling",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+    });
+    if (!access.ok) return access.response;
 
     const body = (await req.json().catch(() => null)) as CheckoutPayload | null;
     if (!body) {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
-    const requestedShopId = String(body.shopId ?? profile.shop_id).trim();
-    if (!requestedShopId || requestedShopId !== profile.shop_id) {
+    const requestedShopId = String(body.shopId ?? access.profile.shop_id).trim();
+    if (!requestedShopId || requestedShopId !== access.profile.shop_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -174,7 +143,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { data: shop, error: shopError } = await supabase
+    const { data: shop, error: shopError } = await access.supabase
       .from("shops")
       .select("id, email, shop_name, name, stripe_customer_id")
       .eq("id", requestedShopId)
@@ -188,7 +157,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Shop not found." }, { status: 404 });
     }
 
-    const customerId = await createCustomerIfMissing(stripe, supabase, shop);
+    const customerId = await createCustomerIfMissing(stripe, access.supabase, shop);
 
     const baseUrl = getBaseUrl();
     const successUrl = `${baseUrl}${
@@ -223,7 +192,7 @@ export async function POST(req: Request) {
         ...(enableTrial ? { trial_period_days: trialDays } : {}),
         metadata: {
           shop_id: shop.id,
-          supabase_user_id: user.id,
+          supabase_user_id: access.profile.id,
           purpose: "profixiq_subscription",
           founding_discount_applied: applyFoundingDiscount ? "true" : "false",
           trial_enabled: enableTrial ? "true" : "false",
@@ -232,7 +201,7 @@ export async function POST(req: Request) {
       },
       metadata: {
         shop_id: shop.id,
-        supabase_user_id: user.id,
+        supabase_user_id: access.profile.id,
         purpose: "profixiq_subscription",
       },
       customer_update: {
@@ -241,25 +210,13 @@ export async function POST(req: Request) {
       },
     });
 
-    if (!session.url) {
-      return NextResponse.json(
-        { error: "Stripe did not return a Checkout URL" },
-        { status: 500 },
-      );
-    }
-
-    return NextResponse.json({
-      ok: true,
-      url: session.url,
-      customerId,
-      priceId,
-    });
+    return NextResponse.json({ ok: true, sessionId: session.id, url: session.url });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
+    const message =
+      error instanceof Error ? error.message : "Failed to create Stripe checkout session.";
+
     console.error("[stripe/checkout] error", error);
-    return NextResponse.json(
-      { error: "Checkout failed", details: message },
-      { status: 500 },
-    );
+
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -2,25 +2,16 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import Stripe from "stripe";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-
 import type { Database } from "@shared/types/types/supabase";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
-
-type ProfileScope = Pick<
-  DB["public"]["Tables"]["profiles"]["Row"],
-  "id" | "role" | "shop_id"
->;
 
 type ShopScope = Pick<
   DB["public"]["Tables"]["shops"]["Row"],
   "id" | "email" | "shop_name" | "name" | "stripe_customer_id"
 >;
-
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -44,7 +35,7 @@ function getShopDisplayName(shop: { shop_name?: string | null; name?: string | n
 
 async function createCustomerIfMissing(
   stripe: Stripe,
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: any,
   shop: ShopScope,
 ): Promise<string> {
   const existingCustomerId = (shop.stripe_customer_id ?? "").trim();
@@ -73,46 +64,24 @@ async function createCustomerIfMissing(
   return customer.id;
 }
 
-export async function POST() {
+export async function POST(req: Request) {
   try {
     const stripe = new Stripe(mustEnv("STRIPE_SECRET_KEY"), {
       apiVersion: "2022-11-15",
     });
 
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBilling",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+    });
+    if (!access.ok) return access.response;
 
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select("id, role, shop_id")
-      .eq("id", user.id)
-      .maybeSingle<ProfileScope>();
-
-    if (profileError) {
-      return NextResponse.json({ error: profileError.message }, { status: 500 });
-    }
-
-    if (!profile?.shop_id) {
-      return NextResponse.json({ error: "No shop found for this account." }, { status: 400 });
-    }
-
-    const actor = getActorCapabilities({ role: profile.role });
-    if (!actor.isKnownRole || !actor.canManageBilling) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const { data: shop, error: shopError } = await supabase
+    const { data: shop, error: shopError } = await access.supabase
       .from("shops")
       .select("id, email, shop_name, name, stripe_customer_id")
-      .eq("id", profile.shop_id)
+      .eq("id", access.profile.shop_id)
       .maybeSingle<ShopScope>();
 
     if (shopError) {
@@ -123,7 +92,7 @@ export async function POST() {
       return NextResponse.json({ error: "Shop not found." }, { status: 404 });
     }
 
-    const customerId = await createCustomerIfMissing(stripe, supabase, shop);
+    const customerId = await createCustomerIfMissing(stripe, access.supabase, shop);
     const returnUrl = `${getSiteUrl()}/dashboard/owner/settings#billing`;
 
     const session = await stripe.billingPortal.sessions.create({

--- a/app/api/stripe/session/route.ts
+++ b/app/api/stripe/session/route.ts
@@ -1,9 +1,8 @@
-// app/api/stripe/session/route.ts
-
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
@@ -11,19 +10,33 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
 
 export async function GET(req: Request) {
   try {
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBilling",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+    });
+    if (!access.ok) return access.response;
+
     const url = new URL(req.url);
-    const sessionId = url.searchParams.get("session_id");
+    const sessionId = (url.searchParams.get("session_id") ?? "").trim();
 
     if (!sessionId) {
       return NextResponse.json({ error: "Missing session_id" }, { status: 400 });
     }
 
+    if (!sessionId.startsWith("cs_")) {
+      return NextResponse.json({ error: "Invalid session_id" }, { status: 400 });
+    }
+
     const session = await stripe.checkout.sessions.retrieve(sessionId);
 
-    // Try customer_details first
+    if (session.metadata?.shop_id !== access.profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     let email: string | null = session.customer_details?.email ?? null;
 
-    // If session.customer is an ID, fetch customer
     if (!email && typeof session.customer === "string") {
       const customer = await stripe.customers.retrieve(session.customer);
 

--- a/app/dashboard/admin/audit/page.tsx
+++ b/app/dashboard/admin/audit/page.tsx
@@ -1,3 +1,7 @@
-
 import AuditClient from "@/features/dashboard/app/dashboard/admin/AuditClient";
-export default function Page(){ return <AuditClient/>; }
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  return <AuditClient />;
+}

--- a/app/dashboard/admin/billing/page.tsx
+++ b/app/dashboard/admin/billing/page.tsx
@@ -1,7 +1,7 @@
-// app/dashboard/admin/billing/page.tsx
+import { redirect } from "next/navigation";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-import BillingClient from "@/features/dashboard/app/dashboard/admin/BillingClient";
-
-export default function Page() {
-  return <BillingClient />;
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  redirect("/dashboard/owner/settings#billing");
 }

--- a/app/dashboard/admin/certifications/page.tsx
+++ b/app/dashboard/admin/certifications/page.tsx
@@ -1,7 +1,7 @@
-// app/dashboard/admin/certifications/page.tsx
+import { redirect } from "next/navigation";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-import CertificationsClient from "@/features/dashboard/app/dashboard/admin/CertificationsClient";
-
-export default function Page() {
-  return <CertificationsClient />;
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  redirect("/dashboard/admin");
 }

--- a/app/dashboard/admin/create-user/page.tsx
+++ b/app/dashboard/admin/create-user/page.tsx
@@ -1,3 +1,7 @@
+import { redirect } from "next/navigation";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-import CreateUserClient from "@/features/dashboard/app/dashboard/admin/CreateUserClient";
-export default function Page(){ return <CreateUserClient/>; }
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  redirect("/dashboard/owner/create-user");
+}

--- a/app/dashboard/admin/employee-docs/page.tsx
+++ b/app/dashboard/admin/employee-docs/page.tsx
@@ -1,3 +1,7 @@
-
 import EmployeeDocsClient from "@/features/dashboard/app/dashboard/admin/EmployeeDocsClient";
-export default function Page(){ return <EmployeeDocsClient/>; }
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  return <EmployeeDocsClient />;
+}

--- a/app/dashboard/admin/employees/page.tsx
+++ b/app/dashboard/admin/employees/page.tsx
@@ -1,3 +1,7 @@
+import { redirect } from "next/navigation";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-import EmployeesClient from "@/features/dashboard/app/dashboard/admin/EmployeesClient";
-export default function Page(){ return <EmployeesClient/>; }
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  redirect("/dashboard/admin/users");
+}

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+const CANONICAL_ADMIN_ROUTES = [
+  { href: "/dashboard/admin/audit", label: "Audit" },
+  { href: "/dashboard/admin/users", label: "User Governance" },
+  { href: "/dashboard/admin/shops", label: "Shop Oversight" },
+] as const;
+
+export default async function AdminLandingPage() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-semibold">Admin</h1>
+      <p className="mt-2 text-sm text-neutral-300">Platform governance and oversight surfaces.</p>
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {CANONICAL_ADMIN_ROUTES.map((route) => (
+          <Link
+            key={route.href}
+            href={route.href}
+            className="rounded-lg border border-white/10 bg-black/30 p-4 hover:border-orange-400/70"
+          >
+            {route.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/admin/roles/page.tsx
+++ b/app/dashboard/admin/roles/page.tsx
@@ -1,3 +1,7 @@
-
 import RolesClient from "@/features/dashboard/app/dashboard/admin/RolesClient";
-export default function Page(){ return <RolesClient/>; }
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  return <RolesClient />;
+}

--- a/app/dashboard/admin/scheduling/page.tsx
+++ b/app/dashboard/admin/scheduling/page.tsx
@@ -1,7 +1,7 @@
-// app/dashboard/admin/scheduling/page.tsx
+import { redirect } from "next/navigation";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-import SchedulingClient from "@/features/dashboard/app/dashboard/admin/SchedulingClient";
-
-export default function Page() {
-  return <SchedulingClient />;
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
+  redirect("/dashboard/appointments");
 }

--- a/app/dashboard/admin/shops/page.tsx
+++ b/app/dashboard/admin/shops/page.tsx
@@ -1,3 +1,7 @@
-
 import ShopsClient from "@/features/dashboard/app/dashboard/admin/ShopsClient";
-export default function Page(){ return <ShopsClient/>; }
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  return <ShopsClient />;
+}

--- a/app/dashboard/admin/teams/page.tsx
+++ b/app/dashboard/admin/teams/page.tsx
@@ -1,7 +1,7 @@
-// app/dashboard/admin/teams/page.tsx
+import { redirect } from "next/navigation";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-import TeamsClient from "@/features/dashboard/app/dashboard/admin/TeamsClient";
-
-export default function Page() {
-  return <TeamsClient />;
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+  redirect("/dashboard/admin");
 }

--- a/app/dashboard/admin/users/page.tsx
+++ b/app/dashboard/admin/users/page.tsx
@@ -1,7 +1,10 @@
 import { Suspense } from "react";
 import UsersPageClient from "@/features/dashboard/app/dashboard/admin/UsersPageClient";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-export default function Page() {
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+
   return (
     <Suspense fallback={<div className="p-6 text-white">Loading users…</div>}>
       <UsersPageClient />

--- a/app/dashboard/owner/create-user/page.tsx
+++ b/app/dashboard/owner/create-user/page.tsx
@@ -1,9 +1,10 @@
-"use client";
-
 import { Suspense } from "react";
 import FeaturePage from "@/features/dashboard/app/dashboard/owner/create-user/page";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-export default function Page() {
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+
   return (
     <Suspense fallback={<div className="p-6 text-white">Loading…</div>}>
       <FeaturePage />

--- a/features/admin/components/AdminQuickPanel.tsx
+++ b/features/admin/components/AdminQuickPanel.tsx
@@ -375,7 +375,7 @@ export default function AdminQuickPanel() {
           <h3 className="text-sm font-semibold text-neutral-300">
             Certifications Expiring (30 days)
           </h3>
-          <Link href="/dashboard/admin/certifications" className="text-xs text-orange-400 underline">
+          <Link href="/dashboard/admin/employee-docs" className="text-xs text-orange-400 underline">
             Manage
           </Link>
         </div>

--- a/features/dashboard/app/dashboard/admin/AdminDashboardClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminDashboardClient.tsx
@@ -7,23 +7,11 @@ import AdminQuickPanel from "@/features/admin/components/AdminQuickPanel";
 
 export default function AdminDashboardClient() {
   const tiles = [
-    // People & HR
-    { href: "/dashboard/admin/employees",        label: "Employees" },
-    { href: "/dashboard/admin/create-user",      label: "Create User" },
-    { href: "/dashboard/admin/employee-docs",    label: "Employee Documents" },
-    { href: "/dashboard/admin/certifications",   label: "Certifications" },
-    { href: "/dashboard/admin/scheduling",       label: "Scheduling" },
-
-    // Org & Access
-    { href: "/dashboard/admin/roles",            label: "Roles" },
-    { href: "/dashboard/admin/teams",            label: "Teams" },
-
-    // Business
-    { href: "/dashboard/admin/shops",            label: "Shops" },
-    { href: "/dashboard/admin/billing",          label: "Billing" },
-
-    // System
-    { href: "/dashboard/admin/audit",            label: "Audit Logs" },
+    { href: "/dashboard/admin/audit", label: "Audit Logs" },
+    { href: "/dashboard/admin/users", label: "User Governance" },
+    { href: "/dashboard/admin/shops", label: "Shops" },
+    { href: "/dashboard/admin/roles", label: "Roles" },
+    { href: "/dashboard/admin/employee-docs", label: "Employee Documents" },
   ];
 
   return (
@@ -31,25 +19,16 @@ export default function AdminDashboardClient() {
       <header className="mb-6 flex items-end justify-between">
         <div>
           <h1 className="text-3xl font-bold text-orange-400">Admin Dashboard</h1>
-          <p className="text-sm opacity-75">HR, roles, shops & audit oversight</p>
-        </div>
-
-        <div className="mt-4">
-          <Link href="/dashboard/admin/employee-docs" className="text-sm underline">
-            Manage Employee Documents
-          </Link>
+          <p className="text-sm opacity-75">Platform governance and privileged oversight.</p>
         </div>
       </header>
 
-      {/* Quick actions */}
       <QuickActions role="admin" className="mb-6" />
 
-      {/* NEW: condensed quick panel */}
       <div className="mb-8">
         <AdminQuickPanel />
       </div>
 
-      {/* Tiles */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {tiles.map((t) => (
           <Link key={t.href} href={t.href} className="block">

--- a/features/dashboard/app/dashboard/admin/UsersPageClient.tsx
+++ b/features/dashboard/app/dashboard/admin/UsersPageClient.tsx
@@ -1,88 +1,13 @@
 // features/dashboard/app/dashboard/admin/UsersPageClient.tsx
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-type Profile = DB["public"]["Tables"]["profiles"]["Row"];
-
-type RowWithShop = {
-  id: Profile["id"];
-  full_name: Profile["full_name"];
-  role: (Profile & { role?: string | null })["role"];
-  shop_id: (Profile & { shop_id?: string | null })["shop_id"];
-  shops: { name: string | null } | null;
-};
+import UsersList from "@/features/admin/components/UsersList";
 
 export default function UsersPageClient() {
-  const supabase = createClientComponentClient<DB>();
-
-  const [rows, setRows] = useState<RowWithShop[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    (async () => {
-      setLoading(true);
-      const { data, error } = await supabase
-        .from("profiles")
-        .select(
-          `
-          id,
-          full_name,
-          role,
-          shop_id,
-          shops:shop_id ( name )
-        `,
-        )
-        .order("full_name", { ascending: true });
-
-      if (!error && data) setRows(data as unknown as RowWithShop[]);
-      setLoading(false);
-    })();
-  }, [supabase]);
-
   return (
     <div className="p-6 text-white">
-      <h1 className="mb-4 text-2xl font-semibold">Employees</h1>
-
-      {loading ? (
-        <p className="opacity-70">Loading…</p>
-      ) : rows.length === 0 ? (
-        <p className="opacity-70">No employees found.</p>
-      ) : (
-        <div className="overflow-auto rounded border border-neutral-700">
-          <table className="min-w-full text-sm">
-            <thead className="bg-neutral-900/50">
-              <tr>
-                <th className="px-3 py-2 text-left">Name</th>
-                <th className="px-3 py-2 text-left">Role</th>
-                <th className="px-3 py-2 text-left">Shop</th>
-                <th className="px-3 py-2 text-left">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r) => (
-                <tr key={r.id} className="border-t border-neutral-800">
-                  <td className="px-3 py-2">{r.full_name ?? "—"}</td>
-                  <td className="px-3 py-2">{r.role ?? "—"}</td>
-                  <td className="px-3 py-2">{r.shops?.name ?? "—"}</td>
-                  <td className="px-3 py-2">
-                    <Link
-                      href={`/dashboard/admin/employees/${r.id}`}
-                      className="text-orange-400 hover:underline"
-                    >
-                      View
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <h1 className="mb-4 text-2xl font-semibold">Users</h1>
+      <UsersList />
     </div>
   );
 }

--- a/features/shared/components/RoleHubTiles/tiles.ts
+++ b/features/shared/components/RoleHubTiles/tiles.ts
@@ -200,7 +200,7 @@ export const TILES: Tile[] = [
     scopes: ["management", "all"],
   },
   {
-    href: "/dashboard/admin/scheduling",
+    href: "/dashboard/appointments",
     title: "Scheduling",
     subtitle: "Calendar & bookings",
     roles: ["owner", "admin", "manager", "advisor"],

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -373,7 +373,7 @@ export const TILES: Tile[] = [
     section: "Admin",
   },
   {
-    href: "/dashboard/admin/scheduling",
+    href: "/dashboard/appointments",
     title: "Scheduling",
     subtitle: "Calendar & bookings",
     roles: ["owner", "admin", "manager", "advisor"],

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -289,14 +289,9 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     icon: "📈",
     roles: ["owner", "admin", "manager"],
   },
-  "/dashboard/admin/scheduling": {
-    title: () => "Scheduling",
-    icon: "📅",
-    roles: ["owner", "admin", "manager", "advisor"],
-  },
-  "/dashboard/admin/billing": {
-    title: () => "Billing",
-    icon: "💳",
+  "/dashboard/admin": {
+    title: () => "Admin",
+    icon: "🛡️",
     roles: ["owner", "admin"],
   },
   "/dashboard/owner/payments": {

--- a/features/shared/lib/server/admin-access.ts
+++ b/features/shared/lib/server/admin-access.ts
@@ -1,0 +1,100 @@
+import "server-only";
+
+import { redirect } from "next/navigation";
+import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { canonicalizeRole, getActorCapabilities, type ActorCapabilities, type CanonicalRole } from "@/features/shared/lib/rbac";
+import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { NextResponse } from "next/server";
+
+type DB = Database;
+type ProfileScope = Pick<DB["public"]["Tables"]["profiles"]["Row"], "id" | "role" | "shop_id">;
+
+type CapabilityKey = keyof ActorCapabilities;
+
+type AdminPageAccessOptions = {
+  allow: CanonicalRole[];
+  redirectTo?: string;
+};
+
+export async function requireAdminPageAccess(options: AdminPageAccessOptions): Promise<{
+  profile: ProfileScope;
+  canonicalRole: CanonicalRole;
+}> {
+  const supabase = createServerSupabaseRSC();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, role, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<ProfileScope>();
+
+  const role = canonicalizeRole(profile?.role);
+  const allowed = options.allow.includes(role);
+
+  if (!profile || !profile.shop_id || !allowed) {
+    redirect(options.redirectTo ?? "/dashboard");
+  }
+
+  return { profile, canonicalRole: role };
+}
+
+type ApiAccessOptions = {
+  requiredCapability?: CapabilityKey;
+  allowRoles?: CanonicalRole[];
+  requireOwnerPin?: boolean;
+  ownerPinRequest?: Request;
+};
+
+export async function requireShopScopedApiAccess(options: ApiAccessOptions = {}): Promise<
+  | {
+      ok: true;
+      profile: ProfileScope;
+      canonicalRole: CanonicalRole;
+      supabase: ReturnType<typeof createServerSupabaseRoute>;
+    }
+  | { ok: false; response: NextResponse }
+> {
+  const supabase = createServerSupabaseRoute();
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+
+  if (userErr || !user) {
+    return { ok: false, response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+  }
+
+  const { data: profile, error: profileErr } = await supabase
+    .from("profiles")
+    .select("id, role, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<ProfileScope>();
+
+  if (profileErr || !profile || !profile.shop_id) {
+    return { ok: false, response: NextResponse.json({ error: "Profile for current user not found" }, { status: 403 }) };
+  }
+
+  const actor = getActorCapabilities({ role: profile.role });
+  const canonicalRole = actor.canonicalRole;
+
+  if (options.allowRoles && !options.allowRoles.includes(canonicalRole)) {
+    return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+
+  if (options.requiredCapability && !actor[options.requiredCapability]) {
+    return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+
+  if (options.requireOwnerPin) {
+    if (!options.ownerPinRequest) {
+      return { ok: false, response: NextResponse.json({ error: "Owner PIN request context missing" }, { status: 500 }) };
+    }
+    const pinCheck = await requireOwnerPinVerified(options.ownerPinRequest, supabase as never, profile.shop_id);
+    if (!pinCheck.ok) return { ok: false, response: pinCheck.response };
+  }
+
+  return { ok: true, profile, canonicalRole, supabase };
+}


### PR DESCRIPTION
### Motivation

- Make admin surfaces intentional and trustable by establishing a canonical `/dashboard/admin` landing and removing/de-surfacing misleading placeholder admin entry points. 
- Enforce explicit role/capability boundaries at page and API entry points to reduce admin/owner/manager ambiguity and close high-risk policy gaps. 
- Harden billing-related Stripe endpoints (notably the `session` lookup) to avoid exposing sensitive checkout data and normalize owner-PIN semantics for sensitive operations.

### Description

- Added a shared server-side access guard (`features/shared/lib/server/admin-access.ts`) that standardizes auth → profile → shop scope → role/capability checks and optional owner PIN verification and applied it to touched admin pages and APIs. 
- Introduced a real canonical admin landing at `/dashboard/admin` and changed non-canonical or placeholder admin pages to either enforce page-entry role checks or redirect to the correct owner/admin surface (examples: `admin/create-user` → `/dashboard/owner/create-user`, `admin/billing` → `/dashboard/owner/settings#billing`, `admin/scheduling` → `/dashboard/appointments`). 
- Standardized and tightened admin user APIs to use the shared guard and preserved tenant boundaries (notably `POST /api/admin/create-user`, `GET /api/admin/users`, `PUT/DELETE /api/admin/users/:id`, and `GET /api/admin/staff-invite-candidates`). 
- Hardened Stripe endpoints by requiring shop-scoped access and optional owner-PIN where appropriate, and added session validation and shop metadata checks to `GET /api/stripe/session` while normalizing PIN checks on `/api/stripe/checkout` and `/api/stripe/portal`.

### Testing

- Ran TypeScript verification with `npx tsc --noEmit` and it completed successfully with no TS errors. 
- No additional automated tests were added; code changes focused on access guards, redirects, and API hardening (lint was not run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc529a68c083289b05d6c8389d393a)