### PR TITLE
Admin Phase 3: refine canonical governance workflows

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -1,77 +1,13 @@
-import Link from "next/link";
-import {
-  AdminEmptyState,
-  AdminPageHeader,
-  AdminPageShell,
-  AdminPanel,
-  AdminPanelTitle,
-} from "@/features/dashboard/app/dashboard/admin/AdminSurface";
+import AdminLandingClient from "@/features/dashboard/app/dashboard/admin/AdminLandingClient";
+import { AdminPageShell } from "@/features/dashboard/app/dashboard/admin/AdminSurface";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
-
-const CANONICAL_ADMIN_ROUTES = [
-  {
-    href: "/dashboard/admin/users",
-    label: "User Governance",
-    description: "Manage account identity, role posture, and privileged profile edits.",
-  },
-  {
-    href: "/dashboard/admin/employees",
-    label: "Employees",
-    description: "Review employee directory posture, role spread, and profile coverage.",
-  },
-  {
-    href: "/dashboard/admin/shops",
-    label: "Shop Oversight",
-    description: "Review tenant records and operational completeness across shops.",
-  },
-  {
-    href: "/dashboard/admin/audit",
-    label: "Audit",
-    description: "Inspect sensitive administrative actions and timeline evidence.",
-  },
-] as const;
 
 export default async function AdminLandingPage() {
   await requireAdminPageAccess({ allow: ["owner", "admin"] });
 
   return (
     <AdminPageShell>
-      <AdminPageHeader
-        eyebrow="Admin Control Surface"
-        title="Administration"
-        subtitle="Canonical governance tools for identity, audit review, and multi-shop oversight."
-      />
-
-      <AdminPanel>
-        <AdminPanelTitle
-          title="Primary Surfaces"
-          description="Use these destinations for controlled high-trust platform administration."
-        />
-
-        <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-4">
-          {CANONICAL_ADMIN_ROUTES.map((route) => (
-            <Link
-              key={route.href}
-              href={route.href}
-              className="rounded-xl border border-white/10 bg-black/25 p-4 transition hover:border-orange-400/70 hover:bg-black/40"
-            >
-              <p className="text-sm font-semibold text-white">{route.label}</p>
-              <p className="mt-2 text-xs text-neutral-400">{route.description}</p>
-            </Link>
-          ))}
-        </div>
-      </AdminPanel>
-
-      <AdminPanel>
-        <AdminPanelTitle
-          title="Operational Expectation"
-          description="Admin surfaces should be used for policy-safe governance work and oversight only."
-        />
-        <AdminEmptyState
-          title="Phase 2 shell normalization is active"
-          body="Remaining legacy routes are intentionally redirected or de-surfaced to protect canonical ownership boundaries."
-        />
-      </AdminPanel>
+      <AdminLandingClient />
     </AdminPageShell>
   );
 }

--- a/features/admin/components/UsersList.tsx
+++ b/features/admin/components/UsersList.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 import {
+  AdminBadge,
   AdminEmptyState,
+  AdminField,
   AdminPanel,
   AdminPanelTitle,
+  AdminStatCard,
+  AdminStatGrid,
+  AdminToolbar,
 } from "@/features/dashboard/app/dashboard/admin/AdminSurface";
 
 type DB = Database;
@@ -22,12 +28,21 @@ type UserRow = {
   shop_id: string | null;
 };
 
