### PR TITLE
Phase 2 shadow preview: operational simulation, contextual gates, and migration confidence UX

### DIFF
--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -1,7 +1,7 @@
 // app/demo/instant-shop-analysis/page.tsx
 "use client";
 
-import React, { useMemo, useState, type FormEvent } from "react";
+import React, { useEffect, useMemo, useState, type FormEvent } from "react";
 import type { ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
 import type { ShadowShopSnapshot } from "@/features/integrations/shopBoost/shadowShop";
 import {
@@ -44,6 +44,14 @@ type ClaimResponse =
       ok: false;
       error: string;
     };
+
+type ResumePreviewContext = {
+  demoId: string;
+  intakeId: string;
+  shopName: string;
+};
+
+const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v1";
 
 
 
@@ -104,6 +112,24 @@ export default function InstantShopAnalysisPage() {
   const [email, setEmail] = useState("");
   const [claimError, setClaimError] = useState<string | null>(null);
   const [claimLoading, setClaimLoading] = useState(false);
+  const [resumePreview, setResumePreview] = useState<ResumePreviewContext | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(PREVIEW_RESUME_STORAGE_KEY);
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored) as Partial<ResumePreviewContext>;
+      if (!parsed.demoId || !parsed.intakeId || !parsed.shopName) return;
+      setResumePreview({
+        demoId: parsed.demoId,
+        intakeId: parsed.intakeId,
+        shopName: parsed.shopName,
+      });
+    } catch {
+      // ignore parse failures from stale client state
+    }
+  }, []);
 
   const handleQuestionnaireChange =
     <K extends keyof QuestionnaireState>(key: K) =>
@@ -274,6 +300,17 @@ export default function InstantShopAnalysisPage() {
                 imported yet.
               </p>
               <div className={THEME.badge}>No login required for the preview analysis.</div>
+              {resumePreview ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    (window.location.href = `/demo/preview/${encodeURIComponent(resumePreview.demoId)}?intakeId=${encodeURIComponent(resumePreview.intakeId)}`)
+                  }
+                  className="inline-flex items-center rounded-full border border-cyan-400/30 bg-cyan-500/10 px-4 py-2 text-[11px] text-cyan-100 hover:bg-cyan-500/20"
+                >
+                  Resume preview for {resumePreview.shopName}
+                </button>
+              ) : null}
             </div>
           </div>
         </div>

--- a/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
+++ b/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
@@ -1,38 +1,112 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import type { ShadowPreviewContext, ShadowPreviewItem, ShadowSetupIssue } from "@/features/integrations/shopBoost/shadowShop";
+import type {
+  ShadowPartSignal,
+  ShadowPreviewContext,
+  ShadowPreviewItem,
+  ShadowSetupIssue,
+  ShadowWorkflowJob,
+} from "@/features/integrations/shopBoost/shadowShop";
 
 type Props = {
   context: ShadowPreviewContext;
 };
 
-type SectionKey = "dashboard" | "customers" | "vehicles" | "work-orders" | "parts" | "setup";
+type SectionKey =
+  | "dashboard"
+  | "work-orders"
+  | "approvals"
+  | "parts"
+  | "customers"
+  | "vehicles"
+  | "setup";
+
+type GateActionContext =
+  | "send-approval"
+  | "edit-customer"
+  | "start-work-order"
+  | "inventory"
+  | "invoice"
+  | "settings";
+
+type GateCopy = {
+  title: string;
+  detail: string;
+};
 
 const sections: Array<{ key: SectionKey; label: string }> = [
   { key: "dashboard", label: "Command Center" },
+  { key: "work-orders", label: "Work Orders" },
+  { key: "approvals", label: "Approval Flow" },
+  { key: "parts", label: "Parts & Inventory" },
   { key: "customers", label: "Customers" },
   { key: "vehicles", label: "Vehicles" },
-  { key: "work-orders", label: "Work Orders" },
-  { key: "parts", label: "Parts" },
   { key: "setup", label: "Setup" },
 ];
 
