### PR TITLE
Polish technician job cards: active pulse, remove premature pills, mute completed, widen rail, and pin active line

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -103,6 +103,11 @@ function fromDatetimeLocalInput(value: string): string | null {
   return d.toISOString();
 }
 
+function isCompletedLineStatus(status: string | null | undefined): boolean {
+  const normalized = String(status ?? "").trim().toLowerCase();
+  return normalized === "completed" || normalized === "ready_to_invoice" || normalized === "invoiced";
+}
+
 /** Normalize “where is the inspection template id stored for this line?” */
 function extractInspectionTemplateId(ln: WorkOrderLineWithInspectionMeta): string | null {
   return (
@@ -940,7 +945,7 @@ export default function WorkOrderIdClient(): JSX.Element {
       maintenance: 3,
       repair: 4,
     };
-    return [...activeJobLines].sort((a, b) => {
+    const baseSorted = [...activeJobLines].sort((a, b) => {
       const pa = pr[String(a.job_type ?? "repair")] ?? 999;
       const pb = pr[String(b.job_type ?? "repair")] ?? 999;
       if (pa !== pb) return pa - pb;
@@ -948,7 +953,34 @@ export default function WorkOrderIdClient(): JSX.Element {
       const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
       return ta - tb;
     });
-  }, [activeJobLines]);
+
+    const activeForCurrentTech = baseSorted.find((line) => {
+      const punchedIn = Boolean(line.punched_in_at) && !line.punched_out_at;
+      if (!punchedIn || isCompletedLineStatus(line.status)) return false;
+
+      if (!currentUserId) return true;
+
+      const assignedTechId =
+        typeof (line as { assigned_tech_id?: string | null }).assigned_tech_id === "string"
+          ? (line as { assigned_tech_id?: string | null }).assigned_tech_id
+          : null;
+      const linkedTechIds = lineTechsByLine[line.id] ?? [];
+      return assignedTechId === currentUserId || linkedTechIds.includes(currentUserId);
+    });
+
+    const pinnedActiveId = activeForCurrentTech?.id ?? null;
+    const nonCompleted = baseSorted.filter(
+      (line) => !isCompletedLineStatus(line.status) && line.id !== pinnedActiveId,
+    );
+    const completed = baseSorted.filter(
+      (line) => isCompletedLineStatus(line.status) && line.id !== pinnedActiveId,
+    );
+
+    if (activeForCurrentTech) {
+      return [activeForCurrentTech, ...nonCompleted, ...completed];
+    }
+    return [...nonCompleted, ...completed];
+  }, [activeJobLines, currentUserId, lineTechsByLine]);
 
   useEffect(() => {
     if (!prefersPanel) return;
@@ -1332,7 +1364,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const showPanel = prefersPanel && !!panelLineId;
 
   return (
-    <div className="w-full bg-background px-3 py-4 text-foreground sm:px-5 lg:px-8 xl:px-10">
+    <div className="w-full bg-[var(--theme-surface-2,#0B1220)] px-3 py-4 text-foreground sm:px-5 lg:px-8 xl:px-10">
       <VoiceContextSetter
         currentView="work_order_page"
         workOrderId={wo?.id}
@@ -1890,6 +1922,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                         onDelete={() => openDeleteForLine(ln.id)}
                         compact={showPanel}
                         selected={panelLineId === ln.id}
+                        hideExecutionStageCompletenessPills
                       />
                     );
                   })}

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -52,6 +52,7 @@ type JobCardProps = {
   reviewOk?: boolean;
   compact?: boolean;
   selected?: boolean;
+  hideExecutionStageCompletenessPills?: boolean;
 };
 
 type JobLinePriority = "low" | "normal" | "high" | "urgent";
