### PR TITLE
Make People/Staff follow-up workflow action-driven

### DIFF
--- a/app/api/admin/people/[id]/route.ts
+++ b/app/api/admin/people/[id]/route.ts
@@ -3,6 +3,8 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type Ctx = { params: { id: string } };
+type ActionSeverity = "blocking" | "warning" | "informational";
+type ActionReason = { code: string; severity: ActionSeverity; label: string; action_label: string; action_href: string };
 
 async function assertTarget(admin: any, shopId: string, userId: string) {
   const { data, error } = await admin.from("profiles").select("id, shop_id").eq("id", userId).maybeSingle();
@@ -63,23 +65,125 @@ export async function GET(_req: NextRequest, context: unknown) {
     notes: null,
   };
 
+  const now = Date.now();
+  const in30 = now + 1000 * 60 * 60 * 24 * 30;
+  const certifications = (certs ?? []).map((cert: any) => {
+    const expiryTs = cert.expiry_date ? new Date(cert.expiry_date).getTime() : null;
+    const isExpired = cert.status === "expired" || (expiryTs ? expiryTs < now : false);
+    const daysRemaining = expiryTs ? Math.ceil((expiryTs - now) / (1000 * 60 * 60 * 24)) : null;
+    let lifecycle_group: "expired" | "expiring_soon" | "active";
+    if (isExpired) lifecycle_group = "expired";
+    else if (expiryTs && expiryTs <= in30) lifecycle_group = "expiring_soon";
+    else lifecycle_group = "active";
+    return { ...cert, days_remaining: daysRemaining, lifecycle_group };
+  });
+
+  const reasons: ActionReason[] = [];
+  if (blocking > 0) {
+    reasons.push({
+      code: "payroll_blocking_exceptions",
+      severity: "blocking",
+      label: `${blocking} payroll blocking issue${blocking > 1 ? "s" : ""}`,
+      action_label: "Review payroll entries",
+      action_href: `/dashboard/admin/payroll-time?person_id=${params.id}`,
+    });
+  }
+  if (!profile.payroll_ready) {
+    reasons.push({
+      code: "payroll_not_ready",
+      severity: "blocking",
+      label: "Payroll profile is not ready",
+      action_label: "Fix payroll data",
+      action_href: `/dashboard/admin/people/${params.id}#workforce`,
+    });
+  }
+  const missingWorkforceData = [
+    !profile.workforce_role ? "Workforce role" : null,
+    !profile.start_date ? "Start date" : null,
+    !person.phone ? "Phone number" : null,
+  ].filter(Boolean) as string[];
+  if (missingWorkforceData.length > 0) {
+    reasons.push({
+      code: "workforce_profile_missing",
+      severity: "blocking",
+      label: `Missing required profile fields: ${missingWorkforceData.join(", ")}`,
+      action_label: "Complete workforce profile",
+      action_href: `/dashboard/admin/people/${params.id}#workforce`,
+    });
+  }
+  const expiredCount = certifications.filter((cert: any) => cert.lifecycle_group === "expired").length;
+  if (expiredCount > 0) {
+    reasons.push({
+      code: "cert_expired",
+      severity: "blocking",
+      label: `${expiredCount} certification${expiredCount > 1 ? "s are" : " is"} expired`,
+      action_label: "Update certification",
+      action_href: `/dashboard/admin/people/${params.id}#certifications`,
+    });
+  }
+  const expiringSoonCount = certifications.filter((cert: any) => cert.lifecycle_group === "expiring_soon").length;
+  if (expiringSoonCount > 0) {
+    reasons.push({
+      code: "cert_expiring_soon",
+      severity: "warning",
+      label: `${expiringSoonCount} certification${expiringSoonCount > 1 ? "s" : ""} expiring soon`,
+      action_label: "Renew certification",
+      action_href: `/dashboard/admin/people/${params.id}#certifications`,
+    });
+  }
+  if (warning > 0) {
+    reasons.push({
+      code: "payroll_warning_exceptions",
+      severity: "warning",
+      label: `${warning} payroll warning${warning > 1 ? "s" : ""}`,
+      action_label: "Review payroll entries",
+      action_href: `/dashboard/admin/payroll-time?person_id=${params.id}`,
+    });
+  }
+  if (profile.employment_status === "inactive" && (openEntries?.count ?? 0) > 0) {
+    reasons.push({
+      code: "inactive_in_payroll_scope",
+      severity: "informational",
+      label: "Inactive employee still has open payroll entries",
+      action_label: "Review payroll entries",
+      action_href: `/dashboard/admin/payroll-time?person_id=${params.id}`,
+    });
+  }
+
+  const prioritizedAudit = (audit ?? [])
+    .map((row: any) => {
+      const action = (row.action ?? "").toLowerCase();
+      const priority = action.includes("employment") || action.includes("role")
+        ? 3
+        : action.includes("cert")
+          ? 2
+          : action.includes("payroll")
+            ? 2
+            : 1;
+      return { ...row, priority };
+    })
+    .sort((a: any, b: any) => (b.priority - a.priority) || ((new Date(b.created_at ?? 0).getTime()) - (new Date(a.created_at ?? 0).getTime())));
+
   return NextResponse.json({
     ...person,
     workforce_profile: profile,
-    certifications: certs ?? [],
+    certifications,
+    needs_action: reasons.length > 0,
+    action_reasons: reasons,
+    action_counts: {
+      blocking: reasons.filter((reason) => reason.severity === "blocking").length,
+      warning: reasons.filter((reason) => reason.severity === "warning").length,
+      informational: reasons.filter((reason) => reason.severity === "informational").length,
+    },
     payroll_posture: {
       is_payroll_ready: Boolean(profile.payroll_ready),
       open_period_entries: openEntries?.count ?? 0,
       blocking_exceptions: blocking,
       warning_exceptions: warning,
       in_current_period: (openEntries?.count ?? 0) > 0,
-      missing_workforce_data: [
-        !profile.workforce_role ? "Workforce role" : null,
-        !profile.start_date ? "Start date" : null,
-        !person.phone ? "Phone number" : null,
-      ].filter(Boolean),
+      missing_workforce_data: missingWorkforceData,
     },
-    audit_preview: audit ?? [],
+    audit_preview: prioritizedAudit,
   });
 }
 

