### PR TITLE
Payroll time tracking foundation: pay periods, derived entries, approval & export

### DIFF
--- a/app/api/payroll-time/_lib/auth.ts
+++ b/app/api/payroll-time/_lib/auth.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type Caller = {
+  id: string;
+  role: string | null;
+  shop_id: string | null;
+};
+
+export async function requirePayrollReviewer() {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+
+  if (authErr || !user) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    };
+  }
+
+  const { data: me, error: meErr } = await supabase
+    .from("profiles")
+    .select("id, role, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<Caller>();
+
+  if (meErr || !me?.shop_id) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Missing shop context" }, { status: 403 }),
+    };
+  }
+
+  const caps = getActorCapabilities({ role: me.role });
+  if (!caps.isKnownRole || !caps.canManageScheduling) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, me };
+}

--- a/app/api/payroll-time/approve/route.ts
+++ b/app/api/payroll-time/approve/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { approvePeriod } from "@/features/payroll-time/server/payrollTime";
+import { requirePayrollReviewer } from "../_lib/auth";
+
+export async function POST(req: Request) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+
+  const body = (await req.json().catch(() => null)) as { period_id?: string } | null;
+  if (!body?.period_id) return NextResponse.json({ error: "period_id is required" }, { status: 400 });
+
+  try {
+    await approvePeriod({ shopId: auth.me.shop_id!, periodId: body.period_id, actorId: auth.me.id });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Approval failed" },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/payroll-time/export/route.ts
+++ b/app/api/payroll-time/export/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { exportPeriod } from "@/features/payroll-time/server/payrollTime";
+import { requirePayrollReviewer } from "../_lib/auth";
+
+export async function POST(req: Request) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+
+  const body = (await req.json().catch(() => null)) as { period_id?: string; provider_type?: string } | null;
+  if (!body?.period_id) return NextResponse.json({ error: "period_id is required" }, { status: 400 });
+
+  try {
+    const result = await exportPeriod({
+      shopId: auth.me.shop_id!,
+      periodId: body.period_id,
+      actorId: auth.me.id,
+      providerType: body.provider_type,
+    });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Export failed" },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { getOrCreateCurrentPeriod } from "@/features/payroll-time/server/payrollTime";
+import { requirePayrollReviewer } from "../_lib/auth";
+
+export async function GET(req: NextRequest) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+
+  const admin = createAdminSupabase() as any;
+  const { me } = auth;
+  const url = new URL(req.url);
+  const periodId = url.searchParams.get("period_id");
+
+  await getOrCreateCurrentPeriod(me.shop_id!, me.id);
+
+  const { data: periods, error: periodErr } = await admin
+    .from("payroll_pay_periods")
+    .select("*")
+    .eq("shop_id", me.shop_id)
+    .order("period_start", { ascending: false })
+    .limit(12);
+
+  if (periodErr) return NextResponse.json({ error: periodErr.message }, { status: 500 });
+
+  const activePeriodId = periodId ?? periods?.[0]?.id ?? null;
+  if (!activePeriodId) return NextResponse.json({ periods: [], entries: [], exceptions: [] });
+
+  const [{ data: entries, error: entriesErr }, { data: exceptions, error: exErr }] = await Promise.all([
+    admin
+      .from("payroll_time_entries")
+      .select("*, profiles:user_id(full_name, email)")
+      .eq("shop_id", me.shop_id)
+      .eq("period_id", activePeriodId)
+      .order("work_date", { ascending: true }),
+    admin
+      .from("payroll_time_exceptions")
+      .select("*")
+      .eq("shop_id", me.shop_id)
+      .eq("period_id", activePeriodId)
+      .order("work_date", { ascending: true }),
+  ]);
+
+  if (entriesErr) return NextResponse.json({ error: entriesErr.message }, { status: 500 });
+  if (exErr) return NextResponse.json({ error: exErr.message }, { status: 500 });
+
+  return NextResponse.json({ periods: periods ?? [], activePeriodId, entries: entries ?? [], exceptions: exceptions ?? [] });
+}

--- a/app/api/payroll-time/rebuild/route.ts
+++ b/app/api/payroll-time/rebuild/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { rebuildPeriod } from "@/features/payroll-time/server/payrollTime";
+import { requirePayrollReviewer } from "../_lib/auth";
+
+export async function POST(req: Request) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+
+  const body = (await req.json().catch(() => null)) as { period_id?: string } | null;
+  if (!body?.period_id) {
+    return NextResponse.json({ error: "period_id is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await rebuildPeriod({
+      shopId: auth.me.shop_id!,
+      actorId: auth.me.id,
+      periodId: body.period_id,
+    });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to rebuild period" },
+      { status: 400 },
+    );
+  }
+}

--- a/app/dashboard/admin/payroll-time/page.tsx
+++ b/app/dashboard/admin/payroll-time/page.tsx
@@ -1,0 +1,7 @@
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import PayrollTimeClient from "@/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient";
+
+export default async function Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin", "manager"] });
+  return <PayrollTimeClient />;
+}

