### PR TITLE
Add integrated staff scheduling and time-off operations foundation

### DIFF
--- a/app/api/admin/people/[id]/route.ts
+++ b/app/api/admin/people/[id]/route.ts
@@ -22,7 +22,7 @@ export async function GET(_req: NextRequest, context: unknown) {
   const check = await assertTarget(admin, access.profile.shop_id!, params.id);
   if (!check.ok) return NextResponse.json({ error: check.message }, { status: 403 });
 
-  const [{ data: person, error: pErr }, { data: workforce }, { data: certs }, { data: openEntries }, { data: openExceptions }] = await Promise.all([
+  const [{ data: person, error: pErr }, { data: workforce }, { data: certs }, { data: openEntries }, { data: openExceptions }, { data: scheduleTemplates }, { data: scheduleOverrides }, { data: upcomingAwayBlocks }, { data: timeOffRequests }] = await Promise.all([
     admin.from("profiles").select("id, full_name, email, phone, role, completed_onboarding, created_at, last_active_at").eq("id", params.id).maybeSingle(),
     admin
       .from("people_workforce_profiles")
@@ -43,6 +43,10 @@ export async function GET(_req: NextRequest, context: unknown) {
       .eq("user_id", params.id)
       .in("approval_state", ["draft", "reviewed"]),
     admin.from("payroll_time_exceptions").select("severity, resolved").eq("shop_id", access.profile.shop_id).eq("user_id", params.id).eq("resolved", false),
+    admin.from("staff_schedule_templates").select("id, day_of_week, start_time, end_time, is_working_day").eq("shop_id", access.profile.shop_id).eq("user_id", params.id),
+    admin.from("staff_schedule_overrides").select("id, schedule_date, start_time, end_time, status").eq("shop_id", access.profile.shop_id).eq("user_id", params.id).gte("schedule_date", new Date().toISOString().slice(0, 10)).order("schedule_date", { ascending: true }).limit(14),
+    admin.from("staff_availability_blocks").select("id, starts_at, ends_at, block_type, label").eq("shop_id", access.profile.shop_id).eq("user_id", params.id).gte("ends_at", new Date().toISOString()).order("starts_at", { ascending: true }).limit(14),
+    admin.from("staff_time_off_requests").select("id, status, starts_at, ends_at, request_type, reason").eq("shop_id", access.profile.shop_id).eq("user_id", params.id).order("created_at", { ascending: false }).limit(14),
   ]);
 
   const { data: audit } = await admin
@@ -183,6 +187,16 @@ export async function GET(_req: NextRequest, context: unknown) {
       in_current_period: (openEntries?.count ?? 0) > 0,
       missing_workforce_data: missingWorkforceData,
     },
+    schedule_posture: {
+      has_recurring_schedule: (scheduleTemplates ?? []).length > 0,
+      recurring_rows: (scheduleTemplates ?? []).length,
+      upcoming_override_count: (scheduleOverrides ?? []).length,
+      upcoming_approved_away_count: (upcomingAwayBlocks ?? []).length,
+      next_override: (scheduleOverrides ?? [])[0] ?? null,
+      next_away_block: (upcomingAwayBlocks ?? [])[0] ?? null,
+    },
+    upcoming_time_off: upcomingAwayBlocks ?? [],
+    recent_time_off_requests: timeOffRequests ?? [],
     audit_preview: prioritizedAudit,
   });
 }

--- a/app/api/admin/people/route.ts
+++ b/app/api/admin/people/route.ts
@@ -13,7 +13,9 @@ type ActionReason = {
     | "payroll_not_ready"
     | "payroll_blocking_exceptions"
     | "payroll_warning_exceptions"
-    | "inactive_in_payroll_scope";
+    | "inactive_in_payroll_scope"
+    | "schedule_missing_for_active_staff"
+    | "pending_time_off_requests";
   severity: ActionSeverity;
   label: string;
   action_label: string;
@@ -33,6 +35,9 @@ export async function GET() {
     { data: exceptions },
     { data: certs },
     { data: periodEntries },
+    { data: scheduleTemplates },
+    { data: pendingTimeOff },
+    { data: upcomingTimeAway },
   ] = await Promise.all([
     admin
       .from("profiles")
@@ -47,6 +52,9 @@ export async function GET() {
       .select("user_id")
       .eq("shop_id", shopId)
       .in("approval_state", ["draft", "reviewed"]),
+    admin.from("staff_schedule_templates").select("user_id").eq("shop_id", shopId),
+    admin.from("staff_time_off_requests").select("user_id, status").eq("shop_id", shopId).eq("status", "pending"),
+    admin.from("staff_availability_blocks").select("user_id, starts_at, ends_at").eq("shop_id", shopId).gte("ends_at", new Date().toISOString()),
   ]);
 
   if (profilesErr) return NextResponse.json({ error: profilesErr.message }, { status: 500 });
@@ -72,6 +80,15 @@ export async function GET() {
   const openEntriesByUser = new Map<string, number>();
   for (const row of periodEntries ?? []) {
     openEntriesByUser.set(row.user_id, (openEntriesByUser.get(row.user_id) ?? 0) + 1);
+  }
+  const hasTemplate = new Set<string>((scheduleTemplates ?? []).map((row: any) => row.user_id));
+  const pendingTimeOffByUser = new Map<string, number>();
+  for (const row of pendingTimeOff ?? []) {
+    pendingTimeOffByUser.set(row.user_id, (pendingTimeOffByUser.get(row.user_id) ?? 0) + 1);
+  }
+  const upcomingAwayByUser = new Map<string, number>();
+  for (const row of upcomingTimeAway ?? []) {
+    upcomingAwayByUser.set(row.user_id, (upcomingAwayByUser.get(row.user_id) ?? 0) + 1);
   }
 
   const certByUser = new Map<string, { open: number; expiring30: number; expiring60: number; expired: number; revoked: number }>();
@@ -99,6 +116,8 @@ export async function GET() {
     const payrollExceptions = exceptionByUser.get(profile.id) ?? { blocking: 0, warning: 0 };
     const cert = certByUser.get(profile.id) ?? { open: 0, expiring30: 0, expiring60: 0, expired: 0, revoked: 0 };
     const openPeriodEntries = openEntriesByUser.get(profile.id) ?? 0;
+    const pendingTimeOffCount = pendingTimeOffByUser.get(profile.id) ?? 0;
+    const upcomingAwayCount = upcomingAwayByUser.get(profile.id) ?? 0;
     const employmentStatus = workforceRow?.employment_status ?? "active";
     const missingWorkforceData = !workforceRow?.workforce_role;
     const reasons: ActionReason[] = [];
@@ -166,6 +185,24 @@ export async function GET() {
         action_href: `/dashboard/admin/payroll-time?person_id=${profile.id}`,
       });
     }
+    if (employmentStatus === "active" && !hasTemplate.has(profile.id)) {
+      reasons.push({
+        code: "schedule_missing_for_active_staff",
+        severity: "warning",
+        label: "No recurring schedule configured",
+        action_label: "Configure schedule",
+        action_href: `/dashboard/admin/scheduling`,
+      });
+    }
+    if (pendingTimeOffCount > 0) {
+      reasons.push({
+        code: "pending_time_off_requests",
+        severity: "informational",
+        label: `${pendingTimeOffCount} pending time-off request${pendingTimeOffCount > 1 ? "s" : ""}`,
+        action_label: "Review in scheduling",
+        action_href: `/dashboard/admin/scheduling`,
+      });
+    }
 
     const highestSeverity: ActionSeverity | null = reasons.length === 0
       ? null
@@ -188,6 +225,9 @@ export async function GET() {
       cert_expiring_60: cert.expiring60,
       expired_certifications: cert.expired,
       revoked_certifications: cert.revoked,
+      has_schedule_template: hasTemplate.has(profile.id),
+      pending_time_off_requests: pendingTimeOffCount,
+      upcoming_approved_time_away: upcomingAwayCount,
       needs_action: reasons.length > 0,
       highest_action_severity: highestSeverity,
       action_reasons: reasons,

--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -44,5 +44,42 @@ export async function GET(req: NextRequest) {
   if (entriesErr) return NextResponse.json({ error: entriesErr.message }, { status: 500 });
   if (exErr) return NextResponse.json({ error: exErr.message }, { status: 500 });
 
-  return NextResponse.json({ periods: periods ?? [], activePeriodId, entries: entries ?? [], exceptions: exceptions ?? [] });
+  const selectedPeriod = (periods ?? []).find((period: any) => period.id === activePeriodId);
+  const periodStartIso = selectedPeriod ? `${selectedPeriod.period_start}T00:00:00.000Z` : null;
+  const periodEndIso = selectedPeriod ? `${selectedPeriod.period_end}T23:59:59.999Z` : null;
+
+  let scheduleRows: Array<{ user_id: string; schedule_date: string; start_time: string | null; end_time: string | null; unpaid_break_minutes: number | null }> = [];
+  let timeAwayRows: Array<{ user_id: string; starts_at: string; ends_at: string }> = [];
+  if (periodStartIso && periodEndIso) {
+    const [{ data: scheduleData }, { data: awayData }] = await Promise.all([
+      admin.from("staff_schedule_overrides").select("user_id, schedule_date, start_time, end_time, unpaid_break_minutes").eq("shop_id", me.shop_id).gte("schedule_date", selectedPeriod.period_start).lte("schedule_date", selectedPeriod.period_end).eq("status", "scheduled"),
+      admin.from("staff_availability_blocks").select("user_id, starts_at, ends_at").eq("shop_id", me.shop_id).lte("starts_at", periodEndIso).gte("ends_at", periodStartIso),
+    ]);
+    scheduleRows = (scheduleData ?? []) as typeof scheduleRows;
+    timeAwayRows = (awayData ?? []) as typeof timeAwayRows;
+  }
+
+  const scheduleMap = new Map<string, number>();
+  for (const row of scheduleRows) {
+    if (!row.start_time || !row.end_time) continue;
+    const mins = Math.max(0, (new Date(row.end_time).getTime() - new Date(row.start_time).getTime()) / 60000 - Number(row.unpaid_break_minutes ?? 0));
+    const key = `${row.user_id}|${row.schedule_date}`;
+    scheduleMap.set(key, Math.round(mins));
+  }
+
+  const awayMap = new Map<string, number>();
+  for (const row of timeAwayRows) {
+    const start = new Date(row.starts_at).getTime();
+    const end = new Date(row.ends_at).getTime();
+    const minutes = Math.max(0, Math.round((end - start) / 60000));
+    awayMap.set(row.user_id, (awayMap.get(row.user_id) ?? 0) + minutes);
+  }
+
+  const enrichedEntries = (entries ?? []).map((entry: any) => ({
+    ...entry,
+    scheduled_minutes: scheduleMap.get(`${entry.user_id}|${entry.work_date}`) ?? 0,
+    approved_time_away_minutes_in_period: awayMap.get(entry.user_id) ?? 0,
+  }));
+
+  return NextResponse.json({ periods: periods ?? [], activePeriodId, entries: enrichedEntries, exceptions: exceptions ?? [] });
 }

--- a/app/api/scheduling/staff/[id]/overrides/route.ts
+++ b/app/api/scheduling/staff/[id]/overrides/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(req: NextRequest, context: Ctx) {
+  const { id } = await context.params;
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const actor = getActorCapabilities({ role: access.profile.role });
+  if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => null) as null | {
+    schedule_date?: string;
+    start_time?: string | null;
+    end_time?: string | null;
+    unpaid_break_minutes?: number | null;
+    notes?: string | null;
+  };
+
+  if (!body?.schedule_date) return NextResponse.json({ error: "schedule_date required" }, { status: 400 });
+
+  const admin = createAdminSupabase() as any;
+  const { error } = await admin.from("staff_schedule_overrides").insert({
+    shop_id: access.profile.shop_id,
+    user_id: id,
+    schedule_date: body.schedule_date,
+    start_time: body.start_time ?? null,
+    end_time: body.end_time ?? null,
+    unpaid_break_minutes: Math.max(0, Number(body.unpaid_break_minutes ?? 0)),
+    notes: body.notes ?? null,
+    source_type: "manual_override",
+    status: "scheduled",
+    created_by: access.profile.id,
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await admin.from("audit_logs").insert({
+    actor_id: access.profile.id,
+    action: "staff.schedule.override.created",
+    target: id,
+    metadata: { shop_id: access.profile.shop_id, schedule_date: body.schedule_date },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/scheduling/staff/[id]/route.ts
+++ b/app/api/scheduling/staff/[id]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+async function checkStaffInShop(admin: any, shopId: string, userId: string) {
+  const { data, error } = await admin.from("profiles").select("id, shop_id, full_name, email, role").eq("id", userId).maybeSingle();
+  if (error) return { ok: false, error: error.message } as const;
+  if (!data || data.shop_id !== shopId) return { ok: false, error: "Staff not found" } as const;
+  return { ok: true, profile: data } as const;
+}
+
+export async function GET(_req: NextRequest, context: Ctx) {
+  const { id } = await context.params;
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const actor = getActorCapabilities({ role: access.profile.role });
+  if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const admin = createAdminSupabase() as any;
+  const check = await checkStaffInShop(admin, access.profile.shop_id!, id);
+  if (!check.ok) return NextResponse.json({ error: check.error }, { status: 404 });
+
+  const [{ data: templates }, { data: overrides }, { data: blocks }, { data: requests }] = await Promise.all([
+    admin.from("staff_schedule_templates").select("*").eq("shop_id", access.profile.shop_id).eq("user_id", id).order("day_of_week", { ascending: true }),
+    admin.from("staff_schedule_overrides").select("*").eq("shop_id", access.profile.shop_id).eq("user_id", id).order("schedule_date", { ascending: true }).limit(60),
+    admin.from("staff_availability_blocks").select("*").eq("shop_id", access.profile.shop_id).eq("user_id", id).order("starts_at", { ascending: true }).limit(60),
+    admin.from("staff_time_off_requests").select("*").eq("shop_id", access.profile.shop_id).eq("user_id", id).order("created_at", { ascending: false }).limit(60),
+  ]);
+
+  return NextResponse.json({ person: check.profile, templates: templates ?? [], overrides: overrides ?? [], availability_blocks: blocks ?? [], time_off_requests: requests ?? [] });
+}
+
+export async function PUT(req: NextRequest, context: Ctx) {
+  const { id } = await context.params;
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const actor = getActorCapabilities({ role: access.profile.role });
+  if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => null) as null | {
+    templates?: Array<{
+      day_of_week: number;
+      is_working_day?: boolean;
+      start_time?: string | null;
+      end_time?: string | null;
+      unpaid_break_minutes?: number | null;
+      effective_from?: string | null;
+      effective_to?: string | null;
+    }>;
+  };
+
+  if (!body?.templates || !Array.isArray(body.templates)) {
+    return NextResponse.json({ error: "templates[] required" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase() as any;
+  const check = await checkStaffInShop(admin, access.profile.shop_id!, id);
+  if (!check.ok) return NextResponse.json({ error: check.error }, { status: 404 });
+
+  await admin.from("staff_schedule_templates").delete().eq("shop_id", access.profile.shop_id).eq("user_id", id);
+
+  const normalized = body.templates
+    .filter((row) => Number.isInteger(row.day_of_week) && row.day_of_week >= 0 && row.day_of_week <= 6)
+    .map((row) => ({
+      shop_id: access.profile.shop_id,
+      user_id: id,
+      day_of_week: row.day_of_week,
+      is_working_day: row.is_working_day ?? true,
+      start_time: row.start_time ?? null,
+      end_time: row.end_time ?? null,
+      unpaid_break_minutes: Math.max(0, Number(row.unpaid_break_minutes ?? 0)),
+      effective_from: row.effective_from ?? null,
+      effective_to: row.effective_to ?? null,
+    }));
+
+  if (normalized.length > 0) {
+    const { error } = await admin.from("staff_schedule_templates").insert(normalized);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await admin.from("audit_logs").insert({
+    actor_id: access.profile.id,
+    action: "staff.schedule.template.updated",
+    target: id,
+    metadata: {
+      shop_id: access.profile.shop_id,
+      template_rows: normalized.length,
+    },
+  });
+
+  return NextResponse.json({ ok: true, templates: normalized });
+}

--- a/app/api/scheduling/staff/overrides/[overrideId]/route.ts
+++ b/app/api/scheduling/staff/overrides/[overrideId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type Ctx = { params: Promise<{ overrideId: string }> };
+
+export async function PATCH(req: NextRequest, context: Ctx) {
+  const { overrideId } = await context.params;
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const actor = getActorCapabilities({ role: access.profile.role });
+  if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => null) as Record<string, unknown> | null;
+  if (!body) return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+
+  const update: Record<string, unknown> = {
+    ...(body.start_time !== undefined ? { start_time: body.start_time } : {}),
+    ...(body.end_time !== undefined ? { end_time: body.end_time } : {}),
+    ...(body.status !== undefined ? { status: body.status } : {}),
+    ...(body.notes !== undefined ? { notes: body.notes } : {}),
+    ...(body.unpaid_break_minutes !== undefined ? { unpaid_break_minutes: Math.max(0, Number(body.unpaid_break_minutes ?? 0)) } : {}),
+    updated_at: new Date().toISOString(),
+  };
+
+  const admin = createAdminSupabase() as any;
+  const { data, error } = await admin
+    .from("staff_schedule_overrides")
+    .update(update)
+    .eq("id", overrideId)
+    .eq("shop_id", access.profile.shop_id)
+    .select("*")
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Override not found" }, { status: 404 });
+
+  await admin.from("audit_logs").insert({
+    actor_id: access.profile.id,
+    action: "staff.schedule.override.updated",
+    target: data.user_id,
+    metadata: { shop_id: access.profile.shop_id, override_id: overrideId, status: data.status },
+  });
+
+  return NextResponse.json({ ok: true, override: data });
+}
+
+export async function DELETE(_req: NextRequest, context: Ctx) {
+  const { overrideId } = await context.params;
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const actor = getActorCapabilities({ role: access.profile.role });
+  if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const admin = createAdminSupabase() as any;
+  const { data, error } = await admin
+    .from("staff_schedule_overrides")
+    .delete()
+    .eq("id", overrideId)
+    .eq("shop_id", access.profile.shop_id)
+    .select("id, user_id")
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Override not found" }, { status: 404 });
+
+  await admin.from("audit_logs").insert({
+    actor_id: access.profile.id,
+    action: "staff.schedule.override.deleted",
+    target: data.user_id,
+    metadata: { shop_id: access.profile.shop_id, override_id: overrideId },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/scheduling/staff/route.ts
+++ b/app/api/scheduling/staff/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+function toDayBounds(date: Date) {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export async function GET(req: NextRequest) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const actor = getActorCapabilities({ role: access.profile.role });
+  if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const admin = createAdminSupabase() as any;
+  const url = new URL(req.url);
+  const from = url.searchParams.get("from") ?? new Date().toISOString();
+  const to = url.searchParams.get("to") ?? new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString();
+
+  const [profilesRes, templatesRes, overridesRes, blocksRes, requestsRes] = await Promise.all([
+    admin.from("profiles").select("id, full_name, email, role").eq("shop_id", access.profile.shop_id).order("full_name", { ascending: true }),
+    admin.from("staff_schedule_templates").select("*").eq("shop_id", access.profile.shop_id),
+    admin.from("staff_schedule_overrides").select("*").eq("shop_id", access.profile.shop_id).gte("schedule_date", from.slice(0, 10)).lte("schedule_date", to.slice(0, 10)),
+    admin.from("staff_availability_blocks").select("*").eq("shop_id", access.profile.shop_id).lte("starts_at", to).gte("ends_at", from),
+    admin.from("staff_time_off_requests").select("*").eq("shop_id", access.profile.shop_id).eq("status", "pending").order("created_at", { ascending: true }).limit(50),
+  ]);
+
+  if (profilesRes.error) return NextResponse.json({ error: profilesRes.error.message }, { status: 500 });
+  if (templatesRes.error) return NextResponse.json({ error: templatesRes.error.message }, { status: 500 });
+  if (overridesRes.error) return NextResponse.json({ error: overridesRes.error.message }, { status: 500 });
+  if (blocksRes.error) return NextResponse.json({ error: blocksRes.error.message }, { status: 500 });
+  if (requestsRes.error) return NextResponse.json({ error: requestsRes.error.message }, { status: 500 });
+
+  const templates = templatesRes.data ?? [];
+  const overrides = overridesRes.data ?? [];
+  const blocks = blocksRes.data ?? [];
+
+  const staff = (profilesRes.data ?? []).map((p: any) => {
+    const personTemplates = templates.filter((t: any) => t.user_id === p.id);
+    const personOverrides = overrides.filter((o: any) => o.user_id === p.id && o.status !== "cancelled");
+    const personBlocks = blocks.filter((b: any) => b.user_id === p.id);
+
+    let recurringMinutes = 0;
+    for (const row of personTemplates) {
+      if (!row.is_working_day || !row.start_time || !row.end_time) continue;
+      const [sh, sm] = String(row.start_time).split(":").map(Number);
+      const [eh, em] = String(row.end_time).split(":").map(Number);
+      recurringMinutes += Math.max(0, (eh * 60 + em) - (sh * 60 + sm) - (row.unpaid_break_minutes ?? 0));
+    }
+
+    const todayBounds = toDayBounds(new Date());
+    const isAwayToday = personBlocks.some((b: any) => b.starts_at < todayBounds.end && b.ends_at > todayBounds.start);
+
+    return {
+      ...p,
+      recurring_template_rows: personTemplates.length,
+      weekly_recurring_minutes: recurringMinutes,
+      override_count_in_range: personOverrides.length,
+      approved_away_blocks_in_range: personBlocks.length,
+      is_away_today: isAwayToday,
+      next_override: personOverrides
+        .slice()
+        .sort((a: any, b: any) => String(a.schedule_date).localeCompare(String(b.schedule_date)))[0] ?? null,
+    };
+  });
+
+  return NextResponse.json({
+    staff,
+    templates,
+    overrides,
+    availability_blocks: blocks,
+    pending_time_off_requests: requestsRes.data ?? [],
+  });
+}

--- a/app/api/time-off/requests/[id]/route.ts
+++ b/app/api/time-off/requests/[id]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, context: Ctx) {
+  const { id } = await context.params;
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const body = await req.json().catch(() => null) as null | {
+    status?: "pending" | "approved" | "declined" | "cancelled";
+    review_note?: string | null;
+  };
+
+  if (!body?.status) return NextResponse.json({ error: "status required" }, { status: 400 });
+
+  const admin = access.supabase as any;
+  const actor = getActorCapabilities({ role: access.profile.role });
+
+  const { data: existing, error: existingErr } = await admin
+    .from("staff_time_off_requests")
+    .select("*")
+    .eq("id", id)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+
+  if (existingErr) return NextResponse.json({ error: existingErr.message }, { status: 500 });
+  if (!existing) return NextResponse.json({ error: "Request not found" }, { status: 404 });
+
+  const isOwn = existing.user_id === access.profile.id;
+  if (!actor.canManageScheduling && !(isOwn && body.status === "cancelled" && existing.status === "pending")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const next: Record<string, unknown> = {
+    status: body.status,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (body.status === "approved" || body.status === "declined") {
+    next.reviewed_at = new Date().toISOString();
+    next.reviewed_by = access.profile.id;
+    next.review_note = body.review_note ?? null;
+  }
+
+  const { data: updated, error: updateErr } = await admin
+    .from("staff_time_off_requests")
+    .update(next)
+    .eq("id", id)
+    .eq("shop_id", access.profile.shop_id)
+    .select("*")
+    .single();
+
+  if (updateErr) return NextResponse.json({ error: updateErr.message }, { status: 500 });
+
+  if (body.status === "approved") {
+    await admin.from("staff_availability_blocks").upsert({
+      shop_id: access.profile.shop_id,
+      user_id: existing.user_id,
+      source_type: "time_off_request",
+      source_id: existing.id,
+      block_type: existing.request_type,
+      starts_at: existing.starts_at,
+      ends_at: existing.ends_at,
+      label: existing.reason ?? `${existing.request_type} time away`,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: "shop_id,source_type,source_id" });
+  }
+
+  if (body.status === "declined" || body.status === "cancelled") {
+    await admin
+      .from("staff_availability_blocks")
+      .delete()
+      .eq("shop_id", access.profile.shop_id)
+      .eq("source_type", "time_off_request")
+      .eq("source_id", existing.id);
+  }
+
+  await admin.from("audit_logs").insert({
+    actor_id: access.profile.id,
+    action: `staff.time_off.${body.status}`,
+    target: existing.user_id,
+    metadata: {
+      shop_id: access.profile.shop_id,
+      request_id: existing.id,
+      previous_status: existing.status,
+      next_status: body.status,
+      review_note: body.review_note ?? null,
+    },
+  });
+
+  return NextResponse.json({ ok: true, request: updated });
+}

--- a/app/api/time-off/requests/route.ts
+++ b/app/api/time-off/requests/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+export async function GET(req: NextRequest) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const actor = getActorCapabilities({ role: access.profile.role });
+  const admin = access.supabase as any;
+  const url = new URL(req.url);
+  const status = url.searchParams.get("status")?.trim() || null;
+  const userId = url.searchParams.get("user_id")?.trim() || null;
+
+  let q = admin
+    .from("staff_time_off_requests")
+    .select("*, requester:requested_by(full_name, email), reviewer:reviewed_by(full_name, email)")
+    .eq("shop_id", access.profile.shop_id)
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  if (!actor.canManageScheduling) {
+    q = q.eq("user_id", access.profile.id);
+  } else if (userId) {
+    q = q.eq("user_id", userId);
+  }
+
+  if (status) q = q.eq("status", status);
+
+  const { data, error } = await q;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ requests: data ?? [] });
+}
+
+export async function POST(req: NextRequest) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const body = await req.json().catch(() => null) as null | {
+    user_id?: string;
+    request_type?: string;
+    starts_at?: string;
+    ends_at?: string;
+    is_partial_day?: boolean;
+    reason?: string | null;
+  };
+
+  if (!body?.starts_at || !body?.ends_at || !body?.request_type) {
+    return NextResponse.json({ error: "request_type, starts_at, ends_at required" }, { status: 400 });
+  }
+
+  const actor = getActorCapabilities({ role: access.profile.role });
+  const targetUserId = actor.canManageScheduling ? (body.user_id ?? access.profile.id) : access.profile.id;
+  if (!targetUserId) return NextResponse.json({ error: "Missing user context" }, { status: 400 });
+
+  const admin = access.supabase as any;
+  const insertPayload = {
+    shop_id: access.profile.shop_id,
+    user_id: targetUserId,
+    request_type: body.request_type,
+    starts_at: body.starts_at,
+    ends_at: body.ends_at,
+    is_partial_day: Boolean(body.is_partial_day),
+    status: "pending",
+    reason: body.reason ?? null,
+    requested_by: access.profile.id,
+  };
+
+  const { data, error } = await admin.from("staff_time_off_requests").insert(insertPayload).select("*").single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await admin.from("audit_logs").insert({
+    actor_id: access.profile.id,
+    action: "staff.time_off.requested",
+    target: targetUserId,
+    metadata: {
+      shop_id: access.profile.shop_id,
+      request_id: data.id,
+      starts_at: body.starts_at,
+      ends_at: body.ends_at,
+      request_type: body.request_type,
+    },
+  });
+
+  return NextResponse.json({ ok: true, request: data });
+}

--- a/app/dashboard/admin/scheduling/page.tsx
+++ b/app/dashboard/admin/scheduling/page.tsx
@@ -1,7 +1,7 @@
-import { redirect } from "next/navigation";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import WorkforceSchedulingClient from "@/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient";
 
 export default async function Page() {
-  await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
-  redirect("/dashboard/appointments");
+  await requireAdminPageAccess({ allow: ["owner", "admin", "manager"] });
+  return <WorkforceSchedulingClient />;
 }

--- a/db/sql/2026-04-15_staff_scheduling_time_off.sql
+++ b/db/sql/2026-04-15_staff_scheduling_time_off.sql
@@ -1,0 +1,117 @@
+-- Staff scheduling + time off foundation (additive)
+
+create table if not exists public.staff_schedule_templates (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  day_of_week int not null check (day_of_week between 0 and 6),
+  is_working_day boolean not null default true,
+  start_time time,
+  end_time time,
+  unpaid_break_minutes int not null default 0,
+  effective_from date,
+  effective_to date,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, user_id, day_of_week, effective_from)
+);
+
+create table if not exists public.staff_schedule_overrides (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  schedule_date date not null,
+  start_time timestamptz,
+  end_time timestamptz,
+  unpaid_break_minutes int not null default 0,
+  source_type text not null default 'manual_override',
+  status text not null default 'scheduled' check (status in ('scheduled', 'cancelled')),
+  notes text,
+  created_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.staff_time_off_requests (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  request_type text not null,
+  starts_at timestamptz not null,
+  ends_at timestamptz not null,
+  is_partial_day boolean not null default false,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'declined', 'cancelled')),
+  reason text,
+  requested_at timestamptz not null default now(),
+  requested_by uuid not null references public.profiles(id) on delete restrict,
+  reviewed_at timestamptz,
+  reviewed_by uuid references public.profiles(id) on delete set null,
+  review_note text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (ends_at > starts_at)
+);
+
+create table if not exists public.staff_availability_blocks (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  source_type text not null,
+  source_id uuid,
+  block_type text not null,
+  starts_at timestamptz not null,
+  ends_at timestamptz not null,
+  label text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (ends_at > starts_at)
+);
+
+create index if not exists idx_staff_sched_templates_shop_user on public.staff_schedule_templates(shop_id, user_id);
+create index if not exists idx_staff_sched_overrides_shop_date on public.staff_schedule_overrides(shop_id, schedule_date);
+create index if not exists idx_staff_sched_overrides_shop_user_date on public.staff_schedule_overrides(shop_id, user_id, schedule_date);
+create index if not exists idx_staff_time_off_shop_status on public.staff_time_off_requests(shop_id, status);
+create index if not exists idx_staff_time_off_shop_user_dates on public.staff_time_off_requests(shop_id, user_id, starts_at, ends_at);
+create index if not exists idx_staff_avail_blocks_shop_user_dates on public.staff_availability_blocks(shop_id, user_id, starts_at, ends_at);
+create unique index if not exists idx_staff_avail_blocks_source on public.staff_availability_blocks(shop_id, source_type, source_id) where source_id is not null;
+
+alter table public.staff_schedule_templates enable row level security;
+alter table public.staff_schedule_overrides enable row level security;
+alter table public.staff_time_off_requests enable row level security;
+alter table public.staff_availability_blocks enable row level security;
+
+do $$ begin
+  create policy staff_schedule_templates_shop_all on public.staff_schedule_templates
+    for all to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy staff_schedule_overrides_shop_all on public.staff_schedule_overrides
+    for all to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy staff_time_off_requests_shop_all on public.staff_time_off_requests
+    for all to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy staff_time_off_requests_self on public.staff_time_off_requests
+    for all to authenticated
+    using (user_id = auth.uid())
+    with check (user_id = auth.uid());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy staff_availability_blocks_shop_all on public.staff_availability_blocks
+    for all to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+

--- a/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
@@ -34,6 +34,9 @@ type PersonRow = {
   cert_expiring_60: number;
   expired_certifications: number;
   revoked_certifications: number;
+  has_schedule_template: boolean;
+  pending_time_off_requests: number;
+  upcoming_approved_time_away: number;
   needs_action: boolean;
   highest_action_severity: "blocking" | "warning" | "informational" | null;
   action_counts: { blocking: number; warning: number; informational: number };
@@ -102,6 +105,7 @@ export default function PeoplePageClient() {
       onboardingMissing: source.filter((row) => !row.completed_onboarding).length,
       payrollFollowUp: source.filter((row) => row.payroll_blocking_exceptions > 0 || row.payroll_warning_exceptions > 0 || !row.payroll_ready).length,
       certFollowUp: source.filter((row) => row.expired_certifications > 0 || row.expiring_certifications > 0).length,
+      pendingTimeOff: source.filter((row) => row.pending_time_off_requests > 0).length,
       inactive: source.filter((row) => row.employment_status === "inactive").length,
       needsAction: source.filter((row) => row.needs_action).length,
     };
@@ -125,6 +129,7 @@ export default function PeoplePageClient() {
           <AdminStatCard label="Onboarding incomplete" value={summary.onboardingMissing} />
           <AdminStatCard label="Payroll follow-up" value={summary.payrollFollowUp} hint="Exceptions or not payroll-ready" />
           <AdminStatCard label="Credential follow-up" value={summary.certFollowUp} hint="Expired or expiring in 30 days" />
+          <AdminStatCard label="Pending time off" value={summary.pendingTimeOff} />
           <AdminStatCard label="Needs action now" value={summary.needsAction} hint="Blocking/warning/informational triage" />
           <AdminStatCard label="Inactive workforce" value={summary.inactive} />
         </AdminStatGrid>
@@ -194,6 +199,7 @@ export default function PeoplePageClient() {
                   <th className="px-4 py-2.5 text-left">Workforce</th>
                   <th className="px-4 py-2.5 text-left">Certifications</th>
                   <th className="px-4 py-2.5 text-left">Payroll posture</th>
+                  <th className="px-4 py-2.5 text-left">Scheduling</th>
                   <th className="px-4 py-2.5 text-left">Follow-up</th>
                 </tr>
               </thead>
@@ -232,6 +238,14 @@ export default function PeoplePageClient() {
                       <td className="px-4 py-2.5 text-xs">
                         {row.payroll_blocking_exceptions > 0 ? `${row.payroll_blocking_exceptions} blocking` : row.payroll_warning_exceptions > 0 ? `${row.payroll_warning_exceptions} warning` : row.payroll_ready ? "Ready" : "Not ready"}
                         <p className="text-neutral-400">{row.payroll_open_period_entries} open entries</p>
+                      </td>
+                      <td className="px-4 py-2.5 text-xs">
+                        <p className={row.has_schedule_template ? "text-emerald-300" : "text-amber-300"}>
+                          {row.has_schedule_template ? "Template set" : "No template"}
+                        </p>
+                        <p className="text-neutral-400">
+                          {row.pending_time_off_requests} pending · {row.upcoming_approved_time_away} upcoming away
+                        </p>
                       </td>
                       <td className="px-4 py-2.5">
                         <AdminBadge>{row.needs_action ? "Needs action" : "Healthy"}</AdminBadge>

--- a/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
@@ -55,6 +55,16 @@ type PersonDetail = {
     in_current_period: boolean;
     missing_workforce_data: string[];
   };
+  schedule_posture: {
+    has_recurring_schedule: boolean;
+    recurring_rows: number;
+    upcoming_override_count: number;
+    upcoming_approved_away_count: number;
+    next_override: { schedule_date?: string | null } | null;
+    next_away_block: { starts_at?: string | null; block_type?: string | null } | null;
+  };
+  upcoming_time_off: Array<{ id: string; starts_at: string; ends_at: string; block_type: string; label?: string | null }>;
+  recent_time_off_requests: Array<{ id: string; status: string; starts_at: string; ends_at: string; request_type: string; reason?: string | null }>;
   needs_action: boolean;
   action_reasons: Array<{
     code: string;
@@ -305,6 +315,8 @@ export default function PersonDetailClient({ personId, from }: { personId: strin
           <AdminStatCard label="Payroll blocking" value={detail.payroll_posture.blocking_exceptions} />
           <AdminStatCard label="Expiring certs (30d)" value={certSummary.expiring30} />
           <AdminStatCard label="Expired certs" value={certSummary.expired} />
+          <AdminStatCard label="Schedule rows" value={detail.schedule_posture.recurring_rows} />
+          <AdminStatCard label="Upcoming time away" value={detail.schedule_posture.upcoming_approved_away_count} />
         </AdminStatGrid>
         <div className="p-4 text-xs text-neutral-300">
           <p className="mb-2 font-medium text-neutral-100">Top missing items</p>
@@ -312,6 +324,23 @@ export default function PersonDetailClient({ personId, from }: { personId: strin
         </div>
       </AdminPanel>
       </div>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Schedule & Time Off Posture" description="Workforce scheduling posture tied to this canonical People record." />
+        <div className="grid gap-3 p-4 md:grid-cols-3">
+          <AdminStatCard label="Recurring schedule" value={detail.schedule_posture.has_recurring_schedule ? "Configured" : "Missing"} />
+          <AdminStatCard label="Overrides (next 2 weeks)" value={detail.schedule_posture.upcoming_override_count} />
+          <AdminStatCard label="Approved away blocks" value={detail.schedule_posture.upcoming_approved_away_count} />
+        </div>
+        <div className="px-4 pb-4 text-xs text-neutral-300">
+          <p className="mb-2">Next actions:</p>
+          <p>• <Link className="text-orange-300 hover:text-orange-200" href="/dashboard/admin/scheduling">Open scheduling board</Link></p>
+          <p>• <Link className="text-orange-300 hover:text-orange-200" href={`/dashboard/admin/payroll-time?person_id=${personId}`}>Open payroll-time review</Link></p>
+          {detail.recent_time_off_requests.slice(0, 3).map((request) => (
+            <p key={request.id}>• {request.request_type} ({request.status}) {new Date(request.starts_at).toLocaleDateString()} → {new Date(request.ends_at).toLocaleDateString()}</p>
+          ))}
+        </div>
+      </AdminPanel>
 
       <AdminPanel>
         <AdminPanelTitle title="Identity & Access" description="Account governance belongs here: identity fields, role, and account posture." />

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -36,6 +36,8 @@ type Entry = {
   has_exceptions: boolean;
   blocking_exception_count: number;
   warning_exception_count: number;
+  scheduled_minutes?: number;
+  approved_time_away_minutes_in_period?: number;
   profiles?: { full_name?: string | null; email?: string | null } | null;
 };
 
@@ -199,6 +201,9 @@ export default function PayrollTimeClient() {
           <Link href="/dashboard/admin/people" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
             Open People Directory
           </Link>
+          <Link href="/dashboard/admin/scheduling" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
+            Open Scheduling Board
+          </Link>
           <span className="text-neutral-400">Use People for all person-level governance, certifications, onboarding, and workforce updates.</span>
         </div>
       </AdminPanel>
@@ -282,6 +287,8 @@ export default function PayrollTimeClient() {
                   <th className="px-4 py-2.5 text-right">OT-ready</th>
                   <th className="px-4 py-2.5 text-right">Unpaid break</th>
                   <th className="px-4 py-2.5 text-right">Job context</th>
+                  <th className="px-4 py-2.5 text-right">Scheduled</th>
+                  <th className="px-4 py-2.5 text-right">Approved away</th>
                   <th className="px-4 py-2.5 text-left">Exceptions</th>
                 </tr>
               </thead>
@@ -298,6 +305,8 @@ export default function PayrollTimeClient() {
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.overtime_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.unpaid_break_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.job_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.scheduled_minutes ?? 0)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.approved_time_away_minutes_in_period ?? 0)}h</td>
                     <td className="px-4 py-2.5">
                       {entry.blocking_exception_count > 0 ? (
                         <AdminBadge>{entry.blocking_exception_count} blocking</AdminBadge>

--- a/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { AdminPageHeader, AdminPageShell, AdminPanel, AdminPanelTitle } from "@/features/dashboard/app/dashboard/admin/AdminSurface";
+
+type Staff = {
+  id: string;
+  full_name: string | null;
+  role: string | null;
+  weekly_recurring_minutes: number;
+  recurring_template_rows: number;
+  override_count_in_range: number;
+  approved_away_blocks_in_range: number;
+  is_away_today: boolean;
+};
+
+type TimeOffRequest = {
+  id: string;
+  user_id: string;
+  request_type: string;
+  starts_at: string;
+  ends_at: string;
+  status: "pending" | "approved" | "declined" | "cancelled";
+  reason: string | null;
+};
+
+type TemplateRow = {
+  day_of_week: number;
+  is_working_day: boolean;
+  start_time: string | null;
+  end_time: string | null;
+  unpaid_break_minutes: number;
+};
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function minsToHours(mins: number) {
+  return (mins / 60).toFixed(1);
+}
+
+function emptyTemplate(): TemplateRow[] {
+  return DAYS.map((_, day_of_week) => ({ day_of_week, is_working_day: day_of_week >= 1 && day_of_week <= 5, start_time: "08:00", end_time: "17:00", unpaid_break_minutes: 30 }));
+}
+
+export default function WorkforceSchedulingClient() {
+  const [staff, setStaff] = useState<Staff[]>([]);
+  const [pending, setPending] = useState<TimeOffRequest[]>([]);
+  const [selectedStaffId, setSelectedStaffId] = useState<string>("");
+  const [templates, setTemplates] = useState<TemplateRow[]>(emptyTemplate());
+  const [overrideDate, setOverrideDate] = useState("");
+  const [overrideStart, setOverrideStart] = useState("");
+  const [overrideEnd, setOverrideEnd] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function load() {
+    const now = new Date();
+    const to = new Date(now);
+    to.setDate(now.getDate() + 7);
+    const qs = new URLSearchParams({ from: now.toISOString(), to: to.toISOString() });
+    const res = await fetch(`/api/scheduling/staff?${qs}`, { cache: "no-store" });
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      setError(body?.error ?? "Failed to load scheduling data");
+      return;
+    }
+    setStaff(body?.staff ?? []);
+    setPending(body?.pending_time_off_requests ?? []);
+    if (!selectedStaffId && body?.staff?.length) setSelectedStaffId(body.staff[0].id);
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedStaffId) return;
+    (async () => {
+      const res = await fetch(`/api/scheduling/staff/${selectedStaffId}`, { cache: "no-store" });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) return;
+      const fromApi = (body?.templates ?? []) as TemplateRow[];
+      setTemplates(fromApi.length ? fromApi : emptyTemplate());
+    })();
+  }, [selectedStaffId]);
+
+  const selected = useMemo(() => staff.find((s) => s.id === selectedStaffId) ?? null, [staff, selectedStaffId]);
+
+  async function saveTemplate() {
+    if (!selectedStaffId) return;
+    setBusy(true);
+    const res = await fetch(`/api/scheduling/staff/${selectedStaffId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ templates }),
+    });
+    const body = await res.json().catch(() => null);
+    setBusy(false);
+    if (!res.ok) {
+      setError(body?.error ?? "Failed to save template");
+      return;
+    }
+    await load();
+  }
+
+  async function addOverride() {
+    if (!selectedStaffId || !overrideDate) return;
+    setBusy(true);
+    const startIso = overrideStart ? `${overrideDate}T${overrideStart}:00.000Z` : null;
+    const endIso = overrideEnd ? `${overrideDate}T${overrideEnd}:00.000Z` : null;
+    const res = await fetch(`/api/scheduling/staff/${selectedStaffId}/overrides`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ schedule_date: overrideDate, start_time: startIso, end_time: endIso }),
+    });
+    const body = await res.json().catch(() => null);
+    setBusy(false);
+    if (!res.ok) return setError(body?.error ?? "Failed to add override");
+    setOverrideDate("");
+    setOverrideStart("");
+    setOverrideEnd("");
+    await load();
+  }
+
+  async function reviewRequest(id: string, status: "approved" | "declined") {
+    setBusy(true);
+    const res = await fetch(`/api/time-off/requests/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    const body = await res.json().catch(() => null);
+    setBusy(false);
+    if (!res.ok) return setError(body?.error ?? "Failed to review request");
+    await load();
+  }
+
+  return (
+    <AdminPageShell>
+      <AdminPageHeader
+        eyebrow="Workforce Operations"
+        title="Staff Scheduling + Time Away"
+        subtitle="Recurring templates, one-off shift overrides, and time off approvals in one scheduling surface tied to People and Payroll Time."
+      />
+
+      <AdminPanel>
+        <AdminPanelTitle title="Team Weekly Posture" description="Scan schedule readiness, override volume, and approved away blocks." />
+        <div className="overflow-x-auto p-4">
+          <table className="min-w-full text-sm">
+            <thead className="text-xs uppercase text-neutral-400"><tr><th className="text-left">Staff</th><th className="text-left">Role</th><th className="text-left">Recurring hrs/wk</th><th className="text-left">Template rows</th><th className="text-left">Overrides (7d)</th><th className="text-left">Away blocks (7d)</th><th className="text-left">Status</th></tr></thead>
+            <tbody className="divide-y divide-white/10">
+              {staff.map((s) => (
+                <tr key={s.id} onClick={() => setSelectedStaffId(s.id)} className={`cursor-pointer ${selectedStaffId === s.id ? "bg-white/10" : "hover:bg-white/5"}`}>
+                  <td className="py-2">{s.full_name ?? "Unnamed"}</td>
+                  <td>{s.role ?? "staff"}</td>
+                  <td>{minsToHours(s.weekly_recurring_minutes)}</td>
+                  <td>{s.recurring_template_rows}</td>
+                  <td>{s.override_count_in_range}</td>
+                  <td>{s.approved_away_blocks_in_range}</td>
+                  <td className={s.is_away_today ? "text-amber-300" : "text-emerald-300"}>{s.is_away_today ? "Away today" : "Available"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Pending Time Off Requests" description="Approve or decline from here; approvals automatically create schedule availability blocks." />
+        <div className="space-y-2 p-4 text-sm">
+          {pending.length === 0 ? <p className="text-neutral-400">No pending requests.</p> : pending.map((r) => (
+            <div key={r.id} className="rounded-lg border border-white/10 bg-black/30 p-3">
+              <p className="font-medium">{r.request_type} • {new Date(r.starts_at).toLocaleString()} → {new Date(r.ends_at).toLocaleString()}</p>
+              <p className="text-xs text-neutral-400">{r.reason ?? "No note"}</p>
+              <div className="mt-2 flex gap-2">
+                <button disabled={busy} onClick={() => void reviewRequest(r.id, "approved")} className="rounded border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">Approve</button>
+                <button disabled={busy} onClick={() => void reviewRequest(r.id, "declined")} className="rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-200">Decline</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle title="Staff Schedule Detail" description="Edit recurring weekly template and create one-off override shifts." />
+        <div className="grid gap-4 p-4 lg:grid-cols-2">
+          <div>
+            <p className="mb-2 text-xs text-neutral-400">Selected: {selected?.full_name ?? "None"}</p>
+            <div className="space-y-2">
+              {templates.sort((a, b) => a.day_of_week - b.day_of_week).map((row, i) => (
+                <div key={row.day_of_week} className="grid grid-cols-12 items-center gap-2 text-xs">
+                  <div className="col-span-2">{DAYS[row.day_of_week]}</div>
+                  <input type="checkbox" checked={row.is_working_day} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, is_working_day: e.target.checked } : x))} />
+                  <input type="time" value={row.start_time ?? ""} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, start_time: e.target.value } : x))} className="col-span-3 rounded border border-white/10 bg-black/30 px-2 py-1" />
+                  <input type="time" value={row.end_time ?? ""} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, end_time: e.target.value } : x))} className="col-span-3 rounded border border-white/10 bg-black/30 px-2 py-1" />
+                  <input type="number" value={row.unpaid_break_minutes} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, unpaid_break_minutes: Number(e.target.value) } : x))} className="col-span-2 rounded border border-white/10 bg-black/30 px-2 py-1" />
+                </div>
+              ))}
+            </div>
+            <button disabled={busy || !selectedStaffId} onClick={() => void saveTemplate()} className="mt-3 rounded border border-white/20 bg-white/10 px-3 py-2 text-xs">Save recurring template</button>
+          </div>
+          <div className="space-y-3 text-sm">
+            <p className="text-xs text-neutral-400">One-off override shift</p>
+            <input type="date" value={overrideDate} onChange={(e) => setOverrideDate(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
+            <input type="time" value={overrideStart} onChange={(e) => setOverrideStart(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
+            <input type="time" value={overrideEnd} onChange={(e) => setOverrideEnd(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
+            <button disabled={busy || !selectedStaffId || !overrideDate} onClick={() => void addOverride()} className="rounded border border-white/20 bg-white/10 px-3 py-2 text-xs">Add override</button>
+            <div className="text-xs text-neutral-400">Cross links: <Link className="text-orange-300" href="/dashboard/admin/people">People</Link> · <Link className="text-orange-300" href="/dashboard/admin/payroll-time">Payroll Time</Link></div>
+          </div>
+        </div>
+        {error ? <p className="px-4 pb-4 text-xs text-red-300">{error}</p> : null}
+      </AdminPanel>
+    </AdminPageShell>
+  );
+}

--- a/features/dashboard/app/dashboard/settings/user/page.tsx
+++ b/features/dashboard/app/dashboard/settings/user/page.tsx
@@ -11,6 +11,15 @@ import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard
 import ProfileContactCard from "@/features/users/components/ProfileContactCard";
 
 type StatusKind = "success" | "error" | "info";
+type TimeOffRequest = {
+  id: string;
+  request_type: string;
+  starts_at: string;
+  ends_at: string;
+  status: "pending" | "approved" | "declined" | "cancelled";
+  reason: string | null;
+  created_at: string;
+};
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -30,6 +39,11 @@ export default function SettingsPage() {
   const [status, setStatus] = useState<string>("");
   const [statusType, setStatusType] = useState<StatusKind>("info");
   const [busy, setBusy] = useState(false);
+  const [requests, setRequests] = useState<TimeOffRequest[]>([]);
+  const [requestType, setRequestType] = useState("vacation");
+  const [requestStart, setRequestStart] = useState("");
+  const [requestEnd, setRequestEnd] = useState("");
+  const [requestReason, setRequestReason] = useState("");
 
   useEffect(() => {
     const loadUser = async () => {
@@ -54,6 +68,10 @@ export default function SettingsPage() {
       setPhone(profile?.phone ?? "");
       setAvatarUrl(profile?.avatar_url ?? null);
       if (profile?.email) setEmail(profile.email);
+
+      const reqRes = await fetch("/api/time-off/requests", { cache: "no-store" });
+      const reqBody = await reqRes.json().catch(() => null);
+      if (reqRes.ok) setRequests((reqBody?.requests ?? []) as TimeOffRequest[]);
     };
     void loadUser();
   }, [supabase]);
@@ -132,6 +150,58 @@ export default function SettingsPage() {
       showStatus("Verification email resent.", "success");
       router.refresh();
     }
+  };
+
+  const loadTimeOff = async () => {
+    const reqRes = await fetch("/api/time-off/requests", { cache: "no-store" });
+    const reqBody = await reqRes.json().catch(() => null);
+    if (reqRes.ok) setRequests((reqBody?.requests ?? []) as TimeOffRequest[]);
+  };
+
+  const submitTimeOff = async () => {
+    if (!requestStart || !requestEnd) {
+      showStatus("Choose a start and end date/time for your request.", "error");
+      return;
+    }
+    setBusy(true);
+    const res = await fetch("/api/time-off/requests", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        request_type: requestType,
+        starts_at: new Date(requestStart).toISOString(),
+        ends_at: new Date(requestEnd).toISOString(),
+        reason: requestReason || null,
+      }),
+    });
+    const body = await res.json().catch(() => null);
+    setBusy(false);
+    if (!res.ok) {
+      showStatus(body?.error ?? "Failed to submit time off request.", "error");
+      return;
+    }
+    setRequestReason("");
+    setRequestStart("");
+    setRequestEnd("");
+    await loadTimeOff();
+    showStatus("Time off request submitted.", "success");
+  };
+
+  const cancelPendingRequest = async (id: string) => {
+    setBusy(true);
+    const res = await fetch(`/api/time-off/requests/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "cancelled" }),
+    });
+    const body = await res.json().catch(() => null);
+    setBusy(false);
+    if (!res.ok) {
+      showStatus(body?.error ?? "Failed to cancel request.", "error");
+      return;
+    }
+    await loadTimeOff();
+    showStatus("Request cancelled.", "success");
   };
 
   const statusClass =
@@ -228,6 +298,50 @@ export default function SettingsPage() {
         </Button>
         {status ? <span className={`text-sm ${statusClass}`}>{status}</span> : null}
       </div>
+
+      <section className="space-y-3 rounded-2xl border border-white/10 bg-black/35 p-4 shadow-card backdrop-blur-xl">
+        <h2 className="text-sm font-semibold text-neutral-50">Time Off</h2>
+        <p className="text-xs text-neutral-400">
+          Submit and track your own time away requests. Approved requests automatically block schedule availability.
+        </p>
+        <div className="grid gap-2 md:grid-cols-2">
+          <select className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm" value={requestType} onChange={(e) => setRequestType(e.target.value)}>
+            <option value="vacation">Vacation</option>
+            <option value="sick">Sick</option>
+            <option value="personal">Personal</option>
+            <option value="unpaid">Unpaid</option>
+          </select>
+          <input className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm" type="datetime-local" value={requestStart} onChange={(e) => setRequestStart(e.target.value)} />
+          <input className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm" type="datetime-local" value={requestEnd} onChange={(e) => setRequestEnd(e.target.value)} />
+          <input className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm md:col-span-2" placeholder="Reason (optional)" value={requestReason} onChange={(e) => setRequestReason(e.target.value)} />
+        </div>
+        <Button onClick={submitTimeOff} disabled={busy || !requestStart || !requestEnd}>
+          {busy ? "Submitting…" : "Request time off"}
+        </Button>
+
+        <div className="space-y-2">
+          {requests.length === 0 ? (
+            <p className="text-xs text-neutral-500">No time off requests yet.</p>
+          ) : (
+            requests.map((r) => (
+              <div key={r.id} className="rounded-lg border border-white/10 bg-black/30 p-3 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium text-neutral-100">
+                    {r.request_type} · {new Date(r.starts_at).toLocaleString()} → {new Date(r.ends_at).toLocaleString()}
+                  </p>
+                  <span className="text-xs uppercase tracking-wide text-neutral-300">{r.status}</span>
+                </div>
+                <p className="mt-1 text-xs text-neutral-400">{r.reason ?? "No note"}</p>
+                {r.status === "pending" ? (
+                  <button className="mt-2 rounded border border-white/15 px-2 py-1 text-xs text-neutral-200" onClick={() => void cancelPendingRequest(r.id)} disabled={busy}>
+                    Cancel request
+                  </button>
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class, shop-scoped workforce scheduling and time-off workflow that extends the canonical People system and ties into payroll/attendance posture.
- Keep changes additive, multi-tenant safe, and consistent with existing RLS and audit patterns so scheduling becomes a native operational surface (templates, overrides, time-off requests, availability blocks).

### Description
- Schema: added additive, shop-scoped tables with RLS and indexes: `staff_schedule_templates`, `staff_schedule_overrides`, `staff_time_off_requests`, `staff_availability_blocks` (including a unique source index and `current_shop_id()` policies). (see `db/sql/2026-04-15_staff_scheduling_time_off.sql`)
- APIs: implemented scheduling and time-off server surface: `GET /api/scheduling/staff`, `GET|PUT /api/scheduling/staff/[id]`, `POST /api/scheduling/staff/[id]/overrides`, `PATCH|DELETE /api/scheduling/staff/overrides/[overrideId]`, `GET|POST /api/time-off/requests`, and `PATCH /api/time-off/requests/[id]` with proper actor capability checks and audit logging; approvals upsert a corresponding availability block and declines/cancels remove it.
- UI: added an admin scheduling console at `/dashboard/admin/scheduling` (`WorkforceSchedulingClient`) with team posture, pending requests queue, recurring template editor, and override creation; and added a staff-facing Time Off section to user settings for request submission, history, and cancellation.
- People & Payroll integration: extended People list/detail responses and UIs to surface schedule/time-off posture and triage reasons, and enriched payroll-period entries with `scheduled_minutes` and `approved_time_away_minutes_in_period` for visibility in payroll review; added cross-links between People, Scheduling, and Payroll Time.
- Governance & traceability: audit events written for request submission/review/cancel and schedule template/override changes; RLS and shop scoping preserved; kept canonical People records as the source of truth for staff.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it completed successfully. ✅
- Lint: ran targeted `eslint` on the touched files; results contained warnings (mostly `no-explicit-any` in API handlers and a React hook dependency warning) but no errors, so the change is type-safe and lint-clean-enough for this v1 foundation. ⚠️
- Notes: manual UI/functional browser tests were not run in this environment; follow-ups should include end-to-end checks for request lifecycle, approval → availability block behavior, and payroll reconciliation of scheduled vs worked minutes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df921ab0fc8328b534edb35756623e)