### PR TITLE
Add info-only work order lines and expected_completion_at (DB, UI, API, guardrails)

### DIFF
--- a/app/api/portal/request/add-custom-line/route.ts
+++ b/app/api/portal/request/add-custom-line/route.ts
@@ -12,6 +12,7 @@ type Body = {
   workOrderId: string;
   description: string; // customer complaint / request
   notes?: string;
+  lineType?: "job" | "info";
 };
 
 function bad(msg: string, status = 400) {
@@ -38,6 +39,7 @@ export async function POST(req: Request) {
     const workOrderId = (body?.workOrderId ?? "").trim();
     const description = (body?.description ?? "").trim();
     const notes = (body?.notes ?? "").trim();
+    const lineType = body?.lineType === "info" ? "info" : "job";
 
     if (!workOrderId || !description) return bad("Missing workOrderId or description");
 
@@ -68,6 +70,8 @@ export async function POST(req: Request) {
       notes: notes || null,
       status: "awaiting_approval",
       approval_state: "pending",
+      line_type: lineType,
+      punchable: lineType === "info" ? false : null,
       // labor_time intentionally null — customer can't set it
       labor_time: null,
       price_estimate: null,

--- a/app/api/work-orders/assign-line/route.ts
+++ b/app/api/work-orders/assign-line/route.ts
@@ -35,6 +35,22 @@ export async function POST(req: Request) {
     const service = must("SUPABASE_SERVICE_ROLE_KEY");
     const supabase = createClient<DB>(url, service);
 
+    const { data: line, error: lineReadErr } = await supabase
+      .from("work_order_lines")
+      .select("id, line_type")
+      .eq("id", lineId)
+      .maybeSingle();
+
+    if (lineReadErr) {
+      return NextResponse.json({ error: lineReadErr.message }, { status: 400 });
+    }
+    if (!line) {
+      return NextResponse.json({ error: "Line not found" }, { status: 404 });
+    }
+    if ((line.line_type ?? "job") === "info") {
+      return NextResponse.json({ error: "Info lines cannot be technician-assigned." }, { status: 409 });
+    }
+
     // 1) keep the simple column up to date
     const { error: lineErr } = await supabase
       .from("work_order_lines")

--- a/app/mobile/tech/queue/page.tsx
+++ b/app/mobile/tech/queue/page.tsx
@@ -165,7 +165,8 @@ export default function MobileTechQueuePage() {
       const { data: techLines, error: linesErr } = await supabase
         .from("work_order_lines")
         .select("*")
-        .eq("assigned_tech_id", user.id);
+        .eq("assigned_tech_id", user.id)
+        .or("line_type.eq.job,line_type.is.null");
 
       if (linesErr) {
         setErr(linesErr.message);
@@ -193,7 +194,8 @@ export default function MobileTechQueuePage() {
             .in("id", woIds),
           supabase
             .from("work_order_lines")
-            .select("id, work_order_id, created_at, job_type, approval_state")
+            .select("id, work_order_id, created_at, job_type, approval_state, line_type")
+            .or("line_type.eq.job,line_type.is.null")
             .in("work_order_id", woIds),
         ]);
 

--- a/app/tech/queue/page.tsx
+++ b/app/tech/queue/page.tsx
@@ -196,6 +196,7 @@ export default function TechQueuePage() {
       const baseQuery = supabase
         .from("work_order_lines")
         .select("*")
+        .or("line_type.eq.job,line_type.is.null")
         .order("created_at", { ascending: false });
 
       const { data: techLines, error: linesErr } = prefs.showUnassigned

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -86,6 +86,22 @@ function splitCustomId(raw: string): { prefix: string; n: number | null } {
   return { prefix: m[1], n: Number.isFinite(n!) ? n : null };
 }
 
+function toDatetimeLocalInput(value: string | null | undefined): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+function fromDatetimeLocalInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const d = new Date(trimmed);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
 /** Normalize “where is the inspection template id stored for this line?” */
 function extractInspectionTemplateId(ln: WorkOrderLineWithInspectionMeta): string | null {
   return (
@@ -232,6 +248,8 @@ export default function WorkOrderIdClient(): JSX.Element {
 
   // per-line technicians
   const [lineTechsByLine, setLineTechsByLine] = useState<Record<string, string[]>>({});
+  const [expectedCompletionInput, setExpectedCompletionInput] = useState<string>("");
+  const [savingExpectedCompletion, setSavingExpectedCompletion] = useState(false);
 
   // ✅ AI review state for status icons
   const [, setReviewChecked] = useState<boolean>(false);
@@ -799,11 +817,20 @@ export default function WorkOrderIdClient(): JSX.Element {
     return a === "pending" || s === "waiting_for_approval" || s === "awaiting_approval";
   };
 
-  const approvalPending = useMemo(() => lines.filter(isPendingApprovalLine), [lines]);
+  const jobLines = useMemo(
+    () => lines.filter((line) => (line.line_type ?? "job") !== "info"),
+    [lines],
+  );
+  const infoLines = useMemo(
+    () => lines.filter((line) => (line.line_type ?? "job") === "info"),
+    [lines],
+  );
+
+  const approvalPending = useMemo(() => jobLines.filter(isPendingApprovalLine), [jobLines]);
 
   const linesNeedingQuote = useMemo(
     () =>
-      lines.filter((l) => {
+      jobLines.filter((l) => {
         const approval = l.approval_state ?? null;
         const status = l.status ?? "awaiting";
 
@@ -822,12 +849,12 @@ export default function WorkOrderIdClient(): JSX.Element {
 
         return true;
       }),
-    [lines],
+    [jobLines],
   );
 
   const activeJobLines = useMemo(
-    () => lines.filter((l) => (l.approval_state ?? null) !== "pending"),
-    [lines],
+    () => jobLines.filter((l) => (l.approval_state ?? null) !== "pending"),
+    [jobLines],
   );
 
   const approvalPendingQuotes = useMemo(
@@ -846,22 +873,22 @@ export default function WorkOrderIdClient(): JSX.Element {
     [approvalPendingQuotes],
   );
   const decisionTimelineStages = useMemo<DecisionTimelineStage[]>(() => {
-    const hasRecommendedLines = lines.length > 0;
-    const hasAwaitingApproval = lines.some(
+    const hasRecommendedLines = jobLines.length > 0;
+    const hasAwaitingApproval = jobLines.some(
       (line) =>
         resolveDecisionStatus({
           approvalState: line.approval_state,
           workStatus: line.status,
         }) === "awaiting_approval",
     );
-    const hasDeclined = lines.some(
+    const hasDeclined = jobLines.some(
       (line) =>
         resolveDecisionStatus({
           approvalState: line.approval_state,
           workStatus: line.status,
         }) === "declined",
     );
-    const hasInProgress = lines.some(
+    const hasInProgress = jobLines.some(
       (line) =>
         resolveDecisionStatus({
           approvalState: line.approval_state,
@@ -894,15 +921,15 @@ export default function WorkOrderIdClient(): JSX.Element {
         state: isCompleted ? "current" : "future",
       },
     ];
-  }, [lines, wo?.status]);
+  }, [jobLines, wo?.status]);
   const decisionEvents = useMemo(
     () =>
       deriveEventsFromWorkOrder({
         workOrder: wo,
-        lines,
+        lines: jobLines,
         actorLabel: "Service team",
       }),
-    [wo, lines],
+    [wo, jobLines],
   );
 
   const sortedLines = useMemo(() => {
@@ -934,11 +961,42 @@ export default function WorkOrderIdClient(): JSX.Element {
   const createdAt = wo?.created_at ? new Date(wo.created_at) : null;
   const createdAtText =
     createdAt && !Number.isNaN(createdAt.getTime()) ? format(createdAt, "PPpp") : "—";
+  const expectedCompletionText = wo?.expected_completion_at
+    ? format(new Date(wo.expected_completion_at), "PPpp")
+    : "—";
+
+  useEffect(() => {
+    setExpectedCompletionInput(toDatetimeLocalInput(wo?.expected_completion_at));
+  }, [wo?.expected_completion_at]);
 
   const canAssign = currentUserRole ? ASSIGN_ROLES.has(currentUserRole) : false;
   const canApprove = currentUserRole ? APPROVAL_ROLES.has(currentUserRole) : false;
 
   const canDeleteLine = currentUserRole ? LINE_DELETE_ROLES.has(currentUserRole) : false;
+
+  const saveExpectedCompletion = useCallback(async () => {
+    if (!wo?.id) return;
+    setSavingExpectedCompletion(true);
+    try {
+      const payload = {
+        expected_completion_at: fromDatetimeLocalInput(expectedCompletionInput),
+      } as DB["public"]["Tables"]["work_orders"]["Update"];
+      const { data, error } = await supabase
+        .from("work_orders")
+        .update(payload)
+        .eq("id", wo.id)
+        .select("*")
+        .single();
+      if (error) throw error;
+      setWo(data as WorkOrder);
+      toast.success("Expected completion updated.");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to update expected completion.";
+      toast.error(msg);
+    } finally {
+      setSavingExpectedCompletion(false);
+    }
+  }, [expectedCompletionInput, wo?.id, setWo]);
 
   const selectedDelLine = useMemo(() => {
     if (!delLineId) return null;
@@ -1311,6 +1369,9 @@ export default function WorkOrderIdClient(): JSX.Element {
                     </span>
                   </h1>
                   <p className="text-xs text-muted-foreground">Created {createdAtText}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Expected completion: {expectedCompletionText}
+                  </p>
                 </div>
 
                 <div className="flex items-center gap-3">
@@ -1340,6 +1401,30 @@ export default function WorkOrderIdClient(): JSX.Element {
                   )}
                 </div>
               </div>
+          </section>
+
+          <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="min-w-[220px] flex-1">
+                <label className="mb-1 block text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                  Expected completion
+                </label>
+                <input
+                  type="datetime-local"
+                  value={expectedCompletionInput}
+                  onChange={(e) => setExpectedCompletionInput(e.target.value)}
+                  className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1.5 text-sm"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => void saveExpectedCompletion()}
+                disabled={savingExpectedCompletion}
+                className="rounded-md border border-[rgba(184,115,51,0.45)] bg-[rgba(184,115,51,0.10)] px-3 py-1.5 text-xs font-semibold text-amber-100 hover:bg-[rgba(184,115,51,0.16)] disabled:opacity-60"
+              >
+                {savingExpectedCompletion ? "Saving…" : "Save target"}
+              </button>
+            </div>
           </section>
 
           <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}> 
@@ -1779,6 +1864,24 @@ export default function WorkOrderIdClient(): JSX.Element {
                     );
                   })}
                 </div>
+              )}
+
+              {infoLines.length > 0 && (
+                <section className={cn(PANEL_VARIANTS.passive, "rounded-xl p-3")}>
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                    Info / Context (non-actionable)
+                  </div>
+                  <div className="space-y-2">
+                    {infoLines.map((line) => (
+                      <div key={line.id} className="rounded-lg border border-white/10 bg-black/20 p-2.5">
+                        <div className="text-sm text-foreground">
+                          {line.description || line.complaint || "Context line"}
+                        </div>
+                        {line.notes && <div className="mt-1 text-xs text-muted-foreground">{line.notes}</div>}
+                      </div>
+                    ))}
+                  </div>
+                </section>
               )}
             </div>
 

--- a/app/work-orders/view/[id]/page.tsx
+++ b/app/work-orders/view/[id]/page.tsx
@@ -73,7 +73,7 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
         const { data: wol, error: wolErr } = await supabase
           .from("work_order_lines")
           .select(
-            "id, line_no, description, complaint, cause, correction, status, labor_time",
+            "id, line_no, description, complaint, cause, correction, status, labor_time, line_type",
           )
           .eq("work_order_id", woRow.id)
           .order("line_no", { ascending: true });
@@ -139,6 +139,9 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
     : "Customer";
 
   const updatedAt = wo?.updated_at ? format(new Date(wo.updated_at), "PPpp") : "—";
+  const expectedCompletionAt = wo?.expected_completion_at
+    ? format(new Date(wo.expected_completion_at), "PPpp")
+    : "—";
 
   const goBack = () => {
     const r = safeTrim(returnUrl);
@@ -195,6 +198,9 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
                   <div className="mt-1 text-[11px] text-neutral-500">
                     Updated: <span className="text-neutral-300">{updatedAt}</span>
                   </div>
+                  <div className="mt-1 text-[11px] text-neutral-500">
+                    Expected completion: <span className="text-neutral-300">{expectedCompletionAt}</span>
+                  </div>
                 </div>
 
                 <div className="inline-flex items-center gap-2">
@@ -213,16 +219,17 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
               </div>
 
               <div className="mt-5 rounded-2xl border border-white/10 bg-black/35 p-4">
-                {/* ✅ Changed: heading + removed the "Complaint • Cause • Correction" strip */}
                 <div className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                  Line Details
+                  Jobs (Punchable)
                 </div>
 
-                {lines.length === 0 ? (
-                  <div className="text-sm text-neutral-300">No line items.</div>
+                {lines.filter((line) => (line.line_type ?? "job") !== "info").length === 0 ? (
+                  <div className="text-sm text-neutral-300">No jobs added yet.</div>
                 ) : (
                   <div className="space-y-2">
-                    {lines.map((l) => {
+                    {lines
+                      .filter((line) => (line.line_type ?? "job") !== "info")
+                      .map((l) => {
                       const label =
                         safeTrim(l.description) ||
                         safeTrim(l.complaint) ||
@@ -271,7 +278,26 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
                           </div>
                         </div>
                       );
-                    })}
+                      })}
+                  </div>
+                )}
+
+                <div className="mb-2 mt-4 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-300">
+                  Info / Context
+                </div>
+                {lines.filter((line) => (line.line_type ?? "job") === "info").length === 0 ? (
+                  <div className="text-sm text-neutral-500">No info/context lines.</div>
+                ) : (
+                  <div className="space-y-2">
+                    {lines
+                      .filter((line) => (line.line_type ?? "job") === "info")
+                      .map((line) => (
+                        <div key={line.id} className="rounded-xl border border-white/10 bg-black/30 p-3">
+                          <div className="text-sm text-neutral-100">
+                            {safeTrim(line.description) || safeTrim(line.complaint) || "Context line"}
+                          </div>
+                        </div>
+                      ))}
                   </div>
                 )}
               </div>

--- a/db/sql/2026-04-15_work_order_info_lines_and_expected_completion.sql
+++ b/db/sql/2026-04-15_work_order_info_lines_and_expected_completion.sql
@@ -1,0 +1,31 @@
+-- Add non-actionable info lines + expected completion target for work orders.
+-- Non-breaking: additive columns with safe defaults and conservative constraints.
+
+alter table public.work_order_lines
+  add column if not exists line_type text;
+
+update public.work_order_lines
+set line_type = 'job'
+where line_type is null;
+
+alter table public.work_order_lines
+  alter column line_type set default 'job';
+
+alter table public.work_order_lines
+  alter column line_type set not null;
+
+alter table public.work_order_lines
+  drop constraint if exists work_order_lines_line_type_check;
+
+alter table public.work_order_lines
+  add constraint work_order_lines_line_type_check
+  check (line_type in ('job', 'info'));
+
+create index if not exists idx_work_order_lines_work_order_line_type
+  on public.work_order_lines (work_order_id, line_type, created_at);
+
+create index if not exists idx_work_order_lines_assigned_line_type
+  on public.work_order_lines (assigned_tech_id, line_type, status);
+
+alter table public.work_orders
+  add column if not exists expected_completion_at timestamptz;

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -219,14 +219,14 @@ export function MobileTechHome({
           const { data: activeLine, error } = await supabase
             .from("work_order_lines")
             .select(
-              "id, work_order_id, description, complaint, job_type, punched_in_at, punched_out_at, assigned_tech_id",
+              "id, work_order_id, description, complaint, job_type, line_type, punched_in_at, punched_out_at, assigned_tech_id",
             )
             .eq("id", activeLineId)
             .maybeSingle();
 
           if (error) {
             console.error("[MobileTechHome] current job active-line load error:", error);
-          } else if (activeLine) {
+          } else if (activeLine && (activeLine.line_type ?? "job") !== "info") {
             line = {
               ...(activeLine as WorkOrderLine),
               active_segment_started_at: activeSegments?.[0]?.started_at ?? null,
@@ -238,9 +238,10 @@ export function MobileTechHome({
           const { data, error } = await supabase
             .from("work_order_lines")
             .select(
-              "id, work_order_id, description, complaint, job_type, punched_in_at, punched_out_at, assigned_tech_id",
+              "id, work_order_id, description, complaint, job_type, line_type, punched_in_at, punched_out_at, assigned_tech_id",
             )
             .eq("assigned_tech_id", uid)
+            .or("line_type.eq.job,line_type.is.null")
             .not("punched_in_at", "is", null)
             .is("punched_out_at", null)
             .order("punched_in_at", { ascending: false })

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -16712,6 +16712,7 @@ export type Database = {
           job_type: string | null
           labor_time: number | null
           line_no: number | null
+          line_type: string
           line_status: string | null
           menu_item_id: string | null
           notes: string | null
@@ -16770,6 +16771,7 @@ export type Database = {
           job_type?: string | null
           labor_time?: number | null
           line_no?: number | null
+          line_type?: string
           line_status?: string | null
           menu_item_id?: string | null
           notes?: string | null
@@ -16828,6 +16830,7 @@ export type Database = {
           job_type?: string | null
           labor_time?: number | null
           line_no?: number | null
+          line_type?: string
           line_status?: string | null
           menu_item_id?: string | null
           notes?: string | null
@@ -17485,6 +17488,7 @@ export type Database = {
           labor_total: number | null
           notes: string | null
           odometer_km: number | null
+          expected_completion_at: string | null
           parts_total: number | null
           portal_submitted_at: string | null
           priority: number | null
@@ -17552,6 +17556,7 @@ export type Database = {
           labor_total?: number | null
           notes?: string | null
           odometer_km?: number | null
+          expected_completion_at?: string | null
           parts_total?: number | null
           portal_submitted_at?: string | null
           priority?: number | null
@@ -17619,6 +17624,7 @@ export type Database = {
           labor_total?: number | null
           notes?: string | null
           odometer_km?: number | null
+          expected_completion_at?: string | null
           parts_total?: number | null
           portal_submitted_at?: string | null
           priority?: number | null

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -206,6 +206,22 @@ const yearToStrOrNull = (
   return s ? s : null;
 };
 
+function toDatetimeLocalInput(value: string | null | undefined): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+function fromDatetimeLocalInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const d = new Date(trimmed);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
 /** Normalize “where is the inspection template id stored for this line?” */
 function extractInspectionTemplateId(
   ln: WorkOrderLineWithInspectionMeta,
@@ -441,6 +457,10 @@ export default function CreateWorkOrderPage() {
   const [priority, setPriority] = useTabState<number>("priority", 3);
   // 👇 waiter flag (customer waiting on-site)
   const [isWaiter, setIsWaiter] = useTabState<boolean>("is_waiter", false);
+  const [expectedCompletionInput, setExpectedCompletionInput] = useTabState<string>(
+    "expected_completion_input",
+    "",
+  );
 
   // Uploads
   const [photoFiles, setPhotoFiles] = useState<File[]>([]);
@@ -569,6 +589,7 @@ useEffect(() => {
     if (!wo) return;
     const flag = (wo as WorkOrderWaiterRow).is_waiter ?? false;
     setIsWaiter(Boolean(flag));
+    setExpectedCompletionInput(toDatetimeLocalInput(wo.expected_completion_at));
   }, [wo, setIsWaiter]);
 
   // get current user id + current profile id
@@ -1036,6 +1057,7 @@ useEffect(() => {
             .update({
               customer_id: cust.id,
               vehicle_id: veh.id,
+              expected_completion_at: fromDatetimeLocalInput(expectedCompletionInput),
               ...(waiter !== undefined ? { is_waiter: waiter } : {}),
             })
             .eq("id", wo.id)
@@ -1079,6 +1101,18 @@ useEffect(() => {
       }
 
       setWo(createdRow as unknown as WorkOrderRow);
+      const expectedCompletionAt = fromDatetimeLocalInput(expectedCompletionInput);
+      if (expectedCompletionAt) {
+        const { data: woWithExpected } = await supabase
+          .from("work_orders")
+          .update({ expected_completion_at: expectedCompletionAt })
+          .eq("id", createdRow.id)
+          .select("*")
+          .single();
+        if (woWithExpected) {
+          setWo(woWithExpected as WorkOrderRow);
+        }
+      }
       await fetchLines();
 
       return String(createdRow.id);
@@ -1743,6 +1777,22 @@ useEffect(() => {
                     Sets the default for new lines you add on this work order.
                   </p>
                 </div>
+
+                <div>
+                  <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
+                    Expected completion
+                  </label>
+                  <input
+                    type="datetime-local"
+                    value={expectedCompletionInput}
+                    onChange={(e) => setExpectedCompletionInput(e.target.value)}
+                    className="input"
+                    disabled={loading}
+                  />
+                  <p className="mt-1 text-[11px] text-neutral-500">
+                    Internal target time for advisor/front-of-house coordination.
+                  </p>
+                </div>
               </div>
             </section>
 
@@ -1959,7 +2009,7 @@ useEffect(() => {
               <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
                 <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                   <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
-                    Add job line
+                    Add work order line
                   </h2>
                   <span className="text-[11px] text-neutral-500">Manual entry</span>
                 </div>
@@ -1998,8 +2048,15 @@ useEffect(() => {
               {!wo?.id || lines.length === 0 ? (
                 <p className="text-sm text-neutral-400">No lines yet.</p>
               ) : (
-                <div className="space-y-2">
-                  {lines.map((ln) => (
+                <div className="space-y-4">
+                  <div>
+                    <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-400">
+                      Jobs (Punchable)
+                    </div>
+                    <div className="space-y-2">
+                      {lines
+                        .filter((ln) => (ln.line_type ?? "job") !== "info")
+                        .map((ln) => (
                     <div
                       key={ln.id}
                       className="flex flex-col gap-3 rounded-xl border border-white/10 bg-black/50 p-3 sm:flex-row sm:items-start sm:justify-between"
@@ -2051,6 +2108,36 @@ useEffect(() => {
                       </div>
                     </div>
                   ))}
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-400">
+                      Info / Context
+                    </div>
+                    <div className="space-y-2">
+                      {lines
+                        .filter((ln) => (ln.line_type ?? "job") === "info")
+                        .map((ln) => (
+                          <div
+                            key={ln.id}
+                            className="rounded-xl border border-white/10 bg-black/30 p-3 text-sm text-neutral-300"
+                          >
+                            <div className="font-medium text-neutral-200">
+                              {ln.description || ln.complaint || "Context line"}
+                            </div>
+                            {(ln.complaint || ln.notes) && (
+                              <div className="mt-1 text-xs text-neutral-500">
+                                {ln.complaint ?? ln.notes}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+                      {lines.every((ln) => (ln.line_type ?? "job") !== "info") && (
+                        <p className="text-xs text-neutral-500">No info/context lines.</p>
+                      )}
+                    </div>
+                  </div>
                 </div>
               )}
             </section>

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -11,6 +11,7 @@ type InsertLine = DB["public"]["Tables"]["work_order_lines"]["Insert"];
 
 // Keep in sync with your DB check constraint
 type WOJobType = "diagnosis" | "inspection" | "maintenance" | "repair";
+type WOLineType = "job" | "info";
 
 const ALLOWED_STATUS = [
   "awaiting",
@@ -78,6 +79,7 @@ export function NewWorkOrderLineForm(props: {
   const [jobType, setJobType] = useState<WOJobType | null>(
     defaultJobType ?? null,
   );
+  const [lineType, setLineType] = useState<WOLineType>("job");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -316,7 +318,10 @@ export function NewWorkOrderLineForm(props: {
         correction: correction.trim() || null,
         labor_time: labor ? Number(labor) : null,
         status: normalizeStatus(status),
-        job_type: normalizeJobType(jobType),
+        job_type: lineType === "info" ? null : normalizeJobType(jobType),
+        line_type: lineType,
+        punchable: lineType === "info" ? false : null,
+        assigned_tech_id: lineType === "info" ? null : undefined,
 
         // IMPORTANT: keep shop_id explicit so all RLS/shop triggers stay deterministic
         shop_id: shopId,
@@ -356,6 +361,7 @@ export function NewWorkOrderLineForm(props: {
       setLabor("");
       setStatus("awaiting");
       setJobType(defaultJobType ?? null);
+      setLineType("job");
       setSmartMatch(null);
 
       onCreated?.();
@@ -372,7 +378,7 @@ export function NewWorkOrderLineForm(props: {
     <div className="rounded-lg border border-neutral-800 bg-neutral-950 p-4 sm:p-5 text-sm text-white space-y-4">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <h3 className="text-sm font-semibold text-neutral-100">Add job line</h3>
+          <h3 className="text-sm font-semibold text-neutral-100">Add work order line</h3>
           <p className="text-[11px] text-neutral-400">
             Complaint is required. Cause / correction can be filled in later.
           </p>
@@ -384,6 +390,23 @@ export function NewWorkOrderLineForm(props: {
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <label className="mb-0.5 block text-xs text-neutral-300">Line type</label>
+          <select
+            value={lineType}
+            onChange={(e) => setLineType(e.target.value as WOLineType)}
+            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none"
+          >
+            <option value="job">Job line (punchable)</option>
+            <option value="info">Info line (context only)</option>
+          </select>
+          <p className="text-[10px] text-neutral-500">
+            Info lines are non-actionable and excluded from technician punch queues.
+          </p>
+        </div>
+
+        <div className="space-y-1" />
+
         <div className="sm:col-span-2 space-y-1">
           <label className="mb-0.5 block text-xs text-neutral-300">
             Complaint <span className="text-red-400">*</span>

--- a/features/work-orders/components/TechJobScreen.tsx
+++ b/features/work-orders/components/TechJobScreen.tsx
@@ -32,6 +32,7 @@ export default function TechJobScreen() {
       .from("work_order_lines")
       .select("*")
       .or(`assigned_tech_id.eq.${user.id},assigned_tech_id.is.null`)
+      .or("line_type.eq.job,line_type.is.null")
       .in("status", ["awaiting", "in_progress", "on_hold"])
       .order("created_at", { ascending: true });
 

--- a/features/work-orders/lib/work-orders/fetchJobs.ts
+++ b/features/work-orders/lib/work-orders/fetchJobs.ts
@@ -37,6 +37,7 @@ export async function fetchAllJobLines(): Promise<JobLine[]> {
       vehicles:vehicle_id ( year, make, model ),
       profiles:assigned_tech_id ( full_name )
     `)
+    .or("line_type.eq.job,line_type.is.null")
     .order("created_at", { ascending: true });
 
   if (error || !data) {

--- a/features/work-orders/lib/work-orders/getQueuedJobsForTech.ts
+++ b/features/work-orders/lib/work-orders/getQueuedJobsForTech.ts
@@ -30,6 +30,7 @@ export async function getQueuedJobsForTech(techId?: string): Promise<JobLine[]> 
         )
       `
     )
+    .or("line_type.eq.job,line_type.is.null")
     .in("status", getWorkOrderLineStatusDbFilter(queueStatuses))
     // highest priority WOs first (1 = highest)
     .order("work_orders(priority)", { ascending: true, nullsFirst: false })

--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -63,6 +63,7 @@ type LineRow = Pick<
   | "cause"
   | "correction"
   | "labor_time"
+  | "line_type"
 >;
 
 function cleanString(value: unknown): string | null {
@@ -87,7 +88,7 @@ export async function applyJobPunchTransition({
   const { data: line, error: lineErr } = await supabase
     .from("work_order_lines")
     .select(
-      "id, work_order_id, status, approval_state, punchable, assigned_tech_id, shop_id, punched_in_at, punched_out_at, hold_reason, cause, correction, labor_time",
+      "id, work_order_id, status, approval_state, punchable, assigned_tech_id, shop_id, punched_in_at, punched_out_at, hold_reason, cause, correction, labor_time, line_type",
     )
     .eq("id", lineId)
     .maybeSingle<LineRow>();
@@ -97,6 +98,7 @@ export async function applyJobPunchTransition({
   }
 
   if (!line) return err(404, "Line not found");
+  if ((line.line_type ?? "job") === "info") return err(409, "Info lines are non-actionable.");
 
   const status = normalizeWorkOrderLineStatus(line.status);
 


### PR DESCRIPTION
### Motivation

- Provide structured, non-actionable "info" lines on work orders so context can be stored as lines without becoming technician jobs.
- Add an internal target time `expected_completion_at` to surface coordination timing separate from scheduling.
- Keep changes incremental, non-breaking, and preserve multi-tenant/RLS protections.

### Description

- Database: added a non-breaking SQL migration that backfills and adds `work_order_lines.line_type` (enum-like check of `job`|`info`) with indexes, and added `work_orders.expected_completion_at timestamptz` (`db/sql/2026-04-15_work_order_info_lines_and_expected_completion.sql`).
- Types: updated Supabase TS schema so `line_type` and `expected_completion_at` are present in `Row/Insert/Update` shapes used by the app (`features/shared/types/types/supabase.ts`).
- UI/UX: added a Line Type selector to the new-line form, split work order create/edit/detail views into two sections (Jobs — punchable, and Info / Context — muted), and added an editable `Expected completion` datetime control on create/edit and the WO header (`features/work-orders/...`, `app/work-orders/[id]/Client.tsx`, `app/work-orders/view/[id]/page.tsx`).
- Backend / API: guardrails to prevent info lines being actionable including blocking assignment in the assign-line API and rejecting punch transitions for `line_type = 'info'`, and updated tech/mobile queue queries to filter to job lines by default; portal custom-line API accepts optional `lineType` (defaults to `job`).

### Testing

- Ran TypeScript compilation with `npx tsc --noEmit` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc55ed7008328a85422c63e0051cb)