### PR TITLE
Harden Shop Boost typing and fix App Router dynamic route signatures

### DIFF
--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -5,12 +5,26 @@ import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type DB = Database;
+type RouteContext = { params: Promise<{ id: string }> };
+type ReviewOutcomeRow = Pick<
+  DB["public"]["Tables"]["shop_boost_review_items"]["Row"],
+  "status" | "resolution_action"
+>;
+type DomainAggregationRow = Pick<
+  DB["public"]["Tables"]["shop_boost_row_results"]["Row"],
+  "target_domain" | "review_required" | "error_reason"
+>;
+type IntakeReportRow = Pick<
+  DB["public"]["Tables"]["shop_boost_intakes"]["Row"],
+  "id" | "shop_id" | "status" | "created_at" | "processed_at" | "intake_basics"
+>;
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
-export async function GET(req: Request, { params }: { params: { id: string } }) {
+export async function GET(req: Request, context: RouteContext) {
+  const { id } = await context.params;
   const supabaseUser = createRouteHandlerClient<DB>({ cookies });
   const {
     data: { user },
@@ -26,13 +40,13 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
   if (!profile?.shop_id) return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
 
-  const admin = createAdminSupabase() as any;
+  const admin = createAdminSupabase();
   const { data: intake, error } = await admin
     .from("shop_boost_intakes")
     .select("id,shop_id,status,created_at,processed_at,intake_basics")
-    .eq("id", params.id)
+    .eq("id", id)
     .eq("shop_id", profile.shop_id)
-    .maybeSingle();
+    .maybeSingle<IntakeReportRow>();
 
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
   if (!intake) return NextResponse.json({ ok: false, error: "Intake not found." }, { status: 404 });
@@ -47,15 +61,15 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
       .from("shop_boost_review_items")
       .select("status,resolution_action")
       .eq("shop_id", profile.shop_id)
-      .eq("intake_id", params.id),
+      .eq("intake_id", id),
     admin
       .from("shop_boost_row_results")
-      .select("domain,review_required,error_reason")
+      .select("target_domain,review_required,error_reason")
       .eq("shop_id", profile.shop_id)
-      .eq("intake_id", params.id),
+      .eq("intake_id", id),
   ]);
 
-  const reviewOutcomes = (reviewRows ?? []).reduce((acc: Record<string, number>, row: Record<string, unknown>) => {
+  const reviewOutcomes = (reviewRows ?? []).reduce((acc: Record<string, number>, row: ReviewOutcomeRow) => {
     const status = String(row.status ?? "unknown");
     acc[`status:${status}`] = (acc[`status:${status}`] ?? 0) + 1;
     const action = String(row.resolution_action ?? "none");
@@ -63,8 +77,8 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     return acc;
   }, {});
 
-  const domainSummaries = (byDomainRows ?? []).reduce((acc: Record<string, { review: number; failed: number; processed: number }>, row: Record<string, unknown>) => {
-    const key = String(row.domain ?? "unknown");
+  const domainSummaries = (byDomainRows ?? []).reduce((acc: Record<string, { review: number; failed: number; processed: number }>, row: DomainAggregationRow) => {
+    const key = String(row.target_domain ?? "unknown");
     const next = acc[key] ?? { review: 0, failed: 0, processed: 0 };
     next.processed += 1;
     if (row.review_required) next.review += 1;
@@ -83,7 +97,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     integrity_results: {
       status: integrity.status ?? null,
       checks: asRecord(integrity.checks),
-      integrity_errors: Array.isArray((integrity as any).integrity_errors) ? (integrity as any).integrity_errors : [],
+      integrity_errors: Array.isArray(integrity.integrity_errors) ? integrity.integrity_errors : [],
     },
     review_outcomes: reviewOutcomes,
   };

--- a/app/api/shop-boost/review-items/[id]/route.ts
+++ b/app/api/shop-boost/review-items/[id]/route.ts
@@ -5,8 +5,10 @@ import type { Database } from "@shared/types/types/supabase";
 import { resolveAndMaterializeReviewItem } from "@/features/integrations/shopBoost/reviewMaterialization";
 
 type DB = Database;
+type RouteContext = { params: Promise<{ id: string }> };
 
-export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+export async function PATCH(req: Request, context: RouteContext) {
+  const { id } = await context.params;
   const supabaseUser = createRouteHandlerClient<DB>({ cookies });
   const {
     data: { user },
@@ -37,7 +39,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   };
 
   const result = await resolveAndMaterializeReviewItem({
-    reviewItemId: params.id,
+    reviewItemId: id,
     shopId: profile.shop_id,
     userId: user.id,
     resolutionAction: body.resolution_action ?? "ignored",

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -3,9 +3,28 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { deriveReviewRecommendation } from "@/features/integrations/shopBoost/reviewGuidance";
+import { confidenceLabelFromScore, deriveReviewRecommendation, type RecommendedAction, type ReviewRecommendation } from "@/features/integrations/shopBoost/reviewGuidance";
 
 type DB = Database;
+type RecommendationDto = ReviewRecommendation;
+type ReviewItemRow = Pick<
+  DB["public"]["Tables"]["shop_boost_review_items"]["Row"],
+  "id" | "intake_id" | "domain" | "issue_type" | "summary" | "raw_payload" | "normalized_payload" | "target_domain" | "blocking_reason" | "dependency_refs" | "downstream_impact_count" | "cluster_key" | "cluster_confidence" | "suggested_matches" | "status" | "resolution_action" | "ignore_reason_code" | "ignore_note" | "ignored_at" | "resolved_at" | "materialized_at" | "materialization_error" | "materialized_record" | "created_at" | "recommended_action" | "recommendation_reason" | "recommendation_confidence" | "candidate_targets" | "recommendation_seen_at" | "recommendation_followed"
+>;
+type ReviewDecisionTransparency = {
+  confidence_score: number;
+  reasoning: string;
+  candidates: RecommendationDto["candidateTargets"];
+  raw_data: Record<string, unknown>;
+  normalized_data: Record<string, unknown>;
+};
+type ReviewListItem = ReviewItemRow & {
+  recommendation: RecommendationDto;
+  affected_domains: string[];
+  review_explanation: string;
+  recommendation_explanation: string;
+  decision_transparency: ReviewDecisionTransparency;
+};
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
@@ -24,6 +43,13 @@ function deriveAffectedDomains(dependencyRefs: unknown, domain: string): string[
   return Array.from(domains);
 }
 
+function toRecommendedAction(value: unknown): RecommendedAction {
+  if (value === "link_existing" || value === "create_new" || value === "merge_candidate" || value === "ignore") {
+    return value;
+  }
+  return "create_new";
+}
+
 function deriveReviewExplanation(item: Record<string, unknown>): string {
   const domain = String(item.domain ?? "record");
   const issueType = String(item.issue_type ?? "ambiguous_match");
@@ -39,14 +65,7 @@ function deriveReviewExplanation(item: Record<string, unknown>): string {
   return `This ${domain} needs review because matching confidence did not clear the auto-apply threshold.`;
 }
 
-function deriveRecommendationExplanation(
-  recommendation: {
-    recommendedAction: string;
-    recommendationReason: string;
-    recommendationConfidence: number;
-    candidateTargets: Array<{ id: string; label: string; score: number }>;
-  },
-): string {
+function deriveRecommendationExplanation(recommendation: RecommendationDto): string {
   const topCandidate = recommendation.candidateTargets[0];
   if (recommendation.recommendedAction === "link_existing" && topCandidate) {
     return `We suggest linking to ${topCandidate.label} based on deterministic identity and similarity scoring (${Math.round(topCandidate.score * 100)}%).`;
@@ -80,7 +99,7 @@ export async function GET(req: Request) {
   const domain = url.searchParams.get("domain");
   const status = url.searchParams.get("status") ?? "pending";
 
-  const admin = createAdminSupabase() as any;
+  const admin = createAdminSupabase();
   let query = admin
     .from("shop_boost_review_items")
     .select("id,intake_id,domain,issue_type,summary,raw_payload,normalized_payload,target_domain,blocking_reason,dependency_refs,downstream_impact_count,cluster_key,cluster_confidence,suggested_matches,status,resolution_action,ignore_reason_code,ignore_note,ignored_at,resolved_at,materialized_at,materialization_error,materialized_record,created_at,recommended_action,recommendation_reason,recommendation_confidence,candidate_targets,recommendation_seen_at,recommendation_followed")
@@ -94,22 +113,17 @@ export async function GET(req: Request) {
   const { data, error } = await query;
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
 
-  const items = (data ?? []).map((item: Record<string, unknown>) => {
+  const items: ReviewListItem[] = (data ?? []).map((item: ReviewItemRow) => {
     const recommendation = item.recommended_action
       ? {
-          recommendedAction: String(item.recommended_action),
+          recommendedAction: toRecommendedAction(item.recommended_action),
           recommendationReason: String(item.recommendation_reason ?? ""),
           recommendationConfidence: Number(item.recommendation_confidence ?? 0),
-          candidateTargets: Array.isArray(item.candidate_targets) ? item.candidate_targets : [],
-          confidenceLabel:
-            Number(item.recommendation_confidence ?? 0) >= 0.85
-              ? "HIGH"
-              : Number(item.recommendation_confidence ?? 0) >= 0.6
-                ? "MEDIUM"
-                : "LOW",
+          candidateTargets: Array.isArray(item.candidate_targets) ? item.candidate_targets as RecommendationDto["candidateTargets"] : [],
+          confidenceLabel: confidenceLabelFromScore(Number(item.recommendation_confidence ?? 0)),
           requiresManualReview: Number(item.recommendation_confidence ?? 0) < 0.85,
           blockedAutoApply: Number(item.recommendation_confidence ?? 0) < 0.85,
-        }
+        } satisfies RecommendationDto
       : deriveReviewRecommendation({
           domain: String(item.domain ?? ""),
           issueType: String(item.issue_type ?? "ambiguous_match"),
@@ -124,20 +138,20 @@ export async function GET(req: Request) {
       recommendation,
       affected_domains: deriveAffectedDomains(item.dependency_refs, String(item.domain ?? "")),
       review_explanation: deriveReviewExplanation(item),
-      recommendation_explanation: deriveRecommendationExplanation(recommendation as any),
+      recommendation_explanation: deriveRecommendationExplanation(recommendation),
       decision_transparency: {
-        confidence_score: Number((recommendation as any).recommendationConfidence ?? 0),
-        reasoning: String((recommendation as any).recommendationReason ?? ""),
-        candidates: Array.isArray((recommendation as any).candidateTargets) ? (recommendation as any).candidateTargets : [],
+        confidence_score: Number(recommendation.recommendationConfidence ?? 0),
+        reasoning: String(recommendation.recommendationReason ?? ""),
+        candidates: recommendation.candidateTargets,
         raw_data: asRecord(item.raw_payload),
         normalized_data: asRecord(item.normalized_payload),
       },
     };
   });
 
-  const unresolved = items.filter((item: any) => item.status === "pending" || item.status === "failed_materialization");
-  const blockers = unresolved.filter((item: any) => Boolean(item.blocking_reason)).length;
-  const highRiskActions = items.filter((item: any) => Boolean(item.materialized_record?.high_risk_action)).length;
+  const unresolved = items.filter((item) => item.status === "pending" || item.status === "failed_materialization");
+  const blockers = unresolved.filter((item) => Boolean(item.blocking_reason)).length;
+  const highRiskActions = items.filter((item) => Boolean(asRecord(item.materialized_record).high_risk_action)).length;
 
   const { data: intake } = await admin
     .from("shop_boost_intakes")
@@ -157,7 +171,7 @@ export async function GET(req: Request) {
       .update({ recommendation_seen_at: new Date().toISOString() })
       .in(
         "id",
-        unresolved.map((item: any) => item.id),
+        unresolved.map((item) => item.id),
       )
       .is("recommendation_seen_at", null);
   }

--- a/app/dashboard/setup/review/page.tsx
+++ b/app/dashboard/setup/review/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 type Recommendation = {
   recommendedAction: "link_existing" | "create_new" | "merge_candidate" | "ignore";
@@ -83,7 +83,7 @@ export default function ShopBoostReviewPage() {
   const [reprocessBusy, setReprocessBusy] = useState<null | "failed" | "unresolved" | "updated_matches">(null);
   const [confirmRiskById, setConfirmRiskById] = useState<Record<string, boolean>>({});
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     const params = new URLSearchParams();
     if (domain) params.set("domain", domain);
@@ -94,11 +94,11 @@ export default function ShopBoostReviewPage() {
     setGuidance(json.guidance ?? null);
     setSelectedIds([]);
     setLoading(false);
-  };
+  }, [domain, statusFilter]);
 
   useEffect(() => {
     void load();
-  }, [domain, statusFilter]);
+  }, [load]);
 
   const grouped = useMemo(
     () =>

--- a/features/dashboard/components/ShopBoostActivationPanel.tsx
+++ b/features/dashboard/components/ShopBoostActivationPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 
 type DomainSummary = {
@@ -68,22 +68,22 @@ export default function ShopBoostActivationPanel() {
   const [intake, setIntake] = useState<IntakeState | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const loadStatus = async () => {
+  const loadStatus = useCallback(async () => {
     const res = await fetch("/api/shop-boost/intakes/latest", { cache: "no-store" });
     const json = (await res.json().catch(() => ({}))) as { ok?: boolean; intake?: IntakeState | null };
     if (json.ok) setIntake(json.intake ?? null);
     setLoading(false);
-  };
+  }, []);
 
   useEffect(() => {
     void loadStatus();
-  }, []);
+  }, [loadStatus]);
 
   useEffect(() => {
     if (!intake || !ACTIVE_STATUSES.has(intake.status)) return;
     const interval = window.setInterval(() => void loadStatus(), 5000);
     return () => window.clearInterval(interval);
-  }, [intake?.id, intake?.status]);
+  }, [intake, loadStatus]);
 
   const percent = useMemo(() => Math.max(0, Math.min(100, intake?.progress?.progressPercent ?? 0)), [intake?.progress?.progressPercent]);
 

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -133,6 +133,12 @@ type InspectionTemplateSuggestionBridgeRef = {
   normalizedName: string;
   confidence: number;
 };
+type IntakeBasics = Record<string, unknown>;
+type CacheCustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "email" | "phone" | "phone_number">;
+type CacheVehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "vin" | "license_plate">;
+type CacheProfileRow = Pick<DB["public"]["Tables"]["profiles"]["Row"], "id" | "email" | "full_name">;
+type RowBucketRow = Pick<DB["public"]["Tables"]["shop_boost_row_results"]["Row"], "match_status" | "review_required" | "error_reason">;
+type KeyFixRow = Pick<DB["public"]["Tables"]["shop_boost_review_items"]["Row"], "domain" | "issue_type" | "status" | "resolution_action">;
 
 function norm(s: string): string {
   return (s ?? "").trim();
@@ -800,7 +806,7 @@ async function insertRowResult(args: {
     rawPayload: args.rawPayload,
     normalizedPayload: args.normalizedPayload,
   });
-  await (args.supabase as any).from("shop_boost_row_results").insert({
+  await args.supabase.from("shop_boost_row_results").insert({
     shop_id: args.shopId,
     intake_id: args.intakeId,
     source_file: args.sourceFile,
@@ -847,7 +853,7 @@ async function createReviewItem(args: {
     clusterConfidence: cluster.confidence,
   });
 
-  await (args.supabase as any).from("shop_boost_review_items").insert({
+  await args.supabase.from("shop_boost_review_items").insert({
     shop_id: args.shopId,
     intake_id: args.intakeId,
     domain: args.domain,
@@ -932,8 +938,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   const intakeRow = intake as IntakeRow;
-  const intakeBasics = isRecord((intakeRow as unknown as Record<string, unknown>).intake_basics)
-    ? ((intakeRow as unknown as Record<string, unknown>).intake_basics as Record<string, unknown>)
+  const intakeBasics = isRecord(intakeRow.intake_basics)
+    ? (intakeRow.intake_basics as IntakeBasics)
     : {};
   const uploadManifest = isRecord(intakeBasics.uploadManifest)
     ? (intakeBasics.uploadManifest as UploadManifestRecord)
@@ -980,8 +986,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   };
 
   await Promise.all([
-    (supabase as any).from("shop_boost_row_results").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
-    (supabase as any).from("shop_boost_review_items").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
+    supabase.from("shop_boost_row_results").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
+    supabase.from("shop_boost_review_items").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
   ]);
 
   await stageSupplementalUploads({ shopId, intakeId, uploadManifest });
@@ -1015,7 +1021,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       .limit(5000);
 
     for (const r of data ?? []) {
-      const rec = r as unknown as Record<string, unknown>;
+      const rec = r as CacheCustomerRow;
       const email = normalizeEmail(String(rec.email ?? ""));
       const phone = normalizePhone(String(rec.phone ?? rec.phone_number ?? ""));
       const id = String(rec.id ?? "");
@@ -1035,7 +1041,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       .limit(5000);
 
     for (const r of data ?? []) {
-      const rec = r as unknown as Record<string, unknown>;
+      const rec = r as CacheVehicleRow;
       const vin = lower(String(rec.vin ?? ""));
       const plate = lower(String(rec.license_plate ?? ""));
       const id = String(rec.id ?? "");
@@ -1053,7 +1059,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       .limit(5000);
 
     for (const r of data ?? []) {
-      const rec = r as unknown as Record<string, unknown>;
+      const rec = r as CacheProfileRow;
       const email = lower(String(rec.email ?? ""));
       const name = lower(String(rec.full_name ?? ""));
       const id = String(rec.id ?? "");
@@ -1939,8 +1945,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     }
   }
 
-  const prevBasics = isRecord((intakeRow as unknown as Record<string, unknown>).intake_basics)
-    ? ((intakeRow as unknown as Record<string, unknown>).intake_basics as Record<string, unknown>)
+  const prevBasics = isRecord(intakeRow.intake_basics)
+    ? (intakeRow.intake_basics as IntakeBasics)
     : {};
   const reviewCounts = await Promise.all([
     supabase
@@ -1975,9 +1981,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const reviewResolvedCount = reviewCounts[3].count ?? 0;
   rowOutcome.ignoredCount = ignoredCount;
   const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
-  const integrityErrors: string[] = Array.isArray((integrity as any).integrityErrors) ? (integrity as any).integrityErrors : [];
+  const integrityErrors: string[] = integrity.integrityErrors;
 
-  const { data: rowBucketRows } = await (supabase as any)
+  const { data: rowBucketRows } = await supabase
     .from("shop_boost_row_results")
     .select("match_status,review_required,error_reason")
     .eq("shop_id", shopId)
@@ -1994,10 +2000,10 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     total_input: totalRows,
     mismatch: 0,
   };
-  for (const row of rowBucketRows ?? []) {
-    const status = String((row as any).match_status ?? "");
-    const reviewRequired = Boolean((row as any).review_required);
-    const hasError = Boolean((row as any).error_reason);
+  for (const row of (rowBucketRows ?? []) as RowBucketRow[]) {
+    const status = String(row.match_status ?? "");
+    const reviewRequired = Boolean(row.review_required);
+    const hasError = Boolean(row.error_reason);
     if (reviewRequired) outcomeBuckets.review_required += 1;
     else if (hasError || status === "invalid") outcomeBuckets.failed += 1;
     else if (status === "matched_existing" || status === "partial_match") outcomeBuckets.linked += 1;
@@ -2018,7 +2024,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   rowOutcome.integrityErrors = integrityErrors;
   rowOutcome.outcomeBuckets = outcomeBuckets;
 
-  const { data: keyFixRows } = await (supabase as any)
+  const { data: keyFixRows } = await supabase
     .from("shop_boost_review_items")
     .select("domain,issue_type,status,resolution_action")
     .eq("shop_id", shopId)
@@ -2026,7 +2032,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     .limit(100000);
 
   const duplicateCustomersMerged = (keyFixRows ?? []).filter(
-    (row: any) =>
+    (row: KeyFixRow) =>
       row.domain === "customer" &&
       (row.issue_type === "duplicate_candidate" || row.issue_type === "conflict") &&
       row.resolution_action === "linked_to_existing" &&

--- a/features/integrations/imports/runPartsImportPipeline.ts
+++ b/features/integrations/imports/runPartsImportPipeline.ts
@@ -1,8 +1,17 @@
 import { createHash } from "crypto";
 
+import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type CsvRow = Record<string, string>;
+type ExistingPartRow = Pick<
+  Database["public"]["Tables"]["parts"]["Row"],
+  "id" | "name" | "part_number" | "sku" | "supplier" | "category" | "shop_id"
+>;
+type StagingInsertResultRow = Pick<
+  Database["public"]["Tables"]["shop_parts_import_staging"]["Row"],
+  "id" | "raw_row_id" | "normalized_name" | "normalized_part_number" | "normalized_sku" | "status" | "matched_part_id" | "match_reason" | "quantity_on_hand"
+>;
 
 type PartsPipelineArgs = {
   shopId: string;
@@ -186,8 +195,9 @@ function normalizePartRow(row: CsvRow, rowNumber: number): ParsedPart {
 }
 
 export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<PartsPipelineSummary> {
-  const supabase = createAdminSupabase() as any;
+  const supabase = createAdminSupabase();
   const { shopId, intakeId, partsCsv, partsFilePath, sourceSystem } = args;
+  let inventorySeededLocations = 0;
 
   const { header, rows } = parseCsv(partsCsv);
   if (rows.length === 0) {
@@ -203,7 +213,7 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
     };
   }
 
-  const existingPartsRows =
+  const existingPartsRows: ExistingPartRow[] =
     (
       await supabase
         .from("parts")
@@ -212,9 +222,9 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
         .limit(5000)
     ).data ?? [];
 
-  const partsByPartNo = new Map<string, { id: string; row: any }>();
-  const partsBySku = new Map<string, { id: string; row: any }>();
-  const partsByName = new Map<string, Array<{ id: string; row: any }>>();
+  const partsByPartNo = new Map<string, { id: string; row: ExistingPartRow }>();
+  const partsBySku = new Map<string, { id: string; row: ExistingPartRow }>();
+  const partsByName = new Map<string, Array<{ id: string; row: ExistingPartRow }>>();
 
   for (const p of existingPartsRows) {
     const partNo = normalizeToken(p.part_number);
@@ -370,13 +380,13 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
   const { data: insertedStagingRows } = await supabase
     .from("shop_parts_import_staging")
     .insert(stagingRowsPayload)
-    .select("id,raw_row_id,normalized_name,normalized_part_number,normalized_sku,status,matched_part_id,match_reason");
+    .select("id,raw_row_id,normalized_name,normalized_part_number,normalized_sku,status,matched_part_id,match_reason,quantity_on_hand");
 
   let promotedRows = 0;
   let matchedRows = 0;
   let ambiguousRows = 0;
 
-  for (const staged of insertedStagingRows ?? []) {
+  for (const staged of ((insertedStagingRows ?? []) as StagingInsertResultRow[])) {
     const shouldAutoPromote = staged.status === "approved" && staged.matched_part_id;
 
     if (staged.status === "matched" || staged.status === "approved") matchedRows += 1;
@@ -441,7 +451,7 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
         .eq("location_id", defaultLocation.id)
         .maybeSingle();
 
-      const seededQty = Number((staged as any).quantity_on_hand ?? 0);
+      const seededQty = Number(staged.quantity_on_hand ?? 0);
       if (existingStock?.id) {
         await supabase
           .from("part_stock")
@@ -528,4 +538,3 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
     inventorySeededLocations,
   };
 }
-  let inventorySeededLocations = 0;

--- a/features/integrations/shopBoost/migrationReliability.ts
+++ b/features/integrations/shopBoost/migrationReliability.ts
@@ -1,4 +1,5 @@
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import type { Database } from "@shared/types/types/supabase";
 
 export type ReviewIssueType =
   | "unmatched"
@@ -28,6 +29,10 @@ export type IgnoreReasonCode =
   | "intentionally_skipped"
   | "unsupported_format"
   | "other";
+type StockRow = Pick<Database["public"]["Tables"]["part_stock"]["Row"], "part_id">;
+type CustomerKeyRow = Pick<Database["public"]["Tables"]["customers"]["Row"], "email" | "phone" | "phone_number" | "name">;
+type VehicleKeyRow = Pick<Database["public"]["Tables"]["vehicles"]["Row"], "vin" | "license_plate" | "year" | "make" | "model" | "customer_id">;
+type PartKeyRow = Pick<Database["public"]["Tables"]["parts"]["Row"], "part_number" | "sku" | "name">;
 
 function normalizeText(value: unknown): string {
   return String(value ?? "")
@@ -176,28 +181,28 @@ export async function runPostMigrationIntegrityValidation(args: {
     supabase.from("invoices").select("id", { count: "exact", head: true }).eq("shop_id", args.shopId).contains("metadata", { source_intake_id: args.intakeId }).is("work_order_id", null),
   ]);
 
-  const stockRows = stockWithoutPart.data ?? [];
-  const stockMissingPart = stockRows.filter((row: any) => !row.part_id).length;
+  const stockRows = (stockWithoutPart.data ?? []) as StockRow[];
+  const stockMissingPart = stockRows.filter((row) => !row.part_id).length;
 
   const dupCustomers = new Map<string, number>();
-  for (const c of duplicateCustomers.data ?? []) {
-    const key = [normalizeToken((c as any).email), normalizePhone((c as any).phone ?? (c as any).phone_number), normalizeText((c as any).name)].filter(Boolean).join("|");
+  for (const c of (duplicateCustomers.data ?? []) as CustomerKeyRow[]) {
+    const key = [normalizeToken(c.email), normalizePhone(c.phone ?? c.phone_number), normalizeText(c.name)].filter(Boolean).join("|");
     if (!key) continue;
     dupCustomers.set(key, (dupCustomers.get(key) ?? 0) + 1);
   }
   const customerDuplicateRisk = Array.from(dupCustomers.values()).filter((n) => n > 1).length;
 
   const dupVehicles = new Map<string, number>();
-  for (const v of duplicateVehicles.data ?? []) {
-    const key = normalizeToken((v as any).vin) || normalizeToken((v as any).license_plate) || [normalizeToken((v as any).year), normalizeText((v as any).make), normalizeText((v as any).model), normalizeToken((v as any).customer_id)].join("|");
+  for (const v of (duplicateVehicles.data ?? []) as VehicleKeyRow[]) {
+    const key = normalizeToken(v.vin) || normalizeToken(v.license_plate) || [normalizeToken(v.year), normalizeText(v.make), normalizeText(v.model), normalizeToken(v.customer_id)].join("|");
     if (!key) continue;
     dupVehicles.set(key, (dupVehicles.get(key) ?? 0) + 1);
   }
   const vehicleDuplicateRisk = Array.from(dupVehicles.values()).filter((n) => n > 1).length;
 
   const dupParts = new Map<string, number>();
-  for (const p of duplicateParts.data ?? []) {
-    const key = normalizeToken((p as any).part_number) || normalizeToken((p as any).sku) || normalizeText((p as any).name);
+  for (const p of (duplicateParts.data ?? []) as PartKeyRow[]) {
+    const key = normalizeToken(p.part_number) || normalizeToken(p.sku) || normalizeText(p.name);
     if (!key) continue;
     dupParts.set(key, (dupParts.get(key) ?? 0) + 1);
   }
@@ -253,7 +258,7 @@ export async function runPostMigrationIntegrityValidation(args: {
     blocking_issues_count: blockingIssuesCount,
     warnings_count: warningsCount,
     checks,
-  } as any);
+  });
 
   return {
     status,

--- a/features/integrations/shopBoost/reviewMaterialization.ts
+++ b/features/integrations/shopBoost/reviewMaterialization.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
 
+import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import {
   computeCompletionState,
@@ -7,8 +8,10 @@ import {
   type IgnoreReasonCode,
 } from "@/features/integrations/shopBoost/migrationReliability";
 import { buildMigrationStory } from "@/features/integrations/shopBoost/migrationStory";
-import { toResolutionAction } from "@/features/integrations/shopBoost/reviewGuidance";
+import { toResolutionAction, type RecommendedAction } from "@/features/integrations/shopBoost/reviewGuidance";
 
+type DB = Database;
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 type ResolutionAction = "linked_to_existing" | "created_new" | "ignored";
 type ReviewStatus = "pending" | "resolved" | "materialized" | "failed_materialization" | "ignored";
 
@@ -40,6 +43,14 @@ type HighRiskCheckResult = {
   highRiskAction: boolean;
   riskReasons: string[];
 };
+type CustomerPhoneLookupRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "phone" | "phone_number">;
+type ReviewItemActionRow = Pick<DB["public"]["Tables"]["shop_boost_review_items"]["Row"], "id" | "recommended_action" | "recommendation_confidence">;
+type ReviewItemCandidateRow = Pick<DB["public"]["Tables"]["shop_boost_review_items"]["Row"], "id" | "recommended_action">;
+
+function toRecommendedAction(value: unknown): RecommendedAction {
+  if (value === "link_existing" || value === "merge_candidate" || value === "ignore") return value;
+  return "create_new";
+}
 
 function norm(value: unknown): string {
   return String(value ?? "").trim();
@@ -83,7 +94,7 @@ function parseMoney(value: string | null): number | null {
 
 
 async function logReviewAuditEvent(args: {
-  supabase: any;
+  supabase: AdminClient;
   item: ReviewItemRow;
   userId: string;
   actionTaken: ResolutionAction | null;
@@ -117,7 +128,7 @@ async function logReviewAuditEvent(args: {
   });
 }
 
-async function findCustomerId(args: { supabase: any; shopId: string; raw: Record<string, unknown>; suggested: unknown; }): Promise<string | null> {
+async function findCustomerId(args: { supabase: AdminClient; shopId: string; raw: Record<string, unknown>; suggested: unknown; }): Promise<string | null> {
   const { supabase, shopId, raw, suggested } = args;
   const suggestedCustomerId = typeof suggested === "object" && suggested && "customerId" in (suggested as Record<string, unknown>)
     ? String((suggested as Record<string, unknown>).customerId ?? "")
@@ -134,14 +145,14 @@ async function findCustomerId(args: { supabase: any; shopId: string; raw: Record
   const phone = normalizePhone(pick(raw, [/customer phone/, /^phone$/]));
   if (phone) {
     const { data } = await supabase.from("customers").select("id,phone,phone_number").eq("shop_id", shopId).limit(3000);
-    const matched = (data ?? []).find((item: any) => normalizePhone(item.phone ?? item.phone_number) === phone);
+    const matched = ((data ?? []) as CustomerPhoneLookupRow[]).find((item) => normalizePhone(item.phone ?? item.phone_number) === phone);
     if (matched?.id) return String(matched.id);
   }
 
   return null;
 }
 
-async function materializeCustomer(args: { supabase: any; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
+async function materializeCustomer(args: { supabase: AdminClient; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
   const { supabase, item, resolutionAction } = args;
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
@@ -185,7 +196,7 @@ async function materializeCustomer(args: { supabase: any; item: ReviewItemRow; r
   return { status: "materialized", materializedRecord: { domain: "customer", customerId }, error: null };
 }
 
-async function materializeVehicle(args: { supabase: any; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
+async function materializeVehicle(args: { supabase: AdminClient; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
   const { supabase, item, resolutionAction } = args;
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
@@ -254,7 +265,7 @@ async function materializeVehicle(args: { supabase: any; item: ReviewItemRow; re
   return { status: "materialized", materializedRecord: { domain: "vehicle", vehicleId, customerId }, error: null };
 }
 
-async function materializeWorkOrder(args: { supabase: any; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
+async function materializeWorkOrder(args: { supabase: AdminClient; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
   const { supabase, item, resolutionAction } = args;
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
@@ -365,7 +376,7 @@ async function materializeWorkOrder(args: { supabase: any; item: ReviewItemRow; 
   return { status: "materialized", materializedRecord: { domain: "work_order", workOrderId, customerId, vehicleId }, error: null };
 }
 
-async function materializePart(args: { supabase: any; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
+async function materializePart(args: { supabase: AdminClient; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
   const { supabase, item, resolutionAction } = args;
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
@@ -453,7 +464,7 @@ async function materializePart(args: { supabase: any; item: ReviewItemRow; resol
   return { status: "materialized", materializedRecord: { domain: "part", partId }, error: null };
 }
 
-async function materializeByDomain(args: { supabase: any; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
+async function materializeByDomain(args: { supabase: AdminClient; item: ReviewItemRow; resolutionAction: ResolutionAction; }): Promise<MaterializeResult> {
   const domain = args.item.domain;
   if (domain === "customer") return materializeCustomer(args);
   if (domain === "vehicle") return materializeVehicle(args);
@@ -462,7 +473,7 @@ async function materializeByDomain(args: { supabase: any; item: ReviewItemRow; r
   return { status: "materialized", materializedRecord: { skipped: true, domain }, error: null };
 }
 
-async function recomputeMigrationProgress(supabase: any, shopId: string, intakeId: string): Promise<void> {
+async function recomputeMigrationProgress(supabase: AdminClient, shopId: string, intakeId: string): Promise<void> {
   const [{ count: pendingCount }, { count: failedCount }, { count: materializedCount }, { count: ignoredCount }, { data: intake }, { count: duplicateMergedCount }] = await Promise.all([
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "pending"),
     supabase.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "failed_materialization"),
@@ -489,7 +500,7 @@ async function recomputeMigrationProgress(supabase: any, shopId: string, intakeI
   );
 
   const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
-  const integrityErrors = Array.isArray((integrity as any).integrityErrors) ? (integrity as any).integrityErrors : [];
+  const integrityErrors = integrity.integrityErrors;
   const importSummary = (basics.importSummary ?? {}) as Record<string, unknown>;
   const linkageSummary = (importSummary.linkageSummary ?? {}) as Record<string, unknown>;
   const linked = (linkageSummary.linked ?? {}) as Record<string, unknown>;
@@ -553,7 +564,7 @@ export async function resolveAndMaterializeReviewItem(args: {
   ignoreReasonCode?: IgnoreReasonCode;
   ignoreNote?: string | null;
 }): Promise<{ ok: boolean; item: ReviewItemRow | null; materializedRecord: Record<string, unknown> | null; error?: string; }> {
-  const supabase = createAdminSupabase() as any;
+  const supabase = createAdminSupabase();
 
   const { data: item } = await supabase
     .from("shop_boost_review_items")
@@ -659,7 +670,7 @@ export async function resolveAndMaterializeReviewItem(args: {
   };
 }
 
-async function replayDependentRows(args: { supabase: any; shopId: string; intakeId: string; }): Promise<void> {
+async function replayDependentRows(args: { supabase: AdminClient; shopId: string; intakeId: string; }): Promise<void> {
   const { supabase, shopId, intakeId } = args;
   const { data: replayCandidates } = await supabase
     .from("shop_boost_review_items")
@@ -731,7 +742,7 @@ export async function applyHighConfidenceRecommendations(args: {
   intakeId?: string;
   threshold?: number;
 }): Promise<Array<{ id: string; ok: boolean; error?: string }>> {
-  const supabase = createAdminSupabase() as any;
+  const supabase = createAdminSupabase();
   const threshold = Math.max(0, Math.min(0.99, args.threshold ?? 0.85));
 
   let query = supabase
@@ -748,10 +759,10 @@ export async function applyHighConfidenceRecommendations(args: {
   const { data } = await query;
 
   const results: Array<{ id: string; ok: boolean; error?: string }> = [];
-  for (const row of data ?? []) {
+  for (const row of (data ?? []) as ReviewItemActionRow[]) {
     const confidence = Number(row.recommendation_confidence ?? 0);
     if (confidence < 0.85) continue;
-    const action = toResolutionAction(String(row.recommended_action) as any);
+    const action = toResolutionAction(toRecommendedAction(row.recommended_action));
     if (action === "linked_to_existing" && String(row.recommended_action) === "merge_candidate") {
       results.push({ id: String(row.id), ok: false, error: "High-risk merge candidates are never auto-applied." });
       continue;
@@ -776,7 +787,7 @@ export async function reprocessReviewItems(args: {
   mode: "failed" | "unresolved" | "updated_matches";
   reprocessReason?: string;
 }): Promise<{ resetCount: number; results: Array<{ id: string; ok: boolean; error?: string }> }> {
-  const supabase = createAdminSupabase() as any;
+  const supabase = createAdminSupabase();
   let statuses: string[] = [];
   if (args.mode === "failed") statuses = ["failed_materialization"];
   if (args.mode === "unresolved") statuses = ["pending", "failed_materialization"];
@@ -792,7 +803,7 @@ export async function reprocessReviewItems(args: {
   if (args.intakeId) base = base.eq("intake_id", args.intakeId);
   const { data: candidates } = await base;
 
-  const ids = (candidates ?? []).map((row: any) => String(row.id));
+  const ids = ((candidates ?? []) as ReviewItemCandidateRow[]).map((row) => String(row.id));
   if (ids.length === 0) return { resetCount: 0, results: [] };
 
   await supabase
@@ -816,8 +827,8 @@ export async function reprocessReviewItems(args: {
   }
 
   const results: Array<{ id: string; ok: boolean; error?: string }> = [];
-  for (const row of candidates ?? []) {
-    const recommended = String(row.recommended_action ?? "create_new") as any;
+  for (const row of (candidates ?? []) as ReviewItemCandidateRow[]) {
+    const recommended = toRecommendedAction(row.recommended_action);
     const action = toResolutionAction(recommended);
     const result = await resolveAndMaterializeReviewItem({
       reviewItemId: String(row.id),

--- a/features/integrations/shopBoost/status.ts
+++ b/features/integrations/shopBoost/status.ts
@@ -47,6 +47,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isMigrationStory(value: unknown): value is MigrationStory {
+  return isRecord(value);
+}
+
 function readIntakeBasics(row: IntakeRow | null): Record<string, unknown> {
   if (!row || !isRecord(row.intake_basics)) return {};
   return row.intake_basics;
@@ -89,10 +93,10 @@ export function toIntakeProgress(row: IntakeRow | null): IntakeProgressState | n
       migration.completionState === "NOT_READY"
         ? migration.completionState
         : undefined,
-    migration_story: isRecord((basics as any).migration_story)
-      ? ((basics as any).migration_story as MigrationStory)
-      : isRecord(migration.migration_story)
-        ? (migration.migration_story as MigrationStory)
+    migration_story: isMigrationStory(basics.migration_story)
+      ? basics.migration_story
+      : isMigrationStory(migration.migration_story)
+        ? migration.migration_story
         : undefined,
   };
 }


### PR DESCRIPTION
### Motivation

- Resolve build and lint failures introduced by Shop Boost migration patches by fixing route signatures and removing unsafe `any` usage. 
- Tighten runtime contracts and Supabase row handling to eliminate fragile unknown casts and preserve multi-tenant safety and migration semantics. 
- Keep all migration/trust/review behavior intact while making the stack production-ready and lint/TS-clean.

### Description

- Fixed App Router dynamic route signatures for `[id]` handlers by using the Promise-based `context.params` signature and awaiting `id` for framework-compatibility. 
- Replaced `as any` and loose `Record<string, unknown>` usage with explicit local DTO types (`Pick<...Row,...>`) across report, review, import, parts pipeline, review materialization, and integrity helpers. 
- Hardened `app/api/shop-boost/intakes/[id]/report/route.ts` and `app/api/shop-boost/review-items/route.ts` with explicit row projections, typed aggregations, and recommendation DTO plumbing (including typed `toRecommendedAction` guard). 
- Removed unsafe casts from import pipelines and materialization flows and added typed staging/cache row types and safe readers; moved `inventorySeededLocations` into function scope and typed inserted staging reads. 
- Updated migration integrity/status/helpers to use typed query projections and removed `any` casts, while preserving integrity checks and migration_story construction. 
- Fixed React hook dependency warnings in review/setup and activation-panel UIs by wrapping loaders in `useCallback` and adjusting `useEffect` deps. 
- Files touched: `app/api/shop-boost/intakes/[id]/report/route.ts`, `app/api/shop-boost/review-items/route.ts`, `app/api/shop-boost/review-items/[id]/route.ts`, `features/integrations/imports/runFullImport.ts`, `features/integrations/imports/runPartsImportPipeline.ts`, `features/integrations/shopBoost/migrationReliability.ts`, `features/integrations/shopBoost/reviewMaterialization.ts`, `features/integrations/shopBoost/status.ts`, `app/dashboard/setup/review/page.tsx`, `features/dashboard/components/ShopBoostActivationPanel.tsx`.

### Testing

- Ran TypeScript build: `npx tsc --noEmit` and it completed successfully with no type errors. 
- Ran ESLint against the targeted Shop Boost files and the modified UI files and the targeted run completed with no new errors (only a small number of pre-existing/allowed warnings were considered and addressed where in-scope). 
- Local static checks confirm no remaining `as any` or invalid App Router route signatures in the modified Shop Boost stack.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbdc5bd2483288b296d8c60bfbb06)