### PR TITLE
Add Shop Boost migration trust story, guided review UX, and exportable report

### DIFF
--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type DB = Database;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const {
+    data: { user },
+  } = await supabaseUser.auth.getUser();
+
+  if (!user?.id) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+
+  const { data: profile } = await supabaseUser
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null }>();
+
+  if (!profile?.shop_id) return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
+
+  const admin = createAdminSupabase() as any;
+  const { data: intake, error } = await admin
+    .from("shop_boost_intakes")
+    .select("id,shop_id,status,created_at,processed_at,intake_basics")
+    .eq("id", params.id)
+    .eq("shop_id", profile.shop_id)
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  if (!intake) return NextResponse.json({ ok: false, error: "Intake not found." }, { status: 404 });
+
+  const basics = asRecord(intake.intake_basics);
+  const migrationProgress = asRecord(basics.migrationProgress);
+  const importSummary = asRecord(basics.importSummary);
+  const integrity = asRecord(importSummary.integrity ?? migrationProgress.integrity);
+
+  const [{ data: reviewRows }, { data: byDomainRows }] = await Promise.all([
+    admin
+      .from("shop_boost_review_items")
+      .select("status,resolution_action")
+      .eq("shop_id", profile.shop_id)
+      .eq("intake_id", params.id),
+    admin
+      .from("shop_boost_row_results")
+      .select("domain,review_required,error_reason")
+      .eq("shop_id", profile.shop_id)
+      .eq("intake_id", params.id),
+  ]);
+
+  const reviewOutcomes = (reviewRows ?? []).reduce((acc: Record<string, number>, row: Record<string, unknown>) => {
+    const status = String(row.status ?? "unknown");
+    acc[`status:${status}`] = (acc[`status:${status}`] ?? 0) + 1;
+    const action = String(row.resolution_action ?? "none");
+    acc[`action:${action}`] = (acc[`action:${action}`] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const domainSummaries = (byDomainRows ?? []).reduce((acc: Record<string, { review: number; failed: number; processed: number }>, row: Record<string, unknown>) => {
+    const key = String(row.domain ?? "unknown");
+    const next = acc[key] ?? { review: 0, failed: 0, processed: 0 };
+    next.processed += 1;
+    if (row.review_required) next.review += 1;
+    if (row.error_reason) next.failed += 1;
+    acc[key] = next;
+    return acc;
+  }, {});
+
+  const report = {
+    intake_id: intake.id,
+    status: intake.status,
+    created_at: intake.created_at,
+    processed_at: intake.processed_at,
+    migration_story: asRecord(basics.migration_story),
+    domain_summaries: domainSummaries,
+    integrity_results: {
+      status: integrity.status ?? null,
+      checks: asRecord(integrity.checks),
+      integrity_errors: Array.isArray((integrity as any).integrity_errors) ? (integrity as any).integrity_errors : [],
+    },
+    review_outcomes: reviewOutcomes,
+  };
+
+  const url = new URL(req.url);
+  const download = url.searchParams.get("download") === "1";
+  if (download) {
+    return new NextResponse(JSON.stringify(report, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename=\"shop-boost-report-${intake.id}.json\"`,
+      },
+    });
+  }
+
+  return NextResponse.json({ ok: true, report });
+}

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -24,6 +24,42 @@ function deriveAffectedDomains(dependencyRefs: unknown, domain: string): string[
   return Array.from(domains);
 }
 
+function deriveReviewExplanation(item: Record<string, unknown>): string {
+  const domain = String(item.domain ?? "record");
+  const issueType = String(item.issue_type ?? "ambiguous_match");
+  if (issueType === "missing_dependency") {
+    return `This ${domain} could not be linked because a required dependency was missing from imported data.`;
+  }
+  if (issueType === "invalid") {
+    return `This ${domain} is missing required identifiers, so it cannot be safely materialized yet.`;
+  }
+  if (issueType === "duplicate_candidate" || issueType === "conflict") {
+    return `This ${domain} matches multiple existing records with conflicting similarity signals.`;
+  }
+  return `This ${domain} needs review because matching confidence did not clear the auto-apply threshold.`;
+}
+
+function deriveRecommendationExplanation(
+  recommendation: {
+    recommendedAction: string;
+    recommendationReason: string;
+    recommendationConfidence: number;
+    candidateTargets: Array<{ id: string; label: string; score: number }>;
+  },
+): string {
+  const topCandidate = recommendation.candidateTargets[0];
+  if (recommendation.recommendedAction === "link_existing" && topCandidate) {
+    return `We suggest linking to ${topCandidate.label} based on deterministic identity and similarity scoring (${Math.round(topCandidate.score * 100)}%).`;
+  }
+  if (recommendation.recommendedAction === "merge_candidate") {
+    return "We suggest a merge workflow because duplicate indicators exceeded the merge threshold, but manual confirmation is required.";
+  }
+  if (recommendation.recommendedAction === "ignore") {
+    return "We suggest ignoring this row because data confidence is too low for safe linking or creation.";
+  }
+  return `${recommendation.recommendationReason} Confidence ${Math.round(recommendation.recommendationConfidence * 100)}%.`;
+}
+
 export async function GET(req: Request) {
   const supabaseUser = createRouteHandlerClient<DB>({ cookies });
   const {
@@ -87,6 +123,15 @@ export async function GET(req: Request) {
       ...item,
       recommendation,
       affected_domains: deriveAffectedDomains(item.dependency_refs, String(item.domain ?? "")),
+      review_explanation: deriveReviewExplanation(item),
+      recommendation_explanation: deriveRecommendationExplanation(recommendation as any),
+      decision_transparency: {
+        confidence_score: Number((recommendation as any).recommendationConfidence ?? 0),
+        reasoning: String((recommendation as any).recommendationReason ?? ""),
+        candidates: Array.isArray((recommendation as any).candidateTargets) ? (recommendation as any).candidateTargets : [],
+        raw_data: asRecord(item.raw_payload),
+        normalized_data: asRecord(item.normalized_payload),
+      },
     };
   });
 

--- a/app/dashboard/setup/review/page.tsx
+++ b/app/dashboard/setup/review/page.tsx
@@ -36,6 +36,15 @@ type ReviewItem = {
   created_at: string;
   affected_domains?: string[];
   recommendation: Recommendation;
+  review_explanation: string;
+  recommendation_explanation: string;
+  decision_transparency: {
+    confidence_score: number;
+    reasoning: string;
+    candidates: Array<{ id: string; label: string; score: number }>;
+    raw_data: Record<string, unknown>;
+    normalized_data: Record<string, unknown>;
+  };
 };
 
 type Guidance = {
@@ -72,7 +81,6 @@ export default function ShopBoostReviewPage() {
   const [guidance, setGuidance] = useState<Guidance | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [reprocessBusy, setReprocessBusy] = useState<null | "failed" | "unresolved" | "updated_matches">(null);
-  const [debugView, setDebugView] = useState(false);
   const [confirmRiskById, setConfirmRiskById] = useState<Record<string, boolean>>({});
 
   const load = async () => {
@@ -103,6 +111,17 @@ export default function ShopBoostReviewPage() {
 
   const isHighRiskItem = (item: ReviewItem, action: "linked_to_existing" | "created_new" | "ignored") =>
     action === "linked_to_existing" && item.recommendation.recommendedAction === "merge_candidate";
+
+  const stepCounts = useMemo(() => {
+    const critical = items.filter((item) => Boolean(item.blocking_reason));
+    const suggested = items.filter((item) => !item.blocking_reason && item.recommendation.confidenceLabel !== "LOW");
+    const cleanup = items.filter((item) => !critical.includes(item) && !suggested.includes(item));
+    return {
+      critical,
+      suggested,
+      cleanup,
+    };
+  }, [items]);
 
   const applySuggested = async (item: ReviewItem) => {
     const resolution_action = toResolutionAction(item.recommendation.recommendedAction);
@@ -204,7 +223,7 @@ export default function ShopBoostReviewPage() {
     <div className="space-y-4">
       <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
         <h1 className="text-xl font-semibold text-white">Shop Boost Guided Review</h1>
-        <p className="mt-1 text-sm text-neutral-300">Resolve migration issues safely with recommendations, confidence signals, and downstream impact visibility.</p>
+        <p className="mt-1 text-sm text-neutral-300">Resolve migration issues in guided steps with transparent reasoning and confidence-backed actions.</p>
         <div className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-300">
           {Object.entries(grouped).map(([key, count]) => (
             <span key={key} className="rounded-full border border-white/15 px-2 py-1">{key}: {count}</span>
@@ -238,7 +257,6 @@ export default function ShopBoostReviewPage() {
             </select>
           </div>
         </div>
-        <label className="inline-flex items-center gap-2 text-xs text-neutral-300"><input type="checkbox" checked={debugView} onChange={(e) => setDebugView(e.target.checked)} /> Advanced debug view</label>
 
         <div className="grid gap-2 md:grid-cols-3 text-xs">
           <button className="rounded border border-emerald-300/40 px-2 py-1 text-emerald-100" onClick={() => void applyAllHighConfidence()}>Apply HIGH confidence only (≥85%)</button>
@@ -246,23 +264,37 @@ export default function ShopBoostReviewPage() {
           <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={() => void runReprocess("unresolved")} disabled={reprocessBusy !== null}>{reprocessBusy === "unresolved" ? "Re-running…" : "Re-run unresolved items"}</button>
           <button className="rounded border border-sky-300/40 px-2 py-1 text-sky-100 md:col-span-3" onClick={() => void runReprocess("updated_matches")} disabled={reprocessBusy !== null}>{reprocessBusy === "updated_matches" ? "Re-running…" : "Re-run with updated matches"}</button>
         </div>
-
-        <div>
-          <label className="text-xs uppercase tracking-[0.16em] text-neutral-400">Ignore reason</label>
-          <select value={ignoreReason} onChange={(e) => setIgnoreReason(e.target.value)} className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white">
-            {["duplicate", "obsolete", "invalid", "test_data", "intentionally_skipped", "unsupported_format", "other"].map((reason) => <option key={reason} value={reason}>{reason}</option>)}
-          </select>
-          <input value={ignoreNote} onChange={(e) => setIgnoreNote(e.target.value)} placeholder="Optional ignore note" className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white" />
-        </div>
-
-        {selectedIds.length > 0 ? (
-          <div className="flex flex-wrap gap-2 text-xs">
-            <button className="rounded border border-sky-300/40 px-2 py-1 text-sky-100" onClick={() => void resolveBulk("linked_to_existing")}>Bulk link to existing</button>
-            <button className="rounded border border-emerald-300/40 px-2 py-1 text-emerald-100" onClick={() => void resolveBulk("created_new")}>Bulk create new</button>
-            <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={() => void resolveBulk("ignored")}>Bulk ignore</button>
-          </div>
-        ) : null}
       </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {[
+          { key: "critical", title: "Step 1: Resolve critical blockers", rows: stepCounts.critical, cta: "Resolve blocker" },
+          { key: "suggested", title: "Step 2: Review suggested fixes", rows: stepCounts.suggested, cta: "Apply suggested" },
+          { key: "cleanup", title: "Step 3: Optional clean-up", rows: stepCounts.cleanup, cta: "Clean up" },
+        ].map((step) => (
+          <details key={step.key} className="rounded-xl border border-white/10 bg-black/20 p-3" open={step.rows.length > 0}>
+            <summary className="cursor-pointer text-sm font-semibold text-white">{step.title}</summary>
+            <div className="mt-2 text-xs text-neutral-300">{step.rows.length} item(s) in this step.</div>
+            {step.rows.length === 0 ? <div className="mt-2 text-xs text-emerald-200">Complete ✅</div> : <div className="mt-2 text-xs text-neutral-400">Use item actions below to {step.cta.toLowerCase()}.</div>}
+          </details>
+        ))}
+      </div>
+
+      <div>
+        <label className="text-xs uppercase tracking-[0.16em] text-neutral-400">Ignore reason</label>
+        <select value={ignoreReason} onChange={(e) => setIgnoreReason(e.target.value)} className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white">
+          {["duplicate", "obsolete", "invalid", "test_data", "intentionally_skipped", "unsupported_format", "other"].map((reason) => <option key={reason} value={reason}>{reason}</option>)}
+        </select>
+        <input value={ignoreNote} onChange={(e) => setIgnoreNote(e.target.value)} placeholder="Optional ignore note" className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white" />
+      </div>
+
+      {selectedIds.length > 0 ? (
+        <div className="flex flex-wrap gap-2 text-xs">
+          <button className="rounded border border-sky-300/40 px-2 py-1 text-sky-100" onClick={() => void resolveBulk("linked_to_existing")}>Bulk link to existing</button>
+          <button className="rounded border border-emerald-300/40 px-2 py-1 text-emerald-100" onClick={() => void resolveBulk("created_new")}>Bulk create new</button>
+          <button className="rounded border border-white/25 px-2 py-1 text-neutral-200" onClick={() => void resolveBulk("ignored")}>Bulk ignore</button>
+        </div>
+      ) : null}
 
       {loading ? <div className="text-sm text-neutral-400">Loading review queue…</div> : items.length === 0 ? (
         <div className="rounded-xl border border-emerald-300/20 bg-emerald-950/20 p-3 text-sm text-emerald-100">No items for this filter.</div>
@@ -276,11 +308,10 @@ export default function ShopBoostReviewPage() {
                   <div>
                     <div className="text-sm font-semibold text-white">{item.summary}</div>
                     <div className="text-xs text-neutral-400">{item.domain} • {item.issue_type} • {item.status}</div>
-                    <div className="mt-1 text-xs text-neutral-500">target: {item.target_domain ?? item.domain} • cluster: {item.cluster_key ?? "n/a"} ({item.cluster_confidence?.toFixed(2) ?? "0.00"})</div>
                     {item.blocking_reason ? <div className="text-xs text-amber-200">Blocker: {item.blocking_reason}</div> : null}
-                    <div className="text-xs text-neutral-300">What is wrong: {item.summary}</div>
-                    <div className="text-xs text-neutral-300">Why it happened: {item.recommendation.recommendationReason}</div>
-                    {(item.downstream_impact_count ?? 0) > 0 ? <div className="text-xs text-sky-200">This will unblock {item.downstream_impact_count} downstream records in {(item.affected_domains ?? []).join(", ") || "related domains"}.</div> : null}
+                    <div className="mt-1 text-xs text-neutral-200">Why this needs review: {item.review_explanation}</div>
+                    <div className="text-xs text-sky-200">Suggested reasoning: {item.recommendation_explanation}</div>
+                    {(item.downstream_impact_count ?? 0) > 0 ? <div className="text-xs text-emerald-200">This can unblock {item.downstream_impact_count} downstream records in {(item.affected_domains ?? []).join(", ") || "related domains"}.</div> : null}
                   </div>
                 </div>
 
@@ -308,24 +339,29 @@ export default function ShopBoostReviewPage() {
                 </div>
               </div>
 
+              <details className="mt-3 rounded-lg border border-white/10 bg-black/30 p-2">
+                <summary className="cursor-pointer text-xs font-medium text-neutral-100">Decision transparency panel</summary>
+                <div className="mt-2 grid gap-3 md:grid-cols-3">
+                  <div>
+                    <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Raw data</div>
+                    <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.decision_transparency.raw_data ?? {}, null, 2)}</pre>
+                  </div>
+                  <div>
+                    <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Normalized data</div>
+                    <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.decision_transparency.normalized_data ?? {}, null, 2)}</pre>
+                  </div>
+                  <div>
+                    <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Candidates + confidence</div>
+                    <div className="mb-2 text-xs text-neutral-300">Confidence score: {(item.decision_transparency.confidence_score * 100).toFixed(0)}%</div>
+                    <div className="mb-2 text-xs text-neutral-300">Reasoning: {item.decision_transparency.reasoning}</div>
+                    <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.decision_transparency.candidates ?? [], null, 2)}</pre>
+                  </div>
+                </div>
+              </details>
+
               {item.materialized_record ? <div className="mt-2 text-xs text-emerald-200">Resolved + Applied → {JSON.stringify(item.materialized_record)}</div> : null}
               {item.status === "ignored" ? <div className="mt-1 text-xs text-neutral-300">Ignored ({item.ignore_reason_code ?? "other"}) {item.ignore_note ? `• ${item.ignore_note}` : ""}</div> : null}
               {item.materialization_error ? <div className="mt-1 text-xs text-rose-300">Materialization error: {item.materialization_error}</div> : null}
-
-              {debugView ? <div className="mt-3 grid gap-3 md:grid-cols-3">
-                <div>
-                  <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Raw imported data</div>
-                  <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.raw_payload ?? {}, null, 2)}</pre>
-                </div>
-                <div>
-                  <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Normalized / target payload</div>
-                  <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.normalized_payload ?? {}, null, 2)}</pre>
-                </div>
-                <div>
-                  <div className="mb-1 text-xs uppercase tracking-[0.14em] text-neutral-500">Suggested matches / system data</div>
-                  <pre className="max-h-64 overflow-auto rounded border border-white/10 bg-black/40 p-2 text-xs text-neutral-200">{JSON.stringify(item.suggested_matches ?? {}, null, 2)}</pre>
-                </div>
-              </div> : null}
             </div>
           ))}
         </div>

--- a/features/dashboard/components/ShopBoostActivationPanel.tsx
+++ b/features/dashboard/components/ShopBoostActivationPanel.tsx
@@ -12,6 +12,25 @@ type DomainSummary = {
   note?: string | null;
 };
 
+type MigrationStory = {
+  total_rows: number;
+  materialized_count: number;
+  linked_count: number;
+  review_resolved_count: number;
+  ignored_count: number;
+  failed_count: number;
+  key_fixes: string[];
+  risk_flags: {
+    duplicates_detected: boolean;
+    missing_identifiers: boolean;
+    inconsistent_data_patterns: boolean;
+  };
+  trust_statement: string;
+  trust_status: "READY" | "NEEDS REVIEW" | "PARTIAL" | "BLOCKED";
+  blockers: string[];
+  confidence_score: number;
+};
+
 type IntakeState = {
   id: string;
   status: string;
@@ -27,6 +46,7 @@ type IntakeState = {
     failed_count?: number;
     completionState?: "COMPLETED_CLEAN" | "COMPLETED_WITH_REVIEW" | "COMPLETED_WITH_WARNINGS" | "PARTIAL_FAILURE" | "READY_FOR_GO_LIVE" | "NOT_READY";
     integrity?: Record<string, unknown>;
+    migration_story?: MigrationStory;
   } | null;
 };
 
@@ -37,13 +57,12 @@ function fmtStep(step: string | undefined): string {
   return step.replaceAll("_", " ").replace(/\b\w/g, (m) => m.toUpperCase());
 }
 
-function completionCopy(state: string | undefined): { title: string; next: string } {
-  if (state === "READY_FOR_GO_LIVE") return { title: "Your shop is ready. You can start using ProFixIQ.", next: "Start operating now" };
-  if (state === "COMPLETED_WITH_REVIEW") return { title: "Import complete with items needing review.", next: "Resolve review items" };
-  if (state === "PARTIAL_FAILURE") return { title: "Some data could not be fully imported.", next: "Re-run failed items" };
-  if (state === "NOT_READY") return { title: "Action required before your data is usable.", next: "Resolve blockers" };
-  return { title: "Migration in progress", next: "Monitor import" };
-}
+const statusTone: Record<MigrationStory["trust_status"], string> = {
+  READY: "border-emerald-400/35 bg-emerald-950/30 text-emerald-100",
+  "NEEDS REVIEW": "border-amber-400/35 bg-amber-950/20 text-amber-100",
+  PARTIAL: "border-orange-400/35 bg-orange-950/20 text-orange-100",
+  BLOCKED: "border-rose-400/35 bg-rose-950/25 text-rose-100",
+};
 
 export default function ShopBoostActivationPanel() {
   const [intake, setIntake] = useState<IntakeState | null>(null);
@@ -70,73 +89,74 @@ export default function ShopBoostActivationPanel() {
 
   if (loading || !intake) return null;
 
-  const result = intake.progress?.resultSummary ?? {};
   const domains = intake.progress?.domainSummaries ?? {};
-  const reviewByDomain = ((result.rowResults as { byDomain?: Record<string, { review?: number; success?: number; failed?: number }> } | undefined)?.byDomain ?? {}) || {};
-  const reviewCount = Number(intake.progress?.review_count ?? 0);
-  const failedCount = Number(intake.progress?.failed_count ?? 0);
-
-  const integrityChecks = (intake.progress?.integrity?.checks as Record<string, number> | undefined) ?? {};
-  const blockers =
-    Number(integrityChecks.vehicles_missing_customer_linkage ?? 0) +
-    Number(integrityChecks.work_orders_missing_customer_linkage ?? 0) +
-    Number(integrityChecks.work_orders_missing_vehicle_linkage ?? 0) +
-    Number(integrityChecks.orphan_work_order_lines ?? 0) +
-    Number(integrityChecks.inventory_without_part_linkage ?? 0);
-  const nonBlocking =
-    Number(integrityChecks.duplicate_customer_risk ?? 0) +
-    Number(integrityChecks.duplicate_vehicle_risk ?? 0) +
-    Number(integrityChecks.duplicate_part_risk ?? 0) +
-    reviewCount;
-
-  const resolvedRatio = Math.max(0, Math.min(1, 1 - (reviewCount + failedCount) / Math.max(1, reviewCount + failedCount + Number(result.customersImported ?? 0) + Number(result.vehiclesImported ?? 0) + Number(result.workOrdersImported ?? 0) + Number(result.partsImported ?? 0))));
-  const autoMatchRatio = Math.max(0, Math.min(1, Number(result.customersImported ?? 0) + Number(result.vehiclesImported ?? 0) > 0 ? 0.8 : 0.5));
-  const reviewPenalty = Math.max(0, Math.min(1, reviewCount / Math.max(1, reviewCount + 20)));
-  const failPenalty = Math.max(0, Math.min(1, failedCount / Math.max(1, failedCount + 10)));
-  const overallConfidenceScore = Math.max(0, Math.min(1, (resolvedRatio * 0.45) + (autoMatchRatio * 0.25) + ((1 - reviewPenalty) * 0.2) + ((1 - failPenalty) * 0.1)));
-  const confidenceLabel = overallConfidenceScore >= 0.85 ? "HIGH" : overallConfidenceScore >= 0.65 ? "MEDIUM" : "LOW";
-
-  const completionState = intake.progress?.completionState;
-  const copy = completionCopy(completionState);
+  const story = intake.progress?.migration_story;
+  const fallbackConfidence = story ? Math.round(story.confidence_score * 100) : 0;
 
   return (
     <section className="mb-2.5 rounded-xl border border-[var(--brand-accent,#E39A6E)]/30 bg-[linear-gradient(140deg,rgba(22,12,8,0.72),rgba(7,12,25,0.86))] p-3">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <p className="text-[11px] uppercase tracking-[0.2em] text-neutral-400">Migration Confidence Summary</p>
-          <h3 className="text-sm font-semibold text-neutral-100">{copy.title}</h3>
+          <p className="text-[11px] uppercase tracking-[0.2em] text-neutral-400">Shop Boost Trust Panel</p>
+          <h3 className="text-sm font-semibold text-neutral-100">Migration Mission Control</h3>
           <p className="mt-1 text-xs text-neutral-300">Status: <span className="font-medium text-neutral-100">{fmtStep(intake.progress?.currentStep ?? intake.status)}</span></p>
         </div>
         <div className="rounded-md border border-white/15 bg-black/30 px-3 py-2 text-xs text-neutral-200">
-          <div>Confidence: <span className="font-semibold">{confidenceLabel} ({Math.round(overallConfidenceScore * 100)}%)</span></div>
-          <div className="text-neutral-400">Weighted by resolved %, review load, and failures.</div>
+          <div>Confidence Score: <span className="font-semibold">{fallbackConfidence}%</span></div>
+          <div className="text-neutral-400">Derived from real row outcomes, reviews, failures, and integrity checks.</div>
         </div>
       </div>
 
       <div className="mt-3 h-2 rounded-full bg-white/10"><div className="h-full rounded-full bg-[var(--brand-accent,#E39A6E)] transition-all" style={{ width: `${percent}%` }} /></div>
 
-      <div className={`mt-3 rounded-md border p-2 text-xs ${blockers === 0 ? "border-emerald-400/30 bg-emerald-950/20 text-emerald-100" : "border-amber-400/35 bg-amber-950/20 text-amber-100"}`}>
-        {blockers === 0 ? "You can start using ProFixIQ now." : "Complete these items before your data is ready."}
-        <div className="mt-1">Operational blockers: {blockers} • Non-blocking issues: {nonBlocking}</div>
-        <div className="mt-2 flex flex-wrap gap-2">
-          <Link href="/dashboard/setup/review" className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">{blockers === 0 ? "Continue setup later" : "Resolve blockers"}</Link>
-          <Link href="/dashboard/setup/review" className="rounded-md border border-amber-300/35 px-2.5 py-1 text-amber-100 hover:bg-white/5">{copy.next}</Link>
-        </div>
-      </div>
-
-      <div className="mt-3 grid gap-2 text-xs text-neutral-300 md:grid-cols-2">
-        {[
-          ["Customers", reviewByDomain.customers],
-          ["Vehicles", reviewByDomain.vehicles],
-          ["Parts", reviewByDomain.parts],
-          ["Work history", reviewByDomain.history],
-        ].map(([label, row]) => (
-          <div key={String(label)} className="rounded-md border border-white/10 bg-black/25 p-2">
-            <div className="font-medium text-neutral-100">{String(label)}</div>
-            <div>Imported: {Number((row as any)?.success ?? 0).toLocaleString()} • Review needed: {Number((row as any)?.review ?? 0).toLocaleString()} • Failed: {Number((row as any)?.failed ?? 0).toLocaleString()}</div>
+      {story ? (
+        <>
+          <div className={`mt-3 rounded-md border p-2 text-xs ${statusTone[story.trust_status]}`}>
+            <div className="font-semibold">{story.trust_status}</div>
+            <div className="mt-1">{story.trust_statement}</div>
+            <div className="mt-2 text-[11px] text-neutral-200">We automatically matched your records where possible. We flagged uncertain data for review. Nothing was changed without validation.</div>
           </div>
-        ))}
-      </div>
+
+          <div className="mt-3 grid gap-2 md:grid-cols-3">
+            <div className="rounded-md border border-white/10 bg-black/25 p-2 text-xs text-neutral-300">
+              <div className="font-medium text-neutral-100">Rows processed</div>
+              <div>{story.total_rows.toLocaleString()} total • {story.materialized_count.toLocaleString()} materialized • {story.linked_count.toLocaleString()} linked</div>
+            </div>
+            <div className="rounded-md border border-white/10 bg-black/25 p-2 text-xs text-neutral-300">
+              <div className="font-medium text-neutral-100">Review outcomes</div>
+              <div>{story.review_resolved_count.toLocaleString()} resolved • {story.ignored_count.toLocaleString()} ignored • {story.failed_count.toLocaleString()} failed</div>
+            </div>
+            <div className="rounded-md border border-white/10 bg-black/25 p-2 text-xs text-neutral-300">
+              <div className="font-medium text-neutral-100">Risk flags</div>
+              <div>Duplicates: {story.risk_flags.duplicates_detected ? "Yes" : "No"} • Missing IDs: {story.risk_flags.missing_identifiers ? "Yes" : "No"} • Inconsistent patterns: {story.risk_flags.inconsistent_data_patterns ? "Yes" : "No"}</div>
+            </div>
+          </div>
+
+          <div className="mt-3 rounded-md border border-white/10 bg-black/25 p-2 text-xs text-neutral-300">
+            <div className="font-medium text-neutral-100">What we automatically fixed</div>
+            <ul className="mt-1 list-disc space-y-1 pl-5">
+              {story.key_fixes.map((fix) => (
+                <li key={fix}>{fix}</li>
+              ))}
+            </ul>
+          </div>
+
+          {story.trust_status !== "READY" ? (
+            <div className="mt-3 rounded-md border border-amber-400/35 bg-amber-950/20 p-2 text-xs text-amber-100">
+              <div className="font-semibold">Exact blockers</div>
+              {story.blockers.length > 0 ? (
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  {story.blockers.map((blocker) => (
+                    <li key={blocker}>{blocker}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="mt-1">Review queue still has unresolved items.</div>
+              )}
+            </div>
+          ) : null}
+        </>
+      ) : null}
 
       {Object.keys(domains).length > 0 ? (
         <div className="mt-3 grid gap-2 md:grid-cols-2">
@@ -150,18 +170,21 @@ export default function ShopBoostActivationPanel() {
         </div>
       ) : null}
 
-      {(completionState === "READY_FOR_GO_LIVE" || intake.status === "completed") ? (
-        <div className="mt-3 rounded-md border border-white/10 bg-black/20 p-2 text-xs">
-          <div className="font-medium text-neutral-100">Get operational fast</div>
+      {(intake.progress?.completionState === "READY_FOR_GO_LIVE" || story?.trust_status === "READY") ? (
+        <div className="mt-3 rounded-md border border-emerald-300/30 bg-emerald-950/20 p-2 text-xs text-emerald-100">
+          <div className="font-semibold">Go live complete</div>
+          <div className="mt-1">Confidence score: {fallbackConfidence}% • What you reviewed: {story?.review_resolved_count ?? 0} • What was ignored: {story?.ignored_count ?? 0}</div>
           <div className="mt-2 flex flex-wrap gap-2">
-            <Link href="/customers" className="rounded-md border border-white/20 px-2.5 py-1 text-neutral-100 hover:bg-white/5">View your customers</Link>
-            <Link href="/work-orders" className="rounded-md border border-white/20 px-2.5 py-1 text-neutral-100 hover:bg-white/5">Open your first work order</Link>
-            <Link href="/parts/inventory" className="rounded-md border border-white/20 px-2.5 py-1 text-neutral-100 hover:bg-white/5">Check your inventory</Link>
-            <Link href="/dashboard" className="rounded-md border border-white/20 px-2.5 py-1 text-neutral-100 hover:bg-white/5">Review recent jobs</Link>
-            <Link href="/dashboard/owner/settings" className="rounded-md border border-white/20 px-2.5 py-1 text-neutral-100 hover:bg-white/5">Finish remaining setup</Link>
+            <Link href="/dashboard" className="rounded-md border border-emerald-300/50 px-2.5 py-1 text-emerald-100 hover:bg-white/5">Enter your system</Link>
+            <Link href={`/api/shop-boost/intakes/${intake.id}/report?download=1`} className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">View full migration report</Link>
           </div>
         </div>
-      ) : null}
+      ) : (
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          <Link href="/dashboard/setup/review" className="rounded-md border border-amber-300/35 px-2.5 py-1 text-amber-100 hover:bg-white/5">Resolve blockers</Link>
+          <Link href={`/api/shop-boost/intakes/${intake.id}/report?download=1`} className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">Download migration report</Link>
+        </div>
+      )}
 
       {intake.progress?.lastError ? <p className="mt-2 text-xs text-amber-300">{intake.progress.lastError}</p> : null}
     </section>

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -15,6 +15,7 @@ import {
   type CompletionState,
   type ReviewIssueType,
 } from "@/features/integrations/shopBoost/migrationReliability";
+import { buildMigrationStory } from "@/features/integrations/shopBoost/migrationStory";
 import { deriveReviewRecommendation } from "@/features/integrations/shopBoost/reviewGuidance";
 
 type DB = Database;
@@ -1960,11 +1961,18 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       .eq("shop_id", shopId)
       .eq("intake_id", intakeId)
       .eq("status", "ignored"),
+    supabase
+      .from("shop_boost_review_items")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", shopId)
+      .eq("intake_id", intakeId)
+      .in("status", ["resolved", "materialized"]),
   ]);
 
   const pendingReviewCount = reviewCounts[0].count ?? 0;
   const failedReviewCount = reviewCounts[1].count ?? 0;
   const ignoredCount = reviewCounts[2].count ?? 0;
+  const reviewResolvedCount = reviewCounts[3].count ?? 0;
   rowOutcome.ignoredCount = ignoredCount;
   const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
   const integrityErrors: string[] = Array.isArray((integrity as any).integrityErrors) ? (integrity as any).integrityErrors : [];
@@ -2009,6 +2017,21 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
   rowOutcome.integrityErrors = integrityErrors;
   rowOutcome.outcomeBuckets = outcomeBuckets;
+
+  const { data: keyFixRows } = await (supabase as any)
+    .from("shop_boost_review_items")
+    .select("domain,issue_type,status,resolution_action")
+    .eq("shop_id", shopId)
+    .eq("intake_id", intakeId)
+    .limit(100000);
+
+  const duplicateCustomersMerged = (keyFixRows ?? []).filter(
+    (row: any) =>
+      row.domain === "customer" &&
+      (row.issue_type === "duplicate_candidate" || row.issue_type === "conflict") &&
+      row.resolution_action === "linked_to_existing" &&
+      (row.status === "resolved" || row.status === "materialized"),
+  ).length;
 
   const autoMatchRatio = rowOutcome.totalRows > 0 ? (outcomeBuckets.materialized + outcomeBuckets.linked) / rowOutcome.totalRows : 0;
   const manualInterventionRatio = rowOutcome.totalRows > 0 ? (pendingReviewCount + ignoredCount) / rowOutcome.totalRows : 0;
@@ -2097,6 +2120,28 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         .is("customer_id", null),
     ]);
 
+  const migrationStory = buildMigrationStory({
+    totalRows: rowOutcome.totalRows,
+    outcomeBuckets: {
+      materialized: outcomeBuckets.materialized,
+      linked: outcomeBuckets.linked,
+      ignored: ignoredCount,
+      failed: outcomeBuckets.failed,
+    },
+    reviewResolvedCount,
+    pendingReviewCount,
+    failedReviewCount,
+    failedCount: rowOutcome.failedCount,
+    integrityErrorsCount: integrityErrors.length,
+    confidenceScore: trustScore,
+    integrityChecks: integrity.checks as Record<string, unknown>,
+    keyFixCounts: {
+      duplicateCustomersMerged,
+      vehiclesLinkedToCustomers: linkageCounters.vehiclesCustomerId,
+      workOrdersRecoveredVehicleLinks: linkageCounters.workOrdersVehicleId,
+    },
+  });
+
   await supabase
     .from("shop_boost_intakes")
     .update(
@@ -2133,7 +2178,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             integrity: { ...integrity, integrity_errors: integrityErrors },
             ignoredCount,
             confidence_score: trustScore,
+            migration_story: migrationStory,
           },
+          migration_story: migrationStory,
           shopBuildSummary,
           migrationProgress: {
             ...(isRecord(prevBasics.migrationProgress) ? prevBasics.migrationProgress : {}),
@@ -2150,6 +2197,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             row_outcome_buckets: outcomeBuckets,
             confidence_score: trustScore,
             confidence_tier: trustScore >= 0.85 ? "HIGH" : trustScore >= 0.6 ? "MEDIUM" : "LOW",
+            migration_story: migrationStory,
             ready_for_go_live_gate:
               integrityErrors.length === 0 &&
               pendingReviewCount === 0 &&

--- a/features/integrations/shopBoost/migrationStory.ts
+++ b/features/integrations/shopBoost/migrationStory.ts
@@ -1,0 +1,123 @@
+type TrustStatus = "READY" | "NEEDS REVIEW" | "PARTIAL" | "BLOCKED";
+
+export type MigrationStory = {
+  total_rows: number;
+  materialized_count: number;
+  linked_count: number;
+  review_resolved_count: number;
+  ignored_count: number;
+  failed_count: number;
+  key_fixes: string[];
+  risk_flags: {
+    duplicates_detected: boolean;
+    missing_identifiers: boolean;
+    inconsistent_data_patterns: boolean;
+  };
+  trust_statement: string;
+  trust_status: TrustStatus;
+  blockers: string[];
+  confidence_score: number;
+};
+
+export function computeTrustStatus(args: {
+  blockers: number;
+  pendingReviewCount: number;
+  failedCount: number;
+  integrityErrorsCount: number;
+}): TrustStatus {
+  if (args.blockers > 0 || args.integrityErrorsCount > 0) return "BLOCKED";
+  if (args.failedCount > 0) return "PARTIAL";
+  if (args.pendingReviewCount > 0) return "NEEDS REVIEW";
+  return "READY";
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(0.99, Number(value.toFixed(2))));
+}
+
+export function buildMigrationStory(args: {
+  totalRows: number;
+  outcomeBuckets: {
+    materialized: number;
+    linked: number;
+    ignored: number;
+    failed: number;
+  };
+  reviewResolvedCount: number;
+  pendingReviewCount: number;
+  failedReviewCount: number;
+  failedCount: number;
+  integrityErrorsCount: number;
+  confidenceScore: number;
+  integrityChecks?: Record<string, unknown>;
+  keyFixCounts: {
+    duplicateCustomersMerged: number;
+    vehiclesLinkedToCustomers: number;
+    workOrdersRecoveredVehicleLinks: number;
+  };
+}): MigrationStory {
+  const checks = args.integrityChecks ?? {};
+  const duplicatesDetected =
+    Number(checks.duplicate_customer_risk ?? 0) > 0 ||
+    Number(checks.duplicate_vehicle_risk ?? 0) > 0 ||
+    Number(checks.duplicate_part_risk ?? 0) > 0 ||
+    args.keyFixCounts.duplicateCustomersMerged > 0;
+  const missingIdentifiers =
+    Number(checks.vehicles_missing_customer_linkage ?? 0) > 0 ||
+    Number(checks.work_orders_missing_customer_linkage ?? 0) > 0 ||
+    Number(checks.work_orders_missing_vehicle_linkage ?? 0) > 0;
+  const inconsistentPatterns = args.integrityErrorsCount > 0;
+
+  const blockers: string[] = [];
+  if (Number(checks.vehicles_missing_customer_linkage ?? 0) > 0) blockers.push("Vehicles missing customer linkage");
+  if (Number(checks.work_orders_missing_customer_linkage ?? 0) > 0) blockers.push("Work orders missing customer linkage");
+  if (Number(checks.work_orders_missing_vehicle_linkage ?? 0) > 0) blockers.push("Work orders missing vehicle linkage");
+  if (Number(checks.orphan_work_order_lines ?? 0) > 0) blockers.push("Orphan work order lines detected");
+  if (Number(checks.inventory_without_part_linkage ?? 0) > 0) blockers.push("Inventory rows missing part linkage");
+  if (args.integrityErrorsCount > 0) blockers.push("Integrity validation errors require review");
+
+  const keyFixes: string[] = [];
+  if (args.keyFixCounts.duplicateCustomersMerged > 0) {
+    keyFixes.push(`Merged ${args.keyFixCounts.duplicateCustomersMerged} duplicate customers`);
+  }
+  if (args.keyFixCounts.vehiclesLinkedToCustomers > 0) {
+    keyFixes.push(`Linked ${args.keyFixCounts.vehiclesLinkedToCustomers} vehicles to existing customers`);
+  }
+  if (args.keyFixCounts.workOrdersRecoveredVehicleLinks > 0) {
+    keyFixes.push(`Recovered ${args.keyFixCounts.workOrdersRecoveredVehicleLinks} work orders missing vehicle links`);
+  }
+  if (keyFixes.length === 0) keyFixes.push("Validated imported records and preserved source traceability");
+
+  const confidenceScore = clampScore(args.confidenceScore);
+  const unresolvedReview = args.pendingReviewCount + args.failedReviewCount;
+  const trustStatus = computeTrustStatus({
+    blockers: blockers.length,
+    pendingReviewCount: args.pendingReviewCount,
+    failedCount: args.failedCount + args.failedReviewCount,
+    integrityErrorsCount: args.integrityErrorsCount,
+  });
+  const trustStatement =
+    unresolvedReview > 0
+      ? `We successfully migrated your data with ${Math.round(confidenceScore * 100)}% confidence. ${unresolvedReview} record${unresolvedReview === 1 ? "" : "s"} still need manual review.`
+      : `We successfully migrated your data with ${Math.round(confidenceScore * 100)}% confidence. All flagged records were validated.`;
+
+  return {
+    total_rows: Math.max(0, args.totalRows),
+    materialized_count: Math.max(0, args.outcomeBuckets.materialized),
+    linked_count: Math.max(0, args.outcomeBuckets.linked),
+    review_resolved_count: Math.max(0, args.reviewResolvedCount),
+    ignored_count: Math.max(0, args.outcomeBuckets.ignored),
+    failed_count: Math.max(0, args.outcomeBuckets.failed + args.failedReviewCount),
+    key_fixes: keyFixes,
+    risk_flags: {
+      duplicates_detected: duplicatesDetected,
+      missing_identifiers: missingIdentifiers,
+      inconsistent_data_patterns: inconsistentPatterns,
+    },
+    trust_statement: trustStatement,
+    trust_status: trustStatus,
+    blockers,
+    confidence_score: confidenceScore,
+  };
+}

--- a/features/integrations/shopBoost/reviewMaterialization.ts
+++ b/features/integrations/shopBoost/reviewMaterialization.ts
@@ -6,6 +6,7 @@ import {
   runPostMigrationIntegrityValidation,
   type IgnoreReasonCode,
 } from "@/features/integrations/shopBoost/migrationReliability";
+import { buildMigrationStory } from "@/features/integrations/shopBoost/migrationStory";
 import { toResolutionAction } from "@/features/integrations/shopBoost/reviewGuidance";
 
 type ResolutionAction = "linked_to_existing" | "created_new" | "ignored";
@@ -462,12 +463,21 @@ async function materializeByDomain(args: { supabase: any; item: ReviewItemRow; r
 }
 
 async function recomputeMigrationProgress(supabase: any, shopId: string, intakeId: string): Promise<void> {
-  const [{ count: pendingCount }, { count: failedCount }, { count: materializedCount }, { count: ignoredCount }, { data: intake }] = await Promise.all([
+  const [{ count: pendingCount }, { count: failedCount }, { count: materializedCount }, { count: ignoredCount }, { data: intake }, { count: duplicateMergedCount }] = await Promise.all([
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "pending"),
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "failed_materialization"),
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "materialized"),
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "ignored"),
     supabase.from("shop_boost_intakes").select("intake_basics").eq("id", intakeId).eq("shop_id", shopId).maybeSingle(),
+    supabase
+      .from("shop_boost_review_items")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", shopId)
+      .eq("intake_id", intakeId)
+      .eq("domain", "customer")
+      .in("issue_type", ["duplicate_candidate", "conflict"])
+      .eq("resolution_action", "linked_to_existing")
+      .in("status", ["resolved", "materialized"]),
   ]);
 
   const basics = (intake?.intake_basics ?? {}) as Record<string, unknown>;
@@ -480,6 +490,31 @@ async function recomputeMigrationProgress(supabase: any, shopId: string, intakeI
 
   const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
   const integrityErrors = Array.isArray((integrity as any).integrityErrors) ? (integrity as any).integrityErrors : [];
+  const importSummary = (basics.importSummary ?? {}) as Record<string, unknown>;
+  const linkageSummary = (importSummary.linkageSummary ?? {}) as Record<string, unknown>;
+  const linked = (linkageSummary.linked ?? {}) as Record<string, unknown>;
+  const existingOutcomeBuckets = (migrationProgress.row_outcome_buckets ?? {}) as Record<string, unknown>;
+  const migrationStory = buildMigrationStory({
+    totalRows: Number(migrationProgress.total_rows ?? 0),
+    outcomeBuckets: {
+      materialized: Number(existingOutcomeBuckets.materialized ?? 0),
+      linked: Number(existingOutcomeBuckets.linked ?? 0),
+      ignored: Number(ignoredCount ?? 0),
+      failed: Number(existingOutcomeBuckets.failed ?? 0),
+    },
+    reviewResolvedCount: Number(materializedCount ?? 0),
+    pendingReviewCount: Number(pendingCount ?? 0),
+    failedReviewCount: Number(failedCount ?? 0),
+    failedCount: Number(migrationProgress.failed_count ?? 0),
+    integrityErrorsCount: integrityErrors.length,
+    confidenceScore: Number(migrationProgress.confidence_score ?? 0.5),
+    integrityChecks: integrity.checks as Record<string, unknown>,
+    keyFixCounts: {
+      duplicateCustomersMerged: Number(duplicateMergedCount ?? 0),
+      vehiclesLinkedToCustomers: Number(linked.vehiclesCustomerId ?? 0),
+      workOrdersRecoveredVehicleLinks: Number(linked.workOrdersVehicleId ?? 0),
+    },
+  });
   const completionState = computeCompletionState({
     failedCount: Number(migrationProgress.failed_count ?? 0),
     pendingReviewCount: pendingCount ?? 0,
@@ -500,7 +535,9 @@ async function recomputeMigrationProgress(supabase: any, shopId: string, intakeI
           ignored_count: ignoredCount ?? 0,
           completionState,
           integrity,
+          migration_story: migrationStory,
         },
+        migration_story: migrationStory,
       },
     })
     .eq("id", intakeId)

--- a/features/integrations/shopBoost/status.ts
+++ b/features/integrations/shopBoost/status.ts
@@ -1,5 +1,6 @@
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import type { MigrationStory } from "@/features/integrations/shopBoost/migrationStory";
 
 type DB = Database;
 
@@ -39,6 +40,7 @@ export type IntakeProgressState = {
     | "FAILED"
     | "READY_FOR_GO_LIVE"
     | "NOT_READY";
+  migration_story?: MigrationStory;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -86,6 +88,11 @@ export function toIntakeProgress(row: IntakeRow | null): IntakeProgressState | n
       migration.completionState === "READY_FOR_GO_LIVE" ||
       migration.completionState === "NOT_READY"
         ? migration.completionState
+        : undefined,
+    migration_story: isRecord((basics as any).migration_story)
+      ? ((basics as any).migration_story as MigrationStory)
+      : isRecord(migration.migration_story)
+        ? (migration.migration_story as MigrationStory)
         : undefined,
   };
 }


### PR DESCRIPTION
### Motivation
- Turn Shop Boost into a trust-first, explainable migration experience that operators accept immediately.  
- Surface deterministic, data-driven statements about what was changed, why, and with what confidence so operators can verify and sign off.  
- Provide an auditable export and guided review flow to reduce friction and improve conversion without altering existing backend safeguards.

### Description
- Added a reusable `migration_story` model and generator in `features/integrations/shopBoost/migrationStory.ts` that summarizes row outcomes, key fixes, risk flags, blockers, trust statement, and a numeric confidence score.  
- Wired `migration_story` creation into the import finalization path in `features/integrations/imports/runFullImport.ts` and into review recomputation in `features/integrations/shopBoost/reviewMaterialization.ts` so the story is deterministic and kept up-to-date after manual review/materialization.  
- Upgraded the UX: `ShopBoostActivationPanel` (now mission-control trust panel) shows confidence meter, trust status, trust summary, key outcomes, “What we automatically fixed”, exact blockers, and go-live/report CTAs; the review page (`app/dashboard/setup/review/page.tsx`) is now a guided 3-step workflow with step counts and collapsible steps.  
- Added per-review-item transparency in `app/api/shop-boost/review-items/route.ts` (deterministic “why this needs review”, recommendation explanation, and decision transparency payload) and implemented an exportable report endpoint `GET /api/shop-boost/intakes/:id/report` in `app/api/shop-boost/intakes/[id]/report/route.ts` that returns the `migration_story`, domain summaries, integrity results, and review outcomes (optionally downloadable JSON).

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` and it completed successfully.  
- No runtime integration tests were added in this pass; the change is additive and preserves existing migration logic and safeguards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb56c72308328858fa3fa17d2a1da)