### PR TITLE
Remove synthetic “Packages” quick-presets and align quick-add to menu_items + inspection_templates

### DIFF
--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -134,17 +134,17 @@ export default function CreateFlowMaintenanceSelector({
   if (!enabled) return null;
 
   return (
-    <section className="rounded-2xl border border-white/10 bg-black/50 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.55)] sm:p-5">
+    <section className="rounded-2xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_84%,transparent)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5">
       <div className="mb-3 flex items-start justify-between gap-3 border-b border-white/10 pb-3">
         <div>
           <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
-            Scheduled maintenance due
+            Scheduled maintenance suggestions
           </h2>
           <p className="mt-1 text-[11px] text-neutral-500">
             History-aware scheduled maintenance due for this vehicle. Selected items will be added after submit as pending approval items.
           </p>
           <p className="mt-1 text-[10px] uppercase tracking-wide text-neutral-500">
-            Separate from quick presets and menu quick-add
+            Separate lane from menu-items catalog and inspection-template quick add
           </p>
         </div>
 

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -1787,7 +1787,7 @@ useEffect(() => {
                     disabled={loading}
                   />
                   <p className="mt-1 text-[11px] text-neutral-500">
-                    Internal planning target for advisor/front-of-house coordination.
+                    Internal advisor planning target in create flow (read-only on technician work-order surfaces).
                   </p>
                 </div>
               </div>
@@ -1992,10 +1992,12 @@ useEffect(() => {
             {wo?.id && (
               <section className={sectionPanel}>
                 <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
-                  <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--copper)]">
-                    Quick add: presets, templates, and menu
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
+                    Reusable adds: menu items & inspection templates
                   </h2>
-                  <span className="text-[11px] text-neutral-500">Static presets + inspection templates + menu_items</span>
+                  <span className="text-[11px] text-neutral-500">
+                    Catalog lane: menu_items • Template lane: inspection_templates
+                  </span>
                 </div>
                 <MenuQuickAdd workOrderId={wo.id} />
               </section>
@@ -2006,9 +2008,11 @@ useEffect(() => {
               <section className={sectionPanel}>
                 <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                   <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
-                    Add work order line
+                    Manual entry line
                   </h2>
-                  <span className="text-[11px] text-neutral-500">Manual entry</span>
+                  <span className="text-[11px] text-neutral-500">
+                    Direct custom line with optional smart repair suggestion
+                  </span>
                 </div>
                 <NewWorkOrderLineForm
                   workOrderId={wo.id}

--- a/features/work-orders/components/MenuQuickAdd.tsx
+++ b/features/work-orders/components/MenuQuickAdd.tsx
@@ -14,25 +14,6 @@ type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
 
 type JobType = "maintenance" | "repair" | "diagnosis" | "inspection";
 
-type QuickPresetItem = {
-  description: string;
-  jobType?: JobType;
-  laborHours?: number | null;
-  notes?: string | null;
-};
-
-// Static UI-only starters shown in create flow quick add.
-// These are intentionally NOT persisted catalog records and are separate from
-// menu_items, inspection_templates, and maintenance bundle logic.
-type QuickPresetDef = {
-  id: string;
-  name: string;
-  summary: string;
-  jobType: "inspection" | "maintenance";
-  estLaborHours: number | null;
-  items: QuickPresetItem[];
-};
-
 type MenuItemRow = DB["public"]["Tables"]["menu_items"]["Row"];
 
 type TemplateRow = DB["public"]["Tables"]["inspection_templates"]["Row"] & {
@@ -67,7 +48,7 @@ type AddMenuParams =
       jobType: JobType;
       laborHours?: number | null;
       notes?: string | null;
-      source?: "single" | "package" | "menu_item" | "ai" | "inspection";
+      source?: "single" | "menu_item" | "ai" | "inspection";
       returnLineId?: boolean;
 
       // ✅ persist linkage
@@ -306,41 +287,6 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const router = useRouter();
 
-  const quickPresets: QuickPresetDef[] = [
-    {
-      id: "oil-gas",
-      name: "Oil Change – Gasoline",
-      jobType: "maintenance",
-      estLaborHours: 0.8,
-      summary: "Oil & filter, fluids, tire pressures, quick leak check.",
-      items: [],
-    },
-    {
-      id: "insp-gas",
-      name: "Multi-Point Inspection – Gas",
-      jobType: "inspection",
-      estLaborHours: 1.0,
-      summary: "Brakes, tires, suspension, battery, lights, codes scan.",
-      items: [],
-    },
-    {
-      id: "maintenance-50",
-      name: "Maintenance 50",
-      jobType: "inspection",
-      estLaborHours: 1.0,
-      summary: "50-point inspection checklist.",
-      items: [],
-    },
-    {
-      id: "maintenance-50-air",
-      name: "Maintenance 50 – Air",
-      jobType: "inspection",
-      estLaborHours: 1.0,
-      summary: "50-point inspection checklist (air systems focus).",
-      items: [],
-    },
-  ];
-
   const [addingId, setAddingId] = useState<string | null>(null);
   const [vehicle, setVehicle] = useState<VehicleLite | null>(null);
   const [, setCustomer] = useState<CustomerLite | null>(null);
@@ -463,7 +409,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
     try {
       await ensureShopContext(shopId);
 
-      // Canonical "From My Menu" source: menu_items only.
+      // Canonical menu catalog source: menu_items only.
       const { data, error } = await supabase
         .from("menu_items")
         .select("*")
@@ -598,17 +544,6 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
     }
   }
 
-  async function addQuickPreset(preset: QuickPresetDef) {
-    await addMenuItem({
-      kind: "normal",
-      name: preset.name,
-      jobType: preset.jobType === "inspection" ? "inspection" : "maintenance",
-      laborHours: preset.estLaborHours ?? null,
-      notes: preset.summary,
-      source: "package",
-    });
-  }
-
   async function addSavedMenuItem(mi: MenuItemRow) {
     const templateId = extractInspectionTemplateIdFromMenuItem(mi);
 
@@ -675,7 +610,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <div className="flex items-center gap-2">
-              <h3 className="text-sm font-semibold text-orange-400">Quick Add Jobs</h3>
+              <h3 className="text-sm font-semibold text-neutral-100">Quick Add Lines</h3>
               <span className="rounded-full border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-[10px] font-mono text-neutral-300">
                 WO {workOrderId.slice(0, 8)}…
               </span>
@@ -693,6 +628,9 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
             ) : (
               <p className="text-[11px] text-neutral-500">Add lines now — you can update vehicle details later.</p>
             )}
+            <p className="text-[10px] uppercase tracking-wide text-neutral-500">
+              Menu items and inspection templates are separate from manual-entry smart suggestions.
+            </p>
           </div>
 
           <div className="flex flex-wrap items-center justify-end gap-2">
@@ -713,37 +651,6 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
               AI Suggest
             </button>
           </div>
-        </div>
-      </div>
-
-      {/* quick presets (static create-flow shortcuts, not catalog records) */}
-      <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 sm:p-4">
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Quick Presets</h4>
-          <p className="text-[10px] text-neutral-500">Static shortcuts for common starting lines.</p>
-        </div>
-        <div className="grid gap-2 sm:grid-cols-2">
-          {quickPresets.map((p) => (
-            <button
-              type="button"
-              key={p.id}
-              onClick={() => void addQuickPreset(p)}
-              disabled={addingId === p.id || !shopReady}
-              className="flex flex-col rounded-md border border-neutral-800 bg-neutral-950 p-3 text-left text-sm hover:border-orange-500/70 hover:bg-neutral-900 disabled:opacity-60"
-              title={p.summary}
-            >
-              <div className="flex items-center justify-between gap-2">
-                <span className="font-medium text-neutral-50">{p.name}</span>
-                <span className="rounded-full border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-[10px] uppercase tracking-wide text-neutral-300">
-                  {p.jobType}
-                </span>
-              </div>
-              <div className="mt-1 text-xs text-neutral-400">
-                {p.estLaborHours != null ? `~${p.estLaborHours.toFixed(1)}h` : "Labor TBD"}
-              </div>
-              <div className="mt-1 line-clamp-2 text-[11px] text-neutral-500">{p.summary}</div>
-            </button>
-          ))}
         </div>
       </div>
 
@@ -782,9 +689,9 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
       <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 sm:p-4">
         <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div className="space-y-1">
-            <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">From My Menu</h4>
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Menu Items</h4>
             <p className="text-[10px] text-neutral-500">
-              Authored menu items for this shop and matching global entries. Matches for this vehicle are shown first.
+              Reusable catalog entries from <span className="font-mono">menu_items</span>. Matches for this vehicle are shown first.
             </p>
           </div>
 

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -386,7 +386,7 @@ export function NewWorkOrderLineForm(props: {
             Complaint is required. Cause / correction can be filled in later.
           </p>
           <p className="mt-1 text-[10px] uppercase tracking-wide text-neutral-500">
-            Manual entry with optional repair suggestions from vehicle/history matching
+            Direct custom line entry with optional smart repair suggestions from complaint + history matching
           </p>
         </div>
         <div className="rounded-full border border-neutral-700 bg-neutral-900 px-3 py-1 text-[10px] text-neutral-300">


### PR DESCRIPTION
### Motivation
- The quick-add panel showed static “package”/preset cards that implied a non-existent authored package domain and caused conceptual drift from the real product model. 
- The intent is to make the create-work-order UI reflect canonical domains: `menu_items` (catalog) and `inspection_templates` (templates), while keeping manual-entry and smart-suggestions separate and unchanged.

### Description
- Deleted the synthetic quick-preset/package definitions and their rendering from `MenuQuickAdd` and removed the `source: 'package'` usage so quick-add shows only menu items and inspection templates. (`features/work-orders/components/MenuQuickAdd.tsx`)
- Clarified headings, subtitles and framing on the create page so lanes read as: catalog lane (`menu_items`) + template lane (`inspection_templates`) + manual entry with smart suggestions; updated copy and a target-completion helper to emphasize advisor/create-flow intent. (`features/work-orders/app/work-orders/create/page.tsx`)
- Tightened manual-entry wording to clearly call out direct custom line entry and that smart repair suggestions are a separate manual-entry-only flow backed by `/api/work-orders/smart-repair-match`. (`features/work-orders/components/NewWorkOrderLineForm.tsx`)
- Normalized maintenance selector card shell and copy to read as a separate lane from the menu/template catalog. (`features/maintenance/components/CreateFlowMaintenanceSelector.tsx`)
- Preserved all existing insertion paths and linkage behavior (menu items still insert with `menu_item_id`; templates still insert via `inspection_template_id`; smart repair suggestions remain backed by `menu_repair_items` + history via the API).

### Testing
- Ran `npx eslint` against the touched files: `features/work-orders/components/MenuQuickAdd.tsx`, `features/work-orders/app/work-orders/create/page.tsx`, `features/work-orders/components/NewWorkOrderLineForm.tsx`, and `features/maintenance/components/CreateFlowMaintenanceSelector.tsx`; the linter completed without errors in this environment. 
- Ran `npx tsc --noEmit`; TypeScript checks passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e136979d4483289c33a9dc22e0c636)