### PR TITLE
Refine desktop tech work-order support band and focused panel layout

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1314,6 +1314,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   );
 
   const cardInner = cn(PANEL_VARIANTS.passive, "p-3");
+  const supportFullyCollapsed = !showDetails && !showApprovalSummary && !showTimeline;
 
   // ✅ layout: desktop keeps the focused cockpit open with a selected (or first) line.
   const panelLineId = focusedJobId ?? sortedLines[0]?.id ?? null;
@@ -1360,23 +1361,11 @@ export default function WorkOrderIdClient(): JSX.Element {
         ) : !wo ? (
           <div className="mt-2 text-sm text-red-400">Work order not found.</div>
         ) : (
-          <div className="space-y-2.5">
-            <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}>
-              <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] xl:items-end">
-                <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                  <div className={cn(cardInner, "p-2.5")}>
-                    <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                      Created
-                    </div>
-                    <div className="mt-1 text-sm font-medium text-foreground">{createdAtText}</div>
-                  </div>
-                  <div className={cn(cardInner, "p-2.5 sm:col-span-2 xl:col-span-1")}>
-                    <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                      Expected completion
-                    </div>
-                    <div className="mt-1 text-sm font-medium text-foreground">{expectedCompletionText}</div>
-                  </div>
-                  <div className={cn(cardInner, "p-2.5")}>
+          <div className={cn("space-y-2.5", supportFullyCollapsed && "space-y-2")}>
+            <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+              <div className="grid gap-2 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,0.65fr)] xl:items-stretch">
+                <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className={cn(cardInner, "p-2")}>
                     <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                       Order state
                     </div>
@@ -1394,30 +1383,42 @@ export default function WorkOrderIdClient(): JSX.Element {
                       )}
                     </div>
                   </div>
+                  <div className={cn(cardInner, "p-2")}>
+                    <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                      Target completion
+                    </div>
+                    <div className="mt-1 text-sm font-medium text-foreground">{expectedCompletionText}</div>
+                  </div>
+                  <div className={cn(cardInner, "p-2 sm:col-span-2 xl:col-span-1")}>
+                    <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                      Created
+                    </div>
+                    <div className="mt-1 text-xs font-medium text-muted-foreground">{createdAtText}</div>
+                  </div>
                 </div>
 
-                <div className={cn(cardInner, "p-2.5")}>
+                <div className={cn(cardInner, "p-2")}>
                   <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                     Target completion
                   </div>
-                  <div className="flex flex-wrap items-end gap-2">
+                  <div className="flex flex-wrap items-end gap-1.5">
                     <input
                       type="datetime-local"
                       value={expectedCompletionInput}
                       onChange={(e) => setExpectedCompletionInput(e.target.value)}
-                      className="min-w-[220px] flex-1 rounded-md border border-white/10 bg-black/30 px-2 py-1.5 text-sm"
+                      className="min-w-[200px] flex-1 rounded-md border border-white/10 bg-black/30 px-2 py-1.5 text-xs sm:text-sm"
                     />
                     <button
                       type="button"
                       onClick={() => void saveExpectedCompletion()}
                       disabled={savingExpectedCompletion}
-                      className="rounded-md border border-[rgba(184,115,51,0.45)] bg-[rgba(184,115,51,0.10)] px-3 py-1.5 text-xs font-semibold text-amber-100 hover:bg-[rgba(184,115,51,0.16)] disabled:opacity-60"
+                      className="rounded-md border border-[rgba(184,115,51,0.45)] bg-[rgba(184,115,51,0.10)] px-2.5 py-1.5 text-[11px] font-semibold text-amber-100 hover:bg-[rgba(184,115,51,0.16)] disabled:opacity-60"
                     >
                       {savingExpectedCompletion ? "Saving…" : "Save target"}
                     </button>
                     <button
                       type="button"
