### PR TITLE
Harden Shop Boost migration reliability and trust-state workflows

### DIFF
--- a/app/api/shop-boost/intakes/process/route.ts
+++ b/app/api/shop-boost/intakes/process/route.ts
@@ -72,7 +72,10 @@ export async function POST(req: NextRequest) {
     const importSummary = await runShopBoostImport({ shopId, intakeId: intake.id, options: { createStaffUsers: false } });
 
     const completedStatus =
-      importSummary.completionState === "PARTIAL_FAILURE" || errors.length > 0
+      importSummary.completionState === "PARTIAL_FAILURE" ||
+      importSummary.completionState === "FAILED" ||
+      importSummary.completionState === "NOT_READY" ||
+      errors.length > 0
         ? "completed_with_errors"
         : "completed";
 

--- a/app/api/shop-boost/review-items/[id]/route.ts
+++ b/app/api/shop-boost/review-items/[id]/route.ts
@@ -24,6 +24,15 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
 
   const body = (await req.json().catch(() => ({}))) as {
     resolution_action?: "linked_to_existing" | "created_new" | "ignored";
+    ignore_reason_code?:
+      | "duplicate"
+      | "obsolete"
+      | "invalid"
+      | "test_data"
+      | "intentionally_skipped"
+      | "unsupported_format"
+      | "other";
+    ignore_note?: string | null;
   };
 
   const result = await resolveAndMaterializeReviewItem({
@@ -31,6 +40,8 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     shopId: profile.shop_id,
     userId: user.id,
     resolutionAction: body.resolution_action ?? "ignored",
+    ignoreReasonCode: body.ignore_reason_code,
+    ignoreNote: body.ignore_note,
   });
 
   if (!result.ok) {

--- a/app/api/shop-boost/review-items/resolve-bulk/route.ts
+++ b/app/api/shop-boost/review-items/resolve-bulk/route.ts
@@ -26,6 +26,15 @@ export async function POST(req: Request) {
   const body = (await req.json().catch(() => ({}))) as {
     review_item_ids?: string[];
     resolution_action?: "linked_to_existing" | "created_new" | "ignored";
+    ignore_reason_code?:
+      | "duplicate"
+      | "obsolete"
+      | "invalid"
+      | "test_data"
+      | "intentionally_skipped"
+      | "unsupported_format"
+      | "other";
+    ignore_note?: string | null;
   };
 
   const ids = Array.isArray(body.review_item_ids) ? body.review_item_ids.filter(Boolean) : [];
@@ -36,6 +45,8 @@ export async function POST(req: Request) {
     userId: user.id,
     reviewItemIds: ids,
     resolutionAction: body.resolution_action ?? "ignored",
+    ignoreReasonCode: body.ignore_reason_code,
+    ignoreNote: body.ignore_note,
   });
 
   return NextResponse.json({

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: Request) {
   const admin = createAdminSupabase() as any;
   let query = admin
     .from("shop_boost_review_items")
-    .select("id,domain,issue_type,summary,raw_payload,suggested_matches,status,resolution_action,resolved_at,materialized_at,materialization_error,materialized_record,created_at")
+    .select("id,domain,issue_type,summary,raw_payload,normalized_payload,target_domain,blocking_reason,dependency_refs,downstream_impact_count,cluster_key,cluster_confidence,suggested_matches,status,resolution_action,ignore_reason_code,ignore_note,ignored_at,resolved_at,materialized_at,materialization_error,materialized_record,created_at")
     .eq("shop_id", profile.shop_id)
     .order("created_at", { ascending: false })
     .limit(250);

--- a/app/dashboard/setup/review/page.tsx
+++ b/app/dashboard/setup/review/page.tsx
@@ -8,9 +8,19 @@ type ReviewItem = {
   issue_type: string;
   summary: string;
   raw_payload: Record<string, unknown>;
+  normalized_payload: Record<string, unknown>;
+  target_domain: string | null;
+  blocking_reason: string | null;
+  dependency_refs: Record<string, unknown> | null;
+  downstream_impact_count: number | null;
+  cluster_key: string | null;
+  cluster_confidence: number | null;
   suggested_matches: unknown;
-  status: "pending" | "resolved" | "materialized" | "failed_materialization";
+  status: "pending" | "resolved" | "materialized" | "failed_materialization" | "ignored";
   resolution_action: "linked_to_existing" | "created_new" | "ignored" | null;
+  ignore_reason_code: string | null;
+  ignore_note: string | null;
+  ignored_at: string | null;
   resolved_at: string | null;
   materialized_at: string | null;
   materialization_error: string | null;
@@ -25,6 +35,8 @@ export default function ShopBoostReviewPage() {
   const [items, setItems] = useState<ReviewItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState("pending");
+  const [ignoreReason, setIgnoreReason] = useState("duplicate");
+  const [ignoreNote, setIgnoreNote] = useState("");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [feedback, setFeedback] = useState<string | null>(null);
 
@@ -120,14 +132,36 @@ export default function ShopBoostReviewPage() {
             <option value="pending">pending</option>
             <option value="failed_materialization">failed materialization</option>
             <option value="materialized">materialized</option>
+            <option value="ignored">ignored</option>
           </select>
+        </div>
+
+        <div>
+          <label className="text-xs uppercase tracking-[0.16em] text-neutral-400">Ignore reason</label>
+          <select value={ignoreReason} onChange={(e) => setIgnoreReason(e.target.value)} className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white">
+            {["duplicate", "obsolete", "invalid", "test_data", "intentionally_skipped", "unsupported_format", "other"].map((reason) => (
+              <option key={reason} value={reason}>{reason}</option>
+            ))}
+          </select>
+          <input value={ignoreNote} onChange={(e) => setIgnoreNote(e.target.value)} placeholder="Optional ignore note" className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white" />
         </div>
 
         {selectedIds.length > 0 ? (
           <div className="flex flex-wrap gap-2 text-xs">
             <button className="rounded border border-sky-300/40 px-2 py-1 text-sky-100" onClick={() => void resolveBulk("linked_to_existing")}>Bulk link to existing</button>
             <button className="rounded border border-emerald-300/40 px-2 py-1 text-emerald-100" onClick={() => void resolveBulk("created_new")}>Bulk create new</button>
-            <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={() => void resolveBulk("ignored")}>Bulk ignore</button>
+            <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={async () => {
+              if (selectedIds.length === 0) return;
+              const res = await fetch("/api/shop-boost/review-items/resolve-bulk", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ review_item_ids: selectedIds, resolution_action: "ignored", ignore_reason_code: ignoreReason, ignore_note: ignoreNote || null }),
+              });
+              const json = (await res.json().catch(() => ({}))) as { ok?: boolean; results?: Array<{ ok: boolean }> };
+              const okCount = (json.results ?? []).filter((item) => item.ok).length;
+              setFeedback(json.ok ? `Ignored (${okCount}/${selectedIds.length})` : `Bulk ignore completed with failures (${okCount}/${selectedIds.length}).`);
+              await load();
+            }}>Bulk ignore</button>
           </div>
         ) : null}
       </div>
@@ -146,8 +180,14 @@ export default function ShopBoostReviewPage() {
                   <div>
                     <div className="text-sm font-semibold text-white">{item.summary}</div>
                     <div className="text-xs text-neutral-400">{item.domain} • {item.issue_type} • {item.status}</div>
+                    <div className="text-xs text-neutral-500">target: {item.target_domain ?? item.domain} • cluster: {item.cluster_key ?? "n/a"} ({item.cluster_confidence?.toFixed(2) ?? "0.00"})</div>
+                    {item.blocking_reason ? <div className="text-xs text-amber-200">blocked: {item.blocking_reason}</div> : null}
+                    {(item.downstream_impact_count ?? 0) > 0 ? <div className="text-xs text-sky-200">downstream impact: {item.downstream_impact_count}</div> : null}
                     {item.materialized_record ? (
                       <div className="mt-1 text-xs text-emerald-200">Resolved + Applied → {JSON.stringify(item.materialized_record)}</div>
+                    ) : null}
+                    {item.status === "ignored" ? (
+                      <div className="mt-1 text-xs text-neutral-300">Ignored ({item.ignore_reason_code ?? "other"}) {item.ignore_note ? `• ${item.ignore_note}` : ""}</div>
                     ) : null}
                     {item.materialization_error ? (
                       <div className="mt-1 text-xs text-rose-300">Materialization error: {item.materialization_error}</div>
@@ -157,7 +197,16 @@ export default function ShopBoostReviewPage() {
                 <div className="flex gap-2 text-xs">
                   <button className="rounded border border-sky-300/40 px-2 py-1 text-sky-100" onClick={() => void resolve(item.id, "linked_to_existing")}>Link to existing</button>
                   <button className="rounded border border-emerald-300/40 px-2 py-1 text-emerald-100" onClick={() => void resolve(item.id, "created_new")}>Create new</button>
-                  <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={() => void resolve(item.id, "ignored")}>Ignore</button>
+                  <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={async () => {
+                    const res = await fetch(`/api/shop-boost/review-items/${item.id}`, {
+                      method: "PATCH",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ resolution_action: "ignored", ignore_reason_code: ignoreReason, ignore_note: ignoreNote || null }),
+                    });
+                    const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+                    setFeedback(json.ok ? "Ignored" : `Ignore failed: ${json.error ?? "unknown error"}`);
+                    await load();
+                  }}>Ignore</button>
                   {item.status === "failed_materialization" ? (
                     <button className="rounded border border-amber-300/40 px-2 py-1 text-amber-100" onClick={() => void resolve(item.id, item.resolution_action ?? "created_new")}>Retry</button>
                   ) : null}
@@ -168,6 +217,10 @@ export default function ShopBoostReviewPage() {
                 <div>
                   <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Raw imported data</div>
                   <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.raw_payload ?? {}, null, 2)}</pre>
+                </div>
+                <div>
+                  <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Normalized / target payload</div>
+                  <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.normalized_payload ?? {}, null, 2)}</pre>
                 </div>
                 <div>
                   <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Suggested matches / system data</div>

--- a/db/sql/2026-04-15_shop_boost_flagship_hardening.sql
+++ b/db/sql/2026-04-15_shop_boost_flagship_hardening.sql
@@ -1,0 +1,90 @@
+-- Shop Boost flagship hardening
+-- Additive schema updates for clustering, ignore semantics, graph integrity, and trust-state summaries.
+
+alter table if exists public.shop_boost_row_results
+  add column if not exists cluster_key text,
+  add column if not exists cluster_confidence numeric(5,4) default 0;
+
+create index if not exists idx_shop_boost_row_results_cluster
+  on public.shop_boost_row_results(shop_id, intake_id, cluster_key);
+
+alter table if exists public.shop_boost_review_items
+  add column if not exists normalized_payload jsonb not null default '{}'::jsonb,
+  add column if not exists target_domain text,
+  add column if not exists blocking_reason text,
+  add column if not exists dependency_refs jsonb not null default '{}'::jsonb,
+  add column if not exists downstream_impact_count integer not null default 0,
+  add column if not exists cluster_key text,
+  add column if not exists cluster_confidence numeric(5,4) default 0,
+  add column if not exists ignore_reason_code text,
+  add column if not exists ignore_note text,
+  add column if not exists ignored_at timestamptz;
+
+create index if not exists idx_shop_boost_review_items_cluster
+  on public.shop_boost_review_items(shop_id, intake_id, cluster_key);
+
+create index if not exists idx_shop_boost_review_items_ignore_reason
+  on public.shop_boost_review_items(shop_id, intake_id, ignore_reason_code)
+  where status = 'ignored';
+
+alter table if exists public.shop_boost_review_items
+  drop constraint if exists shop_boost_review_items_status_check;
+
+alter table if exists public.shop_boost_review_items
+  add constraint shop_boost_review_items_status_check
+  check (status in ('pending', 'resolved', 'materialized', 'failed_materialization', 'ignored'));
+
+alter table if exists public.shop_boost_review_items
+  drop constraint if exists shop_boost_review_items_ignore_reason_check;
+
+alter table if exists public.shop_boost_review_items
+  add constraint shop_boost_review_items_ignore_reason_check
+  check (
+    ignore_reason_code is null
+    or ignore_reason_code in (
+      'duplicate',
+      'obsolete',
+      'invalid',
+      'test_data',
+      'intentionally_skipped',
+      'unsupported_format',
+      'other'
+    )
+  );
+
+create table if not exists public.shop_boost_integrity_reports (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  intake_id uuid not null references public.shop_boost_intakes(id) on delete cascade,
+  status text not null,
+  graph_ready boolean not null default false,
+  blocking_issues_count integer not null default 0,
+  warnings_count integer not null default 0,
+  checks jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_shop_boost_integrity_reports_lookup
+  on public.shop_boost_integrity_reports(shop_id, intake_id, created_at desc);
+
+alter table public.shop_boost_integrity_reports enable row level security;
+
+drop policy if exists "service-role-manage-shop-boost-integrity-reports" on public.shop_boost_integrity_reports;
+create policy "service-role-manage-shop-boost-integrity-reports"
+  on public.shop_boost_integrity_reports
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "shop-users-read-shop-boost-integrity-reports" on public.shop_boost_integrity_reports;
+create policy "shop-users-read-shop-boost-integrity-reports"
+  on public.shop_boost_integrity_reports
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = shop_boost_integrity_reports.shop_id
+    )
+  );

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -8,6 +8,13 @@ import {
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
 import { runPartsImportPipeline, type PartsPipelineSummary } from "@/features/integrations/imports/runPartsImportPipeline";
+import {
+  buildClusterDescriptor,
+  computeCompletionState,
+  runPostMigrationIntegrityValidation,
+  type CompletionState,
+  type ReviewIssueType,
+} from "@/features/integrations/shopBoost/migrationReliability";
 
 type DB = Database;
 
@@ -72,7 +79,7 @@ export type ShopBoostImportSummary = {
     failedCount: number;
     byDomain: Record<string, { success: number; review: number; failed: number }>;
   };
-  completionState: "COMPLETED_CLEAN" | "COMPLETED_WITH_REVIEW" | "PARTIAL_FAILURE";
+  completionState: CompletionState;
 };
 
 type CsvRow = Record<string, string>;
@@ -774,6 +781,11 @@ async function insertRowResult(args: {
   errorReason?: string | null;
   reviewRequired: boolean;
 }): Promise<void> {
+  const cluster = buildClusterDescriptor({
+    domain: args.targetDomain,
+    rawPayload: args.rawPayload,
+    normalizedPayload: args.normalizedPayload,
+  });
   await (args.supabase as any).from("shop_boost_row_results").insert({
     shop_id: args.shopId,
     intake_id: args.intakeId,
@@ -785,6 +797,8 @@ async function insertRowResult(args: {
     match_status: args.matchStatus,
     match_confidence: confidenceScore(args.matchConfidence),
     match_details: args.matchDetails ?? {},
+    cluster_key: cluster.clusterKey,
+    cluster_confidence: cluster.confidence,
     error_reason: args.errorReason ?? null,
     review_required: args.reviewRequired,
   });
@@ -795,11 +809,21 @@ async function createReviewItem(args: {
   shopId: string;
   intakeId: string;
   domain: RowDomain;
-  issueType: "unmatched" | "conflict" | "invalid" | "missing_dependency";
+  issueType: ReviewIssueType;
   summary: string;
   rawPayload: Record<string, unknown>;
+  normalizedPayload?: Record<string, unknown>;
+  targetDomain?: string;
+  blockingReason?: string;
+  dependencyRefs?: Record<string, unknown>;
+  downstreamImpactCount?: number;
   suggestedMatches?: unknown;
 }): Promise<void> {
+  const cluster = buildClusterDescriptor({
+    domain: args.domain,
+    rawPayload: args.rawPayload,
+    normalizedPayload: args.normalizedPayload ?? {},
+  });
   await (args.supabase as any).from("shop_boost_review_items").insert({
     shop_id: args.shopId,
     intake_id: args.intakeId,
@@ -807,6 +831,13 @@ async function createReviewItem(args: {
     issue_type: args.issueType,
     summary: args.summary,
     raw_payload: args.rawPayload,
+    normalized_payload: args.normalizedPayload ?? {},
+    target_domain: args.targetDomain ?? args.domain,
+    blocking_reason: args.blockingReason ?? null,
+    dependency_refs: args.dependencyRefs ?? {},
+    downstream_impact_count: args.downstreamImpactCount ?? 0,
+    cluster_key: cluster.clusterKey,
+    cluster_confidence: cluster.confidence,
     suggested_matches: args.suggestedMatches ?? [],
     status: "pending",
   });
@@ -1871,12 +1902,37 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const prevBasics = isRecord((intakeRow as unknown as Record<string, unknown>).intake_basics)
     ? ((intakeRow as unknown as Record<string, unknown>).intake_basics as Record<string, unknown>)
     : {};
-  const completionState: ShopBoostImportSummary["completionState"] =
-    rowOutcome.failedCount > 0
-      ? "PARTIAL_FAILURE"
-      : rowOutcome.reviewCount > 0
-        ? "COMPLETED_WITH_REVIEW"
-        : "COMPLETED_CLEAN";
+  const reviewCounts = await Promise.all([
+    supabase
+      .from("shop_boost_review_items")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", shopId)
+      .eq("intake_id", intakeId)
+      .eq("status", "pending"),
+    supabase
+      .from("shop_boost_review_items")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", shopId)
+      .eq("intake_id", intakeId)
+      .eq("status", "failed_materialization"),
+    supabase
+      .from("shop_boost_review_items")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", shopId)
+      .eq("intake_id", intakeId)
+      .eq("status", "ignored"),
+  ]);
+
+  const pendingReviewCount = reviewCounts[0].count ?? 0;
+  const failedReviewCount = reviewCounts[1].count ?? 0;
+  const ignoredCount = reviewCounts[2].count ?? 0;
+  const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
+  const completionState: ShopBoostImportSummary["completionState"] = computeCompletionState({
+    failedCount: rowOutcome.failedCount,
+    pendingReviewCount,
+    failedReviewCount,
+    integrityStatus: integrity.status,
+  });
 
   const [
     customersCount,
@@ -1979,6 +2035,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             shopBuildSummary,
             rowResults: rowOutcome,
             completionState,
+            integrity,
+            ignoredCount,
           },
           shopBuildSummary,
           migrationProgress: {
@@ -1988,8 +2046,10 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             success_count: rowOutcome.successCount,
             review_count: rowOutcome.reviewCount,
             failed_count: rowOutcome.failedCount,
+            ignored_count: ignoredCount,
             domains: rowOutcome.byDomain,
             completionState,
+            integrity,
           },
         },
       } satisfies DB["public"]["Tables"]["shop_boost_intakes"]["Update"],

--- a/features/integrations/imports/runPartsImportPipeline.ts
+++ b/features/integrations/imports/runPartsImportPipeline.ts
@@ -19,6 +19,8 @@ export type PartsPipelineSummary = {
   ambiguousRows: number;
   promotedRows: number;
   rejectedRows: number;
+  inventorySeedMode: "snapshot_with_seed_moves";
+  inventorySeededLocations: number;
 };
 
 type ParsedPart = {
@@ -196,6 +198,8 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
       ambiguousRows: 0,
       promotedRows: 0,
       rejectedRows: 0,
+      inventorySeedMode: "snapshot_with_seed_moves",
+      inventorySeededLocations: 0,
     };
   }
 
@@ -420,6 +424,48 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
       })
       .eq("id", staged.matched_part_id);
 
+    const { data: defaultLocation } = await supabase
+      .from("stock_locations")
+      .select("id")
+      .eq("shop_id", shopId)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (defaultLocation?.id) {
+      inventorySeededLocations += 1;
+      const { data: existingStock } = await supabase
+        .from("part_stock")
+        .select("id,qty_on_hand")
+        .eq("part_id", staged.matched_part_id)
+        .eq("location_id", defaultLocation.id)
+        .maybeSingle();
+
+      const seededQty = Number((staged as any).quantity_on_hand ?? 0);
+      if (existingStock?.id) {
+        await supabase
+          .from("part_stock")
+          .update({ qty_on_hand: Math.max(0, seededQty) })
+          .eq("id", existingStock.id);
+      } else {
+        await supabase.from("part_stock").insert({
+          part_id: staged.matched_part_id,
+          location_id: defaultLocation.id,
+          qty_on_hand: Math.max(0, seededQty),
+          qty_reserved: 0,
+        });
+      }
+
+      await supabase.from("stock_moves").insert({
+        shop_id: shopId,
+        part_id: staged.matched_part_id,
+        location_id: defaultLocation.id,
+        qty_delta: Math.max(0, seededQty),
+        reason: "shop_boost_snapshot_seed",
+        metadata: { intake_id: intakeId, staging_row_id: staged.id, source: "shop_boost" },
+      });
+    }
+
     await supabase.from("shop_parts_source_aliases").upsert(
       {
         shop_id: shopId,
@@ -443,10 +489,19 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
       .eq("id", staged.id);
   }
 
+  const { data: intake } = await supabase
+    .from("shop_boost_intakes")
+    .select("intake_basics")
+    .eq("id", intakeId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+  const existingBasics = (intake?.intake_basics ?? {}) as Record<string, unknown>;
+
   await supabase
     .from("shop_boost_intakes")
     .update({
       intake_basics: {
+        ...existingBasics,
         partsImportPipeline: {
           rawRows: rows.length,
           normalizedRows: stagingRowsPayload.length,
@@ -454,6 +509,8 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
           ambiguousRows,
           promotedRows,
           rejectedRows: 0,
+          inventorySeedMode: "snapshot_with_seed_moves",
+          inventorySeededLocations,
         },
       },
     })
@@ -467,5 +524,8 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
     ambiguousRows,
     promotedRows,
     rejectedRows: 0,
+    inventorySeedMode: "snapshot_with_seed_moves",
+    inventorySeededLocations,
   };
 }
+  let inventorySeededLocations = 0;

--- a/features/integrations/shopBoost/migrationReliability.ts
+++ b/features/integrations/shopBoost/migrationReliability.ts
@@ -1,0 +1,264 @@
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+export type ReviewIssueType =
+  | "unmatched"
+  | "conflict"
+  | "invalid"
+  | "missing_dependency"
+  | "ambiguous_match"
+  | "duplicate_candidate"
+  | "failed_materialization";
+
+export type CompletionState =
+  | "COMPLETED_CLEAN"
+  | "COMPLETED_WITH_REVIEW"
+  | "COMPLETED_WITH_WARNINGS"
+  | "PARTIAL_FAILURE"
+  | "FAILED"
+  | "READY_FOR_GO_LIVE"
+  | "NOT_READY";
+
+export type IntegrityStatus = "ready" | "ready_with_warnings" | "not_ready";
+
+export type IgnoreReasonCode =
+  | "duplicate"
+  | "obsolete"
+  | "invalid"
+  | "test_data"
+  | "intentionally_skipped"
+  | "unsupported_format"
+  | "other";
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeToken(value: unknown): string {
+  return normalizeText(value).replace(/\s+/g, "");
+}
+
+function normalizePhone(value: unknown): string {
+  const digits = String(value ?? "").replace(/\D+/g, "");
+  if (digits.length === 11 && digits.startsWith("1")) return digits.slice(1);
+  return digits;
+}
+
+function pick(payload: Record<string, unknown>, patterns: RegExp[]): string {
+  for (const [key, value] of Object.entries(payload)) {
+    const normalizedKey = normalizeText(key);
+    if (!normalizedKey) continue;
+    if (patterns.some((pattern) => pattern.test(normalizedKey))) {
+      const normalized = String(value ?? "").trim();
+      if (normalized) return normalized;
+    }
+  }
+  return "";
+}
+
+export function buildClusterDescriptor(args: {
+  domain: string;
+  rawPayload: Record<string, unknown>;
+  normalizedPayload?: Record<string, unknown>;
+}): { clusterKey: string; confidence: number; issueHint: ReviewIssueType | null } {
+  const payload = { ...(args.rawPayload ?? {}), ...(args.normalizedPayload ?? {}) };
+
+  if (args.domain === "customer") {
+    const external = normalizeToken(pick(payload, [/external/, /legacy id/, /customer id/]));
+    const email = normalizeToken(pick(payload, [/^email$/, /customer email/]));
+    const phone = normalizePhone(pick(payload, [/^phone$/, /customer phone/, /mobile/]));
+    const name = normalizeText(pick(payload, [/^name$/, /customer name/, /full name/]));
+    const address = normalizeText(pick(payload, [/address/, /street/]));
+
+    if (external) return { clusterKey: `customer:external:${external}`, confidence: 1, issueHint: null };
+    if (email) return { clusterKey: `customer:email:${email}`, confidence: 0.98, issueHint: null };
+    if (phone) return { clusterKey: `customer:phone:${phone}`, confidence: 0.95, issueHint: null };
+    if (name && address) return { clusterKey: `customer:name_address:${name}:${address}`, confidence: 0.78, issueHint: null };
+    if (name) return { clusterKey: `customer:name:${name}`, confidence: 0.58, issueHint: "ambiguous_match" };
+    return { clusterKey: "customer:unknown", confidence: 0.2, issueHint: "invalid" };
+  }
+
+  if (args.domain === "vehicle") {
+    const vin = normalizeToken(pick(payload, [/^vin$/, /vehicle vin/]));
+    const plate = normalizeToken(pick(payload, [/plate/, /license/]));
+    const year = normalizeToken(pick(payload, [/^year$/, /model year/]));
+    const make = normalizeText(pick(payload, [/^make$/]));
+    const model = normalizeText(pick(payload, [/^model$/]));
+    const customer = normalizeToken(pick(payload, [/customer id/, /customer email/, /customer phone/]));
+
+    if (vin) return { clusterKey: `vehicle:vin:${vin}`, confidence: 1, issueHint: null };
+    if (plate) return { clusterKey: `vehicle:plate:${plate}`, confidence: 0.92, issueHint: null };
+    if (year && make && model && customer) {
+      return {
+        clusterKey: `vehicle:ymm_customer:${year}:${make}:${model}:${customer}`,
+        confidence: 0.76,
+        issueHint: null,
+      };
+    }
+    return { clusterKey: `vehicle:fallback:${year}:${make}:${model}:${customer}`, confidence: 0.45, issueHint: "ambiguous_match" };
+  }
+
+  if (args.domain === "part") {
+    const partNumber = normalizeToken(pick(payload, [/part number/, /^pn$/, /part #/]));
+    const sku = normalizeToken(pick(payload, [/^sku$/, /stock code/]));
+    const vendor = normalizeText(pick(payload, [/vendor/, /supplier/]));
+    const description = normalizeText(pick(payload, [/description/, /name/, /part name/]));
+
+    if (partNumber) return { clusterKey: `part:number:${partNumber}`, confidence: 1, issueHint: null };
+    if (sku) return { clusterKey: `part:sku:${sku}`, confidence: 0.95, issueHint: null };
+    if (description && vendor) return { clusterKey: `part:desc_vendor:${description}:${vendor}`, confidence: 0.7, issueHint: null };
+    return { clusterKey: `part:desc:${description}`, confidence: 0.45, issueHint: "ambiguous_match" };
+  }
+
+  const invoiceNumber = normalizeToken(pick(payload, [/invoice number/, /ro number/, /work order/]));
+  if (invoiceNumber) return { clusterKey: `${args.domain}:invoice:${invoiceNumber}`, confidence: 0.92, issueHint: null };
+
+  return {
+    clusterKey: `${args.domain}:generic:${normalizeToken(JSON.stringify(payload).slice(0, 120))}`,
+    confidence: 0.4,
+    issueHint: "ambiguous_match",
+  };
+}
+
+export async function runPostMigrationIntegrityValidation(args: {
+  shopId: string;
+  intakeId: string;
+}): Promise<{
+  status: IntegrityStatus;
+  graphReady: boolean;
+  blockingIssuesCount: number;
+  warningsCount: number;
+  checks: Record<string, number>;
+}> {
+  const supabase = createAdminSupabase();
+
+  const [
+    vehiclesMissingCustomer,
+    workOrdersMissingCustomer,
+    workOrdersMissingVehicle,
+    orphanLines,
+    stockWithoutPart,
+    intakeReviewPending,
+    intakeReviewFailed,
+    duplicateCustomers,
+    duplicateVehicles,
+    duplicateParts,
+  ] = await Promise.all([
+    supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", args.shopId).eq("source_intake_id", args.intakeId).is("customer_id", null),
+    supabase.from("work_orders").select("id", { count: "exact", head: true }).eq("shop_id", args.shopId).eq("source_intake_id", args.intakeId).is("customer_id", null),
+    supabase.from("work_orders").select("id", { count: "exact", head: true }).eq("shop_id", args.shopId).eq("source_intake_id", args.intakeId).is("vehicle_id", null),
+    supabase
+      .from("work_order_lines")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", args.shopId)
+      .eq("source_intake_id", args.intakeId)
+      .is("work_order_id", null),
+    supabase
+      .from("part_stock")
+      .select("id,part_id")
+      .limit(5000),
+    supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", args.shopId).eq("intake_id", args.intakeId).eq("status", "pending"),
+    supabase
+      .from("shop_boost_review_items")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", args.shopId)
+      .eq("intake_id", args.intakeId)
+      .eq("status", "failed_materialization"),
+    supabase.from("customers").select("id,name,email,phone,phone_number").eq("shop_id", args.shopId).eq("source_intake_id", args.intakeId).limit(5000),
+    supabase.from("vehicles").select("id,vin,license_plate,year,make,model,customer_id").eq("shop_id", args.shopId).eq("source_intake_id", args.intakeId).limit(5000),
+    supabase.from("parts").select("id,part_number,sku,name").eq("shop_id", args.shopId).eq("source_intake_id", args.intakeId).limit(5000),
+  ]);
+
+  const stockRows = stockWithoutPart.data ?? [];
+  const stockMissingPart = stockRows.filter((row: any) => !row.part_id).length;
+
+  const dupCustomers = new Map<string, number>();
+  for (const c of duplicateCustomers.data ?? []) {
+    const key = [normalizeToken((c as any).email), normalizePhone((c as any).phone ?? (c as any).phone_number), normalizeText((c as any).name)].filter(Boolean).join("|");
+    if (!key) continue;
+    dupCustomers.set(key, (dupCustomers.get(key) ?? 0) + 1);
+  }
+  const customerDuplicateRisk = Array.from(dupCustomers.values()).filter((n) => n > 1).length;
+
+  const dupVehicles = new Map<string, number>();
+  for (const v of duplicateVehicles.data ?? []) {
+    const key = normalizeToken((v as any).vin) || normalizeToken((v as any).license_plate) || [normalizeToken((v as any).year), normalizeText((v as any).make), normalizeText((v as any).model), normalizeToken((v as any).customer_id)].join("|");
+    if (!key) continue;
+    dupVehicles.set(key, (dupVehicles.get(key) ?? 0) + 1);
+  }
+  const vehicleDuplicateRisk = Array.from(dupVehicles.values()).filter((n) => n > 1).length;
+
+  const dupParts = new Map<string, number>();
+  for (const p of duplicateParts.data ?? []) {
+    const key = normalizeToken((p as any).part_number) || normalizeToken((p as any).sku) || normalizeText((p as any).name);
+    if (!key) continue;
+    dupParts.set(key, (dupParts.get(key) ?? 0) + 1);
+  }
+  const partDuplicateRisk = Array.from(dupParts.values()).filter((n) => n > 1).length;
+
+  const checks = {
+    vehicles_missing_customer_linkage: vehiclesMissingCustomer.count ?? 0,
+    work_orders_missing_customer_linkage: workOrdersMissingCustomer.count ?? 0,
+    work_orders_missing_vehicle_linkage: workOrdersMissingVehicle.count ?? 0,
+    orphan_work_order_lines: orphanLines.count ?? 0,
+    inventory_without_part_linkage: stockMissingPart,
+    duplicate_customer_risk: customerDuplicateRisk,
+    duplicate_vehicle_risk: vehicleDuplicateRisk,
+    duplicate_part_risk: partDuplicateRisk,
+    unresolved_review_items: intakeReviewPending.count ?? 0,
+    failed_review_materialization: intakeReviewFailed.count ?? 0,
+  };
+
+  const blockingIssuesCount =
+    checks.vehicles_missing_customer_linkage +
+    checks.work_orders_missing_customer_linkage +
+    checks.work_orders_missing_vehicle_linkage +
+    checks.orphan_work_order_lines +
+    checks.inventory_without_part_linkage;
+
+  const warningsCount = checks.duplicate_customer_risk + checks.duplicate_vehicle_risk + checks.duplicate_part_risk;
+
+  const status: IntegrityStatus =
+    blockingIssuesCount > 0
+      ? "not_ready"
+      : warningsCount > 0 || checks.unresolved_review_items > 0 || checks.failed_review_materialization > 0
+        ? "ready_with_warnings"
+        : "ready";
+
+  const graphReady = status !== "not_ready";
+
+  await supabase.from("shop_boost_integrity_reports").insert({
+    shop_id: args.shopId,
+    intake_id: args.intakeId,
+    status,
+    graph_ready: graphReady,
+    blocking_issues_count: blockingIssuesCount,
+    warnings_count: warningsCount,
+    checks,
+  } as any);
+
+  return {
+    status,
+    graphReady,
+    blockingIssuesCount,
+    warningsCount,
+    checks,
+  };
+}
+
+export function computeCompletionState(args: {
+  failedCount: number;
+  pendingReviewCount: number;
+  failedReviewCount: number;
+  integrityStatus: IntegrityStatus;
+}): CompletionState {
+  if (args.failedCount > 0) return "PARTIAL_FAILURE";
+  if (args.integrityStatus === "not_ready") return "NOT_READY";
+  if (args.pendingReviewCount > 0 || args.failedReviewCount > 0) return "COMPLETED_WITH_REVIEW";
+  if (args.integrityStatus === "ready_with_warnings") return "COMPLETED_WITH_WARNINGS";
+  return "READY_FOR_GO_LIVE";
+}

--- a/features/integrations/shopBoost/reviewMaterialization.ts
+++ b/features/integrations/shopBoost/reviewMaterialization.ts
@@ -1,9 +1,14 @@
 import { createHash } from "crypto";
 
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  computeCompletionState,
+  runPostMigrationIntegrityValidation,
+  type IgnoreReasonCode,
+} from "@/features/integrations/shopBoost/migrationReliability";
 
 type ResolutionAction = "linked_to_existing" | "created_new" | "ignored";
-type ReviewStatus = "pending" | "resolved" | "materialized" | "failed_materialization";
+type ReviewStatus = "pending" | "resolved" | "materialized" | "failed_materialization" | "ignored";
 
 type ReviewItemRow = {
   id: string;
@@ -384,10 +389,11 @@ async function materializeByDomain(args: { supabase: any; item: ReviewItemRow; r
 }
 
 async function recomputeMigrationProgress(supabase: any, shopId: string, intakeId: string): Promise<void> {
-  const [{ count: pendingCount }, { count: failedCount }, { count: materializedCount }, { data: intake }] = await Promise.all([
+  const [{ count: pendingCount }, { count: failedCount }, { count: materializedCount }, { count: ignoredCount }, { data: intake }] = await Promise.all([
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "pending"),
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "failed_materialization"),
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "materialized"),
+    supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "ignored"),
     supabase.from("shop_boost_intakes").select("intake_basics").eq("id", intakeId).eq("shop_id", shopId).maybeSingle(),
   ]);
 
@@ -399,11 +405,13 @@ async function recomputeMigrationProgress(supabase: any, shopId: string, intakeI
     Number(materializedCount ?? 0),
   );
 
-  const completionState = reviewCount === 0 && (failedCount ?? 0) === 0
-    ? "COMPLETED_CLEAN"
-    : (failedCount ?? 0) > 0
-      ? "PARTIAL_FAILURE"
-      : "COMPLETED_WITH_REVIEW";
+  const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
+  const completionState = computeCompletionState({
+    failedCount: Number(migrationProgress.failed_count ?? 0),
+    pendingReviewCount: pendingCount ?? 0,
+    failedReviewCount: failedCount ?? 0,
+    integrityStatus: integrity.status,
+  });
 
   await supabase
     .from("shop_boost_intakes")
@@ -414,7 +422,9 @@ async function recomputeMigrationProgress(supabase: any, shopId: string, intakeI
           ...migrationProgress,
           review_count: reviewCount,
           success_count: successCount,
+          ignored_count: ignoredCount ?? 0,
           completionState,
+          integrity,
         },
       },
     })
@@ -427,6 +437,8 @@ export async function resolveAndMaterializeReviewItem(args: {
   shopId: string;
   userId: string;
   resolutionAction: ResolutionAction;
+  ignoreReasonCode?: IgnoreReasonCode;
+  ignoreNote?: string | null;
 }): Promise<{ ok: boolean; item: ReviewItemRow | null; materializedRecord: Record<string, unknown> | null; error?: string; }> {
   const supabase = createAdminSupabase() as any;
 
@@ -440,20 +452,25 @@ export async function resolveAndMaterializeReviewItem(args: {
   if (!item) return { ok: false, item: null, materializedRecord: null, error: "Review item not found." };
 
   const updateBase = {
-    status: "resolved",
+    status: args.resolutionAction === "ignored" ? "ignored" : "resolved",
     resolution_action: args.resolutionAction,
     resolved_by: args.userId,
     resolved_at: new Date().toISOString(),
+    ignored_at: args.resolutionAction === "ignored" ? new Date().toISOString() : null,
+    ignore_reason_code: args.resolutionAction === "ignored" ? args.ignoreReasonCode ?? "other" : null,
+    ignore_note: args.resolutionAction === "ignored" ? args.ignoreNote ?? null : null,
     materialization_error: null,
   };
 
   await supabase.from("shop_boost_review_items").update(updateBase).eq("id", item.id).eq("shop_id", args.shopId);
 
-  const materialized = await materializeByDomain({
-    supabase,
-    item: { ...item, resolution_action: args.resolutionAction, status: "resolved" } as ReviewItemRow,
-    resolutionAction: args.resolutionAction,
-  });
+  const materialized = args.resolutionAction === "ignored"
+    ? { status: "ignored" as ReviewStatus, materializedRecord: { ignored: true, reason: args.ignoreReasonCode ?? "other" }, error: null }
+    : await materializeByDomain({
+        supabase,
+        item: { ...item, resolution_action: args.resolutionAction, status: "resolved" } as ReviewItemRow,
+        resolutionAction: args.resolutionAction,
+      });
 
   await supabase
     .from("shop_boost_review_items")
@@ -481,7 +498,7 @@ export async function resolveAndMaterializeReviewItem(args: {
     .maybeSingle();
 
   return {
-    ok: materialized.status === "materialized",
+    ok: materialized.status === "materialized" || materialized.status === "ignored",
     item: updatedItem ?? null,
     materializedRecord: materialized.materializedRecord,
     ...(materialized.error ? { error: materialized.error } : {}),
@@ -500,9 +517,15 @@ async function replayDependentRows(args: { supabase: any; shopId: string; intake
     .order("created_at", { ascending: true })
     .limit(100);
 
+  let attempted = 0;
+  let succeeded = 0;
+  let failed = 0;
   for (const candidate of replayCandidates ?? []) {
+    attempted += 1;
     const action: ResolutionAction = candidate.resolution_action ?? "created_new";
     const result = await materializeByDomain({ supabase, item: candidate as ReviewItemRow, resolutionAction: action });
+    if (result.status === "materialized") succeeded += 1;
+    if (result.status === "failed_materialization") failed += 1;
 
     await supabase
       .from("shop_boost_review_items")
@@ -517,6 +540,34 @@ async function replayDependentRows(args: { supabase: any; shopId: string; intake
       .eq("shop_id", shopId)
       .eq("id", candidate.id);
   }
+
+  const { data: intake } = await supabase
+    .from("shop_boost_intakes")
+    .select("intake_basics")
+    .eq("id", intakeId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+  const basics = (intake?.intake_basics ?? {}) as Record<string, unknown>;
+  const migrationProgress = (basics.migrationProgress ?? {}) as Record<string, unknown>;
+
+  await supabase
+    .from("shop_boost_intakes")
+    .update({
+      intake_basics: {
+        ...basics,
+        migrationProgress: {
+          ...migrationProgress,
+          replay_stats: {
+            attempted,
+            succeeded,
+            failed,
+            replayedAt: new Date().toISOString(),
+          },
+        },
+      },
+    })
+    .eq("id", intakeId)
+    .eq("shop_id", shopId);
 }
 
 export async function bulkResolveReviewItems(args: {
@@ -524,6 +575,8 @@ export async function bulkResolveReviewItems(args: {
   userId: string;
   reviewItemIds: string[];
   resolutionAction: ResolutionAction;
+  ignoreReasonCode?: IgnoreReasonCode;
+  ignoreNote?: string | null;
 }): Promise<Array<{ id: string; ok: boolean; error?: string }>> {
   const results: Array<{ id: string; ok: boolean; error?: string }> = [];
   for (const id of args.reviewItemIds) {
@@ -532,6 +585,8 @@ export async function bulkResolveReviewItems(args: {
       shopId: args.shopId,
       userId: args.userId,
       resolutionAction: args.resolutionAction,
+      ignoreReasonCode: args.ignoreReasonCode,
+      ignoreNote: args.ignoreNote,
     });
     results.push({ id, ok: result.ok, ...(result.error ? { error: result.error } : {}) });
   }

--- a/features/integrations/shopBoost/status.ts
+++ b/features/integrations/shopBoost/status.ts
@@ -29,7 +29,16 @@ export type IntakeProgressState = {
   review_count?: number;
   failed_count?: number;
   domains?: Record<string, { success: number; review: number; failed: number }>;
-  completionState?: "COMPLETED_CLEAN" | "COMPLETED_WITH_REVIEW" | "PARTIAL_FAILURE";
+  ignored_count?: number;
+  integrity?: Record<string, unknown>;
+  completionState?:
+    | "COMPLETED_CLEAN"
+    | "COMPLETED_WITH_REVIEW"
+    | "COMPLETED_WITH_WARNINGS"
+    | "PARTIAL_FAILURE"
+    | "FAILED"
+    | "READY_FOR_GO_LIVE"
+    | "NOT_READY";
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -63,13 +72,19 @@ export function toIntakeProgress(row: IntakeRow | null): IntakeProgressState | n
     success_count: typeof migration.success_count === "number" ? migration.success_count : undefined,
     review_count: typeof migration.review_count === "number" ? migration.review_count : undefined,
     failed_count: typeof migration.failed_count === "number" ? migration.failed_count : undefined,
+    ignored_count: typeof migration.ignored_count === "number" ? migration.ignored_count : undefined,
+    integrity: isRecord(migration.integrity) ? (migration.integrity as Record<string, unknown>) : undefined,
     domains: isRecord(migration.domains)
       ? (migration.domains as Record<string, { success: number; review: number; failed: number }>)
       : undefined,
     completionState:
       migration.completionState === "COMPLETED_CLEAN" ||
       migration.completionState === "COMPLETED_WITH_REVIEW" ||
-      migration.completionState === "PARTIAL_FAILURE"
+      migration.completionState === "COMPLETED_WITH_WARNINGS" ||
+      migration.completionState === "PARTIAL_FAILURE" ||
+      migration.completionState === "FAILED" ||
+      migration.completionState === "READY_FOR_GO_LIVE" ||
+      migration.completionState === "NOT_READY"
         ? migration.completionState
         : undefined,
   };


### PR DESCRIPTION
### Motivation
- Ship a production-grade Shop Boost migration engine that handles messy real-world exports with deterministic clustering, safe materialization, auditable ignores, replay, and a truthful readiness signal.  
- Prevent silent failures, duplicate live-record creation, and ambiguous inventory writes by making dedupe, review, replay, and integrity validation first-class and durable.

### Description
- Additive DB migration `db/sql/2026-04-15_shop_boost_flagship_hardening.sql` introducing `cluster_key`/`cluster_confidence` on `shop_boost_row_results`, richer review-item columns (`normalized_payload`, `target_domain`, `blocking_reason`, `dependency_refs`, `downstream_impact_count`, `ignore_reason_code`, `ignored_at`), checks for ignore reason values, and a new `shop_boost_integrity_reports` table with RLS.  
- New reliability module `features/integrations/shopBoost/migrationReliability.ts` providing deterministic cluster descriptors (customers, vehicles, parts, invoices), `runPostMigrationIntegrityValidation`, and `computeCompletionState` to derive honest completion states like `READY_FOR_GO_LIVE` / `NOT_READY`.  
- Import pipeline updates in `features/integrations/imports/runFullImport.ts` to stamp cluster metadata on row results and review items, persist richer review context and downstream impact, run post-import integrity validation, record `ignored` counts and integrity snapshots, and compute completion from review + integrity state.  
- Parts pipeline updates in `features/integrations/imports/runPartsImportPipeline.ts` to implement explicit snapshot seeding for inventory, seed or update `part_stock`, create `stock_moves` for traceable seed actions, and persist `inventorySeedMode` and seeded-location counters into intake basics.  
- Review materialization hardening in `features/integrations/shopBoost/reviewMaterialization.ts` to support explicit `ignored` semantics with `ignore_reason_code`/`ignore_note`/`ignored_at`, idempotent materialization paths, replay of dependent rows with replay stats persisted, and integrity-aware progress recomputation.  
- API and UI changes: review APIs (`app/api/shop-boost/review-items/*.ts`) accept and propagate ignore reason/note and return enriched review-item fields, and the review UI (`app/dashboard/setup/review/page.tsx`) displays clusters/confidence, normalized payload, blocking reason, downstream impact, and provides ignore-reason capture and bulk ignore actions.  
- Intake processing update (`app/api/shop-boost/intakes/process/route.ts`) classifies `FAILED` / `NOT_READY` as `completed_with_errors` so dashboard/tracking reflects true trust state.  

### Testing
- Ran type-check: `npx tsc --noEmit` — succeeded.  
- Ran unit/smoke tests: `pnpm test` (Vitest) — all tests passed (2/2).  
- Notes: changes are additive and typed; DB migration file added and must be applied to the running database before enabling new review/ignore workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa695ddfc8328a5ca68a18e31df9d)