### PR TITLE
Refactor Create User into access-provisioning with People handoff

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -132,6 +132,27 @@ export async function POST(req: Request) {
       );
     }
 
+    // Seed the canonical workforce profile row so People detail is immediately usable.
+    const { error: workforceErr } = await serviceSupabase
+      .from("people_workforce_profiles")
+      .upsert(
+        {
+          shop_id: effectiveShopId,
+          user_id: newUserId,
+          employment_status: "active",
+          payroll_ready: false,
+          notes: "Seeded during account provisioning; complete in People detail.",
+        },
+        { onConflict: "shop_id,user_id" }
+      );
+
+    if (workforceErr) {
+      return NextResponse.json(
+        { error: `Workforce profile seed failed: ${workforceErr.message}` },
+        { status: 400 }
+      );
+    }
+
     return NextResponse.json({
       ok: true,
       user_id: newUserId,
@@ -139,6 +160,7 @@ export async function POST(req: Request) {
       email,
       must_change_password: true,
       shop_id: effectiveShopId,
+      people_record_href: `/dashboard/admin/people/${newUserId}?from=create-user`,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected error.";

--- a/app/api/admin/staff-invite-candidates/[id]/create-user/route.ts
+++ b/app/api/admin/staff-invite-candidates/[id]/create-user/route.ts
@@ -184,6 +184,36 @@ export async function POST(_req: NextRequest, context: unknown) {
       );
     }
 
+    const { error: workforceErr } = await admin
+      .from("people_workforce_profiles")
+      .upsert(
+        {
+          shop_id: shopId,
+          user_id: createdUser.user.id,
+          employment_status: "active",
+          payroll_ready: false,
+          notes: "Seeded from staff invite candidate; complete in People detail.",
+        },
+        { onConflict: "shop_id,user_id" }
+      );
+
+    if (workforceErr) {
+      await admin
+        .from("staff_invite_candidates")
+        .update({
+          status: INVITE_STATUS.error,
+          error: workforceErr.message,
+          updated_at: new Date().toISOString(),
+          created_by: access.profile.id,
+        } as DB["public"]["Tables"]["staff_invite_candidates"]["Update"])
+        .eq("id", candidateId);
+
+      return NextResponse.json(
+        { error: workforceErr.message },
+        { status: 500 },
+      );
+    }
+
     const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://profixiq.com";
 
     const { data: shop } = await admin
@@ -247,6 +277,7 @@ export async function POST(_req: NextRequest, context: unknown) {
       ok: true,
       status: finalStatus,
       created_user_id: createdUser.user.id,
+      people_record_href: `/dashboard/admin/people/${createdUser.user.id}?from=create-user`,
       ...(sendErrMsg
         ? {
             warning: "User created but invite failed to send",

--- a/app/dashboard/admin/people/[id]/page.tsx
+++ b/app/dashboard/admin/people/[id]/page.tsx
@@ -1,10 +1,14 @@
 import PersonDetailClient from "@/features/dashboard/app/dashboard/admin/PersonDetailClient";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-type PageProps = { params: Promise<{ id: string }> };
+type PageProps = {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string }>;
+};
 
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   await requireAdminPageAccess({ allow: ["owner", "admin"] });
   const { id } = await params;
-  return <PersonDetailClient personId={id} />;
+  const query = await searchParams;
+  return <PersonDetailClient personId={id} from={query.from ?? null} />;
 }

--- a/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
@@ -100,7 +100,7 @@ function statusTone(status: "active" | "inactive" | "on_leave") {
   return "text-emerald-300";
 }
 
-export default function PersonDetailClient({ personId }: { personId: string }) {
+export default function PersonDetailClient({ personId, from }: { personId: string; from?: string | null }) {
   const [detail, setDetail] = useState<PersonDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -250,6 +250,22 @@ export default function PersonDetailClient({ personId }: { personId: string }) {
         title={detail.full_name ?? "Person record"}
         subtitle="Manage identity/access, workforce profile, certifications/licensing, payroll posture, and activity from one canonical staff record."
       />
+
+      {from === "create-user" ? (
+        <AdminPanel>
+          <AdminPanelTitle
+            title="Account created successfully"
+            description="This person is now provisioned for access and linked to the canonical People record. Continue setup here."
+          />
+          <div className="space-y-1 px-4 pb-4 text-xs text-neutral-300">
+            <p>Next actions:</p>
+            <p>• Complete workforce profile (role/category/start date).</p>
+            <p>• Add certifications/licensing if required.</p>
+            <p>• Review payroll readiness when staffing details are complete.</p>
+            <p>• Ask the user to sign in and finish personal onboarding details.</p>
+          </div>
+        </AdminPanel>
+      ) : null}
 
       <div id="needs-action">
       <AdminPanel>

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import UsersList from "@/features/admin/components/UsersList";
 import InviteCandidatesList from "@/features/admin/components/InviteCandidatesList";
@@ -22,6 +23,7 @@ type CreatePayload = {
 const COPPER = "#C57A4A";
 
 export default function CreateUserPage(): JSX.Element {
+  const router = useRouter();
   const [form, setForm] = useState<CreatePayload>({
     username: "",
     password: "",
@@ -34,6 +36,9 @@ export default function CreateUserPage(): JSX.Element {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [createdUserId, setCreatedUserId] = useState<string | null>(null);
+  const [createdPersonHref, setCreatedPersonHref] = useState<string | null>(null);
+  const [openPeopleAfterCreate, setOpenPeopleAfterCreate] = useState(true);
 
   // force UsersList to re-run its effect
   const [listRefreshKey, setListRefreshKey] = useState(0);
@@ -84,6 +89,8 @@ export default function CreateUserPage(): JSX.Element {
     setSubmitting(true);
     setError(null);
     setSuccess(null);
+    setCreatedUserId(null);
+    setCreatedPersonHref(null);
 
     try {
       const body: CreatePayload = {
@@ -108,13 +115,16 @@ export default function CreateUserPage(): JSX.Element {
         body: JSON.stringify(body),
       });
 
-      if (!res.ok) {
-        const t = await res.text().catch(() => "");
-        throw new Error(t || "Failed to create user.");
-      }
+      const payload = (await res.json().catch(() => null)) as
+        | { error?: string; user_id?: string; people_record_href?: string }
+        | null;
+
+      if (!res.ok) throw new Error(payload?.error || "Failed to create user.");
 
       // local feedback
       setSuccess(`User "${body.username}" created.`);
+      setCreatedUserId(payload?.user_id ?? null);
+      setCreatedPersonHref(payload?.people_record_href ?? null);
       setRecentUsers((prev) =>
         [
           {
@@ -138,6 +148,10 @@ export default function CreateUserPage(): JSX.Element {
 
       // refresh list below
       setListRefreshKey((k) => k + 1);
+
+      if (openPeopleAfterCreate && payload?.people_record_href) {
+        router.push(payload.people_record_href);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unexpected error");
     } finally {
@@ -179,8 +193,8 @@ export default function CreateUserPage(): JSX.Element {
 
   return (
     <PageShell
-      title="Create User"
-      description="Add shop and fleet staff with a username and temporary password."
+      title="Create User (Access Provisioning)"
+      description="Provision account access, assign the initial role, and link the person to your shop. Complete workforce/profile setup in People."
     >
       {/* top 2-column content */}
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
@@ -189,12 +203,13 @@ export default function CreateUserPage(): JSX.Element {
           <div className="space-y-1">
             <h2 className="text-lg font-semibold text-white">New team member</h2>
             <p className="text-sm text-neutral-400">
-              Create a username-based account for{" "}
+              This step provisions access only: create login credentials, set an
+              initial role, and link the person to your shop. For{" "}
               <span style={{ color: COPPER }}>
-                shop staff, drivers, dispatchers, and fleet managers
+                workforce profile, certifications, payroll readiness, and ongoing
+                staff management
               </span>
-              . They&apos;ll sign in with their username and the temporary
-              password you set here.
+              , continue in People after create.
             </p>
             <p className="text-[11px] text-neutral-500">
               If they forget it later, an owner or manager can issue a new
@@ -211,7 +226,16 @@ export default function CreateUserPage(): JSX.Element {
               )}
               {success && (
                 <div className="rounded-md border border-emerald-500/60 bg-emerald-950/60 px-3 py-2 text-xs text-emerald-100 shadow-[0_0_18px_rgba(6,95,70,0.45)]">
-                  {success}
+                  {success}{" "}
+                  {createdPersonHref ? (
+                    <button
+                      type="button"
+                      onClick={() => router.push(createdPersonHref)}
+                      className="ml-2 underline underline-offset-2"
+                    >
+                      Open People record →
+                    </button>
+                  ) : null}
                 </div>
               )}
             </div>
@@ -330,6 +354,14 @@ export default function CreateUserPage(): JSX.Element {
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
+            <label className="inline-flex items-center gap-2 text-xs text-neutral-400">
+              <input
+                type="checkbox"
+                checked={openPeopleAfterCreate}
+                onChange={(e) => setOpenPeopleAfterCreate(e.target.checked)}
+              />
+              Open People record immediately after create
+            </label>
             <button
               type="button"
               onClick={() => void submit()}
@@ -339,8 +371,8 @@ export default function CreateUserPage(): JSX.Element {
               {submitting ? "Creating…" : "Create user"}
             </button>
             <p className="text-xs text-neutral-500">
-              Share the username and temporary password with the team member
-              when you&apos;re ready for them to sign in.
+              Next step: complete workforce/profile setup in People, then share
+              credentials for first sign-in.
             </p>
           </div>
         </div>
@@ -378,6 +410,18 @@ export default function CreateUserPage(): JSX.Element {
                 ))}
               </ul>
             )}
+            {createdUserId ? (
+              <p className="mt-3 text-xs text-neutral-500">
+                Latest person record:{" "}
+                <button
+                  type="button"
+                  className="text-orange-300 hover:text-orange-200"
+                  onClick={() => router.push(`/dashboard/admin/people/${createdUserId}?from=create-user`)}
+                >
+                  Open workspace
+                </button>
+              </p>
+            ) : null}
           </div>
 
           {/* reset */}


### PR DESCRIPTION
### Motivation
- The existing Create User flow correctly provisioned auth and a `profiles` row but left admins with no clear handoff into the canonical People/Staff workspace. 
- Create User should be scoped to account provisioning (credentials, initial role, shop linkage) while People should be the canonical place for workforce/profile/cert/payroll setup. 
- The change makes the handoff explicit and immediate so newly created users are never left in an orphaned state between auth and People records. 

### Description
- Seed a canonical workforce row on account creation by upserting into `people_workforce_profiles` from `app/api/admin/create-user/route.ts` so People detail is immediately usable. 
- Mirror the same workforce-seed + return a canonical People URL from the staff-invite candidate create path in `app/api/admin/staff-invite-candidates/[id]/create-user/route.ts`. 
- Update the owner Create User UI to clarify purpose (access provisioning), show an optional "open People record" toggle, automatically navigate to the People workspace after create, and surface a CTA to open the latest person workspace in `features/dashboard/app/dashboard/owner/create-user/page.tsx`. 
- Surface contextual onboarding guidance in the person workspace when opened from create-user by passing `from=create-user` and showing a next-actions panel in `features/dashboard/app/dashboard/admin/PersonDetailClient.tsx`, and plumb the query param in `app/dashboard/admin/people/[id]/page.tsx`. 
- Files changed: `app/api/admin/create-user/route.ts`, `app/api/admin/staff-invite-candidates/[id]/create-user/route.ts`, `features/dashboard/app/dashboard/owner/create-user/page.tsx`, `features/dashboard/app/dashboard/admin/PersonDetailClient.tsx`, `app/dashboard/admin/people/[id]/page.tsx`.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully with no type errors. 
- Ran ESLint against the modified files and there were no blocking errors (targeted lint run completed). 
- Basic manual verification: Create User now returns a `people_record_href`, the owner create UI can optionally redirect to the person workspace, and the person detail page shows the post-create guidance when opened with `?from=create-user`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0629b87083288960b4bb294b4e73)