-                      className="rounded-md border border-white/15 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:border-[rgba(184,115,51,0.45)] hover:text-amber-100"
+                      className="rounded-md border border-white/15 px-2.5 py-1.5 text-[11px] font-medium text-muted-foreground hover:border-[rgba(184,115,51,0.45)] hover:text-amber-100"
                       onClick={() => {
                         if (!wo?.id) return;
                         router.push(`/work-orders/${wo.id}/intake`);
@@ -1431,8 +1432,8 @@ export default function WorkOrderIdClient(): JSX.Element {
               </div>
             </section>
 
-            <section className="grid gap-2.5 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.15fr)] xl:items-start">
-              <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}>
+            <section className={cn("grid gap-2 xl:items-start", supportFullyCollapsed ? "xl:grid-cols-[minmax(0,0.95fr)_minmax(0,0.95fr)_minmax(0,1.1fr)]" : "xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.15fr)]")}>
+              <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
                 <div className="flex items-center justify-between gap-2">
                   <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                     Vehicle &amp; Customer
@@ -1447,8 +1448,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                   </button>
                 </div>
 
-                {showDetails && (
-                  <div className="mt-2 grid gap-2.5 sm:grid-cols-2 xl:grid-cols-1">
+                {showDetails ? (
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
                 {/* Vehicle */}
                 <div className={cardInner}>
                   <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -1517,13 +1518,23 @@ export default function WorkOrderIdClient(): JSX.Element {
                   )}
                 </div>
                   </div>
+                ) : (
+                  <div className={cn(cardInner, "mt-2 flex items-center justify-between gap-2 p-2")}>
+                    <p className="truncate text-[11px] text-muted-foreground">
+                      {vehicle ? `${vehicle.year ?? ""} ${vehicle.make ?? ""} ${vehicle.model ?? ""}`.trim() || "Vehicle linked" : "No vehicle linked"}
+                      {" • "}
+                      {customer
+                        ? [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ") || "Customer linked"
+                        : "No customer linked"}
+                    </p>
+                  </div>
                 )}
               </section>
 
               <section
                 className={cn(
                   PANEL_VARIANTS.secondary,
-                  "p-2.5",
+                  "p-2",
                   hasAnyApprovalItems ? "cursor-pointer hover:border-sky-400/35" : "",
                 )}
                 onClick={hasAnyApprovalItems ? openQuoteReview : undefined}
@@ -1699,13 +1710,13 @@ export default function WorkOrderIdClient(): JSX.Element {
                   )}
                 </>
               ) : (
-                <div className="text-[11px] text-muted-foreground">
+                <div className={cn(cardInner, "p-2 text-[11px] text-muted-foreground")}>
                   {approvalPending.length + approvalPendingQuotes.length} item(s) awaiting decision.
                 </div>
               )}
               </section>
 
-              <section className={cn(PANEL_VARIANTS.secondary, "p-2.5")}>
+              <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
                 <button
                   type="button"
                   className="flex w-full items-center justify-between gap-2 text-left"
@@ -1722,7 +1733,7 @@ export default function WorkOrderIdClient(): JSX.Element {
 
                 {showTimeline ? (
                   <div className="mt-2 grid gap-2.5">
-                    <DecisionTimeline stages={decisionTimelineStages} compact />
+                    <DecisionTimeline stages={decisionTimelineStages} compact orientation="vertical" />
                     <div className={cn(PANEL_VARIANTS.passive, "p-2")}>
                       <DecisionEventFeed
                         events={decisionEvents}
@@ -1742,7 +1753,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                     </div>
                   </div>
                 ) : (
-                  <p className="mt-2 text-[11px] text-muted-foreground">
+                  <p className={cn(cardInner, "mt-2 p-2 text-[11px] text-muted-foreground")}>
                     Recent decision history is available when needed.
                   </p>
                 )}
@@ -1750,7 +1761,7 @@ export default function WorkOrderIdClient(): JSX.Element {
             </section>
 
           {/* Workspace */}
-          <section className="grid gap-3 lg:grid-cols-[minmax(0,58fr)_minmax(0,42fr)] lg:items-start lg:gap-4">
+          <section className={cn("grid lg:grid-cols-[minmax(0,58fr)_minmax(0,42fr)] lg:items-start", supportFullyCollapsed ? "gap-2.5 lg:gap-3" : "gap-3 lg:gap-4")}>
             {/* Left: jobs list/cards */}
             <div className="space-y-2">
               {sortedLines.length === 0 ? (
@@ -1762,7 +1773,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                   actions in the focused panel to start building this work order.
                 </p>
               ) : (
-                <div className="space-y-3">
+                <div className="space-y-2.5">
                   {sortedLines.map((ln, idx) => {
                     const punchedIn = !!ln.punched_in_at && !ln.punched_out_at;
 

--- a/features/shared/components/ui/DecisionTimeline.tsx
+++ b/features/shared/components/ui/DecisionTimeline.tsx
@@ -46,7 +46,9 @@ export default function DecisionTimeline({
       </div>
       <ol
         className={cn(
-          vertical ? "space-y-2" : "grid gap-2 md:grid-cols-4",
+          vertical
+            ? "space-y-2"
+            : "grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-2",
         )}
       >
         {stages.map((stage) => (
@@ -58,12 +60,14 @@ export default function DecisionTimeline({
               stageTone(stage.state),
             )}
           >
-            <div className="flex items-center justify-between gap-2">
-              <div className={cn("font-semibold", compact ? "text-[11px]" : "text-xs")}>{stage.label}</div>
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className={cn("min-w-0 break-words font-semibold", compact ? "text-[11px]" : "text-xs")}>
+                {stage.label}
+              </div>
               <StatusBadge
                 size="sm"
                 variant={stage.state === "current" ? "active" : stage.state === "past" ? "success" : "neutral"}
-                className="px-2 py-0.5 text-[9px]"
+                className="shrink-0 px-2 py-0.5 text-[9px]"
               >
                 {stage.state}
               </StatusBadge>

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -6,6 +6,7 @@ import { format } from "date-fns";
 import { toast } from "sonner";
 import { v4 as uuidv4 } from "uuid";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { cn } from "@shared/lib/utils";
 
 import CauseCorrectionModal from "@work-orders/components/workorders/CauseCorrectionModal";
 import PartsRequestModal from "@/features/work-orders/components/workorders/PartsRequestModal";
@@ -158,6 +159,7 @@ export default function FocusedJobModal(props: {
   const [openAi, setOpenAi] = useState(false);
   const [openDtc, setOpenDtc] = useState(false);
   const [openVehicleHistory, setOpenVehicleHistory] = useState(false);
+  const [panelExpanded, setPanelExpanded] = useState(false);
 
   const [prefillCause, setPrefillCause] = useState("");
   const [prefillCorrection, setPrefillCorrection] = useState("");
@@ -207,7 +209,10 @@ export default function FocusedJobModal(props: {
       return;
     }
     closeAllSubModals();
-  }, [isOpen, workOrderLineId, closeAllSubModals]);
+    if (variant !== "panel") {
+      setPanelExpanded(false);
+    }
+  }, [isOpen, workOrderLineId, closeAllSubModals, variant]);
 
   useEffect(() => {
     if (!isOpen || !workOrderLineId) return;
@@ -525,6 +530,7 @@ export default function FocusedJobModal(props: {
     line?.status === "declined" ||
     (!!line?.approval_state && line.approval_state !== "approved");
   const isPanelVariant = variant === "panel";
+  const isExpandedPanel = isPanelVariant && panelExpanded;
   const partsCount = allocs.length;
   const laborDisplay =
     typeof line?.labor_time === "number" ? `${line.labor_time.toFixed(1)} h` : "—";
@@ -555,7 +561,7 @@ export default function FocusedJobModal(props: {
         >
           <div className="mb-2 flex items-start justify-between gap-2">
             <div className="min-w-0">
-              <div className="truncate text-base font-semibold tracking-tight text-white sm:text-lg">
+              <div className="text-base font-semibold tracking-tight text-white sm:text-lg">
                 {titleText}
               </div>
               {workOrder ? (
@@ -568,7 +574,17 @@ export default function FocusedJobModal(props: {
               </div>
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex shrink-0 items-center gap-2">
+              {isPanelVariant ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-xl border border-white/12 bg-black/35 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-neutral-200 transition hover:border-[var(--accent-copper-soft)] hover:text-white"
+                  onClick={() => setPanelExpanded((prev) => !prev)}
+                  title={isExpandedPanel ? "Use compact panel layout" : "Use expanded panel layout"}
+                >
+                  {isExpandedPanel ? "Compact" : "Expand"}
+                </button>
+              ) : null}
               {workOrder?.id ? (
                 <button
                   type="button"
@@ -622,7 +638,7 @@ export default function FocusedJobModal(props: {
           </div>
         </div>
 
-        <div className={`${isPanelVariant ? "" : "min-h-0 flex-1 overflow-y-auto"} px-3 py-3 sm:px-4`}>
+        <div className={`${isPanelVariant ? "px-3 py-3 sm:px-4" : "min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:px-4"}`}>
           {busy && !line ? (
             <div className="grid gap-3">
               <div className="h-6 w-40 animate-pulse rounded-full bg-white/5" />
@@ -631,7 +647,15 @@ export default function FocusedJobModal(props: {
           ) : !line ? (
             <div className="text-sm text-neutral-300">No job found.</div>
           ) : (
-            <div className={isPanelVariant ? "grid gap-3 xl:grid-cols-[1.05fr_1fr]" : "space-y-4"}>
+            <div
+              className={
+                isPanelVariant
+                  ? isExpandedPanel
+                    ? "grid gap-3"
+                    : "grid gap-3 xl:grid-cols-[1.05fr_1fr]"
+                  : "space-y-4"
+              }
+            >
               <div className="space-y-3">
               {mode === "tech" ? (
                 <SectionCard title="Operational actions">
@@ -667,7 +691,7 @@ export default function FocusedJobModal(props: {
                       Complete
                     </button>
 
-                    <div className="grid gap-2 sm:grid-cols-2">
+                    <div className={cn("grid gap-2", isExpandedPanel ? "sm:grid-cols-2 lg:grid-cols-3" : "sm:grid-cols-2")}>
                     <button
                       type="button"
                       className={btnSecondary}
@@ -759,7 +783,7 @@ export default function FocusedJobModal(props: {
               ) : null}
 
               <SectionCard title="Quick status">
-                <div className="grid gap-2.5 sm:grid-cols-2">
+                <div className={cn("grid gap-2.5 sm:grid-cols-2", isExpandedPanel && "xl:grid-cols-3")}>
                   <MetaStat
                     label="Start"
                     value={createdStart}
@@ -875,7 +899,7 @@ export default function FocusedJobModal(props: {
               <div className="space-y-3">
               <SectionCard title="Tech notes">
                 <textarea
-                  rows={3}
+                  rows={isExpandedPanel ? 5 : 3}
                   value={techNotes}
                   onChange={(e) => setTechNotes(e.target.value)}
                   onBlur={saveNotes}
@@ -905,8 +929,8 @@ export default function FocusedJobModal(props: {
                           0;
 
                         return (
-                          <li key={a.id} className="grid grid-cols-12 items-center px-3 py-2 text-sm">
-                            <div className="col-span-7 truncate text-neutral-100">
+                          <li key={a.id} className="grid grid-cols-12 items-center gap-2 px-3 py-2 text-sm">
+                            <div className="col-span-7 min-w-0 break-words text-neutral-100">
                               {a.parts?.name ?? "Part"}
                             </div>
                             <div className="col-span-3 truncate text-neutral-400">


### PR DESCRIPTION
### Motivation
- Tighten and compress the desktop technician work-order command surface so support widgets never dominate the job card list and the page reads as an operational workbench. 
- Make collapsed support panels reclaim vertical space immediately and remove brittle visual weight and spacing drift above the job cards. 
- Fix the decision timeline overlap issues and make the selected-job rail a real expanded layout mode with reliable reflow and wrapping.

### Description
- Files changed: `app/work-orders/[id]/Client.tsx`, `features/shared/components/ui/DecisionTimeline.tsx`, and `features/work-orders/components/workorders/FocusedJobModal.tsx`.
- Top support band: rebalanced hierarchy to emphasize `Order state` over `Created`, made `Target completion` compact and visible, quieted `Created`, tightened paddings/gaps, and adjusted grid proportions to pull the first job card higher when support panels collapse by adding a `supportFullyCollapsed` state.
- Collapsed support panels: vehicle/customer, approval queue, and decision timeline now render compact high-signal rails or single-line summaries to immediately reclaim vertical space and reduce dead air when collapsed.
- Job cards: preserved existing ordering and status semantics while tightening list density so cards remain the visual and operational primary; no scroll-container or business logic changes were made to card ordering or status rules.
- Selected-job rail: introduced a true compact vs expanded `panelExpanded` toggle for `panel` variant, added an explicit expanded layout path with adjusted grid/rows, increased notes area in expanded mode, and improved content wrapping and action/stat grid reflow to avoid overlap and clipping.
- Decision timeline: hardened the shared `DecisionTimeline` component to use a wrapping grid for horizontal layout and allowed the work-order page to use a vertical orientation to avoid overlapping milestone labels while preserving status color semantics.
- Ordering/active-line behavior: left intact — active (punched-in) line still pins to the top and completed lines remain pushed to the bottom.

### Testing
- Ran targeted lint for changed files with `npx eslint app/work-orders/[id]/Client.tsx features/shared/components/ui/DecisionTimeline.tsx features/work-orders/components/workorders/FocusedJobModal.tsx`, which completed successfully (warnings only). 
- Ran full TypeScript check with `npx tsc --noEmit`, which completed successfully with no new type errors. 
- Manual verification checklist prepared (to be validated in a browser): first job card rises when support panels collapse, collapsed panels leave no dead space, selected-job panel compact and expanded modes reflow without clipping, decision timeline labels do not overlap, active line remains pinned to top, and completed lines sort to bottom.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e75365e48328b623a2509824cba0)