### PR TITLE
Unify mobile tech UI surfaces and replace stacked floating CTAs with a dock

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -212,6 +212,109 @@ select {
   border-radius: var(--theme-radius-xl);
 }
 
+
+
+.mobile-tech-page {
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--brand-primary) 10%, transparent), transparent 58%),
+    linear-gradient(180deg, color-mix(in srgb, var(--theme-app-bg) 86%, #020617), var(--theme-app-bg-secondary));
+}
+
+.mobile-tech-panel {
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--metal-border-soft) 88%, transparent);
+  background: linear-gradient(160deg, rgba(12, 20, 34, 0.9), rgba(3, 8, 18, 0.92));
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(10px);
+}
+
+.mobile-tech-subpanel {
+  border-radius: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--metal-border-soft) 74%, transparent);
+  background: rgba(3, 10, 20, 0.78);
+}
+
+.mobile-tech-stat {
+  border-radius: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--metal-border-soft) 82%, transparent);
+  background: rgba(7, 16, 28, 0.9);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.28);
+}
+
+.mobile-tech-input {
+  width: 100%;
+  border-radius: 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--metal-border-soft) 90%, transparent);
+  background: rgba(2, 7, 16, 0.84);
+  color: var(--theme-text-primary);
+}
+
+.mobile-tech-input::placeholder {
+  color: color-mix(in srgb, var(--theme-text-secondary) 92%, #9ca3af);
+}
+
+.mobile-tech-input:focus-visible {
+  border-color: color-mix(in srgb, #38bdf8 58%, var(--brand-accent));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, #38bdf8 56%, transparent),
+    0 0 0 3px color-mix(in srgb, #38bdf8 25%, transparent);
+}
+
+.mobile-tech-btn-primary,
+.mobile-tech-btn-secondary,
+.mobile-tech-btn-ghost,
+.mobile-tech-btn-danger,
+.mobile-tech-btn-utility {
+  border-radius: 0.8rem;
+  border-width: 1px;
+  font-weight: 600;
+  transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+}
+
+.mobile-tech-btn-primary {
+  border-color: color-mix(in srgb, #38bdf8 60%, transparent);
+  background: color-mix(in srgb, #0ea5e9 24%, #081325);
+  color: #e0f2fe;
+}
+
+.mobile-tech-btn-secondary {
+  border-color: color-mix(in srgb, var(--metal-border-soft) 90%, transparent);
+  background: rgba(6, 14, 26, 0.72);
+  color: #e5e7eb;
+}
+
+.mobile-tech-btn-ghost {
+  border-color: color-mix(in srgb, var(--metal-border-soft) 66%, transparent);
+  background: transparent;
+  color: #cbd5e1;
+}
+
+.mobile-tech-btn-danger {
+  border-color: color-mix(in srgb, #f59e0b 62%, transparent);
+  background: color-mix(in srgb, #f59e0b 18%, transparent);
+  color: #fef3c7;
+}
+
+.mobile-tech-btn-utility {
+  border-color: color-mix(in srgb, var(--brand-accent) 46%, transparent);
+  background: color-mix(in srgb, var(--brand-primary) 14%, #07101e);
+  color: color-mix(in srgb, var(--brand-accent) 88%, #f1f5f9);
+}
+
+.mobile-tech-utility-dock {
+  position: fixed;
+  right: 0.75rem;
+  bottom: calc(3.4rem + var(--safe-bottom));
+  z-index: 45;
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.45rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--metal-border-soft) 86%, transparent);
+  background: rgba(2, 7, 16, 0.8);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.38);
+}
 .accent-chip {
   border-radius: 9999px;
   border: 1px solid var(--brand-accent);

--- a/app/mobile/tech/performance/page.tsx
+++ b/app/mobile/tech/performance/page.tsx
@@ -1,7 +1,7 @@
 // app/mobile/tech/performance/page.tsx
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { toast } from "sonner";
 
@@ -45,7 +45,6 @@ export default function MobileTechPerformancePage() {
   const [aiSummary, setAiSummary] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
 
-  // Load profile (user, shop, role)
   useEffect(() => {
     (async () => {
       try {
@@ -80,21 +79,18 @@ export default function MobileTechPerformancePage() {
         setShopId(profile.shop_id);
         setRole(profile.role ?? null);
       } catch (e) {
-        const msg =
-          e instanceof Error ? e.message : "Failed to load profile.";
-        setError(msg);
+        setError(e instanceof Error ? e.message : "Failed to load profile.");
       }
     })();
   }, [supabase]);
 
-  // Load leaderboard data for this shop/range
   useEffect(() => {
     if (!shopId) return;
 
     (async () => {
       setLoading(true);
       setError(null);
-      setAiSummary(null); // reset when changing range/shop
+      setAiSummary(null);
 
       try {
         const result = await getTechLeaderboard(shopId, range);
@@ -103,18 +99,13 @@ export default function MobileTechPerformancePage() {
         setEnd(result.end);
 
         if (userId) {
-          const mine =
-            result.rows.find((row) => row.techId === userId) ?? null;
+          const mine = result.rows.find((row) => row.techId === userId) ?? null;
           setMyRow(mine);
         } else {
           setMyRow(null);
         }
       } catch (e) {
-        const msg =
-          e instanceof Error
-            ? e.message
-            : "Failed to load tech performance.";
-        setError(msg);
+        setError(e instanceof Error ? e.message : "Failed to load tech performance.");
         setRows([]);
         setMyRow(null);
       } finally {
@@ -123,7 +114,6 @@ export default function MobileTechPerformancePage() {
     })();
   }, [shopId, range, userId]);
 
-  // Fire AI summary once we have myRow + rows
   useEffect(() => {
     if (!myRow) return;
 
@@ -160,14 +150,10 @@ export default function MobileTechPerformancePage() {
           }),
         });
 
-        if (!res.ok) {
-          throw new Error(`AI summary failed (${res.status})`);
-        }
+        if (!res.ok) throw new Error(`AI summary failed (${res.status})`);
 
         const json = (await res.json()) as { summary?: string };
-        if (json.summary) {
-          setAiSummary(json.summary);
-        }
+        if (json.summary) setAiSummary(json.summary);
       } catch (e) {
         console.error(e);
         toast.error("AI performance summary could not be generated.");
@@ -179,138 +165,73 @@ export default function MobileTechPerformancePage() {
 
   const dateRangeLabel =
     start && end
-      ? `${new Date(start).toLocaleDateString()} – ${new Date(
-          end,
-        ).toLocaleDateString()}`
+      ? `${new Date(start).toLocaleDateString()} – ${new Date(end).toLocaleDateString()}`
       : RANGE_LABELS[range];
 
   const hasData = rows.length > 0;
 
   return (
-    <main className="min-h-screen bg-black text-white">
-      <div className="mx-auto flex max-w-md flex-col gap-4 px-4 pb-8 pt-6">
-        {/* Header */}
-        <header className="space-y-1">
-          <div className="text-[0.7rem] uppercase tracking-[0.25em] text-neutral-500">
-            ProFixIQ • Tech
-          </div>
-          <h1 className="font-blackops text-xl uppercase tracking-[0.18em] text-orange-400">
-            My Performance
-          </h1>
-          <p className="text-[0.8rem] text-neutral-400">
-            Jobs, hours and efficiency for your chosen time range.
-          </p>
+    <main className="mobile-tech-page min-h-screen text-white">
+      <div className="mx-auto flex max-w-md flex-col gap-3 px-4 pb-8 pt-4">
+        <header className="mobile-tech-panel space-y-1 px-4 py-3">
+          <div className="text-[0.7rem] uppercase tracking-[0.25em] text-neutral-500">ProFixIQ • Tech</div>
+          <h1 className="font-blackops text-lg uppercase tracking-[0.16em] text-sky-300">My Performance</h1>
+          <p className="text-[0.8rem] text-neutral-400">Jobs, hours and efficiency for your chosen time range.</p>
         </header>
 
-        {/* Time range selector */}
-        <section className="space-y-2 rounded-2xl border border-white/10 bg-black/40 px-3 py-3 shadow-card">
+        <section className="mobile-tech-panel space-y-2 px-3 py-3">
           <div className="flex items-center justify-between gap-2">
-            <span className="text-[0.7rem] uppercase tracking-[0.18em] text-neutral-400">
-              Time range
-            </span>
-            <span className="text-[0.7rem] text-neutral-300">
-              {dateRangeLabel}
-            </span>
+            <span className="text-[0.7rem] uppercase tracking-[0.18em] text-neutral-400">Time range</span>
+            <span className="text-[0.7rem] text-neutral-300">{dateRangeLabel}</span>
           </div>
           <div className="flex flex-wrap gap-1.5">
-            {(["weekly", "monthly", "quarterly", "yearly"] as Range[]).map(
-              (r) => {
-                const active = range === r;
-                return (
-                  <Button
-                    key={r}
-                    type="button"
-                    size="xs"
-                    variant={active ? "default" : "outline"}
-                    className={
-                      active
-                        ? "border-orange-500 bg-orange-500 text-black text-[0.7rem] px-3 py-1"
-                        : "border-white/15 bg-transparent text-[0.7rem] px-3 py-1"
-                    }
-                    onClick={() => setRange(r)}
-                  >
-                    {r.charAt(0).toUpperCase() + r.slice(1)}
-                  </Button>
-                );
-              },
-            )}
+            {(["weekly", "monthly", "quarterly", "yearly"] as Range[]).map((r) => {
+              const active = range === r;
+              return (
+                <Button
+                  key={r}
+                  type="button"
+                  size="xs"
+                  variant={active ? "default" : "outline"}
+                  className={
+                    active
+                      ? "mobile-tech-btn-primary border px-3 py-1 text-[0.7rem]"
+                      : "mobile-tech-btn-ghost border px-3 py-1 text-[0.7rem]"
+                  }
+                  onClick={() => setRange(r)}
+                >
+                  {r.charAt(0).toUpperCase() + r.slice(1)}
+                </Button>
+              );
+            })}
           </div>
         </section>
 
-        {/* Error / loading */}
-        {error && (
-          <div className="rounded-xl border border-red-500/40 bg-red-900/30 px-3 py-3 text-[0.8rem] text-red-100">
-            {error}
-          </div>
-        )}
+        {error && <Notice tone="danger">{error}</Notice>}
+        {loading && <Notice>Loading performance…</Notice>}
+        {!loading && !error && !hasData && <Notice>No technician data found for this range.</Notice>}
 
-        {loading && (
-          <div className="rounded-xl border border-white/10 bg-black/40 px-3 py-4 text-[0.8rem] text-neutral-400">
-            Loading performance…
-          </div>
-        )}
-
-        {/* No data */}
-        {!loading && !error && !hasData && (
-          <div className="rounded-xl border border-white/10 bg-black/40 px-3 py-4 text-[0.8rem] text-neutral-400">
-            No technician data found for this range.
-          </div>
-        )}
-
-        {/* My stats summary */}
         {!loading && !error && myRow && (
-          <section className="space-y-3">
-            <div className="grid grid-cols-2 gap-3">
-              <SummaryCard
-                label="Jobs"
-                value={String(myRow.jobs)}
-                accent="text-sky-300"
-              />
-              <SummaryCard
-                label="Revenue"
-                value={formatCurrency(myRow.revenue)}
-                accent="text-emerald-300"
-              />
-              <SummaryCard
-                label="Clocked hours"
-                value={myRow.clockedHours.toFixed(1) + " h"}
-              />
-              <SummaryCard
-                label="Billed hours"
-                value={myRow.billedHours.toFixed(1) + " h"}
-              />
-              <SummaryCard
-                label="Rev / hour"
-                value={formatCurrency(myRow.revenuePerHour)}
-              />
-              <SummaryCard
-                label="Efficiency"
-                value={myRow.efficiencyPct.toFixed(1) + "%"}
-                accent="text-cyan-300"
-              />
-            </div>
+          <section className="grid grid-cols-2 gap-2.5">
+            <StatTile label="Jobs" value={String(myRow.jobs)} accent="text-sky-300" />
+            <StatTile label="Revenue" value={formatCurrency(myRow.revenue)} accent="text-emerald-300" />
+            <StatTile label="Clocked hours" value={`${myRow.clockedHours.toFixed(1)} h`} />
+            <StatTile label="Billed hours" value={`${myRow.billedHours.toFixed(1)} h`} />
+            <StatTile label="Rev / hour" value={formatCurrency(myRow.revenuePerHour)} />
+            <StatTile label="Efficiency" value={`${myRow.efficiencyPct.toFixed(1)}%`} accent="text-sky-300" />
           </section>
         )}
 
-        {/* AI summary */}
         {!loading && !error && (
-          <section className="space-y-1 rounded-2xl border border-white/10 bg-black/40 px-3 py-3 text-xs text-neutral-200">
+          <section className="mobile-tech-panel space-y-1 px-3 py-3 text-xs text-neutral-200">
             <div className="flex items-center justify-between gap-2">
-              <span className="text-[0.65rem] uppercase tracking-[0.18em] text-orange-300">
-                AI summary
-              </span>
-              {aiLoading && (
-                <span className="text-[0.65rem] text-neutral-400">
-                  Analyzing…
-                </span>
-              )}
+              <span className="text-[0.65rem] uppercase tracking-[0.18em] text-neutral-300">AI summary</span>
+              {aiLoading && <span className="text-[0.65rem] text-neutral-400">Analyzing…</span>}
             </div>
             {aiSummary ? (
               <p className="whitespace-pre-wrap">{aiSummary}</p>
             ) : !aiLoading ? (
-              <p className="text-[0.7rem] text-neutral-400">
-                No AI summary yet for this range.
-              </p>
+              <p className="text-[0.7rem] text-neutral-400">No AI summary yet for this range.</p>
             ) : null}
           </section>
         )}
@@ -319,27 +240,25 @@ export default function MobileTechPerformancePage() {
   );
 }
 
-/* ------------------------------------------------------------------------ */
-/* Small mobile summary card                                                */
-/* ------------------------------------------------------------------------ */
-
-function SummaryCard({
-  label,
-  value,
-  accent,
-}: {
-  label: string;
-  value: string;
-  accent?: string;
-}) {
+function StatTile({ label, value, accent }: { label: string; value: string; accent?: string }) {
   return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-3 shadow-card">
-      <div className="text-[0.6rem] uppercase tracking-[0.18em] text-neutral-400">
-        {label}
-      </div>
-      <div className={`mt-1 text-lg font-semibold ${accent ?? ""}`}>
-        {value}
-      </div>
+    <div className="mobile-tech-stat px-3 py-3">
+      <div className="text-[0.62rem] uppercase tracking-[0.18em] text-neutral-400">{label}</div>
+      <div className={`mt-1 text-sm font-semibold text-neutral-100 ${accent ?? ""}`}>{value}</div>
+    </div>
+  );
+}
+
+function Notice({ children, tone = "default" }: { children: ReactNode; tone?: "default" | "danger" }) {
+  return (
+    <div
+      className={
+        tone === "danger"
+          ? "mobile-tech-panel border-red-500/35 bg-red-950/20 px-3 py-3 text-[0.8rem] text-red-100"
+          : "mobile-tech-panel px-3 py-4 text-[0.8rem] text-neutral-400"
+      }
+    >
+      {children}
     </div>
   );
 }

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -74,7 +74,6 @@ export function MobileShell({ children, title }: Props) {
               <span className="h-[2px] w-[14px] rounded-full bg-white" />
               <span className="h-[2px] w-[14px] rounded-full bg-white" />
             </div>
-      <AskAssistantEntry mobile />
           </button>
 
           <span className="text-[0.75rem] font-medium text-neutral-100">
@@ -107,8 +106,10 @@ export function MobileShell({ children, title }: Props) {
         {children}
       </main>
 
+      <AskAssistantEntry mobile placement="dock" />
+
       {/* Footer – simple metal strip with sign-out */}
-      <footer className="metal-bar sticky bottom-0 z-30 flex items-center justify-between px-4 py-2 text-[0.7rem]">
+      <footer className="metal-bar sticky bottom-0 z-30 flex items-center justify-between px-4 py-2 text-[0.7rem] pb-[calc(0.5rem+var(--safe-bottom))]">
         <span className="text-neutral-400">
           ProFixIQ Mobile
         </span>

--- a/features/assistant/components/AskAssistantEntry.tsx
+++ b/features/assistant/components/AskAssistantEntry.tsx
@@ -21,7 +21,7 @@ import {
 
 type Props = {
   mobile?: boolean;
-  placement?: "floating" | "header";
+  placement?: "floating" | "header" | "dock";
 };
 
 function deriveContextFromPath(pathname: string): AssistantContext {
@@ -258,16 +258,16 @@ export default function AskAssistantEntry({
 
   if (mobile) {
     return (
-      <div className="fixed bottom-20 right-4 z-50 flex flex-col gap-2">
+      <div className="mobile-tech-utility-dock" role="navigation" aria-label="Utility actions">
         <Link
           href={assistantHref}
-          className="rounded-full border border-orange-400/50 bg-black/85 px-4 py-3 text-sm font-semibold text-orange-300 shadow-[0_16px_40px_rgba(0,0,0,0.55)] backdrop-blur-md"
+          className="mobile-tech-btn-utility inline-flex items-center rounded-full px-3 py-2 text-[0.72rem] leading-none"
         >
           {assistantLabel}
         </Link>
         <Link
           href={plannerHref}
-          className="rounded-full border border-white/10 bg-black/80 px-4 py-2 text-xs text-neutral-200 shadow-[0_12px_30px_rgba(0,0,0,0.45)] backdrop-blur-md"
+          className="mobile-tech-btn-ghost inline-flex items-center rounded-full px-3 py-2 text-[0.7rem] leading-none"
         >
           {plannerLabel}
         </Link>

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -383,9 +383,9 @@ export function MobileTechHome({
     : null;
 
   return (
-    <div className="space-y-6 px-4 py-4">
+    <div className="mobile-tech-page space-y-5 px-4 py-4">
       {/* hero – brushed metal panel */}
-      <section className="metal-panel metal-panel--hero rounded-2xl border border-[var(--metal-border-soft)] px-4 py-4 text-white shadow-[0_18px_40px_rgba(0,0,0,0.85)]">
+      <section className="mobile-tech-panel px-4 py-4 text-white">
         <div className="space-y-4">
           <div className="text-center">
             <h1 className="text-xl font-semibold leading-tight">
@@ -434,7 +434,7 @@ export function MobileTechHome({
       </section>
 
       {/* stat chips – jobs overview */}
-      <section className="grid grid-cols-3 gap-3">
+      <section className="grid grid-cols-3 gap-2.5">
         <StatCard
           label="Open jobs"
           value={loadingStats ? "…" : openJobs}
@@ -458,7 +458,7 @@ export function MobileTechHome({
             </h2>
             <Link
               href="/mobile/work-orders"
-              className="text-[0.7rem] text-[var(--accent-copper-soft)] underline-offset-4 hover:underline"
+              className="text-[0.7rem] text-sky-300 underline-offset-4 hover:underline"
             >
               View all
             </Link>
@@ -468,11 +468,11 @@ export function MobileTechHome({
               <li key={job.id}>
                 <Link
                   href={job.href}
-                  className="metal-card block rounded-2xl border border-[var(--metal-border-soft)] px-3 py-2 text-xs text-neutral-100"
+                  className="mobile-tech-subpanel block px-3 py-2 text-xs text-neutral-100"
                 >
                   <div className="flex items-center justify-between gap-2">
                     <div className="truncate font-medium">{job.label}</div>
-                    <span className="accent-chip rounded-full px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.12em] text-[var(--accent-copper-soft)]">
+                    <span className="accent-chip rounded-full px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.12em] text-sky-300">
                       {job.status.replace(/_/g, " ")}
                     </span>
                   </div>
@@ -530,7 +530,7 @@ function CurrentJobPill({
 }) {
   if (loading) {
     return (
-      <div className="metal-card inline-flex w-full items-center justify-between rounded-2xl border border-[var(--metal-border-soft)] px-3 py-2 text-[0.75rem] text-neutral-300">
+      <div className="mobile-tech-subpanel inline-flex w-full items-center justify-between px-3 py-2 text-[0.75rem] text-neutral-300">
         <span className="uppercase tracking-[0.16em] text-neutral-400">
           Current job
         </span>
@@ -541,7 +541,7 @@ function CurrentJobPill({
 
   if (!job || !workOrder) {
     return (
-      <div className="metal-card inline-flex w-full items-center justify-between rounded-2xl border border-[var(--metal-border-soft)] px-3 py-2 text-[0.75rem] text-neutral-400">
+      <div className="mobile-tech-subpanel inline-flex w-full items-center justify-between px-3 py-2 text-[0.75rem] text-neutral-400">
         <span className="uppercase tracking-[0.16em] text-neutral-400">
           Current job
         </span>
@@ -569,10 +569,10 @@ function CurrentJobPill({
   return (
     <Link
       href={href}
-      className="metal-card flex items-center justify-between rounded-2xl border border-[var(--accent-copper-soft)] px-3 py-2 text-[0.8rem] text-neutral-100 shadow-[0_0_24px_rgba(212,118,49,0.45)]"
+      className="mobile-tech-subpanel flex items-center justify-between border border-sky-500/35 px-3 py-2 text-[0.8rem] text-neutral-100"
     >
       <div className="flex flex-col">
-        <span className="text-[0.65rem] uppercase tracking-[0.18em] text-[var(--accent-copper-soft)]">
+        <span className="text-[0.65rem] uppercase tracking-[0.18em] text-sky-300">
           Current job
         </span>
         <span className="mt-0.5 truncate text-sm font-medium">{jobLabel}</span>
@@ -581,7 +581,7 @@ function CurrentJobPill({
           {vehicleLabel ? ` • ${vehicleLabel}` : ""}
         </span>
       </div>
-      <span className="ml-3 text-xs text-[var(--accent-copper-soft)]">
+      <span className="ml-3 text-xs text-sky-300">
         Go →
       </span>
     </Link>
@@ -597,13 +597,12 @@ function StatCard({
   value: number | string;
   variant?: "default" | "accent";
 }) {
-  const base =
-    "metal-card rounded-2xl px-3 py-3 shadow-[0_16px_32px_rgba(0,0,0,0.75)]";
+  const base = "mobile-tech-stat px-3 py-3";
 
   const variantClasses =
     variant === "accent"
-      ? "border border-[var(--accent-copper-soft)]/80 shadow-[0_16px_32px_rgba(0,0,0,0.75),0_0_24px_rgba(212,118,49,0.55)]"
-      : "border border-[var(--metal-border-soft)]";
+      ? "border-sky-500/35"
+      : "border-[var(--metal-border-soft)]";
 
   return (
     <div className={`${base} ${variantClasses}`}>
@@ -646,7 +645,7 @@ function SummaryCard({
     loading || eff === null ? "–" : clampEfficiencyText(Number(eff));
 
   return (
-    <div className="metal-panel metal-panel--card rounded-2xl border border-[var(--metal-border-soft)] px-4 py-3 shadow-[0_18px_40px_rgba(0,0,0,0.75)]">
+    <div className="mobile-tech-panel px-4 py-3">
       <div className="text-center text-[0.65rem] uppercase tracking-[0.18em] text-neutral-300">
         {label} – Worked vs Billed
       </div>
@@ -664,7 +663,7 @@ function SummaryCard({
 
       <div className="mt-2 text-center text-[0.7rem] text-neutral-400">
         Efficiency:{" "}
-        <span className="font-semibold text-[var(--accent-copper-soft)]">
+        <span className="font-semibold text-sky-300">
           {effText}
         </span>
       </div>
@@ -696,35 +695,17 @@ function ShiftStatusChip({
   let classes = "";
 
   if (loading) {
-    classes =
-      "border-[var(--metal-border-soft)] text-neutral-100 " +
-      "bg-[linear-gradient(to_right,rgba(148,163,184,0.4),rgba(15,23,42,0.95))]";
+    classes = "border-[var(--metal-border-soft)] text-neutral-100 bg-slate-900/70";
   } else if (status === "active") {
-    classes =
-      "border-emerald-400/80 text-emerald-50 " +
-      "bg-[linear-gradient(to_right,rgba(16,185,129,0.55),rgba(15,23,42,0.97))] " +
-      "shadow-[0_0_16px_rgba(16,185,129,0.45)]";
+    classes = "border-sky-400/70 text-sky-100 bg-sky-500/12";
   } else if (status === "break") {
-    classes =
-      "border-yellow-400/80 text-yellow-50 " +
-      "bg-[linear-gradient(to_right,rgba(250,204,21,0.55),rgba(15,23,42,0.97))] " +
-      "shadow-[0_0_16px_rgba(250,204,21,0.45)]";
+    classes = "border-amber-400/70 text-amber-100 bg-amber-500/12";
   } else if (status === "lunch") {
-    classes =
-      "border-orange-400/80 text-orange-50 " +
-      "bg-[linear-gradient(to_right,rgba(249,115,22,0.65),rgba(15,23,42,0.97))] " +
-      "shadow-[0_0_16px_rgba(249,115,22,0.5)]";
+    classes = "border-amber-500/70 text-amber-100 bg-amber-500/14";
   } else if (status === "ended") {
-    // ended – red gradient
-    classes =
-      "border-red-500/80 text-red-50 " +
-      "bg-[linear-gradient(to_right,rgba(239,68,68,0.7),rgba(15,23,42,0.97))] " +
-      "shadow-[0_0_18px_rgba(239,68,68,0.55)]";
+    classes = "border-red-500/70 text-red-100 bg-red-500/12";
   } else {
-    // none – subtle burnt copper
-    classes =
-      "border-[var(--accent-copper-soft)]/60 text-[var(--accent-copper-soft)] " +
-      "bg-[linear-gradient(to_right,rgba(212,118,49,0.45),rgba(15,23,42,0.96))]";
+    classes = "border-[var(--metal-border-soft)] text-neutral-200 bg-slate-900/70";
   }
 
   return (
@@ -749,7 +730,7 @@ function ToolCard({
   return (
     <Link
       href={href}
-      className="metal-card block rounded-2xl border border-[var(--metal-border-soft)] px-4 py-3 text-sm text-neutral-100 transition hover:border-[var(--accent-copper-soft)]"
+      className="mobile-tech-subpanel block px-4 py-3 text-sm text-neutral-100 transition hover:border-sky-500/45"
     >
       <div className="flex items-center justify-between gap-3">
         <div>
@@ -758,7 +739,7 @@ function ToolCard({
           </div>
           <div className="mt-1 text-sm">{description}</div>
         </div>
-        <span className="text-xs text-[var(--accent-copper-soft)]">›</span>
+        <span className="text-xs text-sky-300">›</span>
       </div>
     </Link>
   );

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -58,25 +58,16 @@ const chip = (s: string | null) =>
 
 /* ---------------------------- UI (theme-only) ---------------------------- */
 
-const panel =
-  "metal-panel metal-panel--card rounded-2xl border border-[var(--metal-border-soft)] bg-black/35 backdrop-blur shadow-[0_18px_45px_rgba(0,0,0,0.85)]";
+const panel = "mobile-tech-panel";
 
-const card =
-  "metal-card rounded-2xl border border-[var(--metal-border-soft)] bg-black/35 backdrop-blur";
+const card = "mobile-tech-subpanel";
 
 const fieldLabel = "text-[11px] uppercase tracking-[0.18em] text-neutral-400";
 
-const btnBase =
-  "rounded-xl border px-3 py-2 text-left text-sm font-medium transition-colors shadow-[0_10px_28px_rgba(0,0,0,0.55)]";
-const btnNeutral =
-  btnBase +
-  " border-[var(--metal-border-soft)] bg-black/40 text-neutral-100 hover:bg-white/5";
-const btnWarn =
-  btnBase +
-  " border-amber-400/70 bg-amber-500/10 text-amber-100 hover:bg-amber-500/20";
-const btnInfo =
-  btnBase +
-  " border-sky-500/70 bg-sky-500/10 text-sky-100 hover:bg-sky-500/20";
+const btnBase = "rounded-xl border px-3 py-2 text-left text-sm font-medium transition-colors";
+const btnNeutral = `${btnBase} mobile-tech-btn-secondary`;
+const btnWarn = `${btnBase} mobile-tech-btn-danger`;
+const btnInfo = `${btnBase} mobile-tech-btn-utility`;
 
 type DB = Database;
 type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
@@ -796,7 +787,7 @@ export default function MobileFocusedJob(props: {
           {workOrder?.id ? (
             <button
               type="button"
-              className="rounded-full border border-[var(--accent-copper-light)] bg-[var(--accent-copper-soft)] px-3 py-1.5 text-[11px] font-semibold text-black shadow-[0_0_12px_rgba(248,113,22,0.35)] hover:bg-[var(--accent-copper-light)]"
+              className="mobile-tech-btn-secondary rounded-full px-3 py-1.5 text-[11px] font-semibold"
               onClick={() => {
                 closeAllSubModals();
                 setOpenAddJob(true);
@@ -811,7 +802,7 @@ export default function MobileFocusedJob(props: {
         </header>
 
         <div className="px-3 pt-2">
-          <div className="rounded-xl border border-[var(--metal-border-soft)] bg-black/35 px-3 py-2 text-xs">
+          <div className="mobile-tech-subpanel px-3 py-2 text-xs">
             <div className="flex items-center justify-between gap-2">
               <span className="text-neutral-200">Sync status</span>
               <span
@@ -841,7 +832,7 @@ export default function MobileFocusedJob(props: {
               <button
                 type="button"
                 onClick={() => void replayOfflineMutations()}
-                className="mt-2 rounded-md border border-[var(--metal-border-soft)] bg-black/40 px-2 py-1 text-[11px] text-neutral-100 hover:bg-black/70"
+                className="mobile-tech-btn-secondary mt-2 rounded-md px-2 py-1 text-[11px] text-neutral-100"
               >
                 Retry sync now
               </button>
@@ -850,7 +841,7 @@ export default function MobileFocusedJob(props: {
         </div>
 
         {/* Body */}
-        <main className="mobile-body-gradient flex-1 overflow-y-auto px-3 py-3">
+        <main className="mobile-tech-page flex-1 overflow-y-auto px-3 py-3">
           <div className="mx-auto max-w-4xl space-y-4">
             {busy && !line ? (
               <div className="grid gap-3">
@@ -888,8 +879,7 @@ export default function MobileFocusedJob(props: {
                           }
                         }}
                         className={[
-                          "flex-1 rounded-xl border px-4 py-3 text-sm font-semibold transition",
-                          "border-[var(--accent-copper-light)] bg-[var(--accent-copper-faint)] text-[var(--accent-copper-light)]",
+                          "mobile-tech-btn-primary flex-1 rounded-xl border px-4 py-3 text-sm font-semibold transition",
                           "disabled:cursor-not-allowed disabled:opacity-45",
                         ].join(" ")}
                       >
@@ -1008,7 +998,9 @@ export default function MobileFocusedJob(props: {
                 )}
 
                 {/* controls */}
-                <div className="grid gap-2 md:grid-cols-3">
+                <div className={`${panel} px-4 py-4`}>
+                  <div className="mb-2 text-[11px] uppercase tracking-[0.18em] text-neutral-400">Operational actions</div>
+                  <div className="grid gap-2 md:grid-cols-3">
                   {mode === "tech" ? (
                     <>
                       <button
@@ -1113,6 +1105,7 @@ export default function MobileFocusedJob(props: {
                       </button>
                     </>
                   )}
+                  </div>
                 </div>
 
                 {/* parts used */}
@@ -1135,7 +1128,7 @@ export default function MobileFocusedJob(props: {
                       {offlineMutations.map((mutation) => (
                         <li
                           key={mutation.clientMutationId}
-                          className="rounded-lg border border-[var(--metal-border-soft)] bg-black/30 px-2 py-2"
+                          className="mobile-tech-subpanel rounded-lg px-2 py-2"
                         >
                           <div className="flex items-center justify-between gap-2">
                             <span className="truncate text-neutral-100">{mutation.actionType.replaceAll("_", " ")}</span>
@@ -1174,7 +1167,7 @@ export default function MobileFocusedJob(props: {
                   ) : allocs.length === 0 ? (
                     <div className="text-sm text-neutral-300">No parts used yet.</div>
                   ) : (
-                    <div className="overflow-hidden rounded-2xl border border-[var(--metal-border-soft)] bg-black/40">
+                    <div className="mobile-tech-subpanel overflow-hidden">
                       <div className="grid grid-cols-12 bg-white/5 px-3 py-2 text-[11px] uppercase tracking-[0.16em] text-neutral-400">
                         <div className="col-span-7">Part</div>
                         <div className="col-span-3">Location</div>
@@ -1218,7 +1211,7 @@ export default function MobileFocusedJob(props: {
                     }}
                     onBlur={saveNotes}
                     disabled={savingNotes}
-                    className="w-full rounded-xl border border-[var(--metal-border-soft)] bg-black/45 px-3 py-2 text-sm text-white placeholder:text-neutral-400 focus:border-[var(--accent-copper-light)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-light)]"
+                    className="mobile-tech-input px-3 py-2 text-sm text-white"
                     placeholder="Add notes for this job…"
                   />
                   {notesDirty && (


### PR DESCRIPTION
### Motivation
- The mobile tech UX used mixed surface treatments, uneven spacing, inconsistent button hierarchy, and multiple floating CTA pills that competed with core work-order actions.
- The goal was a focused design-system pass to make mobile tech pages feel cohesive, premium and task-first without changing behavior or routes.

### Description
- Introduced a shared mobile tech surface grammar and primitives in `app/globals.css` (`mobile-tech-page`, `mobile-tech-panel`, `mobile-tech-subpanel`, `mobile-tech-stat`, `mobile-tech-input`, button variants and a `mobile-tech-utility-dock`) to centralize styling and reduce glow/decoration.
- Replaced stacked floating Assistant/Planner pills with a single bottom utility dock and anchored it in the mobile shell so utility actions are globally available but visually quieter; updated `components/layout/MobileShell.tsx` and `features/assistant/components/AskAssistantEntry.tsx` to use the dock.
- Normalized mobile home and performance screens to the new panel/stat/card language and reduced heavy accent/glow; updated `features/mobile/dashboard/MobileTechHome.tsx` and `app/mobile/tech/performance/page.tsx` to use the shared classes and consistent spacing/typography.
- Aligned the focused job (work order) mobile view to the same grammar, unified input/button classes, and consolidated operational actions into a single “Operational actions” panel while preserving all job state logic and transitions; changes in `features/work-orders/mobile/MobileFocusedJob.tsx` are UI/theme-only.
- Files changed: `app/globals.css`, `components/layout/MobileShell.tsx`, `features/assistant/components/AskAssistantEntry.tsx`, `features/mobile/dashboard/MobileTechHome.tsx`, `app/mobile/tech/performance/page.tsx`, `features/work-orders/mobile/MobileFocusedJob.tsx`.

### Testing
- Ran ESLint on touched TSX files: `npx eslint app/mobile/tech/performance/page.tsx features/mobile/dashboard/MobileTechHome.tsx features/work-orders/mobile/MobileFocusedJob.tsx features/assistant/components/AskAssistantEntry.tsx components/layout/MobileShell.tsx`; result: passed with 2 existing warnings in `MobileFocusedJob.tsx` (`react-hooks/exhaustive-deps` and `@next/next/no-img-element`) that were not introduced by this change.
- Type-checked the repo: `npx tsc --noEmit`; result: passed.
- Note: an initial `eslint` invocation that included the CSS file produced a parser error; the final lint run targeted the modified TSX files as required and succeeded with only the two pre-existing warnings.
- Screenshot capture was not possible in this environment (no browser/screenshot tool available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1913024688328888ec497b93909d6)