### PR TITLE
Polish Parts Phase 4 — UI, trust & status consistency

### DIFF
--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -15,6 +15,13 @@ type MoveLite = Pick<DB["public"]["Tables"]["stock_moves"]["Row"], "id" | "refer
 
 type AllocationView = { a: Alloc; part?: PartLite; loc?: LocLite; wo?: WoLite | null; req?: ReqItemLite | null; move?: MoveLite | null };
 
+function movementReasonLabel(reason: string | null | undefined): string {
+  const key = String(reason ?? "").toLowerCase();
+  if (key === "wo_allocate" || key === "consume") return "Allocated to work order";
+  if (key === "request_receive") return "Received for request item";
+  return key ? key.replaceAll("_", " ") : "—";
+}
+
 async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
@@ -117,15 +124,15 @@ export default function AllocationsPage(): JSX.Element {
             <tbody>
               {filtered.map((r) => (
                 <tr key={String(r.a.id)} className="border-t border-white/10 align-top">
-                  <td className="p-3">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0, 8)}</Link> : <span className="text-neutral-500">—</span>}</td>
-                  <td className="p-3"><div>{r.part?.name ?? String(r.a.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{r.part?.sku ?? ""}</div></td>
-                  <td className="p-3">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td>
-                  <td className="p-3 tabular-nums text-neutral-200">{r.a.qty}</td>
-                  <td className="p-3 text-xs text-neutral-300">
-                    {r.req?.request_id ? <span className="rounded border border-white/10 px-2 py-0.5">Req {String(r.req.request_id).slice(0, 8)}</span> : <span className="text-neutral-500">No request link</span>}
-                    <div className="mt-1 text-neutral-500">{r.move?.reference_kind ?? "—"} · {r.move?.reason ?? "—"}</div>
+                  <td className="p-3.5">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0, 8)}</Link> : <span className="text-neutral-500">—</span>}</td>
+                  <td className="p-3.5"><div className="font-medium text-neutral-100">{r.part?.name ?? String(r.a.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{r.part?.sku ?? ""}</div></td>
+                  <td className="p-3.5">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td>
+                  <td className="p-3.5 tabular-nums text-neutral-200">{r.a.qty}</td>
+                  <td className="p-3.5 text-xs text-neutral-300">
+                    {r.req?.request_id ? <span className="rounded border border-white/10 px-2 py-0.5">Request {String(r.req.request_id).slice(0, 8)}</span> : <span className="text-neutral-500">No request link</span>}
+                    <div className="mt-1 text-neutral-500">{String(r.move?.reference_kind ?? "—").replaceAll("_", " ")} · {movementReasonLabel(r.move?.reason)}</div>
                   </td>
-                  <td className="p-3 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td>
+                  <td className="p-3.5 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td>
                 </tr>
               ))}
             </tbody>

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -30,10 +30,19 @@ function sourceLabel(kind: string | null, reason: string | null): string {
   if (k === "purchase_order") return "PO receive";
   if (k === "manual_receive") return "Manual receive";
   if (k === "request_receive") return "Request receive";
-  if (k === "work_order") return "WO allocation";
+  if (k === "work_order") return "Work order allocation";
   if (k === "csv_import") return "CSV import";
-  if (reason === "consume" || reason === "wo_allocate") return "Allocation / consumption";
+  if (reason === "consume" || reason === "wo_allocate") return "Work order consumption";
   return k || String(reason ?? "movement");
+}
+
+function reasonLabel(reason: string | null): string {
+  const key = String(reason ?? "").toLowerCase();
+  if (key === "wo_allocate" || key === "consume") return "Allocated to work order";
+  if (key === "po_receive") return "Received from purchase order";
+  if (key === "request_receive") return "Received for request item";
+  if (key === "manual_receive") return "Manual receive adjustment";
+  return key ? key.replaceAll("_", " ") : "Movement update";
 }
 
 export default function StockMovementsPage(): JSX.Element {
@@ -131,12 +140,12 @@ export default function StockMovementsPage(): JSX.Element {
                 const ctx = ctxMap[refId] ?? ctxMap[String(m.id)] ?? null;
                 return (
                   <tr key={String(m.id)} className="border-t border-white/10 align-top">
-                    <td className="p-3 text-xs text-neutral-400">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td>
-                    <td className="p-3"><div>{part?.name ?? String(m.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{part?.sku ?? ""}</div></td>
-                    <td className="p-3">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td>
-                    <td className="p-3"><span className={`inline-flex rounded-full border px-2 py-0.5 text-xs ${qty >= 0 ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-200" : "border-rose-500/30 bg-rose-950/20 text-rose-200"}`}>{qty >= 0 ? "+" : ""}{qty}</span></td>
-                    <td className="p-3"><div>{ctx?.sourceLabel ?? sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{String(m.reason ?? "—").replaceAll("_", " ")}</div></td>
-                    <td className="p-3 text-xs">
+                    <td className="p-3.5 text-xs text-neutral-400">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td>
+                    <td className="p-3.5"><div className="font-medium text-neutral-100">{part?.name ?? String(m.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{part?.sku ?? ""}</div></td>
+                    <td className="p-3.5 text-neutral-300">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td>
+                    <td className="p-3.5"><span className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${qty >= 0 ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-200" : "border-rose-500/30 bg-rose-950/20 text-rose-200"}`}>{qty >= 0 ? "+" : ""}{qty}</span></td>
+                    <td className="p-3.5"><div className="text-neutral-200">{ctx?.sourceLabel ?? sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{reasonLabel(m.reason)}</div></td>
+                    <td className="p-3.5 text-xs">
                       <div className="flex flex-wrap gap-2">
                         {ctx?.workOrderId ? <Link className="rounded border border-white/10 px-2 py-0.5 text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(ctx.workOrderId)}`}>WO {ctx.workOrderId.slice(0, 8)}</Link> : <span className="text-neutral-500">No WO</span>}
                         {ctx?.requestItemId ? <span className="rounded border border-white/10 px-2 py-0.5 text-neutral-300">Req item {ctx.requestItemId.slice(0, 8)}</span> : null}

--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -158,11 +158,11 @@ export default function PartsDashboardPage(): JSX.Element {
   const hasOpenRequests = (openRequestsCount ?? 0) > 0;
 
   return (
-    <div className="relative space-y-5 p-5 text-white fade-in md:space-y-6 md:p-6">
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.09),transparent_54%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.9),#020617_72%)]" />
+    <div className="relative space-y-4 p-5 text-white fade-in md:space-y-5 md:p-6">
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.09),transparent_56%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.92),#020617_72%)]" />
 
-      <section className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-5 shadow-card backdrop-blur-md">
-        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(130deg,rgba(56,189,248,0.13),rgba(15,23,42,0.02)_45%,transparent_70%)]" />
+      <section className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-4 shadow-card backdrop-blur-md">
+        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(130deg,rgba(148,163,184,0.1),rgba(15,23,42,0.03)_45%,transparent_70%)]" />
         <div className="relative flex flex-wrap items-start justify-between gap-4">
           <div>
             <div className="text-[10px] uppercase tracking-[0.2em] text-neutral-400">Parts command center</div>
@@ -184,11 +184,11 @@ export default function PartsDashboardPage(): JSX.Element {
       </section>
 
       <section className="grid gap-3 lg:grid-cols-[1.5fr_1fr]">
-        <div className="rounded-xl border border-sky-500/30 bg-sky-950/20 px-4 py-3 shadow-[0_0_24px_rgba(14,116,144,0.18)]">
+        <div className="rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 shadow-[0_0_24px_rgba(15,23,42,0.24)]">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
-              <div className="text-[10px] uppercase tracking-[0.18em] text-sky-200/80">Operational bottleneck</div>
-              <p className="text-sm text-sky-100">{hasOpenRequests ? <>You have <span className="font-semibold">{openReqDisplay}</span> open parts request{openRequestsCount === 1 ? "" : "s"} pending fulfillment flow.</> : "No open parts request bottlenecks right now."}</p>
+              <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-300">Operational bottleneck</div>
+              <p className="text-sm text-neutral-200">{hasOpenRequests ? <>You have <span className="font-semibold">{openReqDisplay}</span> open parts request{openRequestsCount === 1 ? "" : "s"} pending fulfillment flow.</> : "No open parts request bottlenecks right now."}</p>
             </div>
             <ActionButton href="/parts/requests" emphasis>{hasOpenRequests ? "Resolve request queue" : "Review requests"}</ActionButton>
           </div>

--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -8,8 +8,18 @@ import { useParams, useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveScannedCode } from "@/features/parts/server/scanActions";
-import { receiveProgressLabel, toReceiveProgressDisplay } from "@/features/parts/lib/status-display";
-import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
+import {
+  canonicalStatusLabel,
+  receiveProgressLabel,
+  toReceiveProgressDisplay,
+} from "@/features/parts/lib/status-display";
+import {
+  buildPartTrustMeta,
+  trustBadgeTone,
+  trustLevelLabel,
+  trustReasonTone,
+  type PartTrustMeta,
+} from "@/features/parts/lib/trust-signals";
 
 type QuaggaResult = { codeResult?: { code?: string | null } | null };
 
@@ -48,6 +58,13 @@ type PurchaseOrderLine = DB["public"]["Tables"]["purchase_order_lines"]["Row"];
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type SupplierRow = DB["public"]["Tables"]["suppliers"]["Row"];
+type PartTrustFields = Pick<
+  DB["public"]["Tables"]["parts"]["Row"],
+  "id" | "sku" | "part_number" | "normalized_part_key" | "source_intake_id"
+> & { import_confidence?: number | null };
+type AliasLookupRow = { part_id: string | null };
+type StagingLookupRow = { matched_part_id: string | null; status: string | null };
+type CandidateLookupRow = { candidate_part_id: string | null };
 
 function n(v: unknown): number {
   const num = typeof v === "number" ? v : Number(v);
@@ -214,18 +231,29 @@ export default function PoReceivePage(): JSX.Element {
             supabase.from("shop_parts_import_match_candidates").select("candidate_part_id").in("candidate_part_id", partIds).eq("shop_id", sid),
           ]);
           const aliasCount: Record<string, number> = {};
-          (aliasRes.data ?? []).forEach((r: any) => (aliasCount[String(r.part_id)] = (aliasCount[String(r.part_id)] ?? 0) + 1));
+          ((aliasRes.data ?? []) as AliasLookupRow[]).forEach((r) => {
+            const id = String(r.part_id ?? "");
+            if (!id) return;
+            aliasCount[id] = (aliasCount[id] ?? 0) + 1;
+          });
           const stagingCount: Record<string, number> = {};
-          (stagingRes.data ?? []).forEach((r: any) => {
+          ((stagingRes.data ?? []) as StagingLookupRow[]).forEach((r) => {
             const st = String(r.status ?? "").toLowerCase();
             if (st === "pending" || st === "review" || st === "ambiguous") {
-              stagingCount[String(r.matched_part_id)] = (stagingCount[String(r.matched_part_id)] ?? 0) + 1;
+              const id = String(r.matched_part_id ?? "");
+              if (!id) return;
+              stagingCount[id] = (stagingCount[id] ?? 0) + 1;
             }
           });
           const candCount: Record<string, number> = {};
-          (candRes.data ?? []).forEach((r: any) => (candCount[String(r.candidate_part_id)] = (candCount[String(r.candidate_part_id)] ?? 0) + 1));
+          ((candRes.data ?? []) as CandidateLookupRow[]).forEach((r) => {
+            const id = String(r.candidate_part_id ?? "");
+            if (!id) return;
+            candCount[id] = (candCount[id] ?? 0) + 1;
+          });
           const trustMap: Record<string, PartTrustMeta> = {};
-          partList.forEach((p: any) => {
+          partList.forEach((part) => {
+            const p = part as PartTrustFields;
             const id = String(p.id);
             trustMap[id] = buildPartTrustMeta({
               sku: p.sku,
@@ -438,13 +466,13 @@ export default function PoReceivePage(): JSX.Element {
         <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/parts/po"
-            className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm text-neutral-100 hover:border-orange-500/60"
+            className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm text-neutral-100 hover:border-sky-500/40"
           >
             ← POs
           </Link>
           <button
             onClick={() => router.push("/parts/receive")}
-            className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm text-neutral-100 hover:border-orange-500/60"
+            className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm text-neutral-100 hover:border-sky-500/40"
             type="button"
           >
             Generic Receive
@@ -471,7 +499,7 @@ export default function PoReceivePage(): JSX.Element {
               </div>
               <div className="rounded-xl border border-white/10 bg-black/50 p-3">
                 <div className="text-xs text-neutral-400">Remaining</div>
-                <div className="mt-1 text-lg font-semibold text-orange-200">{remaining}</div>
+                <div className="mt-1 text-lg font-semibold text-sky-200">{remaining}</div>
               </div>
               <div className="rounded-xl border border-white/10 bg-black/50 p-3">
                 <div className="text-xs text-neutral-400">Receiving Location</div>
@@ -496,7 +524,7 @@ export default function PoReceivePage(): JSX.Element {
                 {!scanning ? (
                   <button
                     onClick={startScan}
-                    className="rounded-full border border-orange-500/70 bg-orange-500/10 px-4 py-2 text-sm text-orange-200 hover:bg-orange-500/20"
+                    className="rounded-full border border-sky-500/40 bg-sky-950/25 px-4 py-2 text-sm text-sky-200 hover:bg-sky-900/25"
                     type="button"
                   >
                     Start Scanner
@@ -612,7 +640,7 @@ export default function PoReceivePage(): JSX.Element {
                 <button
                   onClick={() => void doReceive(manualPartId, qty)}
                   disabled={!manualPartId || !selectedLoc || qty <= 0}
-                  className="rounded-full border border-orange-500/70 bg-orange-500/10 px-4 py-2 text-sm text-orange-200 hover:bg-orange-500/20 disabled:opacity-50"
+                  className="rounded-full border border-sky-500/40 bg-sky-950/25 px-4 py-2 text-sm text-sky-200 hover:bg-sky-900/25 disabled:opacity-50"
                   type="button"
                 >
                   Receive & Allocate →
@@ -666,15 +694,15 @@ export default function PoReceivePage(): JSX.Element {
                           <div className="text-xs text-neutral-500">{ln.description ?? "—"}</div>
                           <div className="mt-1 flex items-center gap-2">
                             <span className="text-[11px] text-neutral-400">{receiveProgressLabel(recvState)}</span>
-                            {trust ? <span className={`rounded-full border px-2 py-0.5 text-[10px] ${trustBadgeTone(trust.level)}`}>{trust.level}</span> : null}
+                            {trust ? <span className={`rounded-full border px-2 py-0.5 text-[10px] ${trustBadgeTone(trust.level)}`}>{trustLevelLabel(trust.level)}</span> : null}
                           </div>
-                          {trust && trust.reasons.length > 0 ? <div className="text-[11px] text-sky-200">{trust.reasons.slice(0, 1).join(" · ")}</div> : null}
+                          {trust && trust.reasons.length > 0 ? <div className={`text-[11px] ${trustReasonTone(trust.level)}`}>{trust.reasons.slice(0, 1).join(" · ")}</div> : null}
                         </td>
                         <td className="p-3 font-mono">{ordered}</td>
                         <td className="p-3 font-mono">{received}</td>
                         <td className="p-3 font-mono">
                           {rem > 0 ? (
-                            <span className="text-orange-200">{rem}</span>
+                            <span className="text-sky-200">{rem}</span>
                           ) : (
                             <span className="text-neutral-500">0</span>
                           )}
@@ -730,7 +758,7 @@ export default function PoReceivePage(): JSX.Element {
                               {a.request_item_id ? String(a.request_item_id).slice(0, 8) : "—"}
                             </td>
                             <td className="p-2 font-mono text-neutral-200">{n(a.qty_allocated)}</td>
-                            <td className="p-2 text-neutral-300">{a.status ?? "—"}</td>
+                            <td className="p-2 text-neutral-300">{canonicalStatusLabel(a.status)}</td>
                           </tr>
                         ))}
                       </tbody>

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -7,7 +7,12 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveScannedCode } from "@/features/parts/server/scanActions";
 import Link from "next/link";
-import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
+import {
+  buildPartTrustMeta,
+  trustBadgeTone,
+  trustLevelLabel,
+  type PartTrustMeta,
+} from "@/features/parts/lib/trust-signals";
 
 type QuaggaResult = { codeResult?: { code?: string | null } | null };
 
@@ -43,6 +48,10 @@ if (typeof window !== "undefined") {
 type DB = Database;
 type PurchaseOrder = DB["public"]["Tables"]["purchase_orders"]["Row"];
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
+type PartTrustFields = Pick<
+  DB["public"]["Tables"]["parts"]["Row"],
+  "id" | "sku" | "part_number" | "normalized_part_key" | "source_intake_id"
+> & { import_confidence?: number | null };
 
 type ReceiveResult =
   | {
@@ -193,13 +202,14 @@ export default function ReceivePage(): JSX.Element {
         .select("id, sku, part_number, normalized_part_key, source_intake_id, import_confidence")
         .eq("id", part_id)
         .maybeSingle();
+      const trustPart = (partRow ?? null) as PartTrustFields | null;
       setLastTrust(
         buildPartTrustMeta({
-          sku: (partRow as any)?.sku ?? null,
-          partNumber: (partRow as any)?.part_number ?? null,
-          normalizedPartKey: (partRow as any)?.normalized_part_key ?? null,
-          sourceIntakeId: (partRow as any)?.source_intake_id ?? null,
-          importConfidence: (partRow as any)?.import_confidence ?? null,
+          sku: trustPart?.sku ?? null,
+          partNumber: trustPart?.part_number ?? null,
+          normalizedPartKey: trustPart?.normalized_part_key ?? null,
+          sourceIntakeId: trustPart?.source_intake_id ?? null,
+          importConfidence: trustPart?.import_confidence ?? null,
         }),
       );
 
@@ -274,13 +284,13 @@ export default function ReceivePage(): JSX.Element {
         <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/assistant?pageType=scan_receive&pageTitle=Scan%20to%20Receive"
-            className="rounded border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-200 hover:bg-orange-500/15"
+            className="rounded border border-sky-500/35 bg-sky-950/20 px-3 py-2 text-sm text-sky-200 hover:bg-sky-900/25"
           >
             Ask Assistant
           </Link>
           <Link
             href="/agent/planner?planner=ops&allowCreate=0&goal=Review%20scan-to-receive%20workflow%20and%20suggest%20the%20best%20next%20actions"
-            className="rounded border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-200 hover:border-orange-400 hover:text-orange-300"
+            className="rounded border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm text-neutral-200 hover:border-sky-500/30 hover:text-sky-200"
           >
             Open Planner
           </Link>
@@ -361,7 +371,7 @@ export default function ReceivePage(): JSX.Element {
             ) : null}
             {lastTrust ? (
               <div className="mt-1 text-xs">
-                <span className={`inline-flex rounded-full border px-2 py-1 ${trustBadgeTone(lastTrust.level)}`}>Trust: {lastTrust.level}</span>
+                <span className={`inline-flex rounded-full border px-2 py-1 ${trustBadgeTone(lastTrust.level)}`}>Trust: {trustLevelLabel(lastTrust.level)}</span>
                 {lastTrust.reasons.length > 0 ? <span className="ml-2 text-sky-200">{lastTrust.reasons.slice(0, 2).join(" · ")}</span> : null}
               </div>
             ) : null}
@@ -375,7 +385,7 @@ export default function ReceivePage(): JSX.Element {
             <button
               onClick={startScan}
               disabled={busy}
-              className="rounded border border-orange-500 px-3 py-1.5 text-sm text-orange-300 hover:bg-orange-900/20 disabled:opacity-60"
+              className="rounded border border-sky-500/35 px-3 py-1.5 text-sm text-sky-200 hover:bg-sky-900/20 disabled:opacity-60"
             >
               Start Scanner
             </button>

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -14,6 +14,7 @@ import {
 import {
   buildPartTrustMeta,
   trustBadgeTone,
+  trustLevelLabel,
   trustReasonTone,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
@@ -236,7 +237,7 @@ export default function ReceivingInboxPage(): JSX.Element {
       </div>
 
       <div className="text-xs text-neutral-500">
-        Last updated <span className="text-neutral-300">{lastUpdated ? lastUpdated.toLocaleTimeString() : "—"}</span> · {lastUpdated && nowTs - lastUpdated.getTime() > 120000 ? <span className="text-amber-300">stale</span> : <span className="text-emerald-300">fresh</span>}
+        Last updated <span className="text-neutral-300">{lastUpdated ? lastUpdated.toLocaleTimeString() : "—"}</span> · {lastUpdated && nowTs - lastUpdated.getTime() > 120000 ? <span className="text-neutral-300">stale</span> : <span className="text-emerald-300">fresh</span>}
       </div>
 
       <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4">
@@ -267,15 +268,18 @@ export default function ReceivingInboxPage(): JSX.Element {
                 const itemState = toItemFlowDisplay({ rawStatus: it.status, qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 const recvState = toReceiveProgressDisplay({ qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 return (
-                  <tr key={it.id} className="border-t border-white/10">
-                    <td className="p-3">
-                      <div className="font-semibold">{p?.name ? String(p.name) : it.description}</div>
-                      <div className="text-[11px] text-neutral-500">{p?.sku ? `${p.sku} • ` : ""}{itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}</div>
+                  <tr key={it.id} className="border-t border-white/10 align-top">
+                    <td className="p-3.5">
+                      <div className="font-semibold text-neutral-100">{p?.name ? String(p.name) : it.description}</div>
+                      <div className="mt-1 text-[11px] text-neutral-500">{p?.sku ? `${p.sku} • ` : ""}{itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}</div>
                       {trust && trust.reasons.length > 0 ? <div className={`mt-1 text-[11px] ${trustReasonTone(trust.level)}`}>{trust.reasons.slice(0,2).join(" · ")}</div> : null}
                     </td>
-                    <td className="p-3"><span className="inline-flex rounded-full border border-white/10 bg-black/40 px-2 py-1 text-xs">{receiveProgressLabel(recvState)}</span>{trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trust.level}</span> : null}</td>
-                    <td className="p-3 tabular-nums">{it.qty_received} / {it.qty_approved} <span className="text-neutral-500">({it.qty_remaining} rem)</span></td>
-                    <td className="p-3"><button onClick={() => {setDrawerItem({ ...it, part_name: p?.name ?? null, sku: p?.sku ?? null, trust_reasons: trust?.reasons ?? [] }); setDrawerOpen(true);}} className="rounded-lg border border-sky-500/35 px-3 py-1 text-sky-200">Receive</button></td>
+                    <td className="p-3.5">
+                      <span className="inline-flex rounded-full border border-white/10 bg-black/40 px-2 py-1 text-xs">{receiveProgressLabel(recvState)}</span>
+                      {trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trustLevelLabel(trust.level)}</span> : null}
+                    </td>
+                    <td className="p-3.5 tabular-nums text-neutral-200">{it.qty_received} / {it.qty_approved} <span className="text-neutral-500">({it.qty_remaining} rem)</span></td>
+                    <td className="p-3.5"><button onClick={() => {setDrawerItem({ ...it, part_name: p?.name ?? null, sku: p?.sku ?? null, trust_level: trust?.level, trust_reasons: trust?.reasons ?? [] }); setDrawerOpen(true);}} className="rounded-lg border border-sky-500/35 px-3 py-1 text-sky-200">Receive</button></td>
                   </tr>
                 );
               })}

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -20,7 +20,13 @@ import {
   toItemFlowDisplay,
   toRequestFlowDisplay,
 } from "@/features/parts/lib/status-display";
-import { buildPartTrustMeta, trustBadgeTone, type PartTrustMeta } from "@/features/parts/lib/trust-signals";
+import {
+  buildPartTrustMeta,
+  trustBadgeTone,
+  trustLevelLabel,
+  type PartTrustLevel,
+  type PartTrustMeta,
+} from "@/features/parts/lib/trust-signals";
 
 type DB = Database;
 
@@ -28,6 +34,10 @@ type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 type RequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
 type ItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
+type PartTrustFields = Pick<
+  DB["public"]["Tables"]["parts"]["Row"],
+  "id" | "sku" | "part_number" | "normalized_part_key" | "source_intake_id"
+> & { import_confidence?: number | null };
 type LocationRow = DB["public"]["Tables"]["stock_locations"]["Row"];
 type PurchaseOrderRow = DB["public"]["Tables"]["purchase_orders"]["Row"];
 type SupplierRow = DB["public"]["Tables"]["suppliers"]["Row"];
@@ -73,6 +83,7 @@ type DrawerItem = {
   qty_remaining?: number | null;
   part_name?: string | null;
   sku?: string | null;
+  trust_level?: PartTrustLevel;
   trust_reasons?: string[];
 };
 
@@ -428,7 +439,8 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       const partRows = (ps ?? []) as PartRow[];
       setParts(partRows);
       const trustMap: Record<string, PartTrustMeta> = {};
-      partRows.forEach((p: any) => {
+      partRows.forEach((part) => {
+        const p = part as PartTrustFields;
         trustMap[String(p.id)] = buildPartTrustMeta({
           sku: p.sku ?? null,
           partNumber: p.part_number ?? null,
@@ -675,6 +687,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       qty_remaining: remaining,
       part_name: part?.name ? String(part.name) : null,
       sku: part?.sku ? String(part.sku) : null,
+      trust_level: partId ? trustByPartId[partId]?.level : undefined,
       trust_reasons: partId ? (trustByPartId[partId]?.reasons ?? []) : [],
     });
     setRecvOpen(true);
@@ -1363,7 +1376,7 @@ if (!lineId || !isUuid(lineId)) {
                                             </span>
                                             {trustMeta ? (
                                               <span className={`ml-2 inline-flex rounded-full border px-2 py-0.5 ${trustBadgeTone(trustMeta.level)}`}>
-                                                {trustMeta.level}
+                                                {trustLevelLabel(trustMeta.level)}
                                               </span>
                                             ) : null}
                                           </div>

--- a/features/parts/components/ReceiveDrawer.tsx
+++ b/features/parts/components/ReceiveDrawer.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { itemFlowLabel, toItemFlowDisplay } from "@/features/parts/lib/status-display";
-import { trustBadgeTone } from "@/features/parts/lib/trust-signals";
+import { trustBadgeTone, trustLevelLabel, type PartTrustLevel } from "@/features/parts/lib/trust-signals";
 
 type Option = { value: string; label: string };
 
@@ -21,6 +21,7 @@ export type ReceiveDrawerItem = {
 
   part_name?: string | null;
   sku?: string | null;
+  trust_level?: PartTrustLevel;
   trust_reasons?: string[];
 };
 
@@ -230,7 +231,7 @@ export default function ReceiveDrawer(props: {
   const btnBase =
     "inline-flex items-center justify-center rounded-xl border px-4 py-2 text-sm font-semibold transition disabled:opacity-60";
   const btnGhost = `${btnBase} border-white/10 bg-neutral-950/20 hover:bg-white/5`;
-  const btnCopper = `${btnBase} border-sky-500/35 text-sky-200 bg-neutral-950/20 hover:bg-sky-900/20`;
+  const btnPrimary = `${btnBase} border-sky-500/35 text-sky-200 bg-neutral-950/20 hover:bg-sky-900/20`;
 
   return (
     <>
@@ -295,8 +296,10 @@ export default function ReceiveDrawer(props: {
                   </div>
                 </div>
                 {Array.isArray(item.trust_reasons) && item.trust_reasons.length > 0 ? (
-                  <div className={`rounded-lg border px-2 py-1 text-[11px] ${trustBadgeTone("review")}`}>
-                    Trust review: {item.trust_reasons.slice(0, 2).join(" · ")}
+                  <div
+                    className={`rounded-lg border px-2 py-1 text-[11px] ${trustBadgeTone(item.trust_level ?? "review")}`}
+                  >
+                    {trustLevelLabel(item.trust_level ?? "review")}: {item.trust_reasons.slice(0, 2).join(" · ")}
                   </div>
                 ) : null}
               </div>
@@ -410,7 +413,7 @@ export default function ReceiveDrawer(props: {
             <button type="button" className={btnGhost} onClick={close}>
               Cancel
             </button>
-            <button type="button" className={btnCopper} onClick={() => void submit()} disabled={!canSubmit}>
+            <button type="button" className={btnPrimary} onClick={() => void submit()} disabled={!canSubmit}>
               {submitting ? "Receiving…" : "Receive"}
             </button>
           </div>

--- a/features/parts/lib/status-display.ts
+++ b/features/parts/lib/status-display.ts
@@ -42,6 +42,22 @@ export function receiveProgressLabel(status: ReceiveProgressDisplay): string {
   return "Received";
 }
 
+export function canonicalStatusLabel(rawStatus?: string | null): string {
+  const status = String(rawStatus ?? "").trim().toLowerCase();
+  if (!status) return "Pending";
+  if (status === "requested") return "Requested";
+  if (status === "quoted") return "Quoted";
+  if (status === "approved") return "Approved";
+  if (status === "ordered") return "Ordered";
+  if (status === "partially_received") return "Partially Received";
+  if (status === "received") return "Received";
+  if (status === "fulfilled") return "Allocated / Consumed";
+  if (status === "consumed") return "Allocated / Consumed";
+  return status
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
 export function toReceiveProgressDisplay(input: {
   qty?: unknown;
   qtyApproved?: unknown;

--- a/features/parts/lib/trust-signals.ts
+++ b/features/parts/lib/trust-signals.ts
@@ -5,6 +5,17 @@ export type PartTrustMeta = {
   reasons: string[];
 };
 
+const TRUST_REASON = {
+  missingSku: "Missing SKU",
+  missingPartNumber: "Missing part number",
+  weakIdentity: "Weak identity key",
+  aliasBackedImport: "Alias-backed import",
+  stagingNotFinalized: "Staging not finalized",
+  ambiguousLineage: "Ambiguous import lineage",
+  lowImportConfidence: "Low import confidence",
+  importedRecord: "Imported record",
+} as const;
+
 export function buildPartTrustMeta(input: {
   sku?: string | null;
   partNumber?: string | null;
@@ -17,19 +28,22 @@ export function buildPartTrustMeta(input: {
 }): PartTrustMeta {
   const reasons: string[] = [];
 
-  if (!input.sku?.trim()) reasons.push("Missing SKU");
-  if (!input.partNumber?.trim()) reasons.push("Missing part number");
-  if (!input.normalizedPartKey?.trim()) reasons.push("Weak identity");
-  if ((input.aliasCount ?? 0) > 0) reasons.push("Alias-backed import");
-  if ((input.pendingStagingCount ?? 0) > 0) reasons.push("Staging not finalized");
-  if ((input.ambiguousCandidateCount ?? 0) > 0) reasons.push("Ambiguous import lineage");
+  if (!input.sku?.trim()) reasons.push(TRUST_REASON.missingSku);
+  if (!input.partNumber?.trim()) reasons.push(TRUST_REASON.missingPartNumber);
+  if (!input.normalizedPartKey?.trim()) reasons.push(TRUST_REASON.weakIdentity);
+  if ((input.aliasCount ?? 0) > 0) reasons.push(TRUST_REASON.aliasBackedImport);
+  if ((input.pendingStagingCount ?? 0) > 0) reasons.push(TRUST_REASON.stagingNotFinalized);
+  if ((input.ambiguousCandidateCount ?? 0) > 0) reasons.push(TRUST_REASON.ambiguousLineage);
   if (typeof input.importConfidence === "number" && input.importConfidence < 0.75) {
-    reasons.push("Low import confidence");
+    reasons.push(TRUST_REASON.lowImportConfidence);
   }
-  if (input.sourceIntakeId?.trim() && reasons.length === 0) reasons.push("Imported record");
+  if (input.sourceIntakeId?.trim() && reasons.length === 0) reasons.push(TRUST_REASON.importedRecord);
 
-  const low = reasons.some((r) =>
-    ["Weak identity", "Ambiguous import lineage", "Low import confidence"].includes(r),
+  const low = reasons.some(
+    (r) =>
+      r === TRUST_REASON.weakIdentity ||
+      r === TRUST_REASON.ambiguousLineage ||
+      r === TRUST_REASON.lowImportConfidence,
   );
 
   return {


### PR DESCRIPTION
### Motivation
- Stabilize and polish the Phase 4 Parts surfaces for visual and operational consistency without changing behavior or data paths. 
- Eliminate warm/brown/copper visual leftovers and unify trust/status language so the parts UI reads as a single cohesive system.

### Description
- Visual / spacing: neutralized remaining orange/copper action treatments, tightened paddings and row hierarchy, and adjusted dashboard hero/bottleneck rhythm to match the cool glass theme. (multiple pages)
- Trust signals: introduced a single vocabulary for trust reasons (`TRUST_REASON`) and standardized badge labels via `trustLevelLabel(...)` and `trustReasonTone(...)`, and applied these across Receive Drawer, Receiving Inbox, PO receive, Request detail, and Scan receive. (`features/parts/lib/trust-signals.ts`, components/pages)
- Status language: added `canonicalStatusLabel(...)` to normalize user-facing status text and applied it where DB raw text previously leaked (PO allocation results). (`features/parts/lib/status-display.ts`, `app/parts/po/[id]/receive/page.tsx`)
- Readability & clarity: tightened table cells and improved contrast/secondary text, clarified movement/allocation reason wording and source labels so rows are self-explanatory (movements/allocations). (`app/parts/movements/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/receiving/page.tsx`)
- Light type-safety: reduced risky `any` usage in trust mapping and scanner/receive flows by introducing narrow local row types for import/staging/alias lookups and plumbing trust_level into receive drawer/request flows. (several files)

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build passed successfully. ✅
- Ran targeted eslint over all touched files and it passed with warnings only (existing `react-hooks/exhaustive-deps` warnings remained in `receiving` and `movements` load effects); no new errors introduced. ✅

Files changed (high level):
- app/parts/page.tsx
- app/parts/receive/page.tsx
- app/parts/receiving/page.tsx
- app/parts/po/[id]/receive/page.tsx
- app/parts/movements/page.tsx
- app/parts/allocations/page.tsx
- app/parts/requests/[id]/page.tsx
- features/parts/components/ReceiveDrawer.tsx
- features/parts/lib/status-display.ts
- features/parts/lib/trust-signals.ts

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df962652208328ac6f8a8628050f43)