### PR TITLE
Clarify create-work-order lanes: Quick Presets & source boundaries

### DIFF
--- a/app/api/work-orders/lines/add-from-menu-repair/route.ts
+++ b/app/api/work-orders/lines/add-from-menu-repair/route.ts
@@ -69,6 +69,8 @@ export async function POST(req: Request) {
     if (!repairItem?.id) {
       return NextResponse.json({ ok: false, error: "Repair item not found" }, { status: 404 });
     }
+    // Guardrail: this route handles repair-intelligence suggestions (menu_repair_items)
+    // from manual-entry smart-match flows, separate from menu_items quick-add.
 
     const laborOverride =
       typeof body?.laborHours === "number" && Number.isFinite(body.laborHours)

--- a/app/api/work-orders/lines/add-from-menu/route.ts
+++ b/app/api/work-orders/lines/add-from-menu/route.ts
@@ -133,6 +133,8 @@ export async function POST(req: Request): Promise<NextResponse> {
   if (!menu) {
     return NextResponse.json({ ok: false, error: "Menu item not found" }, { status: 404 });
   }
+  // Guardrail: this route is for canonical menu_items only.
+  // Repair-intelligence suggestions (menu_repair_items) must use add-from-menu-repair.
 
   const laborOverride =
     typeof body.laborHours === "number" && Number.isFinite(body.laborHours)

--- a/features/inspections/server/findSmartInspectionMatch.ts
+++ b/features/inspections/server/findSmartInspectionMatch.ts
@@ -202,6 +202,9 @@ export async function findSmartInspectionMatch(args: {
   shopId: string;
   body: MatchBody;
 }): Promise<SmartInspectionMatch | null> {
+  // NOTE: This matcher powers manual line-entry suggestions only.
+  // It intentionally ranks menu_repair_items + shop match feedback and does not
+  // feed the "From My Menu" catalog lane (menu_items).
   const { supabase, shopId, body } = args;
 
   const noteText = [txt(body?.item), txt(body?.notes), txt(body?.section)]

--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -143,6 +143,9 @@ export default function CreateFlowMaintenanceSelector({
           <p className="mt-1 text-[11px] text-neutral-500">
             History-aware scheduled maintenance due for this vehicle. Selected items will be added after submit as pending approval items.
           </p>
+          <p className="mt-1 text-[10px] uppercase tracking-wide text-neutral-500">
+            Separate from quick presets and menu quick-add
+          </p>
         </div>
 
         <div className="flex flex-wrap gap-2">

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -1993,9 +1993,9 @@ useEffect(() => {
               <section className={sectionPanel}>
                 <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                   <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--copper)]">
-                    Quick add from menu
+                    Quick add: presets, templates, and menu
                   </h2>
-                  <span className="text-[11px] text-neutral-500">Saved services</span>
+                  <span className="text-[11px] text-neutral-500">Static presets + inspection templates + menu_items</span>
                 </div>
                 <MenuQuickAdd workOrderId={wo.id} />
               </section>

--- a/features/work-orders/components/MenuQuickAdd.tsx
+++ b/features/work-orders/components/MenuQuickAdd.tsx
@@ -14,20 +14,23 @@ type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
 
 type JobType = "maintenance" | "repair" | "diagnosis" | "inspection";
 
-type PackageItem = {
+type QuickPresetItem = {
   description: string;
   jobType?: JobType;
   laborHours?: number | null;
   notes?: string | null;
 };
 
-type PackageDef = {
+// Static UI-only starters shown in create flow quick add.
+// These are intentionally NOT persisted catalog records and are separate from
+// menu_items, inspection_templates, and maintenance bundle logic.
+type QuickPresetDef = {
   id: string;
   name: string;
   summary: string;
   jobType: "inspection" | "maintenance";
   estLaborHours: number | null;
-  items: PackageItem[];
+  items: QuickPresetItem[];
 };
 
 type MenuItemRow = DB["public"]["Tables"]["menu_items"]["Row"];
@@ -303,7 +306,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const router = useRouter();
 
-  const packages: PackageDef[] = [
+  const quickPresets: QuickPresetDef[] = [
     {
       id: "oil-gas",
       name: "Oil Change – Gasoline",
@@ -460,6 +463,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
     try {
       await ensureShopContext(shopId);
 
+      // Canonical "From My Menu" source: menu_items only.
       const { data, error } = await supabase
         .from("menu_items")
         .select("*")
@@ -489,6 +493,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
 
       const [{ data: auth }, { data, error }] = await Promise.all([
         supabase.auth.getUser(),
+        // Inspection template lane source: inspection_templates (separate domain from menu_items).
         supabase.from("inspection_templates").select("*").order("created_at", { ascending: false }),
       ]);
 
@@ -593,13 +598,13 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
     }
   }
 
-  async function addPackage(pkg: PackageDef) {
+  async function addQuickPreset(preset: QuickPresetDef) {
     await addMenuItem({
       kind: "normal",
-      name: pkg.name,
-      jobType: pkg.jobType === "inspection" ? "inspection" : "maintenance",
-      laborHours: pkg.estLaborHours ?? null,
-      notes: pkg.summary,
+      name: preset.name,
+      jobType: preset.jobType === "inspection" ? "inspection" : "maintenance",
+      laborHours: preset.estLaborHours ?? null,
+      notes: preset.summary,
       source: "package",
     });
   }
@@ -711,18 +716,18 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
         </div>
       </div>
 
-      {/* packages */}
+      {/* quick presets (static create-flow shortcuts, not catalog records) */}
       <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 sm:p-4">
         <div className="mb-2 flex items-center justify-between gap-2">
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Packages</h4>
-          <p className="text-[10px] text-neutral-500">Common services with pre-set labor & notes.</p>
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Quick Presets</h4>
+          <p className="text-[10px] text-neutral-500">Static shortcuts for common starting lines.</p>
         </div>
         <div className="grid gap-2 sm:grid-cols-2">
-          {packages.map((p) => (
+          {quickPresets.map((p) => (
             <button
               type="button"
               key={p.id}
-              onClick={() => void addPackage(p)}
+              onClick={() => void addQuickPreset(p)}
               disabled={addingId === p.id || !shopReady}
               className="flex flex-col rounded-md border border-neutral-800 bg-neutral-950 p-3 text-left text-sm hover:border-orange-500/70 hover:bg-neutral-900 disabled:opacity-60"
               title={p.summary}
@@ -746,7 +751,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
       <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 sm:p-4">
         <div className="mb-2 flex items-center justify-between gap-2">
           <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Inspection Templates</h4>
-          <p className="text-[10px] text-neutral-500">Saved/standard inspections you can attach as jobs.</p>
+          <p className="text-[10px] text-neutral-500">Reusable inspection templates you can attach as jobs.</p>
         </div>
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
           {templatesLoading ? (
@@ -779,7 +784,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
           <div className="space-y-1">
             <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">From My Menu</h4>
             <p className="text-[10px] text-neutral-500">
-              Matches for this vehicle are shown first. Totals use shop labor + tax rules (province engine for CA).
+              Authored menu items for this shop and matching global entries. Matches for this vehicle are shown first.
             </p>
           </div>
 
@@ -825,6 +830,9 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
                   title={mi.description ?? undefined}
                 >
                   <span className="font-medium text-neutral-50">{mi.name}</span>
+                  <div className="mt-1 text-[10px] uppercase tracking-wide text-neutral-500">
+                    Source: menu_items
+                  </div>
 
                   <div className="mt-1 text-xs text-neutral-400">
                     {laborLabel} • {partsLabel} • <span className="text-neutral-100">{totalLabel}</span>

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -161,6 +161,9 @@ export function NewWorkOrderLineForm(props: {
     smartMatchTimer.current = window.setTimeout(async () => {
       setSmartMatchLoading(true);
       try {
+        // Manual-entry-only smart suggestions:
+        // backed by /api/work-orders/smart-repair-match (menu_repair_items + match history).
+        // Intentionally separate from menu_items catalog quick-add.
         const res = await fetch("/api/work-orders/smart-repair-match", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -381,6 +384,9 @@ export function NewWorkOrderLineForm(props: {
           <h3 className="text-sm font-semibold text-neutral-100">Add work order line</h3>
           <p className="text-[11px] text-neutral-400">
             Complaint is required. Cause / correction can be filled in later.
+          </p>
+          <p className="mt-1 text-[10px] uppercase tracking-wide text-neutral-500">
+            Manual entry with optional repair suggestions from vehicle/history matching
           </p>
         </div>
         <div className="rounded-full border border-neutral-700 bg-neutral-900 px-3 py-1 text-[10px] text-neutral-300">


### PR DESCRIPTION
### Motivation
- Reduce conceptual drift in the create-work-order flow by making UI labels and code comments reflect the real domains (static quick presets, authored `menu_items`, `inspection_templates`, and repair-intel suggestions). 
- Make it explicit to users and future devs what is a UI-only preset vs an authored catalog record vs a suggestion, while preserving current behavior and insert paths. 

### Description
- Renamed quick-add preset types/variables and UI from “Packages” → `Quick Presets`, added concise section copy explaining these are static shortcuts, and left the underlying add flow unchanged (`features/work-orders/components/MenuQuickAdd.tsx`).
- Added a small `Source: menu_items` badge on menu cards and clarified that templates are loaded from `inspection_templates`, plus added in-file comments documenting canonical lane boundaries so devs see that `From My Menu` is `menu_items` only (`MenuQuickAdd.tsx`, `features/inspections/server/findSmartInspectionMatch.ts`).
- Added high-signal comments and small UI subtext to the manual entry / smart-match area to confirm repair-intelligence is suggestion-only and powered by the smart-match endpoints (`features/work-orders/components/NewWorkOrderLineForm.tsx`, `features/inspections/server/findSmartInspectionMatch.ts`).
- Added guardrail comments in the two add routes to document lane separation (`app/api/work-orders/lines/add-from-menu/route.ts` and `app/api/work-orders/lines/add-from-menu-repair/route.ts`), adjusted the create page quick-add header, and added a brief clarifying note in the maintenance selector section; no API signatures or DB schema changes were introduced.

### Testing
- Ran `npx eslint` against the touched files and observed no new lint errors for those files; the command completed successfully. 
- Ran `npx tsc --noEmit` and TypeScript compilation completed successfully in this environment. 
- No runtime or integration tests were modified; this is a naming/comment/UI-copy pass only and preserves existing insert paths and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1321b3e9083289c3f9e632721c549)