### PR TITLE
Normalize create-work-order panels to premium dark-navy card language

### DIFF
--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -174,7 +174,7 @@ function CustomerAutocomplete({
           className="
             absolute z-20 mt-1 w-full overflow-hidden rounded-xl
             border border-white/12
-            bg-black/55 backdrop-blur-xl
+            bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_76%,transparent)] backdrop-blur-xl
             shadow-[0_18px_45px_rgba(0,0,0,0.70)]
           "
         >
@@ -300,7 +300,7 @@ function UnitNumberAutocomplete({
           className="
             absolute z-20 mt-1 w-full overflow-hidden rounded-xl
             border border-white/12
-            bg-black/55 backdrop-blur-xl
+            bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_76%,transparent)] backdrop-blur-xl
             shadow-[0_18px_45px_rgba(0,0,0,0.70)]
           "
         >
@@ -493,10 +493,16 @@ export default function CustomerVehicleForm({
     }
   };
 
+  const panelClass =
+    "rounded-2xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] shadow-[0_18px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl";
+  const chipClass =
+    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1 text-[11px] text-white/60";
+  const labelClass = "text-xs text-neutral-300";
+
   return (
     <div className="mx-auto w-full max-w-5xl space-y-8 px-4 py-6 text-white">
       {/* Header card */}
-      <section className="rounded-2xl border border-white/10 bg-black/35 px-4 py-4 shadow-[0_18px_45px_rgba(0,0,0,0.70)] backdrop-blur-xl">
+      <section className={`${panelClass} px-4 py-4`}>
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="text-lg font-blackops tracking-[0.16em] text-[var(--accent-copper-light)]">
@@ -514,7 +520,7 @@ export default function CustomerVehicleForm({
               </span>
             )}
             {shopId && (
-              <span className="rounded-full border border-white/10 bg-black/35 px-3 py-1 text-[11px] font-mono text-white/55">
+              <span className={`${chipClass} font-mono`}>
                 Shop&nbsp;
                 <span className="text-[var(--accent-copper-soft)]">
                   {shopId.slice(0, 8)}
@@ -528,7 +534,7 @@ export default function CustomerVehicleForm({
       {/* Main grid: Customer / Vehicle */}
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr),minmax(0,1.1fr)]">
         {/* Customer card */}
-        <section className="rounded-2xl border border-white/10 bg-black/35 px-4 py-4 shadow-[0_18px_45px_rgba(0,0,0,0.70)] backdrop-blur-xl sm:px-6 sm:py-6 space-y-4">
+        <section className={`${panelClass} space-y-4 px-4 py-4 sm:px-6 sm:py-6`}>
           <div className="flex items-center justify-between gap-2">
             <h2 className="text-sm font-semibold text-white sm:text-base">
               Customer Info
@@ -541,7 +547,7 @@ export default function CustomerVehicleForm({
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {/* Business name + autocomplete */}
             <div className="sm:col-span-2 space-y-1">
-              <label className="text-xs text-white/60">
+              <label className={labelClass}>
                 Business name <span className="text-white/35">(optional)</span>
               </label>
               <input
@@ -561,7 +567,7 @@ export default function CustomerVehicleForm({
 
             {/* First name */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">First name</label>
+              <label className={labelClass}>First name</label>
               <input
                 className="input"
                 placeholder="First name"
@@ -577,7 +583,7 @@ export default function CustomerVehicleForm({
 
             {/* Last name */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Last name</label>
+              <label className={labelClass}>Last name</label>
               <input
                 className="input"
                 placeholder="Last name"
@@ -593,7 +599,7 @@ export default function CustomerVehicleForm({
 
             {/* Phone */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Phone</label>
+              <label className={labelClass}>Phone</label>
               <input
                 className="input"
                 placeholder="Phone"
@@ -609,7 +615,7 @@ export default function CustomerVehicleForm({
 
             {/* Email */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Email</label>
+              <label className={labelClass}>Email</label>
               <input
                 type="email"
                 className="input"
@@ -626,7 +632,7 @@ export default function CustomerVehicleForm({
 
             {/* Address */}
             <div className="sm:col-span-2 space-y-1">
-              <label className="text-xs text-white/60">Address</label>
+              <label className={labelClass}>Address</label>
               <input
                 className="input"
                 placeholder="Street address"
@@ -637,7 +643,7 @@ export default function CustomerVehicleForm({
 
             {/* City */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">City</label>
+              <label className={labelClass}>City</label>
               <input
                 className="input"
                 placeholder="City"
@@ -648,7 +654,7 @@ export default function CustomerVehicleForm({
 
             {/* Province */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Province</label>
+              <label className={labelClass}>Province</label>
               <input
                 className="input"
                 placeholder="Province / State"
@@ -659,7 +665,7 @@ export default function CustomerVehicleForm({
 
             {/* Postal code */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Postal code</label>
+              <label className={labelClass}>Postal code</label>
               <input
                 className="input"
                 placeholder="Postal code"
@@ -673,7 +679,7 @@ export default function CustomerVehicleForm({
         </section>
 
         {/* Vehicle card */}
-        <section className="rounded-2xl border border-white/10 bg-black/35 px-4 py-4 shadow-[0_18px_45px_rgba(0,0,0,0.70)] backdrop-blur-xl sm:px-6 sm:py-6 space-y-4">
+        <section className={`${panelClass} space-y-4 px-4 py-4 sm:px-6 sm:py-6`}>
           <div className="flex items-center justify-between gap-2">
             <h2 className="text-sm font-semibold text-white sm:text-base">
               Vehicle Info
@@ -686,7 +692,7 @@ export default function CustomerVehicleForm({
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {/* Unit # + autocomplete */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Unit #</label>
+              <label className={labelClass}>Unit #</label>
               <input
                 className="input"
                 placeholder="Unit #"
@@ -725,7 +731,7 @@ export default function CustomerVehicleForm({
 
             {/* Year */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Year</label>
+              <label className={labelClass}>Year</label>
               <input
                 inputMode="numeric"
                 className="input"
@@ -737,7 +743,7 @@ export default function CustomerVehicleForm({
 
             {/* Make */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Make</label>
+              <label className={labelClass}>Make</label>
               <input
                 className="input"
                 placeholder="Make"
@@ -748,7 +754,7 @@ export default function CustomerVehicleForm({
 
             {/* Model */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Model</label>
+              <label className={labelClass}>Model</label>
               <input
                 className="input"
                 placeholder="Model"
@@ -759,7 +765,7 @@ export default function CustomerVehicleForm({
 
             {/* VIN */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">VIN</label>
+              <label className={labelClass}>VIN</label>
               <input
                 className="input"
                 placeholder="VIN"
@@ -770,7 +776,7 @@ export default function CustomerVehicleForm({
 
             {/* Plate */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">License plate</label>
+              <label className={labelClass}>License plate</label>
               <input
                 className="input"
                 placeholder="License plate"
@@ -783,7 +789,7 @@ export default function CustomerVehicleForm({
 
             {/* Mileage */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Mileage</label>
+              <label className={labelClass}>Mileage</label>
               <input
                 inputMode="numeric"
                 className="input"
@@ -795,7 +801,7 @@ export default function CustomerVehicleForm({
 
             {/* Color */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Color</label>
+              <label className={labelClass}>Color</label>
               <input
                 className="input"
                 placeholder="Color"
@@ -806,7 +812,7 @@ export default function CustomerVehicleForm({
 
             {/* Engine hours */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Engine hours</label>
+              <label className={labelClass}>Engine hours</label>
               <input
                 inputMode="numeric"
                 className="input"
@@ -820,7 +826,7 @@ export default function CustomerVehicleForm({
 
             {/* Engine / trim */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Engine / Trim</label>
+              <label className={labelClass}>Engine / Trim</label>
               <input
                 className="input"
                 placeholder="e.g. 3.5L EcoBoost"
@@ -831,7 +837,7 @@ export default function CustomerVehicleForm({
 
             {/* Transmission */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Transmission</label>
+              <label className={labelClass}>Transmission</label>
               <select
                 className="input"
                 value={vehicle.transmission ?? ""}
@@ -850,7 +856,7 @@ export default function CustomerVehicleForm({
 
             {/* Fuel type */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Fuel type</label>
+              <label className={labelClass}>Fuel type</label>
               <select
                 className="input"
                 value={vehicle.fuel_type ?? ""}
@@ -870,7 +876,7 @@ export default function CustomerVehicleForm({
 
             {/* Drivetrain */}
             <div className="space-y-1">
-              <label className="text-xs text-white/60">Drivetrain</label>
+              <label className={labelClass}>Drivetrain</label>
               <select
                 className="input"
                 value={vehicle.drivetrain ?? ""}
@@ -926,7 +932,7 @@ export default function CustomerVehicleForm({
               onClick={onClear}
               className="
                 inline-flex items-center rounded-full
-                border border-white/12 bg-white/5
+                border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)]
                 px-3 py-1.5 text-xs sm:text-sm text-white/75
                 transition hover:border-red-400/60 hover:bg-red-950/35 hover:text-red-200
               "

--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -133,6 +133,11 @@ export default function CreateFlowMaintenanceSelector({
 
   if (!enabled) return null;
 
+  const softButtonClass =
+    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_60%,transparent)] disabled:opacity-50";
+  const itemPanelClass =
+    "rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_70%,transparent)] px-3 py-3";
+
   return (
     <section className="rounded-2xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_84%,transparent)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5">
       <div className="mb-3 flex items-start justify-between gap-3 border-b border-white/10 pb-3">
@@ -153,7 +158,7 @@ export default function CreateFlowMaintenanceSelector({
             type="button"
             onClick={() => setReloadKey((v) => v + 1)}
             disabled={!canLoad || loading}
-            className="rounded-full border border-white/10 bg-black/50 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-black/65 disabled:opacity-50"
+            className={softButtonClass}
           >
             Refresh
           </button>
@@ -161,7 +166,7 @@ export default function CreateFlowMaintenanceSelector({
             type="button"
             onClick={() => toggleAll(true)}
             disabled={!rows.length}
-            className="rounded-full border border-white/10 bg-black/50 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-black/65 disabled:opacity-50"
+            className={softButtonClass}
           >
             Select all
           </button>
@@ -169,7 +174,7 @@ export default function CreateFlowMaintenanceSelector({
             type="button"
             onClick={() => toggleAll(false)}
             disabled={!rows.length}
-            className="rounded-full border border-white/10 bg-black/50 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-black/65 disabled:opacity-50"
+            className={softButtonClass}
           >
             Clear
           </button>
@@ -177,7 +182,7 @@ export default function CreateFlowMaintenanceSelector({
       </div>
 
       {!canLoad ? (
-        <div className="rounded-xl border border-dashed border-white/10 bg-black/20 px-3 py-4 text-sm text-neutral-400">
+        <div className="rounded-xl border border-dashed border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-4 text-sm text-neutral-400">
           Save customer and vehicle first to load maintenance suggestions.
         </div>
       ) : error ? (
@@ -187,7 +192,7 @@ export default function CreateFlowMaintenanceSelector({
       ) : loading ? (
         <div className="text-sm text-neutral-400">Loading suggestions...</div>
       ) : rows.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-white/10 bg-black/20 px-3 py-4 text-sm text-neutral-400">
+        <div className="rounded-xl border border-dashed border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-4 text-sm text-neutral-400">
           No active maintenance suggestions for this vehicle.
         </div>
       ) : (
@@ -197,7 +202,7 @@ export default function CreateFlowMaintenanceSelector({
             return (
               <div
                 key={item.serviceCode}
-                className="rounded-xl border border-white/10 bg-black/20 px-3 py-3"
+                className={itemPanelClass}
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <label className="flex min-w-0 flex-1 items-start gap-3">
@@ -231,7 +236,7 @@ export default function CreateFlowMaintenanceSelector({
                     type="button"
                     onClick={() => void dismissCompletedPreviously(item.serviceCode)}
                     disabled={!!busyCode}
-                    className="rounded-full border border-white/10 bg-black/50 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-black/65 disabled:opacity-50"
+                    className={softButtonClass}
                   >
                     {busyCode === item.serviceCode ? "Saving..." : "Mark done elsewhere"}
                   </button>

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -43,6 +43,12 @@ const card =
 const divider = "border-white/10";
 const sectionPanel =
   "rounded-2xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_84%,transparent)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5";
+const childPanel =
+  "rounded-2xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_76%,transparent)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
+const subtlePanel =
+  "rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_70%,transparent)]";
+const softButton =
+  "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_70%,transparent)] text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_62%,transparent)]";
 
 /* =============================================================================
    Types & helpers
@@ -1643,11 +1649,7 @@ useEffect(() => {
             <button
               type="button"
               onClick={() => router.back()}
-              className="
-                shrink-0 rounded-full border border-white/10 bg-black/50
-                px-4 py-2 text-sm font-semibold text-neutral-200
-                hover:bg-black/65
-              "
+              className={cx("shrink-0 px-4 py-2 text-sm font-semibold", softButton)}
             >
               Back to list
             </button>
@@ -1663,14 +1665,14 @@ useEffect(() => {
           )}
 
           {uploadSummary && (
-            <div className="mb-4 rounded-xl border border-white/10 bg-black/50 px-4 py-3 text-sm text-neutral-200">
+            <div className={cx("mb-4 px-4 py-3 text-sm text-neutral-200", subtlePanel)}>
               Uploaded {uploadSummary.uploaded} file(s)
               {uploadSummary.failed ? `, ${uploadSummary.failed} failed` : ""}.
             </div>
           )}
 
           {inviteNotice && (
-            <div className="mb-4 rounded-xl border border-white/10 bg-black/50 px-4 py-3 text-sm text-neutral-200">
+            <div className={cx("mb-4 px-4 py-3 text-sm text-neutral-200", subtlePanel)}>
               {inviteNotice}
             </div>
           )}
@@ -1686,7 +1688,7 @@ useEffect(() => {
               </div>
 
               <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-2xl border border-white/10 bg-black/35 p-4">
+                <div className={cx("p-4", childPanel)}>
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-300">
@@ -1707,7 +1709,7 @@ useEffect(() => {
                         "relative inline-flex h-7 w-14 shrink-0 items-center rounded-full border transition",
                         isWaiter
                           ? "border-[color:var(--copper)]/70 bg-[color:var(--copper)]/20"
-                          : "border-white/10 bg-black/50",
+                          : "border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_62%,transparent)]",
                         loading ? "opacity-60" : "hover:bg-white/5",
                       ].join(" ")}
                     >
@@ -1728,7 +1730,7 @@ useEffect(() => {
                         "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]",
                         isWaiter
                           ? "border-amber-400/50 bg-amber-500/10 text-amber-100"
-                          : "border-white/10 bg-black/40 text-neutral-400",
+                          : "border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_65%,transparent)] text-neutral-400",
                       ].join(" ")}
                     >
                       {isWaiter ? "Waiter" : "Drop-off"}
@@ -1736,7 +1738,7 @@ useEffect(() => {
                   </div>
                 </div>
 
-                <div className="rounded-2xl border border-white/10 bg-black/30 p-3.5">
+                <div className={cx("p-3.5", childPanel)}>
                   <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
                     Priority
                   </label>
@@ -1756,7 +1758,7 @@ useEffect(() => {
                   </p>
                 </div>
 
-                <div className="rounded-2xl border border-white/10 bg-black/30 p-3.5">
+                <div className={cx("p-3.5", childPanel)}>
                   <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
                     Default job type
                   </label>
@@ -1775,7 +1777,7 @@ useEffect(() => {
                   </p>
                 </div>
 
-                <div className="rounded-2xl border border-white/10 bg-black/30 p-3.5">
+                <div className={cx("p-3.5", childPanel)}>
                   <label className="mb-1 block text-xs uppercase tracking-wide text-neutral-400">
                     Target completion
                   </label>
@@ -1794,7 +1796,7 @@ useEffect(() => {
             </section>
 
             {/* Customer & Vehicle */}
-            <section className={cx(sectionPanel, "border-white/15 bg-black/45")}>
+            <section className={sectionPanel}>
               <div className={cx("mb-3 flex items-center justify-between border-b pb-3", divider)}>
                 <h2 className="text-sm font-semibold tracking-[0.08em] text-neutral-100">
                   Customer &amp; Vehicle
@@ -1841,11 +1843,7 @@ useEffect(() => {
                 <button
                   type="button"
                   onClick={handleClearForm}
-                  className="
-                    rounded-full border border-white/15 bg-black/30
-                    px-4 py-2 text-sm font-semibold text-neutral-400
-                    hover:text-neutral-200 hover:bg-black/45
-                  "
+                  className={cx("px-4 py-2 text-sm font-semibold text-neutral-300 hover:text-neutral-100", softButton)}
                 >
                   Clear form
                 </button>
@@ -1894,11 +1892,10 @@ useEffect(() => {
                   }}
                 >
                   <span
-                    className="
-                      cursor-pointer rounded-full border px-4 py-2 text-sm font-semibold
-                      border-white/15 bg-black/35 text-neutral-200
-                      hover:border-[color:var(--copper)]/55 hover:text-[color:var(--copper)]
-                    "
+                    className={cx(
+                      "cursor-pointer px-4 py-2 text-sm font-semibold hover:border-[color:var(--copper)]/55 hover:text-[color:var(--copper)]",
+                      softButton,
+                    )}
                   >
                     Add by VIN / Scan
                   </span>
@@ -1911,7 +1908,7 @@ useEffect(() => {
                   type="checkbox"
                   checked={sendInvite}
                   onChange={(e) => setSendInvite(e.target.checked)}
-                  className="h-4 w-4 rounded border-white/10 bg-black/50"
+                  className="h-4 w-4 rounded border-white/20 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_60%,transparent)]"
                   disabled={loading}
                 />
                 Email a customer portal sign-up link
@@ -2047,7 +2044,9 @@ useEffect(() => {
               </div>
 
               {!wo?.id || lines.length === 0 ? (
-                <p className="text-sm text-neutral-400">No lines yet.</p>
+                <div className={cx("px-4 py-5 text-sm text-neutral-400", subtlePanel)}>
+                  No lines yet.
+                </div>
               ) : (
                 <div className="space-y-4">
                   <div>
@@ -2060,7 +2059,10 @@ useEffect(() => {
                         .map((ln) => (
                     <div
                       key={ln.id}
-                      className="flex flex-col gap-3 rounded-xl border border-white/10 bg-black/50 p-3 sm:flex-row sm:items-start sm:justify-between"
+                      className={cx(
+                        "flex flex-col gap-3 p-3 sm:flex-row sm:items-start sm:justify-between",
+                        subtlePanel,
+                      )}
                     >
                       <div className="min-w-0">
                         <div className="truncate font-medium text-neutral-100">
@@ -2098,11 +2100,9 @@ useEffect(() => {
                         <button
                           type="button"
                           onClick={() => void handleDeleteLine(ln.id)}
-                          className="
-                            rounded-full border border-red-400/25 bg-black/50
-                            px-3 py-2 text-sm font-semibold text-red-200
-                            hover:bg-red-500/10
-                          "
+                          className={cx(
+                            "rounded-full border border-red-400/25 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_62%,transparent)] px-3 py-2 text-sm font-semibold text-red-200 hover:bg-red-500/10",
+                          )}
                         >
                           Delete
                         </button>
@@ -2122,7 +2122,7 @@ useEffect(() => {
                         .map((ln) => (
                           <div
                             key={ln.id}
-                            className="rounded-xl border border-white/10 bg-black/30 p-3 text-sm text-neutral-300"
+                            className={cx("p-3 text-sm text-neutral-300", subtlePanel)}
                           >
                             <div className="font-medium text-neutral-200">
                               {ln.description || ln.complaint || "Context line"}

--- a/features/work-orders/components/MenuQuickAdd.tsx
+++ b/features/work-orders/components/MenuQuickAdd.tsx
@@ -602,20 +602,28 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
   }, [menuItemsAll, menuQuery, includeGlobal, vehicle]);
 
   const currency: "CAD" | "USD" = shopDefaults?.country === "CA" ? "CAD" : "USD";
+  const panelClass =
+    "rounded-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
+  const chipClass =
+    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_68%,transparent)] px-2 py-0.5 text-[10px] text-neutral-300";
+  const itemCardClass =
+    "flex flex-col rounded-lg border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_70%,transparent)] p-3 text-left text-sm hover:border-[color:var(--accent-copper,#C57A4A)]/50 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_63%,transparent)] disabled:opacity-60";
+  const softActionClass =
+    "rounded-md border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1.5 text-xs sm:text-sm text-neutral-100 hover:border-[color:var(--accent-copper,#C57A4A)]/55 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_60%,transparent)]";
 
   return (
     <div className="space-y-5 text-white">
       {/* header */}
-      <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 px-3 py-3 sm:px-4 sm:py-3">
+      <div className={`${panelClass} px-3 py-3 sm:px-4 sm:py-3`}>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <div className="flex items-center gap-2">
               <h3 className="text-sm font-semibold text-neutral-100">Quick Add Lines</h3>
-              <span className="rounded-full border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-[10px] font-mono text-neutral-300">
+              <span className={`${chipClass} font-mono`}>
                 WO {workOrderId.slice(0, 8)}…
               </span>
               {shopDefaults?.labor_rate != null ? (
-                <span className="rounded-full border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-[10px] text-neutral-300">
+                <span className={chipClass}>
                   Labor {shopDefaults.labor_rate.toFixed(0)}/{currency}/hr
                 </span>
               ) : null}
@@ -637,7 +645,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
             <button
               type="button"
               onClick={() => router.push(`/work-orders/quote-review?woId=${workOrderId}`)}
-              className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-xs sm:text-sm text-neutral-100 hover:border-orange-500 hover:bg-neutral-800"
+              className={softActionClass}
             >
               Review quote
               {typeof woLineCount === "number" && woLineCount > 0 ? ` (${woLineCount})` : ""}
@@ -655,7 +663,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
       </div>
 
       {/* templates */}
-      <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 sm:p-4">
+      <div className={`${panelClass} p-3 sm:p-4`}>
         <div className="mb-2 flex items-center justify-between gap-2">
           <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Inspection Templates</h4>
           <p className="text-[10px] text-neutral-500">Reusable inspection templates you can attach as jobs.</p>
@@ -670,7 +678,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
                 type="button"
                 onClick={() => void addTemplateAsLine(t)}
                 disabled={addingId === t.id || !shopReady}
-                className="flex flex-col rounded-md border border-neutral-800 bg-neutral-950 p-3 text-left text-sm hover:border-orange-500/70 hover:bg-neutral-900 disabled:opacity-60"
+                className={itemCardClass}
                 title={t.description ?? undefined}
               >
                 <span className="font-medium text-neutral-50">{t.template_name ?? "Inspection"}</span>
@@ -686,7 +694,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
       </div>
 
       {/* menu items */}
-      <div className="rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 sm:p-4">
+      <div className={`${panelClass} p-3 sm:p-4`}>
         <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div className="space-y-1">
             <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-300">Menu Items</h4>
@@ -700,14 +708,14 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
               value={menuQuery}
               onChange={(e) => setMenuQuery(e.target.value)}
               placeholder="Search menu items (e.g. brakes, alignment, oil)…"
-              className="w-full sm:w-[320px] rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-xs sm:text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none"
+              className="w-full sm:w-[320px] rounded-md border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1.5 text-xs sm:text-sm text-white placeholder:text-neutral-500 focus:border-[color:var(--accent-copper,#C57A4A)] focus:outline-none"
             />
             <label className="flex items-center gap-2 text-[11px] text-neutral-300">
               <input
                 type="checkbox"
                 checked={includeGlobal}
                 onChange={(e) => setIncludeGlobal(e.target.checked)}
-                className="h-4 w-4 rounded border-neutral-700 bg-neutral-900"
+                className="h-4 w-4 rounded border-white/20 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_64%,transparent)]"
               />
               Include global services
             </label>
@@ -733,7 +741,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
                   key={mi.id}
                   onClick={() => void addSavedMenuItem(mi)}
                   disabled={addingId === (mi.name ?? "") || !shopReady}
-                  className="flex flex-col rounded-md border border-neutral-800 bg-neutral-950 p-3 text-left text-sm hover:border-orange-500/70 hover:bg-neutral-900 disabled:opacity-60"
+                  className={itemCardClass}
                   title={mi.description ?? undefined}
                 >
                   <span className="font-medium text-neutral-50">{mi.name}</span>
@@ -746,7 +754,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
                     {taxLabel ? <span className="ml-1 text-neutral-500">• {taxLabel}</span> : null}
 
                     {isGlobalMenuItem(mi) ? (
-                      <span className="ml-2 rounded-full border border-neutral-700 bg-neutral-900 px-2 py-0.5 text-[10px] text-neutral-300">
+                      <span className={`ml-2 ${chipClass}`}>
                         GLOBAL
                       </span>
                     ) : (

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -91,6 +91,12 @@ export function NewWorkOrderLineForm(props: {
 
   const canSave = complaint.trim().length > 0 && !!workOrderId;
   const topRepairDefault = isTopRepairDefault(smartMatch);
+  const formShellClass =
+    "rounded-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] p-4 text-sm text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] sm:p-5";
+  const controlClass =
+    "w-full rounded-md border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-[color:var(--accent-copper,#C57A4A)] focus:outline-none";
+  const mutedPillClass =
+    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1 text-[10px] text-neutral-300";
 
   function normalizeJobType(t: WOJobType | null): InsertLine["job_type"] {
     const allowed: WOJobType[] = [
@@ -378,7 +384,7 @@ export function NewWorkOrderLineForm(props: {
   }
 
   return (
-    <div className="rounded-lg border border-neutral-800 bg-neutral-950 p-4 sm:p-5 text-sm text-white space-y-4">
+    <div className={`${formShellClass} space-y-4`}>
       <div className="flex items-center justify-between gap-2">
         <div>
           <h3 className="text-sm font-semibold text-neutral-100">Add work order line</h3>
@@ -389,7 +395,7 @@ export function NewWorkOrderLineForm(props: {
             Direct custom line entry with optional smart repair suggestions from complaint + history matching
           </p>
         </div>
-        <div className="rounded-full border border-neutral-700 bg-neutral-900 px-3 py-1 text-[10px] text-neutral-300">
+        <div className={mutedPillClass}>
           Linked to WO:{" "}
           <span className="font-mono">{workOrderId.slice(0, 8)}…</span>
         </div>
@@ -401,7 +407,7 @@ export function NewWorkOrderLineForm(props: {
           <select
             value={lineType}
             onChange={(e) => setLineType(e.target.value as WOLineType)}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none"
+            className={controlClass}
           >
             <option value="job">Job line (punchable)</option>
             <option value="info">Info line (context only)</option>
@@ -420,7 +426,7 @@ export function NewWorkOrderLineForm(props: {
           <textarea
             value={complaint}
             onChange={(e) => setComplaint(e.target.value)}
-            className="w-full min-h-[60px] rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none"
+            className={`${controlClass} min-h-[60px]`}
             placeholder="Describe the issue / customer concern"
           />
         </div>
@@ -517,7 +523,7 @@ export function NewWorkOrderLineForm(props: {
           <textarea
             value={cause}
             onChange={(e) => setCause(e.target.value)}
-            className="w-full min-h-[48px] rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none"
+            className={`${controlClass} min-h-[48px]`}
             placeholder="Root cause (optional)"
           />
         </div>
@@ -527,7 +533,7 @@ export function NewWorkOrderLineForm(props: {
           <textarea
             value={correction}
             onChange={(e) => setCorrection(e.target.value)}
-            className="w-full min-h-[48px] rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none"
+            className={`${controlClass} min-h-[48px]`}
             placeholder="What to do / repair plan (optional)"
           />
         </div>
@@ -538,7 +544,7 @@ export function NewWorkOrderLineForm(props: {
             inputMode="decimal"
             value={labor}
             onChange={(e) => setLabor(e.target.value)}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none"
+            className={controlClass}
             placeholder="0.0"
           />
           <p className="text-[10px] text-neutral-500">
@@ -551,7 +557,7 @@ export function NewWorkOrderLineForm(props: {
           <select
             value={normalizeStatus(status)}
             onChange={(e) => setStatus(e.target.value as InsertLine["status"])}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none"
+            className={controlClass}
           >
             <option value="awaiting">Awaiting</option>
             <option value="in_progress">In progress</option>
@@ -566,7 +572,7 @@ export function NewWorkOrderLineForm(props: {
           <select
             value={jobType ?? ""}
             onChange={(e) => setJobType((e.target.value || null) as WOJobType | null)}
-            className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none"
+            className={controlClass}
           >
             <option value="">Unspecified</option>
             <option value="diagnosis">Diagnosis</option>


### PR DESCRIPTION
### Motivation
- The create-work-order flow contained nested flat black panels that visually clashed with the newer navy/glass operational shell and broke visual rhythm. 
- The goal was a focused UI polish to make parent cards, child panels, inputs, and quick-add items read as one cohesive premium surface without changing behavior.

### Description
- Introduced a small set of local surface recipes and applied them across the create flow (`childPanel`, `subtlePanel`, `softButton`, `panelClass`, `itemCardClass`, `controlClass`, `formShellClass`, etc.) and replaced scattered `bg-black/...` with theme-aware `color-mix(...)` fills and consistent borders/radii. 
- Normalized inner panels, chips, and button treatments for the following files: `features/work-orders/app/work-orders/create/page.tsx`, `features/work-orders/components/MenuQuickAdd.tsx`, `features/work-orders/components/NewWorkOrderLineForm.tsx`, `features/inspections/components/inspection/CustomerVehicleForm.tsx`, and `features/maintenance/components/CreateFlowMaintenanceSelector.tsx`. 
- Unified form control visuals by centralizing input/select/textarea class usage (new `controlClass`) so inputs share background, border, radius, and focus behavior with surrounding cards. 
- Touched only presentation: autocomplete dropdowns, empty states, quick-add cards, manual line shell, maintenance suggestion rows, notice banners and secondary actions were updated to the same visual family.
- No layout/order changes, no data model or API/insert logic changes, and no business logic modifications were made.

### Testing
- Ran `npx eslint` against the modified files listed above (no new lint errors introduced). 
- Ran `npx tsc --noEmit` to validate TypeScript (build check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15e4d9d108328893d53ae6e9d139f)