### PR TITLE
Fix target completion ownership in tech cockpit and refine create work-order UI

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -86,22 +86,6 @@ function splitCustomId(raw: string): { prefix: string; n: number | null } {
   return { prefix: m[1], n: Number.isFinite(n!) ? n : null };
 }
 
-function toDatetimeLocalInput(value: string | null | undefined): string {
-  if (!value) return "";
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return "";
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
-}
-
-function fromDatetimeLocalInput(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const d = new Date(trimmed);
-  if (Number.isNaN(d.getTime())) return null;
-  return d.toISOString();
-}
-
 function isCompletedLineStatus(status: string | null | undefined): boolean {
   const normalized = String(status ?? "").trim().toLowerCase();
   return normalized === "completed" || normalized === "ready_to_invoice" || normalized === "invoiced";
@@ -251,8 +235,6 @@ export default function WorkOrderIdClient(): JSX.Element {
 
   // per-line technicians
   const [lineTechsByLine, setLineTechsByLine] = useState<Record<string, string[]>>({});
-  const [expectedCompletionInput, setExpectedCompletionInput] = useState<string>("");
-  const [savingExpectedCompletion, setSavingExpectedCompletion] = useState(false);
 
   // ✅ AI review state for status icons
   const [, setReviewChecked] = useState<boolean>(false);
@@ -971,10 +953,6 @@ export default function WorkOrderIdClient(): JSX.Element {
     ? format(new Date(wo.expected_completion_at), "PPpp")
     : "—";
 
-  useEffect(() => {
-    setExpectedCompletionInput(toDatetimeLocalInput(wo?.expected_completion_at));
-  }, [wo?.expected_completion_at]);
-
   const canAssign = currentUserRole ? ASSIGN_ROLES.has(currentUserRole) : false;
   const canApprove = currentUserRole ? APPROVAL_ROLES.has(currentUserRole) : false;
 
@@ -993,30 +971,6 @@ export default function WorkOrderIdClient(): JSX.Element {
     },
     [routeId],
   );
-
-  const saveExpectedCompletion = useCallback(async () => {
-    if (!wo?.id) return;
-    setSavingExpectedCompletion(true);
-    try {
-      const payload = {
-        expected_completion_at: fromDatetimeLocalInput(expectedCompletionInput),
-      } as DB["public"]["Tables"]["work_orders"]["Update"];
-      const { data, error } = await supabase
-        .from("work_orders")
-        .update(payload)
-        .eq("id", wo.id)
-        .select("*")
-        .single();
-      if (error) throw error;
-      setWo(data as WorkOrder);
-      toast.success("Expected completion updated.");
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "Failed to update expected completion.";
-      toast.error(msg);
-    } finally {
-      setSavingExpectedCompletion(false);
-    }
-  }, [expectedCompletionInput, wo?.id, setWo]);
 
   const selectedDelLine = useMemo(() => {
     if (!delLineId) return null;
@@ -1363,8 +1317,7 @@ export default function WorkOrderIdClient(): JSX.Element {
         ) : (
           <div className={cn("space-y-2.5", supportFullyCollapsed && "space-y-2")}>
             <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
-              <div className="grid gap-2 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,0.65fr)] xl:items-stretch">
-                <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">
+              <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">
                   <div className={cn(cardInner, "p-2")}>
                     <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                       Order state
@@ -1388,6 +1341,9 @@ export default function WorkOrderIdClient(): JSX.Element {
                       Target completion
                     </div>
                     <div className="mt-1 text-sm font-medium text-foreground">{expectedCompletionText}</div>
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      Planning target set from intake/advisor flow.
+                    </p>
                   </div>
                   <div className={cn(cardInner, "p-2 sm:col-span-2 xl:col-span-1")}>
                     <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
@@ -1395,40 +1351,6 @@ export default function WorkOrderIdClient(): JSX.Element {
                     </div>
                     <div className="mt-1 text-xs font-medium text-muted-foreground">{createdAtText}</div>
                   </div>
-                </div>
-
-                <div className={cn(cardInner, "p-2")}>
-                  <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                    Target completion
-                  </div>
-                  <div className="flex flex-wrap items-end gap-1.5">
-                    <input
-                      type="datetime-local"
-                      value={expectedCompletionInput}
-                      onChange={(e) => setExpectedCompletionInput(e.target.value)}
-                      className="min-w-[200px] flex-1 rounded-md border border-white/10 bg-black/30 px-2 py-1.5 text-xs sm:text-sm"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => void saveExpectedCompletion()}
-                      disabled={savingExpectedCompletion}
-                      className="rounded-md border border-[rgba(184,115,51,0.45)] bg-[rgba(184,115,51,0.10)] px-2.5 py-1.5 text-[11px] font-semibold text-amber-100 hover:bg-[rgba(184,115,51,0.16)] disabled:opacity-60"
-                    >
-                      {savingExpectedCompletion ? "Saving…" : "Save target"}
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-md border border-white/15 px-2.5 py-1.5 text-[11px] font-medium text-muted-foreground hover:border-[rgba(184,115,51,0.45)] hover:text-amber-100"
-                      onClick={() => {
-                        if (!wo?.id) return;
-                        router.push(`/work-orders/${wo.id}/intake`);
-                      }}
-                      title="Open intake"
-                    >
-                      Intake
-                    </button>
-                  </div>
-                </div>
               </div>
             </section>
 

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -39,8 +39,10 @@ const InspectionModal = dynamic(
 const COPPER = "#C57A4A";
 
 const card =
-  "rounded-2xl border border-white/10 bg-black/40 shadow-[0_24px_70px_rgba(0,0,0,0.65)]";
+  "rounded-2xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_90%,transparent)] shadow-[var(--theme-shadow-medium,0_22px_52px_rgba(0,0,0,0.5))] backdrop-blur-xl";
 const divider = "border-white/10";
+const sectionPanel =
+  "rounded-2xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_84%,transparent)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5";
 
 /* =============================================================================
    Types & helpers
@@ -590,7 +592,7 @@ useEffect(() => {
     const flag = (wo as WorkOrderWaiterRow).is_waiter ?? false;
     setIsWaiter(Boolean(flag));
     setExpectedCompletionInput(toDatetimeLocalInput(wo.expected_completion_at));
-  }, [wo, setIsWaiter]);
+  }, [wo, setIsWaiter, setExpectedCompletionInput]);
 
   // get current user id + current profile id
   useEffect((): void => {
@@ -1609,12 +1611,11 @@ useEffect(() => {
   return (
     <div
       className="
-        min-h-screen px-4 py-6 text-foreground
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
+        min-h-screen bg-[var(--theme-surface-2,#0B1220)] px-4 py-6 text-foreground
       "
       style={{ ["--copper" as never]: COPPER }}
     >
-      <div className="mx-auto max-w-6xl space-y-6">
+      <div className="mx-auto max-w-7xl space-y-6">
         {/* Header */}
         <div className={cx(card, "px-5 py-4")}>
           <div className="flex items-start justify-between gap-4">
@@ -1622,16 +1623,12 @@ useEffect(() => {
               <div className="text-xs uppercase tracking-[0.25em] text-neutral-400">
                 Work Orders
               </div>
-              <h1
-                className="mt-1 text-2xl font-semibold text-white"
-                style={{ fontFamily: "var(--font-blackops), system-ui" }}
-              >
-                Create Work Order
-              </h1>
-              <p className="mt-1 text-sm text-neutral-400">
-                Link a customer and vehicle, add jobs and inspections, then send to
-                approval and signature.
-              </p>
+                <h1 className="mt-1 text-2xl font-semibold text-white">
+                  Create Work Order
+                </h1>
+                <p className="mt-1 text-sm text-neutral-400">
+                  Intake and plan the visit, then continue to approvals once the order is ready.
+                </p>
 
               {wo?.custom_id && (
                 <p className="mt-1 text-xs text-neutral-500">
@@ -1658,7 +1655,7 @@ useEffect(() => {
         </div>
 
         {/* Body */}
-        <section className={cx(card, "px-4 py-5 backdrop-blur-xl sm:px-6 sm:py-6")}>
+        <section className={cx(card, "px-4 py-5 sm:px-6 sm:py-6")}>
           {error && (
             <div className="mb-4 rounded-xl border border-red-400/20 bg-red-500/10 px-4 py-3 text-sm text-red-200">
               {error}
@@ -1680,16 +1677,16 @@ useEffect(() => {
 
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Visit setup */}
-            <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+            <section className={sectionPanel}>
               <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                 <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
                   Visit Setup
                 </h2>
-                <span className="text-[11px] text-neutral-500">Applies before save</span>
+                <span className="text-[11px] text-neutral-500">Planning controls</span>
               </div>
 
-              <div className="grid gap-3 lg:grid-cols-[1.2fr_1fr_1fr]">
-                <div className="rounded-2xl border border-[color:var(--copper)]/20 bg-[color:var(--copper)]/5 p-4">
+              <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-2xl border border-white/10 bg-black/35 p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-300">
@@ -1739,7 +1736,7 @@ useEffect(() => {
                   </div>
                 </div>
 
-                <div>
+                <div className="rounded-2xl border border-white/10 bg-black/30 p-3.5">
                   <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
                     Priority
                   </label>
@@ -1759,7 +1756,7 @@ useEffect(() => {
                   </p>
                 </div>
 
-                <div>
+                <div className="rounded-2xl border border-white/10 bg-black/30 p-3.5">
                   <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
                     Default job type
                   </label>
@@ -1778,9 +1775,9 @@ useEffect(() => {
                   </p>
                 </div>
 
-                <div>
+                <div className="rounded-2xl border border-white/10 bg-black/30 p-3.5">
                   <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
-                    Expected completion
+                    Target completion
                   </label>
                   <input
                     type="datetime-local"
@@ -1790,20 +1787,20 @@ useEffect(() => {
                     disabled={loading}
                   />
                   <p className="mt-1 text-[11px] text-neutral-500">
-                    Internal target time for advisor/front-of-house coordination.
+                    Internal planning target for advisor/front-of-house coordination.
                   </p>
                 </div>
               </div>
             </section>
 
             {/* Customer & Vehicle */}
-            <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+            <section className={cx(sectionPanel, "border-white/15 bg-black/45")}>
               <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
-                <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
+                <h2 className="text-sm font-semibold tracking-[0.08em] text-neutral-100">
                   Customer &amp; Vehicle
                 </h2>
                 <span className="text-[11px] text-neutral-500">
-                  Save first, then add lines
+                  Primary intake section
                 </span>
               </div>
 
@@ -1833,9 +1830,9 @@ useEffect(() => {
                   }}
                   disabled={savingCv || loading}
                   className="
-                    rounded-full border border-white/10 bg-black/50
-                    px-4 py-2 text-sm font-semibold text-neutral-200
-                    hover:bg-black/65 disabled:opacity-60
+                    rounded-full border border-[color:var(--copper)]/70
+                    bg-[color:var(--copper)]/12 px-4 py-2 text-sm font-semibold
+                    text-[color:var(--copper)] hover:bg-[color:var(--copper)]/18 disabled:opacity-60
                   "
                 >
                   {savingCv ? "Saving…" : "Save & Continue"}
@@ -1845,9 +1842,9 @@ useEffect(() => {
                   type="button"
                   onClick={handleClearForm}
                   className="
-                    rounded-full border border-red-400/25 bg-black/50
-                    px-4 py-2 text-sm font-semibold text-red-200
-                    hover:bg-red-500/10
+                    rounded-full border border-white/15 bg-black/30
+                    px-4 py-2 text-sm font-semibold text-neutral-400
+                    hover:text-neutral-200 hover:bg-black/45
                   "
                 >
                   Clear form
@@ -1899,8 +1896,8 @@ useEffect(() => {
                   <span
                     className="
                       cursor-pointer rounded-full border px-4 py-2 text-sm font-semibold
-                      bg-[color:var(--copper)]/10 text-[color:var(--copper)]
-                      border-[color:var(--copper)]/70 hover:bg-[color:var(--copper)]/15
+                      border-white/15 bg-black/35 text-neutral-200
+                      hover:border-[color:var(--copper)]/55 hover:text-[color:var(--copper)]
                     "
                   >
                     Add by VIN / Scan
@@ -1931,7 +1928,7 @@ useEffect(() => {
             />
 
             {/* Uploads */}
-            <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+            <section className={sectionPanel}>
               <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                 <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
                   Uploads
@@ -1970,7 +1967,7 @@ useEffect(() => {
             </section>
 
             {/* Internal notes */}
-            <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+            <section className={sectionPanel}>
               <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                 <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
                   Internal Notes
@@ -1993,7 +1990,7 @@ useEffect(() => {
 
             {/* Menu quick add */}
             {wo?.id && (
-              <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+              <section className={sectionPanel}>
                 <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                   <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--copper)]">
                     Quick add from menu
@@ -2006,7 +2003,7 @@ useEffect(() => {
 
             {/* Add line */}
             {wo?.id && (
-              <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+              <section className={sectionPanel}>
                 <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                   <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
                     Add work order line
@@ -2024,7 +2021,7 @@ useEffect(() => {
             )}
 
             {/* Current lines */}
-            <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+            <section className={sectionPanel}>
               <div className={cx("mb-3 flex flex-col gap-2 border-b pb-3 sm:flex-row sm:items-center sm:justify-between", divider)}>
                 <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
                   Current lines
@@ -2143,7 +2140,8 @@ useEffect(() => {
             </section>
 
             {/* Footer actions */}
-            <div className="flex flex-wrap items-center gap-3">
+            <div className="sticky bottom-3 z-10 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_85%,transparent)] p-3 backdrop-blur-xl">
+              <div className="flex flex-wrap items-center gap-3">
               <button
                 type="submit"
                 disabled={loading}
@@ -2154,7 +2152,7 @@ useEffect(() => {
                   disabled:opacity-60
                 "
               >
-                {loading ? "Creating..." : "Approve & Sign"}
+                {loading ? "Creating..." : "Create & Continue to Approval"}
               </button>
 
               <button
@@ -2165,6 +2163,7 @@ useEffect(() => {
               >
                 Cancel
               </button>
+              </div>
             </div>
           </form>
 


### PR DESCRIPTION
### Motivation
- Prevent technicians from editing the internal planning/target completion value and keep that metadata owned by intake/advisor/front-of-house workflows. 
- Make the Create Work Order page visually consistent with the ProFixIQ premium cockpit language and clarify primary vs secondary intake controls. 

### Description
- Removed the editable datetime input and “Save target” button from the technician operational cockpit at `app/work-orders/[id]/Client.tsx` and replaced it with a read-only target completion display plus helper copy indicating intake/advisor ownership. 
- Kept and clarified the editable target completion control inside the create/intake flow at `features/work-orders/app/work-orders/create/page.tsx`, pairing it with Visit Setup fields (waiter, priority, default job type) and updating helper text to emphasize internal planning ownership. 
- Polished the create page visual hierarchy by standardizing panel/card treatment (`card`/`sectionPanel`), toning down heavy copper background blocks, strengthening Visit Setup as the top planning block, and making Customer & Vehicle the primary intake section. 
- Adjusted CTA hierarchy and copy: made `Save & Continue` the primary action in Customer & Vehicle, de-emphasized `Add by VIN / Scan` and `Clear form`, and changed the footer submit CTA to `Create & Continue to Approval`. 
- Files changed: `app/work-orders/[id]/Client.tsx`, `features/work-orders/app/work-orders/create/page.tsx`.

### Testing
- Ran targeted lint on the modified files with `npx eslint app/work-orders/[id]/Client.tsx features/work-orders/app/work-orders/create/page.tsx`, which returned no blocking errors after a small dependency array fix. 
- Ran typecheck with `npx tsc --noEmit`, which completed without type errors. 
- No database/schema changes were made and no business logic around work order lines or RBAC helper usage was altered; role gating was preserved (no ad-hoc role string checks introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12c1f40548328b295bc7f0e408843)