### PR TITLE
Admin Phase 1.5: adopt canonical guard and harden billing/settings

### DIFF
--- a/app/api/admin/reset-user-password/route.ts
+++ b/app/api/admin/reset-user-password/route.ts
@@ -1,10 +1,8 @@
 // app/api/admin/reset-user-password/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 function mustEnv(name: string) {
   const v = process.env[name];
@@ -13,30 +11,11 @@ function mustEnv(name: string) {
 }
 
 export async function POST(req: Request) {
-  const authClient = createRouteHandlerClient<Database>({ cookies });
-  const {
-    data: { user: callerUser },
-    error: callerAuthError,
-  } = await authClient.auth.getUser();
-
-  if (callerAuthError || !callerUser) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: callerProfile, error: callerProfileError } = await authClient
-    .from("profiles")
-    .select("id, role, shop_id")
-    .eq("id", callerUser.id)
-    .maybeSingle();
-
-  if (callerProfileError || !callerProfile?.shop_id) {
-    return NextResponse.json({ error: "Unable to resolve caller profile" }, { status: 400 });
-  }
-
-  const actor = getActorCapabilities({ role: callerProfile.role });
-  if (!actor.isKnownRole || !actor.canManageUsers) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
 
   const { username, password } = (await req.json()) as {
     username?: string;
@@ -62,7 +41,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
-  if (profile.shop_id !== callerProfile.shop_id) {
+  if (profile.shop_id !== access.profile.shop_id) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/app/api/admin/staff-invite-candidates/[id]/create-user/route.ts
+++ b/app/api/admin/staff-invite-candidates/[id]/create-user/route.ts
@@ -3,12 +3,9 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse, type NextRequest } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { sendUserInviteEmail } from "@/features/email/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
 
@@ -40,9 +37,7 @@ function makeTempPassword(length = 12): string {
   return out;
 }
 
-export async function POST(req: NextRequest, context: unknown) {
-  void req;
-
+export async function POST(_req: NextRequest, context: unknown) {
   try {
     const { params } = context as RouteContext;
     const candidateId = params?.id;
@@ -51,41 +46,29 @@ export async function POST(req: NextRequest, context: unknown) {
       return NextResponse.json({ error: "Missing candidate id" }, { status: 400 });
     }
 
-    const supabaseUser = createServerSupabaseRoute();
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabaseUser.auth.getUser();
-
-    if (userErr || !user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    const { data: me, error: meErr } = await supabaseUser
-      .from("profiles")
-      .select("id, role, shop_id, full_name, first_name, last_name")
-      .eq("id", user.id)
-      .maybeSingle();
-
-    if (meErr || !me || !me.shop_id) {
-      return NextResponse.json(
-        { error: "Profile for current user not found" },
-        { status: 403 },
-      );
-    }
-
-    const actor = getActorCapabilities({ role: me.role });
-    if (!actor.canManageUsers) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageUsers",
+      allowRoles: ["owner", "admin"],
+    });
+    if (!access.ok) return access.response;
 
     const admin = createAdminSupabase();
+    const shopId = access.profile.shop_id;
+    if (!shopId) {
+      return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
+    }
+
+    const { data: me } = await access.supabase
+      .from("profiles")
+      .select("id, full_name, first_name, last_name")
+      .eq("id", access.profile.id)
+      .maybeSingle();
 
     const { data: candidate, error: candErr } = await admin
       .from("staff_invite_candidates")
       .select("*")
       .eq("id", candidateId)
-      .eq("shop_id", me.shop_id)
+      .eq("shop_id", shopId)
       .maybeSingle();
 
     if (candErr) {
@@ -106,7 +89,7 @@ export async function POST(req: NextRequest, context: unknown) {
           status: INVITE_STATUS.error,
           error: "Missing/invalid email. Cannot send invite.",
           updated_at: new Date().toISOString(),
-          created_by: user.id,
+          created_by: access.profile.id,
         } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
         .eq("id", candidateId);
 
@@ -123,7 +106,7 @@ export async function POST(req: NextRequest, context: unknown) {
           status: INVITE_STATUS.error,
           error: "Missing username. Cannot send invite.",
           updated_at: new Date().toISOString(),
-          created_by: user.id,
+          created_by: access.profile.id,
         } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
         .eq("id", candidateId);
 
@@ -160,7 +143,7 @@ export async function POST(req: NextRequest, context: unknown) {
           status: INVITE_STATUS.error,
           error: createUserErr?.message ?? "Failed to create auth user",
           updated_at: new Date().toISOString(),
-          created_by: user.id,
+          created_by: access.profile.id,
         } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
         .eq("id", candidateId);
 
@@ -172,7 +155,7 @@ export async function POST(req: NextRequest, context: unknown) {
 
     const profileInsert: DB["public"]["Tables"]["profiles"]["Insert"] = {
       id: createdUser.user.id,
-      shop_id: me.shop_id,
+      shop_id: shopId,
       role: candidate.role ?? "mechanic",
       email,
       username,
@@ -191,7 +174,7 @@ export async function POST(req: NextRequest, context: unknown) {
           status: INVITE_STATUS.error,
           error: profileInsertErr.message,
           updated_at: new Date().toISOString(),
-          created_by: user.id,
+          created_by: access.profile.id,
         } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
         .eq("id", candidateId);
 
@@ -206,7 +189,7 @@ export async function POST(req: NextRequest, context: unknown) {
     const { data: shop } = await admin
       .from("shops")
       .select("shop_name, name")
-      .eq("id", me.shop_id)
+      .eq("id", shopId)
       .maybeSingle<{ shop_name: string | null; name: string | null }>();
 
     const shopName =
@@ -215,8 +198,8 @@ export async function POST(req: NextRequest, context: unknown) {
       "ProFixIQ";
 
     const inviterName =
-      String(me.full_name ?? "").trim() ||
-      [String(me.first_name ?? "").trim(), String(me.last_name ?? "").trim()]
+      String(me?.full_name ?? "").trim() ||
+      [String(me?.first_name ?? "").trim(), String(me?.last_name ?? "").trim()]
         .filter(Boolean)
         .join(" ")
         .trim() ||
@@ -227,7 +210,7 @@ export async function POST(req: NextRequest, context: unknown) {
 
     try {
       await sendUserInviteEmail({
-        shopId: me.shop_id,
+        shopId,
         to: email,
         loginUrl: `${SITE_URL}/login`,
         username,
@@ -237,7 +220,7 @@ export async function POST(req: NextRequest, context: unknown) {
         inviterName,
         fullName: fullName ?? username,
         resend: false,
-        createdBy: user.id,
+        createdBy: access.profile.id,
       });
     } catch (error) {
       finalStatus = INVITE_STATUS.error;
@@ -252,7 +235,7 @@ export async function POST(req: NextRequest, context: unknown) {
         status: finalStatus,
         error: sendErrMsg,
         updated_at: new Date().toISOString(),
-        created_by: user.id,
+        created_by: access.profile.id,
         created_user_id: createdUser.user.id,
         created_profile_id: createdUser.user.id,
         email_lc: email,

--- a/app/api/admin/staff-invite-candidates/[id]/resend-invite/route.ts
+++ b/app/api/admin/staff-invite-candidates/[id]/resend-invite/route.ts
@@ -3,12 +3,9 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse, type NextRequest } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { sendUserInviteEmail } from "@/features/email/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
 
@@ -29,9 +26,7 @@ function isValidEmail(v: string): boolean {
   return !!v && v.includes("@");
 }
 
-export async function POST(req: NextRequest, context: unknown) {
-  void req;
-
+export async function POST(_req: NextRequest, context: unknown) {
   try {
     const { params } = context as RouteContext;
     const candidateId = params?.id;
@@ -40,41 +35,29 @@ export async function POST(req: NextRequest, context: unknown) {
       return NextResponse.json({ error: "Missing candidate id" }, { status: 400 });
     }
 
-    const supabaseUser = createServerSupabaseRoute();
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabaseUser.auth.getUser();
-
-    if (userErr || !user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    const { data: me, error: meErr } = await supabaseUser
-      .from("profiles")
-      .select("id, role, shop_id, full_name, first_name, last_name")
-      .eq("id", user.id)
-      .maybeSingle();
-
-    if (meErr || !me || !me.shop_id) {
-      return NextResponse.json(
-        { error: "Profile for current user not found" },
-        { status: 403 },
-      );
-    }
-
-    const actor = getActorCapabilities({ role: me.role });
-    if (!actor.canManageUsers) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageUsers",
+      allowRoles: ["owner", "admin"],
+    });
+    if (!access.ok) return access.response;
 
     const admin = createAdminSupabase();
+    const shopId = access.profile.shop_id;
+    if (!shopId) {
+      return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
+    }
+
+    const { data: me } = await access.supabase
+      .from("profiles")
+      .select("id, full_name, first_name, last_name")
+      .eq("id", access.profile.id)
+      .maybeSingle();
 
     const { data: candidate, error: candErr } = await admin
       .from("staff_invite_candidates")
       .select("*")
       .eq("id", candidateId)
-      .eq("shop_id", me.shop_id)
+      .eq("shop_id", shopId)
       .maybeSingle();
 
     if (candErr) {
@@ -102,7 +85,7 @@ export async function POST(req: NextRequest, context: unknown) {
           status: INVITE_STATUS.error,
           error: "Missing/invalid email. Cannot resend invite.",
           updated_at: new Date().toISOString(),
-          created_by: user.id,
+          created_by: access.profile.id,
         } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
         .eq("id", candidateId);
 
@@ -119,7 +102,7 @@ export async function POST(req: NextRequest, context: unknown) {
           status: INVITE_STATUS.error,
           error: "Missing username. Cannot resend invite.",
           updated_at: new Date().toISOString(),
-          created_by: user.id,
+          created_by: access.profile.id,
         } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
         .eq("id", candidateId);
 
@@ -134,7 +117,7 @@ export async function POST(req: NextRequest, context: unknown) {
     const { data: shop } = await admin
       .from("shops")
       .select("shop_name, name")
-      .eq("id", me.shop_id)
+      .eq("id", shopId)
       .maybeSingle<{ shop_name: string | null; name: string | null }>();
 
     const shopName =
@@ -143,15 +126,15 @@ export async function POST(req: NextRequest, context: unknown) {
       "ProFixIQ";
 
     const inviterName =
-      String(me.full_name ?? "").trim() ||
-      [String(me.first_name ?? "").trim(), String(me.last_name ?? "").trim()]
+      String(me?.full_name ?? "").trim() ||
+      [String(me?.first_name ?? "").trim(), String(me?.last_name ?? "").trim()]
         .filter(Boolean)
         .join(" ")
         .trim() ||
       "ProFixIQ";
 
     await sendUserInviteEmail({
-      shopId: me.shop_id,
+      shopId,
       to: email,
       loginUrl: `${SITE_URL}/login`,
       username,
@@ -161,7 +144,7 @@ export async function POST(req: NextRequest, context: unknown) {
       inviterName,
       fullName: fullName ?? username,
       resend: true,
-      createdBy: user.id,
+      createdBy: access.profile.id,
     });
 
     await admin
@@ -170,7 +153,7 @@ export async function POST(req: NextRequest, context: unknown) {
         status: INVITE_STATUS.invited,
         error: null,
         updated_at: new Date().toISOString(),
-        created_by: user.id,
+        created_by: access.profile.id,
         email_lc: email,
         username_lc: username,
       } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])

--- a/app/api/admin/user-count/route.ts
+++ b/app/api/admin/user-count/route.ts
@@ -1,44 +1,22 @@
 import { NextResponse } from "next/server";
 import {
-  createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
-
-const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager"]);
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export async function GET() {
-  const supabaseUser = createServerSupabaseRoute();
-
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabaseUser.auth.getUser();
-
-  if (userErr || !user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
-  const { data: me, error: meErr } = await supabaseUser
-    .from("profiles")
-    .select("id, role, shop_id")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (meErr || !me || !me.shop_id) {
-    return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
-  }
-
-  const role = String(me.role ?? "").toLowerCase();
-  if (!ADMIN_ROLES.has(role)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
 
   const admin = createAdminSupabase();
 
   const { count, error: cErr } = await admin
     .from("profiles")
     .select("id", { count: "exact", head: true })
-    .eq("shop_id", me.shop_id);
+    .eq("shop_id", access.profile.shop_id);
 
   if (cErr) {
     return NextResponse.json({ error: cErr.message || "Failed to count users" }, { status: 500 });

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -37,6 +37,7 @@ type PutBody = {
 };
 
 type RouteContext = { params: { id: string } };
+const ADMIN_LEVEL_ROLES = new Set<NonNullable<PutBody["role"]>>(["owner", "admin"]);
 
 export async function PUT(req: NextRequest, context: unknown) {
   const { params } = context as RouteContext;
@@ -74,6 +75,15 @@ export async function PUT(req: NextRequest, context: unknown) {
     ...(body.phone !== undefined ? { phone: body.phone } : {}),
     ...(body.role !== undefined ? { role: body.role } : {}),
   };
+
+  if (
+    body.role !== undefined &&
+    body.role !== null &&
+    ADMIN_LEVEL_ROLES.has(body.role) &&
+    access.canonicalRole !== "owner"
+  ) {
+    return NextResponse.json({ error: "Only owners can assign owner/admin roles" }, { status: 403 });
+  }
 
   const { error } = await admin.from("profiles").update(update).eq("id", id);
 

--- a/app/api/settings/hours/route.ts
+++ b/app/api/settings/hours/route.ts
@@ -1,59 +1,46 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-type DB = Database;
-
-type HoursRow = {
-  day_of_week: number;
-  open_time: string | null;
-  close_time: string | null;
-  is_closed: boolean | null;
+type HourInput = {
+  weekday?: number;
+  day_of_week?: number;
+  open_time?: string | null;
+  close_time?: string | null;
+  closed?: boolean;
+  is_closed?: boolean | null;
 };
 
 type Body = {
   shopId?: string | null;
-  hours?: HoursRow[] | null;
+  hours?: HourInput[] | null;
 };
 
 export async function GET() {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBranding",
+      allowRoles: ["owner", "admin"],
+    });
+    if (!access.ok) return access.response;
 
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { data: profile, error: profileErr } = await supabase
-      .from("profiles")
-      .select("shop_id")
-      .eq("id", user.id)
-      .single();
-
-    if (profileErr || !profile?.shop_id) {
-      return NextResponse.json({ error: "Shop not found" }, { status: 404 });
-    }
-
-    const shopId = profile.shop_id;
-
-    const { data, error } = await supabase
+    const { data, error } = await access.supabase
       .from("shop_hours")
       .select("day_of_week, open_time, close_time, is_closed")
-      .eq("shop_id", shopId)
+      .eq("shop_id", access.profile.shop_id)
       .order("day_of_week", { ascending: true });
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ hours: data ?? [] });
+    return NextResponse.json({
+      hours: (data ?? []).map((row) => ({
+        weekday: row.day_of_week,
+        open_time: row.open_time,
+        close_time: row.close_time,
+        closed: !!row.is_closed,
+      })),
+    });
   } catch (err) {
     console.error("settings/hours GET error", err);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
@@ -62,54 +49,39 @@ export async function GET() {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBranding",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+    });
+    if (!access.ok) return access.response;
 
     const body = (await req.json().catch(() => ({}))) as Body;
-    const shopId = body.shopId?.trim() ?? "";
+    const shopId = body.shopId?.trim() ?? access.profile.shop_id;
 
-    if (!shopId) {
-      return NextResponse.json({ error: "shopId required" }, { status: 400 });
-    }
-
-    const pinCheck = await requireOwnerPinVerified(req, supabase as any, shopId);
-    if (!pinCheck.ok) {
-      return pinCheck.response;
-    }
-
-    const { data: profile, error: profileErr } = await supabase
-      .from("profiles")
-      .select("shop_id, role")
-      .eq("id", user.id)
-      .single();
-
-    if (profileErr || !profile?.shop_id || profile.shop_id !== shopId) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const actor = getActorCapabilities({ role: profile.role });
-    if (!actor.isKnownRole || (actor.canonicalRole !== "owner" && actor.canonicalRole !== "admin")) {
+    if (!shopId || shopId !== access.profile.shop_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const hours = Array.isArray(body.hours) ? body.hours : [];
 
-    const normalized = hours.map((row) => ({
-      shop_id: shopId,
-      day_of_week: row.day_of_week,
-      open_time: row.is_closed ? null : row.open_time ?? null,
-      close_time: row.is_closed ? null : row.close_time ?? null,
-      is_closed: Boolean(row.is_closed),
-    }));
+    const normalized = hours.map((row) => {
+      const dayOfWeek = Number.isFinite(row.weekday)
+        ? Number(row.weekday)
+        : Number(row.day_of_week);
+      const isClosed = Boolean(row.closed ?? row.is_closed);
 
-    const { error: deleteErr } = await supabase
+      return {
+        shop_id: shopId,
+        day_of_week: dayOfWeek,
+        open_time: isClosed ? null : row.open_time ?? null,
+        close_time: isClosed ? null : row.close_time ?? null,
+        is_closed: isClosed,
+      };
+    });
+
+    const { error: deleteErr } = await access.supabase
       .from("shop_hours")
       .delete()
       .eq("shop_id", shopId);
@@ -119,7 +91,7 @@ export async function POST(req: Request) {
     }
 
     if (normalized.length > 0) {
-      const { error: insertErr } = await supabase.from("shop_hours").insert(normalized);
+      const { error: insertErr } = await access.supabase.from("shop_hours").insert(normalized);
       if (insertErr) {
         return NextResponse.json({ error: insertErr.message }, { status: 500 });
       }

--- a/app/api/settings/pricing-valid-days/route.ts
+++ b/app/api/settings/pricing-valid-days/route.ts
@@ -1,70 +1,23 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
-
-type DB = Database;
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 function clamp(v: number): number {
   if (!Number.isFinite(v)) return 30;
   return Math.max(1, Math.min(90, Math.round(v)));
 }
 
-// 🔒 Owner PIN check helper (same pattern as others)
-async function verifyOwnerPin(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
-
-  const pin = req.headers.get("x-owner-pin") || "";
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { ok: false };
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role, shop_id, owner_pin_hash")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  const actor = getActorCapabilities({ role: profile?.role });
-  if (!profile || actor.canonicalRole !== "owner") return { ok: false };
-
-  if (!profile.owner_pin_hash || pin !== profile.owner_pin_hash) {
-    return { ok: false };
-  }
-
-  return { ok: true, shopId: profile.shop_id };
-}
-
 // GET current value
-export async function GET(_req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+export async function GET() {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageBranding",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return NextResponse.json({ ok: false }, { status: 401 });
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("shop_id")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (!profile?.shop_id) {
-    return NextResponse.json({ ok: false }, { status: 400 });
-  }
-
-  const { data } = await supabase
+  const { data } = await access.supabase
     .from("shops")
     .select("menu_repair_pricing_valid_days")
-    .eq("id", profile.shop_id)
+    .eq("id", access.profile.shop_id)
     .maybeSingle();
 
   return NextResponse.json({
@@ -74,22 +27,23 @@ export async function GET(_req: NextRequest) {
 }
 
 // UPDATE value (PIN protected)
-export async function POST(req: NextRequest) {
-  const pinCheck = await verifyOwnerPin(req);
-  if (!pinCheck.ok) {
-    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 403 });
-  }
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageBranding",
+    allowRoles: ["owner", "admin"],
+    requireOwnerPin: true,
+    ownerPinRequest: req,
+  });
+  if (!access.ok) return access.response;
 
   const body = await req.json().catch(() => null);
   const raw = typeof body?.days === "number" ? body.days : 30;
   const days = clamp(raw);
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
-
-  const { error } = await supabase
+  const { error } = await access.supabase
     .from("shops")
     .update({ menu_repair_pricing_valid_days: days })
-    .eq("id", pinCheck.shopId);
+    .eq("id", access.profile.shop_id);
 
   if (error) {
     return NextResponse.json({ ok: false, error: error.message }, { status: 500 });

--- a/app/api/settings/time-off/route.ts
+++ b/app/api/settings/time-off/route.ts
@@ -1,60 +1,51 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
-
-type DB = Database;
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type TimeOffRow = {
   id?: string;
-  start_date: string;
-  end_date: string;
+  start_date?: string;
+  end_date?: string;
+  starts_at?: string;
+  ends_at?: string;
   label?: string | null;
+  reason?: string | null;
   notes?: string | null;
 };
 
 type Body = {
   shopId?: string | null;
   entry?: TimeOffRow | null;
+  range?: TimeOffRow | null;
   entries?: TimeOffRow[] | null;
   id?: string | null;
 };
 
 export async function GET() {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBranding",
+      allowRoles: ["owner", "admin"],
+    });
+    if (!access.ok) return access.response;
 
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { data: profile, error: profileErr } = await supabase
-      .from("profiles")
-      .select("shop_id")
-      .eq("id", user.id)
-      .single();
-
-    if (profileErr || !profile?.shop_id) {
-      return NextResponse.json({ error: "Shop not found" }, { status: 404 });
-    }
-
-    const { data, error } = await supabase
+    const { data, error } = await access.supabase
       .from("shop_time_off")
       .select("*")
-      .eq("shop_id", profile.shop_id)
+      .eq("shop_id", access.profile.shop_id)
       .order("start_date", { ascending: true });
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ entries: data ?? [] });
+    const entries = (data ?? []).map((row) => ({
+      ...row,
+      starts_at: row.start_date,
+      ends_at: row.end_date,
+      reason: row.label,
+    }));
+
+    return NextResponse.json({ entries, items: entries });
   } catch (err) {
     console.error("settings/time-off GET error", err);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
@@ -63,59 +54,40 @@ export async function GET() {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBranding",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+    });
+    if (!access.ok) return access.response;
 
     const body = (await req.json().catch(() => ({}))) as Body;
-    const shopId = body.shopId?.trim() ?? "";
+    const shopId = body.shopId?.trim() ?? access.profile.shop_id;
 
-    if (!shopId) {
-      return NextResponse.json({ error: "shopId required" }, { status: 400 });
-    }
-
-    const pinCheck = await requireOwnerPinVerified(req, supabase as any, shopId);
-    if (!pinCheck.ok) {
-      return pinCheck.response;
-    }
-
-    const { data: profile, error: profileErr } = await supabase
-      .from("profiles")
-      .select("shop_id, role")
-      .eq("id", user.id)
-      .single();
-
-    if (profileErr || !profile?.shop_id || profile.shop_id !== shopId) {
+    if (!shopId || shopId !== access.profile.shop_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const actor = getActorCapabilities({ role: profile.role });
-    if (!actor.isKnownRole || (actor.canonicalRole !== "owner" && actor.canonicalRole !== "admin")) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const entry = body.entry ?? body.range;
+    const startDate = entry?.start_date ?? entry?.starts_at;
+    const endDate = entry?.end_date ?? entry?.ends_at;
 
-    const entry = body.entry;
-    if (!entry?.start_date || !entry?.end_date) {
+    if (!startDate || !endDate) {
       return NextResponse.json(
         { error: "entry.start_date and entry.end_date required" },
         { status: 400 }
       );
     }
 
-    const { data, error } = await supabase
+    const { data, error } = await access.supabase
       .from("shop_time_off")
       .insert({
         shop_id: shopId,
-        start_date: entry.start_date,
-        end_date: entry.end_date,
-        label: entry.label ?? null,
-        notes: entry.notes ?? null,
+        start_date: startDate,
+        end_date: endDate,
+        label: entry?.label ?? entry?.reason ?? null,
+        notes: entry?.notes ?? null,
       })
       .select("*")
       .single();
@@ -133,45 +105,23 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBranding",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+    });
+    if (!access.ok) return access.response;
 
     const body = (await req.json().catch(() => ({}))) as Body;
-    const shopId = body.shopId?.trim() ?? "";
+    const shopId = body.shopId?.trim() ?? access.profile.shop_id;
     const id = body.id?.trim() ?? "";
 
-    if (!shopId || !id) {
+    if (!shopId || shopId !== access.profile.shop_id || !id) {
       return NextResponse.json({ error: "shopId and id required" }, { status: 400 });
     }
 
-    const pinCheck = await requireOwnerPinVerified(req, supabase as any, shopId);
-    if (!pinCheck.ok) {
-      return pinCheck.response;
-    }
-
-    const { data: profile, error: profileErr } = await supabase
-      .from("profiles")
-      .select("shop_id, role")
-      .eq("id", user.id)
-      .single();
-
-    if (profileErr || !profile?.shop_id || profile.shop_id !== shopId) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const actor = getActorCapabilities({ role: profile.role });
-    if (!actor.isKnownRole || (actor.canonicalRole !== "owner" && actor.canonicalRole !== "admin")) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const { error } = await supabase
+    const { error } = await access.supabase
       .from("shop_time_off")
       .delete()
       .eq("id", id)

--- a/app/api/settings/update/route.ts
+++ b/app/api/settings/update/route.ts
@@ -1,11 +1,7 @@
 // app/api/settings/update/route.ts
 import { NextResponse } from "next/server";
-import { cookies as nextCookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
-
-const COOKIE_NAME = "pfq_owner_pin_shop";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 // Whitelist fields that can be updated from Settings
 const ALLOWED_FIELDS = new Set([
@@ -58,21 +54,15 @@ function isNaCountry(v: unknown): v is "US" | "CA" {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<Database>({
-      cookies: nextCookies,
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBranding",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
     });
+    if (!access.ok) return access.response;
 
-    // 1) Auth required
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabase.auth.getUser();
-
-    if (userErr || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // 2) Parse body (UNCHANGED)
+    // 1) Parse body (UNCHANGED)
     const { shopId, update } = (await req.json().catch(() => ({}))) as Payload;
     if (!shopId || !update || typeof update !== "object") {
       return NextResponse.json(
@@ -81,34 +71,12 @@ export async function POST(req: Request) {
       );
     }
 
-    // 3) Role + shop scope check
-    const { data: profile, error: profErr } = await supabase
-      .from("profiles")
-      .select("role, shop_id")
-      .eq("id", user.id)
-      .maybeSingle();
-
-    if (profErr) {
-      return NextResponse.json({ error: profErr.message }, { status: 500 });
-    }
-
-    if (!profile?.shop_id || profile.shop_id !== shopId) {
+    // 2) shop scope check
+    if (access.profile.shop_id !== shopId) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const actor = getActorCapabilities({ role: profile.role });
-    if (!actor.isKnownRole || !actor.canManageBranding) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    // 4) Require valid owner-PIN cookie for this shop
-    const cookieStore = await nextCookies();
-    const pinCookie = cookieStore.get(COOKIE_NAME)?.value;
-    if (!pinCookie || pinCookie !== shopId) {
-      return NextResponse.json({ error: "Owner PIN required" }, { status: 401 });
-    }
-
-    // 5) Filter payload to allowed fields only + normalize
+    // 3) Filter payload to allowed fields only + normalize
     const safeUpdate: Record<string, unknown> = {};
 
     const numericKeys = new Set([
@@ -163,7 +131,7 @@ export async function POST(req: Request) {
       safeUpdate[k] = typeof v === "string" ? v.trim() : v;
     }
 
-    // 5b) Keep legacy columns in sync (street/address, name/shop_name)
+    // 3b) Keep legacy columns in sync (street/address, name/shop_name)
     const incoming = safeUpdate;
 
     const street = typeof incoming.street === "string" ? incoming.street : null;
@@ -190,8 +158,8 @@ export async function POST(req: Request) {
       );
     }
 
-    // 6) Update shops
-    const { error: updErr } = await supabase
+    // 4) Update shops
+    const { error: updErr } = await access.supabase
       .from("shops")
       .update(incoming)
       .eq("id", shopId);
@@ -203,7 +171,7 @@ export async function POST(req: Request) {
       );
     }
 
-    // 7) Keep shop_profiles country/province in sync (best-effort)
+    // 5) Keep shop_profiles country/province in sync (best-effort)
     type ShopProfileInsert =
       Database["public"]["Tables"]["shop_profiles"]["Insert"];
 
@@ -217,7 +185,7 @@ if (typeof incoming.province === "string") {
   profilePatch.province = incoming.province;
 }
     if (Object.keys(profilePatch).length > 1) {
-      const { error: spErr } = await supabase
+      const { error: spErr } = await access.supabase
         .from("shop_profiles")
         .upsert(profilePatch, { onConflict: "shop_id" });
 

--- a/app/api/stripe/session/route.ts
+++ b/app/api/stripe/session/route.ts
@@ -30,8 +30,28 @@ export async function GET(req: Request) {
     }
 
     const session = await stripe.checkout.sessions.retrieve(sessionId);
+    const { data: shop } = await access.supabase
+      .from("shops")
+      .select("id, stripe_customer_id")
+      .eq("id", access.profile.shop_id)
+      .maybeSingle();
 
-    if (session.metadata?.shop_id !== access.profile.shop_id) {
+    if (!shop) {
+      return NextResponse.json({ error: "Shop not found" }, { status: 404 });
+    }
+
+    const metadataShopId = String(session.metadata?.shop_id ?? "").trim();
+    const metadataPurpose = String(session.metadata?.purpose ?? "").trim();
+    const sessionCustomer = typeof session.customer === "string" ? session.customer : null;
+    const shopCustomer = String(shop.stripe_customer_id ?? "").trim() || null;
+
+    if (
+      metadataShopId !== access.profile.shop_id ||
+      metadataPurpose !== "profixiq_subscription" ||
+      !sessionCustomer ||
+      !shopCustomer ||
+      sessionCustomer !== shopCustomer
+    ) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/dashboard/owner/settings/integrations/quickbooks/page.tsx
+++ b/app/dashboard/owner/settings/integrations/quickbooks/page.tsx
@@ -1,4 +1,5 @@
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
@@ -13,6 +14,8 @@ export default async function QuickBooksSettingsPage({
 }: {
   searchParams: SearchParams;
 }) {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+
   const params = await searchParams;
   const connected = pickFirst(params.connected);
   const error = pickFirst(params.error);

--- a/app/dashboard/owner/settings/maintenance-mappings/page.tsx
+++ b/app/dashboard/owner/settings/maintenance-mappings/page.tsx
@@ -1,6 +1,9 @@
 import MaintenanceMappingsAdmin from "@/features/maintenance/components/MaintenanceMappingsAdmin";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-export default function OwnerMaintenanceMappingsPage() {
+export default async function OwnerMaintenanceMappingsPage() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+
   return (
     <div className="w-full px-4 py-6 xl:px-6">
       <MaintenanceMappingsAdmin />

--- a/app/dashboard/owner/settings/page.tsx
+++ b/app/dashboard/owner/settings/page.tsx
@@ -1,9 +1,10 @@
-"use client";
-
 import { Suspense } from "react";
 import FeaturePage from "@/features/dashboard/app/dashboard/owner/settings/page";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-export default function Page() {
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"] });
+
   return (
     <Suspense fallback={<div className="p-6 text-white">Loading…</div>}>
       <FeaturePage />


### PR DESCRIPTION
### Motivation
- Stabilize the Phase 1 admin boundary by making the shared server-side guard the canonical policy entry and removing scattered ad-hoc auth/role/shop checks.  
- Tighten ownership/redirect semantics and close Stripe/billing cross-shop exposure paths on routes touched in Phase 1.  
- Align owner user-management and settings API contracts with the UI and enforce clearer owner/privileged boundaries where appropriate.

### Description
- Replaced ad-hoc authentication/profile/role checks with the shared guard `requireShopScopedApiAccess` on sensitive APIs including `POST /api/admin/reset-user-password`, `GET /api/admin/user-count`, staff-invite create/resend, `POST /api/settings/update`, `GET/POST /api/settings/pricing-valid-days`, `GET/POST /api/settings/hours`, and `GET/POST/DELETE /api/settings/time-off` (see updated files under `app/api/...`).
- Added server-side page guard `requireAdminPageAccess` to owner settings entry pages so owner/settings surfaces are enforced on the server (`app/dashboard/owner/settings/page.tsx`, QuickBooks integration, maintenance mappings).
- Hardened Stripe session lookup (`GET /api/stripe/session`) to require matching `session.metadata.shop_id`, expected `metadata.purpose`, and that the Stripe session customer equals the shop’s stored `stripe_customer_id`, blocking lookups that lack tenant/customer alignment. (`app/api/stripe/session/route.ts`).
- Tightened user-management boundary by preventing non-owner actors from assigning `owner`/`admin` roles in `PUT /api/admin/users/[id]` (only owners may assign those admin-level roles). (`app/api/admin/users/[id]/route.ts`).
- Aligned settings API contracts to the UI: `settings/hours` now accepts/emits the UI shape (supports `weekday` + `closed`) and persists canonical table fields, and `settings/time-off` accepts both legacy and current shapes (`entry`/`range`, `start_date`/`starts_at`) and returns both `entries` and `items` for compatibility (files under `app/api/settings/*`).

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript surface area; result: success (no TypeScript errors; only an unrelated npm env warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5699b5c08328bf5c014328bccfd6)