### PR TITLE
Harden portal API actor scoping and centralize approvals & bookings reads

### DIFF
--- a/app/api/portal/approvals/route.ts
+++ b/app/api/portal/approvals/route.ts
@@ -1,219 +1,31 @@
-// app/api/portal/approvals/route.ts
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { listPortalApprovalsForCustomer } from "@/features/portal/server/listPortalApprovals";
 
 type DB = Database;
-
-type CustomerPick = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "shop_id">;
-
-type PartRequestHeaderPick = Pick<
-  DB["public"]["Tables"]["part_requests"]["Row"],
-  "id" | "status" | "created_at"
->;
-
-type ApprovalLine = {
-  id: string;
-  description: string | null;
-  complaint: string | null;
-  approval_state: string | null;
-  status: string | null;
-  hold_reason: string | null;
-  work_order_id: string;
-  created_at: string | null;
-  work_orders: {
-    id: string;
-    custom_id: string | null;
-    created_at: string | null;
-    customer_id: string | null;
-  };
-  part_request_items: Array<{
-    id: string;
-    request_id: string | null;
-    description: string | null;
-    qty: number | null;
-    quoted_price: number | null;
-    vendor: string | null;
-    approved: boolean | null;
-    work_order_line_id: string | null;
-  }>;
-};
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null;
-}
-function asString(v: unknown): string | null {
-  return typeof v === "string" ? v : null;
-}
-function asNumber(v: unknown): number | null {
-  return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
-function asBoolean(v: unknown): boolean | null {
-  return typeof v === "boolean" ? v : null;
-}
-function asArray(v: unknown): unknown[] {
-  return Array.isArray(v) ? v : [];
-}
-function uniqStrings(values: Array<string | null>): string[] {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  for (const v of values) {
-    if (!v) continue;
-    if (seen.has(v)) continue;
-    seen.add(v);
-    out.push(v);
-  }
-  return out;
-}
-
-function pickWorkOrder(v: unknown): ApprovalLine["work_orders"] {
-  // Supabase relation might come back as object OR array. We accept both.
-  const wo = Array.isArray(v) ? v[0] : v;
-  if (!isRecord(wo)) {
-    return { id: "", custom_id: null, created_at: null, customer_id: null };
-  }
-  return {
-    id: asString(wo.id) ?? "",
-    custom_id: asString(wo.custom_id),
-    created_at: asString(wo.created_at),
-    customer_id: asString(wo.customer_id),
-  };
-}
-
-function pickItems(v: unknown): ApprovalLine["part_request_items"] {
-  const arr = asArray(v);
-  const out: ApprovalLine["part_request_items"] = [];
-
-  for (const it of arr) {
-    if (!isRecord(it)) continue;
-
-    const id = asString(it.id);
-    if (!id) continue;
-
-    out.push({
-      id,
-      request_id: asString(it.request_id),
-      description: asString(it.description),
-      qty: asNumber(it.qty),
-      quoted_price: asNumber(it.quoted_price),
-      vendor: asString(it.vendor),
-      approved: asBoolean(it.approved),
-      work_order_line_id: asString(it.work_order_line_id),
-    });
-  }
-
-  return out;
-}
-
-function normalizeLines(rowsUnknown: unknown): ApprovalLine[] {
-  const rows = asArray(rowsUnknown);
-  const out: ApprovalLine[] = [];
-
-  for (const r of rows) {
-    if (!isRecord(r)) continue;
-
-    const id = asString(r.id);
-    const workOrderId = asString(r.work_order_id);
-    if (!id || !workOrderId) continue;
-
-    const workOrders = pickWorkOrder(r.work_orders);
-    if (!workOrders.id) continue; // inner join should guarantee this, but keep it safe
-
-    out.push({
-      id,
-      description: asString(r.description),
-      complaint: asString(r.complaint),
-      approval_state: asString(r.approval_state),
-      status: asString(r.status),
-      hold_reason: asString(r.hold_reason),
-      work_order_id: workOrderId,
-      created_at: asString(r.created_at),
-      work_orders: workOrders,
-      part_request_items: pickItems(r.part_request_items),
-    });
-  }
-
-  return out;
-}
 
 export async function GET() {
   const supabase = createRouteHandlerClient<DB>({ cookies });
 
-  const {
-    data: { user },
-    error: authErr,
-  } = await supabase.auth.getUser();
+  try {
+    const actor = await requirePortalCustomerActor(supabase);
 
-  if (authErr) return NextResponse.json({ error: authErr.message }, { status: 401 });
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    const result = await listPortalApprovalsForCustomer({
+      supabase,
+      customer: actor.customer,
+    });
 
-  const { data: customer, error: custErr } = await supabase
-    .from("customers")
-    .select("id, shop_id")
-    .eq("user_id", user.id)
-    .maybeSingle<CustomerPick>();
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
 
-  if (custErr) return NextResponse.json({ error: custErr.message }, { status: 400 });
-  if (!customer?.id) {
-    return NextResponse.json(
-      { error: "No customer record linked to this account." },
-      { status: 404 },
-    );
+    return NextResponse.json(result.data);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Not authenticated";
+    const status = message.toLowerCase().includes("not authenticated") ? 401 : 404;
+    return NextResponse.json({ error: message }, { status });
   }
-
-  const { data: rows, error } = await supabase
-    .from("work_order_lines")
-    .select(
-      `
-      id,
-      description,
-      complaint,
-      approval_state,
-      status,
-      hold_reason,
-      work_order_id,
-      created_at,
-      work_orders!inner (
-        id,
-        custom_id,
-        created_at,
-        customer_id
-      ),
-      part_request_items (
-        id,
-        request_id,
-        description,
-        qty,
-        quoted_price,
-        vendor,
-        approved,
-        work_order_line_id
-      )
-    `,
-    )
-    .eq("work_orders.customer_id", customer.id)
-    .eq("approval_state", "pending")
-    .order("created_at", { ascending: false });
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-
-  // Critical: treat as unknown, then normalize (no type predicates / no any)
-  const lines = normalizeLines(rows as unknown);
-
-  const requestIds = uniqStrings(
-    lines.flatMap((ln) => ln.part_request_items.map((it) => it.request_id)),
-  );
-
-  let partRequestHeaders: PartRequestHeaderPick[] = [];
-  if (requestIds.length) {
-    const h = await supabase
-      .from("part_requests")
-      .select("id, status, created_at")
-      .in("id", requestIds);
-
-    partRequestHeaders = Array.isArray(h.data) ? (h.data as PartRequestHeaderPick[]) : [];
-  }
-
-  return NextResponse.json({ lines, partRequestHeaders });
 }

--- a/app/api/portal/book/route.ts
+++ b/app/api/portal/book/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   createPortalBooking,
   type CreatePortalBookingInput,
@@ -22,6 +23,19 @@ export async function POST(req: Request) {
     } = await supabase.auth.getUser();
 
     if (authErr || !user) return bad("Not authenticated", 401);
+
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle<{ role: string | null }>();
+
+    if (profileErr) return bad(profileErr.message, 403);
+
+    const actor = getActorCapabilities({ role: profile?.role ?? null });
+    if (!actor.isKnownRole || (!actor.canManageScheduling && !actor.canViewShopWideData)) {
+      return bad("This legacy endpoint is staff-only", 403);
+    }
 
     const body = (await req.json()) as CreatePortalBookingInput;
     const result = await createPortalBooking({

--- a/app/api/portal/customer-bookings/[id]/route.ts
+++ b/app/api/portal/customer-bookings/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { cancelCustomerBooking } from "@/features/portal/server/customerBookings";
 
 type DB = Database;
 
@@ -13,40 +15,29 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }>
   const { id } = await ctx.params;
   if (!id) return NextResponse.json({ error: "Missing booking id" }, { status: 400 });
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
-  const {
-    data: { user },
-    error: authErr,
-  } = await supabase.auth.getUser();
-
-  if (authErr || !user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
   const body = (await req.json().catch(() => ({}))) as Body;
   if (body.status !== "cancelled") {
     return NextResponse.json({ error: "Only cancellation is allowed" }, { status: 400 });
   }
 
-  const { data: customer, error: custErr } = await supabase
-    .from("customers")
-    .select("id")
-    .eq("user_id", user.id)
-    .maybeSingle();
+  const supabase = createRouteHandlerClient<DB>({ cookies });
 
-  if (custErr) return NextResponse.json({ error: custErr.message }, { status: 500 });
-  if (!customer?.id) return NextResponse.json({ error: "Customer profile not found" }, { status: 404 });
+  try {
+    const actor = await requirePortalCustomerActor(supabase);
+    const result = await cancelCustomerBooking({
+      supabase,
+      bookingId: id,
+      customerId: actor.customer.id,
+    });
 
-  const { data: updated, error: updateErr } = await supabase
-    .from("bookings")
-    .update({ status: "cancelled" })
-    .eq("id", id)
-    .eq("customer_id", customer.id)
-    .select("id, starts_at, ends_at, notes, status")
-    .maybeSingle();
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
 
-  if (updateErr) return NextResponse.json({ error: updateErr.message }, { status: 500 });
-  if (!updated) return NextResponse.json({ error: "Booking not found" }, { status: 404 });
-
-  return NextResponse.json(updated);
+    return NextResponse.json(result.data);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Not authenticated";
+    const status = message.toLowerCase().includes("not authenticated") ? 401 : 404;
+    return NextResponse.json({ error: message }, { status });
+  }
 }

--- a/app/api/portal/customer-bookings/route.ts
+++ b/app/api/portal/customer-bookings/route.ts
@@ -2,37 +2,29 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { listCustomerBookings } from "@/features/portal/server/customerBookings";
 
 type DB = Database;
 
 export async function GET() {
   const supabase = createRouteHandlerClient<DB>({ cookies });
-  const {
-    data: { user },
-    error: authErr,
-  } = await supabase.auth.getUser();
 
-  if (authErr || !user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  try {
+    const actor = await requirePortalCustomerActor(supabase);
+    const bookings = await listCustomerBookings({
+      supabase,
+      customerId: actor.customer.id,
+    });
+
+    if (!bookings.ok) {
+      return NextResponse.json({ error: bookings.error }, { status: bookings.status });
+    }
+
+    return NextResponse.json(bookings.data);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Not authenticated";
+    const status = message.toLowerCase().includes("not authenticated") ? 401 : 404;
+    return NextResponse.json({ error: message }, { status });
   }
-
-  const { data: customer, error: custErr } = await supabase
-    .from("customers")
-    .select("id")
-    .eq("user_id", user.id)
-    .maybeSingle();
-
-  if (custErr) return NextResponse.json({ error: custErr.message }, { status: 500 });
-  if (!customer?.id) {
-    return NextResponse.json({ error: "Customer profile not found" }, { status: 404 });
-  }
-
-  const { data: bookings, error: bookingErr } = await supabase
-    .from("bookings")
-    .select("id, starts_at, ends_at, notes, status")
-    .eq("customer_id", customer.id)
-    .order("starts_at", { ascending: true });
-
-  if (bookingErr) return NextResponse.json({ error: bookingErr.message }, { status: 500 });
-  return NextResponse.json(Array.isArray(bookings) ? bookings : []);
 }

--- a/features/portal/server/customerBookings.ts
+++ b/features/portal/server/customerBookings.ts
@@ -1,0 +1,48 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+export type CustomerBookingPayload = Pick<
+  DB["public"]["Tables"]["bookings"]["Row"],
+  "id" | "starts_at" | "ends_at" | "notes" | "status"
+>;
+
+export async function listCustomerBookings({
+  supabase,
+  customerId,
+}: {
+  supabase: SupabaseClient<DB>;
+  customerId: string;
+}): Promise<{ ok: true; data: CustomerBookingPayload[] } | { ok: false; error: string; status: number }> {
+  const { data: bookings, error } = await supabase
+    .from("bookings")
+    .select("id, starts_at, ends_at, notes, status")
+    .eq("customer_id", customerId)
+    .order("starts_at", { ascending: true });
+
+  if (error) return { ok: false, error: error.message, status: 500 };
+  return { ok: true, data: Array.isArray(bookings) ? bookings : [] };
+}
+
+export async function cancelCustomerBooking({
+  supabase,
+  customerId,
+  bookingId,
+}: {
+  supabase: SupabaseClient<DB>;
+  customerId: string;
+  bookingId: string;
+}): Promise<{ ok: true; data: CustomerBookingPayload } | { ok: false; error: string; status: number }> {
+  const { data: updated, error } = await supabase
+    .from("bookings")
+    .update({ status: "cancelled" })
+    .eq("id", bookingId)
+    .eq("customer_id", customerId)
+    .select("id, starts_at, ends_at, notes, status")
+    .maybeSingle();
+
+  if (error) return { ok: false, error: error.message, status: 500 };
+  if (!updated) return { ok: false, error: "Booking not found", status: 404 };
+  return { ok: true, data: updated };
+}

--- a/features/portal/server/listPortalApprovals.ts
+++ b/features/portal/server/listPortalApprovals.ts
@@ -1,0 +1,206 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import type { PortalCustomer } from "@/features/portal/server/portalAuth";
+
+type DB = Database;
+
+type PartRequestHeaderPick = Pick<
+  DB["public"]["Tables"]["part_requests"]["Row"],
+  "id" | "status" | "created_at"
+>;
+
+type PortalApprovalItem = {
+  id: string;
+  request_id: string | null;
+  description: string | null;
+  qty: number | null;
+  quoted_price: number | null;
+  vendor: string | null;
+  approved: boolean | null;
+  work_order_line_id: string | null;
+};
+
+export type PortalApprovalLine = {
+  id: string;
+  description: string | null;
+  complaint: string | null;
+  approval_state: string | null;
+  status: string | null;
+  hold_reason: string | null;
+  work_order_id: string;
+  created_at: string | null;
+  work_orders: {
+    id: string;
+    custom_id: string | null;
+    created_at: string | null;
+  };
+  part_request_items: PortalApprovalItem[];
+};
+
+export type PortalApprovalsPayload = {
+  lines: PortalApprovalLine[];
+  partRequestHeaders: PartRequestHeaderPick[];
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function asBoolean(v: unknown): boolean | null {
+  return typeof v === "boolean" ? v : null;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+function uniqStrings(values: Array<string | null>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const v of values) {
+    if (!v || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+function pickWorkOrder(v: unknown): PortalApprovalLine["work_orders"] | null {
+  const wo = Array.isArray(v) ? v[0] : v;
+  if (!isRecord(wo)) return null;
+
+  const id = asString(wo.id);
+  if (!id) return null;
+
+  return {
+    id,
+    custom_id: asString(wo.custom_id),
+    created_at: asString(wo.created_at),
+  };
+}
+
+function pickItems(v: unknown): PortalApprovalItem[] {
+  const arr = asArray(v);
+  const out: PortalApprovalItem[] = [];
+
+  for (const it of arr) {
+    if (!isRecord(it)) continue;
+
+    const id = asString(it.id);
+    if (!id) continue;
+
+    out.push({
+      id,
+      request_id: asString(it.request_id),
+      description: asString(it.description),
+      qty: asNumber(it.qty),
+      quoted_price: asNumber(it.quoted_price),
+      vendor: asString(it.vendor),
+      approved: asBoolean(it.approved),
+      work_order_line_id: asString(it.work_order_line_id),
+    });
+  }
+
+  return out;
+}
+
+function normalizeLines(rowsUnknown: unknown): PortalApprovalLine[] {
+  const rows = asArray(rowsUnknown);
+  const out: PortalApprovalLine[] = [];
+
+  for (const r of rows) {
+    if (!isRecord(r)) continue;
+
+    const id = asString(r.id);
+    const workOrderId = asString(r.work_order_id);
+    if (!id || !workOrderId) continue;
+
+    const workOrders = pickWorkOrder(r.work_orders);
+    if (!workOrders?.id) continue;
+
+    out.push({
+      id,
+      description: asString(r.description),
+      complaint: asString(r.complaint),
+      approval_state: asString(r.approval_state),
+      status: asString(r.status),
+      hold_reason: asString(r.hold_reason),
+      work_order_id: workOrderId,
+      created_at: asString(r.created_at),
+      work_orders: workOrders,
+      part_request_items: pickItems(r.part_request_items),
+    });
+  }
+
+  return out;
+}
+
+export async function listPortalApprovalsForCustomer({
+  supabase,
+  customer,
+}: {
+  supabase: SupabaseClient<DB>;
+  customer: Pick<PortalCustomer, "id">;
+}): Promise<{ ok: true; data: PortalApprovalsPayload } | { ok: false; error: string; status: number }> {
+  const { data: rows, error } = await supabase
+    .from("work_order_lines")
+    .select(
+      `
+      id,
+      description,
+      complaint,
+      approval_state,
+      status,
+      hold_reason,
+      work_order_id,
+      created_at,
+      work_orders!inner (
+        id,
+        custom_id,
+        created_at
+      ),
+      part_request_items (
+        id,
+        request_id,
+        description,
+        qty,
+        quoted_price,
+        vendor,
+        approved,
+        work_order_line_id
+      )
+    `,
+    )
+    .eq("work_orders.customer_id", customer.id)
+    .eq("approval_state", "pending")
+    .order("created_at", { ascending: false });
+
+  if (error) return { ok: false, error: error.message, status: 400 };
+
+  const lines = normalizeLines(rows as unknown);
+  const requestIds = uniqStrings(lines.flatMap((ln) => ln.part_request_items.map((it) => it.request_id)));
+
+  let partRequestHeaders: PartRequestHeaderPick[] = [];
+  if (requestIds.length) {
+    const h = await supabase.from("part_requests").select("id, status, created_at").in("id", requestIds);
+
+    if (h.error) return { ok: false, error: h.error.message, status: 400 };
+    partRequestHeaders = Array.isArray(h.data) ? (h.data as PartRequestHeaderPick[]) : [];
+  }
+
+  return {
+    ok: true,
+    data: {
+      lines,
+      partRequestHeaders,
+    },
+  };
+}

--- a/features/portal/server/requirePortalActor.ts
+++ b/features/portal/server/requirePortalActor.ts
@@ -1,0 +1,22 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { requireAuthedUser, requirePortalCustomer, type PortalCustomer } from "@/features/portal/server/portalAuth";
+
+export type DB = Database;
+
+export type PortalActor = {
+  userId: string;
+  customer: PortalCustomer;
+};
+
+/**
+ * Portal customer routes must always resolve ownership from auth user -> customer row.
+ * No staff fallback logic is allowed in this helper.
+ */
+export async function requirePortalCustomerActor(
+  supabase: SupabaseClient<DB>,
+): Promise<PortalActor> {
+  const { id: userId } = await requireAuthedUser(supabase);
+  const customer = await requirePortalCustomer(supabase, userId);
+  return { userId, customer };
+}


### PR DESCRIPTION
### Motivation
- Remove ambiguous legacy portal booking write surface and prevent customer-facing routes from silently acting with staff authority.
- Stabilize the portal approvals read path by reusing canonical query/normalization logic and avoiding route-level aggregation drift.
- Reduce duplicated query logic for customer bookings and approvals and make portal routes explicitly customer-scoped to prepare for future canonical API alignment.

### Description
- Added an explicit portal-customer actor helper `requirePortalCustomerActor` that always derives ownership from the authenticated user → customer record and forbids staff-fallback logic (`features/portal/server/requirePortalActor.ts`).
- Centralized approval query + normalization into `listPortalApprovalsForCustomer` and replaced the route with a thin orchestration that returns a minimal, shaped payload (no sensitive fields; `work_orders` is limited to `id/custom_id/created_at`) (`features/portal/server/listPortalApprovals.ts`, `app/api/portal/approvals/route.ts`).
- Consolidated customer booking reads/updates into shared helpers `listCustomerBookings` and `cancelCustomerBooking` and rewired `GET /api/portal/customer-bookings` and `PATCH /api/portal/customer-bookings/[id]` to use them via the portal actor helper (`features/portal/server/customerBookings.ts`, `app/api/portal/customer-bookings/route.ts`, `app/api/portal/customer-bookings/[id]/route.ts`).
- Locked the legacy `POST /api/portal/book` route to staff-only callers by adding an explicit role/capability guard using `getActorCapabilities`, while keeping the new `bookings` endpoints customer-mode for portal UI (`app/api/portal/book/route.ts`).

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript; the run failed due to pre-existing duplicate identifiers in generated Supabase types (`features/shared/types/types/supabase.ts`) and is unrelated to the changes in this patch.
- No other automated test targets were executed as part of this change set; route-level behavior was implemented to be non-breaking and to reuse existing shared helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03959c1b48328827dd1ddafbb2b14)