### PR TITLE
Phase 1 mobile alignment fixes: canonical RBAC, scoped paths, and API-safe mutations

### DIFF
--- a/app/api/mobile/home-payload/route.ts
+++ b/app/api/mobile/home-payload/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getMobileHomePayload } from "@/features/mobile/dashboard/server/getMobileHomePayload";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const payload = await getMobileHomePayload();
+    return NextResponse.json({ ok: true, payload });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load mobile dashboard payload";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/mobile/shifts/route.ts
+++ b/app/api/mobile/shifts/route.ts
@@ -1,0 +1,165 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+type Action = "start_shift" | "end_shift" | "toggle_break" | "toggle_lunch";
+
+type ShiftMode = "none" | "shift" | "break" | "lunch" | "ended";
+
+type Caller = { id: string; shop_id: string | null };
+
+async function authz() {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { ok: false as const, res: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+  }
+
+  const { data: me } = await supabase
+    .from("profiles")
+    .select("id, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<Caller>();
+
+  if (!me?.shop_id) {
+    return { ok: false as const, res: NextResponse.json({ error: "Missing shop" }, { status: 403 }) };
+  }
+
+  return { ok: true as const, me };
+}
+
+async function loadOpenShift(admin: ReturnType<typeof createAdminSupabase>, userId: string, shopId: string) {
+  const { data } = await admin
+    .from("tech_shifts")
+    .select("id,start_time,type,status,end_time")
+    .eq("shop_id", shopId)
+    .eq("user_id", userId)
+    .eq("status", "open")
+    .is("end_time", null)
+    .order("start_time", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return data ?? null;
+}
+
+export async function POST(req: NextRequest) {
+  const a = await authz();
+  if (!a.ok) return a.res;
+
+  const body = (await req.json().catch(() => null)) as { action?: Action } | null;
+  if (!body?.action) {
+    return NextResponse.json({ error: "Missing action" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const now = new Date().toISOString();
+  const shopId = a.me.shop_id;
+  if (!shopId) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 403 });
+  }
+  const current = await loadOpenShift(admin, a.me.id, shopId);
+
+  const insertPunch = async (shiftId: string, eventType: Action | "break_end" | "lunch_end") => {
+    const mapped = eventType === "toggle_break" ? "break_start" : eventType === "toggle_lunch" ? "lunch_start" : eventType;
+    await admin.from("punch_events").insert({
+      shift_id: shiftId,
+      event_type: mapped,
+      timestamp: now,
+    });
+  };
+
+  if (body.action === "start_shift") {
+    if (current) {
+      return NextResponse.json({ ok: true, shiftId: current.id, startTime: current.start_time, mode: "shift" as ShiftMode });
+    }
+
+    const { data, error } = await admin
+      .from("tech_shifts")
+      .insert({
+        shop_id: shopId,
+        user_id: a.me.id,
+        start_time: now,
+        end_time: null,
+        type: "shift",
+        status: "open",
+      })
+      .select("id,start_time")
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ error: error?.message ?? "Failed to start shift" }, { status: 500 });
+    }
+
+    await insertPunch(data.id, "start_shift");
+    return NextResponse.json({ ok: true, shiftId: data.id, startTime: data.start_time, mode: "shift" as ShiftMode });
+  }
+
+  if (!current) {
+    return NextResponse.json({ error: "Open shift not found" }, { status: 409 });
+  }
+
+  if (body.action === "end_shift") {
+    await admin
+      .from("work_order_lines")
+      .update({ punched_out_at: now })
+      .eq("shop_id", shopId)
+      .eq("assigned_tech_id", a.me.id)
+      .not("punched_in_at", "is", null)
+      .is("punched_out_at", null)
+      .neq("status", "completed");
+
+    const { error } = await admin
+      .from("tech_shifts")
+      .update({ end_time: now, status: "closed", type: "shift" })
+      .eq("id", current.id)
+      .eq("shop_id", shopId)
+      .eq("user_id", a.me.id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    await insertPunch(current.id, "end_shift");
+    return NextResponse.json({ ok: true, shiftId: null, startTime: null, mode: "ended" as ShiftMode });
+  }
+
+  if (body.action === "toggle_break") {
+    const isEnding = current.type === "break";
+    const { error } = await admin
+      .from("tech_shifts")
+      .update({ type: isEnding ? "shift" : "break", status: "open" })
+      .eq("id", current.id)
+      .eq("shop_id", shopId)
+      .eq("user_id", a.me.id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    await insertPunch(current.id, isEnding ? "break_end" : "toggle_break");
+    return NextResponse.json({ ok: true, shiftId: current.id, startTime: current.start_time, mode: (isEnding ? "shift" : "break") as ShiftMode });
+  }
+
+  if (body.action === "toggle_lunch") {
+    const isEnding = current.type === "lunch";
+    const { error } = await admin
+      .from("tech_shifts")
+      .update({ type: isEnding ? "shift" : "lunch", status: "open" })
+      .eq("id", current.id)
+      .eq("shop_id", shopId)
+      .eq("user_id", a.me.id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    await insertPunch(current.id, isEnding ? "lunch_end" : "toggle_lunch");
+    return NextResponse.json({ ok: true, shiftId: current.id, startTime: current.start_time, mode: (isEnding ? "shift" : "lunch") as ShiftMode });
+  }
+
+  return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+}

--- a/app/api/work-orders/quotes/[id]/decline/route.ts
+++ b/app/api/work-orders/quotes/[id]/decline/route.ts
@@ -1,0 +1,73 @@
+import "server-only";
+import { NextResponse, type NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+export const runtime = "nodejs";
+
+type DB = Database;
+
+export async function POST(req: NextRequest) {
+  const supabase = createRouteHandlerClient<DB>({ cookies });
+
+  try {
+    const {
+      data: { user },
+      error: authErr,
+    } = await supabase.auth.getUser();
+    if (authErr || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("shop_id, role")
+      .eq("id", user.id)
+      .single();
+
+    if (profileErr || !profile?.shop_id) {
+      return NextResponse.json({ error: "Unable to resolve actor profile" }, { status: 403 });
+    }
+
+    const actor = getActorCapabilities({ role: profile.role });
+    if (!actor.isKnownRole || !actor.canAuthorizeQuotes) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const segments = req.nextUrl.pathname.split("/").filter(Boolean);
+    const id = segments[segments.length - 2];
+
+    if (!id) {
+      return NextResponse.json({ error: "Missing quote line id" }, { status: 400 });
+    }
+
+    const { data: q, error: qErr } = await supabase
+      .from("work_order_quote_lines")
+      .select("id,shop_id")
+      .eq("id", id)
+      .single();
+
+    if (qErr || !q) {
+      return NextResponse.json({ error: "Quote line not found" }, { status: 404 });
+    }
+
+    if (q.shop_id !== profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { error: updErr } = await supabase
+      .from("work_order_quote_lines")
+      .update({ status: "declined", declined_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq("id", id);
+
+    if (updErr) {
+      return NextResponse.json({ error: updErr.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Failed to decline quote" }, { status: 500 });
+  }
+}

--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { canonicalizeRole, getActorCapabilities } from "@/features/shared/lib/rbac";
 
 import {
   MobileTechHome,
@@ -68,11 +69,6 @@ function calcEfficiencyPct(worked: number, billed: number): number | null {
   return (billed / worked) * 100;
 }
 
-function isTechRole(role: string | null): boolean {
-  const r = (role ?? "").trim().toLowerCase();
-  return r === "mechanic" || r === "tech" || r === "technician";
-}
-
 export default function MobileHome() {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
@@ -83,6 +79,11 @@ export default function MobileHome() {
   const [stats, setStats] = useState<MobileTechStats | null>(null);
   const [jobs, setJobs] = useState<MobileTechJob[]>([]);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [homePayload, setHomePayload] = useState<{
+    advisor: { awaitingApprovals: number; waiters: number; callbacks: number };
+    manager: { activeWos: number; waiters: number; techniciansOnShift: number };
+    leadhand: { techsOnShift: number; jobsInProgress: number; jobsBlocked: number };
+  } | null>(null);
 
   // Load profile + shop
   useEffect(() => {
@@ -127,7 +128,8 @@ export default function MobileHome() {
   useEffect(() => {
     const loadStats = async () => {
       if (!profile?.id) return;
-      if (!isTechRole(profile.role)) return;
+      const actor = getActorCapabilities({ role: profile.role });
+      if (actor.canonicalRole !== "mechanic") return;
 
       setStatsLoading(true);
       try {
@@ -283,7 +285,7 @@ export default function MobileHome() {
               id: String(l.id),
               label: base,
               status: String(l.status ?? "in_progress"),
-              href: `/mobile/work-orders?focus=${l.id}`,
+              href: "/mobile/tech/queue",
             };
           }) ?? [];
 
@@ -313,7 +315,30 @@ export default function MobileHome() {
     void loadStats();
   }, [profile, supabase]);
 
-  const role = (profile?.role ?? null) as MobileRole | null;
+  useEffect(() => {
+    const loadPayload = async () => {
+      const res = await fetch("/api/mobile/home-payload", { method: "GET" });
+      const json = (await res.json().catch(() => null)) as
+        | {
+            ok?: boolean;
+            payload?: {
+              advisor: { awaitingApprovals: number; waiters: number; callbacks: number };
+              manager: { activeWos: number; waiters: number; techniciansOnShift: number };
+              leadhand: { techsOnShift: number; jobsInProgress: number; jobsBlocked: number };
+            };
+          }
+        | null;
+      if (res.ok && json?.ok && json.payload) {
+        setHomePayload(json.payload);
+      }
+    };
+
+    if (!profile?.id) return;
+    void loadPayload();
+  }, [profile?.id]);
+
+  const canonicalRole = canonicalizeRole(profile?.role);
+  const role = (canonicalRole === "unknown" ? null : canonicalRole) as MobileRole | null;
   const userName = profile?.full_name ?? null;
   const shopName = shop?.name ?? null;
 
@@ -339,7 +364,7 @@ export default function MobileHome() {
   /* Role-specific mobile home pages                                    */
   /* ------------------------------------------------------------------ */
 
-  if (profile && isTechRole(role)) {
+  if (profile && canonicalRole === "mechanic") {
     return (
       <main className="min-h-screen bg-black text-white">
         <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
@@ -362,36 +387,35 @@ export default function MobileHome() {
           <MobileAdvisorHome
             advisorName={profile.full_name || "Advisor"}
             role="advisor"
+            stats={homePayload?.advisor}
           />
         </div>
       </main>
     );
   }
 
-  if (
-    profile &&
-    (role === "manager" || role === "owner" || role === "admin")
-  ) {
+  if (profile && (role === "manager" || role === "owner" || role === "admin")) {
     return (
       <main className="min-h-screen bg-black text-white">
         <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
           <MobileManagerHome
             managerName={profile.full_name || "Manager"}
             role={role}
+            stats={homePayload?.manager}
           />
         </div>
       </main>
     );
   }
 
-  // optional: if you’re using a separate "lead hand" MobileRole mapped from profiles
-  if (profile && (role as string) === "lead_hand") {
+  if (profile && role === "lead_hand") {
     return (
       <main className="min-h-screen bg-black text-white">
         <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
           <MobileLeadHome
             leadName={profile.full_name || "Lead"}
-            role={role as MobileRole}
+            role={role}
+            stats={homePayload?.leadhand}
           />
         </div>
       </main>

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -5,6 +5,11 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { canonicalizeRole, getActorCapabilities } from "@/features/shared/lib/rbac";
+import {
+  getMobileTilesForRole,
+  type MobileRole,
+} from "@/features/mobile/config/mobile-tiles";
 
 import MobileShiftTracker from "@/features/mobile/components/MobileShiftTracker";
 
@@ -14,13 +19,6 @@ type NavItem = {
   href: string;
   label: string;
 };
-
-const NAV_ITEMS: NavItem[] = [
-  { href: "/mobile", label: "Home" },
-  { href: "/mobile/work-orders", label: "Jobs" },
-  { href: "/mobile/messages", label: "Inbox" },
-  { href: "/mobile/settings", label: "Me" },
-];
 
 type Props = {
   open: boolean;
@@ -79,6 +77,7 @@ export function MobileBottomNav({ open, onClose }: Props) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
+  const [role, setRole] = useState<MobileRole | null>(null);
 
   /* ---------------------------------------------------------------------- */
   /* Load current user – shift logic is handled inside MobileShiftTracker   */
@@ -91,10 +90,43 @@ export function MobileBottomNav({ open, onClose }: Props) {
 
       const id = session?.user?.id ?? null;
       setUserId(id);
+      if (!id) {
+        setRole(null);
+        return;
+      }
+
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", id)
+        .maybeSingle();
+
+      const actor = getActorCapabilities({ role: profile?.role ?? null });
+      const canonicalRole = canonicalizeRole(profile?.role ?? null);
+      const allowedRole = actor.isKnownRole ? canonicalRole : null;
+      setRole((allowedRole === "unknown" ? null : allowedRole) as MobileRole | null);
     };
 
     void load();
   }, [supabase]);
+
+  const navItems = useMemo<NavItem[]>(() => {
+    if (!role) {
+      return [
+        { href: "/mobile", label: "Home" },
+        { href: "/mobile/settings", label: "Me" },
+      ];
+    }
+
+    const primary = getMobileTilesForRole(role, ["home"]).slice(0, 2);
+    const dynamic = primary.map((tile) => ({
+      href: tile.href,
+      label: tile.title,
+    }));
+
+    const items = [{ href: "/mobile", label: "Home" }, ...dynamic, { href: "/mobile/settings", label: "Me" }];
+    return items.filter((item, index) => items.findIndex((x) => x.href === item.href) === index);
+  }, [role]);
 
   /* ---------------------------------------------------------------------- */
   /* UI – Slide-in drawer                                                    */
@@ -152,7 +184,7 @@ export function MobileBottomNav({ open, onClose }: Props) {
         <nav className="flex-1 overflow-y-auto px-2 py-3">
           <NavSection
             title="Mobile"
-            items={NAV_ITEMS}
+            items={navItems}
             pathname={pathname}
             onClose={onClose}
           />

--- a/features/mobile/components/MobileRoleHub.tsx
+++ b/features/mobile/components/MobileRoleHub.tsx
@@ -4,7 +4,7 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import {
-  MOBILE_TILES,
+  getMobileTilesForRole,
   type MobileRole,
   type MobileScope,
 } from "@/features/mobile/config/mobile-tiles";
@@ -23,12 +23,7 @@ export function MobileRoleHub({
   subtitle,
 }: Props) {
   const tiles = useMemo(
-    () =>
-      MOBILE_TILES.filter(
-        (tile) =>
-          tile.roles.includes(role) &&
-          tile.scopes.some((s) => scopes.includes(s)),
-      ),
+    () => getMobileTilesForRole(role, scopes),
     [role, scopes],
   );
 

--- a/features/mobile/components/MobileShiftTracker.tsx
+++ b/features/mobile/components/MobileShiftTracker.tsx
@@ -5,7 +5,6 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { formatDistanceToNow } from "date-fns";
 import type { Database } from "@shared/types/types/supabase";
 import {
-  runMutationWithOfflineQueue,
   getOfflineSyncSummary,
   replayQueuedMutations,
   subscribeOfflineMutations,
@@ -51,48 +50,6 @@ export default function MobileShiftTracker({ userId }: Props) {
     return subscribeOfflineMutations(refreshOfflineSummary);
   }, [refreshOfflineSummary]);
 
-  const insertPunch = useCallback(
-    async (sid: string, event: PunchEventType) => {
-      const timestamp = new Date().toISOString();
-      const mutationId =
-        typeof crypto !== "undefined" && "randomUUID" in crypto
-          ? crypto.randomUUID()
-          : `${sid}:${event}:${Date.now()}`;
-
-      try {
-        const result = await runMutationWithOfflineQueue({
-          clientMutationId: mutationId,
-          actionType: "shift:punch-event",
-          payload: {
-            shift_id: sid,
-            user_id: userId,
-            profile_id: userId,
-            event_type: event,
-            timestamp,
-          },
-          runner: async () => {
-            const { error } = await supabase.from("punch_events").insert({
-              shift_id: sid,
-              user_id: userId,
-              profile_id: userId,
-              event_type: event,
-              timestamp,
-            });
-            if (error) throw error;
-          },
-        });
-        if (result.queued) {
-          setErr("Punch event queued for sync once connection is restored.");
-        }
-      } catch (error) {
-        const e = error as { code?: string; message?: string };
-        console.error("[MobileShiftTracker] insertPunch failed:", error);
-        setErr(`${e.code ?? "punch_error"}: ${e.message ?? "Failed to record punch event"}`);
-      }
-    },
-    [supabase, userId],
-  );
-
   const replayOfflineMutations = useCallback(async () => {
     const result = await replayQueuedMutations({
       handlers: {
@@ -109,14 +66,19 @@ export default function MobileShiftTracker({ userId }: Props) {
           if (!payload?.shift_id || !payload?.user_id || !payload?.event_type || !payload?.timestamp) {
             return { conflicted: "Queued shift punch payload is incomplete." };
           }
-          const { error } = await supabase.from("punch_events").insert({
-            shift_id: payload.shift_id,
-            user_id: payload.user_id,
-            profile_id: payload.profile_id ?? payload.user_id,
-            event_type: payload.event_type,
-            timestamp: payload.timestamp,
+          const res = await fetch("/api/scheduling/punches", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              shift_id: payload.shift_id,
+              event_type: payload.event_type,
+              timestamp: payload.timestamp,
+            }),
           });
-          if (error) throw error;
+          if (!res.ok) {
+            const body = (await res.json().catch(() => null)) as { error?: string } | null;
+            throw new Error(body?.error ?? "Failed to replay punch event");
+          }
         },
       },
     });
@@ -125,23 +87,6 @@ export default function MobileShiftTracker({ userId }: Props) {
       setErr(`${result.failed} queued punch event(s) still failing to sync.`);
     }
   }, [supabase]);
-
-  const punchOutActiveJobsForShiftEnd = useCallback(async () => {
-    if (!userId) return;
-
-    const nowIso = new Date().toISOString();
-    const { error } = await supabase
-      .from("work_order_lines")
-      .update({ punched_out_at: nowIso })
-      .eq("assigned_tech_id", userId)
-      .not("punched_in_at", "is", null)
-      .is("punched_out_at", null)
-      .neq("status", "completed");
-
-    if (error) {
-      console.warn("[MobileShiftTracker] failed to close active job punches on shift end:", error);
-    }
-  }, [supabase, userId]);
 
   const loadOpenShift = useCallback(async () => {
     if (!userId) return;
@@ -241,51 +186,25 @@ export default function MobileShiftTracker({ userId }: Props) {
     setErr(null);
 
     try {
-      const { data: existing, error: exErr } = await supabase
-        .from("tech_shifts")
-        .select("id, start_time")
-        .eq("user_id", userId)
-        .eq("status", "open")
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      const res = await fetch("/api/mobile/shifts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "start_shift" }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; shiftId?: string | null; startTime?: string | null; mode?: Mode }
+        | null;
+      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to start shift");
 
-      if (exErr) throw exErr;
-
-      if (existing) {
-        setShiftId(existing.id);
-        setStartTime(existing.start_time ?? null);
-        setMode("shift");
-        return;
-      }
-
-      const now = new Date().toISOString();
-
-      const { data, error } = await supabase
-        .from("tech_shifts")
-        .insert({
-          user_id: userId,
-          start_time: now,
-          type: "shift",
-          status: "open",
-          end_time: null,
-        })
-        .select("id, start_time")
-        .single();
-
-      if (error) throw error;
-
-      setShiftId(data.id);
-      setStartTime(data.start_time ?? now);
-      setMode("shift");
-
-      await insertPunch(data.id, "start_shift");
+      setShiftId(body.shiftId ?? null);
+      setStartTime(body.startTime ?? null);
+      setMode(body.mode ?? "shift");
     } catch (e: any) {
       setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to start shift"}`);
     } finally {
       setBusy(false);
     }
-  }, [busy, supabase, userId, insertPunch]);
+  }, [busy, userId]);
 
   const endShift = useCallback(async () => {
     if (busy || !shiftId) return;
@@ -293,29 +212,26 @@ export default function MobileShiftTracker({ userId }: Props) {
     setErr(null);
 
     try {
-      const now = new Date().toISOString();
-
-      await punchOutActiveJobsForShiftEnd();
-
-      const { error } = await supabase
-        .from("tech_shifts")
-        .update({ end_time: now, status: "closed", type: "shift" })
-        .eq("id", shiftId);
-
-      if (error) throw error;
-
-      await insertPunch(shiftId, "end_shift");
+      const res = await fetch("/api/mobile/shifts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "end_shift" }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; shiftId?: string | null; startTime?: string | null; mode?: Mode }
+        | null;
+      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to end shift");
       window.dispatchEvent(new CustomEvent("wol:refresh"));
 
-      setShiftId(null);
-      setStartTime(null);
-      setMode("ended");
+      setShiftId(body.shiftId ?? null);
+      setStartTime(body.startTime ?? null);
+      setMode(body.mode ?? "ended");
     } catch (e: any) {
       setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to end shift"}`);
     } finally {
       setBusy(false);
     }
-  }, [busy, supabase, shiftId, insertPunch, punchOutActiveJobsForShiftEnd]);
+  }, [busy, shiftId]);
 
   const toggleBreak = useCallback(async () => {
     if (busy || !shiftId) return;
@@ -323,24 +239,22 @@ export default function MobileShiftTracker({ userId }: Props) {
     setErr(null);
 
     try {
-      const isEnding = mode === "break";
-      const nextType: ShiftType = isEnding ? "shift" : "break";
-
-      const { error } = await supabase
-        .from("tech_shifts")
-        .update({ type: nextType, status: "open" })
-        .eq("id", shiftId);
-
-      if (error) throw error;
-
-      await insertPunch(shiftId, isEnding ? "break_end" : "break_start");
-      setMode(nextType);
+      const res = await fetch("/api/mobile/shifts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "toggle_break" }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; mode?: Mode }
+        | null;
+      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to toggle break");
+      setMode(body.mode ?? "shift");
     } catch (e: any) {
       setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to toggle break"}`);
     } finally {
       setBusy(false);
     }
-  }, [busy, supabase, shiftId, mode, insertPunch]);
+  }, [busy, shiftId]);
 
   const toggleLunch = useCallback(async () => {
     if (busy || !shiftId) return;
@@ -348,24 +262,22 @@ export default function MobileShiftTracker({ userId }: Props) {
     setErr(null);
 
     try {
-      const isEnding = mode === "lunch";
-      const nextType: ShiftType = isEnding ? "shift" : "lunch";
-
-      const { error } = await supabase
-        .from("tech_shifts")
-        .update({ type: nextType, status: "open" })
-        .eq("id", shiftId);
-
-      if (error) throw error;
-
-      await insertPunch(shiftId, isEnding ? "lunch_end" : "lunch_start");
-      setMode(nextType);
+      const res = await fetch("/api/mobile/shifts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "toggle_lunch" }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; mode?: Mode }
+        | null;
+      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to toggle lunch");
+      setMode(body.mode ?? "shift");
     } catch (e: any) {
       setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to toggle lunch"}`);
     } finally {
       setBusy(false);
     }
-  }, [busy, supabase, shiftId, mode, insertPunch]);
+  }, [busy, shiftId]);
 
   const niceStatus =
     mode === "none" ? "Off shift" : mode === "ended" ? "Shift ended" : mode;

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -1,15 +1,19 @@
 // features/mobile/config/mobile-tiles.ts
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
 
-export type MobileRole =
+export type MobileRole = Extract<
+  CanonicalRole,
   | "owner"
   | "admin"
   | "manager"
   | "advisor"
   | "mechanic"
+  | "lead_hand"
   | "parts"
   | "driver"
   | "dispatcher"
-  | "fleet_manager";
+  | "fleet_manager"
+>;
 
 export type MobileScope =
   | "home"
@@ -35,17 +39,24 @@ export type MobileTile = {
 
 export const MOBILE_TILES: MobileTile[] = [
   {
-    href: "/mobile/work-orders",
+    href: "/mobile/tech/queue",
     title: "My Jobs",
     subtitle: "Assigned work orders",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic"],
+    scopes: ["home", "jobs", "work_orders", "all"],
+  },
+  {
+    href: "/mobile/work-orders",
+    title: "Work Orders",
+    subtitle: "Shop work order board",
+    roles: ["manager", "lead_hand", "advisor", "owner", "admin"],
     scopes: ["home", "jobs", "work_orders", "all"],
   },
   {
     href: "/mobile/inspections",
     title: "Inspections",
     subtitle: "Run checklists on vehicles",
-    roles: ["mechanic", "advisor", "manager"],
+    roles: ["mechanic", "advisor", "manager", "lead_hand"],
     scopes: ["home", "inspect", "inspections", "work_orders", "all"],
   },
   // 🔁 Planner → Appointments (mobile day planner)
@@ -53,21 +64,21 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/appointments",
     title: "Appointments",
     subtitle: "Today’s schedule",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic", "manager", "lead_hand", "owner", "admin"],
     scopes: ["home", "appointments", "work_orders", "all"],
   },
   {
     href: "/mobile/messages",
     title: "Team Chat",
     subtitle: "Stay in sync",
-    roles: ["mechanic", "advisor", "manager", "owner", "admin", "parts"],
+    roles: ["mechanic", "advisor", "manager", "lead_hand", "owner", "admin", "parts"],
     scopes: ["home", "messages", "all"],
   },
   {
     href: "/mobile/settings",
     title: "Settings",
     subtitle: "Account & mobile options",
-    roles: ["mechanic", "advisor", "manager", "owner", "admin", "parts"],
+    roles: ["mechanic", "advisor", "manager", "lead_hand", "owner", "admin", "parts"],
     scopes: ["home", "settings", "all"],
   },
 
@@ -76,7 +87,7 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/reports",
     title: "Reports",
     subtitle: "Revenue & tech efficiency",
-    roles: ["owner", "admin", "manager"],
+    roles: ["owner", "admin", "manager", "lead_hand"],
     scopes: ["home", "work_orders", "all"],
   },
 
@@ -85,7 +96,7 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/technicians",
     title: "Technicians",
     subtitle: "Roster & performance",
-    roles: ["owner", "admin", "manager"],
+    roles: ["owner", "admin", "manager", "lead_hand"],
     scopes: ["home", "jobs", "work_orders", "all"],
   },
 
@@ -112,7 +123,7 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/tech/performance",
     title: "My Performance",
     subtitle: "Jobs, hours & efficiency",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic", "manager", "lead_hand", "owner", "admin"],
     scopes: ["home", "jobs", "all"],
   },
 
@@ -121,7 +132,18 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/fleet/service-requests",
     title: "Service Requests",
     subtitle: "Fleet issues & follow-up",
-    roles: ["owner", "admin", "manager", "mechanic", "parts", "fleet_manager", "dispatcher"],
+    roles: ["owner", "admin", "manager", "lead_hand", "mechanic", "parts", "fleet_manager", "dispatcher"],
     scopes: ["home", "work_orders", "inspections", "fleet", "all"],
   },
 ];
+
+export function getMobileTilesForRole(
+  role: MobileRole,
+  scopes: MobileScope[] = ["home"],
+): MobileTile[] {
+  return MOBILE_TILES.filter(
+    (tile) =>
+      tile.roles.includes(role) &&
+      tile.scopes.some((scope) => scopes.includes(scope)),
+  );
+}

--- a/features/mobile/dashboard/server/getMobileHomePayload.ts
+++ b/features/mobile/dashboard/server/getMobileHomePayload.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+import { canonicalizeRole, type CanonicalRole } from "@/features/shared/lib/rbac";
+
+export type MobileHomePayload = {
+  role: CanonicalRole;
+  advisor: {
+    awaitingApprovals: number;
+    waiters: number;
+    callbacks: number;
+  };
+  manager: {
+    activeWos: number;
+    waiters: number;
+    techniciansOnShift: number;
+  };
+  leadhand: {
+    techsOnShift: number;
+    jobsInProgress: number;
+    jobsBlocked: number;
+  };
+};
+
+export async function getMobileHomePayload(): Promise<MobileHomePayload> {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return {
+      role: "unknown",
+      advisor: { awaitingApprovals: 0, waiters: 0, callbacks: 0 },
+      manager: { activeWos: 0, waiters: 0, techniciansOnShift: 0 },
+      leadhand: { techsOnShift: 0, jobsInProgress: 0, jobsBlocked: 0 },
+    };
+  }
+
+  const [{ data: profile }, ops] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("role, shop_id")
+      .eq("id", user.id)
+      .maybeSingle(),
+    getOperationsDashboardPayload(),
+  ]);
+
+  const role = canonicalizeRole(profile?.role ?? null);
+  const shopId = profile?.shop_id ?? ops.identity.shopId;
+
+  let callbacks = 0;
+  let quotePending = 0;
+
+  if (shopId) {
+    const [{ count: callbackCount }, { count: quoteCount }] = await Promise.all([
+      supabase
+        .from("followups")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", user.id)
+        .eq("sent", false),
+      supabase
+        .from("work_order_quote_lines")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", shopId)
+        .not("status", "in", "('converted','declined')"),
+    ]);
+
+    callbacks = callbackCount ?? 0;
+    quotePending = quoteCount ?? 0;
+  }
+
+  return {
+    role,
+    advisor: {
+      awaitingApprovals: ops.topSummary.waitingApprovals,
+      waiters: quotePending,
+      callbacks,
+    },
+    manager: {
+      activeWos: ops.topSummary.activeJobs,
+      waiters: ops.topSummary.blockedJobs,
+      techniciansOnShift: ops.technicianActivity.length,
+    },
+    leadhand: {
+      techsOnShift: ops.technicianActivity.length,
+      jobsInProgress: ops.topSummary.activeJobs,
+      jobsBlocked: ops.topSummary.blockedJobs,
+    },
+  };
+}

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -832,12 +832,14 @@ export default function MobileWorkOrderClient({
   const declineQuote = useCallback(
     async (quoteId: string) => {
       if (!quoteId) return;
-      const { error } = await supabase
-        .from("work_order_quote_lines")
-        .update({ status: "declined" })
-        .eq("id", quoteId);
-      if (error) {
-        toast.error(error.message);
+      const res = await fetch(`/api/work-orders/quotes/${quoteId}/decline`, {
+        method: "POST",
+      });
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string }
+        | null;
+      if (!res.ok || !json?.ok) {
+        toast.error(json?.error ?? "Failed to decline quote");
         return;
       }
       toast.success("Quote declined");


### PR DESCRIPTION
### Motivation
- Mobile role checks were using ad-hoc/raw strings causing role drift and missing `lead_hand` support, producing incorrect routing and UI scope.
- Non-tech mobile dashboards showed placeholder zeros instead of real aggregated payloads.
- Technician entry points were pointing at the shop-wide board instead of a tech-scoped queue, causing data leakage to technicians.
- Certain client components performed high-risk direct table writes (`work_order_quote_lines`, `tech_shifts`, `punch_events`) from the browser which should be routed through server endpoints.

### Description
- Unified mobile role resolution to canonical RBAC by using `canonicalizeRole` and `getActorCapabilities` in `app/mobile/page.tsx` and other mobile flows, and added `lead_hand` to the `MobileRole` typing so aliases map to the canonical `lead_hand` role. (files: `app/mobile/page.tsx`, `features/mobile/config/mobile-tiles.ts`, `features/shared/lib/rbac.ts` usage).
- Rewired non-tech dashboards to use a lightweight server payload by adding `features/mobile/dashboard/server/getMobileHomePayload.ts` and exposing `GET /api/mobile/home-payload` which reuses `getOperationsDashboardPayload` to return advisor/manager/leadhand metrics; mobile pages now fetch and pass these payloads into `MobileAdvisorHome`, `MobileManagerHome`, and `MobileLeadHandHome`. (files: `features/mobile/dashboard/server/getMobileHomePayload.ts`, `app/api/mobile/home-payload/route.ts`, `app/mobile/page.tsx`).
- Fixed technician path so "My Jobs" routes to `/mobile/tech/queue` and preserved shop-board access for manager/leadhand/advisor/owner/admin by updating mobile tile config and job links; added `getMobileTilesForRole` helper and used it for role hubs/nav. (files: `features/mobile/config/mobile-tiles.ts`, `features/mobile/components/MobileRoleHub.tsx`, `app/mobile/page.tsx`).
- Removed high-risk client-side mutations by introducing server endpoints and routing calls through them: a new `POST /api/work-orders/quotes/[id]/decline` for quote declines and `POST /api/mobile/shifts` for shift lifecycle actions; updated `MobileWorkOrderClient` and `MobileShiftTracker` to call these endpoints instead of writing directly to `work_order_quote_lines`, `tech_shifts`, or `punch_events`. (files: `app/api/work-orders/quotes/[id]/decline/route.ts`, `app/api/mobile/shifts/route.ts`, `features/work-orders/mobile/MobileWorkOrderClient.tsx`, `features/mobile/components/MobileShiftTracker.tsx`).
- Made mobile navigation role-aware by loading the canonical role in `MobileBottomNav` and building the nav dynamically from the tile config rather than a static list. (file: `components/layout/MobileBottomNav.tsx`).

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` to ensure type correctness; the run surfaced existing, pre-existing generated-type issues in `features/shared/types/types/supabase.ts` (duplicate `job_priority` identifiers) that were not introduced by these changes and prevented a clean `--noEmit` success. This failure is external to the mobile changes and relates to generated Supabase types.  
- No other automated test suites were run by this PR; runtime behavior for the patched flows should be validated manually as described in the Phase 1 acceptance checklist (tech lands at `/mobile/tech/queue`, advisor/manager/leadhand see real payload data, quote decline and shift actions operate through the new APIs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e027bc9f088328a5d4d764f06715b5)