### PR TITLE
Surface admin dashboard in main navigation and make /dashboard role-aware

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -15,6 +15,11 @@ const CANONICAL_ADMIN_ROUTES = [
     description: "Manage account identity, role posture, and privileged profile edits.",
   },
   {
+    href: "/dashboard/admin/employees",
+    label: "Employees",
+    description: "Review employee directory posture, role spread, and profile coverage.",
+  },
+  {
     href: "/dashboard/admin/shops",
     label: "Shop Oversight",
     description: "Review tenant records and operational completeness across shops.",
@@ -43,7 +48,7 @@ export default async function AdminLandingPage() {
           description="Use these destinations for controlled high-trust platform administration."
         />
 
-        <div className="grid gap-3 p-4 md:grid-cols-3">
+        <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-4">
           {CANONICAL_ADMIN_ROUTES.map((route) => (
             <Link
               key={route.href}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
 
 import {
   DASHBOARD_LAST_VIEW_KEY,
   type DashboardView,
 } from "@/features/dashboard/lib/dashboard-views";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 function isDashboardView(value: string | null): value is DashboardView {
   return value === "operations" || value === "performance";
@@ -16,10 +19,36 @@ export default function DashboardEntryPage() {
   const router = useRouter();
 
   useEffect(() => {
-    const stored = window.localStorage.getItem(DASHBOARD_LAST_VIEW_KEY);
-    const view: DashboardView = isDashboardView(stored) ? stored : "operations";
+    const supabase = createClientComponentClient<Database>();
 
-    router.replace(view === "performance" ? "/dashboard/performance" : "/dashboard/operations");
+    (async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      const uid = session?.user?.id;
+      let role = "unknown";
+
+      if (uid) {
+        const { data: profile } = await supabase
+          .from("profiles")
+          .select("role")
+          .eq("id", uid)
+          .maybeSingle();
+
+        role = canonicalizeRole(profile?.role);
+      }
+
+      if (role === "admin") {
+        router.replace("/dashboard/admin");
+        return;
+      }
+
+      const stored = window.localStorage.getItem(DASHBOARD_LAST_VIEW_KEY);
+      const view: DashboardView = isDashboardView(stored) ? stored : "operations";
+
+      router.replace(view === "performance" ? "/dashboard/performance" : "/dashboard/operations");
+    })();
   }, [router]);
 
   return null;

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -349,6 +349,46 @@ export const TILES: Tile[] = [
   /* ADMIN                                                                   */
   /* ---------------------------------------------------------------------- */
   {
+    href: "/dashboard/admin",
+    title: "Admin Dashboard",
+    subtitle: "Governance command surface",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Admin",
+  },
+  {
+    href: "/dashboard/admin/users",
+    title: "User Governance",
+    subtitle: "Users, identity posture, and role controls",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Admin",
+  },
+  {
+    href: "/dashboard/admin/employees",
+    title: "Employees",
+    subtitle: "Employee directory and role visibility",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Admin",
+  },
+  {
+    href: "/dashboard/admin/shops",
+    title: "Shop Oversight",
+    subtitle: "Tenant records and shop-level readiness",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Admin",
+  },
+  {
+    href: "/dashboard/admin/audit",
+    title: "Audit",
+    subtitle: "Administrative action trails",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Admin",
+  },
+  {
     href: "/dashboard/owner/create-user",
     title: "Create User",
     subtitle: "Add team members",


### PR DESCRIPTION
### Motivation
- Admin pages existed but were not discoverable because the `/dashboard` entry always routed to owner-oriented operations/performance views and sidebar tiles lacked canonical admin links.
- The goal is to fix exposure/navigation so admins land on and can reach canonical admin surfaces without changing RBAC or deep workflows.

### Description
- Make `/dashboard` role-aware by reading the signed-in profile role and routing canonical `admin` users to `/dashboard/admin`; other roles keep the existing last-view behavior (operations/performance). (file: `app/dashboard/page.tsx`)
- Add explicit Admin tiles so the sidebar surfaces canonical admin destinations: `/dashboard/admin`, `/dashboard/admin/users`, `/dashboard/admin/employees`, `/dashboard/admin/shops`, `/dashboard/admin/audit`. (file: `features/shared/config/tiles.ts`)
- Surface the `Employees` card on the admin landing and adjust the admin landing grid to ensure canonical admin surfaces are visible at-a-glance. (file: `app/dashboard/admin/page.tsx`)
- No RBAC, schema, or workflow logic was changed; this is strictly navigation/composition wiring.

### Testing
- Ran TypeScript check with `npx tsc --noEmit` and it passed.
- Linted the touched files with `npx eslint app/dashboard/page.tsx app/dashboard/admin/page.tsx features/shared/config/tiles.ts` and it passed.
- Files changed: `app/dashboard/page.tsx`, `features/shared/config/tiles.ts`, `app/dashboard/admin/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5ed8dde48328b37eb168b2a000db)