@@ -316,6 +317,7 @@ export function JobCard({
   reviewOk,
   compact = false,
   selected = false,
+  hideExecutionStageCompletenessPills = false,
 }: JobCardProps): JSX.Element {
   const [collapsed, setCollapsed] = useState<boolean>(false);
 
@@ -325,6 +327,7 @@ export function JobCard({
   );
 
   const isCompletedLike = statusVisual.muted;
+  const isActiveLine = statusVisual.label === "Active";
 
   useEffect(() => {
     setCollapsed(isCompletedLike);
@@ -383,13 +386,13 @@ export function JobCard({
           METALLIC_CARD_SURFACE,
           statusVisual.borderClass,
           statusVisual.glowClass,
-          statusVisual.muted && "opacity-[0.84] saturate-[0.7]",
+          statusVisual.muted && "border-slate-600/35 opacity-[0.74] saturate-[0.56] contrast-[0.9]",
           "hover:-translate-y-[1px] hover:border-white/25",
           "focus-within:border-white/35",
           selected && "border-white/35 shadow-[0_0_0_1px_rgba(148,163,184,0.45)]",
         )}
       >
-        <div className={cn("absolute inset-y-0 left-0 w-1", statusVisual.railClass)} />
+        <div className={cn("absolute inset-y-0 left-0 w-1.5", statusVisual.railClass, statusVisual.muted && "opacity-75")} />
 
         <div className={cn("relative pl-5", compact ? "p-3" : "p-4")}>
           <div className={cn("flex flex-col", compact ? "gap-2" : "gap-3")}>
@@ -406,6 +409,9 @@ export function JobCard({
                     className={cn(
                       "inline-flex items-center rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em]",
                       statusVisual.chipClass,
+                      isActiveLine &&
+                        "shadow-[0_0_18px_rgba(103,232,249,0.28)] [animation:pulse_2.6s_ease-in-out_infinite]",
+                      statusVisual.muted && "text-slate-300",
                     )}
                   >
                     {statusVisual.label}
@@ -436,7 +442,7 @@ export function JobCard({
                 </p>
               </div>
 
-              <div className={cn("flex flex-wrap items-center", compact ? "gap-1" : "gap-1.5")}>
+              <div className={cn("flex flex-wrap items-center", compact ? "gap-1" : "gap-1.5", statusVisual.muted && "opacity-80")}>
                 <Button type="button" variant={selected ? "secondary" : "outline"} size="sm" onClick={onOpen}>
                   Open
                 </Button>
@@ -473,12 +479,16 @@ export function JobCard({
               </div>
             </div>
 
-            <div className={cn("flex flex-wrap", compact ? "gap-1" : "gap-1.5")}>
-              {reviewFlags.missingCause ? <ReviewPill tone="warn" label="Cause Missing" title="Cause completeness" /> : null}
-              {reviewFlags.missingCorrection ? (
+            <div className={cn("flex flex-wrap", compact ? "gap-1" : "gap-1.5", statusVisual.muted && "opacity-85")}>
+              {!hideExecutionStageCompletenessPills && reviewFlags.missingCause ? (
+                <ReviewPill tone="warn" label="Cause Missing" title="Cause completeness" />
+              ) : null}
+              {!hideExecutionStageCompletenessPills && reviewFlags.missingCorrection ? (
                 <ReviewPill tone="warn" label="Correction Missing" title="Correction completeness" />
               ) : null}
-              {reviewFlags.noParts ? <ReviewPill tone="warn" label="No Parts" title="Parts completeness" /> : null}
+              {!hideExecutionStageCompletenessPills && reviewFlags.noParts ? (
+                <ReviewPill tone="warn" label="No Parts" title="Parts completeness" />
+              ) : null}
               {isBlocked ? <ReviewPill tone="warn" label="Blocked" title="Line currently blocked or on hold" /> : null}
               {waitingApproval ? (
                 <ReviewPill tone="info" label="Awaiting Approval" title="Waiting for approval decision" />


### PR DESCRIPTION
### Motivation
- Improve technician work-order card clarity and scanability without changing workflow logic or role behavior. 
- Reduce downstream/billing noise during technician execution and make the active line easier to find. 
- Make completed lines visually recede and remove the warm/brown page cast so cards match the app shell.

### Description
- Added a `hideExecutionStageCompletenessPills` prop to `JobCard` and stopped rendering the `Cause Missing`, `Correction Missing`, and `No Parts` review pills for the technician execution surface (render logic change, not CSS hide). (files: `features/work-orders/components/JobCard.tsx`, `app/work-orders/[id]/Client.tsx`) 
- Refined active status pill to a restrained pulse/glow and slightly brighter treatment, widened the left status rail from `w-1` to `w-1.5`, and reduced completed-card contrast/saturation so completed lines visually recede while remaining readable. (file: `features/work-orders/components/JobCard.tsx`) 
- Replaced the warm/brown page background on the technician work-order surface by switching the wrapper from `bg-background` to the shared cool-neutral surface token `bg-[var(--theme-surface-2,#0B1220)]`. (file: `app/work-orders/[id]/Client.tsx`) 
- Implemented canonical ordering in `sortedLines` so the list now: 1) pins the currently active/punched-in line for the current technician to the top, 2) keeps other non-completed lines in stable existing order, and 3) moves completed-like lines (`completed`, `ready_to_invoice`, `invoiced`) to the bottom; added helper `isCompletedLineStatus`. (file: `app/work-orders/[id]/Client.tsx`) 
- Preserved compact vertical spacing and existing button/action row structure; only the job-card surface and the ordering logic were touched. (files changed: `app/work-orders/[id]/Client.tsx`, `features/work-orders/components/JobCard.tsx`) 

### Testing
- Ran targeted eslint on changed files: `npx eslint app/work-orders/[id]/Client.tsx features/work-orders/components/JobCard.tsx`, which completed without errors. 
- Ran TypeScript check: `npx tsc --noEmit`, which completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e069f8ce0c8328acb14227cf234ae1)