+const ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = [
+  { value: "owner", label: "Owner" },
+  { value: "admin", label: "Admin" },
+  { value: "manager", label: "Manager" },
+  { value: "advisor", label: "Advisor" },
+  { value: "mechanic", label: "Mechanic" },
+];
+
 function safeMsg(e: unknown, fallback: string): string {
   return e instanceof Error ? e.message : fallback;
 }
 
 export default function UsersList(): JSX.Element {
   const [search, setSearch] = useState<string>("");
+  const [roleFilter, setRoleFilter] = useState<UserRole | "all">("all");
   const [rows, setRows] = useState<UserRow[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -60,6 +75,21 @@ export default function UsersList(): JSX.Element {
     void load();
   }, [load]);
 
+  const filteredRows = useMemo(
+    () => rows.filter((row) => (roleFilter === "all" ? true : row.role === roleFilter)),
+    [roleFilter, rows],
+  );
+
+  const summary = useMemo(() => {
+    const privileged = rows.filter((row) => row.role === "owner" || row.role === "admin").length;
+    const missingPhone = rows.filter((row) => !row.phone).length;
+    return {
+      total: rows.length,
+      privileged,
+      missingPhone,
+    };
+  }, [rows]);
+
   async function saveEdit(): Promise<void> {
     if (!editId) return;
 
@@ -76,7 +106,8 @@ export default function UsersList(): JSX.Element {
     });
 
     if (!res.ok) {
-      setError(`Failed to save (${res.status})`);
+      const payload = (await res.json().catch(() => null)) as { error?: string } | null;
+      setError(payload?.error ?? `Failed to save (${res.status})`);
       return;
     }
 
@@ -105,28 +136,62 @@ export default function UsersList(): JSX.Element {
     <div className="space-y-4">
       <AdminPanel>
         <AdminPanelTitle
-          title="Filter"
-          description="Query by name, email, or phone to quickly locate managed users."
+          title="Workflow Purpose"
+          description="Users covers account governance. Use Employees for workforce posture and activity review."
+          action={
+            <Link href="/dashboard/admin/employees" className="text-xs font-medium text-orange-300 hover:text-orange-200">
+              Open Employees →
+            </Link>
+          }
+        />
+        <AdminStatGrid>
+          <AdminStatCard label="Users in scope" value={summary.total} />
+          <AdminStatCard label="Privileged users" value={summary.privileged} hint="Owner/Admin roles" />
+          <AdminStatCard label="Missing phone" value={summary.missingPhone} hint="Potential contact gaps" />
+          <AdminStatCard label="Visible rows" value={filteredRows.length} hint="After role filters" />
+        </AdminStatGrid>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Filter & Locate"
+          description="Search by name, email, or phone, then narrow by role for targeted governance actions."
           action={
             <Button type="button" variant="default" className="font-semibold" onClick={() => void load()} disabled={loading}>
-              {loading ? "Loading…" : "Search"}
+              {loading ? "Loading…" : "Refresh"}
             </Button>
           }
         />
 
-        <div className="p-4">
-          <input
-            className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
-            placeholder="Search name, email, or phone…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-          {error ? <p className="mt-2 text-xs text-red-300">{error}</p> : null}
-        </div>
+        <AdminToolbar>
+          <AdminField label="Search" className="flex-1">
+            <input
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
+              placeholder="Search name, email, or phone…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </AdminField>
+          <AdminField label="Role" className="w-full md:w-52">
+            <select
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-orange-400/70"
+              value={roleFilter}
+              onChange={(e) => setRoleFilter(e.target.value as UserRole | "all")}
+            >
+              <option value="all">All roles</option>
+              {ROLE_OPTIONS.map((role) => (
+                <option key={role.value} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </select>
+          </AdminField>
+        </AdminToolbar>
+        {error ? <p className="px-4 pb-3 text-xs text-red-300">{error}</p> : null}
       </AdminPanel>
 
       <AdminPanel>
-        <AdminPanelTitle title="Directory" description="Administrative user list with role and contact context." />
+        <AdminPanelTitle title="User Directory" description="Edit or remove account records. Review role and identity context before changes." />
 
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
@@ -136,11 +201,12 @@ export default function UsersList(): JSX.Element {
                 <th className="px-4 py-2.5 text-left">Email</th>
                 <th className="px-4 py-2.5 text-left">Phone</th>
                 <th className="px-4 py-2.5 text-left">Role</th>
+                <th className="px-4 py-2.5 text-left">Created</th>
                 <th className="px-4 py-2.5 text-right">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-white/10">
-              {rows.map((u) => (
+              {filteredRows.map((u) => (
                 <tr key={u.id} className="text-neutral-200">
                   <td className="px-4 py-2.5">
                     <div className="font-medium text-neutral-100">{u.full_name ?? "—"}</div>
@@ -149,7 +215,10 @@ export default function UsersList(): JSX.Element {
                   <td className="px-4 py-2.5">{u.email ?? "—"}</td>
                   <td className="px-4 py-2.5">{u.phone ?? "—"}</td>
                   <td className="px-4 py-2.5">
-                    <span className="rounded-full border border-white/15 bg-black/30 px-2 py-0.5 text-xs">{u.role ?? "—"}</span>
+                    <AdminBadge>{u.role ?? "—"}</AdminBadge>
+                  </td>
+                  <td className="px-4 py-2.5 text-neutral-300">
+                    {u.created_at ? new Date(u.created_at).toLocaleDateString() : "—"}
                   </td>
                   <td className="px-4 py-2.5 text-right">
                     <div className="inline-flex gap-2">
@@ -167,7 +236,13 @@ export default function UsersList(): JSX.Element {
                       >
                         Edit
                       </Button>
-                      <Button type="button" size="xs" variant="ghost" className="text-red-300" onClick={() => void deleteUser(u.id)}>
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="ghost"
+                        className="text-red-300"
+                        onClick={() => void deleteUser(u.id)}
+                      >
                         Delete
                       </Button>
                     </div>
@@ -177,8 +252,11 @@ export default function UsersList(): JSX.Element {
             </tbody>
           </table>
 
-          {!loading && rows.length === 0 ? (
-            <AdminEmptyState title="No users found" body="Try expanding your search terms or add users from Owner onboarding tools." />
+          {!loading && filteredRows.length === 0 ? (
+            <AdminEmptyState
+              title="No users found"
+              body="Try adjusting search and role filters, or confirm users exist in the current shop scope."
+            />
           ) : null}
 
           {loading ? <AdminEmptyState title="Loading users" body="Fetching the latest user directory." /> : null}
@@ -215,11 +293,11 @@ export default function UsersList(): JSX.Element {
                   onChange={(e) => setEditRole(e.target.value as UserRole | "")}
                 >
                   <option value="">—</option>
-                  <option value="owner">Owner</option>
-                  <option value="admin">Admin</option>
-                  <option value="manager">Manager</option>
-                  <option value="advisor">Advisor</option>
-                  <option value="mechanic">Mechanic</option>
+                  {ROLE_OPTIONS.map((role) => (
+                    <option key={role.value} value={role.value}>
+                      {role.label}
+                    </option>
+                  ))}
                 </select>
               </label>
 

--- a/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  AdminEmptyState,
+  AdminPageHeader,
+  AdminPanel,
+  AdminPanelTitle,
+  AdminStatCard,
+  AdminStatGrid,
+} from "@/features/dashboard/app/dashboard/admin/AdminSurface";
+
+type AdminSummary = {
+  userCount: number;
+  employeeCount: number;
+  shopCount: number;
+  audit24hCount: number;
+  incompleteShopCount: number;
+};
+
+const CANONICAL_ADMIN_ROUTES = [
+  {
+    href: "/dashboard/admin/users",
+    label: "User Governance",
+    description: "Identity records, role updates, and account-level controls.",
+    nextStep: "Review roles and profile edits",
+  },
+  {
+    href: "/dashboard/admin/employees",
+    label: "Employees",
+    description: "Workforce profile coverage and activity posture by role.",
+    nextStep: "Find missing profile and onboarding data",
+  },
+  {
+    href: "/dashboard/admin/shops",
+    label: "Shop Oversight",
+    description: "Tenant directory quality, contact posture, and plan status.",
+    nextStep: "Review shops with incomplete operations profile",
+  },
+  {
+    href: "/dashboard/admin/audit",
+    label: "Audit",
+    description: "Recent privileged actions and governance event timeline.",
+    nextStep: "Scan for high-impact actions in the latest 24 hours",
+  },
+] as const;
+
+export default function AdminLandingClient() {
+  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const [summary, setSummary] = useState<AdminSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const now = new Date();
+      const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+      const [usersCount, employeesCount, shopsCount, audit24hCount, incompleteShops] = await Promise.all([
+        supabase.from("profiles").select("id", { count: "exact", head: true }),
+        supabase.from("profiles").select("id", { count: "exact", head: true }).not("role", "is", null),
+        supabase.from("shops").select("id", { count: "exact", head: true }),
+        supabase.from("audit_logs").select("id", { count: "exact", head: true }).gte("created_at", dayAgo),
+        supabase
+          .from("shops")
+          .select("id", { count: "exact", head: true })
+          .or("email.is.null,phone_number.is.null,timezone.is.null"),
+      ]);
+
+      const failed = [usersCount, employeesCount, shopsCount, audit24hCount, incompleteShops].find((r) => r.error);
+      if (failed?.error) {
+        setError(failed.error.message);
+        setSummary(null);
+        return;
+      }
+
+      setSummary({
+        userCount: usersCount.count ?? 0,
+        employeeCount: employeesCount.count ?? 0,
+        shopCount: shopsCount.count ?? 0,
+        audit24hCount: audit24hCount.count ?? 0,
+        incompleteShopCount: incompleteShops.count ?? 0,
+      });
+    })();
+  }, [supabase]);
+
+  return (
+    <>
+      <AdminPageHeader
+        eyebrow="Admin Control Surface"
+        title="Administration"
+        subtitle="Use this page to triage governance work, then move directly into users, employees, shops, or audit actions."
+      />
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Immediate Attention"
+          description="Live snapshot from current admin datasets."
+        />
+        {error ? <p className="px-4 py-3 text-xs text-red-300">Failed to load summary: {error}</p> : null}
+        {!summary ? (
+          <AdminEmptyState title="Loading governance summary" body="Collecting counts from canonical admin surfaces." />
+        ) : (
+          <AdminStatGrid>
+            <AdminStatCard label="Users" value={summary.userCount} hint="Identity records in profiles." />
+            <AdminStatCard label="Employees" value={summary.employeeCount} hint="Profiles with assigned roles." />
+            <AdminStatCard label="Shops" value={summary.shopCount} hint="Tenant records in oversight scope." />
+            <AdminStatCard label="Audit (24h)" value={summary.audit24hCount} hint="Privileged events in last day." />
+          </AdminStatGrid>
+        )}
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Canonical Governance Workflows"
+          description="Each route represents a concrete admin task area with a clear next action."
+        />
+
+        <div className="grid gap-3 p-4 md:grid-cols-2">
+          {CANONICAL_ADMIN_ROUTES.map((route) => (
+            <Link
+              key={route.href}
+              href={route.href}
+              className="rounded-xl border border-white/10 bg-black/25 p-4 transition hover:border-orange-400/70 hover:bg-black/40"
+            >
+              <p className="text-sm font-semibold text-white">{route.label}</p>
+              <p className="mt-2 text-xs text-neutral-400">{route.description}</p>
+              <p className="mt-3 text-xs font-medium text-orange-300">Next: {route.nextStep}</p>
+            </Link>
+          ))}
+        </div>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Governance Guidance"
+          description="Use canonical pages for task completion and auditable operational decisions."
+        />
+        <div className="space-y-2 p-4 text-sm text-neutral-300">
+          <p>• Use Users for account-level edits and role governance actions.</p>
+          <p>• Use Employees for workforce profile completeness and activity posture.</p>
+          <p>• Use Shops to identify incomplete tenant records before operational impact.</p>
+          <p>• Use Audit to validate sensitive changes and investigate anomalies quickly.</p>
+          {summary ? (
+            <p className="pt-1 text-xs text-neutral-400">
+              Shops currently needing baseline profile follow-up (email/phone/timezone missing): {summary.incompleteShopCount}
+            </p>
+          ) : null}
+        </div>
+      </AdminPanel>
+    </>
+  );
+}

--- a/features/dashboard/app/dashboard/admin/AdminSurface.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminSurface.tsx
@@ -73,3 +73,50 @@ export function AdminEmptyState({ title, body }: { title: string; body: string }
     </div>
   );
 }
+
+export function AdminStatGrid({ children }: { children: ReactNode }) {
+  return <div className="grid gap-3 p-4 sm:grid-cols-2 xl:grid-cols-4">{children}</div>;
+}
+
+export function AdminStatCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+}) {
+  return (
+    <article className="rounded-xl border border-white/10 bg-black/25 p-3">
+      <p className="text-[0.68rem] uppercase tracking-[0.12em] text-neutral-400">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-white">{value}</p>
+      {hint ? <p className="mt-1 text-xs text-neutral-400">{hint}</p> : null}
+    </article>
+  );
+}
+
+export function AdminToolbar({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-3 p-4 md:flex-row md:items-end">{children}</div>;
+}
+
+export function AdminField({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <label className={`block text-xs uppercase tracking-[0.12em] text-neutral-400 ${className}`.trim()}>
+      {label}
+      <div className="mt-1">{children}</div>
+    </label>
+  );
+}
+
+export function AdminBadge({ children }: { children: ReactNode }) {
+  return <span className="rounded-full border border-white/15 bg-black/30 px-2 py-0.5 text-xs">{children}</span>;
+}

--- a/features/dashboard/app/dashboard/admin/AuditClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AuditClient.tsx
@@ -2,81 +2,191 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import type { Database, Json } from "@shared/types/types/supabase";
 import {
+  AdminBadge,
   AdminEmptyState,
+  AdminField,
   AdminPageHeader,
   AdminPageShell,
   AdminPanel,
   AdminPanelTitle,
+  AdminStatCard,
+  AdminStatGrid,
+  AdminToolbar,
 } from "@/features/dashboard/app/dashboard/admin/AdminSurface";
 
 type AuditRow = Pick<
   Database["public"]["Tables"]["audit_logs"]["Row"],
-  "id" | "created_at" | "actor_id" | "action" | "target"
+  "id" | "created_at" | "actor_id" | "action" | "target" | "metadata"
 >;
+
+function classifySeverity(action: string | null): "high" | "normal" {
+  const value = (action ?? "").toLowerCase();
+  return value.includes("delete") || value.includes("remove") || value.includes("role") ? "high" : "normal";
+}
+
+function stringifyMetadata(metadata: Json | null): string {
+  if (!metadata) return "";
+  try {
+    return JSON.stringify(metadata);
+  } catch {
+    return "";
+  }
+}
 
 export default function AdminAuditClient() {
   const supabase = useMemo(() => createClientComponentClient<Database>(), []);
 
   const [rows, setRows] = useState<AuditRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [actionFilter, setActionFilter] = useState("");
+  const [actorFilter, setActorFilter] = useState("");
+  const [severityFilter, setSeverityFilter] = useState<"all" | "high" | "normal">("all");
 
   useEffect(() => {
     (async () => {
       const { data, error } = await supabase
         .from("audit_logs")
-        .select("id, created_at, actor_id, action, target")
+        .select("id, created_at, actor_id, action, target, metadata")
         .order("created_at", { ascending: false })
-        .limit(75);
+        .limit(150);
 
       if (error) setErr(error.message);
       setRows((data as AuditRow[]) ?? []);
     })();
   }, [supabase]);
 
+  const filteredRows = useMemo(() => {
+    const actionQuery = actionFilter.trim().toLowerCase();
+    const actorQuery = actorFilter.trim().toLowerCase();
+
+    return (rows ?? []).filter((row) => {
+      const severity = classifySeverity(row.action);
+      const matchesSeverity = severityFilter === "all" ? true : severity === severityFilter;
+      const matchesAction = !actionQuery || (row.action ?? "").toLowerCase().includes(actionQuery);
+      const matchesActor = !actorQuery || (row.actor_id ?? "").toLowerCase().includes(actorQuery);
+      return Boolean(matchesSeverity && matchesAction && matchesActor);
+    });
+  }, [actionFilter, actorFilter, rows, severityFilter]);
+
+  const summary = useMemo(() => {
+    const allRows = rows ?? [];
+    const highSeverity = allRows.filter((row) => classifySeverity(row.action) === "high").length;
+    const last24h = allRows.filter((row) => {
+      const diff = Date.now() - new Date(row.created_at).getTime();
+      return diff <= 1000 * 60 * 60 * 24;
+    }).length;
+    return {
+      total: allRows.length,
+      highSeverity,
+      last24h,
+      visible: filteredRows.length,
+    };
+  }, [filteredRows.length, rows]);
+
   return (
     <AdminPageShell>
       <AdminPageHeader
         eyebrow="Governance Trail"
         title="Audit"
-        subtitle="Review recent privileged actions and impacted targets in a single timeline surface."
+        subtitle="Audit supports daily review of sensitive actions, with enough context to triage and follow up quickly."
       />
+
+      <AdminPanel>
+        <AdminPanelTitle title="Audit Review Summary" description="Use these counts to prioritize what needs review first." />
+        <AdminStatGrid>
+          <AdminStatCard label="Recent events" value={summary.total} hint="Current timeline window" />
+          <AdminStatCard label="High-severity" value={summary.highSeverity} hint="Delete/remove/role actions" />
+          <AdminStatCard label="Last 24 hours" value={summary.last24h} />
+          <AdminStatCard label="Visible rows" value={summary.visible} />
+        </AdminStatGrid>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Filter Timeline"
+          description="Narrow by action, actor, and severity to investigate events with less noise."
+        />
+        <AdminToolbar>
+          <AdminField label="Action contains" className="flex-1">
+            <input
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
+              placeholder="e.g. user.update, shop.delete"
+              value={actionFilter}
+              onChange={(event) => setActionFilter(event.target.value)}
+            />
+          </AdminField>
+          <AdminField label="Actor ID contains" className="flex-1">
+            <input
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
+              placeholder="Filter by actor id"
+              value={actorFilter}
+              onChange={(event) => setActorFilter(event.target.value)}
+            />
+          </AdminField>
+          <AdminField label="Severity" className="w-full md:w-44">
+            <select
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-orange-400/70"
+              value={severityFilter}
+              onChange={(event) => setSeverityFilter(event.target.value as "all" | "high" | "normal")}
+            >
+              <option value="all">All</option>
+              <option value="high">High</option>
+              <option value="normal">Normal</option>
+            </select>
+          </AdminField>
+        </AdminToolbar>
+
+        {err ? <p className="px-4 pb-3 text-xs text-red-300">Audit query failed: {err}</p> : null}
+      </AdminPanel>
 
       <AdminPanel>
         <AdminPanelTitle
           title="Recent Audit Events"
-          description="Most recent entries first. Use this surface for governance validation and incident review."
+          description="Review time, actor, and target together so follow-up actions are immediately clear."
         />
-
-        {err ? <p className="px-4 py-3 text-xs text-red-300">Audit query failed: {err}</p> : null}
 
         {!rows ? (
           <AdminEmptyState title="Loading audit entries" body="Gathering latest governance events." />
-        ) : rows.length === 0 ? (
-          <AdminEmptyState title="No audit entries" body="No audit records were returned for this environment." />
+        ) : filteredRows.length === 0 ? (
+          <AdminEmptyState title="No audit entries" body="No entries match current filters." />
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
               <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400">
                 <tr>
                   <th className="px-4 py-2.5 text-left">Time</th>
-                  <th className="px-4 py-2.5 text-left">Actor</th>
                   <th className="px-4 py-2.5 text-left">Action</th>
+                  <th className="px-4 py-2.5 text-left">Actor</th>
                   <th className="px-4 py-2.5 text-left">Target</th>
+                  <th className="px-4 py-2.5 text-left">Context</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10">
-                {rows.map((r) => (
-                  <tr key={r.id} className="text-neutral-200">
-                    <td className="whitespace-nowrap px-4 py-2.5 text-neutral-300">
-                      {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
-                    </td>
-                    <td className="px-4 py-2.5">{r.actor_id ?? "—"}</td>
-                    <td className="px-4 py-2.5 font-medium text-neutral-100">{r.action ?? "—"}</td>
-                    <td className="px-4 py-2.5">{r.target ?? "—"}</td>
-                  </tr>
-                ))}
+                {filteredRows.map((r) => {
+                  const severity = classifySeverity(r.action);
+                  const metadataPreview = stringifyMetadata(r.metadata);
+
+                  return (
+                    <tr key={r.id} className="text-neutral-200">
+                      <td className="whitespace-nowrap px-4 py-2.5 text-neutral-300">
+                        {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
+                      </td>
+                      <td className="px-4 py-2.5 font-medium text-neutral-100">
+                        <div className="flex items-center gap-2">
+                          <span>{r.action ?? "—"}</span>
+                          <AdminBadge>{severity}</AdminBadge>
+                        </div>
+                      </td>
+                      <td className="px-4 py-2.5">{r.actor_id ?? "—"}</td>
+                      <td className="px-4 py-2.5">{r.target ?? "—"}</td>
+                      <td className="max-w-sm px-4 py-2.5 text-xs text-neutral-400">
+                        {metadataPreview ? metadataPreview.slice(0, 140) : "No metadata"}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/features/dashboard/app/dashboard/admin/EmployeesClient.tsx
+++ b/features/dashboard/app/dashboard/admin/EmployeesClient.tsx
@@ -4,26 +4,37 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import {
+  AdminBadge,
   AdminEmptyState,
+  AdminField,
   AdminPageHeader,
   AdminPageShell,
   AdminPanel,
   AdminPanelTitle,
+  AdminStatCard,
+  AdminStatGrid,
+  AdminToolbar,
 } from "@/features/dashboard/app/dashboard/admin/AdminSurface";
 
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
-type EmpRow = Pick<Profile, "id" | "full_name" | "email" | "role">;
+type EmpRow = Pick<
+  Profile,
+  "id" | "full_name" | "email" | "phone" | "role" | "completed_onboarding" | "last_active_at" | "shop_id"
+>;
 
 export default function AdminEmployeesClient() {
   const supabase = useMemo(() => createClientComponentClient<Database>(), []);
   const [rows, setRows] = useState<EmpRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<string>("all");
 
   useEffect(() => {
     (async () => {
       const { data, error } = await supabase
         .from("profiles")
-        .select("id, full_name, email, role")
+        .select("id, full_name, email, phone, role, completed_onboarding, last_active_at, shop_id")
+        .not("role", "is", null)
         .order("full_name", { ascending: true })
         .returns<EmpRow[]>();
 
@@ -32,39 +43,136 @@ export default function AdminEmployeesClient() {
     })();
   }, [supabase]);
 
+  const roleOptions = useMemo(() => {
+    const set = new Set((rows ?? []).map((row) => row.role).filter(Boolean) as string[]);
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [rows]);
+
+  const filteredRows = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (rows ?? []).filter((row) => {
+      const matchesRole = roleFilter === "all" ? true : row.role === roleFilter;
+      const matchesSearch =
+        !query ||
+        row.full_name?.toLowerCase().includes(query) ||
+        row.email?.toLowerCase().includes(query) ||
+        row.phone?.toLowerCase().includes(query);
+      return Boolean(matchesRole && matchesSearch);
+    });
+  }, [roleFilter, rows, search]);
+
+  const summary = useMemo(() => {
+    const allRows = rows ?? [];
+    const onboardingMissing = allRows.filter((row) => !row.completed_onboarding).length;
+    const contactGaps = allRows.filter((row) => !row.email || !row.phone).length;
+    const recentlyActive = allRows.filter((row) => {
+      if (!row.last_active_at) return false;
+      const diff = Date.now() - new Date(row.last_active_at).getTime();
+      return diff <= 1000 * 60 * 60 * 24 * 30;
+    }).length;
+
+    return {
+      total: allRows.length,
+      onboardingMissing,
+      contactGaps,
+      recentlyActive,
+    };
+  }, [rows]);
+
   return (
     <AdminPageShell>
       <AdminPageHeader
         eyebrow="Workforce Directory"
         title="Employees"
-        subtitle="View employee profile coverage and role distribution for administrative oversight."
+        subtitle="Employees focuses on workforce completeness and activity posture, distinct from account-level governance actions in Users."
       />
 
       <AdminPanel>
-        <AdminPanelTitle title="Employee Records" description="Core identity and role data sourced from profile records." />
+        <AdminPanelTitle
+          title="Workforce Oversight Summary"
+          description="Use these signals to find profile quality gaps before they impact operations."
+        />
+        <AdminStatGrid>
+          <AdminStatCard label="Employees" value={summary.total} />
+          <AdminStatCard label="Onboarding incomplete" value={summary.onboardingMissing} />
+          <AdminStatCard label="Contact gaps" value={summary.contactGaps} hint="Missing email or phone" />
+          <AdminStatCard label="Active in 30d" value={summary.recentlyActive} />
+        </AdminStatGrid>
+      </AdminPanel>
 
-        {err ? <p className="px-4 py-3 text-xs text-red-300">Profile query failed: {err}</p> : null}
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Filter Workforce"
+          description="Search by name/contact and filter by role to target specific follow-up."
+        />
+
+        <AdminToolbar>
+          <AdminField label="Search" className="flex-1">
+            <input
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
+              placeholder="Search name, email, or phone"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </AdminField>
+          <AdminField label="Role" className="w-full md:w-52">
+            <select
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-orange-400/70"
+              value={roleFilter}
+              onChange={(event) => setRoleFilter(event.target.value)}
+            >
+              <option value="all">All roles</option>
+              {roleOptions.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </select>
+          </AdminField>
+        </AdminToolbar>
+
+        {err ? <p className="px-4 pb-3 text-xs text-red-300">Profile query failed: {err}</p> : null}
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Employee Records"
+          description="Directory posture across role, onboarding, contact completeness, and activity recency."
+        />
 
         {!rows ? (
           <AdminEmptyState title="Loading employees" body="Pulling profile records." />
-        ) : rows.length === 0 ? (
-          <AdminEmptyState title="No employees found" body="No profile rows are currently available." />
+        ) : filteredRows.length === 0 ? (
+          <AdminEmptyState title="No employees found" body="Adjust filters or confirm workforce profiles exist." />
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
               <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400">
                 <tr>
-                  <th className="px-4 py-2.5 text-left">Name</th>
-                  <th className="px-4 py-2.5 text-left">Email</th>
+                  <th className="px-4 py-2.5 text-left">Employee</th>
                   <th className="px-4 py-2.5 text-left">Role</th>
+                  <th className="px-4 py-2.5 text-left">Onboarding</th>
+                  <th className="px-4 py-2.5 text-left">Contact</th>
+                  <th className="px-4 py-2.5 text-left">Last active</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10">
-                {rows.map((r) => (
+                {filteredRows.map((r) => (
                   <tr key={r.id} className="text-neutral-200">
-                    <td className="px-4 py-2.5 font-medium text-neutral-100">{r.full_name ?? "—"}</td>
-                    <td className="px-4 py-2.5">{r.email ?? "—"}</td>
-                    <td className="px-4 py-2.5">{r.role ?? "—"}</td>
+                    <td className="px-4 py-2.5">
+                      <p className="font-medium text-neutral-100">{r.full_name ?? "—"}</p>
+                      <p className="text-xs text-neutral-500">{r.email ?? "No email"}</p>
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <AdminBadge>{r.role ?? "—"}</AdminBadge>
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <AdminBadge>{r.completed_onboarding ? "Complete" : "Needs follow-up"}</AdminBadge>
+                    </td>
+                    <td className="px-4 py-2.5 text-neutral-300">{r.phone ?? "Missing phone"}</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-neutral-300">
+                      {r.last_active_at ? new Date(r.last_active_at).toLocaleDateString() : "Never recorded"}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/features/dashboard/app/dashboard/admin/ShopsClient.tsx
+++ b/features/dashboard/app/dashboard/admin/ShopsClient.tsx
@@ -4,54 +4,138 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import {
+  AdminBadge,
   AdminEmptyState,
+  AdminField,
   AdminPageHeader,
   AdminPageShell,
   AdminPanel,
   AdminPanelTitle,
+  AdminStatCard,
+  AdminStatGrid,
+  AdminToolbar,
 } from "@/features/dashboard/app/dashboard/admin/AdminSurface";
 
 type ShopRow = Pick<
   Database["public"]["Tables"]["shops"]["Row"],
-  "id" | "name" | "city" | "province" | "email" | "phone_number" | "timezone"
+  | "id"
+  | "name"
+  | "city"
+  | "province"
+  | "email"
+  | "phone_number"
+  | "timezone"
+  | "plan"
+  | "owner_id"
+  | "created_at"
 >;
+
+function healthLabel(shop: ShopRow): "Complete" | "Needs profile" {
+  return shop.email && shop.phone_number && shop.timezone ? "Complete" : "Needs profile";
+}
 
 export default function AdminShopsClient() {
   const supabase = useMemo(() => createClientComponentClient<Database>(), []);
 
   const [rows, setRows] = useState<ShopRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [healthFilter, setHealthFilter] = useState<"all" | "Complete" | "Needs profile">("all");
 
   useEffect(() => {
     (async () => {
       const { data, error } = await supabase
         .from("shops")
-        .select("id, name, city, province, email, phone_number, timezone")
+        .select("id, name, city, province, email, phone_number, timezone, plan, owner_id, created_at")
         .order("name", { ascending: true })
-        .limit(100);
+        .limit(200);
 
       if (error) setErr(error.message);
       setRows((data as ShopRow[]) ?? []);
     })();
   }, [supabase]);
 
+  const filteredRows = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (rows ?? []).filter((row) => {
+      const matchesHealth = healthFilter === "all" ? true : healthLabel(row) === healthFilter;
+      const matchesSearch =
+        !query ||
+        row.name?.toLowerCase().includes(query) ||
+        row.city?.toLowerCase().includes(query) ||
+        row.email?.toLowerCase().includes(query);
+      return Boolean(matchesHealth && matchesSearch);
+    });
+  }, [healthFilter, rows, search]);
+
+  const summary = useMemo(() => {
+    const allRows = rows ?? [];
+    const needsProfile = allRows.filter((row) => healthLabel(row) === "Needs profile").length;
+    const withOwner = allRows.filter((row) => !!row.owner_id).length;
+
+    return {
+      total: allRows.length,
+      needsProfile,
+      withOwner,
+      visible: filteredRows.length,
+    };
+  }, [filteredRows.length, rows]);
+
   return (
     <AdminPageShell>
       <AdminPageHeader
         eyebrow="Tenant Oversight"
         title="Shops"
-        subtitle="Monitor shop identity and baseline operating profile completeness."
+        subtitle="Shops is the governance view for tenant identity completeness, ownership posture, and baseline operating metadata."
       />
 
       <AdminPanel>
-        <AdminPanelTitle title="Shop Directory" description="Active shop records across tenant scope." />
+        <AdminPanelTitle title="Shop Governance Summary" description="Highlights for fast oversight triage." />
+        <AdminStatGrid>
+          <AdminStatCard label="Shops" value={summary.total} />
+          <AdminStatCard label="Needs profile follow-up" value={summary.needsProfile} hint="Missing email, phone, or timezone" />
+          <AdminStatCard label="Has owner assigned" value={summary.withOwner} />
+          <AdminStatCard label="Visible rows" value={summary.visible} />
+        </AdminStatGrid>
+      </AdminPanel>
 
-        {err ? <p className="px-4 py-3 text-xs text-red-300">Shop query failed: {err}</p> : null}
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Filter Shop Directory"
+          description="Search key identity fields and narrow by profile health for practical follow-up."
+        />
+        <AdminToolbar>
+          <AdminField label="Search" className="flex-1">
+            <input
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
+              placeholder="Search shop, city, or email"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </AdminField>
+          <AdminField label="Health" className="w-full md:w-56">
+            <select
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-orange-400/70"
+              value={healthFilter}
+              onChange={(event) => setHealthFilter(event.target.value as "all" | "Complete" | "Needs profile")}
+            >
+              <option value="all">All shops</option>
+              <option value="Complete">Complete profile</option>
+              <option value="Needs profile">Needs profile</option>
+            </select>
+          </AdminField>
+        </AdminToolbar>
+
+        {err ? <p className="px-4 pb-3 text-xs text-red-300">Shop query failed: {err}</p> : null}
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Shop Directory" description="Review key metadata and governance posture before taking follow-up action." />
 
         {!rows ? (
           <AdminEmptyState title="Loading shops" body="Reading tenant shop records." />
-        ) : rows.length === 0 ? (
-          <AdminEmptyState title="No shops found" body="No shop records are available in the current environment." />
+        ) : filteredRows.length === 0 ? (
+          <AdminEmptyState title="No shops found" body="Adjust filters or confirm shop records are available." />
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
@@ -59,19 +143,28 @@ export default function AdminShopsClient() {
                 <tr>
                   <th className="px-4 py-2.5 text-left">Shop</th>
                   <th className="px-4 py-2.5 text-left">Location</th>
-                  <th className="px-4 py-2.5 text-left">Email</th>
-                  <th className="px-4 py-2.5 text-left">Phone</th>
-                  <th className="px-4 py-2.5 text-left">Timezone</th>
+                  <th className="px-4 py-2.5 text-left">Contact</th>
+                  <th className="px-4 py-2.5 text-left">Plan</th>
+                  <th className="px-4 py-2.5 text-left">Health</th>
+                  <th className="px-4 py-2.5 text-left">Created</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10">
-                {rows.map((s) => (
+                {filteredRows.map((s) => (
                   <tr key={s.id} className="text-neutral-200">
                     <td className="px-4 py-2.5 font-medium text-neutral-100">{s.name ?? s.id}</td>
                     <td className="px-4 py-2.5">{[s.city, s.province].filter(Boolean).join(", ") || "—"}</td>
-                    <td className="px-4 py-2.5">{s.email ?? "—"}</td>
-                    <td className="px-4 py-2.5">{s.phone_number ?? "—"}</td>
-                    <td className="px-4 py-2.5">{s.timezone ?? "—"}</td>
+                    <td className="px-4 py-2.5 text-xs text-neutral-300">
+                      <p>{s.email ?? "No email"}</p>
+                      <p>{s.phone_number ?? "No phone"}</p>
+                    </td>
+                    <td className="px-4 py-2.5">{s.plan ?? "—"}</td>
+                    <td className="px-4 py-2.5">
+                      <AdminBadge>{healthLabel(s)}</AdminBadge>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-neutral-300">
+                      {s.created_at ? new Date(s.created_at).toLocaleDateString() : "—"}
+                    </td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
### Motivation
- Make the surfaced canonical admin pages operationally coherent so admins can triage and act, not just click links.
- Clarify the distinct purposes and workflows for Users (account governance) vs Employees (workforce posture) and provide actionable signals for Shops and Audit. 
- Improve cross-page consistency (filters, summary cards, toolbars) while staying strictly within the Phase 3 scope and avoiding RBAC/schema changes.

### Description
- Convert the admin landing into a data-backed control surface by adding `AdminLandingClient` with live summary cards, next-step guidance, and governance guidance; this replaces the previous static landing content. 
- Improve Users workflow by refactoring `UsersList` to add role filtering, summary metrics (privileged users, missing contact), consistent toolbar/field primitives, and improved API error handling for edits. 
- Improve Employees, Shops, and Audit pages by adding workforce and shop-health summaries, consistent search/role/health filters, summary stat grids, and an audit triage surface with severity classification and metadata previews. 
- Add shared admin UI primitives (`AdminStatGrid`, `AdminStatCard`, `AdminToolbar`, `AdminField`, `AdminBadge`) in the Admin surface to align layout and interaction patterns across canonical pages.
- Files changed: `app/dashboard/admin/page.tsx`, `features/dashboard/app/dashboard/admin/AdminLandingClient.tsx` (new), `features/admin/components/UsersList.tsx`, `features/dashboard/app/dashboard/admin/AdminSurface.tsx`, `features/dashboard/app/dashboard/admin/EmployeesClient.tsx`, `features/dashboard/app/dashboard/admin/ShopsClient.tsx`, `features/dashboard/app/dashboard/admin/AuditClient.tsx`.

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript; result: success. 
- Ran `npx eslint` against the modified admin files (`app/dashboard/admin/page.tsx`, `features/dashboard/app/dashboard/admin/AdminSurface.tsx`, `features/dashboard/app/dashboard/admin/AdminLandingClient.tsx`, `features/dashboard/app/dashboard/admin/EmployeesClient.tsx`, `features/dashboard/app/dashboard/admin/ShopsClient.tsx`, `features/dashboard/app/dashboard/admin/AuditClient.tsx`, `features/admin/components/UsersList.tsx`); result: success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6321095c832889fec1338c788909)