--- a/db/sql/2026-04-13_payroll_time_tracking_foundation.sql
+++ b/db/sql/2026-04-13_payroll_time_tracking_foundation.sql
@@ -1,0 +1,171 @@
+-- Payroll time tracking foundation (attendance-first, payroll-processing out of scope)
+-- Additive, shop-scoped, and non-breaking.
+
+create table if not exists public.shop_payroll_settings (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  cadence text not null default 'biweekly' check (cadence in ('weekly','biweekly','semimonthly')),
+  week_starts_on smallint not null default 1 check (week_starts_on between 0 and 6),
+  daily_overtime_after_minutes integer not null default 480 check (daily_overtime_after_minutes >= 0),
+  weekly_overtime_after_minutes integer not null default 2400 check (weekly_overtime_after_minutes >= 0),
+  suspicious_shift_minutes integer not null default 960 check (suspicious_shift_minutes >= 60),
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id)
+);
+
+create table if not exists public.payroll_pay_periods (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  period_start date not null,
+  period_end date not null,
+  status text not null default 'open' check (status in ('draft','open','approved','exported')),
+  locked_at timestamptz,
+  approved_at timestamptz,
+  approved_by uuid references public.profiles(id) on delete set null,
+  exported_at timestamptz,
+  exported_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  notes text,
+  check (period_end >= period_start),
+  unique (shop_id, period_start, period_end)
+);
+
+create table if not exists public.payroll_time_entries (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  period_id uuid not null references public.payroll_pay_periods(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  work_date date not null,
+  worked_minutes integer not null default 0,
+  unpaid_break_minutes integer not null default 0,
+  paid_break_minutes integer not null default 0,
+  regular_minutes integer not null default 0,
+  overtime_minutes integer not null default 0,
+  attendance_minutes integer not null default 0,
+  job_minutes integer not null default 0,
+  adjustment_minutes integer not null default 0,
+  has_exceptions boolean not null default false,
+  blocking_exception_count integer not null default 0,
+  warning_exception_count integer not null default 0,
+  approval_state text not null default 'draft' check (approval_state in ('draft','reviewed','approved','locked')),
+  approved_at timestamptz,
+  approved_by uuid references public.profiles(id) on delete set null,
+  source_snapshot jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (period_id, user_id, work_date)
+);
+
+create table if not exists public.payroll_time_exceptions (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  period_id uuid not null references public.payroll_pay_periods(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  work_date date,
+  severity text not null check (severity in ('warning','blocking')),
+  code text not null,
+  message text not null,
+  source_type text not null default 'attendance' check (source_type in ('attendance','job_time','manual_adjustment','system')),
+  source_ref jsonb not null default '{}'::jsonb,
+  resolved boolean not null default false,
+  resolved_at timestamptz,
+  resolved_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  unique (period_id, user_id, work_date, code, message)
+);
+
+create table if not exists public.payroll_export_batches (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  period_id uuid not null references public.payroll_pay_periods(id) on delete cascade,
+  provider_type text not null default 'csv' check (provider_type in ('csv','wagepoint','payworks','dayforce','generic')),
+  status text not null default 'pending' check (status in ('pending','generated','failed','exported')),
+  exported_at timestamptz,
+  exported_by uuid references public.profiles(id) on delete set null,
+  row_count integer not null default 0,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.payroll_export_rows (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  batch_id uuid not null references public.payroll_export_batches(id) on delete cascade,
+  period_id uuid not null references public.payroll_pay_periods(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  employee_external_id text,
+  regular_hours numeric(10,2) not null default 0,
+  overtime_hours numeric(10,2) not null default 0,
+  unpaid_break_hours numeric(10,2) not null default 0,
+  total_hours numeric(10,2) not null default 0,
+  row_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.payroll_employee_mappings (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  provider_type text not null default 'generic' check (provider_type in ('wagepoint','payworks','dayforce','generic')),
+  external_employee_id text,
+  pay_group text,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, user_id, provider_type)
+);
+
+create index if not exists idx_payroll_periods_shop_status on public.payroll_pay_periods(shop_id, status, period_start desc);
+create index if not exists idx_payroll_entries_period_user on public.payroll_time_entries(period_id, user_id, work_date);
+create index if not exists idx_payroll_exceptions_period_severity on public.payroll_time_exceptions(period_id, severity, resolved);
+create index if not exists idx_payroll_export_batches_period on public.payroll_export_batches(period_id, created_at desc);
+
+alter table public.shop_payroll_settings enable row level security;
+alter table public.payroll_pay_periods enable row level security;
+alter table public.payroll_time_entries enable row level security;
+alter table public.payroll_time_exceptions enable row level security;
+alter table public.payroll_export_batches enable row level security;
+alter table public.payroll_export_rows enable row level security;
+alter table public.payroll_employee_mappings enable row level security;
+
+do $$ begin
+  create policy shop_payroll_settings_shop_select on public.shop_payroll_settings
+    for select to authenticated using (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy shop_payroll_settings_shop_insert on public.shop_payroll_settings
+    for insert to authenticated with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy shop_payroll_settings_shop_update on public.shop_payroll_settings
+    for update to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy payroll_pay_periods_shop_all on public.payroll_pay_periods
+    for all to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy payroll_time_entries_shop_all on public.payroll_time_entries
+    for all to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy payroll_time_exceptions_shop_all on public.payroll_time_exceptions
+    for all to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy payroll_export_batches_shop_all on public.payroll_export_batches
+    for all to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy payroll_export_rows_shop_all on public.payroll_export_rows
+    for all to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+do $$ begin
+  create policy payroll_employee_mappings_shop_all on public.payroll_employee_mappings
+    for all to authenticated using (shop_id = public.current_shop_id()) with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AdminBadge,
+  AdminEmptyState,
+  AdminPageHeader,
+  AdminPageShell,
+  AdminPanel,
+  AdminPanelTitle,
+  AdminStatCard,
+  AdminStatGrid,
+  AdminToolbar,
+} from "@/features/dashboard/app/dashboard/admin/AdminSurface";
+
+type Period = {
+  id: string;
+  period_start: string;
+  period_end: string;
+  status: "draft" | "open" | "approved" | "exported";
+  approved_at: string | null;
+  exported_at: string | null;
+};
+
+type Entry = {
+  id: string;
+  user_id: string;
+  work_date: string;
+  worked_minutes: number;
+  regular_minutes: number;
+  overtime_minutes: number;
+  unpaid_break_minutes: number;
+  job_minutes: number;
+  has_exceptions: boolean;
+  blocking_exception_count: number;
+  warning_exception_count: number;
+  profiles?: { full_name?: string | null; email?: string | null } | null;
+};
+
+type Exception = {
+  id: string;
+  user_id: string;
+  work_date: string | null;
+  severity: "warning" | "blocking";
+  code: string;
+  message: string;
+  resolved: boolean;
+};
+
+function fmtHours(minutes: number | null | undefined) {
+  return ((minutes ?? 0) / 60).toFixed(2);
+}
+
+export default function PayrollTimeClient() {
+  const [periods, setPeriods] = useState<Period[]>([]);
+  const [activePeriodId, setActivePeriodId] = useState<string | null>(null);
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [exceptions, setExceptions] = useState<Exception[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [csvPreview, setCsvPreview] = useState<string | null>(null);
+
+  const activePeriod = useMemo(
+    () => periods.find((p) => p.id === activePeriodId) ?? null,
+    [periods, activePeriodId],
+  );
+
+  const summary = useMemo(() => {
+    const employeeSet = new Set(entries.map((entry) => entry.user_id));
+    const totalMinutes = entries.reduce((acc, entry) => acc + Number(entry.worked_minutes ?? 0), 0);
+    const overtimeMinutes = entries.reduce((acc, entry) => acc + Number(entry.overtime_minutes ?? 0), 0);
+    const blocking = exceptions.filter((item) => item.severity === "blocking" && !item.resolved).length;
+    const warnings = exceptions.filter((item) => item.severity === "warning" && !item.resolved).length;
+    return {
+      employees: employeeSet.size,
+      totalHours: fmtHours(totalMinutes),
+      overtimeHours: fmtHours(overtimeMinutes),
+      blocking,
+      warnings,
+    };
+  }, [entries, exceptions]);
+
+  const load = useCallback(async (periodId?: string | null) => {
+    setLoading(true);
+    setError(null);
+    const url = periodId ? `/api/payroll-time/periods?period_id=${periodId}` : "/api/payroll-time/periods";
+    const res = await fetch(url, { cache: "no-store" });
+    const body = await res.json().catch(() => null);
+
+    if (!res.ok) {
+      setError(body?.error ?? "Failed to load payroll time data");
+      setLoading(false);
+      return;
+    }
+
+    setPeriods((body?.periods ?? []) as Period[]);
+    setActivePeriodId((body?.activePeriodId as string | null) ?? null);
+    setEntries((body?.entries ?? []) as Entry[]);
+    setExceptions((body?.exceptions ?? []) as Exception[]);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function runAction(path: string, actionName: string, payload: Record<string, unknown>) {
+    setBusyAction(actionName);
+    setError(null);
+    const res = await fetch(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      setError(body?.error ?? `${actionName} failed`);
+      setBusyAction(null);
+      return null;
+    }
+    setBusyAction(null);
+    return body;
+  }
+
+  async function handleRebuild() {
+    if (!activePeriodId) return;
+    const result = await runAction("/api/payroll-time/rebuild", "rebuild", { period_id: activePeriodId });
+    if (result) await load(activePeriodId);
+  }
+
+  async function handleApprove() {
+    if (!activePeriodId) return;
+    const result = await runAction("/api/payroll-time/approve", "approve", { period_id: activePeriodId });
+    if (result) await load(activePeriodId);
+  }
+
+  async function handleExport() {
+    if (!activePeriodId) return;
+    const result = await runAction("/api/payroll-time/export", "export", {
+      period_id: activePeriodId,
+      provider_type: "csv",
+    });
+    if (result?.csv) setCsvPreview(String(result.csv));
+    await load(activePeriodId);
+  }
+
+  return (
+    <AdminPageShell>
+      <AdminPageHeader
+        eyebrow="Workforce Payroll-Ready Time"
+        title="Payroll Time Tracking"
+        subtitle="Attendance-first payroll-hour review by pay period with exception triage, approval locking, and export snapshots."
+      />
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Current Period Signals"
+          description="Trust posture before approval/export. Blocking exceptions should be cleared before lock."
+        />
+        <AdminStatGrid>
+          <AdminStatCard label="Employees in period" value={summary.employees} />
+          <AdminStatCard label="Worked hours" value={summary.totalHours} />
+          <AdminStatCard label="Overtime-ready hours" value={summary.overtimeHours} />
+          <AdminStatCard label="Blocking exceptions" value={summary.blocking} />
+          <AdminStatCard label="Warnings" value={summary.warnings} />
+        </AdminStatGrid>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Pay Period Review" description="Rebuild while open, approve to lock, then export to a payroll-provider-ready CSV snapshot." />
+        <AdminToolbar>
+          <select
+            className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none md:w-80"
+            value={activePeriodId ?? ""}
+            onChange={(event) => void load(event.target.value)}
+          >
+            {periods.map((period) => (
+              <option key={period.id} value={period.id}>
+                {period.period_start} → {period.period_end} ({period.status})
+              </option>
+            ))}
+          </select>
+          <button
+            className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-xs uppercase tracking-[0.12em] text-neutral-100 disabled:opacity-50"
+            onClick={() => void handleRebuild()}
+            disabled={!activePeriodId || busyAction !== null || activePeriod?.status === "approved" || activePeriod?.status === "exported"}
+          >
+            {busyAction === "rebuild" ? "Rebuilding…" : "Rebuild from source"}
+          </button>
+          <button
+            className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs uppercase tracking-[0.12em] text-emerald-200 disabled:opacity-50"
+            onClick={() => void handleApprove()}
+            disabled={!activePeriodId || busyAction !== null || activePeriod?.status === "approved" || activePeriod?.status === "exported"}
+          >
+            {busyAction === "approve" ? "Approving…" : "Approve + lock"}
+          </button>
+          <button
+            className="rounded-lg border border-sky-500/40 bg-sky-500/10 px-3 py-2 text-xs uppercase tracking-[0.12em] text-sky-200 disabled:opacity-50"
+            onClick={() => void handleExport()}
+            disabled={!activePeriodId || busyAction !== null || activePeriod?.status !== "approved"}
+          >
+            {busyAction === "export" ? "Exporting…" : "Export CSV snapshot"}
+          </button>
+        </AdminToolbar>
+
+        {activePeriod ? (
+          <div className="px-4 pb-4 text-xs text-neutral-400">
+            <span className="mr-2">Period status:</span>
+            <AdminBadge>{activePeriod.status}</AdminBadge>
+            {activePeriod.approved_at ? <span className="ml-3">Approved: {new Date(activePeriod.approved_at).toLocaleString()}</span> : null}
+            {activePeriod.exported_at ? <span className="ml-3">Exported: {new Date(activePeriod.exported_at).toLocaleString()}</span> : null}
+          </div>
+        ) : null}
+
+        {error ? <p className="px-4 pb-4 text-xs text-red-300">{error}</p> : null}
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Employee Daily Payroll Entries" description="Attendance is payroll base truth; job time is supplemental visibility for productivity context." />
+        {loading ? (
+          <AdminEmptyState title="Loading payroll period" body="Collecting derived payroll-ready rows." />
+        ) : entries.length === 0 ? (
+          <AdminEmptyState title="No derived entries" body="Run rebuild to derive payroll-ready entries from attendance and job source layers." />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400">
+                <tr>
+                  <th className="px-4 py-2.5 text-left">Employee</th>
+                  <th className="px-4 py-2.5 text-left">Date</th>
+                  <th className="px-4 py-2.5 text-right">Worked</th>
+                  <th className="px-4 py-2.5 text-right">Regular</th>
+                  <th className="px-4 py-2.5 text-right">OT-ready</th>
+                  <th className="px-4 py-2.5 text-right">Unpaid break</th>
+                  <th className="px-4 py-2.5 text-right">Job context</th>
+                  <th className="px-4 py-2.5 text-left">Exceptions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {entries.map((entry) => (
+                  <tr key={entry.id} className="text-neutral-200">
+                    <td className="px-4 py-2.5">
+                      <p className="font-medium text-neutral-100">{entry.profiles?.full_name ?? entry.user_id}</p>
+                      <p className="text-xs text-neutral-500">{entry.profiles?.email ?? ""}</p>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-2.5">{entry.work_date}</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.worked_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.regular_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.overtime_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.unpaid_break_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.job_minutes)}h</td>
+                    <td className="px-4 py-2.5">
+                      {entry.blocking_exception_count > 0 ? (
+                        <AdminBadge>{entry.blocking_exception_count} blocking</AdminBadge>
+                      ) : entry.warning_exception_count > 0 ? (
+                        <AdminBadge>{entry.warning_exception_count} warning</AdminBadge>
+                      ) : (
+                        <span className="text-xs text-neutral-500">Clean</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Exception Queue" description="Exceptions keep traceability; unresolved blocking exceptions prevent period approval." />
+        {exceptions.length === 0 ? (
+          <AdminEmptyState title="No exceptions" body="No flagged anomalies in this period." />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400">
+                <tr>
+                  <th className="px-4 py-2.5 text-left">Severity</th>
+                  <th className="px-4 py-2.5 text-left">Code</th>
+                  <th className="px-4 py-2.5 text-left">Date</th>
+                  <th className="px-4 py-2.5 text-left">Message</th>
+                  <th className="px-4 py-2.5 text-left">State</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {exceptions.map((item) => (
+                  <tr key={item.id} className="text-neutral-200">
+                    <td className="px-4 py-2.5">
+                      <AdminBadge>{item.severity}</AdminBadge>
+                    </td>
+                    <td className="px-4 py-2.5">{item.code}</td>
+                    <td className="px-4 py-2.5">{item.work_date ?? "—"}</td>
+                    <td className="px-4 py-2.5">{item.message}</td>
+                    <td className="px-4 py-2.5">{item.resolved ? "resolved" : "open"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </AdminPanel>
+
+      {csvPreview ? (
+        <AdminPanel>
+          <AdminPanelTitle title="Latest CSV Snapshot" description="Export foundation artifact (provider adapter-compatible row shape)." />
+          <pre className="overflow-x-auto rounded-lg border border-white/10 bg-black/30 p-4 text-xs text-neutral-300">{csvPreview}</pre>
+        </AdminPanel>
+      ) : null}
+    </AdminPageShell>
+  );
+}

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -1,0 +1,448 @@
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+export type PayrollPeriodStatus = "draft" | "open" | "approved" | "exported";
+
+export type PayrollException = {
+  user_id: string;
+  work_date: string | null;
+  severity: "warning" | "blocking";
+  code: string;
+  message: string;
+  source_type: "attendance" | "job_time" | "manual_adjustment" | "system";
+  source_ref: Record<string, unknown>;
+};
+
+const MINUTES_IN_HOUR = 60;
+
+function startOfUtcDay(dateIso: string): Date {
+  const d = new Date(dateIso);
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addDays(d: Date, days: number): Date {
+  const out = new Date(d);
+  out.setUTCDate(out.getUTCDate() + days);
+  return out;
+}
+
+function dateDiffMinutes(start: string, end: string): number {
+  return Math.max(0, Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000));
+}
+
+export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) {
+  const admin = createAdminSupabase() as any;
+  const today = new Date();
+
+  const { data: settings } = await admin
+    .from("shop_payroll_settings")
+    .select("*")
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  let payrollSettings = settings;
+  if (!payrollSettings) {
+    const inserted = await admin
+      .from("shop_payroll_settings")
+      .insert({ shop_id: shopId, cadence: "biweekly" })
+      .select("*")
+      .single();
+    payrollSettings = inserted.data;
+  }
+
+  const cadence = payrollSettings?.cadence ?? "biweekly";
+  const weekStartsOn = Number(payrollSettings?.week_starts_on ?? 1);
+
+  const todayUtc = startOfUtcDay(today.toISOString());
+  const day = todayUtc.getUTCDay();
+  const diffToWeekStart = (day - weekStartsOn + 7) % 7;
+  const currentWeekStart = addDays(todayUtc, -diffToWeekStart);
+  const currentWeekEnd = addDays(currentWeekStart, 6);
+
+  let periodStart = currentWeekStart;
+  let periodEnd = currentWeekEnd;
+
+  if (cadence === "biweekly") {
+    const epoch = Date.UTC(2024, 0, 1);
+    const weeksSinceEpoch = Math.floor((currentWeekStart.getTime() - epoch) / (7 * 24 * 60 * 60 * 1000));
+    const isEven = weeksSinceEpoch % 2 === 0;
+    periodStart = isEven ? currentWeekStart : addDays(currentWeekStart, -7);
+    periodEnd = addDays(periodStart, 13);
+  }
+
+  const periodStartIso = toIsoDate(periodStart);
+  const periodEndIso = toIsoDate(periodEnd);
+
+  const existing = await admin
+    .from("payroll_pay_periods")
+    .select("*")
+    .eq("shop_id", shopId)
+    .eq("period_start", periodStartIso)
+    .eq("period_end", periodEndIso)
+    .maybeSingle();
+
+  if (existing.data) return { settings: payrollSettings, period: existing.data };
+
+  const created = await admin
+    .from("payroll_pay_periods")
+    .insert({
+      shop_id: shopId,
+      period_start: periodStartIso,
+      period_end: periodEndIso,
+      status: "open",
+      notes: `Auto-created by ${actorId}`,
+    })
+    .select("*")
+    .single();
+
+  return { settings: payrollSettings, period: created.data };
+}
+
+export async function rebuildPeriod(params: { shopId: string; actorId: string; periodId: string }) {
+  const { shopId, periodId } = params;
+  const admin = createAdminSupabase() as any;
+
+  const { data: period, error: periodErr } = await admin
+    .from("payroll_pay_periods")
+    .select("*")
+    .eq("id", periodId)
+    .eq("shop_id", shopId)
+    .single();
+
+  if (periodErr || !period) throw new Error(periodErr?.message ?? "Pay period not found");
+  if (period.status === "approved" || period.status === "exported") {
+    throw new Error("Approved/exported periods are locked");
+  }
+
+  const { data: settings } = await admin
+    .from("shop_payroll_settings")
+    .select("*")
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  const dailyOvertimeAfter = Number(settings?.daily_overtime_after_minutes ?? 480);
+  const suspiciousShiftMinutes = Number(settings?.suspicious_shift_minutes ?? 960);
+
+  const rangeStart = `${period.period_start}T00:00:00.000Z`;
+  const rangeEnd = `${period.period_end}T23:59:59.999Z`;
+
+  const [{ data: shifts, error: shiftsErr }, { data: jobSegments, error: jobsErr }] = await Promise.all([
+    admin
+      .from("tech_shifts")
+      .select("id, user_id, type, status, start_time, end_time")
+      .eq("shop_id", shopId)
+      .gte("start_time", rangeStart)
+      .lte("start_time", rangeEnd),
+    admin
+      .from("work_order_line_labor_segments")
+      .select("id, technician_id, started_at, ended_at")
+      .eq("shop_id", shopId)
+      .gte("started_at", rangeStart)
+      .lte("started_at", rangeEnd),
+  ]);
+
+  if (shiftsErr) throw new Error(shiftsErr.message);
+  if (jobsErr) throw new Error(jobsErr.message);
+
+  const rowsByKey = new Map<string, {
+    user_id: string;
+    work_date: string;
+    attendance_minutes: number;
+    unpaid_break_minutes: number;
+    paid_break_minutes: number;
+    job_minutes: number;
+    warnings: number;
+    blocking: number;
+    source_snapshot: Record<string, unknown>;
+  }>();
+
+  const exceptions: PayrollException[] = [];
+
+  for (const shift of shifts ?? []) {
+    if (!shift.user_id) continue;
+    const workDate = toIsoDate(startOfUtcDay(shift.start_time));
+    const key = `${shift.user_id}:${workDate}`;
+    const row = rowsByKey.get(key) ?? {
+      user_id: shift.user_id,
+      work_date: workDate,
+      attendance_minutes: 0,
+      unpaid_break_minutes: 0,
+      paid_break_minutes: 0,
+      job_minutes: 0,
+      warnings: 0,
+      blocking: 0,
+      source_snapshot: { shift_ids: [], open_shift_ids: [] },
+    };
+
+    const endTime = shift.end_time ?? new Date().toISOString();
+    const duration = dateDiffMinutes(shift.start_time, endTime);
+
+    if (shift.type === "shift") {
+      row.attendance_minutes += duration;
+    }
+    if (shift.type === "break" || shift.type === "lunch") {
+      row.unpaid_break_minutes += duration;
+    }
+
+    const ids = Array.isArray(row.source_snapshot.shift_ids)
+      ? (row.source_snapshot.shift_ids as string[])
+      : [];
+    ids.push(shift.id);
+    row.source_snapshot.shift_ids = ids;
+
+    if (!shift.end_time) {
+      const openIds = Array.isArray(row.source_snapshot.open_shift_ids)
+        ? (row.source_snapshot.open_shift_ids as string[])
+        : [];
+      openIds.push(shift.id);
+      row.source_snapshot.open_shift_ids = openIds;
+      row.blocking += 1;
+      exceptions.push({
+        user_id: shift.user_id,
+        work_date: workDate,
+        severity: "blocking",
+        code: "open_punch",
+        message: "Shift is still open and missing clock-out.",
+        source_type: "attendance",
+        source_ref: { shift_id: shift.id },
+      });
+    }
+
+    if (duration > suspiciousShiftMinutes) {
+      row.warnings += 1;
+      exceptions.push({
+        user_id: shift.user_id,
+        work_date: workDate,
+        severity: "warning",
+        code: "suspicious_shift",
+        message: `Shift length ${duration} minutes exceeds threshold ${suspiciousShiftMinutes}.`,
+        source_type: "attendance",
+        source_ref: { shift_id: shift.id, duration },
+      });
+    }
+
+    if (duration <= 0) {
+      row.blocking += 1;
+      exceptions.push({
+        user_id: shift.user_id,
+        work_date: workDate,
+        severity: "blocking",
+        code: "invalid_duration",
+        message: "Shift duration is invalid or negative.",
+        source_type: "attendance",
+        source_ref: { shift_id: shift.id },
+      });
+    }
+
+    rowsByKey.set(key, row);
+  }
+
+  for (const seg of jobSegments ?? []) {
+    if (!seg.technician_id || !seg.started_at) continue;
+    const workDate = toIsoDate(startOfUtcDay(seg.started_at));
+    const key = `${seg.technician_id}:${workDate}`;
+    const row = rowsByKey.get(key) ?? {
+      user_id: seg.technician_id,
+      work_date: workDate,
+      attendance_minutes: 0,
+      unpaid_break_minutes: 0,
+      paid_break_minutes: 0,
+      job_minutes: 0,
+      warnings: 0,
+      blocking: 0,
+      source_snapshot: { shift_ids: [], open_shift_ids: [], job_segment_ids: [] },
+    };
+
+    if (!seg.ended_at) {
+      row.warnings += 1;
+      exceptions.push({
+        user_id: seg.technician_id,
+        work_date: workDate,
+        severity: "warning",
+        code: "open_job_segment",
+        message: "Job segment is still active.",
+        source_type: "job_time",
+        source_ref: { segment_id: seg.id },
+      });
+    }
+
+    const duration = seg.ended_at ? dateDiffMinutes(seg.started_at, seg.ended_at) : 0;
+    row.job_minutes += duration;
+
+    const segIds = Array.isArray(row.source_snapshot.job_segment_ids)
+      ? (row.source_snapshot.job_segment_ids as string[])
+      : [];
+    segIds.push(seg.id);
+    row.source_snapshot.job_segment_ids = segIds;
+    rowsByKey.set(key, row);
+  }
+
+  const upserts = Array.from(rowsByKey.values()).map((row) => {
+    const netWorked = Math.max(0, row.attendance_minutes - row.unpaid_break_minutes);
+    const overtime = Math.max(0, netWorked - dailyOvertimeAfter);
+    const regular = Math.max(0, netWorked - overtime);
+
+    return {
+      shop_id: shopId,
+      period_id: periodId,
+      user_id: row.user_id,
+      work_date: row.work_date,
+      worked_minutes: netWorked,
+      attendance_minutes: row.attendance_minutes,
+      unpaid_break_minutes: row.unpaid_break_minutes,
+      paid_break_minutes: row.paid_break_minutes,
+      regular_minutes: regular,
+      overtime_minutes: overtime,
+      job_minutes: row.job_minutes,
+      adjustment_minutes: 0,
+      has_exceptions: row.warnings + row.blocking > 0,
+      warning_exception_count: row.warnings,
+      blocking_exception_count: row.blocking,
+      approval_state: "draft",
+      source_snapshot: row.source_snapshot,
+    };
+  });
+
+  await admin.from("payroll_time_entries").delete().eq("shop_id", shopId).eq("period_id", periodId);
+  await admin.from("payroll_time_exceptions").delete().eq("shop_id", shopId).eq("period_id", periodId);
+
+  if (upserts.length > 0) {
+    const { error } = await admin.from("payroll_time_entries").insert(upserts);
+    if (error) throw new Error(error.message);
+  }
+
+  if (exceptions.length > 0) {
+    const { error } = await admin.from("payroll_time_exceptions").insert(
+      exceptions.map((item) => ({ ...item, shop_id: shopId, period_id: periodId })),
+    );
+    if (error) throw new Error(error.message);
+  }
+
+  await admin
+    .from("payroll_pay_periods")
+    .update({ status: "open", updated_at: new Date().toISOString() })
+    .eq("id", periodId)
+    .eq("shop_id", shopId);
+
+  return { rows: upserts.length, exceptions: exceptions.length };
+}
+
+export async function approvePeriod(params: { shopId: string; periodId: string; actorId: string }) {
+  const admin = createAdminSupabase() as any;
+  const { shopId, periodId, actorId } = params;
+
+  const { data: blocking } = await admin
+    .from("payroll_time_exceptions")
+    .select("id", { count: "exact", head: true })
+    .eq("shop_id", shopId)
+    .eq("period_id", periodId)
+    .eq("severity", "blocking")
+    .eq("resolved", false);
+
+  if ((blocking?.length ?? 0) > 0) {
+    throw new Error("Cannot approve period with unresolved blocking exceptions.");
+  }
+
+  const now = new Date().toISOString();
+  const { error: entriesErr } = await admin
+    .from("payroll_time_entries")
+    .update({ approval_state: "approved", approved_at: now, approved_by: actorId })
+    .eq("shop_id", shopId)
+    .eq("period_id", periodId);
+
+  if (entriesErr) throw new Error(entriesErr.message);
+
+  const { error: periodErr } = await admin
+    .from("payroll_pay_periods")
+    .update({ status: "approved", approved_at: now, approved_by: actorId, locked_at: now, updated_at: now })
+    .eq("id", periodId)
+    .eq("shop_id", shopId);
+
+  if (periodErr) throw new Error(periodErr.message);
+}
+
+export async function exportPeriod(params: { shopId: string; periodId: string; actorId: string; providerType?: string }) {
+  const admin = createAdminSupabase() as any;
+  const { shopId, periodId, actorId } = params;
+  const providerType = params.providerType ?? "csv";
+
+  const { data: entries, error: entriesErr } = await admin
+    .from("payroll_time_entries")
+    .select("user_id, regular_minutes, overtime_minutes, unpaid_break_minutes, worked_minutes")
+    .eq("shop_id", shopId)
+    .eq("period_id", periodId)
+    .order("user_id", { ascending: true });
+
+  if (entriesErr) throw new Error(entriesErr.message);
+
+  const { data: mappings } = await admin
+    .from("payroll_employee_mappings")
+    .select("user_id, external_employee_id")
+    .eq("shop_id", shopId)
+    .eq("provider_type", providerType);
+
+  const mappingByUser = new Map<string, string | null>((mappings ?? []).map((m: any) => [m.user_id, m.external_employee_id ?? null]));
+
+  const grouped = new Map<string, { regular: number; overtime: number; unpaidBreak: number; worked: number }>();
+  for (const e of entries ?? []) {
+    const agg = grouped.get(e.user_id) ?? { regular: 0, overtime: 0, unpaidBreak: 0, worked: 0 };
+    agg.regular += Number(e.regular_minutes ?? 0);
+    agg.overtime += Number(e.overtime_minutes ?? 0);
+    agg.unpaidBreak += Number(e.unpaid_break_minutes ?? 0);
+    agg.worked += Number(e.worked_minutes ?? 0);
+    grouped.set(e.user_id, agg);
+  }
+
+  const { data: batch, error: batchErr } = await admin
+    .from("payroll_export_batches")
+    .insert({
+      shop_id: shopId,
+      period_id: periodId,
+      provider_type: providerType,
+      status: "generated",
+      exported_by: actorId,
+      exported_at: new Date().toISOString(),
+      row_count: grouped.size,
+      payload: { generated_from: "payroll_time_entries" },
+    })
+    .select("id")
+    .single();
+
+  if (batchErr || !batch?.id) throw new Error(batchErr?.message ?? "Failed to create export batch");
+
+  const rows = Array.from(grouped.entries()).map(([userId, agg]) => ({
+    shop_id: shopId,
+    batch_id: batch.id,
+    period_id: periodId,
+    user_id: userId,
+    employee_external_id: mappingByUser.get(userId) ?? null,
+    regular_hours: Number((agg.regular / MINUTES_IN_HOUR).toFixed(2)),
+    overtime_hours: Number((agg.overtime / MINUTES_IN_HOUR).toFixed(2)),
+    unpaid_break_hours: Number((agg.unpaidBreak / MINUTES_IN_HOUR).toFixed(2)),
+    total_hours: Number((agg.worked / MINUTES_IN_HOUR).toFixed(2)),
+    row_payload: { source: "period_snapshot" },
+  }));
+
+  if (rows.length > 0) {
+    const { error: rowsErr } = await admin.from("payroll_export_rows").insert(rows);
+    if (rowsErr) throw new Error(rowsErr.message);
+  }
+
+  const now = new Date().toISOString();
+  await admin
+    .from("payroll_pay_periods")
+    .update({ status: "exported", exported_at: now, exported_by: actorId, locked_at: now, updated_at: now })
+    .eq("id", periodId)
+    .eq("shop_id", shopId);
+
+  const csvHeaders = ["user_id", "employee_external_id", "regular_hours", "overtime_hours", "unpaid_break_hours", "total_hours"];
+  const csvLines = [
+    csvHeaders.join(","),
+    ...rows.map((r) => [r.user_id, r.employee_external_id ?? "", r.regular_hours, r.overtime_hours, r.unpaid_break_hours, r.total_hours].join(",")),
+  ];
+
+  return { batchId: batch.id, rowCount: rows.length, csv: csvLines.join("\n") };
+}


### PR DESCRIPTION
### Motivation
- Establish an attendance-first, payroll-ready time tracking foundation inside the existing multi-tenant ProFixIQ architecture. 
- Provide a rebuildable derived layer (pay-period-oriented) that converts raw attendance and job segments into export-ready summaries while preserving source traceability and exceptions.
- Offer a practical manager review/approval flow and a CSV-ready export snapshot without adding payroll compliance or tax functionality.

### Description
- Additive DB schema in `db/sql/2026-04-13_payroll_time_tracking_foundation.sql` introducing `shop_payroll_settings`, `payroll_pay_periods`, `payroll_time_entries`, `payroll_time_exceptions`, `payroll_export_batches`, `payroll_export_rows`, and `payroll_employee_mappings` with indexes and RLS policies scoped to `current_shop_id()`.
- Server-side derivation and orchestration in `features/payroll-time/server/payrollTime.ts` implementing period bootstrap (`getOrCreateCurrentPeriod`), period `rebuildPeriod` from `tech_shifts` (attendance) and `work_order_line_labor_segments` (job context), exception detection, approval locking, and `exportPeriod` CSV snapshot + export batch/row persistence.
- REST API endpoints under `app/api/payroll-time/` for period listing (`periods`), rebuild (`rebuild`), approve (`approve`), and export (`export`) with a shared reviewer guard at `app/api/payroll-time/_lib/auth.ts` that enforces shop context and role capability checks consistent with existing patterns.
- Admin UI surface at `/dashboard/admin/payroll-time` (`app/dashboard/admin/payroll-time/page.tsx` + `features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx`) providing period selector, rebuild/approve/export actions, dense per-employee/day derived rows, exception queue, and CSV preview using existing admin UI primitives.

### Testing
- Ran TypeScript verification: `npx tsc --noEmit` and it completed successfully (no type errors).
- Ran targeted linting: `npx eslint app/api/payroll-time features/payroll-time features/dashboard/app/dashboard/admin/payroll-time app/dashboard/admin/payroll-time/page.tsx` which completed with warnings only (explicit `any` usage in admin-supabase interactions for the newly added tables).
- No runtime integration tests were added in this pass; manual API/UI integration and exception-resolution UX are planned as follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc69c9ab44832895482d34a77725cb)