### PR TITLE
Shop Boost: Add activation context, CTA continuity, and preview→import handoff

### DIFF
--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -1,0 +1,204 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
+import { runShopBoostImport } from "@/features/integrations/imports/runFullImport";
+import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
+import {
+  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
+
+type DB = Database;
+
+type ActivationBody = {
+  demoId?: string;
+  intakeId?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function isUuid(value: string | null | undefined): value is string {
+  return !!value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function extractPaths(snapshot: unknown): Partial<Record<ShopBoostUploadDatasetKey, string>> {
+  const root = isRecord(snapshot) ? snapshot : {};
+  const uploadPaths = isRecord(root.activationUploadPaths) ? root.activationUploadPaths : {};
+  const result: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
+
+  for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+    const value = uploadPaths[key];
+    if (typeof value === "string" && value.length > 0) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function pathBasename(path: string): string {
+  const chunks = path.split("/").filter(Boolean);
+  return chunks[chunks.length - 1] ?? "upload.csv";
+}
+
+export async function POST(req: NextRequest) {
+  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabaseUser.auth.getUser();
+
+  if (authErr || !user?.id) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as ActivationBody;
+  const demoId = body.demoId?.trim();
+  const intakeId = body.intakeId?.trim();
+
+  if (!isUuid(demoId) || !isUuid(intakeId)) {
+    return NextResponse.json({ ok: false, error: "Invalid demo activation identifiers." }, { status: 400 });
+  }
+
+  const { data: profile } = await supabaseUser
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null }>();
+
+  if (!profile?.shop_id) {
+    return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
+  }
+
+  const shopId = profile.shop_id;
+  const admin = createAdminSupabase();
+
+  const { data: demoRow, error: demoErr } = await admin
+    .from("demo_shop_boosts")
+    .select("id,snapshot")
+    .eq("id", demoId)
+    .maybeSingle();
+
+  if (demoErr || !demoRow?.snapshot) {
+    return NextResponse.json({ ok: false, error: "Preview expired. Please run analysis again." }, { status: 404 });
+  }
+
+  const snapshot = isRecord(demoRow.snapshot) ? demoRow.snapshot : null;
+  const snapshotIntake = asString(snapshot?.intakeId);
+  if (!snapshot || snapshotIntake !== intakeId) {
+    return NextResponse.json({ ok: false, error: "Preview/intake mismatch. Please restart preview." }, { status: 409 });
+  }
+
+  const sourcePaths = extractPaths(snapshot);
+  if (Object.keys(sourcePaths).length === 0) {
+    return NextResponse.json({ ok: false, error: "Preview files expired. Please run analysis again." }, { status: 410 });
+  }
+
+  const existing = await admin
+    .from("shop_boost_intakes")
+    .select("id,status")
+    .eq("shop_id", shopId)
+    .eq("id", intakeId)
+    .maybeSingle();
+
+  if (existing.data?.id) {
+    return NextResponse.json({ ok: true, intakeId, status: existing.data.status, reused: true });
+  }
+
+  const copiedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
+  for (const [datasetKey, sourcePath] of Object.entries(sourcePaths) as Array<[ShopBoostUploadDatasetKey, string]>) {
+    const targetPath = `shops/${shopId}/${intakeId}/${datasetKey}-${pathBasename(sourcePath)}`;
+    const { error: copyErr } = await admin.storage.from("shop-imports").copy(sourcePath, targetPath);
+    if (copyErr) {
+      return NextResponse.json(
+        { ok: false, error: `Failed to prepare ${datasetKey} for activation import.` },
+        { status: 500 },
+      );
+    }
+    copiedPaths[datasetKey] = targetPath;
+  }
+
+  const intakeInsert: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
+    id: intakeId,
+    shop_id: shopId,
+    questionnaire: {},
+    customers_file_path: copiedPaths.customers ?? null,
+    vehicles_file_path: copiedPaths.vehicles ?? null,
+    parts_file_path: copiedPaths.parts ?? null,
+    history_file_path: copiedPaths.history ?? null,
+    staff_file_path: copiedPaths.staff ?? null,
+    intake_basics: {
+      source: "demo_preview_activation",
+      demoId,
+      activatedByUserId: user.id,
+      activatedAt: new Date().toISOString(),
+    },
+    status: "pending",
+  };
+
+  const { error: insertErr } = await admin.from("shop_boost_intakes").insert(intakeInsert);
+  if (insertErr) {
+    return NextResponse.json({ ok: false, error: `Failed to start intake: ${insertErr.message}` }, { status: 500 });
+  }
+
+  await updateIntakeProgress({
+    intakeId,
+    status: "queued",
+    currentStep: "activation_started",
+    progressPercent: 8,
+    patch: { startedAt: new Date().toISOString(), lastError: null },
+  });
+
+  await updateIntakeProgress({
+    intakeId,
+    status: "processing",
+    currentStep: "generating_suggestions",
+    progressPercent: 35,
+  });
+  await buildShopBoostProfile({ shopId, intakeId });
+
+  await updateIntakeProgress({
+    intakeId,
+    currentStep: "materializing_operating_layer",
+    progressPercent: 62,
+  });
+
+  const importSummary = await runShopBoostImport({ shopId, intakeId, options: { createStaffUsers: false } });
+
+  const completedStatus =
+    importSummary.completionState === "PARTIAL_FAILURE" ||
+    importSummary.completionState === "FAILED" ||
+    importSummary.completionState === "NOT_READY"
+      ? "completed_with_errors"
+      : "completed";
+
+  await updateIntakeProgress({
+    intakeId,
+    status: completedStatus,
+    currentStep: "completed",
+    progressPercent: 100,
+    patch: {
+      completedAt: new Date().toISOString(),
+      failedAt: null,
+      resultSummary: {
+        customersImported: importSummary.customersImported,
+        vehiclesImported: importSummary.vehiclesImported,
+        partsImported: importSummary.partsImported,
+        workOrdersImported: importSummary.workOrdersImported,
+        invoicesImported: importSummary.invoicesImported,
+        completionState: importSummary.completionState,
+      },
+    },
+  });
+
+  return NextResponse.json({ ok: true, intakeId, status: completedStatus });
+}

--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -28,6 +28,8 @@ type DemoRunErrorResponse = {
 
 type DemoRunResponse = DemoRunSuccessResponse | DemoRunErrorResponse;
 
+const SHOP_IMPORT_BUCKET = "shop-imports";
+
 function safeShopName(name: string): string {
   return name.trim().replace(/\s+/g, " ").slice(0, 80);
 }
@@ -89,14 +91,38 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
     });
 
     const supabase = createAdminSupabase();
+    const demoId = randomUUID();
+
+    const uploadedPathEntries = await Promise.all(
+      Object.entries(filesByDataset).map(async ([dataset, file]) => {
+        const path = `demos/${demoId}/${intakeId}/${dataset}-${safeShopName(file.name || `${dataset}.csv`)}`;
+        const { error: uploadErr } = await supabase.storage
+          .from(SHOP_IMPORT_BUCKET)
+          .upload(path, file, { upsert: true, contentType: file.type || "text/csv" });
+
+        if (uploadErr) {
+          throw new Error(`Failed to stage ${dataset} demo file: ${uploadErr.message}`);
+        }
+
+        return [dataset, path] as const;
+      }),
+    );
+
+    const activationUploadPaths = Object.fromEntries(uploadedPathEntries);
+    const snapshotWithActivation = {
+      ...snapshot,
+      activationUploadPaths,
+    };
+
     const { data: demoRow, error: demoErr } = await supabase
       .from("demo_shop_boosts")
       .insert({
+        id: demoId,
         shop_id: null,
         intake_id: null,
         shop_name: shopName,
         country: countryValue,
-        snapshot,
+        snapshot: snapshotWithActivation,
       } as DB["public"]["Tables"]["demo_shop_boosts"]["Insert"])
       .select("id")
       .single();
@@ -114,7 +140,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
         ok: true,
         demoId: demoRow.id as string,
         intakeId,
-        analysis: snapshot,
+        analysis: snapshotWithActivation,
       },
       { status: 200 },
     );

