### PR TITLE
Constrain Shop Boost visibility and scope technician operations payload

### DIFF
--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -21,26 +21,37 @@ function getCountSeverity(count: number): "neutral" | "amber" | "red" {
   return "neutral";
 }
 
+function isOwnerAdminRole(role: string | null): boolean {
+  const normalizedRole = (role ?? "").toLowerCase();
+  return normalizedRole === "owner" || normalizedRole === "admin";
+}
+
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
+  const isTechnicianView = payload.viewerScope === "technician";
   const hasTechnicianActivity = payload.technicianActivity.length > 0;
   const hasRightRailSignals = payload.blockerStack.length > 0 || payload.alerts.length > 0 || payload.suggestedActions.length > 0;
+  const canSeeShopBoostMissionControl = isOwnerAdminRole(payload.identity.role);
 
   return (
     <DashboardShell>
       <DashboardTopStrip
         view="operations"
-        title="Operations Dashboard"
+        title={isTechnicianView ? "Technician Dashboard" : "Operations Dashboard"}
         name={`Welcome back, ${displayName}`}
-        subtitle="Live command center for active jobs, bottlenecks, and immediate dispatch actions."
+        subtitle={
+          isTechnicianView
+            ? "Your personal workbench for assigned jobs, blockers, and immediate next actions."
+            : "Live command center for active jobs, bottlenecks, and immediate dispatch actions."
+        }
         actions={[
           { label: "Create work order", href: "/work-orders/create", tone: "primary" },
           { label: "Dispatch", href: "/dashboard/manager/dispatch", tone: "secondary" },
         ]}
       />
 
-      <ShopBoostActivationPanel />
+      {canSeeShopBoostMissionControl ? <ShopBoostActivationPanel eligible /> : null}
 
       <MetricStrip
         className="mb-0"
@@ -101,7 +112,7 @@ export default async function OperationsDashboardView() {
           >
             <div className="grid gap-1.5 md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)] xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]">
             <DashboardPanel
-              title="Live Work Command Surface"
+              title={isTechnicianView ? "My active assigned jobs" : "Live Work Command Surface"}
               className="min-h-[300px] border-white/5 bg-[linear-gradient(155deg,rgba(7,13,28,0.9),rgba(8,14,30,0.78))]"
               action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-neutral-300 hover:text-white">Open board <ArrowRight className="h-3 w-3" /></Link>}
             >
@@ -161,7 +172,7 @@ export default async function OperationsDashboardView() {
               </div>
             </DashboardPanel>
 
-            <DashboardPanel title="Active Job Summary" className="min-h-[300px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
+            <DashboardPanel title={isTechnicianView ? "My workload snapshot" : "Active Job Summary"} className="min-h-[300px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
               <div className="space-y-2">
                 {payload.activeJobSummary.map((metric) => (
                   <div key={metric.label} className="rounded-lg border border-white/5 bg-black/15 p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
@@ -182,12 +193,12 @@ export default async function OperationsDashboardView() {
           </div>
 
             <div className="grid gap-1.5 md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)] xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]">
-            <DashboardPanel title="Live Shop Load" className="min-h-[236px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
+            <DashboardPanel title={isTechnicianView ? "My queue mix" : "Live Shop Load"} className="min-h-[236px] border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]">
               <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
             </DashboardPanel>
 
             <DashboardPanel
-              title="Daily Summary"
+              title={isTechnicianView ? "My daily summary" : "Daily Summary"}
               className="border-white/5 bg-[linear-gradient(155deg,rgba(7,12,25,0.84),rgba(8,14,29,0.74))]"
               action={<Link href="/dashboard/bookings" className="text-xs text-neutral-300 hover:text-white">Open</Link>}
             >
@@ -223,7 +234,7 @@ export default async function OperationsDashboardView() {
           </div>
 
           {hasTechnicianActivity ? (
-            <DashboardPanel title="Technician Activity" className="min-h-[236px]">
+            <DashboardPanel title={isTechnicianView ? "My activity" : "Technician Activity"} className="min-h-[236px]">
               <div className="space-y-1.5">
                 {payload.technicianActivity.map((tech) => (
                   <Link

--- a/features/dashboard/components/ShopBoostActivationPanel.tsx
+++ b/features/dashboard/components/ShopBoostActivationPanel.tsx
@@ -51,6 +51,8 @@ type IntakeState = {
 };
 
 const ACTIVE_STATUSES = new Set(["queued", "pending", "processing"]);
+const ACTIONABLE_STATUSES = new Set(["failed", "blocked", "requires_review", "review_needed"]);
+const RECENT_COMPLETED_DAYS = 14;
 
 function fmtStep(step: string | undefined): string {
   if (!step) return "Queued";
@@ -64,7 +66,31 @@ const statusTone: Record<MigrationStory["trust_status"], string> = {
   BLOCKED: "border-rose-400/35 bg-rose-950/25 text-rose-100",
 };
 
-export default function ShopBoostActivationPanel() {
+function isRecentlyProcessed(intake: IntakeState): boolean {
+  const ts = intake.processedAt ?? intake.createdAt;
+  if (!ts) return false;
+  const ageMs = Date.now() - new Date(ts).getTime();
+  return Number.isFinite(ageMs) && ageMs >= 0 && ageMs <= RECENT_COMPLETED_DAYS * 24 * 60 * 60 * 1000;
+}
+
+function getPanelMode(intake: IntakeState | null): "hidden" | "full" | "summary" {
+  if (!intake) return "hidden";
+  if (ACTIVE_STATUSES.has(intake.status) || ACTIONABLE_STATUSES.has(intake.status)) return "full";
+
+  const completionState = intake.progress?.completionState;
+  const trustStatus = intake.progress?.migration_story?.trust_status;
+  if (trustStatus && trustStatus !== "READY" && isRecentlyProcessed(intake)) return "full";
+  const isCompletedLike =
+    completionState === "READY_FOR_GO_LIVE" ||
+    completionState === "COMPLETED_CLEAN" ||
+    completionState === "COMPLETED_WITH_REVIEW" ||
+    completionState === "COMPLETED_WITH_WARNINGS" ||
+    trustStatus === "READY";
+
+  return isCompletedLike && isRecentlyProcessed(intake) ? "summary" : "hidden";
+}
+
+export default function ShopBoostActivationPanel({ eligible = false }: { eligible?: boolean }) {
   const [intake, setIntake] = useState<IntakeState | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -76,8 +102,12 @@ export default function ShopBoostActivationPanel() {
   }, []);
 
   useEffect(() => {
+    if (!eligible) {
+      setLoading(false);
+      return;
+    }
     void loadStatus();
-  }, [loadStatus]);
+  }, [eligible, loadStatus]);
 
   useEffect(() => {
     if (!intake || !ACTIVE_STATUSES.has(intake.status)) return;
@@ -86,12 +116,33 @@ export default function ShopBoostActivationPanel() {
   }, [intake, loadStatus]);
 
   const percent = useMemo(() => Math.max(0, Math.min(100, intake?.progress?.progressPercent ?? 0)), [intake?.progress?.progressPercent]);
+  const mode = useMemo(() => getPanelMode(intake), [intake]);
 
-  if (loading || !intake) return null;
+  if (!eligible || loading || !intake || mode === "hidden") return null;
 
   const domains = intake.progress?.domainSummaries ?? {};
   const story = intake.progress?.migration_story;
   const fallbackConfidence = story ? Math.round(story.confidence_score * 100) : 0;
+
+  if (mode === "summary") {
+    return (
+      <section className="mb-2.5 rounded-xl border border-emerald-300/30 bg-[linear-gradient(140deg,rgba(10,26,18,0.65),rgba(7,12,25,0.84))] p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.2em] text-emerald-200/75">Shop Boost Summary</p>
+            <h3 className="text-sm font-semibold text-emerald-100">Recent migration completion</h3>
+            <p className="mt-1 text-xs text-emerald-100/80">
+              Completed {fmtStep(intake.progress?.completionState ?? intake.status)} with confidence {fallbackConfidence}%.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <Link href="/dashboard" className="rounded-md border border-emerald-300/45 px-2.5 py-1 text-emerald-100 hover:bg-white/5">Open dashboard</Link>
+            <Link href={`/api/shop-boost/intakes/${intake.id}/report?download=1`} className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">Download report</Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="mb-2.5 rounded-xl border border-[var(--brand-accent,#E39A6E)]/30 bg-[linear-gradient(140deg,rgba(22,12,8,0.72),rgba(7,12,25,0.86))] p-3">

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -4,6 +4,7 @@ import { createDashboardServerClient, getDashboardIdentity } from "@/features/da
 
 const OPEN_PART_STATUSES = ["requested", "quoted", "approved"] as const;
 const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
+const TECH_ROLES = new Set(["tech", "technician", "mechanic"]);
 
 type OpSignal = {
   label: string;
@@ -21,6 +22,7 @@ type OpAction = {
 
 export type OperationsDashboardPayload = {
   identity: Awaited<ReturnType<typeof getDashboardIdentity>>;
+  viewerScope: "shop" | "technician";
   topSummary: {
     activeJobs: number;
     blockedJobs: number;
@@ -86,8 +88,11 @@ function elapsedLabel(updatedAt: string | null): string {
 
 export async function getOperationsDashboardPayload(): Promise<OperationsDashboardPayload> {
   const identity = await getDashboardIdentity();
+  const normalizedRole = (identity.role ?? "").toLowerCase();
+  const isTechnicianScoped = Boolean(identity.userId) && TECH_ROLES.has(normalizedRole);
   const payload: OperationsDashboardPayload = {
     identity,
+    viewerScope: isTechnicianScoped ? "technician" : "shop",
     topSummary: {
       activeJobs: 0,
       blockedJobs: 0,
@@ -123,6 +128,36 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   const todayEnd = endOfDay(new Date()).toISOString();
   const monthStart = startOfMonth(new Date()).toISOString();
 
+  const approvalsQuery = supabase
+    .from("work_order_lines")
+    .select("id,work_order_id,status,updated_at", { count: "exact" })
+    .eq("shop_id", identity.shopId)
+    .in("approval_state", ["requested", "pending", "awaiting_approval"]);
+  const scopedApprovalsQuery = isTechnicianScoped && identity.userId
+    ? approvalsQuery.eq("assigned_tech_id", identity.userId)
+    : approvalsQuery;
+
+  const partsQuery = supabase
+    .from("part_requests")
+    .select("id,status,work_order_id,job_id,created_at", { count: "exact" })
+    .eq("shop_id", identity.shopId)
+    .in("status", OPEN_PART_STATUSES as unknown as string[]);
+  const scopedPartsQuery = isTechnicianScoped && identity.userId
+    ? partsQuery.or(`requested_by.eq.${identity.userId},assigned_tech_id.eq.${identity.userId}`)
+    : partsQuery;
+
+  const activeLinesQuery = supabase
+    .from("work_order_lines")
+    .select("work_order_id,assigned_tech_id,status,updated_at")
+    .eq("shop_id", identity.shopId)
+    .not("status", "in", `(${CLOSED_LINE_STATUSES.map((status) => `'${status}'`).join(",")})`)
+    .not("assigned_tech_id", "is", null)
+    .order("updated_at", { ascending: false })
+    .limit(400);
+  const scopedActiveLinesQuery = isTechnicianScoped && identity.userId
+    ? activeLinesQuery.eq("assigned_tech_id", identity.userId)
+    : activeLinesQuery;
+
   const [
     boardResult,
     approvalsResult,
@@ -137,31 +172,15 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       .select("work_order_id,custom_id,display_name,overall_stage,risk_level,priority")
       .eq("shop_id", identity.shopId)
       .order("activity_at", { ascending: false })
-      .limit(48),
-    supabase
-      .from("work_order_lines")
-      .select("id,work_order_id,status,updated_at", { count: "exact" })
-      .eq("shop_id", identity.shopId)
-      .in("approval_state", ["requested", "pending", "awaiting_approval"]),
-    supabase
-      .from("part_requests")
-      .select("id,status,work_order_id,job_id,created_at", { count: "exact" })
-      .eq("shop_id", identity.shopId)
-      .in("status", OPEN_PART_STATUSES as unknown as string[])
-      .limit(120),
+      .limit(isTechnicianScoped ? 200 : 48),
+    scopedApprovalsQuery,
+    scopedPartsQuery.limit(120),
     supabase
       .from("profiles")
       .select("id,full_name")
       .eq("shop_id", identity.shopId)
       .in("role", ["tech", "mechanic", "technician"]),
-    supabase
-      .from("work_order_lines")
-      .select("assigned_tech_id,status,updated_at")
-      .eq("shop_id", identity.shopId)
-      .not("status", "in", `(${CLOSED_LINE_STATUSES.map((status) => `'${status}'`).join(",")})`)
-      .not("assigned_tech_id", "is", null)
-      .order("updated_at", { ascending: false })
-      .limit(400),
+    scopedActiveLinesQuery,
     supabase
       .from("invoices")
       .select("total,labor_cost,created_at")
@@ -176,7 +195,29 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   ]);
 
   const boardRows = boardResult.error ? [] : boardResult.data ?? [];
-  const activeBoardRows = boardRows.filter((row) => row.overall_stage !== "completed");
+  const activeLines = activeLinesResult.error ? [] : activeLinesResult.data ?? [];
+  const scopedWorkOrderIds = new Set<string>();
+
+  if (isTechnicianScoped) {
+    const approvalRows = approvalsResult.error ? [] : approvalsResult.data ?? [];
+    const partRows = partsResult.error ? [] : partsResult.data ?? [];
+
+    for (const row of approvalRows) {
+      if (row.work_order_id) scopedWorkOrderIds.add(row.work_order_id);
+    }
+    for (const row of partRows) {
+      if (row.work_order_id) scopedWorkOrderIds.add(row.work_order_id);
+    }
+  }
+
+  for (const row of activeLines) {
+    if (row.work_order_id) scopedWorkOrderIds.add(row.work_order_id);
+  }
+
+  const boardRowsForViewer = isTechnicianScoped
+    ? boardRows.filter((row) => scopedWorkOrderIds.has(row.work_order_id))
+    : boardRows;
+  const activeBoardRows = boardRowsForViewer.filter((row) => row.overall_stage !== "completed");
   const mostRecentBlockedWorkOrderId =
     activeBoardRows.find(
       (row) => row.overall_stage === "waiting_parts" || row.overall_stage === "on_hold",
@@ -281,21 +322,21 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
 
   payload.blockerStack = [
     {
-      label: "Approvals pending",
+      label: isTechnicianScoped ? "My approvals pending" : "Approvals pending",
       value: String(payload.topSummary.waitingApprovals),
       tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
       href: approvalTargetHref,
       targetKind: approvalTargetKind,
     },
     {
-      label: "Waiting parts",
+      label: isTechnicianScoped ? "My waiting parts" : "Waiting parts",
       value: String(payload.topSummary.waitingParts),
       tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
       href: waitingPartsTargetHref,
       targetKind: waitingPartsTargetKind,
     },
     {
-      label: "On hold / blocked",
+      label: isTechnicianScoped ? "My blocked jobs" : "On hold / blocked",
       value: String(payload.topSummary.blockedJobs),
       tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default",
       href: blockedTargetHref,
@@ -307,30 +348,48 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     payload.sectionErrors.push(`Daily summary section: ${bookingsTodayResult.error.message}`);
   }
 
-  payload.dailySummary = [
-    { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
-    {
-      label: "Approval queue",
-      value: String(payload.topSummary.waitingApprovals),
-      tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
-      href: approvalTargetHref,
-      targetKind: approvalTargetKind,
-    },
-    {
-      label: "Parts waiting",
-      value: String(payload.topSummary.waitingParts),
-      tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
-      href: waitingPartsTargetHref,
-      targetKind: waitingPartsTargetKind,
-    },
-    { label: "Active board", value: String(payload.topSummary.activeJobs) },
-  ];
+  payload.dailySummary = isTechnicianScoped
+    ? [
+        { label: "My queue", value: String(payload.topSummary.activeJobs) },
+        {
+          label: "My approvals",
+          value: String(payload.topSummary.waitingApprovals),
+          tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
+          href: approvalTargetHref,
+          targetKind: approvalTargetKind,
+        },
+        {
+          label: "My parts delays",
+          value: String(payload.topSummary.waitingParts),
+          tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
+          href: waitingPartsTargetHref,
+          targetKind: waitingPartsTargetKind,
+        },
+        { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
+      ]
+    : [
+        { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
+        {
+          label: "Approval queue",
+          value: String(payload.topSummary.waitingApprovals),
+          tone: payload.topSummary.waitingApprovals > 0 ? "accent" : "default",
+          href: approvalTargetHref,
+          targetKind: approvalTargetKind,
+        },
+        {
+          label: "Parts waiting",
+          value: String(payload.topSummary.waitingParts),
+          tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
+          href: waitingPartsTargetHref,
+          targetKind: waitingPartsTargetKind,
+        },
+        { label: "Active board", value: String(payload.topSummary.activeJobs) },
+      ];
 
   if (techProfilesResult.error || activeLinesResult.error) {
     payload.sectionErrors.push("Technician activity section is degraded due to query failures.");
   } else {
     const techs = techProfilesResult.data ?? [];
-    const activeLines = activeLinesResult.data ?? [];
     const counts = new Map<string, { activeLines: number; latestStatus: string; lastUpdated: string | null }>();
 
     activeLines.forEach((line) => {
@@ -344,7 +403,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     });
 
     const maxLines = Math.max(1, ...[...counts.values()].map((entry) => entry.activeLines));
-    payload.technicianActivity = techs
+    const technicianRows = techs
       .map((tech) => {
         const activity = counts.get(tech.id);
         return {
@@ -355,93 +414,142 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           elapsed: elapsedLabel(activity?.lastUpdated ?? null),
           utilizationPct: asPct(activity?.activeLines ?? 0, maxLines),
         };
-      })
-      .sort((a, b) => b.activeLines - a.activeLines)
-      .slice(0, 6);
+      });
+
+    payload.technicianActivity = isTechnicianScoped
+      ? technicianRows.filter((tech) => tech.id === identity.userId)
+      : technicianRows.sort((a, b) => b.activeLines - a.activeLines).slice(0, 6);
   }
 
   payload.alerts = [
     payload.topSummary.blockedJobs > 0
       ? {
-          label: "Blocked jobs climbing",
-          detail: `${payload.topSummary.blockedJobs} jobs currently in blocked stages.`,
+          label: isTechnicianScoped ? "My blocked jobs need action" : "Blocked jobs climbing",
+          detail: isTechnicianScoped
+            ? `${payload.topSummary.blockedJobs} of your assigned jobs are currently blocked.`
+            : `${payload.topSummary.blockedJobs} jobs currently in blocked stages.`,
           tone: "critical",
           href: blockedTargetHref,
           targetKind: blockedTargetKind,
         }
       : {
-          label: "Blocker pressure stable",
-          detail: "No blocked stage spike detected.",
+          label: isTechnicianScoped ? "My blocker pressure stable" : "Blocker pressure stable",
+          detail: isTechnicianScoped
+            ? "None of your assigned jobs are currently blocked."
+            : "No blocked stage spike detected.",
           tone: "info",
           href: "/work-orders/board?stage=on_hold",
           targetKind: "filtered",
         },
     payload.topSummary.waitingApprovals > 3
       ? {
-          label: "Approval queue aging",
-          detail: `${payload.topSummary.waitingApprovals} approvals need advisor follow-up.`,
+          label: isTechnicianScoped ? "My approvals are aging" : "Approval queue aging",
+          detail: isTechnicianScoped
+            ? `${payload.topSummary.waitingApprovals} of your lines need approval follow-up.`
+            : `${payload.topSummary.waitingApprovals} approvals need advisor follow-up.`,
           tone: "warning",
           href: approvalTargetHref,
           targetKind: approvalTargetKind,
         }
       : {
-          label: "Approval queue healthy",
-          detail: "Approval queue is below action threshold.",
+          label: isTechnicianScoped ? "My approval queue healthy" : "Approval queue healthy",
+          detail: isTechnicianScoped
+            ? "Your approval-dependent lines are below action threshold."
+            : "Approval queue is below action threshold.",
           tone: "info",
           href: "/work-orders/board?stage=awaiting_approval",
           targetKind: "filtered",
         },
     payload.topSummary.waitingParts > 0
       ? {
-          label: "Parts constraints active",
-          detail: `${payload.topSummary.waitingParts} open part requests still unresolved.`,
+          label: isTechnicianScoped ? "My parts constraints active" : "Parts constraints active",
+          detail: isTechnicianScoped
+            ? `${payload.topSummary.waitingParts} of your part requests are still unresolved.`
+            : `${payload.topSummary.waitingParts} open part requests still unresolved.`,
           tone: "warning",
           href: waitingPartsTargetHref,
           targetKind: waitingPartsTargetKind,
         }
       : {
-          label: "No parts constraints",
-          detail: "Parts flow is currently clear.",
+          label: isTechnicianScoped ? "No parts constraints on my work" : "No parts constraints",
+          detail: isTechnicianScoped
+            ? "Your assigned jobs currently have no open parts blockers."
+            : "Parts flow is currently clear.",
           tone: "info",
           href: "/parts/requests?status=requested,quoted,approved",
           targetKind: "filtered",
         },
   ];
 
-  payload.suggestedActions = [
-    payload.topSummary.waitingApprovals > 0
-      ? {
-          label: "Clear approval queue",
-          href: approvalTargetHref,
-          tone: "primary",
-          detail: "Prioritize pending approvals to free advisor handoffs.",
-        }
-      : {
-          label: "Review active board",
-          href: "/work-orders/board",
+  payload.suggestedActions = isTechnicianScoped
+    ? [
+        payload.topSummary.waitingParts > 0
+          ? {
+              label: "Follow up on my parts",
+              href: waitingPartsTargetHref,
+              tone: "primary",
+              detail: "Parts delays are blocking your assigned work.",
+            }
+          : {
+              label: "Open my active board",
+              href: "/work-orders/board",
+              tone: "neutral",
+              detail: "Review your assigned jobs and move the next line forward.",
+            },
+        payload.topSummary.waitingApprovals > 0
+          ? {
+              label: "Nudge approvals",
+              href: approvalTargetHref,
+              tone: "primary",
+              detail: "Pending approvals are holding your active lines.",
+            }
+          : {
+              label: "Update next job status",
+              href: "/work-orders/board",
+              tone: "neutral",
+              detail: "Keep your queue moving with clear status updates.",
+            },
+        {
+          label: "Check dispatch notes",
+          href: "/dashboard/manager/dispatch",
           tone: "neutral",
-          detail: "No immediate queue pressure detected.",
+          detail: "Confirm assignment updates and immediate next actions.",
         },
-    payload.topSummary.waitingParts > 0
-      ? {
-          label: "Resolve waiting parts",
-          href: waitingPartsTargetHref,
-          tone: "primary",
-          detail: "Parts backlog is blocking active jobs.",
-        }
-      : {
-          label: "Create work order",
-          href: "/work-orders/create",
+      ]
+    : [
+        payload.topSummary.waitingApprovals > 0
+          ? {
+              label: "Clear approval queue",
+              href: approvalTargetHref,
+              tone: "primary",
+              detail: "Prioritize pending approvals to free advisor handoffs.",
+            }
+          : {
+              label: "Review active board",
+              href: "/work-orders/board",
+              tone: "neutral",
+              detail: "No immediate queue pressure detected.",
+            },
+        payload.topSummary.waitingParts > 0
+          ? {
+              label: "Resolve waiting parts",
+              href: waitingPartsTargetHref,
+              tone: "primary",
+              detail: "Parts backlog is blocking active jobs.",
+            }
+          : {
+              label: "Create work order",
+              href: "/work-orders/create",
+              tone: "neutral",
+              detail: "Keep bay utilization steady with next intake.",
+            },
+        {
+          label: "Open dispatch view",
+          href: "/dashboard/manager/dispatch",
           tone: "neutral",
-          detail: "Keep bay utilization steady with next intake.",
+          detail: "Review technician assignment and bay balancing.",
         },
-    {
-      label: "Open dispatch view",
-      href: "/dashboard/manager/dispatch",
-      tone: "neutral",
-      detail: "Review technician assignment and bay balancing.",
-    },
-  ];
+      ];
 
   if (invoicesMonthResult.error) {
     payload.sectionErrors.push(`Revenue snapshot section: ${invoicesMonthResult.error.message}`);


### PR DESCRIPTION
### Motivation
- Prevent the Shop Boost "Migration Mission Control" panel from appearing for users who are not owners/admins and avoid irrelevant migration noise on non-owner dashboards.
- Make the technician operations view truly user-scoped so technicians see their assigned queue, parts/approval blockers, and personal suggested actions instead of shop-wide surfaces.
- Keep changes minimal and localized to payload composition and rendering eligibility without touching global auth, RLS, or dashboard architecture.

### Description
- Gate Shop Boost rendering in `OperationsDashboardView` so the `ShopBoostActivationPanel` is mounted only for owner/admin roles and pass an `eligible` flag to avoid unnecessary fetches. (app/dashboard/_components/OperationsDashboardView.tsx)
- Add relevance/eligibility logic to `ShopBoostActivationPanel` so it only fetches/renders when meaningful: supports `full`, `summary` (recent completion within 14 days) and `hidden` modes, and returns early when `eligible` is false. (features/dashboard/components/ShopBoostActivationPanel.tsx)
- Introduce technician scoping in server payload: detect technician roles, add `viewerScope` to the payload, and run scoped queries for approvals, part requests, and active lines when technician-scoped. (features/dashboard/server/getOperationsDashboardPayload.ts)
- Compose a technician-focused view server-side by filtering board rows to only work orders relevant to the signed-in technician, adjusting `dailySummary`, `blockerStack`, `alerts`, and `suggestedActions` to use personal labels and targets, and producing technician-only `technicianActivity`. (features/dashboard/server/getOperationsDashboardPayload.ts)
- Update UI labels/titles/subtitles in the operations view to reflect a personal "Technician Dashboard" when `viewerScope` is `technician`. (app/dashboard/_components/OperationsDashboardView.tsx)
- Changes are limited to three files and only touch the composition/payload and rendering logic as scoped above.

### Testing
- Ran TypeScript typecheck with `npx tsc --noEmit` which failed due to pre-existing unrelated duplicate identifier errors in generated Supabase types (`features/shared/types/types/supabase.ts`), so no type regressions were introduced by this patch were fixed in scope. (result: failed — pre-existing)
- Ran ESLint targeted at the modified files with `npx eslint app/dashboard/_components/OperationsDashboardView.tsx features/dashboard/components/ShopBoostActivationPanel.tsx features/dashboard/server/getOperationsDashboardPayload.ts` and it completed successfully. (result: passed)
- Verified changes committed: updated `app/dashboard/_components/OperationsDashboardView.tsx`, `features/dashboard/components/ShopBoostActivationPanel.tsx`, and `features/dashboard/server/getOperationsDashboardPayload.ts` and committed with message "Constrain Shop Boost visibility and scope technician operations payload". (result: committed)

Files changed: `app/dashboard/_components/OperationsDashboardView.tsx`, `features/dashboard/components/ShopBoostActivationPanel.tsx`, `features/dashboard/server/getOperationsDashboardPayload.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e019a3319483288f481ece8846efa3)