--- a/app/api/admin/people/route.ts
+++ b/app/api/admin/people/route.ts
@@ -3,6 +3,22 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const DAY = 1000 * 60 * 60 * 24;
+type ActionSeverity = "blocking" | "warning" | "informational";
+
+type ActionReason = {
+  code:
+    | "cert_expired"
+    | "cert_expiring_soon"
+    | "workforce_profile_missing"
+    | "payroll_not_ready"
+    | "payroll_blocking_exceptions"
+    | "payroll_warning_exceptions"
+    | "inactive_in_payroll_scope";
+  severity: ActionSeverity;
+  label: string;
+  action_label: string;
+  action_href: string;
+};
 
 export async function GET() {
   const access = await requireShopScopedApiAccess({ requiredCapability: "canManageUsers", allowRoles: ["owner", "admin"] });
@@ -83,11 +99,86 @@ export async function GET() {
     const payrollExceptions = exceptionByUser.get(profile.id) ?? { blocking: 0, warning: 0 };
     const cert = certByUser.get(profile.id) ?? { open: 0, expiring30: 0, expiring60: 0, expired: 0, revoked: 0 };
     const openPeriodEntries = openEntriesByUser.get(profile.id) ?? 0;
+    const employmentStatus = workforceRow?.employment_status ?? "active";
+    const missingWorkforceData = !workforceRow?.workforce_role;
+    const reasons: ActionReason[] = [];
+
+    if (payrollExceptions.blocking > 0) {
+      reasons.push({
+        code: "payroll_blocking_exceptions",
+        severity: "blocking",
+        label: `${payrollExceptions.blocking} payroll blocking issue${payrollExceptions.blocking > 1 ? "s" : ""}`,
+        action_label: "Review payroll entries",
+        action_href: `/dashboard/admin/payroll-time?person_id=${profile.id}`,
+      });
+    }
+    if (!workforceRow?.payroll_ready) {
+      reasons.push({
+        code: "payroll_not_ready",
+        severity: "blocking",
+        label: "Payroll profile is not ready",
+        action_label: "Fix payroll data",
+        action_href: `/dashboard/admin/people/${profile.id}`,
+      });
+    }
+    if (missingWorkforceData) {
+      reasons.push({
+        code: "workforce_profile_missing",
+        severity: "blocking",
+        label: "Workforce role is missing",
+        action_label: "Complete workforce profile",
+        action_href: `/dashboard/admin/people/${profile.id}`,
+      });
+    }
+    if (cert.expired > 0) {
+      reasons.push({
+        code: "cert_expired",
+        severity: "blocking",
+        label: `${cert.expired} certification${cert.expired > 1 ? "s are" : " is"} expired`,
+        action_label: "Update certification",
+        action_href: `/dashboard/admin/people/${profile.id}#certifications`,
+      });
+    }
+    if (payrollExceptions.warning > 0) {
+      reasons.push({
+        code: "payroll_warning_exceptions",
+        severity: "warning",
+        label: `${payrollExceptions.warning} payroll warning${payrollExceptions.warning > 1 ? "s" : ""}`,
+        action_label: "Review payroll entries",
+        action_href: `/dashboard/admin/payroll-time?person_id=${profile.id}`,
+      });
+    }
+    if (cert.expiring30 > 0) {
+      reasons.push({
+        code: "cert_expiring_soon",
+        severity: "warning",
+        label: `${cert.expiring30} certification${cert.expiring30 > 1 ? "s" : ""} expiring in 30 days`,
+        action_label: "Renew certification",
+        action_href: `/dashboard/admin/people/${profile.id}#certifications`,
+      });
+    }
+    if (employmentStatus === "inactive" && openPeriodEntries > 0) {
+      reasons.push({
+        code: "inactive_in_payroll_scope",
+        severity: "informational",
+        label: "Inactive employee still has open payroll entries",
+        action_label: "Review payroll entries",
+        action_href: `/dashboard/admin/payroll-time?person_id=${profile.id}`,
+      });
+    }
+
+    const highestSeverity: ActionSeverity | null = reasons.length === 0
+      ? null
+      : reasons.some((reason) => reason.severity === "blocking")
+        ? "blocking"
+        : reasons.some((reason) => reason.severity === "warning")
+          ? "warning"
+          : "informational";
 
     return {
       ...profile,
       workforce_role: workforceRow?.workforce_role ?? null,
-      employment_status: workforceRow?.employment_status ?? "active",
+      employment_status: employmentStatus,
       payroll_ready: Boolean(workforceRow?.payroll_ready),
       payroll_blocking_exceptions: payrollExceptions.blocking,
       payroll_warning_exceptions: payrollExceptions.warning,
@@ -97,6 +188,14 @@ export async function GET() {
       cert_expiring_60: cert.expiring60,
       expired_certifications: cert.expired,
       revoked_certifications: cert.revoked,
+      needs_action: reasons.length > 0,
+      highest_action_severity: highestSeverity,
+      action_reasons: reasons,
+      action_counts: {
+        blocking: reasons.filter((reason) => reason.severity === "blocking").length,
+        warning: reasons.filter((reason) => reason.severity === "warning").length,
+        informational: reasons.filter((reason) => reason.severity === "informational").length,
+      },
     };
   });
 

--- a/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
@@ -34,6 +34,16 @@ type PersonRow = {
   cert_expiring_60: number;
   expired_certifications: number;
   revoked_certifications: number;
+  needs_action: boolean;
+  highest_action_severity: "blocking" | "warning" | "informational" | null;
+  action_counts: { blocking: number; warning: number; informational: number };
+  action_reasons: Array<{
+    code: string;
+    severity: "blocking" | "warning" | "informational";
+    label: string;
+    action_label: string;
+    action_href: string;
+  }>;
 };
 
 function certificationPosture(row: PersonRow) {
@@ -49,6 +59,7 @@ export default function PeoplePageClient() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive" | "on_leave">("all");
+  const [actionFilter, setActionFilter] = useState<"all" | "needs_action" | "payroll_issues" | "cert_expiry">("all");
 
   useEffect(() => {
     (async () => {
@@ -65,12 +76,24 @@ export default function PeoplePageClient() {
 
   const filteredRows = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return (rows ?? []).filter((row) => {
+    return (rows ?? [])
+      .filter((row) => {
       const matchesStatus = statusFilter === "all" ? true : (row.employment_status ?? "active") === statusFilter;
+      const matchesActionFilter = actionFilter === "all"
+        ? true
+        : actionFilter === "needs_action"
+          ? row.needs_action
+          : actionFilter === "payroll_issues"
+            ? row.payroll_blocking_exceptions > 0 || row.payroll_warning_exceptions > 0 || !row.payroll_ready
+            : row.expired_certifications > 0 || row.expiring_certifications > 0;
       const text = `${row.full_name ?? ""} ${row.email ?? ""} ${row.phone ?? ""} ${row.role ?? ""} ${row.workforce_role ?? ""}`.toLowerCase();
-      return matchesStatus && (!q || text.includes(q));
-    });
-  }, [rows, search, statusFilter]);
+      return matchesStatus && matchesActionFilter && (!q || text.includes(q));
+      })
+      .sort((a, b) => {
+        const score = (value: PersonRow["highest_action_severity"]) => (value === "blocking" ? 3 : value === "warning" ? 2 : value === "informational" ? 1 : 0);
+        return score(b.highest_action_severity) - score(a.highest_action_severity);
+      });
+  }, [rows, search, statusFilter, actionFilter]);
 
   const summary = useMemo(() => {
     const source = rows ?? [];
@@ -80,6 +103,7 @@ export default function PeoplePageClient() {
       payrollFollowUp: source.filter((row) => row.payroll_blocking_exceptions > 0 || row.payroll_warning_exceptions > 0 || !row.payroll_ready).length,
       certFollowUp: source.filter((row) => row.expired_certifications > 0 || row.expiring_certifications > 0).length,
       inactive: source.filter((row) => row.employment_status === "inactive").length,
+      needsAction: source.filter((row) => row.needs_action).length,
     };
   }, [rows]);
 
@@ -101,6 +125,7 @@ export default function PeoplePageClient() {
           <AdminStatCard label="Onboarding incomplete" value={summary.onboardingMissing} />
           <AdminStatCard label="Payroll follow-up" value={summary.payrollFollowUp} hint="Exceptions or not payroll-ready" />
           <AdminStatCard label="Credential follow-up" value={summary.certFollowUp} hint="Expired or expiring in 30 days" />
+          <AdminStatCard label="Needs action now" value={summary.needsAction} hint="Blocking/warning/informational triage" />
           <AdminStatCard label="Inactive workforce" value={summary.inactive} />
         </AdminStatGrid>
       </AdminPanel>
@@ -137,6 +162,18 @@ export default function PeoplePageClient() {
               <option value="on_leave">On leave</option>
             </select>
           </AdminField>
+          <AdminField label="Triage filter" className="w-full md:w-56">
+            <select
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-orange-400/70"
+              value={actionFilter}
+              onChange={(event) => setActionFilter(event.target.value as "all" | "needs_action" | "payroll_issues" | "cert_expiry")}
+            >
+              <option value="all">All people</option>
+              <option value="needs_action">Needs action</option>
+              <option value="payroll_issues">Payroll issues</option>
+              <option value="cert_expiry">Cert expiry</option>
+            </select>
+          </AdminField>
         </AdminToolbar>
         {error ? <p className="px-4 pb-4 text-xs text-red-300">{error}</p> : null}
       </AdminPanel>
@@ -163,7 +200,12 @@ export default function PeoplePageClient() {
               <tbody className="divide-y divide-white/10">
                 {filteredRows.map((row) => {
                   const cert = certificationPosture(row);
-                  const needsFollowUp = row.payroll_blocking_exceptions > 0 || row.expired_certifications > 0 || !row.completed_onboarding;
+                  const topReason = row.action_reasons[0];
+                  const severityTone = row.highest_action_severity === "blocking"
+                    ? "text-red-300"
+                    : row.highest_action_severity === "warning"
+                      ? "text-amber-300"
+                      : "text-sky-300";
 
                   return (
                     <tr
@@ -176,6 +218,7 @@ export default function PeoplePageClient() {
                       <td className="px-4 py-2.5">
                         <p className="font-medium text-neutral-100">{row.full_name ?? "Unnamed"}</p>
                         <p className="text-xs text-neutral-500">{row.email ?? "No email"}</p>
+                        <p className="text-xs text-neutral-400">{row.action_counts.blocking} blocking • {row.action_counts.warning} warning</p>
                       </td>
                       <td className="px-4 py-2.5"><AdminBadge>{row.role ?? "Unassigned"}</AdminBadge></td>
                       <td className="px-4 py-2.5">
@@ -191,7 +234,10 @@ export default function PeoplePageClient() {
                         <p className="text-neutral-400">{row.payroll_open_period_entries} open entries</p>
                       </td>
                       <td className="px-4 py-2.5">
-                        <AdminBadge>{needsFollowUp ? "Needs action" : "Healthy"}</AdminBadge>
+                        <AdminBadge>{row.needs_action ? "Needs action" : "Healthy"}</AdminBadge>
+                        {row.needs_action ? (
+                          <p className={`mt-1 text-xs ${severityTone}`}>{topReason?.label ?? "Action required"}</p>
+                        ) : null}
                       </td>
                     </tr>
                   );

--- a/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
@@ -26,6 +26,8 @@ type Certification = {
   expiry_date: string | null;
   status: "active" | "expired" | "revoked" | "pending";
   notes: string | null;
+  days_remaining?: number | null;
+  lifecycle_group?: "expired" | "expiring_soon" | "active";
 };
 
 type PersonDetail = {
@@ -53,6 +55,15 @@ type PersonDetail = {
     in_current_period: boolean;
     missing_workforce_data: string[];
   };
+  needs_action: boolean;
+  action_reasons: Array<{
+    code: string;
+    severity: "blocking" | "warning" | "informational";
+    label: string;
+    action_label: string;
+    action_href: string;
+  }>;
+  action_counts: { blocking: number; warning: number; informational: number };
   audit_preview: Array<{ id: string; action: string | null; created_at: string | null; target: string | null; actor_id: string | null; metadata: unknown }>;
   certifications: Certification[];
 };
@@ -81,6 +92,12 @@ function certPosture(cert: Certification) {
   if (expiry && expiry <= in30) return "Expiring ≤30 days";
   if (expiry && expiry <= in60) return "Expiring 31-60 days";
   return cert.status === "expired" ? "Expired" : "Active";
+}
+
+function statusTone(status: "active" | "inactive" | "on_leave") {
+  if (status === "inactive") return "text-red-300";
+  if (status === "on_leave") return "text-amber-300";
+  return "text-emerald-300";
 }
 
 export default function PersonDetailClient({ personId }: { personId: string }) {
@@ -128,6 +145,17 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
       else base.active += 1;
     }
     return base;
+  }, [detail]);
+
+  const groupedCertifications = useMemo(() => {
+    if (!detail) return { expired: [] as Certification[], expiringSoon: [] as Certification[], active: [] as Certification[] };
+    const groups = { expired: [] as Certification[], expiringSoon: [] as Certification[], active: [] as Certification[] };
+    for (const cert of detail.certifications) {
+      if (cert.lifecycle_group === "expired") groups.expired.push(cert);
+      else if (cert.lifecycle_group === "expiring_soon") groups.expiringSoon.push(cert);
+      else groups.active.push(cert);
+    }
+    return groups;
   }, [detail]);
 
   async function saveIdentityAndWorkforce() {
@@ -223,11 +251,41 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
         subtitle="Manage identity/access, workforce profile, certifications/licensing, payroll posture, and activity from one canonical staff record."
       />
 
+      <div id="needs-action">
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Needs Action"
+          description={detail.needs_action ? "Prioritized follow-up for this person. Resolve blocking issues first." : "No follow-up issues are currently open."}
+        />
+        <div className="grid gap-3 p-4 md:grid-cols-3">
+          <AdminStatCard label="Blocking" value={detail.action_counts.blocking} />
+          <AdminStatCard label="Warning" value={detail.action_counts.warning} />
+          <AdminStatCard label="Informational" value={detail.action_counts.informational} />
+        </div>
+        {detail.needs_action ? (
+          <div className="space-y-2 px-4 pb-4">
+            {detail.action_reasons.map((reason, idx) => (
+              <div key={`${reason.code}-${idx}`} className="flex flex-col gap-2 rounded-lg border border-white/10 bg-black/30 p-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className={`text-xs uppercase tracking-[0.16em] ${reason.severity === "blocking" ? "text-red-300" : reason.severity === "warning" ? "text-amber-300" : "text-sky-300"}`}>{reason.severity}</p>
+                  <p className="text-sm text-neutral-100">{reason.label}</p>
+                </div>
+                <Link href={reason.action_href} className="inline-flex rounded-lg border border-white/15 bg-black/30 px-3 py-1.5 text-xs font-medium text-orange-300 hover:text-orange-200">
+                  {reason.action_label} →
+                </Link>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </AdminPanel>
+      </div>
+
+      <div id="workforce">
       <AdminPanel>
         <AdminPanelTitle title="Overview" description="Use this to see readiness posture before editing deeper sections." />
         <AdminStatGrid>
           <AdminStatCard label="Role" value={detail.role ?? "Unassigned"} />
-          <AdminStatCard label="Employment" value={detail.workforce_profile.employment_status} />
+          <AdminStatCard label="Employment" value={detail.workforce_profile.employment_status} hint={detail.workforce_profile.employment_status} />
           <AdminStatCard label="Payroll blocking" value={detail.payroll_posture.blocking_exceptions} />
           <AdminStatCard label="Expiring certs (30d)" value={certSummary.expiring30} />
           <AdminStatCard label="Expired certs" value={certSummary.expired} />
@@ -237,9 +295,15 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
           {missingChecklist.length === 0 ? <p>Record is operationally complete.</p> : missingChecklist.map((item) => <p key={item}>• {item}</p>)}
         </div>
       </AdminPanel>
+      </div>
 
       <AdminPanel>
         <AdminPanelTitle title="Identity & Access" description="Account governance belongs here: identity fields, role, and account posture." />
+        <div className="px-4 pb-2">
+          <AdminBadge>
+            Employment status: <span className={statusTone(detail.workforce_profile.employment_status)}>{detail.workforce_profile.employment_status}</span>
+          </AdminBadge>
+        </div>
         <AdminToolbar>
           <AdminField label="Full name" className="flex-1">
             <input className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm" value={detail.full_name ?? ""} onChange={(e) => setDetail((prev) => prev ? { ...prev, full_name: e.target.value } : prev)} />
@@ -311,15 +375,18 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
         {detail.certifications.length === 0 ? (
           <AdminEmptyState title="No credentials yet" body="Add certifications/licenses so readiness and expiry posture are visible." />
         ) : (
-          <div className="overflow-x-auto">
+          <div id="certifications" className="overflow-x-auto">
+            <div className="px-4 pb-2 text-xs text-neutral-400">
+              <p>Expired: {groupedCertifications.expired.length} • Expiring soon: {groupedCertifications.expiringSoon.length} • Active: {groupedCertifications.active.length}</p>
+            </div>
             <table className="min-w-full text-sm">
               <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400"><tr><th className="px-4 py-2.5 text-left">Credential</th><th className="px-4 py-2.5 text-left">Issuer</th><th className="px-4 py-2.5 text-left">Dates</th><th className="px-4 py-2.5 text-left">Posture</th><th className="px-4 py-2.5 text-left">Actions</th></tr></thead>
               <tbody className="divide-y divide-white/10">
-                {detail.certifications.map((cert) => (
+                {[...groupedCertifications.expired, ...groupedCertifications.expiringSoon, ...groupedCertifications.active].map((cert) => (
                   <tr key={cert.id} className="text-neutral-200">
                     <td className="px-4 py-2.5"><p className="font-medium text-neutral-100">{cert.cert_name}</p><p className="text-xs text-neutral-500">{cert.cert_type} {cert.cert_number ? `• ${cert.cert_number}` : ""}</p></td>
                     <td className="px-4 py-2.5 text-xs">{cert.issuing_body ?? "—"}</td>
-                    <td className="px-4 py-2.5 text-xs">Issued: {cert.issue_date ?? "—"}<br />Expires: {cert.expiry_date ?? "—"}</td>
+                    <td className="px-4 py-2.5 text-xs">Issued: {cert.issue_date ?? "—"}<br />Expires: {cert.expiry_date ?? "—"}{typeof cert.days_remaining === "number" ? <><br />{cert.days_remaining >= 0 ? `${cert.days_remaining} days remaining` : `${Math.abs(cert.days_remaining)} days overdue`}</> : null}</td>
                     <td className="px-4 py-2.5"><AdminBadge>{certPosture(cert)}</AdminBadge></td>
                     <td className="px-4 py-2.5 text-xs">
                       <button
@@ -338,6 +405,24 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
                           });
                         }}
                       >Edit</button>
+                      {(cert.lifecycle_group === "expired" || cert.lifecycle_group === "expiring_soon") ? (
+                        <button
+                          className="mr-3 text-emerald-300 hover:text-emerald-200"
+                          onClick={() => {
+                            setEditingCertId(cert.id);
+                            setEditingCert({
+                              cert_type: cert.cert_type,
+                              cert_name: cert.cert_name,
+                              cert_number: cert.cert_number,
+                              issuing_body: cert.issuing_body,
+                              issue_date: cert.issue_date,
+                              expiry_date: cert.expiry_date,
+                              status: "active",
+                              notes: cert.notes,
+                            });
+                          }}
+                        >Mark renewed</button>
+                      ) : null}
                       <button className="text-red-300 hover:text-red-200" onClick={() => void deleteCertification(cert.id)}>Delete</button>
                     </td>
                   </tr>
@@ -367,12 +452,13 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
         ) : null}
       </AdminPanel>
 
+      <div id="payroll-posture">
       <AdminPanel>
         <AdminPanelTitle title="Payroll Time Posture" description="Review payroll-readiness context before jumping into period approval/export." />
         <div className="grid gap-3 p-4 text-xs md:grid-cols-2">
           <div className="rounded-lg border border-white/10 bg-black/25 p-3">
             <p className="font-medium text-neutral-100">Readiness posture</p>
-            <p className="mt-1">{detail.payroll_posture.is_payroll_ready ? "Marked payroll-ready" : "Not payroll-ready"}</p>
+            <p className={`mt-1 font-medium ${detail.payroll_posture.is_payroll_ready ? "text-emerald-300" : "text-red-300"}`}>{detail.payroll_posture.is_payroll_ready ? "Ready for payroll processing" : `Not payroll ready — ${Math.max(1, detail.payroll_posture.blocking_exceptions)} blocking issue${Math.max(1, detail.payroll_posture.blocking_exceptions) > 1 ? "s" : ""}`}</p>
             <p>{detail.payroll_posture.blocking_exceptions} blocking • {detail.payroll_posture.warning_exceptions} warning</p>
             <p>{detail.payroll_posture.in_current_period ? "Included in current open period" : "No open-period entries yet"}</p>
           </div>
@@ -383,10 +469,11 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
             ) : (
               detail.payroll_posture.missing_workforce_data.map((item) => <p key={item}>• {item}</p>)
             )}
-            <Link href={`/dashboard/admin/payroll-time?person_id=${detail.id}`} className="mt-2 inline-block rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">Open Payroll Time →</Link>
+            <Link href={`/dashboard/admin/payroll-time?person_id=${detail.id}`} className="mt-2 inline-block rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">Fix payroll issues →</Link>
           </div>
         </div>
       </AdminPanel>
+      </div>
 
       <AdminPanel>
         <AdminPanelTitle title="Activity / Audit" description="Recent governance events linked to this person record." action={<Link href="/dashboard/admin/audit" className="text-xs font-medium text-orange-300 hover:text-orange-200">Open full audit →</Link>} />


### PR DESCRIPTION
### Motivation
- Convert the People system from a passive record viewer into an operational triage surface that drives and guides remediation work.  
- Compute per-person follow-up metadata so the UI can surface priorities, direct actions, and reduce ad-hoc inspection of multiple pages.

### Description
- Add computed action model to directory API including `needs_action`, `action_reasons[]`, `highest_action_severity`, and `action_counts` so callers can triage by severity without persisting new schema fields (`app/api/admin/people/route.ts`).
- Extend person detail API to compute certification lifecycle metadata (`days_remaining`, `lifecycle_group`), produce per-person `action_reasons` and `action_counts`, and return a prioritized audit preview for more useful timelines (`app/api/admin/people/[id]/route.ts`).
- Upgrade People directory UI to a triage surface with quick triage filters (`Needs action`, `Payroll issues`, `Cert expiry`), severity-first ordering, per-row action counts and top-reason preview, and a new summary stat (`features/dashboard/.../PeoplePageClient.tsx`).
- Improve Person detail workspace with a dedicated "Needs Action" panel that lists prioritized reasons with direct CTAs, stronger payroll posture messaging and CTA, employment status badge, certification lifecycle grouping + expiry countdown, and a quick "Mark renewed" edit shortcut (`features/dashboard/.../PersonDetailClient.tsx`).

### Testing
- Ran type checking with `npx tsc --noEmit` and the build passed with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd029bbac0832899dced74d1375df7)