### PR TITLE
Refine technician job card UI hierarchy and canonical status styling

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1783,7 +1783,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                   actions in the focused panel to start building this work order.
                 </p>
               ) : (
-                <div className="max-h-[72vh] space-y-1.5 overflow-auto pr-1">
+                <div className="space-y-3">
                   {sortedLines.map((ln, idx) => {
                     const punchedIn = !!ln.punched_in_at && !ln.punched_out_at;
 

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -7,21 +7,12 @@ import { ChevronDown, ChevronUp, CircleAlert, CircleCheck, Wrench } from "lucide
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 import Card from "@shared/components/ui/Card";
-import StatusBadge from "@shared/components/ui/StatusBadge";
 import { cn } from "@shared/lib/utils";
 
 type WorkOrderLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
 type WorkOrderPartAllocation =
   Database["public"]["Tables"]["work_order_part_allocations"]["Row"];
 type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
-
-type KnownStatus =
-  | "awaiting"
-  | "in_progress"
-  | "on_hold"
-  | "completed"
-  | "ready_to_invoice"
-  | "invoiced";
 
 type ReviewIssue = {
   kind?: string | null;
@@ -65,93 +56,27 @@ type JobCardProps = {
 
 type JobLinePriority = "low" | "normal" | "high" | "urgent";
 
+type StatusVisual = {
+  label: string;
+  railClass: string;
+  chipClass: string;
+  orbClass: string;
+  borderClass: string;
+  glowClass: string;
+  muted: boolean;
+};
+
 const PRIORITY_OPTIONS: JobLinePriority[] = ["urgent", "high", "normal", "low"];
 
 const PRIORITY_CHIP_STYLES: Record<JobLinePriority, string> = {
-  urgent: "border-red-400/60 bg-red-900/30 text-red-100",
-  high: "border-orange-400/60 bg-orange-900/30 text-orange-100",
-  normal: "border-white/15 bg-black/35 text-neutral-200",
-  low: "border-slate-400/60 bg-slate-900/30 text-slate-200",
+  urgent: "border-red-400/50 bg-red-500/10 text-red-100",
+  high: "border-amber-400/50 bg-amber-500/10 text-amber-100",
+  normal: "border-white/12 bg-black/25 text-neutral-300",
+  low: "border-slate-400/45 bg-slate-500/10 text-slate-300",
 };
 
-const CARD_SURFACE: Record<
-  KnownStatus,
-  {
-    badgeVariant: "info" | "active" | "warning" | "success";
-    surfaceClass: string;
-    label: string;
-  }
-> = {
-  awaiting: {
-    badgeVariant: "info",
-    surfaceClass:
-      "bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.12),rgba(10,10,10,0.96))]",
-    label: "Awaiting",
-  },
-  in_progress: {
-    badgeVariant: "active",
-    surfaceClass:
-      "bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),rgba(10,10,10,0.96))]",
-    label: "In Progress",
-  },
-  on_hold: {
-    badgeVariant: "warning",
-    surfaceClass:
-      "bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.14),rgba(10,10,10,0.96))]",
-    label: "On Hold",
-  },
-  completed: {
-    badgeVariant: "success",
-    surfaceClass:
-      "bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(10,10,10,0.96))]",
-    label: "Completed",
-  },
-  ready_to_invoice: {
-    badgeVariant: "success",
-    surfaceClass:
-      "bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(10,10,10,0.96))]",
-    label: "Ready to Invoice",
-  },
-  invoiced: {
-    badgeVariant: "success",
-    surfaceClass:
-      "bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(10,10,10,0.96))]",
-    label: "Invoiced",
-  },
-};
-
-function statusRailTone(args: {
-  status: string | null;
-  holdReason: string | null;
-  approvalState: string | null;
-  reviewFlags: ReviewFlags;
-}): "healthy" | "needs" | "blocked" {
-  const status = norm(args.status);
-  const hold = norm(args.holdReason);
-  const approval = norm(args.approvalState);
-
-  if (
-    status === "on_hold" ||
-    status === "declined" ||
-    hold.includes("block") ||
-    hold.includes("part") ||
-    hold.includes("urgent")
-  ) {
-    return "blocked";
-  }
-
-  if (
-    approval === "pending" ||
-    args.reviewFlags.missingCause ||
-    args.reviewFlags.missingComplaint ||
-    args.reviewFlags.missingCorrection ||
-    args.reviewFlags.noParts
-  ) {
-    return "needs";
-  }
-
-  return "healthy";
-}
+const METALLIC_CARD_SURFACE =
+  "bg-[linear-gradient(155deg,rgba(255,255,255,0.07)_0%,rgba(255,255,255,0.02)_18%,rgba(15,23,42,0.82)_54%,rgba(2,6,23,0.96)_100%)]";
 
 function norm(s: unknown): string {
   return String(s ?? "").trim().toLowerCase();
@@ -172,6 +97,112 @@ function formatCurrency(value: number | null | undefined): string {
   }).format(amount);
 }
 
+function statusLabelFromKey(status: string): string {
+  return status.replaceAll("_", " ").replace(/\b\w/g, (x) => x.toUpperCase());
+}
+
+function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boolean): StatusVisual {
+  const raw = norm(status).replaceAll("-", "_");
+
+  if (isPunchedIn || raw === "in_progress" || raw === "active") {
+    return {
+      label: "Active",
+      railClass: "bg-cyan-400/90",
+      chipClass: "border-cyan-300/65 bg-cyan-500/14 text-cyan-100",
+      orbClass: "bg-cyan-300",
+      borderClass: "border-cyan-400/45",
+      glowClass: "shadow-[0_0_22px_rgba(34,211,238,0.25)]",
+      muted: false,
+    };
+  }
+
+  if (
+    raw === "completed" ||
+    raw === "ready_to_invoice" ||
+    raw === "invoiced"
+  ) {
+    return {
+      label: statusLabelFromKey(raw),
+      railClass: "bg-slate-400/75",
+      chipClass: "border-slate-400/55 bg-slate-500/10 text-slate-200",
+      orbClass: "bg-slate-300",
+      borderClass: "border-slate-500/45",
+      glowClass: "",
+      muted: true,
+    };
+  }
+
+  if (raw === "on_hold") {
+    return {
+      label: "On Hold",
+      railClass: "bg-amber-400/90",
+      chipClass: "border-amber-300/60 bg-amber-500/12 text-amber-100",
+      orbClass: "bg-amber-300",
+      borderClass: "border-amber-400/45",
+      glowClass: "shadow-[0_0_20px_rgba(251,191,36,0.18)]",
+      muted: false,
+    };
+  }
+
+  if (raw === "waiting_parts" || raw === "pending_parts") {
+    return {
+      label: "Waiting Parts",
+      railClass: "bg-indigo-400/90",
+      chipClass: "border-indigo-300/60 bg-indigo-500/14 text-indigo-100",
+      orbClass: "bg-indigo-300",
+      borderClass: "border-indigo-400/45",
+      glowClass: "shadow-[0_0_20px_rgba(129,140,248,0.18)]",
+      muted: false,
+    };
+  }
+
+  if (raw === "awaiting_approval" || raw === "needs_approval") {
+    return {
+      label: "Awaiting Approval",
+      railClass: "bg-amber-500/90",
+      chipClass: "border-amber-300/60 bg-amber-500/14 text-amber-100",
+      orbClass: "bg-amber-300",
+      borderClass: "border-amber-500/45",
+      glowClass: "shadow-[0_0_20px_rgba(245,158,11,0.2)]",
+      muted: false,
+    };
+  }
+
+  if (raw === "blocked" || raw === "declined" || raw === "critical") {
+    return {
+      label: "Blocked",
+      railClass: "bg-red-400/90",
+      chipClass: "border-red-300/60 bg-red-500/12 text-red-100",
+      orbClass: "bg-red-300",
+      borderClass: "border-red-400/45",
+      glowClass: "shadow-[0_0_22px_rgba(248,113,113,0.2)]",
+      muted: false,
+    };
+  }
+
+  if (raw === "queued" || raw === "ready") {
+    return {
+      label: statusLabelFromKey(raw),
+      railClass: "bg-sky-400/90",
+      chipClass: "border-sky-300/60 bg-sky-500/12 text-sky-100",
+      orbClass: "bg-sky-300",
+      borderClass: "border-sky-400/45",
+      glowClass: "shadow-[0_0_20px_rgba(56,189,248,0.16)]",
+      muted: false,
+    };
+  }
+
+  return {
+    label: raw ? statusLabelFromKey(raw) : "Awaiting",
+    railClass: "bg-sky-500/80",
+    chipClass: "border-sky-400/55 bg-sky-500/10 text-sky-100",
+    orbClass: "bg-sky-300",
+    borderClass: "border-sky-500/40",
+    glowClass: "",
+    muted: false,
+  };
+}
+
 function computeReviewFlags(args: {
   line: WorkOrderLine;
   partsCount: number;
@@ -179,9 +210,7 @@ function computeReviewFlags(args: {
 }): ReviewFlags {
   const localMissingCause = !norm(args.line.cause);
   const localMissingCorrection = !norm(args.line.correction);
-  const localMissingComplaint =
-    !norm(args.line.complaint) &&
-    !norm(args.line.description);
+  const localMissingComplaint = !norm(args.line.complaint) && !norm(args.line.description);
   const localNoParts = args.partsCount === 0;
 
   const issues = Array.isArray(args.reviewIssues) ? args.reviewIssues : [];
@@ -241,10 +270,10 @@ function ReviewPill({
       className={cn(
         "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.1em]",
         tone === "ok"
-          ? "border-emerald-400/60 bg-emerald-400/10 text-emerald-100"
+          ? "border-emerald-400/50 bg-emerald-400/10 text-emerald-100"
           : tone === "warn"
-            ? "border-amber-400/60 bg-amber-400/10 text-amber-100"
-            : "border-white/10 bg-white/5 text-neutral-200",
+            ? "border-amber-400/55 bg-amber-400/10 text-amber-100"
+            : "border-white/12 bg-white/5 text-neutral-200",
       )}
     >
       {icon}
@@ -262,9 +291,7 @@ function MetaTile({
 }) {
   return (
     <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
-      <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-        {label}
-      </div>
+      <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">{label}</div>
       <div className="mt-1 text-sm text-neutral-100">{value}</div>
     </div>
   );
@@ -290,58 +317,47 @@ export function JobCard({
   compact = false,
   selected = false,
 }: JobCardProps): JSX.Element {
-  const rawStatus = (line.status ?? "awaiting")
-    .toLowerCase()
-    .replaceAll(" ", "_");
+  const [collapsed, setCollapsed] = useState<boolean>(false);
 
-  const statusKey = (
-    isPunchedIn
-      ? "in_progress"
-      : rawStatus === "in-progress"
-        ? "in_progress"
-        : rawStatus
-  ) as KnownStatus;
+  const statusVisual = useMemo(
+    () => resolveStatusVisual(line.status, isPunchedIn),
+    [line.status, isPunchedIn],
+  );
 
-  const surfaceCfg = CARD_SURFACE[statusKey] ?? CARD_SURFACE.awaiting;
-
-  const isCompletedLike = () => {
-    const s = (line.status ?? "").toLowerCase();
-    return s === "completed" || s === "ready_to_invoice" || s === "invoiced";
-  };
-
-  const [collapsed, setCollapsed] = useState<boolean>(isCompletedLike());
+  const isCompletedLike = statusVisual.muted;
 
   useEffect(() => {
-    setCollapsed(isCompletedLike());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [line.status]);
+    setCollapsed(isCompletedLike);
+  }, [isCompletedLike]);
 
   const jobLabel = line.description || line.complaint || "Untitled job";
   const assignedTech = useMemo(() => {
     const techId = line.assigned_tech_id;
     return technicians.find((tech) => tech.id === techId)?.full_name || "Unassigned";
   }, [line.assigned_tech_id, technicians]);
+
   const linePriority = toLinePriority(line);
+  const quietPriority = linePriority === "urgent" || linePriority === "high" ? linePriority : null;
 
   const reviewFlags = computeReviewFlags({
     line,
     partsCount: parts.length,
     reviewIssues,
   });
-  const railTone = statusRailTone({
-    status: line.status,
-    holdReason: line.hold_reason,
-    approvalState: line.approval_state,
-    reviewFlags,
-  });
 
   const createdLabel = line.created_at
     ? formatDistanceToNow(new Date(line.created_at), { addSuffix: true })
     : "—";
 
+  const updatedLabel = line.updated_at
+    ? formatDistanceToNow(new Date(line.updated_at), { addSuffix: true })
+    : "—";
+
   const lineTotal =
-    pricing?.lineTotal ??
-    (Number(pricing?.laborTotal ?? 0) + Number(pricing?.partsTotal ?? 0));
+    pricing?.lineTotal ?? (Number(pricing?.laborTotal ?? 0) + Number(pricing?.partsTotal ?? 0));
+
+  const isBlocked = norm(line.status) === "on_hold" || norm(line.status) === "blocked";
+  const waitingApproval = norm(line.approval_state) === "pending";
 
   void canDelete;
   void onDelete;
@@ -363,208 +379,189 @@ export function JobCard({
     >
       <Card
         className={cn(
-        "relative overflow-hidden p-0",
-        "transition hover:-translate-y-[1px] hover:border-[color:var(--accent-copper-soft,#fdba74)]",
-        "focus-within:border-[color:var(--accent-copper-light,#fdba74)] focus-within:shadow-[0_0_0_1px_rgba(253,186,116,0.55),0_10px_30px_rgba(249,115,22,0.18)]",
-        selected &&
-          "scale-[1.01] border-[color:var(--accent-copper-light,#fdba74)] bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.2),rgba(10,10,10,0.96))] shadow-[0_0_0_1px_rgba(253,186,116,0.7),0_12px_34px_rgba(249,115,22,0.24)]",
-        surfaceCfg.surfaceClass,
-      )}
+          "relative overflow-hidden border p-0 transition",
+          METALLIC_CARD_SURFACE,
+          statusVisual.borderClass,
+          statusVisual.glowClass,
+          statusVisual.muted && "opacity-[0.84] saturate-[0.7]",
+          "hover:-translate-y-[1px] hover:border-white/25",
+          "focus-within:border-white/35",
+          selected && "border-white/35 shadow-[0_0_0_1px_rgba(148,163,184,0.45)]",
+        )}
       >
-        <div
-          className={cn(
-            "absolute inset-y-0 left-0 w-1",
-            railTone === "healthy"
-              ? "bg-emerald-400/90"
-              : railTone === "needs"
-                ? "bg-amber-400/90"
-                : "bg-red-400/90",
-          )}
-        />
+        <div className={cn("absolute inset-y-0 left-0 w-1", statusVisual.railClass)} />
 
         <div className={cn("relative pl-5", compact ? "p-3" : "p-4")}>
           <div className={cn("flex flex-col", compact ? "gap-2" : "gap-3")}>
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <StatusBadge variant={surfaceCfg.badgeVariant}>
-                  {surfaceCfg.label}
-                </StatusBadge>
-                <StatusBadge variant={isPunchedIn ? "active" : "neutral"}>
-                  {isPunchedIn ? "Punched In" : "Not Punched In"}
-                </StatusBadge>
-                <span
-                  className={cn(
-                    "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em]",
-                    PRIORITY_CHIP_STYLES[linePriority],
-                  )}
-                >
-                  {linePriority}
-                </span>
-                {reviewOk ? (
-                  <StatusBadge variant="success">Review Ready</StatusBadge>
-                ) : null}
-              </div>
-
-              <div className={cn("flex items-start gap-2.5", compact ? "mt-1.5" : "mt-2")}>
-                <div className={cn("flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-xs font-semibold text-neutral-200", compact ? "h-6 w-6" : "h-8 w-8")}>
-                  {index + 1}
-                </div>
-
-                <div className="min-w-0">
-                  <h3 className={cn("font-semibold text-white", compact ? "text-sm sm:text-[15px]" : "text-[15px] sm:text-base")}>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0 space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-full border border-white/12 bg-black/35 px-2 text-xs font-semibold text-neutral-100">
+                    {index + 1}
+                  </span>
+                  <h3 className={cn("truncate font-semibold text-white", compact ? "text-sm sm:text-[15px]" : "text-[15px] sm:text-base")}>
                     {jobLabel}
                   </h3>
-                  <p className={cn("text-xs uppercase tracking-[0.16em] text-neutral-500", compact ? "mt-0.5" : "mt-1")}>
-                    Created {createdLabel}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className={cn("flex flex-wrap items-center", compact ? "gap-1" : "gap-1.5")}>
-              <Button type="button" variant={selected ? "secondary" : "outline"} size="sm" onClick={onOpen}>
-                Open
-              </Button>
-
-              {onOpenInspection ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={onOpenInspection}
-                >
-                  Inspection
-                </Button>
-              ) : null}
-
-              {onAddPart ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={onAddPart}
-                >
-                  Add Part
-                </Button>
-              ) : null}
-
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setCollapsed((v) => !v)}
-                className={cn("border border-white/10 bg-black/20", compact && "px-2")}
-              >
-                {collapsed ? (
-                  <>
-                    Expand <ChevronDown className="ml-1 h-4 w-4" />
-                  </>
-                ) : (
-                  <>
-                    Collapse <ChevronUp className="ml-1 h-4 w-4" />
-                  </>
-                )}
-              </Button>
-            </div>
-          </div>
-
-          <div className={cn("flex flex-wrap", compact ? "gap-1" : "gap-1.5")}>
-            {reviewFlags.missingComplaint ? (
-              <ReviewPill tone="warn" label="Complaint missing" title="Complaint / description completeness" />
-            ) : null}
-            {reviewFlags.missingCause ? (
-              <ReviewPill tone="warn" label="Cause missing" title="Cause completeness" />
-            ) : null}
-            {reviewFlags.missingCorrection ? (
-              <ReviewPill tone="warn" label="Correction missing" title="Correction completeness" />
-            ) : null}
-            {reviewFlags.noParts ? (
-              <ReviewPill tone="warn" label="No parts" title="Parts completeness" />
-            ) : null}
-            {norm(line.status) === "on_hold" ? (
-              <ReviewPill tone="warn" label="Blocked" title="Line currently blocked or on hold" />
-            ) : null}
-            {norm(line.approval_state) === "pending" ? (
-              <ReviewPill tone="info" label="Waiting approval" title="Waiting for approval decision" />
-            ) : null}
-            {reviewFlags.otherIssues > 0 ? (
-              <ReviewPill
-                tone="info"
-                label={`${reviewFlags.otherIssues} other`}
-                title="Additional review issues"
-              />
-            ) : null}
-          </div>
-
-          {!collapsed ? (
-            <>
-              <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-4">
-                <MetaTile label="Assigned Tech" value={assignedTech} />
-                <MetaTile label="Parts" value={String(parts.length)} />
-                <MetaTile
-                  label="Labor"
-                  value={formatCurrency(pricing?.laborTotal ?? 0)}
-                />
-                <MetaTile label="Line Total" value={formatCurrency(lineTotal)} />
-              </div>
-
-              {canAssign && onAssign ? (
-                <div className="rounded-xl border border-white/10 bg-black/25 p-3">
-                  <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-                    Assign technician
-                  </div>
-
-                  <div className="mt-2.5 flex flex-wrap gap-1.5">
-                    {technicians.length === 0 ? (
-                      <span className="text-sm text-neutral-400">
-                        No technicians available.
-                      </span>
-                    ) : (
-                      technicians.map((tech) => {
-                        const isAssigned = tech.id === line.assigned_tech_id;
-
-                        return (
-                          <button
-                            key={tech.id}
-                            type="button"
-                            onClick={() => onAssign(tech.id)}
-                            className={cn(
-                              "rounded-full border px-3 py-1.5 text-xs font-semibold transition",
-                              isAssigned
-                                ? "border-[color:var(--accent-copper-soft,#fdba74)] bg-[color:var(--accent-copper,#f97316)]/15 text-[color:var(--accent-copper-light,#fdba74)]"
-                                : "border-white/10 bg-white/5 text-neutral-200 hover:border-white/20 hover:bg-white/10",
-                            )}
-                          >
-                            {tech.full_name || "Unnamed tech"}
-                          </button>
-                        );
-                      })
+                  <span
+                    className={cn(
+                      "inline-flex items-center rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em]",
+                      statusVisual.chipClass,
                     )}
-                  </div>
-                </div>
-              ) : null}
-              {onPriorityChange ? (
-                <div className="rounded-xl border border-white/10 bg-black/25 p-3">
-                  <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-                    Job priority
-                  </div>
-                  <select
-                    className="mt-2 w-full rounded-lg border border-white/15 bg-black/40 px-2.5 py-1.5 text-sm text-neutral-100"
-                    value={linePriority}
-                    onChange={(event) => onPriorityChange(event.target.value as JobLinePriority)}
                   >
-                    {PRIORITY_OPTIONS.map((priority) => (
-                      <option key={priority} value={priority}>
-                        {priority[0].toUpperCase() + priority.slice(1)}
-                      </option>
-                    ))}
-                  </select>
+                    {statusVisual.label}
+                  </span>
+                  {isPunchedIn ? (
+                    <span
+                      className={cn(
+                        "inline-flex h-2.5 w-2.5 animate-pulse rounded-full",
+                        statusVisual.orbClass,
+                      )}
+                      title="Active labor session"
+                    />
+                  ) : null}
+                  {quietPriority ? (
+                    <span
+                      className={cn(
+                        "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.1em]",
+                        PRIORITY_CHIP_STYLES[quietPriority],
+                      )}
+                    >
+                      {quietPriority}
+                    </span>
+                  ) : null}
                 </div>
+
+                <p className="text-xs uppercase tracking-[0.16em] text-neutral-500">
+                  Created {createdLabel}
+                </p>
+              </div>
+
+              <div className={cn("flex flex-wrap items-center", compact ? "gap-1" : "gap-1.5")}>
+                <Button type="button" variant={selected ? "secondary" : "outline"} size="sm" onClick={onOpen}>
+                  Open
+                </Button>
+
+                {onOpenInspection ? (
+                  <Button type="button" variant="secondary" size="sm" onClick={onOpenInspection}>
+                    Inspection
+                  </Button>
+                ) : null}
+
+                {onAddPart ? (
+                  <Button type="button" variant="secondary" size="sm" onClick={onAddPart}>
+                    Add Part
+                  </Button>
+                ) : null}
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setCollapsed((v) => !v)}
+                  className={cn("border border-white/10 bg-black/20", compact && "px-2")}
+                >
+                  {collapsed ? (
+                    <>
+                      Expand <ChevronDown className="ml-1 h-4 w-4" />
+                    </>
+                  ) : (
+                    <>
+                      Collapse <ChevronUp className="ml-1 h-4 w-4" />
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+
+            <div className={cn("flex flex-wrap", compact ? "gap-1" : "gap-1.5")}>
+              {reviewFlags.missingCause ? <ReviewPill tone="warn" label="Cause Missing" title="Cause completeness" /> : null}
+              {reviewFlags.missingCorrection ? (
+                <ReviewPill tone="warn" label="Correction Missing" title="Correction completeness" />
               ) : null}
-            </>
-          ) : null}
-        </div>
+              {reviewFlags.noParts ? <ReviewPill tone="warn" label="No Parts" title="Parts completeness" /> : null}
+              {isBlocked ? <ReviewPill tone="warn" label="Blocked" title="Line currently blocked or on hold" /> : null}
+              {waitingApproval ? (
+                <ReviewPill tone="info" label="Awaiting Approval" title="Waiting for approval decision" />
+              ) : null}
+              {reviewFlags.missingComplaint ? (
+                <ReviewPill tone="info" label="Complaint Missing" title="Complaint / description completeness" />
+              ) : null}
+              {reviewFlags.otherIssues > 0 ? (
+                <ReviewPill tone="info" label={`${reviewFlags.otherIssues} Other`} title="Additional review issues" />
+              ) : null}
+              {reviewOk ? <ReviewPill tone="ok" label="Review Ready" title="Review checks are clear" /> : null}
+            </div>
+
+            {!collapsed ? (
+              <>
+                <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-4">
+                  <MetaTile label="Assigned Tech" value={assignedTech} />
+                  <MetaTile label="Labor" value={formatCurrency(pricing?.laborTotal ?? 0)} />
+                  <MetaTile label="Parts" value={String(parts.length)} />
+                  <MetaTile label="Line Total" value={formatCurrency(lineTotal)} />
+                </div>
+
+                {(line.complaint || line.cause || line.correction || line.hold_reason) ? (
+                  <div className="rounded-xl border border-white/10 bg-black/25 p-3 text-xs text-neutral-300">
+                    {line.complaint ? <div>Complaint: {line.complaint}</div> : null}
+                    {line.cause ? <div>Cause: {line.cause}</div> : null}
+                    {line.correction ? <div>Correction: {line.correction}</div> : null}
+                    {line.hold_reason ? <div>Blocker: {line.hold_reason}</div> : null}
+                    <div className="mt-2 text-[11px] text-neutral-500">Updated {updatedLabel}</div>
+                  </div>
+                ) : null}
+
+                {canAssign && onAssign ? (
+                  <div className="rounded-xl border border-white/10 bg-black/25 p-3">
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">Assign technician</div>
+
+                    <div className="mt-2.5 flex flex-wrap gap-1.5">
+                      {technicians.length === 0 ? (
+                        <span className="text-sm text-neutral-400">No technicians available.</span>
+                      ) : (
+                        technicians.map((tech) => {
+                          const isAssigned = tech.id === line.assigned_tech_id;
+
+                          return (
+                            <button
+                              key={tech.id}
+                              type="button"
+                              onClick={() => onAssign(tech.id)}
+                              className={cn(
+                                "rounded-full border px-3 py-1.5 text-xs font-semibold transition",
+                                isAssigned
+                                  ? "border-cyan-300/50 bg-cyan-500/10 text-cyan-100"
+                                  : "border-white/10 bg-white/5 text-neutral-200 hover:border-white/20 hover:bg-white/10",
+                              )}
+                            >
+                              {tech.full_name || "Unnamed tech"}
+                            </button>
+                          );
+                        })
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+
+                {onPriorityChange ? (
+                  <div className="rounded-xl border border-white/10 bg-black/25 p-3">
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">Job priority</div>
+                    <select
+                      className="mt-2 w-full rounded-lg border border-white/15 bg-black/40 px-2.5 py-1.5 text-sm text-neutral-100"
+                      value={linePriority}
+                      onChange={(event) => onPriorityChange(event.target.value as JobLinePriority)}
+                    >
+                      {PRIORITY_OPTIONS.map((priority) => (
+                        <option key={priority} value={priority}>
+                          {priority[0].toUpperCase() + priority.slice(1)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
         </div>
       </Card>
     </div>


### PR DESCRIPTION
### Motivation
- Make the technician job card surface feel like a primary, premium operational surface by removing the embedded scroll panel and giving each card a standalone metallic treatment.
- Reduce visual noise by centralizing status presentation and removing duplicated pills so status is the single source of truth.
- Preserve existing work-order behavior and interactions while improving visual hierarchy and technician-first readability.

### Description
- Removed the inner scroll container so job cards flow naturally with the page by updating `app/work-orders/[id]/Client.tsx` (removed `max-h`/`overflow-auto` wrapper and added consistent spacing between cards).
- Replaced per-status full-card fills with a single restrained premium dark metallic surface (`METALLIC_CARD_SURFACE`) for all job cards in `features/work-orders/components/JobCard.tsx`.
- Introduced a single status → visual mapping helper `resolveStatusVisual` that drives the left status rail, lifecycle status chip, active orb color, border/glow accent, and completed muted state in `features/work-orders/components/JobCard.tsx`.
- Removed the duplicate punched-in status pill and substituted a small pulsing orb to indicate an active labor session, and reduced loudness of other secondary signals.
- Refined card hierarchy so the top row now shows line number, title, canonical status chip, optional active orb and quiet priority, the action row contains Open/Inspection/Add Part/Expand, and the exception row shows only meaningful issue pills; expanded content shows assigned tech, labor/parts/line total and notes.
- Files changed: `app/work-orders/[id]/Client.tsx` and `features/work-orders/components/JobCard.tsx`.

### Testing
- Ran lint on touched files with `npx eslint app/work-orders/[id]/Client.tsx features/work-orders/components/JobCard.tsx` and it completed against the targeted files.
- Ran type-check with `npx tsc --noEmit` and the codebase type-check passed with no new TypeScript errors introduced.
- No functional/workflow logic was changed; existing job actions (Open, Inspection, Add Part, Assign, priority) remain intact and were not altered in behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05138cecc83289b762f61ff0ba8ac)