--- a/app/compare-plans/page.tsx
+++ b/app/compare-plans/page.tsx
@@ -3,9 +3,15 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { Toaster, toast } from "sonner";
-
+import {
+  appendActivationContextToHref,
+  parseActivationContextFromSearchParams,
+  persistActivationContext,
+} from "@/features/integrations/shopBoost/activationContext";
+import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 import PricingSection from "@/features/shared/components/ui/PricingSection";
 
 type Interval = "monthly" | "yearly";
@@ -14,6 +20,24 @@ export default function ComparePlansPage() {
   const searchParams = useSearchParams();
   const demoId = searchParams.get("demoId");
   const intakeId = searchParams.get("intakeId");
+  const activationContext = parseActivationContextFromSearchParams(searchParams);
+  const comparePlansHref = activationContext
+    ? appendActivationContextToHref(
+        `/compare-plans?${new URLSearchParams({
+          ...(demoId ? { demoId } : {}),
+          ...(intakeId ? { intakeId } : {}),
+        }).toString()}`,
+        activationContext,
+      )
+    : `/compare-plans?${new URLSearchParams({
+        ...(demoId ? { demoId } : {}),
+        ...(intakeId ? { intakeId } : {}),
+      }).toString()}`;
+
+  useEffect(() => {
+    if (!activationContext) return;
+    persistActivationContext(activationContext);
+  }, [activationContext]);
 
   const handleCheckout = async ({
     priceId,
@@ -39,11 +63,19 @@ export default function ComparePlansPage() {
 
       if (!res.ok) {
         if (res.status === 401 || res.status === 403) {
-          const next = `/compare-plans?${new URLSearchParams({
-            ...(demoId ? { demoId } : {}),
-            ...(intakeId ? { intakeId } : {}),
-          }).toString()}`;
-          window.location.href = `/signup?redirect=${encodeURIComponent(next)}${demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
+          const next = comparePlansHref;
+          const signupHref = activationContext
+            ? appendActivationContextToHref(
+                `/signup?redirect=${encodeURIComponent(next)}${demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`,
+                activationContext,
+              )
+            : `/signup?redirect=${encodeURIComponent(next)}${demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
+          trackShopBoostEvent("cta_clicked", {
+            demoId: demoId ?? "unknown",
+            intakeId: intakeId ?? undefined,
+            source: "compare_plans_auth_required",
+          });
+          window.location.href = signupHref;
           return;
         }
         toast.error(data?.details || data?.error || "Checkout failed");
@@ -123,7 +155,21 @@ export default function ComparePlansPage() {
           {demoId ? (
             <div className="mt-4">
               <Link
-                href={`/signup?redirect=${encodeURIComponent(`/compare-plans?demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`)}&demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`}
+                href={
+                  activationContext
+                    ? appendActivationContextToHref(
+                        `/signup?redirect=${encodeURIComponent(comparePlansHref)}&demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`,
+                        activationContext,
+                      )
+                    : `/signup?redirect=${encodeURIComponent(comparePlansHref)}&demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`
+                }
+                onClick={() =>
+                  trackShopBoostEvent("cta_clicked", {
+                    demoId,
+                    intakeId: intakeId ?? undefined,
+                    source: "compare_plans_signup",
+                  })
+                }
                 className="inline-flex items-center rounded-lg border border-white/15 bg-white/[0.04] px-4 py-2 text-xs font-semibold text-neutral-100 hover:bg-white/[0.08]"
               >
                 Continue setup via signup
@@ -137,8 +183,7 @@ export default function ComparePlansPage() {
             What happens after checkout?
           </div>
           <p className="mt-1 text-sm text-neutral-400">
-            After payment, we&apos;ll continue onboarding and create your shop + account
-            attached to the plan you picked.
+            After payment, we&apos;ll continue activation and start your real import based on this preview context.
           </p>
           <p className="mt-2 text-[11px] text-neutral-500">
             Cancel anytime. Taxes billed per your Stripe setup.

--- a/app/confirm/ConfirmContent.tsx
+++ b/app/confirm/ConfirmContent.tsx
@@ -4,12 +4,19 @@ import { useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  appendActivationContextToHref,
+  parseActivationContextFromSearchParams,
+  persistActivationContext,
+} from "@/features/integrations/shopBoost/activationContext";
+import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 
 export default function ConfirmContent() {
   const router = useRouter();
   const sp = useSearchParams();
   const supabase = createClientComponentClient<Database>();
   const ran = useRef(false);
+  const activationContext = parseActivationContextFromSearchParams(sp);
 
   useEffect(() => {
     const run = async () => {
@@ -49,13 +56,24 @@ export default function ConfirmContent() {
       // ✅ Route depending on onboarding status
 
       const params = new URLSearchParams();
-      const passthroughKeys = ["priceId", "interval", "trial", "founding", "session_id", "demoId", "intakeId"];
+      const passthroughKeys = ["priceId", "interval", "trial", "founding", "session_id", "demoId", "intakeId", "activationContext"];
       for (const key of passthroughKeys) {
         const value = sp.get(key);
         if (value) params.set(key, value);
       }
       const onboardingDest = `/onboarding${params.toString() ? `?${params.toString()}` : ""}`;
-      const dest = completed ? (redirect ?? "/dashboard/operations") : onboardingDest;
+      const destBase = completed ? (redirect ?? "/dashboard/operations") : onboardingDest;
+      const dest = activationContext ? appendActivationContextToHref(destBase, activationContext) : destBase;
+      if (activationContext) {
+        persistActivationContext(activationContext);
+        trackShopBoostEvent("activation_started", {
+          demoId: activationContext.demoId,
+          intakeId: activationContext.intakeId,
+          readiness: activationContext.readiness,
+          confidence: activationContext.confidence,
+          source: "confirm_page",
+        });
+      }
       router.replace(dest);
 
       // ✅ Hard fallback for Safari / mobile cache
@@ -68,7 +86,7 @@ export default function ConfirmContent() {
     };
 
     void run();
-  }, [router, sp, supabase]);
+  }, [activationContext, router, sp, supabase]);
 
   return (
     <div className="min-h-[60vh] grid place-items-center text-white">

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState, type FormEvent } from "react";
+import { appendActivationContextToHref, type ActivationContext } from "@/features/integrations/shopBoost/activationContext";
 import type { ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
 import type { ShadowShopSnapshot } from "@/features/integrations/shopBoost/shadowShop";
 import {
@@ -138,14 +139,35 @@ export default function InstantShopAnalysisPage() {
     };
 
   const goToSignup = () => {
+    const activationContext: ActivationContext | null =
+      demoId && intakeId && analysis
+        ? {
+            demoId,
+            intakeId,
+            confidence: analysis.dashboard.trustScore,
+            readiness:
+              analysis.dashboard.readinessLabel === "READY_FOR_GO_LIVE" || analysis.dashboard.readinessLabel === "COMPLETED_CLEAN"
+                ? "READY"
+                : analysis.dashboard.readinessLabel === "FAILED" ||
+                    analysis.dashboard.readinessLabel === "PARTIAL_FAILURE" ||
+                    analysis.dashboard.readinessLabel === "NOT_READY"
+                  ? "BLOCKED"
+                  : "REVIEW_REQUIRED",
+            blockers: analysis.setupIssues.filter((issue) => issue.severity === "blocker").map((issue) => issue.title),
+            domains: analysis.preflightReport.domains.map((domainSummary) => domainSummary.domain),
+          }
+        : null;
     const next = demoId
       ? `/compare-plans?demoId=${encodeURIComponent(demoId)}${
           intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""
         }`
       : "/compare-plans";
-    window.location.href = `/signup?redirect=${encodeURIComponent(next)}${
+    const signupHref = `/signup?redirect=${encodeURIComponent(next)}${
       demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""
     }${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
+    window.location.href = activationContext
+      ? appendActivationContextToHref(signupHref, activationContext)
+      : signupHref;
   };
 
   const handleRun = async (event: FormEvent<HTMLFormElement>) => {

--- a/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
+++ b/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
@@ -2,6 +2,14 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import {
+  appendActivationContextToHref,
+  persistActivationContext,
+  type ActivationContext,
+  type ActivationReadiness,
+} from "@/features/integrations/shopBoost/activationContext";
+import { getActivationCTA } from "@/features/integrations/shopBoost/getActivationCTA";
+import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 import type {
   ShadowPartSignal,
   ShadowPreviewContext,
@@ -48,16 +56,16 @@ const sections: Array<{ key: SectionKey; label: string }> = [
 
 const gateCopyByAction: Record<GateActionContext, GateCopy> = {
   "send-approval": {
-    title: "Activate to send real approvals",
-    detail: "Activation unlocks customer approval links, recommendation delivery, and response tracking.",
+    title: "Activate to send approval requests",
+    detail: "This will notify your customer and create a live approval request.",
   },
   "edit-customer": {
-    title: "Activate to manage your customer records",
-    detail: "Activation enables editing your live customer database and contact routing.",
+    title: "Activate to edit customer records",
+    detail: "This will update real customer records.",
   },
   "start-work-order": {
-    title: "Activate to run live work orders",
-    detail: "Activation starts real technician workflow states, labor tracking, and job progression.",
+    title: "Activate to start work orders",
+    detail: "This will create a real job in your system.",
   },
   inventory: {
     title: "Activate to track real inventory",
@@ -75,14 +83,58 @@ const gateCopyByAction: Record<GateActionContext, GateCopy> = {
 
 const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v1";
 
+function toActivationReadiness(readiness: string): ActivationReadiness {
+  if (readiness === "READY_FOR_GO_LIVE" || readiness === "COMPLETED_CLEAN") return "READY";
+  if (readiness === "FAILED" || readiness === "PARTIAL_FAILURE" || readiness === "NOT_READY") {
+    return "BLOCKED";
+  }
+  return "REVIEW_REQUIRED";
+}
+
 export default function ShadowPreviewClient({ context }: Props) {
   const [active, setActive] = useState<SectionKey>("dashboard");
   const [gateAction, setGateAction] = useState<GateActionContext | null>(null);
 
-  const query = useMemo(
-    () => new URLSearchParams({ demoId: context.demoId, intakeId: context.intakeId }).toString(),
-    [context.demoId, context.intakeId],
+  const activationContext = useMemo<ActivationContext>(() => {
+    const blockers = context.snapshot.setupIssues
+      .filter((issue) => issue.severity === "blocker")
+      .map((issue) => issue.title);
+    const domains = context.snapshot.preflightReport.domains.map((domain) => domain.domain);
+
+    return {
+      demoId: context.demoId,
+      intakeId: context.intakeId,
+      confidence: context.snapshot.dashboard.trustScore,
+      readiness: toActivationReadiness(context.snapshot.dashboard.readinessLabel),
+      blockers,
+      domains,
+    };
+  }, [context]);
+
+  const query = useMemo(() => new URLSearchParams({
+    demoId: context.demoId,
+    intakeId: context.intakeId,
+  }).toString(), [context.demoId, context.intakeId]);
+  const activationCta = useMemo(
+    () =>
+      getActivationCTA({
+        readiness: activationContext.readiness,
+        blockers: activationContext.blockers,
+        confidence: activationContext.confidence,
+      }),
+    [activationContext],
   );
+  const comparePlansHref = useMemo(
+    () => appendActivationContextToHref(`/compare-plans?${query}`, activationContext),
+    [activationContext, query],
+  );
+  const signupHref = useMemo(() => {
+    const redirect = appendActivationContextToHref(`/compare-plans?${query}`, activationContext);
+    return appendActivationContextToHref(
+      `/signup?redirect=${encodeURIComponent(redirect)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`,
+      activationContext,
+    );
+  }, [activationContext, context.demoId, context.intakeId, query]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -97,6 +149,20 @@ export default function ShadowPreviewClient({ context }: Props) {
     );
   }, [context.demoId, context.intakeId, context.shopName]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const nav = window.performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+    const eventName = nav?.type === "reload" ? "preview_resumed" : "preview_opened";
+    persistActivationContext(activationContext);
+    trackShopBoostEvent(eventName, {
+      demoId: context.demoId,
+      intakeId: context.intakeId,
+      readiness: activationContext.readiness,
+      confidence: activationContext.confidence,
+      source: "shadow_preview",
+    });
+  }, [activationContext, context.demoId, context.intakeId]);
+
   const gateCopy = gateAction ? gateCopyByAction[gateAction] : null;
 
   return (
@@ -109,8 +175,22 @@ export default function ShadowPreviewClient({ context }: Props) {
             <p className="text-[11px] text-neutral-400">This operational sandbox is generated from your uploaded analysis data. No tenant rows were created.</p>
           </div>
           <div className="flex gap-2">
-            <Link href={`/compare-plans?${query}`} className="rounded-md border border-white/20 px-3 py-1.5 text-xs hover:bg-white/[0.05]">See Plans</Link>
-            <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="rounded-md bg-[var(--accent-copper)] px-3 py-1.5 text-xs font-semibold text-black hover:brightness-110">Activate Your Shop</Link>
+            <Link href={comparePlansHref} className="rounded-md border border-white/20 px-3 py-1.5 text-xs hover:bg-white/[0.05]">See Plans</Link>
+            <Link
+              href={signupHref}
+              onClick={() =>
+                trackShopBoostEvent("cta_clicked", {
+                  demoId: context.demoId,
+                  intakeId: context.intakeId,
+                  readiness: activationContext.readiness,
+                  confidence: activationContext.confidence,
+                  source: "preview_header",
+                })
+              }
+              className="rounded-md bg-[var(--accent-copper)] px-3 py-1.5 text-xs font-semibold text-black hover:brightness-110"
+            >
+              {activationCta.label}
+            </Link>
           </div>
         </div>
       </header>
@@ -132,6 +212,9 @@ export default function ShadowPreviewClient({ context }: Props) {
         </aside>
 
         <main className="space-y-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-100">
+            This is a preview based on your uploaded data. No changes have been made yet. Activation will begin real import.
+          </div>
           {active === "dashboard" ? <Dashboard context={context} onGate={setGateAction} /> : null}
           {active === "work-orders" ? <WorkflowPanel jobs={context.snapshot.workflowJobs} onGate={setGateAction} /> : null}
           {active === "approvals" ? <ApprovalPanel context={context} onGate={setGateAction} /> : null}
@@ -143,16 +226,24 @@ export default function ShadowPreviewClient({ context }: Props) {
 
         <aside className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
           <p className="text-[11px] uppercase tracking-[0.15em] text-neutral-400">Activation rail</p>
-          <p className="text-xs text-neutral-300">This preview will carry into compare-plans, signup, and onboarding. Activation starts real import and setup.</p>
-          <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="block rounded-md bg-[var(--accent-copper)] px-3 py-2 text-center text-xs font-semibold text-black hover:brightness-110">Activate Your Shop</Link>
-          <Link href={`/compare-plans?${query}`} className="block rounded-md border border-white/20 px-3 py-2 text-center text-xs hover:bg-white/[0.05]">See Plans</Link>
+          <p className="text-xs text-neutral-300">{activationCta.subtext}</p>
+          <div className="grid grid-cols-2 gap-2 text-[11px] text-neutral-300">
+            <MiniPill label="Confidence" value={`${activationContext.confidence}%`} />
+            <MiniPill label="Readiness" value={activationContext.readiness.replace(/_/g, " ")} />
+            <MiniPill label="Blockers" value={String(activationContext.blockers.length)} />
+            <MiniPill label="Domains" value={String(activationContext.domains.length)} />
+          </div>
+          <Link href={signupHref} className="block rounded-md bg-[var(--accent-copper)] px-3 py-2 text-center text-xs font-semibold text-black hover:brightness-110">{activationCta.label}</Link>
+          <Link href={comparePlansHref} className="block rounded-md border border-white/20 px-3 py-2 text-center text-xs hover:bg-white/[0.05]">See Plans</Link>
           <button onClick={() => setGateAction("settings")} className="w-full rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-200 hover:bg-white/[0.05]">Start real import (locked)</button>
           <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/10 p-3 text-[11px] text-cyan-100">
             <p className="font-semibold">What happens when you activate</p>
             <ul className="mt-2 list-disc space-y-1 pl-4 text-cyan-50/90">
-              <li>We use this exact preview context to begin your live import.</li>
-              <li>Flagged items are routed into guided review queues.</li>
-              <li>No data has been written yet in preview mode.</li>
+              <li>We will import your data into your real shop workspace.</li>
+              <li>We will create your shop setup baseline and migration queue.</li>
+              <li>Flagged items will be reviewable in guided setup.</li>
+              <li>Nothing has been written yet.</li>
+              <li>This preview is based on your uploaded data.</li>
             </ul>
           </div>
         </aside>
@@ -165,8 +256,8 @@ export default function ShadowPreviewClient({ context }: Props) {
             <p className="mt-2 text-sm text-neutral-300">{gateCopy.detail}</p>
             <p className="mt-2 text-xs text-neutral-500">Preview is read-only. Nothing has been written to a live tenant or shop yet.</p>
             <div className="mt-4 flex flex-wrap gap-2">
-              <Link href={`/signup?redirect=${encodeURIComponent(`/compare-plans?${query}`)}&demoId=${encodeURIComponent(context.demoId)}&intakeId=${encodeURIComponent(context.intakeId)}`} className="rounded-md bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-black">Activate Your Shop</Link>
-              <Link href={`/compare-plans?${query}`} className="rounded-md border border-white/20 px-3 py-2 text-xs">See Plans</Link>
+              <Link href={signupHref} className="rounded-md bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-black">{activationCta.label}</Link>
+              <Link href={comparePlansHref} className="rounded-md border border-white/20 px-3 py-2 text-xs">See Plans</Link>
               <button onClick={() => setGateAction(null)} className="rounded-md border border-white/20 px-3 py-2 text-xs text-neutral-300">Stay in preview</button>
             </div>
           </div>

--- a/app/demo/preview/[demoId]/page.tsx
+++ b/app/demo/preview/[demoId]/page.tsx
@@ -11,6 +11,8 @@ export default async function DemoPreviewPage({ params, searchParams }: PageProp
   const { demoId } = await params;
   const sp = await searchParams;
   const intakeId = typeof sp.intakeId === "string" ? sp.intakeId : "";
+  const isUuid = (value: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 
   if (!intakeId) {
     return (
@@ -23,15 +25,26 @@ export default async function DemoPreviewPage({ params, searchParams }: PageProp
       </div>
     );
   }
+  if (!isUuid(demoId) || !isUuid(intakeId)) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-black px-4 text-white">
+        <div className="max-w-md rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-center">
+          <p className="text-lg font-semibold">Preview expired</p>
+          <p className="mt-2 text-sm text-neutral-400">This preview link is invalid or expired. Start a new analysis to continue.</p>
+          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-white/20 px-3 py-1.5 text-xs">Restart analysis</Link>
+        </div>
+      </div>
+    );
+  }
 
   const context = await loadShadowPreviewContext({ demoId, intakeId });
   if (!context) {
     return (
       <div className="grid min-h-screen place-items-center bg-black px-4 text-white">
         <div className="max-w-md rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-center">
-          <p className="text-lg font-semibold">Preview not available</p>
-          <p className="mt-2 text-sm text-neutral-400">We couldn&apos;t validate this demo scope. Please run Instant Shop Analysis again to generate a fresh preview.</p>
-          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-white/20 px-3 py-1.5 text-xs">Run analysis again</Link>
+          <p className="text-lg font-semibold">Preview expired</p>
+          <p className="mt-2 text-sm text-neutral-400">The demo snapshot is missing or no longer matches this intake link. Please restart Instant Shop Analysis.</p>
+          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-white/20 px-3 py-1.5 text-xs">Restart analysis</Link>
         </div>
       </div>
     );

--- a/features/analytics/shopBoostEvents.ts
+++ b/features/analytics/shopBoostEvents.ts
@@ -1,0 +1,37 @@
+export type ShopBoostEventName =
+  | "preview_opened"
+  | "preview_resumed"
+  | "cta_clicked"
+  | "activation_started"
+  | "signup_completed"
+  | "import_started"
+  | "import_completed";
+
+export type ShopBoostEventPayload = {
+  demoId: string;
+  intakeId?: string;
+  readiness?: "READY" | "REVIEW_REQUIRED" | "BLOCKED";
+  confidence?: number;
+  source?: string;
+  [key: string]: unknown;
+};
+
+export function trackShopBoostEvent(event: ShopBoostEventName, payload: ShopBoostEventPayload): void {
+  if (typeof window === "undefined") return;
+
+  const detail = {
+    event,
+    ...payload,
+    timestamp: new Date().toISOString(),
+  };
+
+  window.dispatchEvent(new CustomEvent("shop-boost-event", { detail }));
+
+  const analyticsLayer = (window as Window & { dataLayer?: Array<Record<string, unknown>> }).dataLayer;
+  analyticsLayer?.push(detail);
+
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.info("[shop-boost-event]", detail);
+  }
+}

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -6,6 +6,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  appendActivationContextToHref,
+  parseActivationContextFromSearchParams,
+  persistActivationContext,
+} from "@/features/integrations/shopBoost/activationContext";
+import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 
 type Role = "owner" | "admin" | "manager" | "advisor" | "mechanic";
 
@@ -47,6 +53,7 @@ export default function OnboardingPage() {
   const searchParams = useSearchParams();
   const demoId = searchParams.get("demoId");
   const intakeId = searchParams.get("intakeId");
+  const activationContext = parseActivationContextFromSearchParams(searchParams);
 
   const [sessionChecked, setSessionChecked] = useState(false);
   const [hasSession, setHasSession] = useState(false);
@@ -74,6 +81,7 @@ export default function OnboardingPage() {
   const [asOwner, setAsOwner] = useState(true);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [activationBusy, setActivationBusy] = useState(false);
 
   const fieldClassName =
     "w-full rounded-md border border-white/10 bg-[var(--glass-bg)] px-3 py-2 text-sm text-white placeholder:text-neutral-500";
@@ -89,15 +97,19 @@ export default function OnboardingPage() {
         await supabase.auth.exchangeCodeForSession(code);
       } finally {
         const keepSid = searchParams.get("session_id");
-        const clean = keepSid
-          ? `/onboarding?session_id=${encodeURIComponent(keepSid)}`
-          : "/onboarding";
+        const cleanParams = new URLSearchParams();
+        if (keepSid) cleanParams.set("session_id", keepSid);
+        if (demoId) cleanParams.set("demoId", demoId);
+        if (intakeId) cleanParams.set("intakeId", intakeId);
+        const activationContextParam = searchParams.get("activationContext");
+        if (activationContextParam) cleanParams.set("activationContext", activationContextParam);
+        const clean = `/onboarding${cleanParams.toString() ? `?${cleanParams.toString()}` : ""}`;
         router.replace(clean);
         setTimeout(() => router.refresh(), 0);
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [demoId, intakeId, router, searchParams, supabase.auth]);
 
   useEffect(() => {
     (async () => {
@@ -149,6 +161,11 @@ export default function OnboardingPage() {
   useEffect(() => {
     setAsOwner(role === "owner");
   }, [role]);
+
+  useEffect(() => {
+    if (!activationContext) return;
+    persistActivationContext(activationContext);
+  }, [activationContext]);
 
   const provinceLabel = country === "CA" ? "Province" : "State";
   const postalLabel = country === "CA" ? "Postal code" : "ZIP code";
@@ -229,10 +246,44 @@ export default function OnboardingPage() {
         return;
       }
 
+      if (demoId && intakeId) {
+        setActivationBusy(true);
+        trackShopBoostEvent("import_started", {
+          demoId,
+          intakeId,
+          source: "onboarding_owner_submit",
+        });
+        const activationRes = await fetch("/api/demo/shop-boost/activate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ demoId, intakeId }),
+        });
+        const activationJson = (await activationRes.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+        if (!activationRes.ok || !activationJson.ok) {
+          setError(activationJson.error || "Failed to start activation import. Please restart preview.");
+          setLoading(false);
+          setActivationBusy(false);
+          return;
+        }
+        trackShopBoostEvent("import_completed", {
+          demoId,
+          intakeId,
+          source: "onboarding_owner_submit",
+        });
+        const setupReviewHref = activationContext
+          ? appendActivationContextToHref("/dashboard/setup/review", activationContext)
+          : "/dashboard/setup/review";
+        router.replace(setupReviewHref);
+        setLoading(false);
+        setActivationBusy(false);
+        return;
+      }
+
       const next = new URLSearchParams();
       if (demoId) next.set("demoId", demoId);
       if (intakeId) next.set("intakeId", intakeId);
-      router.replace(`/onboarding/shop-boost${next.toString() ? `?${next.toString()}` : ""}`);
+      const baseHref = `/onboarding/shop-boost${next.toString() ? `?${next.toString()}` : ""}`;
+      router.replace(activationContext ? appendActivationContextToHref(baseHref, activationContext) : baseHref);
       setLoading(false);
       return;
     }
@@ -303,8 +354,13 @@ export default function OnboardingPage() {
         <div className="flex-1 space-y-6">
           {demoId ? (
             <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-4 py-3 text-xs text-cyan-100">
-              Preview continuity active: when setup finishes, we’ll carry your analysis into Shop Boost activation.
+              Preview continuity active: setup will start your real import from preview context.
               {intakeId ? ` Intake: ${intakeId}` : ""}
+            </div>
+          ) : null}
+          {activationBusy ? (
+            <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-xs text-emerald-100">
+              Activation import is running. We&apos;ll take you to guided review as soon as it starts.
             </div>
           ) : null}
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/features/auth/app/signup/SignUpClient.tsx
+++ b/features/auth/app/signup/SignUpClient.tsx
@@ -5,6 +5,12 @@ import { useState, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  appendActivationContextToHref,
+  parseActivationContextFromSearchParams,
+  persistActivationContext,
+} from "@/features/integrations/shopBoost/activationContext";
+import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 
 export default function SignUpClient() {
   const supabase = createClientComponentClient<Database>();
@@ -18,6 +24,7 @@ export default function SignUpClient() {
   const [loading, setLoading] = useState(false);
   const demoId = sp.get("demoId");
   const intakeId = sp.get("intakeId");
+  const activationContext = parseActivationContextFromSearchParams(sp);
 
   const origin = useMemo(() => {
     if (typeof window !== "undefined") return window.location.origin;
@@ -36,6 +43,7 @@ export default function SignUpClient() {
     const founding = sp.get("founding");
     const demoId = sp.get("demoId");
     const intakeId = sp.get("intakeId");
+    const activationContextRaw = sp.get("activationContext");
 
     if (redirect) params.set("redirect", redirect);
     if (priceId) params.set("priceId", priceId);
@@ -44,10 +52,16 @@ export default function SignUpClient() {
     if (founding) params.set("founding", founding);
     if (demoId) params.set("demoId", demoId);
     if (intakeId) params.set("intakeId", intakeId);
+    if (activationContextRaw) params.set("activationContext", activationContextRaw);
 
     const tail = params.toString();
     return `${origin}/confirm${tail ? `?${tail}` : ""}`;
   }, [origin, sp]);
+
+  useEffect(() => {
+    if (!activationContext) return;
+    persistActivationContext(activationContext);
+  }, [activationContext]);
 
   useEffect(() => {
     const sid = sp.get("session_id");
@@ -84,11 +98,17 @@ export default function SignUpClient() {
         if (demoId) params.set("demoId", demoId);
         if (intakeId) params.set("intakeId", intakeId);
 
-        const onboardingTarget = `/onboarding${params.toString() ? `?${params.toString()}` : ""}`;
-        router.replace(redirect || onboardingTarget);
+        let onboardingTarget = `/onboarding${params.toString() ? `?${params.toString()}` : ""}`;
+        if (activationContext) onboardingTarget = appendActivationContextToHref(onboardingTarget, activationContext);
+        const destination = redirect
+          ? activationContext
+            ? appendActivationContextToHref(redirect, activationContext)
+            : redirect
+          : onboardingTarget;
+        router.replace(destination);
       }
     })();
-  }, [router, sp, supabase]);
+  }, [activationContext, router, sp, supabase]);
 
   const go = async (href: string) => {
     await supabase.auth.getSession();
@@ -149,8 +169,15 @@ export default function SignUpClient() {
     if (intakeId) params.set("intakeId", intakeId);
 
     const onboardingTarget = `/onboarding${params.toString() ? `?${params.toString()}` : ""}`;
-
-    await go(redirect || onboardingTarget);
+    const destination = activationContext
+      ? appendActivationContextToHref(redirect || onboardingTarget, activationContext)
+      : redirect || onboardingTarget;
+    trackShopBoostEvent("signup_completed", {
+      demoId: demoId ?? "unknown",
+      intakeId: intakeId ?? undefined,
+      source: "signup_form",
+    });
+    await go(destination);
     setLoading(false);
   };
 

--- a/features/integrations/shopBoost/activationContext.ts
+++ b/features/integrations/shopBoost/activationContext.ts
@@ -1,0 +1,137 @@
+export type ActivationReadiness = "READY" | "REVIEW_REQUIRED" | "BLOCKED";
+
+export type ActivationContext = {
+  demoId: string;
+  intakeId: string;
+  confidence: number;
+  readiness: ActivationReadiness;
+  blockers: string[];
+  domains: string[];
+};
+
+const ACTIVATION_CONTEXT_STORAGE_KEY = "shop-boost-activation-context-v1";
+
+function clampConfidence(value: unknown): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function safeAtob(input: string): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.atob(input);
+  } catch {
+    return null;
+  }
+}
+
+function safeBtoa(input: string): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.btoa(input);
+  } catch {
+    return null;
+  }
+}
+
+export function serializeActivationContext(context: ActivationContext): string {
+  const encoded = safeBtoa(JSON.stringify(context));
+  return encoded ?? JSON.stringify(context);
+}
+
+export function parseActivationContext(raw: string | null | undefined): ActivationContext | null {
+  if (!raw) return null;
+
+  const decode = (value: string) => {
+    const base64Decoded = safeAtob(value);
+    return base64Decoded ?? value;
+  };
+
+  try {
+    const parsed = asRecord(JSON.parse(decode(raw)));
+    const demoId = typeof parsed.demoId === "string" ? parsed.demoId : "";
+    const intakeId = typeof parsed.intakeId === "string" ? parsed.intakeId : "";
+    const readiness = parsed.readiness;
+
+    if (!demoId || !intakeId) return null;
+    if (readiness !== "READY" && readiness !== "REVIEW_REQUIRED" && readiness !== "BLOCKED") {
+      return null;
+    }
+
+    return {
+      demoId,
+      intakeId,
+      confidence: clampConfidence(parsed.confidence),
+      readiness,
+      blockers: parseStringArray(parsed.blockers),
+      domains: parseStringArray(parsed.domains),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function parseActivationContextFromSearchParams(
+  searchParams: URLSearchParams | ReadonlyURLSearchParams,
+): ActivationContext | null {
+  const contextFromQuery = searchParams.get("activationContext");
+  return parseActivationContext(contextFromQuery);
+}
+
+export function persistActivationContext(context: ActivationContext): void {
+  if (typeof window === "undefined") return;
+
+  const serialized = serializeActivationContext(context);
+  window.localStorage.setItem(ACTIVATION_CONTEXT_STORAGE_KEY, serialized);
+
+  const url = new URL(window.location.href);
+  url.searchParams.set("demoId", context.demoId);
+  url.searchParams.set("intakeId", context.intakeId);
+  url.searchParams.set("activationContext", serialized);
+  window.history.replaceState(window.history.state, "", url.toString());
+}
+
+export function readPersistedActivationContext(
+  searchParams?: URLSearchParams | ReadonlyURLSearchParams,
+): ActivationContext | null {
+  const fromSearch = searchParams ? parseActivationContextFromSearchParams(searchParams) : null;
+  if (fromSearch) return fromSearch;
+
+  if (typeof window === "undefined") return null;
+  return parseActivationContext(window.localStorage.getItem(ACTIVATION_CONTEXT_STORAGE_KEY));
+}
+
+export function toActivationQueryParams(context: ActivationContext): URLSearchParams {
+  return new URLSearchParams({
+    demoId: context.demoId,
+    intakeId: context.intakeId,
+    activationContext: serializeActivationContext(context),
+  });
+}
+
+export function appendActivationContextToHref(href: string, context: ActivationContext): string {
+  const [path, existingQuery = ""] = href.split("?");
+  const params = new URLSearchParams(existingQuery);
+  const activationParams = toActivationQueryParams(context);
+  for (const [key, value] of activationParams.entries()) {
+    params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+type ReadonlyURLSearchParams = Pick<URLSearchParams, "get">;

--- a/features/integrations/shopBoost/getActivationCTA.ts
+++ b/features/integrations/shopBoost/getActivationCTA.ts
@@ -1,0 +1,37 @@
+import type { ActivationReadiness } from "@/features/integrations/shopBoost/activationContext";
+
+type ActivationCTAArgs = {
+  readiness: ActivationReadiness;
+  blockers: string[];
+  confidence: number;
+};
+
+export type ActivationCTA = {
+  label: string;
+  subtext: string;
+  urgencyTone: "low" | "medium" | "high";
+};
+
+export function getActivationCTA(args: ActivationCTAArgs): ActivationCTA {
+  if (args.readiness === "READY") {
+    return {
+      label: "Activate your shop",
+      subtext: `Start free trial and import now (${args.confidence}% confidence).`,
+      urgencyTone: "low",
+    };
+  }
+
+  if (args.readiness === "REVIEW_REQUIRED") {
+    return {
+      label: "Activate and review flagged items",
+      subtext: `Start setup with guided fixes. ${args.blockers.length} items are flagged for review.`,
+      urgencyTone: "medium",
+    };
+  }
+
+  return {
+    label: "Fix blockers and activate",
+    subtext: `Resolve issues to continue. ${args.blockers.length} blocker${args.blockers.length === 1 ? "" : "s"} detected.`,
+    urgencyTone: "high",
+  };
+}


### PR DESCRIPTION
### Motivation

- Make the Shop Boost shadow preview conversion-ready by preserving demo/intake activation context across preview → plans → signup → onboarding flows so activation is frictionless and trustworthy.
- Surface readiness/confidence and explicit explainer copy so users understand this is a read-only preview and what activation will do.
- Provide a safe, validated handoff from preview snapshots into a real shop-scoped intake and import without writing live shop rows during preview.

### Description

- Added a reusable activation context module with serialization, parsing, localStorage + URL persistence, and helpers to append context to hrefs (`features/integrations/shopBoost/activationContext.ts`).
- Implemented a readiness-aware CTA helper (`features/integrations/shopBoost/getActivationCTA.ts`) and a lightweight conversion event tracker (`features/analytics/shopBoostEvents.ts`).
- Upgraded the shadow preview UI to persist and surface activation context, add a prominent trust banner and explainer panel, and replace generic CTAs with state-aware CTAs that carry context into `/compare-plans` and `/signup` (changes to `app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx` and `app/demo/preview/[demoId]/page.tsx`).
- Preserved activation context across compare/plans, signup, confirm, onboarding, and instant-analysis flows and emitted conversion events on key actions (`app/compare-plans/page.tsx`, `features/auth/app/signup/SignUpClient.tsx`, `app/confirm/ConfirmContent.tsx`, `features/auth/app/onboarding/OnboardingPage.tsx`, `app/demo/instant-shop-analysis/page.tsx`).
- Implemented preview → import handoff: demo run now stages uploaded demo files and embeds activation upload paths into the demo snapshot, and a new activation endpoint copies staged demo files into a shop-scoped intake and runs the Shop Boost intake + import pipeline (`app/api/demo/shop-boost/run/route.ts`, new `app/api/demo/shop-boost/activate/route.ts`).
- Hardened preview link handling and copy for expired/mismatched demo or intake IDs and added restart guidance in the preview page (`app/demo/preview/[demoId]/page.tsx`).

### Testing

- Ran `npx tsc --noEmit`; TypeScript check failed due to pre-existing duplicate identifier errors in generated Supabase types that are unrelated to this change (reported, not introduced by this PR). (failed)
- Ran repository ESLint (`npx eslint app features --max-warnings=0`); this surfaced many pre-existing repo-wide lint issues outside the scope of this patch (reported, not introduced by this PR). (failed)
- Ran targeted ESLint on modified/new Shop Boost files and client flows: `npx eslint` for the set of changed files (preview client, compare-plans, signup, confirm, onboarding, instant analysis, demo run, activate, activationContext, getActivationCTA, shopBoostEvents) and it passed with no warnings. (passed)

Notes: activation keeps preview read-only and does not modify real shop tables until the user completes activation and a validated `/api/demo/shop-boost/activate` call runs under an authenticated owner session; demo snapshot pairing and file expiry/mismatch cases are explicitly handled with clear user guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd994fe988328b794290a27396269)