### PR TITLE
Harden API route typing and remove explicit any usage

### DIFF
--- a/app/api/admin/people/[id]/certifications/[certId]/route.ts
+++ b/app/api/admin/people/[id]/certifications/[certId]/route.ts
@@ -3,6 +3,17 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type Ctx = { params: { id: string; certId: string } };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
+type CertificationPayload = {
+  cert_type?: string;
+  cert_name: string;
+  cert_number?: string | null;
+  issuing_body?: string | null;
+  issue_date?: string | null;
+  expiry_date?: string | null;
+  status?: string;
+  notes?: string | null;
+};
 
 function normalizeDate(value: unknown) {
   if (!value) return null;
@@ -11,7 +22,7 @@ function normalizeDate(value: unknown) {
   return parsed.toISOString().slice(0, 10);
 }
 
-async function findCertification(admin: any, shopId: string, userId: string, certId: string) {
+async function findCertification(admin: AdminClient, shopId: string, userId: string, certId: string) {
   return admin
     .from("staff_certifications")
     .select("id, cert_type, cert_name, cert_number, issuing_body, issue_date, expiry_date, status, notes")
@@ -26,7 +37,7 @@ export async function PATCH(req: NextRequest, context: unknown) {
   const access = await requireShopScopedApiAccess({ requiredCapability: "canManageUsers", allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const { data: existing, error: existingErr } = await findCertification(admin, access.profile.shop_id!, params.id, params.certId);
   if (existingErr) return NextResponse.json({ error: existingErr.message }, { status: 500 });
   if (!existing) return NextResponse.json({ error: "Certification not found" }, { status: 404 });
@@ -39,15 +50,16 @@ export async function PATCH(req: NextRequest, context: unknown) {
   if (body.issue_date && !issueDate) return NextResponse.json({ error: "issue_date must be a valid date" }, { status: 400 });
   if (body.expiry_date && !expiryDate) return NextResponse.json({ error: "expiry_date must be a valid date" }, { status: 400 });
 
+  const payload = body as CertificationPayload;
   const updatePayload = {
-    cert_type: body.cert_type ?? "certification",
-    cert_name: body.cert_name.trim(),
-    cert_number: body.cert_number?.trim() || null,
-    issuing_body: body.issuing_body?.trim() || null,
+    cert_type: payload.cert_type ?? "certification",
+    cert_name: payload.cert_name.trim(),
+    cert_number: payload.cert_number?.trim() || null,
+    issuing_body: payload.issuing_body?.trim() || null,
     issue_date: issueDate,
     expiry_date: expiryDate,
-    status: body.status ?? "active",
-    notes: body.notes?.trim() || null,
+    status: payload.status ?? "active",
+    notes: payload.notes?.trim() || null,
   };
 
   const { data, error } = await admin
@@ -83,7 +95,7 @@ export async function DELETE(_req: NextRequest, context: unknown) {
   const access = await requireShopScopedApiAccess({ requiredCapability: "canManageUsers", allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const { data: existing, error: existingErr } = await findCertification(admin, access.profile.shop_id!, params.id, params.certId);
   if (existingErr) return NextResponse.json({ error: existingErr.message }, { status: 500 });
   if (!existing) return NextResponse.json({ error: "Certification not found" }, { status: 404 });

--- a/app/api/admin/people/[id]/certifications/route.ts
+++ b/app/api/admin/people/[id]/certifications/route.ts
@@ -3,6 +3,17 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type Ctx = { params: { id: string } };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
+type CertificationPayload = {
+  cert_type?: string;
+  cert_name: string;
+  cert_number?: string | null;
+  issuing_body?: string | null;
+  issue_date?: string | null;
+  expiry_date?: string | null;
+  status?: string;
+  notes?: string | null;
+};
 
 function normalizeDate(value: unknown) {
   if (!value) return null;
@@ -26,20 +37,21 @@ export async function POST(req: NextRequest, context: unknown) {
   if (body.issue_date && !issueDate) return NextResponse.json({ error: "issue_date must be a valid date" }, { status: 400 });
   if (body.expiry_date && !expiryDate) return NextResponse.json({ error: "expiry_date must be a valid date" }, { status: 400 });
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
+  const payload = body as CertificationPayload;
   const { data, error } = await admin
     .from("staff_certifications")
     .insert({
       shop_id: access.profile.shop_id,
       user_id: params.id,
-      cert_type: body.cert_type ?? "certification",
-      cert_name: body.cert_name.trim(),
-      cert_number: body.cert_number?.trim() || null,
-      issuing_body: body.issuing_body?.trim() || null,
+      cert_type: payload.cert_type ?? "certification",
+      cert_name: payload.cert_name.trim(),
+      cert_number: payload.cert_number?.trim() || null,
+      issuing_body: payload.issuing_body?.trim() || null,
       issue_date: issueDate,
       expiry_date: expiryDate,
-      status: body.status ?? "active",
-      notes: body.notes?.trim() || null,
+      status: payload.status ?? "active",
+      notes: payload.notes?.trim() || null,
     })
     .select("id, cert_type, cert_name, cert_number, issuing_body, issue_date, expiry_date, status, notes")
     .single();

--- a/app/api/admin/people/[id]/route.ts
+++ b/app/api/admin/people/[id]/route.ts
@@ -5,8 +5,26 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 type Ctx = { params: { id: string } };
 type ActionSeverity = "blocking" | "warning" | "informational";
 type ActionReason = { code: string; severity: ActionSeverity; label: string; action_label: string; action_href: string };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
-async function assertTarget(admin: any, shopId: string, userId: string) {
+type WorkforceProfilePayload = {
+  workforce_role?: string | null;
+  workforce_category?: string | null;
+  employment_status?: "active" | "inactive" | "on_leave" | null;
+  start_date?: string | null;
+  payroll_ready?: boolean | null;
+  notes?: string | null;
+};
+
+type PersonUpdatePayload = {
+  full_name?: string | null;
+  phone?: string | null;
+  role?: string | null;
+  completed_onboarding?: boolean;
+  workforce_profile?: WorkforceProfilePayload;
+};
+
+async function assertTarget(admin: AdminClient, shopId: string, userId: string) {
   const { data, error } = await admin.from("profiles").select("id, shop_id").eq("id", userId).maybeSingle();
   if (error) return { ok: false, message: error.message } as const;
   if (!data || data.shop_id !== shopId) return { ok: false, message: "Person not found in this shop" } as const;
@@ -18,11 +36,11 @@ export async function GET(_req: NextRequest, context: unknown) {
   const access = await requireShopScopedApiAccess({ requiredCapability: "canManageUsers", allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
 
-  const admin = createAdminSupabase() as any;
+  const admin = createAdminSupabase();
   const check = await assertTarget(admin, access.profile.shop_id!, params.id);
   if (!check.ok) return NextResponse.json({ error: check.message }, { status: 403 });
 
-  const [{ data: person, error: pErr }, { data: workforce }, { data: certs }, { data: openEntries }, { data: openExceptions }, { data: scheduleTemplates }, { data: scheduleOverrides }, { data: upcomingAwayBlocks }, { data: timeOffRequests }] = await Promise.all([
+  const [{ data: person, error: pErr }, { data: workforce }, { data: certs }, { count: openEntriesCount }, { data: openExceptions }, { data: scheduleTemplates }, { data: scheduleOverrides }, { data: upcomingAwayBlocks }, { data: timeOffRequests }] = await Promise.all([
     admin.from("profiles").select("id, full_name, email, phone, role, completed_onboarding, created_at, last_active_at").eq("id", params.id).maybeSingle(),
     admin
       .from("people_workforce_profiles")
@@ -58,8 +76,8 @@ export async function GET(_req: NextRequest, context: unknown) {
 
   if (pErr || !person) return NextResponse.json({ error: pErr?.message ?? "Person not found" }, { status: 404 });
 
-  const blocking = (openExceptions ?? []).filter((row: any) => row.severity === "blocking").length;
-  const warning = (openExceptions ?? []).filter((row: any) => row.severity === "warning").length;
+  const blocking = (openExceptions ?? []).filter((row) => row.severity === "blocking").length;
+  const warning = (openExceptions ?? []).filter((row) => row.severity === "warning").length;
   const profile = workforce ?? {
     workforce_role: null,
     workforce_category: null,
@@ -71,7 +89,7 @@ export async function GET(_req: NextRequest, context: unknown) {
 
   const now = Date.now();
   const in30 = now + 1000 * 60 * 60 * 24 * 30;
-  const certifications = (certs ?? []).map((cert: any) => {
+  const certifications = (certs ?? []).map((cert) => {
     const expiryTs = cert.expiry_date ? new Date(cert.expiry_date).getTime() : null;
     const isExpired = cert.status === "expired" || (expiryTs ? expiryTs < now : false);
     const daysRemaining = expiryTs ? Math.ceil((expiryTs - now) / (1000 * 60 * 60 * 24)) : null;
@@ -115,7 +133,7 @@ export async function GET(_req: NextRequest, context: unknown) {
       action_href: `/dashboard/admin/people/${params.id}#workforce`,
     });
   }
-  const expiredCount = certifications.filter((cert: any) => cert.lifecycle_group === "expired").length;
+  const expiredCount = certifications.filter((cert) => cert.lifecycle_group === "expired").length;
   if (expiredCount > 0) {
     reasons.push({
       code: "cert_expired",
@@ -125,7 +143,7 @@ export async function GET(_req: NextRequest, context: unknown) {
       action_href: `/dashboard/admin/people/${params.id}#certifications`,
     });
   }
-  const expiringSoonCount = certifications.filter((cert: any) => cert.lifecycle_group === "expiring_soon").length;
+  const expiringSoonCount = certifications.filter((cert) => cert.lifecycle_group === "expiring_soon").length;
   if (expiringSoonCount > 0) {
     reasons.push({
       code: "cert_expiring_soon",
@@ -144,7 +162,7 @@ export async function GET(_req: NextRequest, context: unknown) {
       action_href: `/dashboard/admin/payroll-time?person_id=${params.id}`,
     });
   }
-  if (profile.employment_status === "inactive" && (openEntries?.count ?? 0) > 0) {
+  if (profile.employment_status === "inactive" && (openEntriesCount ?? 0) > 0) {
     reasons.push({
       code: "inactive_in_payroll_scope",
       severity: "informational",
@@ -155,7 +173,7 @@ export async function GET(_req: NextRequest, context: unknown) {
   }
 
   const prioritizedAudit = (audit ?? [])
-    .map((row: any) => {
+    .map((row) => {
       const action = (row.action ?? "").toLowerCase();
       const priority = action.includes("employment") || action.includes("role")
         ? 3
@@ -166,7 +184,7 @@ export async function GET(_req: NextRequest, context: unknown) {
             : 1;
       return { ...row, priority };
     })
-    .sort((a: any, b: any) => (b.priority - a.priority) || ((new Date(b.created_at ?? 0).getTime()) - (new Date(a.created_at ?? 0).getTime())));
+    .sort((a, b) => (b.priority - a.priority) || ((new Date(b.created_at ?? 0).getTime()) - (new Date(a.created_at ?? 0).getTime())));
 
   return NextResponse.json({
     ...person,
@@ -181,10 +199,10 @@ export async function GET(_req: NextRequest, context: unknown) {
     },
     payroll_posture: {
       is_payroll_ready: Boolean(profile.payroll_ready),
-      open_period_entries: openEntries?.count ?? 0,
+      open_period_entries: openEntriesCount ?? 0,
       blocking_exceptions: blocking,
       warning_exceptions: warning,
-      in_current_period: (openEntries?.count ?? 0) > 0,
+      in_current_period: (openEntriesCount ?? 0) > 0,
       missing_workforce_data: missingWorkforceData,
     },
     schedule_posture: {
@@ -206,14 +224,14 @@ export async function PUT(req: NextRequest, context: unknown) {
   const access = await requireShopScopedApiAccess({ requiredCapability: "canManageUsers", allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
 
-  const admin = createAdminSupabase() as any;
+  const admin = createAdminSupabase();
   const check = await assertTarget(admin, access.profile.shop_id!, params.id);
   if (!check.ok) return NextResponse.json({ error: check.message }, { status: 403 });
 
   const body = await req.json().catch(() => null);
   if (!body) return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
 
-  const { full_name, phone, role, completed_onboarding, workforce_profile } = body as any;
+  const { full_name, phone, role, completed_onboarding, workforce_profile } = body as PersonUpdatePayload;
 
   const { error: pErr } = await admin
     .from("profiles")

--- a/app/api/admin/people/route.ts
+++ b/app/api/admin/people/route.ts
@@ -21,12 +21,13 @@ type ActionReason = {
   action_label: string;
   action_href: string;
 };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
 export async function GET() {
   const access = await requireShopScopedApiAccess({ requiredCapability: "canManageUsers", allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const shopId = access.profile.shop_id;
 
   const [
@@ -81,7 +82,7 @@ export async function GET() {
   for (const row of periodEntries ?? []) {
     openEntriesByUser.set(row.user_id, (openEntriesByUser.get(row.user_id) ?? 0) + 1);
   }
-  const hasTemplate = new Set<string>((scheduleTemplates ?? []).map((row: any) => row.user_id));
+  const hasTemplate = new Set<string>((scheduleTemplates ?? []).map((row) => row.user_id));
   const pendingTimeOffByUser = new Map<string, number>();
   for (const row of pendingTimeOff ?? []) {
     pendingTimeOffByUser.set(row.user_id, (pendingTimeOffByUser.get(row.user_id) ?? 0) + 1);
@@ -111,7 +112,7 @@ export async function GET() {
     certByUser.set(cert.user_id, current);
   }
 
-  const people = (profiles ?? []).map((profile: any) => {
+  const people = (profiles ?? []).map((profile) => {
     const workforceRow = workforceByUser.get(profile.id);
     const payrollExceptions = exceptionByUser.get(profile.id) ?? { blocking: 0, warning: 0 };
     const cert = certByUser.get(profile.id) ?? { open: 0, expiring30: 0, expiring60: 0, expired: 0, revoked: 0 };

--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { getOrCreateCurrentPeriod } from "@/features/payroll-time/server/payrollTime";
 import { requirePayrollReviewer } from "../_lib/auth";
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
 export async function GET(req: NextRequest) {
   const auth = await requirePayrollReviewer();
   if (!auth.ok) return auth.response;
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const { me } = auth;
   const url = new URL(req.url);
   const periodId = url.searchParams.get("period_id");
@@ -44,7 +45,7 @@ export async function GET(req: NextRequest) {
   if (entriesErr) return NextResponse.json({ error: entriesErr.message }, { status: 500 });
   if (exErr) return NextResponse.json({ error: exErr.message }, { status: 500 });
 
-  const selectedPeriod = (periods ?? []).find((period: any) => period.id === activePeriodId);
+  const selectedPeriod = (periods ?? []).find((period) => period.id === activePeriodId);
   const periodStartIso = selectedPeriod ? `${selectedPeriod.period_start}T00:00:00.000Z` : null;
   const periodEndIso = selectedPeriod ? `${selectedPeriod.period_end}T23:59:59.999Z` : null;
 
@@ -75,7 +76,7 @@ export async function GET(req: NextRequest) {
     awayMap.set(row.user_id, (awayMap.get(row.user_id) ?? 0) + minutes);
   }
 
-  const enrichedEntries = (entries ?? []).map((entry: any) => ({
+  const enrichedEntries = (entries ?? []).map((entry) => ({
     ...entry,
     scheduled_minutes: scheduleMap.get(`${entry.user_id}|${entry.work_date}`) ?? 0,
     approved_time_away_minutes_in_period: awayMap.get(entry.user_id) ?? 0,

--- a/app/api/scheduling/staff/[id]/overrides/route.ts
+++ b/app/api/scheduling/staff/[id]/overrides/route.ts
@@ -4,6 +4,7 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type Ctx = { params: Promise<{ id: string }> };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
 export async function POST(req: NextRequest, context: Ctx) {
   const { id } = await context.params;
@@ -22,7 +23,7 @@ export async function POST(req: NextRequest, context: Ctx) {
 
   if (!body?.schedule_date) return NextResponse.json({ error: "schedule_date required" }, { status: 400 });
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const { error } = await admin.from("staff_schedule_overrides").insert({
     shop_id: access.profile.shop_id,
     user_id: id,

--- a/app/api/scheduling/staff/[id]/route.ts
+++ b/app/api/scheduling/staff/[id]/route.ts
@@ -4,8 +4,9 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type Ctx = { params: Promise<{ id: string }> };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
-async function checkStaffInShop(admin: any, shopId: string, userId: string) {
+async function checkStaffInShop(admin: AdminClient, shopId: string, userId: string) {
   const { data, error } = await admin.from("profiles").select("id, shop_id, full_name, email, role").eq("id", userId).maybeSingle();
   if (error) return { ok: false, error: error.message } as const;
   if (!data || data.shop_id !== shopId) return { ok: false, error: "Staff not found" } as const;
@@ -19,7 +20,7 @@ export async function GET(_req: NextRequest, context: Ctx) {
   const actor = getActorCapabilities({ role: access.profile.role });
   if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const check = await checkStaffInShop(admin, access.profile.shop_id!, id);
   if (!check.ok) return NextResponse.json({ error: check.error }, { status: 404 });
 
@@ -56,7 +57,7 @@ export async function PUT(req: NextRequest, context: Ctx) {
     return NextResponse.json({ error: "templates[] required" }, { status: 400 });
   }
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const check = await checkStaffInShop(admin, access.profile.shop_id!, id);
   if (!check.ok) return NextResponse.json({ error: check.error }, { status: 404 });
 

--- a/app/api/scheduling/staff/overrides/[overrideId]/route.ts
+++ b/app/api/scheduling/staff/overrides/[overrideId]/route.ts
@@ -4,6 +4,7 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type Ctx = { params: Promise<{ overrideId: string }> };
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
 export async function PATCH(req: NextRequest, context: Ctx) {
   const { overrideId } = await context.params;
@@ -24,7 +25,7 @@ export async function PATCH(req: NextRequest, context: Ctx) {
     updated_at: new Date().toISOString(),
   };
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const { data, error } = await admin
     .from("staff_schedule_overrides")
     .update(update)
@@ -53,7 +54,7 @@ export async function DELETE(_req: NextRequest, context: Ctx) {
   const actor = getActorCapabilities({ role: access.profile.role });
   if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const { data, error } = await admin
     .from("staff_schedule_overrides")
     .delete()

--- a/app/api/scheduling/staff/route.ts
+++ b/app/api/scheduling/staff/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+type AdminClient = ReturnType<typeof createAdminSupabase>;
 
 function toDayBounds(date: Date) {
   const start = new Date(date);
@@ -17,7 +18,7 @@ export async function GET(req: NextRequest) {
   const actor = getActorCapabilities({ role: access.profile.role });
   if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const admin = createAdminSupabase() as any;
+  const admin: AdminClient = createAdminSupabase();
   const url = new URL(req.url);
   const from = url.searchParams.get("from") ?? new Date().toISOString();
   const to = url.searchParams.get("to") ?? new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString();
@@ -40,10 +41,10 @@ export async function GET(req: NextRequest) {
   const overrides = overridesRes.data ?? [];
   const blocks = blocksRes.data ?? [];
 
-  const staff = (profilesRes.data ?? []).map((p: any) => {
-    const personTemplates = templates.filter((t: any) => t.user_id === p.id);
-    const personOverrides = overrides.filter((o: any) => o.user_id === p.id && o.status !== "cancelled");
-    const personBlocks = blocks.filter((b: any) => b.user_id === p.id);
+  const staff = (profilesRes.data ?? []).map((p) => {
+    const personTemplates = templates.filter((t) => t.user_id === p.id);
+    const personOverrides = overrides.filter((o) => o.user_id === p.id && o.status !== "cancelled");
+    const personBlocks = blocks.filter((b) => b.user_id === p.id);
 
     let recurringMinutes = 0;
     for (const row of personTemplates) {
@@ -54,7 +55,7 @@ export async function GET(req: NextRequest) {
     }
 
     const todayBounds = toDayBounds(new Date());
-    const isAwayToday = personBlocks.some((b: any) => b.starts_at < todayBounds.end && b.ends_at > todayBounds.start);
+    const isAwayToday = personBlocks.some((b) => b.starts_at < todayBounds.end && b.ends_at > todayBounds.start);
 
     return {
       ...p,
@@ -65,7 +66,7 @@ export async function GET(req: NextRequest) {
       is_away_today: isAwayToday,
       next_override: personOverrides
         .slice()
-        .sort((a: any, b: any) => String(a.schedule_date).localeCompare(String(b.schedule_date)))[0] ?? null,
+        .sort((a, b) => String(a.schedule_date).localeCompare(String(b.schedule_date)))[0] ?? null,
     };
   });
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
@@ -77,7 +78,7 @@ async function resolvePriceId(stripe: Stripe, input: string): Promise<string | n
 
 async function createCustomerIfMissing(
   stripe: Stripe,
-  supabase: any,
+  supabase: SupabaseClient<DB>,
   shop: ShopScope,
 ): Promise<string> {
   const existing = (shop.stripe_customer_id ?? "").trim();

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
@@ -35,7 +36,7 @@ function getShopDisplayName(shop: { shop_name?: string | null; name?: string | n
 
 async function createCustomerIfMissing(
   stripe: Stripe,
-  supabase: any,
+  supabase: SupabaseClient<DB>,
   shop: ShopScope,
 ): Promise<string> {
   const existingCustomerId = (shop.stripe_customer_id ?? "").trim();

--- a/app/api/time-off/requests/[id]/route.ts
+++ b/app/api/time-off/requests/[id]/route.ts
@@ -16,7 +16,7 @@ export async function PATCH(req: NextRequest, context: Ctx) {
 
   if (!body?.status) return NextResponse.json({ error: "status required" }, { status: 400 });
 
-  const admin = access.supabase as any;
+  const admin = access.supabase;
   const actor = getActorCapabilities({ role: access.profile.role });
 
   const { data: existing, error: existingErr } = await admin

--- a/app/api/time-off/requests/route.ts
+++ b/app/api/time-off/requests/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   if (!access.ok) return access.response;
 
   const actor = getActorCapabilities({ role: access.profile.role });
-  const admin = access.supabase as any;
+  const admin = access.supabase;
   const url = new URL(req.url);
   const status = url.searchParams.get("status")?.trim() || null;
   const userId = url.searchParams.get("user_id")?.trim() || null;
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
   const targetUserId = actor.canManageScheduling ? (body.user_id ?? access.profile.id) : access.profile.id;
   if (!targetUserId) return NextResponse.json({ error: "Missing user context" }, { status: 400 });
 
-  const admin = access.supabase as any;
+  const admin = access.supabase;
   const insertPayload = {
     shop_id: access.profile.shop_id,
     user_id: targetUserId,


### PR DESCRIPTION
### Motivation
- Remove all unsafe `any` usages in audited API route handlers to improve type-safety and maintainability.
- Ensure route handlers and Supabase interactions have clear DTOs and client typing while preserving existing behavior and shop scoping.
- Fix a TypeScript correctness issue around payroll entry counting that caused incorrect property access on query results.

### Description
- Introduced a typed `AdminClient = ReturnType<typeof createAdminSupabase>` alias and explicit payload DTOs (`PersonUpdatePayload`, `WorkforceProfilePayload`, `CertificationPayload`) and applied them across API routes to eliminate `any` usage.
- Replaced `as any` and untyped variables with the new aliases and DTO casts in multiple admin/scheduling/payroll/time-off/stripe handlers and tightened map/filter callbacks to avoid implicit `any` access.
- Corrected payroll open-entry handling by reading the Supabase `count` field from the response instead of treating it as row data.
- Updated Stripe helper signatures to accept `SupabaseClient<DB>` for typed DB updates and kept all existing flows intact (no behavior removed); files changed include the API handlers under `app/api/admin/people`, `app/api/payroll-time`, `app/api/scheduling/staff`, `app/api/stripe`, and `app/api/time-off/requests`.

### Testing
- Ran `npx eslint app/api features/integrations/shopBoost features/integrations/imports app/dashboard --max-warnings=0` and the lint check passed for the modified scope.
- Ran `npx tsc --noEmit` and the TypeScript typecheck completed successfully with no errors.
- No runtime or functional behavior was removed; changes are type-level hardening only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc309dbc88328bdd93f0176f91202)