### PR TITLE
Shadow Shop Preview: read-only demo workspace and shadow adapter

### DIFF
--- a/app/api/demo/shop-boost/claim/route.ts
+++ b/app/api/demo/shop-boost/claim/route.ts
@@ -7,6 +7,7 @@ type DB = Database;
 
 type ClaimBody = {
   demoId?: string;
+  intakeId?: string;
   email?: string;
 };
 
@@ -35,6 +36,7 @@ export async function POST(
     const body = (await req.json().catch(() => null)) as ClaimBody | null;
 
     const demoId = body?.demoId?.trim();
+    const intakeId = body?.intakeId?.trim() ?? null;
     const emailRaw = body?.email?.trim();
 
     if (!demoId || !emailRaw) {
@@ -47,7 +49,6 @@ export async function POST(
     const emailNormalized = emailRaw.toLowerCase();
     const supabase = createAdminSupabase();
 
-    // 1) Enforce one free run per email
     const { data: existingLead, error: existingErr } = await supabase
       .from("demo_shop_boost_leads")
       .select("id")
@@ -65,7 +66,6 @@ export async function POST(
       );
     }
 
-    // 2) Load demo analysis payload
     const { data: demoRow, error: demoErr } = await supabase
       .from("demo_shop_boosts")
       .select("id, snapshot")
@@ -81,15 +81,21 @@ export async function POST(
     }
 
     const rawPayload = asRecord(demoRow.snapshot);
-    const maybeSnapshot = asRecord(rawPayload.snapshot);
-    const summary =
-      typeof maybeSnapshot.narrativeSummary === "string"
-        ? maybeSnapshot.narrativeSummary
-        : typeof rawPayload.narrativeSummary === "string"
-          ? rawPayload.narrativeSummary
-          : null;
+    if (intakeId) {
+      const snapshotIntakeId = typeof rawPayload.intakeId === "string" ? rawPayload.intakeId : null;
+      if (!snapshotIntakeId || snapshotIntakeId !== intakeId) {
+        return NextResponse.json(
+          { ok: false, error: "This preview link does not match the analysis intake." },
+          { status: 403 },
+        );
+      }
+    }
 
-    // 3) Insert lead row
+    const summary =
+      typeof rawPayload.preflightSummary === "string"
+        ? rawPayload.preflightSummary
+        : "Shop Boost preview unlocked";
+
     const { error: leadErr } = await supabase
       .from("demo_shop_boost_leads")
       .insert({
@@ -106,7 +112,6 @@ export async function POST(
       );
     }
 
-    // 4) Mark demo as unlocked
     const { error: updateErr } = await supabase
       .from("demo_shop_boosts")
       .update({ has_unlocked: true })

--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -3,35 +3,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 import {
-  buildShopBoostPreflightReport,
-  type ShopBoostPreflightReport,
-} from "@/features/integrations/shopBoost/preflightAnalysis";
+  buildShadowShopSnapshot,
+  type ShadowShopSnapshot,
+} from "@/features/integrations/shopBoost/shadowShop";
 import {
   SHOP_BOOST_UPLOAD_DATASET_KEYS,
-  SHOP_BOOST_UPLOAD_DATASETS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
 
-const SHOP_IMPORT_BUCKET = "shop-imports";
-
-// Seeded demo owner (profiles.id / auth.users.id)
-const DEMO_OWNER_ID = "22fab07e-3b6f-432b-9434-e5476a7ade28";
-
-// shops.plan CHECK allows only: free, diy, pro, pro_plus
-const DEMO_SHOP_PLAN: DB["public"]["Tables"]["shops"]["Insert"]["plan"] = "pro";
-
 type DemoRunSuccessResponse = {
   ok: true;
   demoId: string;
   intakeId: string;
-  analysis: {
-    snapshot: unknown;
-    preflightReport: ShopBoostPreflightReport;
-  };
+  analysis: ShadowShopSnapshot;
 };
 
 type DemoRunErrorResponse = {
@@ -45,38 +32,18 @@ function safeShopName(name: string): string {
   return name.trim().replace(/\s+/g, " ").slice(0, 80);
 }
 
-function makeUniqueName(base: string): string {
-  const suffix = randomUUID().slice(0, 8);
-  return `${base} (Demo ${suffix})`.slice(0, 80);
-}
-
-function safeFileName(name: string): string {
-  const base = (name || "upload.csv").trim();
-  const cleaned = base.replace(/[^a-zA-Z0-9._-]/g, "_");
-  return cleaned.length ? cleaned : "upload.csv";
-}
-
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-/**
- * Avoid `instanceof File` (unreliable across runtimes/bundlers).
- * Next route handlers provide a file-like object with name/type/arrayBuffer().
- */
 function asFile(v: FormDataEntryValue | null): File | null {
   if (!v || typeof v !== "object") return null;
-
   const rec = v as unknown;
   if (!isRecord(rec)) return null;
 
-  const ab = rec["arrayBuffer"];
-  const name = rec["name"];
-  const type = rec["type"];
-
-  if (typeof ab !== "function") return null;
-  if (typeof name !== "string") return null;
-  if (typeof type !== "string") return null;
+  const ab = rec.arrayBuffer;
+  const name = rec.name;
+  if (typeof ab !== "function" || typeof name !== "string") return null;
 
   return v as File;
 }
@@ -87,7 +54,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
 
     const rawShopName = formData.get("shopName");
     const rawCountry = formData.get("country");
-    const rawQuestionnaire = formData.get("questionnaire");
 
     const shopName =
       typeof rawShopName === "string" && rawShopName.trim().length > 0
@@ -103,15 +69,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
         ? rawCountry
         : "US";
 
-    let questionnaire: unknown = {};
-    if (typeof rawQuestionnaire === "string" && rawQuestionnaire.trim().length > 0) {
-      try {
-        questionnaire = JSON.parse(rawQuestionnaire) as unknown;
-      } catch {
-        questionnaire = {};
-      }
-    }
-
     const filesByDataset: Partial<Record<ShopBoostUploadDatasetKey, File>> = {};
     for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
       const file = asFile(formData.get(`${key}File`));
@@ -120,173 +77,31 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
 
     if (Object.values(filesByDataset).length === 0) {
       return NextResponse.json(
-        { ok: false, error: "Please upload at least one CSV so we have some history to analyze." },
+        { ok: false, error: "Please upload at least one CSV so we have data to analyze." },
         { status: 400 },
       );
     }
 
-    const supabase = createAdminSupabase();
-
-    // 1) Create a demo shop row
-    const insertShop = async (nameValue: string) => {
-      return supabase
-        .from("shops")
-        .insert({
-          owner_id: DEMO_OWNER_ID,
-          business_name: nameValue,
-          name: nameValue,
-          country: countryValue,
-          plan: DEMO_SHOP_PLAN,
-        } as DB["public"]["Tables"]["shops"]["Insert"])
-        .select("id")
-        .single();
-    };
-
-    let { data: shopRow, error: shopErr } = await insertShop(shopName);
-
-    if (shopErr) {
-      const retryName = makeUniqueName(shopName);
-      const retry = await insertShop(retryName);
-      shopRow = retry.data ?? null;
-      shopErr = retry.error ?? null;
-    }
-
-    if (shopErr || !shopRow?.id) {
-      // eslint-disable-next-line no-console
-      console.error("Failed to create demo shop", shopErr);
-      return NextResponse.json(
-        { ok: false, error: "We couldn't create a demo shop record. Please try again. (Shop insert failed)" },
-        { status: 500 },
-      );
-    }
-
-    const shopId = shopRow.id as string;
     const intakeId = randomUUID();
-
-    const uploadIfPresent = async (
-      file: File | undefined,
-      kind: ShopBoostUploadDatasetKey,
-    ): Promise<string | null> => {
-      if (!file) return null;
-
-      // ✅ Keep first segment == shopId (matches your Storage RLS convention)
-      const safeName = safeFileName(file.name || `${kind}.csv`);
-      const path = `shops/${shopId}/demo/${intakeId}/${kind}-${safeName}`;
-
-      const { error: uploadErr } = await supabase.storage.from(SHOP_IMPORT_BUCKET).upload(path, file, {
-        cacheControl: "3600",
-        upsert: true,
-        contentType: file.type || "text/csv",
-      });
-
-      if (uploadErr) throw new Error(`Failed to upload ${kind} file: ${uploadErr.message}`);
-
-      return path;
-    };
-
-    // 2) Upload CSVs
-    const uploadedPathEntries = await Promise.all(
-      SHOP_BOOST_UPLOAD_DATASET_KEYS.map(async (key) => [key, await uploadIfPresent(filesByDataset[key], key)] as const),
-    );
-    const uploadPaths = Object.fromEntries(uploadedPathEntries) as Record<
-      ShopBoostUploadDatasetKey,
-      string | null
-    >;
-    const uploadManifest = SHOP_BOOST_UPLOAD_DATASETS.reduce((acc, dataset) => {
-      const path = uploadPaths[dataset.key];
-      if (!path) return acc;
-      const file = filesByDataset[dataset.key];
-      acc[dataset.key] = {
-        dataset: dataset.key,
-        path,
-        fileName: file?.name ?? null,
-        contentType: file?.type ?? null,
-        sizeBytes: file?.size ?? null,
-        target: dataset.target,
-        importMode: dataset.importMode,
-      };
-      return acc;
-    }, {} as Record<string, unknown>);
-
-    // 3) Create intake row
-    const intakePayload: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
-      id: intakeId,
-      shop_id: shopId,
-      questionnaire:
-        questionnaire as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["questionnaire"],
-      customers_file_path: uploadPaths.customers,
-      vehicles_file_path: uploadPaths.vehicles,
-      parts_file_path: uploadPaths.parts,
-      history_file_path: uploadPaths.history,
-      staff_file_path: uploadPaths.staff,
-      intake_basics: {
-        uploadManifest,
-      } as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["intake_basics"],
-      status: "pending",
-    };
-
-    const { error: intakeErr } = await supabase.from("shop_boost_intakes").insert(intakePayload);
-
-    if (intakeErr) {
-      // eslint-disable-next-line no-console
-      console.error("Failed to insert shop_boost_intakes", intakeErr);
-      return NextResponse.json(
-        { ok: false, error: "We couldn't start the analysis. Please try again." },
-        { status: 500 },
-      );
-    }
-
-    // 4) Run pipeline
-    const snapshot = await buildShopBoostProfile({ shopId, intakeId });
-
-    if (!snapshot) {
-      return NextResponse.json(
-        { ok: false, error: "The AI analysis failed. Please try again with a different export." },
-        { status: 500 },
-      );
-    }
-
-    const { data: importRows } = await supabase
-      .from("shop_import_rows")
-      .select("entity_type,raw,normalized")
-      .eq("intake_id", intakeId)
-      .limit(20000);
-
-    const preflightReport = buildShopBoostPreflightReport({
-      rows: (importRows ?? []) as Array<{ entity_type: string | null; raw: unknown; normalized: unknown }>,
-      hasHistoryData: Boolean(uploadPaths.history),
-      hasVehicleData: Boolean(uploadPaths.vehicles),
-      hasCustomerData: Boolean(uploadPaths.customers),
-      menuSuggestionCount:
-        Array.isArray((snapshot as { menuSuggestions?: unknown[] }).menuSuggestions)
-          ? ((snapshot as { menuSuggestions?: unknown[] }).menuSuggestions?.length ?? 0)
-          : 0,
-      inspectionSuggestionCount:
-        Array.isArray((snapshot as { inspectionSuggestions?: unknown[] }).inspectionSuggestions)
-          ? ((snapshot as { inspectionSuggestions?: unknown[] }).inspectionSuggestions?.length ?? 0)
-          : 0,
+    const snapshot = await buildShadowShopSnapshot({
+      intakeId,
+      uploadedFiles: filesByDataset,
     });
 
-    const analysisPayload = {
-      snapshot,
-      preflightReport,
-    };
-
-    // 5) Store snapshot in demo_shop_boosts for later unlock + CRM usage
+    const supabase = createAdminSupabase();
     const { data: demoRow, error: demoErr } = await supabase
       .from("demo_shop_boosts")
       .insert({
-        shop_id: shopId,
-        intake_id: intakeId,
+        shop_id: null,
+        intake_id: null,
         shop_name: shopName,
         country: countryValue,
-        snapshot: analysisPayload,
+        snapshot,
       } as DB["public"]["Tables"]["demo_shop_boosts"]["Insert"])
       .select("id")
       .single();
 
     if (demoErr || !demoRow?.id) {
-      // eslint-disable-next-line no-console
       console.error("Failed to insert demo_shop_boosts", demoErr);
       return NextResponse.json(
         { ok: false, error: "We ran the analysis, but could not save the demo result." },
@@ -299,14 +114,13 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
         ok: true,
         demoId: demoRow.id as string,
         intakeId,
-        analysis: analysisPayload,
+        analysis: snapshot,
       },
       { status: 200 },
     );
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Unexpected error while running demo analysis.";
-    // eslint-disable-next-line no-console
     console.error("Demo run error", err);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }

--- a/app/compare-plans/page.tsx
+++ b/app/compare-plans/page.tsx
@@ -38,6 +38,14 @@ export default function ComparePlansPage() {
       const data = await res.json().catch(() => ({}));
 
       if (!res.ok) {
+        if (res.status === 401 || res.status === 403) {
+          const next = `/compare-plans?${new URLSearchParams({
+            ...(demoId ? { demoId } : {}),
+            ...(intakeId ? { intakeId } : {}),
+          }).toString()}`;
+          window.location.href = `/signup?redirect=${encodeURIComponent(next)}${demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
+          return;
+        }
         toast.error(data?.details || data?.error || "Checkout failed");
         return;
       }
@@ -84,7 +92,7 @@ export default function ComparePlansPage() {
 
             {demoId ? (
               <p className="mt-2 text-[11px] text-neutral-500">
-                Analysis reference: <span className="text-neutral-300">{demoId}</span>
+                Your analysis is ready to carry forward. Reference: <span className="text-neutral-300">{demoId}</span>
                 {intakeId ? <span className="text-neutral-400"> • Intake: {intakeId}</span> : null}
               </p>
             ) : null}
@@ -99,6 +107,11 @@ export default function ComparePlansPage() {
         </div>
 
         <div className="rounded-3xl border border-white/10 bg-black/35 p-4 backdrop-blur-xl md:p-6">
+          {demoId ? (
+            <div className="mb-4 rounded-2xl border border-cyan-500/30 bg-cyan-500/10 px-4 py-3 text-xs text-cyan-100">
+              Preview continuity: nothing has been imported yet. After activation, this analysis will seed your real Shop Boost onboarding.
+            </div>
+          ) : null}
           <PricingSection
             onCheckout={handleCheckout}
             onStartFree={() => {
@@ -107,6 +120,16 @@ export default function ComparePlansPage() {
               });
             }}
           />
+          {demoId ? (
+            <div className="mt-4">
+              <Link
+                href={`/signup?redirect=${encodeURIComponent(`/compare-plans?demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`)}&demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`}
+                className="inline-flex items-center rounded-lg border border-white/15 bg-white/[0.04] px-4 py-2 text-xs font-semibold text-neutral-100 hover:bg-white/[0.08]"
+              >
+                Continue setup via signup
+              </Link>
+            </div>
+          ) : null}
         </div>
 
         <div className="mt-8 rounded-3xl border border-white/10 bg-black/25 p-5 backdrop-blur-xl">

--- a/app/confirm/ConfirmContent.tsx
+++ b/app/confirm/ConfirmContent.tsx
@@ -49,7 +49,7 @@ export default function ConfirmContent() {
       // ✅ Route depending on onboarding status
 
       const params = new URLSearchParams();
-      const passthroughKeys = ["priceId", "interval", "trial", "founding", "session_id"];
+      const passthroughKeys = ["priceId", "interval", "trial", "founding", "session_id", "demoId", "intakeId"];
       for (const key of passthroughKeys) {
         const value = sp.get(key);
         if (value) params.set(key, value);

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -2,8 +2,8 @@
 "use client";
 
 import React, { useMemo, useState, type FormEvent } from "react";
-import type { ShopHealthSnapshot } from "@/features/integrations/ai/shopBoostType";
 import type { ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
+import type { ShadowShopSnapshot } from "@/features/integrations/shopBoost/shadowShop";
 import {
   SHOP_BOOST_UPLOAD_DATASETS,
   type ShopBoostUploadDatasetKey,
@@ -21,10 +21,7 @@ type QuestionnaireState = {
 
 type DemoStep = "form" | "analyzing" | "preview" | "unlocked";
 
-type InstantAnalysisPayload = {
-  snapshot: ShopHealthSnapshot;
-  preflightReport: ShopBoostPreflightReport;
-};
+type InstantAnalysisPayload = ShadowShopSnapshot;
 
 type RunResponse =
   | {
@@ -50,44 +47,14 @@ type ClaimResponse =
 
 
 
-function buildFallbackPreflight(): ShopBoostPreflightReport {
-  return {
-    totals: {
-      detectedRecords: 0,
-      estimatedAutoImportCoverage: 0,
-      likelyAutoImportCount: 0,
-      likelyReviewNeededCount: 0,
-      likelyBlockerCount: 0,
-    },
-    confidence: {
-      score: 0,
-      label: "low",
-      readiness: "NOT_READY",
-      integrityStatus: "not_ready",
-    },
-    blockers: [],
-    domains: [],
-    projectedPreparation: ["Foundational import mapping and identifier checks"],
-    reviewNotes: ["Nothing has been imported yet — this is a preview only."],
-  };
-}
-
 function normalizeAnalysisPayload(payload: unknown): InstantAnalysisPayload | null {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
   const rec = payload as Record<string, unknown>;
-  const maybeSnapshot = rec.snapshot;
-  if (!maybeSnapshot || typeof maybeSnapshot !== "object" || Array.isArray(maybeSnapshot)) {
+  const intakeId = rec.intakeId;
+  if (typeof intakeId !== "string" || intakeId.length === 0) {
     return null;
   }
-  const preflight =
-    rec.preflightReport && typeof rec.preflightReport === "object" && !Array.isArray(rec.preflightReport)
-      ? (rec.preflightReport as ShopBoostPreflightReport)
-      : buildFallbackPreflight();
-
-  return {
-    snapshot: maybeSnapshot as ShopHealthSnapshot,
-    preflightReport: preflight,
-  };
+  return rec as ShadowShopSnapshot;
 }
 
 const THEME = {
@@ -150,7 +117,9 @@ export default function InstantShopAnalysisPage() {
           intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""
         }`
       : "/compare-plans";
-    window.location.href = `/auth/signup?next=${encodeURIComponent(next)}`;
+    window.location.href = `/signup?redirect=${encodeURIComponent(next)}${
+      demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""
+    }${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
   };
 
   const handleRun = async (event: FormEvent<HTMLFormElement>) => {
@@ -245,7 +214,7 @@ export default function InstantShopAnalysisPage() {
       const res = await fetch("/api/demo/shop-boost/claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ demoId, email: email.trim() }),
+        body: JSON.stringify({ demoId, intakeId, email: email.trim() }),
       });
 
       const json = (await res.json()) as ClaimResponse;
@@ -503,7 +472,7 @@ export default function InstantShopAnalysisPage() {
 
                     <button
                       type="button"
-                      onClick={handleClaim}
+                    onClick={handleClaim}
                       disabled={claimLoading}
                       className={[
                         "inline-flex items-center justify-center rounded-md px-4 py-1.5 text-xs font-semibold shadow-sm transition",
@@ -517,6 +486,12 @@ export default function InstantShopAnalysisPage() {
                   </div>
 
                   {claimError ? <p className="mt-2 text-[11px] text-red-400">{claimError}</p> : null}
+                  <a
+                    href={`/demo/preview/${encodeURIComponent(demoId ?? "")}?intakeId=${encodeURIComponent(intakeId ?? analysis.intakeId ?? "")}`}
+                    className="mt-3 inline-flex items-center justify-center rounded-md border border-white/15 px-3 py-1.5 text-[11px] text-neutral-200 transition hover:bg-white/[0.04]"
+                  >
+                    Enter your system preview
+                  </a>
                 </div>
               </div>
             )}
@@ -540,6 +515,16 @@ export default function InstantShopAnalysisPage() {
                 </div>
 
                 <div className="flex flex-wrap gap-2">
+                  <a
+                    href={`/demo/preview/${encodeURIComponent(demoId ?? "")}?intakeId=${encodeURIComponent(intakeId ?? analysis.intakeId)}`}
+                    className={[
+                      "inline-flex items-center justify-center rounded-md px-4 py-1.5 text-xs font-semibold shadow-sm transition",
+                      THEME.cta,
+                      THEME.ctaHover,
+                    ].join(" ")}
+                  >
+                    Enter your system preview
+                  </a>
                   <button type="button" onClick={goToSignup} className={[
                     "inline-flex items-center justify-center rounded-md px-4 py-1.5 text-xs font-semibold shadow-sm transition",
                     THEME.cta,

--- a/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
+++ b/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { ShadowPreviewContext, ShadowPreviewItem, ShadowSetupIssue } from "@/features/integrations/shopBoost/shadowShop";
+
+type Props = {
+  context: ShadowPreviewContext;
+};
+
+type SectionKey = "dashboard" | "customers" | "vehicles" | "work-orders" | "parts" | "setup";
+
+const sections: Array<{ key: SectionKey; label: string }> = [
+  { key: "dashboard", label: "Command Center" },
+  { key: "customers", label: "Customers" },
+  { key: "vehicles", label: "Vehicles" },
+  { key: "work-orders", label: "Work Orders" },
+  { key: "parts", label: "Parts" },
+  { key: "setup", label: "Setup" },
+];
+
+export default function ShadowPreviewClient({ context }: Props) {
+  const [active, setActive] = useState<SectionKey>("dashboard");
+  const [gateOpen, setGateOpen] = useState(false);
+
+  const query = useMemo(() => new URLSearchParams({ demoId: context.demoId, intakeId: context.intakeId }).toString(), [context.demoId, context.intakeId]);
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <header className="sticky top-0 z-20 border-b border-white/10 bg-black/80 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-300">Preview mode • read only</p>
+            <h1 className="text-xl font-semibold">{context.shopName} • Shadow Workspace</h1>
+            <p className="text-[11px] text-neutral-400">Nothing has been imported yet. This environment is derived from your Instant Shop Analysis.</p>
+          </div>
+          <div className="flex gap-2">
+            <Link href={`/compare-plans?${query}`} className="rounded-md border border-white/20 px-3 py-1.5 text-xs hover:bg-white/[0.05]">See Plans</Link>
+            <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="rounded-md bg-[var(--accent-copper)] px-3 py-1.5 text-xs font-semibold text-black hover:brightness-110">Activate Your Shop</Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto grid max-w-7xl gap-4 px-4 py-4 sm:px-6 lg:grid-cols-[220px_1fr_280px]">
+        <aside className="rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+          <p className="mb-2 text-[11px] uppercase tracking-[0.18em] text-neutral-400">Preview areas</p>
+          <nav className="space-y-1">
+            {sections.map((section) => (
+              <button key={section.key} onClick={() => setActive(section.key)} className={`w-full rounded-md px-3 py-2 text-left text-xs ${active === section.key ? "bg-white/[0.08] text-white" : "text-neutral-300 hover:bg-white/[0.04]"}`}>
+                {section.label}
+              </button>
+            ))}
+          </nav>
+        </aside>
+
+        <main className="space-y-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          {active === "dashboard" ? <Dashboard context={context} onLockedAction={() => setGateOpen(true)} /> : null}
+          {active === "customers" ? <DomainTable title="Customers" items={context.snapshot.customers} onLockedAction={() => setGateOpen(true)} /> : null}
+          {active === "vehicles" ? <DomainTable title="Vehicles" items={context.snapshot.vehicles} onLockedAction={() => setGateOpen(true)} /> : null}
+          {active === "work-orders" ? <DomainTable title="Work history" items={context.snapshot.workOrders} onLockedAction={() => setGateOpen(true)} /> : null}
+          {active === "parts" ? <DomainTable title="Parts & inventory" items={context.snapshot.parts} onLockedAction={() => setGateOpen(true)} /> : null}
+          {active === "setup" ? <SetupPanel issues={context.snapshot.setupIssues} onLockedAction={() => setGateOpen(true)} /> : null}
+        </main>
+
+        <aside className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-[11px] uppercase tracking-[0.15em] text-neutral-400">Activation rail</p>
+          <p className="text-xs text-neutral-300">Your analysis is ready to carry forward. Activate to import for real and unlock write access.</p>
+          <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="block rounded-md bg-[var(--accent-copper)] px-3 py-2 text-center text-xs font-semibold text-black hover:brightness-110">Activate Your Shop</Link>
+          <Link href={`/compare-plans?${query}`} className="block rounded-md border border-white/20 px-3 py-2 text-center text-xs hover:bg-white/[0.05]">See Plans</Link>
+          <button onClick={() => setGateOpen(true)} className="w-full rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-200 hover:bg-white/[0.05]">Import This Into My Shop</button>
+        </aside>
+      </div>
+
+      {gateOpen ? (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4">
+          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#090909] p-5">
+            <p className="text-lg font-semibold">Activate your shop to continue</p>
+            <p className="mt-2 text-sm text-neutral-300">This preview shows what ProFixIQ can build from your data. Nothing has been imported yet and write actions stay locked until activation.</p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="rounded-md bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-black">Activate Your Shop</Link>
+              <Link href={`/compare-plans?${query}`} className="rounded-md border border-white/20 px-3 py-2 text-xs">See Plans</Link>
+              <button onClick={() => setGateOpen(false)} className="rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-300">Stay in preview</button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Dashboard({ context, onLockedAction }: { context: ShadowPreviewContext; onLockedAction: () => void }) {
+  const report = context.snapshot.preflightReport;
+  const uploadSummary = context.snapshot.uploadSummary;
+
+  return (
+    <section className="space-y-4">
+      <div className="rounded-xl border border-cyan-500/25 bg-cyan-500/10 p-3 text-xs text-cyan-100">Preview environment: derived from analysis and trust checks. No live tenant has been created.</div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Metric label="Trust score" value={`${context.snapshot.dashboard.trustScore}%`} />
+        <Metric label="Estimated importable" value={String(context.snapshot.dashboard.estimatedImportedRecords)} />
+        <Metric label="Review needed" value={String(context.snapshot.dashboard.reviewQueueCount)} />
+        <Metric label="Blockers" value={String(context.snapshot.dashboard.blockerCount)} />
+      </div>
+      <div className="rounded-xl border border-white/10 bg-black/30 p-3 text-xs text-neutral-300">
+        <p className="font-semibold text-white">Readiness: {context.snapshot.dashboard.readinessLabel}</p>
+        <p className="mt-1">What we automatically fixed: high-confidence rows are queued for automated mapping after activation.</p>
+        <p className="mt-1">What still needs review: {report.totals.likelyReviewNeededCount} rows and {report.totals.likelyBlockerCount} blockers across domain checks.</p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {Object.entries(uploadSummary).map(([key, value]) => (
+          <div key={key} className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-neutral-300">
+            <p className="font-semibold capitalize text-white">{key}</p>
+            <p className="mt-1">Estimated records: {value.count.toLocaleString()}</p>
+            <p className="text-neutral-500">Source: {value.fileName ?? "Not uploaded"}</p>
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button onClick={onLockedAction} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Create work order</button>
+        <button onClick={onLockedAction} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Approve recommendation</button>
+        <button onClick={onLockedAction} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Update settings</button>
+      </div>
+    </section>
+  );
+}
+
+function DomainTable({ title, items, onLockedAction }: { title: string; items: ShadowPreviewItem[]; onLockedAction: () => void }) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <button onClick={onLockedAction} className="rounded-md border border-white/15 px-3 py-1 text-xs">Edit (locked)</button>
+      </div>
+      <div className="space-y-2">
+        {items.length === 0 ? <p className="text-sm text-neutral-400">No preview rows were detected for this dataset.</p> : null}
+        {items.map((item) => (
+          <div key={item.id} className="grid grid-cols-[1fr_auto] items-center gap-3 rounded-lg border border-white/10 bg-black/30 p-3">
+            <div>
+              <p className="text-sm font-medium">{item.title}</p>
+              <p className="text-xs text-neutral-400">{item.subtitle}</p>
+            </div>
+            <div className="text-right text-xs">
+              <p className="text-neutral-300">{item.confidence}% confidence</p>
+              {item.blocked ? <p className="text-rose-300">Blocked</p> : item.reviewFlag ? <p className="text-amber-300">Needs review</p> : <p className="text-emerald-300">Clean</p>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SetupPanel({ issues, onLockedAction }: { issues: ShadowSetupIssue[]; onLockedAction: () => void }) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Migration setup issues</h2>
+        <button onClick={onLockedAction} className="rounded-md border border-white/15 px-3 py-1 text-xs">Continue setup (locked)</button>
+      </div>
+      {issues.map((issue) => (
+        <div key={issue.id} className={`rounded-lg border p-3 text-sm ${issue.severity === "blocker" ? "border-rose-500/30 bg-rose-500/10" : "border-amber-500/30 bg-amber-500/10"}`}>
+          <p className="font-semibold capitalize">{issue.severity}: {issue.title}</p>
+          <p className="mt-1 text-neutral-200">{issue.detail}</p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+      <p className="text-[11px] uppercase tracking-[0.1em] text-neutral-400">{label}</p>
+      <p className="mt-1 text-xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/app/demo/preview/[demoId]/page.tsx
+++ b/app/demo/preview/[demoId]/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { loadShadowPreviewContext } from "@/features/integrations/shopBoost/shadowShop";
+import ShadowPreviewClient from "./_components/ShadowPreviewClient";
+
+type PageProps = {
+  params: Promise<{ demoId: string }>;
+  searchParams: Promise<{ intakeId?: string }>;
+};
+
+export default async function DemoPreviewPage({ params, searchParams }: PageProps) {
+  const { demoId } = await params;
+  const sp = await searchParams;
+  const intakeId = typeof sp.intakeId === "string" ? sp.intakeId : "";
+
+  if (!intakeId) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-black px-4 text-white">
+        <div className="max-w-md rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-center">
+          <p className="text-lg font-semibold">Missing preview intake</p>
+          <p className="mt-2 text-sm text-neutral-400">This preview link is incomplete. Return to Instant Shop Analysis and relaunch preview mode.</p>
+          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-white/20 px-3 py-1.5 text-xs">Back to analysis</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const context = await loadShadowPreviewContext({ demoId, intakeId });
+  if (!context) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-black px-4 text-white">
+        <div className="max-w-md rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-center">
+          <p className="text-lg font-semibold">Preview not available</p>
+          <p className="mt-2 text-sm text-neutral-400">We couldn&apos;t validate this demo scope. Please run Instant Shop Analysis again to generate a fresh preview.</p>
+          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-white/20 px-3 py-1.5 text-xs">Run analysis again</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return <ShadowPreviewClient context={context} />;
+}

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -45,6 +45,8 @@ export default function OnboardingPage() {
   const supabase = useMemo(() => createClientComponentClient<Database>(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const demoId = searchParams.get("demoId");
+  const intakeId = searchParams.get("intakeId");
 
   const [sessionChecked, setSessionChecked] = useState(false);
   const [hasSession, setHasSession] = useState(false);
@@ -227,7 +229,10 @@ export default function OnboardingPage() {
         return;
       }
 
-      router.replace("/onboarding/shop-boost");
+      const next = new URLSearchParams();
+      if (demoId) next.set("demoId", demoId);
+      if (intakeId) next.set("intakeId", intakeId);
+      router.replace(`/onboarding/shop-boost${next.toString() ? `?${next.toString()}` : ""}`);
       setLoading(false);
       return;
     }
@@ -296,6 +301,12 @@ export default function OnboardingPage() {
 
       <main className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 lg:flex-row">
         <div className="flex-1 space-y-6">
+          {demoId ? (
+            <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-4 py-3 text-xs text-cyan-100">
+              Preview continuity active: when setup finishes, we’ll carry your analysis into Shop Boost activation.
+              {intakeId ? ` Intake: ${intakeId}` : ""}
+            </div>
+          ) : null}
           <form onSubmit={handleSubmit} className="space-y-6">
             <section className={sectionClassName}>
               <div className="mb-4">

--- a/features/auth/app/signup/SignUpClient.tsx
+++ b/features/auth/app/signup/SignUpClient.tsx
@@ -16,6 +16,8 @@ export default function SignUpClient() {
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
   const [loading, setLoading] = useState(false);
+  const demoId = sp.get("demoId");
+  const intakeId = sp.get("intakeId");
 
   const origin = useMemo(() => {
     if (typeof window !== "undefined") return window.location.origin;
@@ -32,12 +34,16 @@ export default function SignUpClient() {
     const interval = sp.get("interval");
     const trial = sp.get("trial");
     const founding = sp.get("founding");
+    const demoId = sp.get("demoId");
+    const intakeId = sp.get("intakeId");
 
     if (redirect) params.set("redirect", redirect);
     if (priceId) params.set("priceId", priceId);
     if (interval) params.set("interval", interval);
     if (trial) params.set("trial", trial);
     if (founding) params.set("founding", founding);
+    if (demoId) params.set("demoId", demoId);
+    if (intakeId) params.set("intakeId", intakeId);
 
     const tail = params.toString();
     return `${origin}/confirm${tail ? `?${tail}` : ""}`;
@@ -68,11 +74,15 @@ export default function SignUpClient() {
         const interval = sp.get("interval");
         const trial = sp.get("trial");
         const founding = sp.get("founding");
+        const demoId = sp.get("demoId");
+        const intakeId = sp.get("intakeId");
 
         if (priceId) params.set("priceId", priceId);
         if (interval) params.set("interval", interval);
         if (trial) params.set("trial", trial);
         if (founding) params.set("founding", founding);
+        if (demoId) params.set("demoId", demoId);
+        if (intakeId) params.set("intakeId", intakeId);
 
         const onboardingTarget = `/onboarding${params.toString() ? `?${params.toString()}` : ""}`;
         router.replace(redirect || onboardingTarget);
@@ -128,11 +138,15 @@ export default function SignUpClient() {
     const interval = sp.get("interval");
     const trial = sp.get("trial");
     const founding = sp.get("founding");
+    const demoId = sp.get("demoId");
+    const intakeId = sp.get("intakeId");
 
     if (priceId) params.set("priceId", priceId);
     if (interval) params.set("interval", interval);
     if (trial) params.set("trial", trial);
     if (founding) params.set("founding", founding);
+    if (demoId) params.set("demoId", demoId);
+    if (intakeId) params.set("intakeId", intakeId);
 
     const onboardingTarget = `/onboarding${params.toString() ? `?${params.toString()}` : ""}`;
 
@@ -146,6 +160,12 @@ export default function SignUpClient() {
         <h1 className="mb-6 text-3xl font-blackops tracking-[0.08em] text-[var(--accent-copper-light)]">
           Create Account
         </h1>
+        {demoId ? (
+          <div className="mb-4 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-[11px] text-cyan-100">
+            Your preview analysis is ready to carry forward.
+            {intakeId ? ` Intake: ${intakeId}` : ""}
+          </div>
+        ) : null}
         <form onSubmit={handleSignUp} className="space-y-4">
           <input
             type="email"

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -1,0 +1,286 @@
+import Papa from "papaparse";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { buildShopBoostPreflightReport, type ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
+import { SHOP_BOOST_UPLOAD_DATASET_KEYS, type ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
+
+type CsvRow = Record<string, string>;
+
+type ShadowDomainKey = "customers" | "vehicles" | "history" | "parts" | "staff";
+const SHADOW_DATASET_KEYS: ShadowDomainKey[] = ["customers", "vehicles", "history", "parts", "staff"];
+
+export type ShadowPreviewItem = {
+  id: string;
+  title: string;
+  subtitle: string;
+  confidence: number;
+  reviewFlag: boolean;
+  blocked: boolean;
+};
+
+export type ShadowSetupIssue = {
+  id: string;
+  severity: "review" | "blocker";
+  title: string;
+  detail: string;
+};
+
+export type ShadowShopSnapshot = {
+  intakeId: string;
+  generatedAt: string;
+  uploadSummary: Record<ShadowDomainKey, { count: number; fileName: string | null }>;
+  preflightReport: ShopBoostPreflightReport;
+  dashboard: {
+    estimatedImportedRecords: number;
+    reviewQueueCount: number;
+    blockerCount: number;
+    readinessLabel: string;
+    trustScore: number;
+  };
+  customers: ShadowPreviewItem[];
+  vehicles: ShadowPreviewItem[];
+  workOrders: ShadowPreviewItem[];
+  parts: ShadowPreviewItem[];
+  setupIssues: ShadowSetupIssue[];
+};
+
+export type ShadowPreviewContext = {
+  demoId: string;
+  intakeId: string;
+  shopName: string;
+  country: string;
+  snapshot: ShadowShopSnapshot;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function parseCsv(text: string): CsvRow[] {
+  const result = Papa.parse<CsvRow>(text, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: (header) => header.trim().toLowerCase().replace(/\s+/g, "_"),
+  });
+
+  if (result.errors.length > 0) {
+    return [];
+  }
+
+  return result.data.map((row) => {
+    const cleaned: CsvRow = {};
+    for (const [key, value] of Object.entries(row)) {
+      cleaned[key] = String(value ?? "").trim();
+    }
+    return cleaned;
+  });
+}
+
+function pick(row: CsvRow, keys: string[], fallback: string): string {
+  for (const key of keys) {
+    const value = row[key];
+    if (value && value.trim().length > 0) return value.trim();
+  }
+  return fallback;
+}
+
+function confidenceFromCompleteness(row: CsvRow, keys: string[]): number {
+  if (keys.length === 0) return 70;
+  const populated = keys.reduce((count, key) => (row[key]?.trim() ? count + 1 : count), 0);
+  const ratio = populated / keys.length;
+  return Math.max(35, Math.min(98, Math.round(45 + ratio * 53)));
+}
+
+function buildItems(rows: CsvRow[], domain: ShadowDomainKey): ShadowPreviewItem[] {
+  return rows.slice(0, 8).map((row, index) => {
+    if (domain === "customers") {
+      const name = pick(row, ["name", "customer_name", "full_name", "company"], `Customer ${index + 1}`);
+      const contact = pick(row, ["email", "phone", "phone_number", "mobile"], "No contact provided");
+      const confidence = confidenceFromCompleteness(row, ["name", "email", "phone"]);
+      return {
+        id: `customer-${index}`,
+        title: name,
+        subtitle: contact,
+        confidence,
+        reviewFlag: confidence < 78,
+        blocked: false,
+      };
+    }
+
+    if (domain === "vehicles") {
+      const unit = pick(row, ["vin", "license_plate", "plate", "unit_number"], `Vehicle ${index + 1}`);
+      const descriptor = [row.year, row.make, row.model].filter(Boolean).join(" ") || "Vehicle profile";
+      const confidence = confidenceFromCompleteness(row, ["vin", "license_plate", "make", "model"]);
+      return {
+        id: `vehicle-${index}`,
+        title: unit,
+        subtitle: descriptor,
+        confidence,
+        reviewFlag: confidence < 76,
+        blocked: !row.vin && !row.license_plate,
+      };
+    }
+
+    if (domain === "history") {
+      const roNumber = pick(row, ["work_order", "ro", "invoice_number", "order_number"], `RO-${index + 1}`);
+      const descriptor = pick(row, ["description", "concern", "job", "service"], "Historical repair order");
+      const confidence = confidenceFromCompleteness(row, ["work_order", "invoice_number", "customer", "vehicle"]);
+      return {
+        id: `history-${index}`,
+        title: roNumber,
+        subtitle: descriptor,
+        confidence,
+        reviewFlag: confidence < 75,
+        blocked: false,
+      };
+    }
+
+    const partId = pick(row, ["part_number", "sku", "item", "name"], `Part ${index + 1}`);
+    const descriptor = pick(row, ["description", "name", "category"], "Catalog item");
+    const confidence = confidenceFromCompleteness(row, ["part_number", "sku", "name"]);
+    return {
+      id: `part-${index}`,
+      title: partId,
+      subtitle: descriptor,
+      confidence,
+      reviewFlag: confidence < 74,
+      blocked: !row.part_number && !row.sku,
+    };
+  });
+}
+
+function mapEntityType(key: ShadowDomainKey): string {
+  if (key === "history") return "history";
+  return key;
+}
+
+export async function buildShadowShopSnapshot(args: {
+  intakeId: string;
+  uploadedFiles: Partial<Record<ShopBoostUploadDatasetKey, File>>;
+}): Promise<ShadowShopSnapshot> {
+  const rowsByDomain: Record<ShadowDomainKey, CsvRow[]> = {
+    customers: [],
+    vehicles: [],
+    history: [],
+    parts: [],
+    staff: [],
+  };
+
+  const uploadSummary: Record<ShadowDomainKey, { count: number; fileName: string | null }> = {
+    customers: { count: 0, fileName: null },
+    vehicles: { count: 0, fileName: null },
+    history: { count: 0, fileName: null },
+    parts: { count: 0, fileName: null },
+    staff: { count: 0, fileName: null },
+  };
+
+  for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+    if (!SHADOW_DATASET_KEYS.includes(key as ShadowDomainKey)) continue;
+    const shadowKey = key as ShadowDomainKey;
+    const file = args.uploadedFiles[key];
+    if (!file) continue;
+    const text = await file.text();
+    const rows = parseCsv(text);
+    rowsByDomain[shadowKey] = rows;
+    uploadSummary[shadowKey] = {
+      count: rows.length,
+      fileName: file.name,
+    };
+  }
+
+  const preflightRows = (Object.keys(rowsByDomain) as ShadowDomainKey[]).flatMap((domain) =>
+    rowsByDomain[domain].map((row) => ({
+      entity_type: mapEntityType(domain),
+      raw: row,
+      normalized: row,
+    })),
+  );
+
+  const preflightReport = buildShopBoostPreflightReport({
+    rows: preflightRows,
+    hasHistoryData: rowsByDomain.history.length > 0,
+    hasVehicleData: rowsByDomain.vehicles.length > 0,
+    hasCustomerData: rowsByDomain.customers.length > 0,
+    menuSuggestionCount: 0,
+    inspectionSuggestionCount: 0,
+  });
+
+  const setupIssues: ShadowSetupIssue[] = [
+    ...preflightReport.blockers.map((blocker, index) => ({
+      id: `blocker-${index}`,
+      severity: "blocker" as const,
+      title: blocker.code.replace(/_/g, " "),
+      detail: blocker.guidance,
+    })),
+    ...(preflightReport.reviewNotes.slice(0, 3).map((note, index) => ({
+      id: `review-${index}`,
+      severity: "review" as const,
+      title: "Manual review recommendation",
+      detail: note,
+    }))),
+  ];
+
+  return {
+    intakeId: args.intakeId,
+    generatedAt: new Date().toISOString(),
+    uploadSummary,
+    preflightReport,
+    dashboard: {
+      estimatedImportedRecords: preflightReport.totals.likelyAutoImportCount,
+      reviewQueueCount: preflightReport.totals.likelyReviewNeededCount,
+      blockerCount: preflightReport.totals.likelyBlockerCount,
+      readinessLabel: preflightReport.confidence.readiness,
+      trustScore: preflightReport.confidence.score,
+    },
+    customers: buildItems(rowsByDomain.customers, "customers"),
+    vehicles: buildItems(rowsByDomain.vehicles, "vehicles"),
+    workOrders: buildItems(rowsByDomain.history, "history"),
+    parts: buildItems(rowsByDomain.parts, "parts"),
+    setupIssues,
+  };
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function parseSnapshot(value: unknown): ShadowShopSnapshot | null {
+  const record = asRecord(value);
+  const intakeId = asString(record.intakeId);
+  if (!isUuid(intakeId)) return null;
+  const report = asRecord(record.preflightReport);
+  if (!report.totals || !report.confidence) return null;
+  return record as unknown as ShadowShopSnapshot;
+}
+
+export async function loadShadowPreviewContext(args: {
+  demoId: string;
+  intakeId: string;
+}): Promise<ShadowPreviewContext | null> {
+  if (!isUuid(args.demoId) || !isUuid(args.intakeId)) return null;
+
+  const supabase = createAdminSupabase();
+  const { data, error } = await supabase
+    .from("demo_shop_boosts")
+    .select("id, shop_name, country, snapshot")
+    .eq("id", args.demoId)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  const snapshot = parseSnapshot(data.snapshot);
+  if (!snapshot || snapshot.intakeId !== args.intakeId) return null;
+
+  return {
+    demoId: data.id,
+    intakeId: snapshot.intakeId,
+    shopName: data.shop_name,
+    country: data.country,
+    snapshot,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a realistic, read-only “shadow” ProFixIQ workspace for Instant Shop Analysis results so prospects can explore a live-feeling environment without creating real tenants or writing to operational tables. 
- Preserve conversion continuity by carrying `demoId` and `intakeId` through compare-plans → signup → onboarding so the preview can be activated into a real Shop Boost import.
- Ensure safety: no persisted shop or intake rows are created for previews and preview reads are strictly scoped to the requested `demoId` + `intakeId`.

### Description
- Implemented a typed shadow data adapter at `features/integrations/shopBoost/shadowShop.ts` that parses uploaded CSVs, derives preflight/trust metrics and typed preview DTOs (dashboard, customers, vehicles, work history, parts, setup issues), and validates `demoId`/`intakeId` pairing on load.
- Replaced the demo run route to generate a shadow snapshot instead of creating a real shop/intake; `app/api/demo/shop-boost/run/route.ts` now calls `buildShadowShopSnapshot` and inserts a `demo_shop_boosts` row with `shop_id: null` and `intake_id: null`, returning a `demoId` + generated `intakeId` and the derived snapshot.
- Hardened claim flow in `app/api/demo/shop-boost/claim/route.ts` to accept and validate optional `intakeId`, insert a lead (`demo_shop_boost_leads`), and mark demos unlocked without creating tenant data.
- Added preview routing and UI: new route `app/demo/preview/[demoId]` plus client `ShadowPreviewClient` providing the dashboard, customers, vehicles, work history, parts, and setup surfaces, an app-wide preview banner, locked/write-action gating, and premium activation CTAs that persist `demoId`/`intakeId`.
- Threaded demo context through the conversion flow by updating: `app/demo/instant-shop-analysis/page.tsx`, `app/compare-plans/page.tsx`, `features/auth/app/signup/SignUpClient.tsx`, `app/confirm/ConfirmContent.tsx`, and `features/auth/app/onboarding/OnboardingPage.tsx` so `demoId`/`intakeId` are preserved and displayed during signup/onboarding.
- Enforced read-only preview behavior by deriving all UI datasets from the shadow snapshot and exposing a polished activation gate modal for any attempted write-like action.

### Testing
- Ran `npx tsc --noEmit` and it passed successfully after fixes to the new adapter and pages.
- Ran targeted ESLint on the modified files and resolved issues until `eslint` passed for the changed files listed in the rollout, with final lint checks completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcd18429883289eaa18f6da47a4b1)