+const gateCopyByAction: Record<GateActionContext, GateCopy> = {
+  "send-approval": {
+    title: "Activate to send real approvals",
+    detail: "Activation unlocks customer approval links, recommendation delivery, and response tracking.",
+  },
+  "edit-customer": {
+    title: "Activate to manage your customer records",
+    detail: "Activation enables editing your live customer database and contact routing.",
+  },
+  "start-work-order": {
+    title: "Activate to run live work orders",
+    detail: "Activation starts real technician workflow states, labor tracking, and job progression.",
+  },
+  inventory: {
+    title: "Activate to track real inventory",
+    detail: "Activation unlocks receiving, stocking, and part reconciliation against imported jobs.",
+  },
+  invoice: {
+    title: "Activate to bill from imported jobs",
+    detail: "Activation enables invoice generation, posting, and payment collection from your migrated history.",
+  },
+  settings: {
+    title: "Activate to finish setup",
+    detail: "Activation unlocks shop setup actions and launches your real import + onboarding flow.",
+  },
+};
+
+const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v1";
+
 export default function ShadowPreviewClient({ context }: Props) {
   const [active, setActive] = useState<SectionKey>("dashboard");
-  const [gateOpen, setGateOpen] = useState(false);
+  const [gateAction, setGateAction] = useState<GateActionContext | null>(null);
 
-  const query = useMemo(() => new URLSearchParams({ demoId: context.demoId, intakeId: context.intakeId }).toString(), [context.demoId, context.intakeId]);
+  const query = useMemo(
+    () => new URLSearchParams({ demoId: context.demoId, intakeId: context.intakeId }).toString(),
+    [context.demoId, context.intakeId],
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(
+      PREVIEW_RESUME_STORAGE_KEY,
+      JSON.stringify({
+        demoId: context.demoId,
+        intakeId: context.intakeId,
+        shopName: context.shopName,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+  }, [context.demoId, context.intakeId, context.shopName]);
+
+  const gateCopy = gateAction ? gateCopyByAction[gateAction] : null;
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <header className="sticky top-0 z-20 border-b border-white/10 bg-black/80 backdrop-blur-xl">
+      <header className="sticky top-0 z-30 border-b border-white/10 bg-black/85 backdrop-blur-xl">
         <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6">
           <div>
-            <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-300">Preview mode • read only</p>
+            <p className="text-[11px] uppercase tracking-[0.22em] text-cyan-300">Preview mode • read only • no writes</p>
             <h1 className="text-xl font-semibold">{context.shopName} • Shadow Workspace</h1>
-            <p className="text-[11px] text-neutral-400">Nothing has been imported yet. This environment is derived from your Instant Shop Analysis.</p>
+            <p className="text-[11px] text-neutral-400">This operational sandbox is generated from your uploaded analysis data. No tenant rows were created.</p>
           </div>
           <div className="flex gap-2">
             <Link href={`/compare-plans?${query}`} className="rounded-md border border-white/20 px-3 py-1.5 text-xs hover:bg-white/[0.05]">See Plans</Link>
@@ -46,7 +120,11 @@ export default function ShadowPreviewClient({ context }: Props) {
           <p className="mb-2 text-[11px] uppercase tracking-[0.18em] text-neutral-400">Preview areas</p>
           <nav className="space-y-1">
             {sections.map((section) => (
-              <button key={section.key} onClick={() => setActive(section.key)} className={`w-full rounded-md px-3 py-2 text-left text-xs ${active === section.key ? "bg-white/[0.08] text-white" : "text-neutral-300 hover:bg-white/[0.04]"}`}>
+              <button
+                key={section.key}
+                onClick={() => setActive(section.key)}
+                className={`w-full rounded-md px-3 py-2 text-left text-xs ${active === section.key ? "bg-white/[0.08] text-white" : "text-neutral-300 hover:bg-white/[0.04]"}`}
+              >
                 {section.label}
               </button>
             ))}
@@ -54,32 +132,42 @@ export default function ShadowPreviewClient({ context }: Props) {
         </aside>
 
         <main className="space-y-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-          {active === "dashboard" ? <Dashboard context={context} onLockedAction={() => setGateOpen(true)} /> : null}
-          {active === "customers" ? <DomainTable title="Customers" items={context.snapshot.customers} onLockedAction={() => setGateOpen(true)} /> : null}
-          {active === "vehicles" ? <DomainTable title="Vehicles" items={context.snapshot.vehicles} onLockedAction={() => setGateOpen(true)} /> : null}
-          {active === "work-orders" ? <DomainTable title="Work history" items={context.snapshot.workOrders} onLockedAction={() => setGateOpen(true)} /> : null}
-          {active === "parts" ? <DomainTable title="Parts & inventory" items={context.snapshot.parts} onLockedAction={() => setGateOpen(true)} /> : null}
-          {active === "setup" ? <SetupPanel issues={context.snapshot.setupIssues} onLockedAction={() => setGateOpen(true)} /> : null}
+          {active === "dashboard" ? <Dashboard context={context} onGate={setGateAction} /> : null}
+          {active === "work-orders" ? <WorkflowPanel jobs={context.snapshot.workflowJobs} onGate={setGateAction} /> : null}
+          {active === "approvals" ? <ApprovalPanel context={context} onGate={setGateAction} /> : null}
+          {active === "parts" ? <PartsPanel signals={context.snapshot.partsSignals} onGate={setGateAction} /> : null}
+          {active === "customers" ? <DomainTable title="Customers" items={context.snapshot.customers} actionContext="edit-customer" onGate={setGateAction} /> : null}
+          {active === "vehicles" ? <DomainTable title="Vehicles" items={context.snapshot.vehicles} actionContext="settings" onGate={setGateAction} /> : null}
+          {active === "setup" ? <SetupPanel issues={context.snapshot.setupIssues} onGate={setGateAction} /> : null}
         </main>
 
         <aside className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
           <p className="text-[11px] uppercase tracking-[0.15em] text-neutral-400">Activation rail</p>
-          <p className="text-xs text-neutral-300">Your analysis is ready to carry forward. Activate to import for real and unlock write access.</p>
+          <p className="text-xs text-neutral-300">This preview will carry into compare-plans, signup, and onboarding. Activation starts real import and setup.</p>
           <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="block rounded-md bg-[var(--accent-copper)] px-3 py-2 text-center text-xs font-semibold text-black hover:brightness-110">Activate Your Shop</Link>
           <Link href={`/compare-plans?${query}`} className="block rounded-md border border-white/20 px-3 py-2 text-center text-xs hover:bg-white/[0.05]">See Plans</Link>
-          <button onClick={() => setGateOpen(true)} className="w-full rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-200 hover:bg-white/[0.05]">Import This Into My Shop</button>
+          <button onClick={() => setGateAction("settings")} className="w-full rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-200 hover:bg-white/[0.05]">Start real import (locked)</button>
+          <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/10 p-3 text-[11px] text-cyan-100">
+            <p className="font-semibold">What happens when you activate</p>
+            <ul className="mt-2 list-disc space-y-1 pl-4 text-cyan-50/90">
+              <li>We use this exact preview context to begin your live import.</li>
+              <li>Flagged items are routed into guided review queues.</li>
+              <li>No data has been written yet in preview mode.</li>
+            </ul>
+          </div>
         </aside>
       </div>
 
-      {gateOpen ? (
+      {gateCopy ? (
         <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4">
           <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#090909] p-5">
-            <p className="text-lg font-semibold">Activate your shop to continue</p>
-            <p className="mt-2 text-sm text-neutral-300">This preview shows what ProFixIQ can build from your data. Nothing has been imported yet and write actions stay locked until activation.</p>
+            <p className="text-lg font-semibold">{gateCopy.title}</p>
+            <p className="mt-2 text-sm text-neutral-300">{gateCopy.detail}</p>
+            <p className="mt-2 text-xs text-neutral-500">Preview is read-only. Nothing has been written to a live tenant or shop yet.</p>
             <div className="mt-4 flex flex-wrap gap-2">
               <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="rounded-md bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-black">Activate Your Shop</Link>
               <Link href={`/compare-plans?${query}`} className="rounded-md border border-white/20 px-3 py-2 text-xs">See Plans</Link>
-              <button onClick={() => setGateOpen(false)} className="rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-300">Stay in preview</button>
+              <button onClick={() => setGateAction(null)} className="rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-300">Stay in preview</button>
             </div>
           </div>
         </div>
@@ -88,48 +176,170 @@ export default function ShadowPreviewClient({ context }: Props) {
   );
 }
 
-function Dashboard({ context, onLockedAction }: { context: ShadowPreviewContext; onLockedAction: () => void }) {
-  const report = context.snapshot.preflightReport;
-  const uploadSummary = context.snapshot.uploadSummary;
+function Dashboard({
+  context,
+  onGate,
+}: {
+  context: ShadowPreviewContext;
+  onGate: (action: GateActionContext) => void;
+}) {
+  const { snapshot } = context;
 
   return (
     <section className="space-y-4">
-      <div className="rounded-xl border border-cyan-500/25 bg-cyan-500/10 p-3 text-xs text-cyan-100">Preview environment: derived from analysis and trust checks. No live tenant has been created.</div>
+      <div className="rounded-xl border border-cyan-500/25 bg-cyan-500/10 p-3 text-xs text-cyan-100">Operational preview: ProFixIQ inferred workflow states from your CSVs and preflight trust logic.</div>
+
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Metric label="Trust score" value={`${context.snapshot.dashboard.trustScore}%`} />
-        <Metric label="Estimated importable" value={String(context.snapshot.dashboard.estimatedImportedRecords)} />
-        <Metric label="Review needed" value={String(context.snapshot.dashboard.reviewQueueCount)} />
-        <Metric label="Blockers" value={String(context.snapshot.dashboard.blockerCount)} />
+        <Metric label="Trust score" value={`${snapshot.dashboard.trustScore}%`} />
+        <Metric label="Jobs identified" value={String(snapshot.operationalNarrative.jobsIdentified)} />
+        <Metric label="Ready to flow" value={String(snapshot.operationalNarrative.workReadyCount)} />
+        <Metric label="Needs review" value={String(snapshot.operationalNarrative.reviewNeededCount)} />
       </div>
+
+      <div className="rounded-xl border border-white/10 bg-black/30 p-3 text-sm text-neutral-200">
+        <p className="font-semibold text-white">Operational narrative</p>
+        <ul className="mt-2 space-y-1 text-xs text-neutral-300">
+          <li>{snapshot.operationalNarrative.jobsIdentified} jobs were identified from your uploaded history.</li>
+          <li>{snapshot.operationalNarrative.approvalsLikelyNeeded} jobs look ready for approval routing.</li>
+          <li>{snapshot.operationalNarrative.partsInventoryConflicts} parts signals need inventory reconciliation.</li>
+          <li>{snapshot.operationalNarrative.unresolvedCustomerVehicleLinks} records need customer/vehicle link review before full history cleanup.</li>
+        </ul>
+      </div>
+
       <div className="rounded-xl border border-white/10 bg-black/30 p-3 text-xs text-neutral-300">
-        <p className="font-semibold text-white">Readiness: {context.snapshot.dashboard.readinessLabel}</p>
-        <p className="mt-1">What we automatically fixed: high-confidence rows are queued for automated mapping after activation.</p>
-        <p className="mt-1">What still needs review: {report.totals.likelyReviewNeededCount} rows and {report.totals.likelyBlockerCount} blockers across domain checks.</p>
+        <p className="font-semibold text-white">What we prepared for you</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          {snapshot.migrationStory.highlights.map((highlight) => (
+            <li key={highlight}>{highlight}</li>
+          ))}
+        </ul>
       </div>
-      <div className="grid gap-3 md:grid-cols-2">
-        {Object.entries(uploadSummary).map(([key, value]) => (
-          <div key={key} className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-neutral-300">
-            <p className="font-semibold capitalize text-white">{key}</p>
-            <p className="mt-1">Estimated records: {value.count.toLocaleString()}</p>
-            <p className="text-neutral-500">Source: {value.fileName ?? "Not uploaded"}</p>
-          </div>
-        ))}
+
+      <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-3 text-xs text-emerald-100">
+        <p className="font-semibold">Go-live confidence</p>
+        <p className="mt-1">{snapshot.operationalSignals.goLiveMomentumLabel}</p>
+        <p className="mt-1 text-emerald-50/80">{snapshot.activationConfidence.confidenceCopy}</p>
       </div>
+
       <div className="flex flex-wrap gap-2">
-        <button onClick={onLockedAction} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Create work order</button>
-        <button onClick={onLockedAction} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Approve recommendation</button>
-        <button onClick={onLockedAction} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Update settings</button>
+        <button onClick={() => onGate("start-work-order")} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Start work order (locked)</button>
+        <button onClick={() => onGate("send-approval")} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Send approval (locked)</button>
+        <button onClick={() => onGate("invoice")} className="rounded-md bg-white/10 px-3 py-1.5 text-xs">Create invoice (locked)</button>
       </div>
     </section>
   );
 }
 
-function DomainTable({ title, items, onLockedAction }: { title: string; items: ShadowPreviewItem[]; onLockedAction: () => void }) {
+function WorkflowPanel({
+  jobs,
+  onGate,
+}: {
+  jobs: ShadowWorkflowJob[];
+  onGate: (action: GateActionContext) => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Shadow job flow</h2>
+        <button onClick={() => onGate("start-work-order")} className="rounded-md border border-white/15 px-3 py-1 text-xs">Run job flow (locked)</button>
+      </div>
+
+      {jobs.length === 0 ? <p className="text-sm text-neutral-400">Upload history data to simulate workflow-ready jobs.</p> : null}
+
+      <div className="space-y-2">
+        {jobs.map((job) => (
+          <div key={job.id} className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-neutral-200">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold text-white">{job.roNumber}</p>
+                <p className="text-neutral-400">{job.customer} • {job.vehicle}</p>
+                <p className="mt-1 text-neutral-300">{job.concernSummary}</p>
+              </div>
+              <p className="rounded-full border border-white/15 px-2 py-0.5 text-[11px] uppercase tracking-[0.08em] text-neutral-200">{job.status.replace(/_/g, " ")}</p>
+            </div>
+            <div className="mt-2 grid gap-2 sm:grid-cols-4">
+              <MiniPill label="Parts" value={job.hasParts ? "Present" : "None"} />
+              <MiniPill label="Labor" value={job.hasLabor ? "Present" : "None"} />
+              <MiniPill label="Approval" value={job.approvalState.replace(/_/g, " ")} />
+              <MiniPill label="Invoice" value={job.invoiceState} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ApprovalPanel({
+  context,
+  onGate,
+}: {
+  context: ShadowPreviewContext;
+  onGate: (action: GateActionContext) => void;
+}) {
+  const flow = context.snapshot.approvalFlow;
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Approval flow preview</h2>
+        <button onClick={() => onGate("send-approval")} className="rounded-md border border-white/15 px-3 py-1 text-xs">Send approvals (locked)</button>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <Metric label="Inspection ready" value={String(flow.inspectionReady)} />
+        <Metric label="Recommendations drafted" value={String(flow.recommendationDrafted)} />
+        <Metric label="Waiting approval" value={String(flow.waitingCustomerApproval)} />
+        <Metric label="Invoice ready" value={String(flow.invoiceReady)} />
+      </div>
+      <p className="text-xs text-neutral-400">This path mirrors advisor → inspection findings → recommendation approval → invoice readiness in read-only mode.</p>
+    </section>
+  );
+}
+
+function PartsPanel({
+  signals,
+  onGate,
+}: {
+  signals: ShadowPartSignal[];
+  onGate: (action: GateActionContext) => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Parts & inventory signal</h2>
+        <button onClick={() => onGate("inventory")} className="rounded-md border border-white/15 px-3 py-1 text-xs">Receive part (locked)</button>
+      </div>
+      <div className="space-y-2">
+        {signals.map((signal) => (
+          <div key={signal.id} className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-neutral-200">
+            <div className="flex items-center justify-between gap-3">
+              <p className="font-medium text-white">{signal.label}</p>
+              <p className="text-[11px] uppercase tracking-[0.08em] text-neutral-300">{signal.status.replace(/_/g, " ")}</p>
+            </div>
+            <p className="mt-1 text-neutral-300">{signal.confidenceNote}</p>
+            <p className="mt-1 text-neutral-500">Referenced by {signal.referencedByJobs} workflow jobs.</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DomainTable({
+  title,
+  items,
+  actionContext,
+  onGate,
+}: {
+  title: string;
+  items: ShadowPreviewItem[];
+  actionContext: GateActionContext;
+  onGate: (action: GateActionContext) => void;
+}) {
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">{title}</h2>
-        <button onClick={onLockedAction} className="rounded-md border border-white/15 px-3 py-1 text-xs">Edit (locked)</button>
+        <button onClick={() => onGate(actionContext)} className="rounded-md border border-white/15 px-3 py-1 text-xs">Edit (locked)</button>
       </div>
       <div className="space-y-2">
         {items.length === 0 ? <p className="text-sm text-neutral-400">No preview rows were detected for this dataset.</p> : null}
@@ -150,13 +360,20 @@ function DomainTable({ title, items, onLockedAction }: { title: string; items: S
   );
 }
 
-function SetupPanel({ issues, onLockedAction }: { issues: ShadowSetupIssue[]; onLockedAction: () => void }) {
+function SetupPanel({
+  issues,
+  onGate,
+}: {
+  issues: ShadowSetupIssue[];
+  onGate: (action: GateActionContext) => void;
+}) {
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Migration setup issues</h2>
-        <button onClick={onLockedAction} className="rounded-md border border-white/15 px-3 py-1 text-xs">Continue setup (locked)</button>
+        <button onClick={() => onGate("settings")} className="rounded-md border border-white/15 px-3 py-1 text-xs">Continue setup (locked)</button>
       </div>
+      {issues.length === 0 ? <p className="text-sm text-neutral-400">No setup blockers were detected in this shadow pass.</p> : null}
       {issues.map((issue) => (
         <div key={issue.id} className={`rounded-lg border p-3 text-sm ${issue.severity === "blocker" ? "border-rose-500/30 bg-rose-500/10" : "border-amber-500/30 bg-amber-500/10"}`}>
           <p className="font-semibold capitalize">{issue.severity}: {issue.title}</p>
@@ -172,6 +389,15 @@ function Metric({ label, value }: { label: string; value: string }) {
     <div className="rounded-lg border border-white/10 bg-black/30 p-3">
       <p className="text-[11px] uppercase tracking-[0.1em] text-neutral-400">{label}</p>
       <p className="mt-1 text-xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function MiniPill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-white/10 bg-white/[0.02] px-2 py-1">
+      <p className="text-[10px] uppercase tracking-[0.08em] text-neutral-500">{label}</p>
+      <p className="text-xs text-neutral-200">{value}</p>
     </div>
   );
 }

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -1,12 +1,28 @@
 import Papa from "papaparse";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { buildShopBoostPreflightReport, type ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
-import { SHOP_BOOST_UPLOAD_DATASET_KEYS, type ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
+import {
+  buildShopBoostPreflightReport,
+  type ShopBoostPreflightReport,
+} from "@/features/integrations/shopBoost/preflightAnalysis";
+import {
+  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
 
 type CsvRow = Record<string, string>;
 
 type ShadowDomainKey = "customers" | "vehicles" | "history" | "parts" | "staff";
 const SHADOW_DATASET_KEYS: ShadowDomainKey[] = ["customers", "vehicles", "history", "parts", "staff"];
+
+type ShadowStagedRow = {
+  id: string;
+  domain: ShadowDomainKey;
+  raw: CsvRow;
+  normalized: CsvRow;
+  confidence: number;
+  reviewFlag: boolean;
+  blocked: boolean;
+};
 
 export type ShadowPreviewItem = {
   id: string;
@@ -24,6 +40,75 @@ export type ShadowSetupIssue = {
   detail: string;
 };
 
+export type ShadowOperationalNarrative = {
+  jobsIdentified: number;
+  approvalsLikelyNeeded: number;
+  partsInventoryConflicts: number;
+  unresolvedCustomerVehicleLinks: number;
+  suggestedInspections: number;
+  suggestedMenuOpportunities: number;
+  estimatedOperationalBlockers: number;
+  workReadyCount: number;
+  blockedCount: number;
+  reviewNeededCount: number;
+};
+
+export type ShadowWorkflowJob = {
+  id: string;
+  roNumber: string;
+  customer: string;
+  vehicle: string;
+  concernSummary: string;
+  status: "queued" | "in_inspection" | "awaiting_approval" | "ready_to_invoice" | "blocked";
+  hasParts: boolean;
+  hasLabor: boolean;
+  approvalState: "ready" | "blocked" | "not_required";
+  inspectionState: "ready" | "needs_review";
+  quoteState: "draft_ready" | "needs_review";
+  invoiceState: "ready" | "pending";
+  confidence: number;
+};
+
+export type ShadowApprovalFlowPreview = {
+  inspectionReady: number;
+  recommendationDrafted: number;
+  waitingCustomerApproval: number;
+  invoiceReady: number;
+};
+
+export type ShadowPartSignal = {
+  id: string;
+  label: string;
+  status: "likely_stocked" | "likely_missing" | "review_needed";
+  confidenceNote: string;
+  referencedByJobs: number;
+};
+
+export type ShadowDashboardSignals = {
+  jobsInProgress: number;
+  jobsBlockedByDataQuality: number;
+  jobsReadyForCustomerCommunication: number;
+  goLiveMomentumLabel: string;
+};
+
+export type ShadowMigrationStory = {
+  autoMatchedCustomersPct: number;
+  linkedVehicleProfiles: number;
+  preparedWorkflowJobs: number;
+  recordsNeedingReview: number;
+  recurringPatternsDetected: number;
+  highlights: string[];
+};
+
+export type ShadowActivationConfidence = {
+  previewBasedOnUploadedData: boolean;
+  realImportStartsOnActivation: boolean;
+  flaggedItemsReviewableAfterActivation: boolean;
+  noWritesBeforeActivation: boolean;
+  contextCarriesForward: boolean;
+  confidenceCopy: string;
+};
+
 export type ShadowShopSnapshot = {
   intakeId: string;
   generatedAt: string;
@@ -36,6 +121,13 @@ export type ShadowShopSnapshot = {
     readinessLabel: string;
     trustScore: number;
   };
+  operationalNarrative: ShadowOperationalNarrative;
+  workflowJobs: ShadowWorkflowJob[];
+  approvalFlow: ShadowApprovalFlowPreview;
+  partsSignals: ShadowPartSignal[];
+  operationalSignals: ShadowDashboardSignals;
+  migrationStory: ShadowMigrationStory;
+  activationConfidence: ShadowActivationConfidence;
   customers: ShadowPreviewItem[];
   vehicles: ShadowPreviewItem[];
   workOrders: ShadowPreviewItem[];
@@ -96,60 +188,59 @@ function confidenceFromCompleteness(row: CsvRow, keys: string[]): number {
   return Math.max(35, Math.min(98, Math.round(45 + ratio * 53)));
 }
 
-function buildItems(rows: CsvRow[], domain: ShadowDomainKey): ShadowPreviewItem[] {
+function buildItems(rows: ShadowStagedRow[], domain: ShadowDomainKey): ShadowPreviewItem[] {
   return rows.slice(0, 8).map((row, index) => {
+    const source = row.normalized;
+
     if (domain === "customers") {
-      const name = pick(row, ["name", "customer_name", "full_name", "company"], `Customer ${index + 1}`);
-      const contact = pick(row, ["email", "phone", "phone_number", "mobile"], "No contact provided");
-      const confidence = confidenceFromCompleteness(row, ["name", "email", "phone"]);
+      const name = pick(source, ["name", "customer_name", "full_name", "company"], `Customer ${index + 1}`);
+      const contact = pick(source, ["email", "phone", "phone_number", "mobile"], "No contact provided");
       return {
-        id: `customer-${index}`,
+        id: row.id,
         title: name,
         subtitle: contact,
-        confidence,
-        reviewFlag: confidence < 78,
-        blocked: false,
+        confidence: row.confidence,
+        reviewFlag: row.reviewFlag,
+        blocked: row.blocked,
       };
     }
 
     if (domain === "vehicles") {
-      const unit = pick(row, ["vin", "license_plate", "plate", "unit_number"], `Vehicle ${index + 1}`);
-      const descriptor = [row.year, row.make, row.model].filter(Boolean).join(" ") || "Vehicle profile";
-      const confidence = confidenceFromCompleteness(row, ["vin", "license_plate", "make", "model"]);
+      const unit = pick(source, ["vin", "license_plate", "plate", "unit_number"], `Vehicle ${index + 1}`);
+      const descriptor =
+        [source.year, source.make, source.model].filter(Boolean).join(" ") || "Vehicle profile";
       return {
-        id: `vehicle-${index}`,
+        id: row.id,
         title: unit,
         subtitle: descriptor,
-        confidence,
-        reviewFlag: confidence < 76,
-        blocked: !row.vin && !row.license_plate,
+        confidence: row.confidence,
+        reviewFlag: row.reviewFlag,
+        blocked: row.blocked,
       };
     }
 
     if (domain === "history") {
-      const roNumber = pick(row, ["work_order", "ro", "invoice_number", "order_number"], `RO-${index + 1}`);
-      const descriptor = pick(row, ["description", "concern", "job", "service"], "Historical repair order");
-      const confidence = confidenceFromCompleteness(row, ["work_order", "invoice_number", "customer", "vehicle"]);
+      const roNumber = pick(source, ["work_order", "ro", "invoice_number", "order_number"], `RO-${index + 1}`);
+      const descriptor = pick(source, ["description", "concern", "job", "service"], "Historical repair order");
       return {
-        id: `history-${index}`,
+        id: row.id,
         title: roNumber,
         subtitle: descriptor,
-        confidence,
-        reviewFlag: confidence < 75,
-        blocked: false,
+        confidence: row.confidence,
+        reviewFlag: row.reviewFlag,
+        blocked: row.blocked,
       };
     }
 
-    const partId = pick(row, ["part_number", "sku", "item", "name"], `Part ${index + 1}`);
-    const descriptor = pick(row, ["description", "name", "category"], "Catalog item");
-    const confidence = confidenceFromCompleteness(row, ["part_number", "sku", "name"]);
+    const partId = pick(source, ["part_number", "sku", "item", "name"], `Part ${index + 1}`);
+    const descriptor = pick(source, ["description", "name", "category"], "Catalog item");
     return {
-      id: `part-${index}`,
+      id: row.id,
       title: partId,
       subtitle: descriptor,
-      confidence,
-      reviewFlag: confidence < 74,
-      blocked: !row.part_number && !row.sku,
+      confidence: row.confidence,
+      reviewFlag: row.reviewFlag,
+      blocked: row.blocked,
     };
   });
 }
@@ -159,11 +250,299 @@ function mapEntityType(key: ShadowDomainKey): string {
   return key;
 }
 
+function stageRowsByDomain(rows: CsvRow[], domain: ShadowDomainKey): ShadowStagedRow[] {
+  return rows.map((row, index) => {
+    if (domain === "customers") {
+      const confidence = confidenceFromCompleteness(row, ["name", "email", "phone"]);
+      return {
+        id: `customer-${index}`,
+        domain,
+        raw: row,
+        normalized: row,
+        confidence,
+        reviewFlag: confidence < 78,
+        blocked: false,
+      };
+    }
+
+    if (domain === "vehicles") {
+      const confidence = confidenceFromCompleteness(row, ["vin", "license_plate", "make", "model"]);
+      return {
+        id: `vehicle-${index}`,
+        domain,
+        raw: row,
+        normalized: row,
+        confidence,
+        reviewFlag: confidence < 76,
+        blocked: !row.vin && !row.license_plate,
+      };
+    }
+
+    if (domain === "history") {
+      const confidence = confidenceFromCompleteness(row, ["work_order", "invoice_number", "customer", "vehicle"]);
+      return {
+        id: `history-${index}`,
+        domain,
+        raw: row,
+        normalized: row,
+        confidence,
+        reviewFlag: confidence < 75,
+        blocked: !row.work_order && !row.invoice_number,
+      };
+    }
+
+    if (domain === "parts") {
+      const confidence = confidenceFromCompleteness(row, ["part_number", "sku", "name"]);
+      return {
+        id: `part-${index}`,
+        domain,
+        raw: row,
+        normalized: row,
+        confidence,
+        reviewFlag: confidence < 74,
+        blocked: !row.part_number && !row.sku,
+      };
+    }
+
+    const confidence = confidenceFromCompleteness(row, ["name", "email", "role"]);
+    return {
+      id: `staff-${index}`,
+      domain,
+      raw: row,
+      normalized: row,
+      confidence,
+      reviewFlag: confidence < 70,
+      blocked: false,
+    };
+  });
+}
+
+function collectRecurringServicePatterns(historyRows: ShadowStagedRow[]): number {
+  const patternCounts = new Map<string, number>();
+
+  for (const row of historyRows) {
+    const service = pick(
+      row.normalized,
+      ["service", "description", "concern", "job", "category"],
+      "",
+    )
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    if (service.length < 5) continue;
+
+    const key = service.split(" ").slice(0, 4).join(" ");
+    patternCounts.set(key, (patternCounts.get(key) ?? 0) + 1);
+  }
+
+  return Array.from(patternCounts.values()).filter((count) => count >= 2).length;
+}
+
+function inferWorkflowJobs(historyRows: ShadowStagedRow[]): ShadowWorkflowJob[] {
+  return historyRows.slice(0, 12).map((row, index) => {
+    const confidence = row.confidence;
+    const hasParts = Boolean(
+      row.normalized.part_number || row.normalized.part || row.normalized.parts || row.normalized.sku,
+    );
+    const hasLabor = Boolean(
+      row.normalized.labor || row.normalized.labor_hours || row.normalized.hours || row.normalized.technician,
+    );
+
+    const needsReview = row.reviewFlag;
+    const blocked = row.blocked;
+    const status: ShadowWorkflowJob["status"] = blocked
+      ? "blocked"
+      : confidence >= 87
+      ? "ready_to_invoice"
+      : confidence >= 78
+      ? "awaiting_approval"
+      : needsReview
+      ? "in_inspection"
+      : "queued";
+
+    const approvalState: ShadowWorkflowJob["approvalState"] =
+      status === "awaiting_approval" ? "ready" : blocked ? "blocked" : "not_required";
+
+    const invoiceState: ShadowWorkflowJob["invoiceState"] = status === "ready_to_invoice" ? "ready" : "pending";
+
+    return {
+      id: row.id,
+      roNumber: pick(row.normalized, ["work_order", "ro", "invoice_number", "order_number"], `RO-${index + 1}`),
+      customer: pick(row.normalized, ["customer", "customer_name", "name"], "Customer match pending"),
+      vehicle: pick(row.normalized, ["vehicle", "vin", "license_plate", "unit_number"], "Vehicle match pending"),
+      concernSummary: pick(row.normalized, ["description", "concern", "service", "job"], "General service workflow"),
+      status,
+      hasParts,
+      hasLabor,
+      approvalState,
+      inspectionState: needsReview ? "needs_review" : "ready",
+      quoteState: needsReview ? "needs_review" : "draft_ready",
+      invoiceState,
+      confidence,
+    };
+  });
+}
+
+function inferPartsSignals(partsRows: ShadowStagedRow[], workflowJobs: ShadowWorkflowJob[]): ShadowPartSignal[] {
+  const fromCatalog = partsRows.slice(0, 8).map((row, index) => {
+    const label = pick(row.normalized, ["part_number", "sku", "name", "item"], `Part ${index + 1}`);
+    const referencedByJobs = workflowJobs.filter((job) => job.hasParts).length;
+    const status: ShadowPartSignal["status"] = row.blocked
+      ? "review_needed"
+      : row.reviewFlag
+      ? "likely_missing"
+      : "likely_stocked";
+
+    const confidenceNote =
+      status === "likely_stocked"
+        ? "Part mapping has stable identifiers"
+        : status === "likely_missing"
+        ? "Part is referenced but inventory certainty is limited"
+        : "Part identifiers need reconciliation before import";
+
+    return {
+      id: row.id,
+      label,
+      status,
+      confidenceNote,
+      referencedByJobs,
+    };
+  });
+
+  if (fromCatalog.length > 0) return fromCatalog;
+
+  const fallback = workflowJobs.filter((job) => job.hasParts).slice(0, 6);
+  return fallback.map((job, index) => ({
+    id: `job-part-${index}`,
+    label: `${job.roNumber} parts cluster`,
+    status: "review_needed",
+    confidenceNote: "No parts catalog uploaded. Parts references will be reviewed during activation.",
+    referencedByJobs: 1,
+  }));
+}
+
+function deriveOperationalPayload(args: {
+  rowsByDomain: Record<ShadowDomainKey, ShadowStagedRow[]>;
+  preflightReport: ShopBoostPreflightReport;
+}): Pick<
+  ShadowShopSnapshot,
+  | "operationalNarrative"
+  | "workflowJobs"
+  | "approvalFlow"
+  | "partsSignals"
+  | "operationalSignals"
+  | "migrationStory"
+  | "activationConfidence"
+> {
+  const historyRows = args.rowsByDomain.history;
+  const vehiclesRows = args.rowsByDomain.vehicles;
+  const customersRows = args.rowsByDomain.customers;
+  const partsRows = args.rowsByDomain.parts;
+
+  const workflowJobs = inferWorkflowJobs(historyRows);
+  const recurringPatterns = collectRecurringServicePatterns(historyRows);
+  const unresolvedLinks = historyRows.filter(
+    (row) =>
+      !pick(row.normalized, ["customer", "customer_name"], "") ||
+      !pick(row.normalized, ["vehicle", "vin", "license_plate"], ""),
+  ).length;
+
+  const partsSignals = inferPartsSignals(partsRows, workflowJobs);
+  const partsConflicts = partsSignals.filter((signal) => signal.status !== "likely_stocked").length;
+
+  const approvalsLikelyNeeded = workflowJobs.filter((job) => job.status === "awaiting_approval").length;
+  const jobsReady = workflowJobs.filter((job) => job.status === "ready_to_invoice").length;
+  const jobsBlocked = workflowJobs.filter((job) => job.status === "blocked").length;
+  const jobsReview = workflowJobs.filter((job) => job.inspectionState === "needs_review").length;
+
+  const approvalFlow: ShadowApprovalFlowPreview = {
+    inspectionReady: workflowJobs.filter((job) => job.inspectionState === "ready").length,
+    recommendationDrafted: workflowJobs.filter((job) => job.quoteState === "draft_ready").length,
+    waitingCustomerApproval: approvalsLikelyNeeded,
+    invoiceReady: workflowJobs.filter((job) => job.invoiceState === "ready").length,
+  };
+
+  const operationalNarrative: ShadowOperationalNarrative = {
+    jobsIdentified: historyRows.length,
+    approvalsLikelyNeeded,
+    partsInventoryConflicts: partsConflicts,
+    unresolvedCustomerVehicleLinks: unresolvedLinks,
+    suggestedInspections: Math.max(2, Math.min(historyRows.length, Math.round(historyRows.length * 0.28))),
+    suggestedMenuOpportunities: Math.max(recurringPatterns, Math.round(historyRows.length * 0.2)),
+    estimatedOperationalBlockers: args.preflightReport.totals.likelyBlockerCount,
+    workReadyCount: jobsReady,
+    blockedCount: jobsBlocked,
+    reviewNeededCount: jobsReview,
+  };
+
+  const goLiveMomentumLabel =
+    args.preflightReport.confidence.readiness === "READY_FOR_GO_LIVE" ||
+    args.preflightReport.confidence.readiness === "COMPLETED_CLEAN"
+      ? "Most of your data looks go-live ready after activation."
+      : args.preflightReport.totals.likelyBlockerCount > 0
+      ? "You are close to go-live once flagged blockers are reviewed."
+      : "You are close to go-live with a short review queue.";
+
+  const operationalSignals: ShadowDashboardSignals = {
+    jobsInProgress: workflowJobs.filter((job) => job.status === "in_inspection" || job.status === "awaiting_approval").length,
+    jobsBlockedByDataQuality: jobsBlocked,
+    jobsReadyForCustomerCommunication: approvalsLikelyNeeded,
+    goLiveMomentumLabel,
+  };
+
+  const autoMatchedCustomersPct =
+    customersRows.length > 0
+      ? Math.max(
+          0,
+          Math.min(
+            99,
+            Math.round(((customersRows.length - customersRows.filter((row) => row.reviewFlag).length) / customersRows.length) * 100),
+          ),
+        )
+      : 0;
+
+  const migrationStory: ShadowMigrationStory = {
+    autoMatchedCustomersPct,
+    linkedVehicleProfiles: vehiclesRows.length - vehiclesRows.filter((row) => row.blocked).length,
+    preparedWorkflowJobs: workflowJobs.length,
+    recordsNeedingReview: args.preflightReport.totals.likelyReviewNeededCount,
+    recurringPatternsDetected: recurringPatterns,
+    highlights: [
+      `${autoMatchedCustomersPct}% of customers look auto-matchable from uploaded identifiers.`,
+      `Prepared ${workflowJobs.length} workflow-ready jobs from your uploaded history.`,
+      `${args.preflightReport.totals.likelyReviewNeededCount} records are flagged for guided review before full cutover.`,
+      `${Math.max(recurringPatterns, 1)} recurring service patterns can seed menu and inspection setup.`,
+    ],
+  };
+
+  const activationConfidence: ShadowActivationConfidence = {
+    previewBasedOnUploadedData: true,
+    realImportStartsOnActivation: true,
+    flaggedItemsReviewableAfterActivation: true,
+    noWritesBeforeActivation: true,
+    contextCarriesForward: true,
+    confidenceCopy:
+      "This preview is generated from your uploaded files using the same preflight logic used for migration readiness. Activating starts your real import and carries this context into onboarding.",
+  };
+
+  return {
+    operationalNarrative,
+    workflowJobs,
+    approvalFlow,
+    partsSignals,
+    operationalSignals,
+    migrationStory,
+    activationConfidence,
+  };
+}
+
 export async function buildShadowShopSnapshot(args: {
   intakeId: string;
   uploadedFiles: Partial<Record<ShopBoostUploadDatasetKey, File>>;
 }): Promise<ShadowShopSnapshot> {
-  const rowsByDomain: Record<ShadowDomainKey, CsvRow[]> = {
+  const parsedRowsByDomain: Record<ShadowDomainKey, CsvRow[]> = {
     customers: [],
     vehicles: [],
     history: [],
@@ -186,28 +565,39 @@ export async function buildShadowShopSnapshot(args: {
     if (!file) continue;
     const text = await file.text();
     const rows = parseCsv(text);
-    rowsByDomain[shadowKey] = rows;
+    parsedRowsByDomain[shadowKey] = rows;
     uploadSummary[shadowKey] = {
       count: rows.length,
       fileName: file.name,
     };
   }
 
-  const preflightRows = (Object.keys(rowsByDomain) as ShadowDomainKey[]).flatMap((domain) =>
-    rowsByDomain[domain].map((row) => ({
+  const stagedRowsByDomain: Record<ShadowDomainKey, ShadowStagedRow[]> = {
+    customers: stageRowsByDomain(parsedRowsByDomain.customers, "customers"),
+    vehicles: stageRowsByDomain(parsedRowsByDomain.vehicles, "vehicles"),
+    history: stageRowsByDomain(parsedRowsByDomain.history, "history"),
+    parts: stageRowsByDomain(parsedRowsByDomain.parts, "parts"),
+    staff: stageRowsByDomain(parsedRowsByDomain.staff, "staff"),
+  };
+
+  const preflightRows = (Object.keys(stagedRowsByDomain) as ShadowDomainKey[]).flatMap((domain) =>
+    stagedRowsByDomain[domain].map((row) => ({
       entity_type: mapEntityType(domain),
-      raw: row,
-      normalized: row,
+      raw: row.raw,
+      normalized: row.normalized,
     })),
   );
 
+  const menuSuggestionCount = collectRecurringServicePatterns(stagedRowsByDomain.history);
+  const inspectionSuggestionCount = Math.max(0, Math.round(stagedRowsByDomain.history.length * 0.28));
+
   const preflightReport = buildShopBoostPreflightReport({
     rows: preflightRows,
-    hasHistoryData: rowsByDomain.history.length > 0,
-    hasVehicleData: rowsByDomain.vehicles.length > 0,
-    hasCustomerData: rowsByDomain.customers.length > 0,
-    menuSuggestionCount: 0,
-    inspectionSuggestionCount: 0,
+    hasHistoryData: stagedRowsByDomain.history.length > 0,
+    hasVehicleData: stagedRowsByDomain.vehicles.length > 0,
+    hasCustomerData: stagedRowsByDomain.customers.length > 0,
+    menuSuggestionCount,
+    inspectionSuggestionCount,
   });
 
   const setupIssues: ShadowSetupIssue[] = [
@@ -217,13 +607,18 @@ export async function buildShadowShopSnapshot(args: {
       title: blocker.code.replace(/_/g, " "),
       detail: blocker.guidance,
     })),
-    ...(preflightReport.reviewNotes.slice(0, 3).map((note, index) => ({
+    ...preflightReport.reviewNotes.slice(0, 3).map((note, index) => ({
       id: `review-${index}`,
       severity: "review" as const,
       title: "Manual review recommendation",
       detail: note,
-    }))),
+    })),
   ];
+
+  const operationalPayload = deriveOperationalPayload({
+    rowsByDomain: stagedRowsByDomain,
+    preflightReport,
+  });
 
   return {
     intakeId: args.intakeId,
@@ -237,10 +632,17 @@ export async function buildShadowShopSnapshot(args: {
       readinessLabel: preflightReport.confidence.readiness,
       trustScore: preflightReport.confidence.score,
     },
-    customers: buildItems(rowsByDomain.customers, "customers"),
-    vehicles: buildItems(rowsByDomain.vehicles, "vehicles"),
-    workOrders: buildItems(rowsByDomain.history, "history"),
-    parts: buildItems(rowsByDomain.parts, "parts"),
+    operationalNarrative: operationalPayload.operationalNarrative,
+    workflowJobs: operationalPayload.workflowJobs,
+    approvalFlow: operationalPayload.approvalFlow,
+    partsSignals: operationalPayload.partsSignals,
+    operationalSignals: operationalPayload.operationalSignals,
+    migrationStory: operationalPayload.migrationStory,
+    activationConfidence: operationalPayload.activationConfidence,
+    customers: buildItems(stagedRowsByDomain.customers, "customers"),
+    vehicles: buildItems(stagedRowsByDomain.vehicles, "vehicles"),
+    workOrders: buildItems(stagedRowsByDomain.history, "history"),
+    parts: buildItems(stagedRowsByDomain.parts, "parts"),
     setupIssues,
   };
 }


### PR DESCRIPTION
### Motivation
- Upgrade the Phase 1 data-preview into a Phase 2 operational sandbox that feels like a real ProFixIQ workspace while preserving the read-only, no-tenant creation preview boundary. 
- Surface migration value and conversion tension by turning inferred analysis into workflow-ready signals, contextual activation gates, and a visible migration story. 
- Improve preview parity with the real import pipeline by introducing a staged derivation layer so the preview is driven by analyzed data rather than hand-authored copy.

### Description
- Introduced a staged shadow derivation pipeline and richer preview DTOs by refactoring `features/integrations/shopBoost/shadowShop.ts` to stage rows, run preflight, and derive: operational narrative, workflow jobs, approval flow, parts signals, migration story, and activation-confidence metadata. 
- Rebuilt the preview UI in `app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx` to present a command-center dashboard, workflow/approval/parts preview panels, migration-story highlights, persistent preview labeling, and a contextual gating system keyed to action intent (e.g. `send-approval`, `edit-customer`, `start-work-order`, `inventory`, `invoice`, `settings`). 
- Added preview continuity by persisting last preview context and exposing a `Resume preview` CTA in `app/demo/instant-shop-analysis/page.tsx` so users can re-enter the same `demoId`/`intakeId` session. 
- Kept safety constraints explicit: preview remains read-only, demo scoping (`demoId + intakeId`) is preserved in activation links, and no real shop/shop_id creation or writes are performed in preview code paths.

### Testing
- Ran type checking with `npx tsc --noEmit`, which completed successfully. 
- Ran linting for the touched files with `npx eslint features/integrations/shopBoost/shadowShop.ts app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx app/demo/instant-shop-analysis/page.tsx`, which completed successfully. 
- No automated unit tests were added; changes are UI/derivation focused and validated via static checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd626405c832898b805c5dfed293d)