### PR TITLE
Refine inspection modal/page hierarchy and footer CTA clarity

### DIFF
--- a/features/inspections/components/InspectionModal.tsx
+++ b/features/inspections/components/InspectionModal.tsx
@@ -252,14 +252,14 @@ export default function InspectionModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-start justify-between gap-3 rounded-t-2xl border-b border-slate-700/80 bg-slate-950/95 px-4 py-3">
+        <div className="flex items-start justify-between gap-3 rounded-t-2xl border-b border-slate-700/80 bg-slate-950/95 px-4 py-2.5">
           <div className="space-y-1">
             <Dialog.Title className="text-base font-semibold tracking-wide text-foreground sm:text-lg">
               {title}
             </Dialog.Title>
 
             {derived.displayTemplate && (
-              <p className="text-[11px] text-muted-foreground">
+              <p className="text-[10px] text-muted-foreground">
                 Template:{" "}
                 <span className="font-mono text-[rgba(184,115,51,0.95)]">
                   {derived.displayTemplate}
@@ -315,7 +315,7 @@ export default function InspectionModal({
           )}
 
           {/* Footer actions */}
-          <div className="mt-4 flex flex-col gap-2 border-t border-slate-800 pt-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="sticky bottom-0 mt-4 flex flex-col gap-2 border-t border-slate-800 bg-slate-950/95 pt-3 sm:flex-row sm:items-center sm:justify-between">
             <button
               type="button"
               onClick={() => setCompact((v) => !v)}
@@ -327,16 +327,9 @@ export default function InspectionModal({
               <button
                 type="button"
                 onClick={close}
-                className="rounded-full border border-slate-700 bg-slate-900 px-4 py-1.5 text-xs text-muted-foreground hover:bg-slate-800 sm:text-sm"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={close}
                 className="rounded-full border border-[rgba(184,115,51,0.9)] bg-[rgba(184,115,51,0.12)] px-4 py-1.5 text-xs font-medium text-[rgba(252,211,77,0.98)] hover:bg-[rgba(184,115,51,0.22)] sm:text-sm"
               >
-                Close
+                Close inspection
               </button>
             </div>
           </div>

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -2491,9 +2491,9 @@ type SmartMatchRow = {
     ? "relative mx-auto max-w-[1100px] px-3 py-4 pb-36"
     : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-40";
 
-  const headerCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-6 md:py-5 mb-4 md:mb-6`;
+  const headerCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-4 mb-3 md:mb-4`;
   const sectionCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-5 mb-4 md:mb-6`;
-  const supportCard = `${PANEL_VARIANTS.secondary} px-3 py-2.5 md:px-4 md:py-3`;
+  const supportCard = `${PANEL_VARIANTS.secondary} px-3 py-2 md:px-4 md:py-2.5`;
   const passiveCard = `${PANEL_VARIANTS.passive} px-3 py-2.5 md:px-4 md:py-3`;
 
   const sectionTitle =
@@ -2515,24 +2515,37 @@ type SmartMatchRow = {
   }, [inspectionId, workOrderId, workOrderLineId, templateName]);
 
 
+  const allItems = (session.sections ?? []).flatMap((s) => s.items ?? []);
+  const failed = allItems.filter(
+    (it) => String(it.status ?? "").toLowerCase() === "fail",
+  );
+  const recommended = allItems.filter(
+    (it) => String(it.status ?? "").toLowerCase() === "recommend",
+  );
+  const otherOkNa = allItems.filter((it) => {
+    const st = String(it.status ?? "").toLowerCase();
+    return st === "ok" || st === "na" || st === "" || st === "pass";
+  });
+  const linesAdded = session.voiceMeta?.linesAddedToWorkOrder ?? 0;
+
   const actions = (
     <>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="font-medium border-[rgba(184,115,51,0.75)] text-[11px] tracking-[0.16em] uppercase"
-        onClick={() => router.push(findingsHref)}
-        disabled={isLocked}
-      >
-        Review findings
-      </Button>
-
       <SaveInspectionButton
         session={session}
         workOrderLineId={workOrderLineId}
         disabled={isLocked}
       />
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="font-medium border-white/20 text-[11px] tracking-[0.16em] uppercase text-neutral-200"
+        onClick={() => router.push(findingsHref)}
+        disabled={isLocked}
+      >
+        Open findings list
+      </Button>
 
       {workOrderLineId && (
         <FinishInspectionButton
@@ -2582,15 +2595,23 @@ type SmartMatchRow = {
         className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--brand-accent,#E39A6E)_18%,transparent),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]"
       />
 
-      <div className="relative space-y-4">
+      <div className="relative space-y-3">
         <div className={headerCard}>
-          <div className="mb-3 border-b border-[var(--theme-card-border,#334155)] pb-3 text-center">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--theme-text-muted,#64748B)]">
-              Inspection
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-[var(--theme-card-border,#334155)] pb-2">
+            <div>
+              <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--theme-text-muted,#64748B)]">
+                Inspection
+              </div>
+              <div className="mt-0.5 text-base md:text-lg font-semibold text-[var(--theme-text-primary,#E2E8F0)]">
+                {session?.templateitem || templateName || "Inspection"}
+              </div>
             </div>
-            <div className="mt-1 text-lg md:text-xl font-semibold text-[var(--theme-text-primary,#E2E8F0)]">
-              {session?.templateitem || templateName || "Inspection"}
-            </div>
+            <ProgressTracker
+              currentItem={session.currentItemIndex}
+              currentSection={session.currentSectionIndex}
+              totalSections={session.sections.length}
+              totalItems={session.sections[safeSectionIndex]?.items?.length ?? 0}
+            />
           </div>
 
           <CustomerVehicleHeader
@@ -2600,256 +2621,133 @@ type SmartMatchRow = {
           />
         </div>
 
-        <div className="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
-          {!isLocked && (
-            <StartListeningButton
-              isListening={isListening}
-              onStart={startListening}
-            />
-          )}
-
-          {!isLocked && (isListening || isPaused) && (
-            <PauseResumeButton
-              isPaused={isPaused}
-              onPause={() => {
-                setIsPaused(true);
-                pauseSession();
-                stopListening();
-              }}
-              onResume={() => {
-                setIsPaused(false);
-                resumeSession();
-                void startListening();
-              }}
-            />
-          )}
-
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full justify-center border-orange-300/70 bg-black/60 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-100 hover:border-orange-400 hover:bg-black/80"
-            onClick={(): void => setUnit(unit === "metric" ? "imperial" : "metric")}
-          >
-            Unit: {unit === "metric" ? "Metric (mm / kPa)" : "Imperial (in / psi)"}
-          </Button>
-        </div>
-
-        <div className="mt-1 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.85fr)] lg:items-start">
-          <section className="space-y-2">
-            <div className="flex items-center justify-center gap-2 lg:justify-start">
-          <div className={voicePulse ? "rounded-full shadow-[0_0_0_6px_rgba(16,185,129,0.12)]" : ""}>
-            <StatusBadge
-              variant={
-                voiceState === "listening"
-                  ? "success"
+        <div className={supportCard}>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className={voicePulse ? "rounded-full shadow-[0_0_0_6px_rgba(16,185,129,0.12)]" : ""}>
+              <StatusBadge
+                variant={
+                  voiceState === "listening"
+                    ? "success"
+                    : voiceState === "connecting"
+                      ? "warning"
+                      : voiceState === "error"
+                        ? "danger"
+                        : "neutral"
+                }
+                size="md"
+                className="inline-flex items-center gap-2 px-3 py-1"
+              >
+                <span
+                  className={[
+                    "h-2 w-2 rounded-full",
+                    voiceState === "listening"
+                      ? "bg-emerald-400"
+                      : voiceState === "connecting"
+                        ? "bg-amber-400"
+                        : voiceState === "error"
+                          ? "bg-red-400"
+                          : "bg-neutral-500",
+                    voiceState === "listening" ? "animate-pulse" : "",
+                  ].join(" ")}
+                />
+                {voiceState === "listening"
+                  ? "Listening…"
                   : voiceState === "connecting"
-                    ? "warning"
+                    ? "Connecting…"
                     : voiceState === "error"
-                      ? "danger"
-                      : "neutral"
-              }
-              size="md"
-              className="inline-flex items-center gap-2 px-3 py-1"
+                      ? "Voice error"
+                      : "Voice idle"}
+                {voicePulse && <span className="text-emerald-200/80">• audio</span>}
+              </StatusBadge>
+            </div>
+
+            {wakeActive && (
+              <div className="rounded-full border border-orange-400/60 bg-orange-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-orange-200">
+                Ready
+              </div>
+            )}
+
+            {!isLocked && (
+              <StartListeningButton isListening={isListening} onStart={startListening} />
+            )}
+
+            {!isLocked && (isListening || isPaused) && (
+              <PauseResumeButton
+                isPaused={isPaused}
+                onPause={() => {
+                  setIsPaused(true);
+                  pauseSession();
+                  stopListening();
+                }}
+                onResume={() => {
+                  setIsPaused(false);
+                  resumeSession();
+                  void startListening();
+                }}
+              />
+            )}
+
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full justify-center border-orange-300/70 bg-black/60 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-100 hover:border-orange-400 hover:bg-black/80 sm:w-auto"
+              onClick={(): void => setUnit(unit === "metric" ? "imperial" : "metric")}
             >
-            <span
-              className={[
-                "h-2 w-2 rounded-full",
-                voiceState === "listening"
-                  ? "bg-emerald-400"
-                  : voiceState === "connecting"
-                    ? "bg-amber-400"
-                    : voiceState === "error"
-                      ? "bg-red-400"
-                      : "bg-neutral-500",
-                voiceState === "listening" ? "animate-pulse" : "",
-              ].join(" ")}
-            />
-            {voiceState === "listening"
-              ? "Listening…"
-              : voiceState === "connecting"
-                ? "Connecting…"
-                : voiceState === "error"
-                ? "Voice error"
-                  : "Voice idle"}
-            {voicePulse && <span className="text-emerald-200/80">• audio</span>}
-            </StatusBadge>
+              Unit: {unit === "metric" ? "Metric (mm / kPa)" : "Imperial (in / psi)"}
+            </Button>
+
+            <div className="ml-auto flex items-center gap-2 text-[11px]">
+              <span className="rounded-full border border-red-500/35 bg-red-500/10 px-2 py-0.5 text-red-100">
+                Fail {failed.length}
+              </span>
+              <span className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2 py-0.5 text-amber-100">
+                Rec {recommended.length}
+              </span>
+              <span className="rounded-full border border-emerald-500/35 bg-emerald-500/10 px-2 py-0.5 text-emerald-100">
+                OK/NA {otherOkNa.length}
+              </span>
+              <span className="rounded-full border border-sky-500/35 bg-sky-500/10 px-2 py-0.5 text-sky-100">
+                WO lines {linesAdded}
+              </span>
+            </div>
           </div>
 
-          {/* ✅ visible wake indicator so you’re not relying on toast/beep */}
-          {wakeActive && (
-            <div className="rounded-full border border-orange-400/60 bg-orange-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-orange-200">
-              Ready
-            </div>
+          {Array.isArray(session.voiceTrace) && session.voiceTrace.length > 0 && (
+            <details className={`${passiveCard} mt-2`}>
+              <summary className="cursor-pointer list-none text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
+                Voice log ({session.voiceTrace.length})
+              </summary>
+              <div className="mt-2 space-y-2">
+                {session.voiceTrace
+                  .slice(-6)
+                  .reverse()
+                  .map((e) => {
+                    const okCount = (e.applied ?? []).filter((a) => a.ok).length;
+                    const failCount = (e.applied ?? []).filter((a) => !a.ok).length;
+
+                    return (
+                      <div
+                        key={e.id}
+                        className="rounded-xl border border-white/10 bg-black/50 px-3 py-2"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div className="text-xs text-neutral-200">{e.rawFinal}</div>
+                          <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                            {new Date(e.ts).toLocaleTimeString()}
+                          </div>
+                        </div>
+
+                        <div className="mt-1 flex items-center gap-2 text-[11px]">
+                          <span className="text-emerald-200">✓ {okCount}</span>
+                          <span className="text-red-200">✕ {failCount}</span>
+                          <span className="text-neutral-500">parsed: {(e.parsed ?? []).length}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+              </div>
+            </details>
           )}
-        </div>
-
-
-            {/* ✅ UI ADDITION: Summary + Voice Log */}
-            {(() => {
-          const sections = session.sections ?? [];
-          const allItems = sections.flatMap((s) => s.items ?? []);
-
-          const failed = allItems.filter(
-            (it) => String(it.status ?? "").toLowerCase() === "fail",
-          );
-          const rec = allItems.filter(
-            (it) => String(it.status ?? "").toLowerCase() === "recommend",
-          );
-
-          const otherOkNa = allItems.filter((it) => {
-            const st = String(it.status ?? "").toLowerCase();
-            return st === "ok" || st === "na" || st === "" || st === "pass";
-          });
-
-          const linesAdded = session.voiceMeta?.linesAddedToWorkOrder ?? 0;
-
-          return (
-            <div className={supportCard}>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
-                Inspection Summary
-              </div>
-
-              <ul className="mt-2 space-y-1 text-xs text-neutral-300">
-                <li className="text-neutral-200">
-                  • current{" "}
-                  <span className="font-semibold">
-                    {session.templateitem || templateName || "inspection"}
-                  </span>
-                  .
-                </li>
-
-                <li>
-                  • Failed items:{" "}
-                  <span
-                    className={
-                      failed.length
-                        ? "text-red-200 font-semibold"
-                        : "text-neutral-200"
-                    }
-                  >
-                    {failed.length}
-                  </span>
-                </li>
-                {failed.slice(0, 6).map((it, idx) => (
-                  <li key={`fail-${idx}`} className="ml-3 text-red-200/90">
-                    - {String(it.item ?? "Item")}
-                    {String(it.notes ?? "").trim()
-                      ? ` — ${String(it.notes).trim()}`
-                      : ""}
-                  </li>
-                ))}
-
-                <li className="mt-1">
-                  • Recommended items:{" "}
-                  <span
-                    className={
-                      rec.length
-                        ? "text-amber-200 font-semibold"
-                        : "text-neutral-200"
-                    }
-                  >
-                    {rec.length}
-                  </span>
-                </li>
-                {rec.slice(0, 6).map((it, idx) => (
-                  <li key={`rec-${idx}`} className="ml-3 text-amber-200/90">
-                    - {String(it.item ?? "Item")}
-                    {String(it.notes ?? "").trim()
-                      ? ` — ${String(it.notes).trim()}`
-                      : ""}
-                  </li>
-                ))}
-
-                <li className="mt-1 text-neutral-200">
-                  • All other inspection items OK/NA:{" "}
-                  <span className="font-semibold">{otherOkNa.length}</span>
-                </li>
-
-                <li className="text-neutral-200">
-                  • Lines added and sent for quote:{" "}
-                  <span
-                    className={
-                      linesAdded
-                        ? "font-semibold text-emerald-200"
-                        : "font-semibold text-neutral-200"
-                    }
-                  >
-                    {linesAdded}
-                  </span>
-                </li>
-              </ul>
-            </div>
-          );
-        })()}
-          </section>
-
-          <aside className="space-y-2 lg:sticky lg:top-4">
-        {Array.isArray(session.voiceTrace) && session.voiceTrace.length > 0 ? (
-          <div className={passiveCard}>
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-300">
-                Voice Log
-              </div>
-              <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-                {session.voiceTrace.length} events
-              </div>
-            </div>
-
-            <div className="mt-2 space-y-2">
-              {session.voiceTrace
-                .slice(-8)
-                .reverse()
-                .map((e) => {
-                  const okCount = (e.applied ?? []).filter((a) => a.ok).length;
-                  const failCount = (e.applied ?? []).filter((a) => !a.ok).length;
-
-                  return (
-                    <div
-                      key={e.id}
-                      className="rounded-xl border border-white/10 bg-black/50 px-3 py-2"
-                    >
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <div className="text-xs text-neutral-200">
-                          <span className="font-semibold">Heard:</span>{" "}
-                          <span className="text-neutral-300">{e.rawFinal}</span>
-                        </div>
-                        <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-                          {new Date(e.ts).toLocaleTimeString()}
-                        </div>
-                      </div>
-
-                      <div className="mt-1 text-xs text-neutral-300">
-                        <span className="font-semibold">Command:</span>{" "}
-                        {e.wakeCommand ?? "(wake only)"}
-                      </div>
-
-                      <div className="mt-1 flex items-center gap-2 text-[11px]">
-                        <span className="text-emerald-200">✓ {okCount}</span>
-                        <span className="text-red-200">✕ {failCount}</span>
-                        <span className="text-neutral-500">
-                          parsed: {(e.parsed ?? []).length}
-                        </span>
-                      </div>
-                    </div>
-                  );
-                })}
-            </div>
-          </div>
-        ) : (
-          <div className="mt-2 text-center text-[11px] text-neutral-500">
-            No voice commands captured yet.
-          </div>
-        )}
-
-        <div className={supportCard + " mb-4"}>
-          <ProgressTracker
-            currentItem={session.currentItemIndex}
-            currentSection={session.currentSectionIndex}
-            totalSections={session.sections.length}
-            totalItems={session.sections[safeSectionIndex]?.items?.length ?? 0}
-          />
-        </div>
-          </aside>
         </div>
 
         <InspectionFormCtx.Provider value={{ updateItem, updateSection }}>
@@ -3163,9 +3061,14 @@ type SmartMatchRow = {
                             onDismissSmartMatch={dismissSmartMatch}
                           />
 
-                          <div className="mt-4 border-t border-[var(--theme-card-border,#334155)] pt-3">
-                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-muted,#64748B)]">
-                              Add custom item
+                          <div className="mt-3 rounded-xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_65%,transparent)] px-3 py-3">
+                            <div className="mb-2 flex items-center justify-between gap-2">
+                              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-muted,#64748B)]">
+                                Section authoring
+                              </div>
+                              <div className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                                Add custom item
+                              </div>
                             </div>
                             <div className="flex flex-col gap-2 md:flex-row md:items-center">
                               <input


### PR DESCRIPTION
### Motivation
- Compress inspection top-of-screen layers and reduce toolbar-stack feeling so section work appears faster and remains the visual priority.
- Remove duplicated / competing primary actions in footers (particularly the duplicate “Review Findings”) and make footer CTA hierarchy deliberate.
- Integrate the custom item input into the section body so authoring feels part of inspection work rather than a detached utility strip.
- Preserve existing visual language and avoid changing inspection business logic or data shape.

### Description
- Tightened the inspection modal header spacing and lowered template label type-size, made the modal footer disciplined and sticky with one clear primary CTA (`Close inspection`) and a subordinate size toggle utility; removed duplicate cancel/close footer button. (file: `features/inspections/components/InspectionModal.tsx`)
- Compressed the full inspection screen top stack by reducing header card spacing and moving the `ProgressTracker` into the compact header row so the first section appears sooner. (file: `features/inspections/screens/GenericInspectionScreen.tsx`)
- Reworked the top utility band into a single compact support row that groups voice state, wake indicator, voice controls, unit toggle, and compact status chips (Fail / Rec / OK‑NA / WO lines) to reduce pill/chip overload and toolbar stacking. (file: `features/inspections/screens/GenericInspectionScreen.tsx`)
- Converted the voice log into a collapsible `details` block to lower visual weight but keep access to recent events. (file: `features/inspections/screens/GenericInspectionScreen.tsx`)
- Removed the duplicated footer “Review findings” emphasis and renamed the secondary findings utility to `Open findings list`, leaving `FinishInspectionButton` as the single primary findings progression action. (file: `features/inspections/screens/GenericInspectionScreen.tsx`)
- Integrated the “Add custom item” UI into an in-flow `Section authoring` block with a compact header so custom items feel attached to the section body rather than a detached strip. (file: `features/inspections/screens/GenericInspectionScreen.tsx`)
- Exact files changed: `features/inspections/components/InspectionModal.tsx`, `features/inspections/screens/GenericInspectionScreen.tsx`.

### Testing
- Ran targeted lint for changed files with `pnpm eslint features/inspections/components/InspectionModal.tsx features/inspections/screens/GenericInspectionScreen.tsx`, which passed with one pre-existing `react-hooks/exhaustive-deps` warning in `GenericInspectionScreen.tsx` (no new errors introduced).
- Ran typecheck `npx tsc --noEmit`, which completed successfully.
- Manual verification checklist to run locally: open inspection modal and full inspection page, confirm only one primary footer action appears, verify section content is reached sooner, confirm voice/unit controls and custom item add still function, verify corner grids and section cards render without layout regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e070388eec8328b352c237203fd046)