### PR TITLE
Unify auth shell sizing and centering across sign-in flows

### DIFF
--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-
+import AuthShell from "@/features/auth/components/AuthShell";
 
 const COPPER = "#C57A4A";
 const SHOP_USER_DOMAIN = "local.profix-internal";
@@ -105,30 +105,14 @@ export default function PortalSignInPage() {
       : "Use the email and password you created when you signed up.";
 
   return (
-    <div
-      className="
-        min-h-screen px-4 text-foreground
-        bg-background
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
-      "
-    >
-      <div className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center py-8">
-        <div
+    <AuthShell>
+      {/* Back to landing */}
+      <div className="mb-4 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={goLanding}
+          disabled={loading}
           className="
-            w-full rounded-3xl border
-            border-[color:var(--metal-border-soft,#1f2937)]
-            bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]
-            shadow-[0_32px_80px_rgba(0,0,0,0.95)]
-            px-6 py-7 sm:px-8 sm:py-9
-          "
-        >
-          {/* Back to landing */}
-          <div className="mb-4 flex items-center justify-between">
-            <button
-              type="button"
-              onClick={goLanding}
-              disabled={loading}
-              className="
                 inline-flex items-center gap-2 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/60 px-3 py-1.5 text-[11px]
@@ -136,46 +120,48 @@ export default function PortalSignInPage() {
                 hover:bg-black/70 hover:text-white
                 disabled:cursor-not-allowed disabled:opacity-60
               "
-            >
-              <span aria-hidden className="text-base leading-none">←</span>
-              Back
-            </button>
+        >
+          <span aria-hidden className="text-base leading-none">
+            ←
+          </span>
+          Back
+        </button>
 
-            <div className="text-[10px] text-neutral-500">
-              {portalType === "fleet" ? "Fleet access" : "Customer access"}
-            </div>
-          </div>
+        <div className="text-[10px] text-neutral-500">
+          {portalType === "fleet" ? "Fleet access" : "Customer access"}
+        </div>
+      </div>
 
-          {/* Portal switcher */}
-          <div className="mb-4 flex items-center justify-center gap-2 rounded-full border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-1 text-[11px]">
-            <button
-              type="button"
-              onClick={() => setPortalType("customer")}
-              className={`flex-1 rounded-full px-3 py-1 uppercase tracking-[0.18em] transition ${
-                portalType === "customer"
-                  ? "bg-[color:var(--accent-copper)] text-black font-semibold shadow-[0_0_18px_rgba(197,122,74,0.85)]"
-                  : "text-neutral-300 hover:bg-black/60"
-              }`}
-            >
-              Customer
-            </button>
-            <button
-              type="button"
-              onClick={() => setPortalType("fleet")}
-              className={`flex-1 rounded-full px-3 py-1 uppercase tracking-[0.18em] transition ${
-                portalType === "fleet"
-                  ? "bg-[color:var(--accent-copper)] text-black font-semibold shadow-[0_0_18px_rgba(197,122,74,0.85)]"
-                  : "text-neutral-300 hover:bg-black/60"
-              }`}
-            >
-              Fleet
-            </button>
-          </div>
+      {/* Portal switcher */}
+      <div className="mb-4 flex items-center justify-center gap-2 rounded-full border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-1 text-[11px]">
+        <button
+          type="button"
+          onClick={() => setPortalType("customer")}
+          className={`flex-1 rounded-full px-3 py-1 uppercase tracking-[0.18em] transition ${
+            portalType === "customer"
+              ? "bg-[color:var(--accent-copper)] text-black font-semibold shadow-[0_0_18px_rgba(197,122,74,0.85)]"
+              : "text-neutral-300 hover:bg-black/60"
+          }`}
+        >
+          Customer
+        </button>
+        <button
+          type="button"
+          onClick={() => setPortalType("fleet")}
+          className={`flex-1 rounded-full px-3 py-1 uppercase tracking-[0.18em] transition ${
+            portalType === "fleet"
+              ? "bg-[color:var(--accent-copper)] text-black font-semibold shadow-[0_0_18px_rgba(197,122,74,0.85)]"
+              : "text-neutral-300 hover:bg-black/60"
+          }`}
+        >
+          Fleet
+        </button>
+      </div>
 
-          {/* Brand / title */}
-          <div className="mb-6 space-y-2 text-center">
-            <div
-              className="
+      {/* Brand / title */}
+      <div className="mb-6 space-y-2 text-center">
+        <div
+          className="
                 inline-flex items-center gap-1 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/70
@@ -183,47 +169,74 @@ export default function PortalSignInPage() {
                 uppercase tracking-[0.22em]
                 text-neutral-300
               "
-              style={{ color: COPPER }}
-            >
-              {portalLabel}
-            </div>
+          style={{ color: COPPER }}
+        >
+          {portalLabel}
+        </div>
 
-            <h1
-              className="mt-2 text-3xl sm:text-4xl font-semibold text-white"
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              Sign in
-            </h1>
+        <h1
+          className="mt-2 text-3xl sm:text-4xl font-semibold text-white"
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+        >
+          Sign in
+        </h1>
 
-            <p className="text-xs text-muted-foreground sm:text-sm">
-              {helperCopy}
+        <p className="text-xs text-muted-foreground sm:text-sm">{helperCopy}</p>
+      </div>
+
+      {/* Error */}
+      {error ? (
+        <div className="mb-3 rounded-lg border border-red-500/60 bg-red-950/70 px-3 py-2 text-xs text-red-100 shadow-[0_0_18px_rgba(127,29,29,0.5)]">
+          {error}
+        </div>
+      ) : null}
+
+      {/* Form */}
+      <form onSubmit={handleSignIn} className="space-y-4">
+        <div className="space-y-1 text-sm">
+          <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+            {portalType === "fleet" ? "Email or username" : "Email"}
+          </label>
+          <input
+            type={portalType === "fleet" ? "text" : "email"}
+            autoComplete={portalType === "fleet" ? "username" : "email"}
+            placeholder={
+              portalType === "fleet"
+                ? "dispatch@fleet.com or fleet username"
+                : "you@example.com"
+            }
+            value={identifier}
+            onChange={(e) => setIdentifier(e.target.value)}
+            className="
+                  w-full rounded-lg border
+                  border-[color:var(--metal-border-soft,#1f2937)]
+                  bg-black/70 px-3 py-2 text-sm text-white
+                  placeholder:text-neutral-500
+                  focus:outline-none focus:ring-2
+                  focus:ring-[var(--accent-copper-soft)]
+                  focus:border-[var(--accent-copper-soft)]
+                "
+            required
+          />
+          {portalType === "fleet" ? (
+            <p className="text-[11px] text-muted-foreground">
+              Fleet accounts can sign in using the username provided by your
+              shop/dispatch.
             </p>
-          </div>
-
-          {/* Error */}
-          {error ? (
-            <div className="mb-3 rounded-lg border border-red-500/60 bg-red-950/70 px-3 py-2 text-xs text-red-100 shadow-[0_0_18px_rgba(127,29,29,0.5)]">
-              {error}
-            </div>
           ) : null}
+        </div>
 
-          {/* Form */}
-          <form onSubmit={handleSignIn} className="space-y-4">
-            <div className="space-y-1 text-sm">
-              <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                {portalType === "fleet" ? "Email or username" : "Email"}
-              </label>
-              <input
-                type={portalType === "fleet" ? "text" : "email"}
-                autoComplete={portalType === "fleet" ? "username" : "email"}
-                placeholder={
-                  portalType === "fleet"
-                    ? "dispatch@fleet.com or fleet username"
-                    : "you@example.com"
-                }
-                value={identifier}
-                onChange={(e) => setIdentifier(e.target.value)}
-                className="
+        <div className="space-y-1 text-sm">
+          <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+            Password
+          </label>
+          <input
+            type="password"
+            autoComplete="current-password"
+            placeholder="••••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="
                   w-full rounded-lg border
                   border-[color:var(--metal-border-soft,#1f2937)]
                   bg-black/70 px-3 py-2 text-sm text-white
@@ -232,44 +245,15 @@ export default function PortalSignInPage() {
                   focus:ring-[var(--accent-copper-soft)]
                   focus:border-[var(--accent-copper-soft)]
                 "
-                required
-              />
-              {portalType === "fleet" ? (
-                <p className="text-[11px] text-muted-foreground">
-                  Fleet accounts can sign in using the username provided by your
-                  shop/dispatch.
-                </p>
-              ) : null}
-            </div>
+            required
+            minLength={6}
+          />
+        </div>
 
-            <div className="space-y-1 text-sm">
-              <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                Password
-              </label>
-              <input
-                type="password"
-                autoComplete="current-password"
-                placeholder="••••••••"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="
-                  w-full rounded-lg border
-                  border-[color:var(--metal-border-soft,#1f2937)]
-                  bg-black/70 px-3 py-2 text-sm text-white
-                  placeholder:text-neutral-500
-                  focus:outline-none focus:ring-2
-                  focus:ring-[var(--accent-copper-soft)]
-                  focus:border-[var(--accent-copper-soft)]
-                "
-                required
-                minLength={6}
-              />
-            </div>
-
-            <button
-              type="submit"
-              disabled={loading}
-              className="
+        <button
+          type="submit"
+          disabled={loading}
+          className="
                 mt-3 w-full rounded-full
                 bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))]
                 py-2.5 text-center text-sm
@@ -278,33 +262,31 @@ export default function PortalSignInPage() {
                 hover:brightness-110
                 disabled:cursor-not-allowed disabled:opacity-60
               "
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              {loading ? "Signing in…" : "Sign in"}
-            </button>
-          </form>
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
 
-          {/* Footer copy differs by portal type */}
-          <div className="mt-5 flex items-center justify-between text-sm text-neutral-400">
-            {portalType === "customer" ? (
-              <>
-                <span>Need an account?</span>
-                <Link
-                  href="/portal/auth/sign-up"
-                  className="text-[11px] font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline underline-offset-2"
-                >
-                  Sign up
-                </Link>
-              </>
-            ) : (
-              <p className="text-[11px] text-neutral-400">
-                Fleet logins are created by your shop or dispatch. If you need
-                access, contact your shop administrator.
-              </p>
-            )}
-          </div>
-        </div>
+      {/* Footer copy differs by portal type */}
+      <div className="mt-5 flex items-center justify-between text-sm text-neutral-400">
+        {portalType === "customer" ? (
+          <>
+            <span>Need an account?</span>
+            <Link
+              href="/portal/auth/sign-up"
+              className="text-[11px] font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline underline-offset-2"
+            >
+              Sign up
+            </Link>
+          </>
+        ) : (
+          <p className="text-[11px] text-neutral-400">
+            Fleet logins are created by your shop or dispatch. If you need
+            access, contact your shop administrator.
+          </p>
+        )}
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/app/portal/auth/sign-in/page.tsx
+++ b/app/portal/auth/sign-in/page.tsx
@@ -3,13 +3,14 @@
 
 import { Suspense } from "react";
 import PortalSignInForm from "./PortalSignInForm";
+import AuthShell from "@/features/auth/components/AuthShell";
 
 const COPPER = "#C57A4A";
 
 function LoadingCard({ label }: { label: string }) {
   return (
-    <div className="mx-auto max-w-lg">
-      <div className="rounded-2xl border border-white/10 bg-black/25 p-5 backdrop-blur-md sm:p-6">
+    <AuthShell cardClassName="rounded-2xl border-white/10 bg-black/25 p-5 backdrop-blur-md sm:p-6">
+      <div>
         <div
           className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] uppercase tracking-[0.2em]"
           style={{ color: COPPER }}
@@ -24,7 +25,7 @@ function LoadingCard({ label }: { label: string }) {
           />
         </div>
       </div>
-    </div>
+    </AuthShell>
   );
 }
 

--- a/app/portal/auth/sign-up/PortalSignUpForm.tsx
+++ b/app/portal/auth/sign-up/PortalSignUpForm.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import AuthShell from "@/features/auth/components/AuthShell";
 
 const COPPER = "#C57A4A";
 
@@ -72,30 +73,14 @@ export default function PortalSignUpForm() {
   };
 
   return (
-    <div
-      className="
-        min-h-screen px-4 text-foreground
-        bg-background
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
-      "
-    >
-      <div className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center py-8">
-        <div
+    <AuthShell>
+      {/* Back to landing */}
+      <div className="mb-4 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={goLanding}
+          disabled={loading}
           className="
-            w-full rounded-3xl border
-            border-[color:var(--metal-border-soft,#1f2937)]
-            bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]
-            shadow-[0_32px_80px_rgba(0,0,0,0.95)]
-            px-6 py-7 sm:px-8 sm:py-9
-          "
-        >
-          {/* Back to landing */}
-          <div className="mb-4 flex items-center justify-between">
-            <button
-              type="button"
-              onClick={goLanding}
-              disabled={loading}
-              className="
                 inline-flex items-center gap-2 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/60 px-3 py-1.5 text-[11px]
@@ -103,20 +88,20 @@ export default function PortalSignUpForm() {
                 hover:bg-black/70 hover:text-white
                 disabled:cursor-not-allowed disabled:opacity-60
               "
-            >
-              <span aria-hidden className="text-base leading-none">
-                ←
-              </span>
-              Back
-            </button>
+        >
+          <span aria-hidden className="text-base leading-none">
+            ←
+          </span>
+          Back
+        </button>
 
-            <div className="text-[10px] text-neutral-500">Customer portal</div>
-          </div>
+        <div className="text-[10px] text-neutral-500">Customer portal</div>
+      </div>
 
-          {/* Brand / title */}
-          <div className="mb-6 space-y-2 text-center">
-            <div
-              className="
+      {/* Brand / title */}
+      <div className="mb-6 space-y-2 text-center">
+        <div
+          className="
                 inline-flex items-center gap-1 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/70
@@ -124,49 +109,49 @@ export default function PortalSignUpForm() {
                 uppercase tracking-[0.22em]
                 text-neutral-300
               "
-              style={{ color: COPPER }}
-            >
-              Customer Portal
-            </div>
+          style={{ color: COPPER }}
+        >
+          Customer Portal
+        </div>
 
-            <h1
-              className="mt-2 text-3xl sm:text-4xl font-semibold text-white"
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              Sign up
-            </h1>
+        <h1
+          className="mt-2 text-3xl sm:text-4xl font-semibold text-white"
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+        >
+          Sign up
+        </h1>
 
-            <p className="text-xs text-muted-foreground sm:text-sm">
-              Create your portal account to view service history and documents.
-            </p>
-          </div>
+        <p className="text-xs text-muted-foreground sm:text-sm">
+          Create your portal account to view service history and documents.
+        </p>
+      </div>
 
-          {/* Error / Notice */}
-          {error ? (
-            <div className="mb-3 rounded-lg border border-red-500/60 bg-red-950/70 px-3 py-2 text-xs text-red-100 shadow-[0_0_18px_rgba(127,29,29,0.5)]">
-              {error}
-            </div>
-          ) : null}
+      {/* Error / Notice */}
+      {error ? (
+        <div className="mb-3 rounded-lg border border-red-500/60 bg-red-950/70 px-3 py-2 text-xs text-red-100 shadow-[0_0_18px_rgba(127,29,29,0.5)]">
+          {error}
+        </div>
+      ) : null}
 
-          {notice ? (
-            <div className="mb-3 rounded-lg border border-emerald-500/30 bg-emerald-950/25 px-3 py-2 text-xs text-emerald-100 shadow-[0_0_18px_rgba(6,78,59,0.35)]">
-              {notice}
-            </div>
-          ) : null}
+      {notice ? (
+        <div className="mb-3 rounded-lg border border-emerald-500/30 bg-emerald-950/25 px-3 py-2 text-xs text-emerald-100 shadow-[0_0_18px_rgba(6,78,59,0.35)]">
+          {notice}
+        </div>
+      ) : null}
 
-          {/* Form */}
-          <form onSubmit={handleSignUp} className="space-y-4">
-            <div className="space-y-1 text-sm">
-              <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                Email
-              </label>
-              <input
-                type="email"
-                autoComplete="email"
-                placeholder="you@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="
+      {/* Form */}
+      <form onSubmit={handleSignUp} className="space-y-4">
+        <div className="space-y-1 text-sm">
+          <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+            Email
+          </label>
+          <input
+            type="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="
                   w-full rounded-lg border
                   border-[color:var(--metal-border-soft,#1f2937)]
                   bg-black/70 px-3 py-2 text-sm text-white
@@ -175,21 +160,21 @@ export default function PortalSignUpForm() {
                   focus:ring-[var(--accent-copper-soft)]
                   focus:border-[var(--accent-copper-soft)]
                 "
-                required
-              />
-            </div>
+            required
+          />
+        </div>
 
-            <div className="space-y-1 text-sm">
-              <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                Password
-              </label>
-              <input
-                type="password"
-                autoComplete="new-password"
-                placeholder="At least 6 characters"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="
+        <div className="space-y-1 text-sm">
+          <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+            Password
+          </label>
+          <input
+            type="password"
+            autoComplete="new-password"
+            placeholder="At least 6 characters"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="
                   w-full rounded-lg border
                   border-[color:var(--metal-border-soft,#1f2937)]
                   bg-black/70 px-3 py-2 text-sm text-white
@@ -198,15 +183,15 @@ export default function PortalSignUpForm() {
                   focus:ring-[var(--accent-copper-soft)]
                   focus:border-[var(--accent-copper-soft)]
                 "
-                required
-                minLength={6}
-              />
-            </div>
+            required
+            minLength={6}
+          />
+        </div>
 
-            <button
-              type="submit"
-              disabled={loading}
-              className="
+        <button
+          type="submit"
+          disabled={loading}
+          className="
                 mt-3 w-full rounded-full
                 bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))]
                 py-2.5 text-center text-sm
@@ -215,23 +200,21 @@ export default function PortalSignUpForm() {
                 hover:brightness-110
                 disabled:cursor-not-allowed disabled:opacity-60
               "
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              {loading ? "Creating account…" : "Sign up"}
-            </button>
-          </form>
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+        >
+          {loading ? "Creating account…" : "Sign up"}
+        </button>
+      </form>
 
-          <div className="mt-5 flex items-center justify-between text-sm text-neutral-400">
-            <span>Already have an account?</span>
-            <Link
-              href="/portal/auth/sign-in"
-              className="text-[11px] font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline underline-offset-2"
-            >
-              Sign in
-            </Link>
-          </div>
-        </div>
+      <div className="mt-5 flex items-center justify-between text-sm text-neutral-400">
+        <span>Already have an account?</span>
+        <Link
+          href="/portal/auth/sign-in"
+          className="text-[11px] font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline underline-offset-2"
+        >
+          Sign in
+        </Link>
       </div>
-    </div>
+    </AuthShell>
   );
 }

--- a/app/portal/auth/sign-up/page.tsx
+++ b/app/portal/auth/sign-up/page.tsx
@@ -3,31 +3,16 @@
 
 import { Suspense } from "react";
 import PortalSignUpForm from "./PortalSignUpForm";
+import AuthShell from "@/features/auth/components/AuthShell";
 
 const COPPER = "#C57A4A";
 
 function LoadingCard({ label }: { label: string }) {
   return (
-    <div
-      className="
-        min-h-screen px-4 text-foreground
-        bg-background
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
-      "
-    >
-      <div className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center py-8">
+    <AuthShell>
+      <div className="mb-6 space-y-2 text-center">
         <div
           className="
-            w-full rounded-3xl border
-            border-[color:var(--metal-border-soft,#1f2937)]
-            bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]
-            shadow-[0_32px_80px_rgba(0,0,0,0.95)]
-            px-6 py-7 sm:px-8 sm:py-9
-          "
-        >
-          <div className="mb-6 space-y-2 text-center">
-            <div
-              className="
                 inline-flex items-center gap-1 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/70
@@ -35,30 +20,28 @@ function LoadingCard({ label }: { label: string }) {
                 uppercase tracking-[0.22em]
                 text-neutral-300
               "
-              style={{ color: COPPER }}
-            >
-              Customer Portal
-            </div>
-
-            <div
-              className="mt-2 text-2xl sm:text-3xl font-semibold text-white"
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              Sign up
-            </div>
-
-            <div className="text-xs text-neutral-400">{label}</div>
-          </div>
-
-          <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full border border-white/10 bg-white/5">
-            <div
-              className="h-full w-1/2 animate-pulse rounded-full"
-              style={{ backgroundColor: COPPER }}
-            />
-          </div>
+          style={{ color: COPPER }}
+        >
+          Customer Portal
         </div>
+
+        <div
+          className="mt-2 text-2xl sm:text-3xl font-semibold text-white"
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+        >
+          Sign up
+        </div>
+
+        <div className="text-xs text-neutral-400">{label}</div>
       </div>
-    </div>
+
+      <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full border border-white/10 bg-white/5">
+        <div
+          className="h-full w-1/2 animate-pulse rounded-full"
+          style={{ backgroundColor: COPPER }}
+        />
+      </div>
+    </AuthShell>
   );
 }
 

--- a/features/auth/components/AuthShell.tsx
+++ b/features/auth/components/AuthShell.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/features/shared/lib/utils";
+
+type AuthShellProps = {
+  children: ReactNode;
+  viewportClassName?: string;
+  cardClassName?: string;
+};
+
+export default function AuthShell({
+  children,
+  viewportClassName,
+  cardClassName,
+}: AuthShellProps) {
+  return (
+    <div
+      className={cn(
+        "min-h-screen min-h-[100dvh] px-4 py-[clamp(1rem,3.5vh,2.5rem)] text-foreground bg-background bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]",
+        viewportClassName,
+      )}
+    >
+      <div className="mx-auto flex min-h-[calc(100dvh-clamp(2rem,7vh,5rem))] w-full max-w-5xl items-center justify-center">
+        <div
+          className={cn(
+            "w-full max-w-[42rem] rounded-3xl border border-[color:var(--metal-border-soft,#1f2937)] bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)] px-5 py-6 shadow-[0_32px_80px_rgba(0,0,0,0.95)] sm:px-7 sm:py-7 lg:px-8 lg:py-8",
+            cardClassName,
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import AuthShell from "@/features/auth/components/AuthShell";
 
 type Mode = "sign-in" | "sign-up";
 
@@ -201,30 +202,17 @@ export default function AuthPage() {
   };
 
   return (
-    <div
-      className="
-        min-h-screen px-4 text-foreground
-        bg-background
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.16),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
-      "
+    <AuthShell
+      viewportClassName="bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.16),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]"
+      cardClassName="bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.2),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]"
     >
-      <div className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center py-8">
-        <div
+      {/* Back to landing */}
+      <div className="mb-4 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={goLanding}
+          disabled={loading}
           className="
-            w-full rounded-3xl border
-            border-[color:var(--metal-border-soft,#1f2937)]
-            bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.2),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]
-            shadow-[0_32px_80px_rgba(0,0,0,0.95)]
-            px-6 py-7 sm:px-8 sm:py-9
-          "
-        >
-          {/* Back to landing */}
-          <div className="mb-4 flex items-center justify-between">
-            <button
-              type="button"
-              onClick={goLanding}
-              disabled={loading}
-              className="
                 inline-flex items-center gap-2 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/60 px-3 py-1.5 text-[11px]
@@ -232,20 +220,22 @@ export default function AuthPage() {
                 hover:bg-black/70 hover:text-white
                 disabled:cursor-not-allowed disabled:opacity-60
               "
-            >
-              <span aria-hidden className="text-base leading-none">←</span>
-              Back
-            </button>
+        >
+          <span aria-hidden className="text-base leading-none">
+            ←
+          </span>
+          Back
+        </button>
 
-            <div className="text-[10px] text-neutral-500">
-              {isMobileMode ? "Mobile companion" : "Shop access"}
-            </div>
-          </div>
+        <div className="text-[10px] text-neutral-500">
+          {isMobileMode ? "Mobile companion" : "Shop access"}
+        </div>
+      </div>
 
-          {/* Brand / title */}
-          <div className="mb-6 space-y-2 text-center">
-            <div
-              className="
+      {/* Brand / title */}
+      <div className="mb-6 space-y-2 text-center">
+        <div
+          className="
                 inline-flex items-center gap-1 rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/70
@@ -253,102 +243,98 @@ export default function AuthPage() {
                 uppercase tracking-[0.22em]
                 text-neutral-300
               "
-            >
-              <span
-                className="text-[10px] font-semibold text-[var(--accent-copper-light)]"
-                style={{ fontFamily: "var(--font-blackops), system-ui" }}
-              >
-                ProFixIQ
-              </span>
-              <span className="h-1 w-1 rounded-full bg-[var(--accent-copper-light)]" />
-              <span>
-                {isMobileMode ? "Shop • Mobile" : "Shop Dashboard"}
-              </span>
-            </div>
+        >
+          <span
+            className="text-[10px] font-semibold text-[var(--accent-copper-light)]"
+            style={{ fontFamily: "var(--font-blackops), system-ui" }}
+          >
+            ProFixIQ
+          </span>
+          <span className="h-1 w-1 rounded-full bg-[var(--accent-copper-light)]" />
+          <span>{isMobileMode ? "Shop • Mobile" : "Shop Dashboard"}</span>
+        </div>
 
-            <h1
-              className="mt-2 text-3xl sm:text-4xl font-semibold text-white"
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              {isSignIn ? "Sign in" : "Create your account"}
-            </h1>
+        <h1
+          className="mt-2 text-3xl sm:text-4xl font-semibold text-white"
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+        >
+          {isSignIn ? "Sign in" : "Create your account"}
+        </h1>
 
-            <p className="text-xs text-muted-foreground sm:text-sm">
-              {isSignIn
-                ? "Use your shop username or email to access the ProFixIQ dashboard."
-                : "Create a shop account with your email to get started."}
-            </p>
-          </div>
+        <p className="text-xs text-muted-foreground sm:text-sm">
+          {isSignIn
+            ? "Use your shop username or email to access the ProFixIQ dashboard."
+            : "Create a shop account with your email to get started."}
+        </p>
+      </div>
 
-          {/* Mode switch */}
-          <div className="mb-5 flex items-center justify-center">
-            <div
-              className="
+      {/* Mode switch */}
+      <div className="mb-5 flex items-center justify-center">
+        <div
+          className="
                 inline-flex rounded-full border
                 border-[color:var(--metal-border-soft,#1f2937)]
                 bg-black/70 p-1 text-xs
                 shadow-[0_0_18px_rgba(15,23,42,0.8)]
               "
-            >
-              <button
-                type="button"
-                className={`px-3 py-1 rounded-full transition-all ${
-                  isSignIn
-                    ? "bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] text-black font-semibold shadow-[0_0_18px_rgba(212,118,49,0.7)]"
-                    : "text-neutral-300 hover:text-white"
-                }`}
-                onClick={() => setMode("sign-in")}
-                disabled={loading}
-              >
-                Sign in
-              </button>
-              <button
-                type="button"
-                className={`px-3 py-1 rounded-full transition-all ${
-                  !isSignIn
-                    ? "bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] text-black font-semibold shadow-[0_0_18px_rgba(212,118,49,0.7)]"
-                    : "text-neutral-300 hover:text-white"
-                }`}
-                onClick={() => setMode("sign-up")}
-                disabled={loading}
-              >
-                Sign up
-              </button>
-            </div>
-          </div>
-
-          {/* Error / notice */}
-          {error && (
-            <div className="mb-3 rounded-lg border border-red-500/60 bg-red-950/70 px-3 py-2 text-xs text-red-100 shadow-[0_0_18px_rgba(127,29,29,0.5)]">
-              {error}
-            </div>
-          )}
-          {notice && (
-            <div className="mb-3 rounded-lg border border-emerald-500/60 bg-emerald-950/70 px-3 py-2 text-xs text-emerald-100 shadow-[0_0_18px_rgba(6,95,70,0.5)]">
-              {notice}
-            </div>
-          )}
-
-          {/* Form */}
-          <form
-            onSubmit={isSignIn ? handleSignIn : handleSignUp}
-            className="space-y-4"
+        >
+          <button
+            type="button"
+            className={`px-3 py-1 rounded-full transition-all ${
+              isSignIn
+                ? "bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] text-black font-semibold shadow-[0_0_18px_rgba(212,118,49,0.7)]"
+                : "text-neutral-300 hover:text-white"
+            }`}
+            onClick={() => setMode("sign-in")}
+            disabled={loading}
           >
-            <div className="space-y-1 text-sm">
-              <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                {isSignIn ? "Email or username" : "Email"}
-              </label>
-              <input
-                type={isSignIn ? "text" : "email"}
-                placeholder={
-                  isSignIn
-                    ? "jane@shop.com or shop username"
-                    : "you@example.com"
-                }
-                autoComplete={isSignIn ? "username" : "email"}
-                value={identifier}
-                onChange={(e) => setIdentifier(e.target.value)}
-                className="
+            Sign in
+          </button>
+          <button
+            type="button"
+            className={`px-3 py-1 rounded-full transition-all ${
+              !isSignIn
+                ? "bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] text-black font-semibold shadow-[0_0_18px_rgba(212,118,49,0.7)]"
+                : "text-neutral-300 hover:text-white"
+            }`}
+            onClick={() => setMode("sign-up")}
+            disabled={loading}
+          >
+            Sign up
+          </button>
+        </div>
+      </div>
+
+      {/* Error / notice */}
+      {error && (
+        <div className="mb-3 rounded-lg border border-red-500/60 bg-red-950/70 px-3 py-2 text-xs text-red-100 shadow-[0_0_18px_rgba(127,29,29,0.5)]">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="mb-3 rounded-lg border border-emerald-500/60 bg-emerald-950/70 px-3 py-2 text-xs text-emerald-100 shadow-[0_0_18px_rgba(6,95,70,0.5)]">
+          {notice}
+        </div>
+      )}
+
+      {/* Form */}
+      <form
+        onSubmit={isSignIn ? handleSignIn : handleSignUp}
+        className="space-y-4"
+      >
+        <div className="space-y-1 text-sm">
+          <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+            {isSignIn ? "Email or username" : "Email"}
+          </label>
+          <input
+            type={isSignIn ? "text" : "email"}
+            placeholder={
+              isSignIn ? "jane@shop.com or shop username" : "you@example.com"
+            }
+            autoComplete={isSignIn ? "username" : "email"}
+            value={identifier}
+            onChange={(e) => setIdentifier(e.target.value)}
+            className="
                   w-full rounded-lg border
                   border-[color:var(--metal-border-soft,#1f2937)]
                   bg-black/70 px-3 py-2 text-sm text-white
@@ -357,27 +343,27 @@ export default function AuthPage() {
                   focus:ring-[var(--accent-copper-soft)]
                   focus:border-[var(--accent-copper-soft)]
                 "
-                required
-              />
-              {isSignIn && (
-                <p className="text-[11px] text-muted-foreground">
-                  Shop accounts can sign in using the username provided by your
-                  admin.
-                </p>
-              )}
-            </div>
+            required
+          />
+          {isSignIn && (
+            <p className="text-[11px] text-muted-foreground">
+              Shop accounts can sign in using the username provided by your
+              admin.
+            </p>
+          )}
+        </div>
 
-            <div className="space-y-1 text-sm">
-              <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
-                Password
-              </label>
-              <input
-                type="password"
-                placeholder="••••••••"
-                autoComplete={isSignIn ? "current-password" : "new-password"}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="
+        <div className="space-y-1 text-sm">
+          <label className="block text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+            Password
+          </label>
+          <input
+            type="password"
+            placeholder="••••••••"
+            autoComplete={isSignIn ? "current-password" : "new-password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="
                   w-full rounded-lg border
                   border-[color:var(--metal-border-soft,#1f2937)]
                   bg-black/70 px-3 py-2 text-sm text-white
@@ -386,34 +372,34 @@ export default function AuthPage() {
                   focus:ring-[var(--accent-copper-soft)]
                   focus:border-[var(--accent-copper-soft)]
                 "
-                required
-                minLength={6}
-              />
-            </div>
+            required
+            minLength={6}
+          />
+        </div>
 
-            {/* Forgot password */}
-            {isSignIn && (
-              <div className="flex items-center justify-end">
-                <button
-                  type="button"
-                  onClick={goForgotPassword}
-                  disabled={loading}
-                  className="
+        {/* Forgot password */}
+        {isSignIn && (
+          <div className="flex items-center justify-end">
+            <button
+              type="button"
+              onClick={goForgotPassword}
+              disabled={loading}
+              className="
                     text-[11px] font-medium
                     text-[var(--accent-copper-light)]
                     hover:text-[var(--accent-copper)]
                     hover:underline underline-offset-2
                     disabled:cursor-not-allowed disabled:opacity-60
                   "
-                >
-                  Forgot password?
-                </button>
-              </div>
-            )}
+            >
+              Forgot password?
+            </button>
+          </div>
+        )}
 
-            <button
-              type="submit"
-              className="
+        <button
+          type="submit"
+          className="
                 mt-3 w-full rounded-full
                 bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))]
                 py-2.5 text-center text-sm
@@ -422,62 +408,60 @@ export default function AuthPage() {
                 hover:brightness-110
                 disabled:cursor-not-allowed disabled:opacity-60
               "
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-              disabled={loading}
-            >
-              {loading
-                ? isSignIn
-                  ? "Signing in…"
-                  : "Creating account…"
-                : isSignIn
-                ? "Sign in"
-                : "Sign up"}
-            </button>
-          </form>
+          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+          disabled={loading}
+        >
+          {loading
+            ? isSignIn
+              ? "Signing in…"
+              : "Creating account…"
+            : isSignIn
+              ? "Sign in"
+              : "Sign up"}
+        </button>
+      </form>
 
-          {/* Mobile companion deep link */}
-          {isSignIn && !isMobileMode && (
-            <div className="mt-4 text-center">
-              <button
-                type="button"
-                onClick={() => router.push("/sign-in?mode=mobile")}
-                className="
+      {/* Mobile companion deep link */}
+      {isSignIn && !isMobileMode && (
+        <div className="mt-4 text-center">
+          <button
+            type="button"
+            onClick={() => router.push("/sign-in?mode=mobile")}
+            className="
                   text-[11px] font-medium
                   text-[var(--accent-copper-light)]
                   hover:text-[var(--accent-copper)]
                   hover:underline underline-offset-2
                 "
-                disabled={loading}
-              >
-                Sign in to mobile companion
-              </button>
-              <p className="mt-1 text-[10px] text-muted-foreground">
-                Opens the tech-friendly mobile layout for phones and tablets.
-              </p>
-            </div>
-          )}
-
-          <div className="mt-6 text-center text-[11px] text-muted-foreground">
-            <p>
-              By continuing you agree to our{" "}
-              <a
-                href="/terms"
-                className="font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline"
-              >
-                Terms
-              </a>{" "}
-              and{" "}
-              <a
-                href="/privacy"
-                className="font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline"
-              >
-                Privacy Policy
-              </a>
-              .
-            </p>
-          </div>
+            disabled={loading}
+          >
+            Sign in to mobile companion
+          </button>
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            Opens the tech-friendly mobile layout for phones and tablets.
+          </p>
         </div>
+      )}
+
+      <div className="mt-6 text-center text-[11px] text-muted-foreground">
+        <p>
+          By continuing you agree to our{" "}
+          <a
+            href="/terms"
+            className="font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline"
+          >
+            Terms
+          </a>{" "}
+          and{" "}
+          <a
+            href="/privacy"
+            className="font-medium text-[var(--accent-copper-light)] hover:text-[var(--accent-copper)] hover:underline"
+          >
+            Privacy Policy
+          </a>
+          .
+        </p>
       </div>
-    </div>
+    </AuthShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Auth entry pages used duplicated full-height wrappers and narrow `max-w-md` cards with large vertical padding, which made the auth card feel oversized and sit low on large screens; this change centralizes layout so the card is intentionally centered and more compact. 
- The goal is a single, cohesive auth-shell behavior for shop, customer, and fleet sign-in variants while preserving branding and auth logic.

### Description
- Added a shared `AuthShell` component at `features/auth/components/AuthShell.tsx` that standardizes viewport centering and card constraints and accepts optional `viewportClassName` and `cardClassName` for per-page flavoring. 
- Migrated the shop sign-in/sign-up UI to use `AuthShell` in `features/auth/components/SignIn.tsx` and migrated portal customer/fleet sign-in and sign-up forms and loading fallbacks to use the same shell (`app/portal/auth/sign-in/PortalSignInForm.tsx`, `app/portal/auth-sign-in/page.tsx`, `app/portal/auth/sign-up/PortalSignUpForm.tsx`, `app/portal/auth/sign-up/page.tsx`). 
- Exact responsive sizing/alignment changes: viewport uses `min-h-[100dvh]` and clamp-based vertical padding (`py-[clamp(1rem,3.5vh,2.5rem)]`), centering uses `min-h-[calc(100dvh-clamp(2rem,7vh,5rem))] items-center justify-center`, and the auth card is widened to `max-w-[42rem]` (~672px) with reduced vertical padding (`px-5 py-6` / `sm:px-7 sm:py-7` / `lg:px-8 lg:py-8`). 
- Preserved brand/visual styles (dark industrial + copper accents) and made no changes to auth business logic or routes.

### Testing
- Ran targeted linting on the touched files with `npx eslint` (targeted files); lint completed without introducing new errors. 
- Ran full typecheck with `npx tsc --noEmit`; typecheck completed successfully. 
- Layout change is presentation-only and preserves form markup and accessibility attributes, with responsive behavior implemented using `dvh`/clamp and Tailwind utility classes for desktop, tablet, and mobile consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1042abcf88328989304ece9f18623)