### PR TITLE
Fix mobile shift resolver false-negatives and dedupe mobile WO live actions

### DIFF
--- a/app/api/mobile/shifts/route.ts
+++ b/app/api/mobile/shifts/route.ts
@@ -7,6 +7,16 @@ type ShiftMode = "none" | "shift" | "break" | "lunch" | "ended";
 
 type Caller = { id: string; shop_id: string | null };
 
+type OpenShift = {
+  id: string;
+  start_time: string | null;
+  type: "shift" | "break" | "lunch" | null;
+  status: string | null;
+  end_time: string | null;
+  shop_id: string | null;
+  user_id: string | null;
+};
+
 async function authz() {
   const supabase = createServerSupabaseRoute();
   const {
@@ -18,32 +28,111 @@ async function authz() {
     return { ok: false as const, res: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
   }
 
-  const { data: me } = await supabase
+  let { data: me } = await supabase
     .from("profiles")
     .select("id, shop_id")
     .eq("id", user.id)
     .maybeSingle<Caller>();
 
+  if (!me) {
+    const byUser = await supabase
+      .from("profiles")
+      .select("id, shop_id")
+      .eq("user_id", user.id)
+      .maybeSingle<Caller>();
+    me = byUser.data ?? null;
+  }
+
   if (!me?.shop_id) {
     return { ok: false as const, res: NextResponse.json({ error: "Missing shop" }, { status: 403 }) };
   }
 
-  return { ok: true as const, me };
+  return { ok: true as const, me, authUserId: user.id };
 }
 
-async function loadOpenShift(admin: ReturnType<typeof createAdminSupabase>, userId: string, shopId: string) {
-  const { data } = await admin
+async function loadOpenShift(admin: ReturnType<typeof createAdminSupabase>, userIds: string[], shopId: string) {
+  const cleanUserIds = [...new Set(userIds.filter(Boolean))];
+  if (cleanUserIds.length === 0) return null;
+
+  const baseColumns = "id,start_time,type,status,end_time,shop_id,user_id";
+
+  const { data: scopedOpen } = await admin
     .from("tech_shifts")
-    .select("id,start_time,type,status,end_time")
+    .select(baseColumns)
     .eq("shop_id", shopId)
-    .eq("user_id", userId)
+    .in("user_id", cleanUserIds)
     .eq("status", "open")
     .is("end_time", null)
     .order("start_time", { ascending: false })
     .limit(1)
-    .maybeSingle();
+    .maybeSingle<OpenShift>();
 
-  return data ?? null;
+  if (scopedOpen) return scopedOpen;
+
+  const { data: scopedByEndTime } = await admin
+    .from("tech_shifts")
+    .select(baseColumns)
+    .eq("shop_id", shopId)
+    .in("user_id", cleanUserIds)
+    .is("end_time", null)
+    .order("start_time", { ascending: false })
+    .limit(1)
+    .maybeSingle<OpenShift>();
+
+  if (scopedByEndTime) return scopedByEndTime;
+
+  const { data: legacyNoShop } = await admin
+    .from("tech_shifts")
+    .select(baseColumns)
+    .is("shop_id", null)
+    .in("user_id", cleanUserIds)
+    .eq("status", "open")
+    .is("end_time", null)
+    .order("start_time", { ascending: false })
+    .limit(1)
+    .maybeSingle<OpenShift>();
+
+  return legacyNoShop ?? null;
+}
+
+async function deriveMode(admin: ReturnType<typeof createAdminSupabase>, shift: OpenShift | null): Promise<ShiftMode> {
+  if (!shift) return "none";
+
+  const { data: lastPunch } = await admin
+    .from("punch_events")
+    .select("event_type")
+    .eq("shift_id", shift.id)
+    .order("timestamp", { ascending: false })
+    .limit(1)
+    .maybeSingle<{ event_type: string | null }>();
+
+  const eventType = lastPunch?.event_type ?? null;
+  if (eventType === "break_start") return "break";
+  if (eventType === "lunch_start") return "lunch";
+  if (eventType === "end_shift") return "ended";
+  if (shift.type === "break") return "break";
+  if (shift.type === "lunch") return "lunch";
+  return "shift";
+}
+
+export async function GET() {
+  const a = await authz();
+  if (!a.ok) return a.res;
+
+  const admin = createAdminSupabase();
+  const shopId = a.me.shop_id;
+  if (!shopId) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 403 });
+  }
+  const shift = await loadOpenShift(admin, [a.me.id, a.authUserId], shopId);
+  const mode = await deriveMode(admin, shift);
+
+  return NextResponse.json({
+    ok: true,
+    shiftId: shift?.id ?? null,
+    startTime: shift?.start_time ?? null,
+    mode,
+  });
 }
 
 export async function POST(req: NextRequest) {
@@ -61,7 +150,8 @@ export async function POST(req: NextRequest) {
   if (!shopId) {
     return NextResponse.json({ error: "Missing shop" }, { status: 403 });
   }
-  const current = await loadOpenShift(admin, a.me.id, shopId);
+  const current = await loadOpenShift(admin, [a.me.id, a.authUserId], shopId);
+  const activeShiftUserId = current?.user_id ?? a.me.id;
 
   const insertPunch = async (shiftId: string, eventType: Action | "break_end" | "lunch_end") => {
     const mapped = eventType === "toggle_break" ? "break_start" : eventType === "toggle_lunch" ? "lunch_start" : eventType;
@@ -107,7 +197,7 @@ export async function POST(req: NextRequest) {
       .from("work_order_lines")
       .update({ punched_out_at: now })
       .eq("shop_id", shopId)
-      .eq("assigned_tech_id", a.me.id)
+      .eq("assigned_tech_id", activeShiftUserId)
       .not("punched_in_at", "is", null)
       .is("punched_out_at", null)
       .neq("status", "completed");
@@ -117,7 +207,7 @@ export async function POST(req: NextRequest) {
       .update({ end_time: now, status: "closed", type: "shift" })
       .eq("id", current.id)
       .eq("shop_id", shopId)
-      .eq("user_id", a.me.id);
+      .eq("user_id", activeShiftUserId);
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
@@ -134,7 +224,7 @@ export async function POST(req: NextRequest) {
       .update({ type: isEnding ? "shift" : "break", status: "open" })
       .eq("id", current.id)
       .eq("shop_id", shopId)
-      .eq("user_id", a.me.id);
+      .eq("user_id", activeShiftUserId);
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
@@ -151,7 +241,7 @@ export async function POST(req: NextRequest) {
       .update({ type: isEnding ? "shift" : "lunch", status: "open" })
       .eq("id", current.id)
       .eq("shop_id", shopId)
-      .eq("user_id", a.me.id);
+      .eq("user_id", activeShiftUserId);
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });

--- a/features/mobile/components/MobileShiftTracker.tsx
+++ b/features/mobile/components/MobileShiftTracker.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useCallback, useEffect, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import type { Database } from "@shared/types/types/supabase";
 import {
   getOfflineSyncSummary,
   replayQueuedMutations,
@@ -11,9 +9,6 @@ import {
   type PendingMutation,
 } from "@/features/shared/lib/offline/mutations";
 
-type DB = Database;
-
-type ShiftType = "shift" | "break" | "lunch";
 type Mode = "none" | "shift" | "break" | "lunch" | "ended";
 
 type PunchEventType =
@@ -26,15 +21,7 @@ type PunchEventType =
 
 type Props = { userId: string };
 
-function toShiftType(input: unknown, fallback: ShiftType): ShiftType {
-  const v = String(input ?? "").toLowerCase().trim();
-  if (v === "shift" || v === "break" || v === "lunch") return v;
-  return fallback;
-}
-
 export default function MobileShiftTracker({ userId }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
-
   const [shiftId, setShiftId] = useState<string | null>(null);
   const [startTime, setStartTime] = useState<string | null>(null);
   const [mode, setMode] = useState<Mode>("none");
@@ -86,85 +73,35 @@ export default function MobileShiftTracker({ userId }: Props) {
     if (result.failed > 0) {
       setErr(`${result.failed} queued punch event(s) still failing to sync.`);
     }
-  }, [supabase]);
+  }, []);
 
   const loadOpenShift = useCallback(async () => {
     if (!userId) return;
     setErr(null);
 
-    const { data: shift, error: sErr } = await supabase
-      .from("tech_shifts")
-      .select("id, start_time, type, status, end_time")
-      .eq("user_id", userId)
-      .eq("status", "open")
-      .order("start_time", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (sErr) {
-      setErr(`${sErr.code ?? "load_error"}: ${sErr.message}`);
+    const res = await fetch("/api/mobile/shifts", { cache: "no-store" });
+    const body = (await res.json().catch(() => null)) as
+      | { ok?: boolean; error?: string; shiftId?: string | null; startTime?: string | null; mode?: Mode }
+      | null;
+    if (!res.ok || !body?.ok) {
+      setErr(body?.error ?? "Failed to load shift state");
       setShiftId(null);
       setStartTime(null);
       setMode("none");
       return;
     }
 
-    let open = shift ?? null;
-
-    if (!open) {
-      const { data: fb, error: fbErr } = await supabase
-        .from("tech_shifts")
-        .select("id, start_time, type, status, end_time")
-        .eq("user_id", userId)
-        .is("end_time", null)
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (fbErr) {
-        setErr(`${fbErr.code ?? "load_error"}: ${fbErr.message}`);
-        setShiftId(null);
-        setStartTime(null);
-        setMode("none");
-        return;
-      }
-      open = fb ?? null;
-    }
-
-    if (!open) {
+    if (!body.shiftId) {
       setShiftId(null);
       setStartTime(null);
       setMode("none");
       return;
     }
 
-    setShiftId(open.id);
-    setStartTime(open.start_time ?? null);
-
-    const { data: lastPunch, error: pErr } = await supabase
-      .from("punch_events")
-      .select("event_type")
-      .eq("shift_id", open.id)
-      .order("timestamp", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (pErr) {
-      setMode(toShiftType(open.type, "shift"));
-      return;
-    }
-
-    const ev = lastPunch?.event_type ?? null;
-
-    const computed: Mode =
-      ev === "break_start"
-        ? "break"
-        : ev === "lunch_start"
-          ? "lunch"
-          : "shift";
-
-    setMode(computed);
-  }, [supabase, userId]);
+    setShiftId(body.shiftId);
+    setStartTime(body.startTime ?? null);
+    setMode(body.mode ?? "shift");
+  }, [userId]);
 
   useEffect(() => {
     void loadOpenShift();

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -29,7 +29,6 @@ import AIAssistantModal from "@work-orders/components/workorders/AiAssistantModa
 
 import NewChatModal from "@/features/ai/components/chat/NewChatModal";
 import SuggestedQuickAdd from "@work-orders/components/SuggestedQuickAdd";
-import JobPunchButton from "@/features/work-orders/components/JobPunchButton";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
 
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
@@ -79,18 +78,6 @@ type AllocationRow =
   DB["public"]["Tables"]["work_order_part_allocations"]["Row"] & {
     parts?: { name: string | null } | null;
   };
-
-type WorkflowStatus =
-  | "awaiting"
-  | "awaiting_approval"
-  | "declined"
-  | "queued"
-  | "in_progress"
-  | "on_hold"
-  | "paused"
-  | "completed"
-  | "assigned"
-  | "unassigned";
 
 type SyncSummary = ReturnType<typeof getOfflineSyncSummary>;
 type StagedPhoto = {
@@ -746,12 +733,6 @@ export default function MobileFocusedJob(props: {
   const createdStart = startAt ? format(new Date(startAt), "PPpp") : "—";
   const createdFinish = finishAt ? format(new Date(finishAt), "PPpp") : "—";
 
-  const punchDisabled =
-    busy ||
-    !canPunch(line) ||
-    // keep your existing additional guard
-    (!!line?.approval_state && line.approval_state !== "approved");
-
   const lineLabel =
     (line?.complaint ?? "").trim() ||
     (line?.description ?? "").trim() ||
@@ -1071,56 +1052,12 @@ export default function MobileFocusedJob(props: {
                   </div>
                 </div>
 
-                {/* punch — hide once completed */}
-                {mode === "tech" && line && line.status !== "completed" && (
-                  <div className={`${panel} px-4 py-4`}>
-                    <JobPunchButton
-                      lineId={line.id}
-                      punchedInAt={line.punched_in_at}
-                      punchedOutAt={line.punched_out_at}
-                      status={line.status as WorkflowStatus}
-                      onFinishRequested={() => {
-                        closeAllSubModals();
-                        setPrefillCause(line.cause ?? "");
-                        setPrefillCorrection(line.correction ?? "");
-                        setOpenComplete(true);
-                      }}
-                      onUpdated={refresh}
-                      disabled={punchDisabled}
-                    />
-
-                    {(line.status === "awaiting_approval" ||
-                      (line.approval_state && line.approval_state !== "approved") ||
-                      line.status === "declined") && (
-                      <div className="mt-2 text-[11px] text-amber-300">
-                        {line.status === "awaiting_approval"
-                          ? "Awaiting approval — punching disabled"
-                          : line.status === "declined"
-                            ? "Declined — punching disabled"
-                            : "Not approved — punching disabled"}
-                      </div>
-                    )}
-                  </div>
-                )}
-
                 {/* controls */}
                 <div className={`${panel} px-4 py-4`}>
                   <div className="mb-2 text-[11px] uppercase tracking-[0.18em] text-neutral-400">Operational actions</div>
                   <div className="grid gap-2 md:grid-cols-3">
                   {mode === "tech" ? (
                     <>
-                      <button
-                        type="button"
-                        className={btnWarn}
-                        onClick={() => {
-                          closeAllSubModals();
-                          setOpenHold(true);
-                        }}
-                        disabled={busy}
-                      >
-                        {line.status === "on_hold" ? "On Hold" : "Hold"}
-                      </button>
-
                       <button
                         type="button"
                         className={btnNeutral}


### PR DESCRIPTION
### Motivation
- Repair two regressions from the mobile tech refinement: the mobile drawer showing “Open shift not found” when an active shift exists, and duplicated live job controls (dual Finish/Hold) on the mobile work-order detail page.
- Keep canonical state and action wiring consistent between mobile UI and server logic and remove duplicated legacy UI surfaces so the primary action surface is unique.

### Description
- Unify mobile shift source-of-truth by adding a canonical `GET /api/mobile/shifts` that returns the current open shift (id, startTime, mode) and derive the mode from the last punch or shift type. (added `deriveMode`, `OpenShift` shaping, `GET` handler). (`app/api/mobile/shifts/route.ts`)
- Harden shift resolution on the server: profile lookup now falls back to `profiles.user_id` when `profiles.id` misses, and open-shift lookup checks scoped shop rows, end_time null rows, and legacy no-shop rows; lookups search for shifts by multiple possible user ids to handle profile/auth id variants. (`app/api/mobile/shifts/route.ts`)
- Keep POST actions on `/api/mobile/shifts` but make them use the same open-shift resolver; ensure operations (end shift, toggle break/lunch, update work_order_lines) target the active shift's `user_id` when the canonical open shift belongs to a different profile binding. (`app/api/mobile/shifts/route.ts`)
- Mobile shift UI now reads canonical shift state from `GET /api/mobile/shifts` instead of issuing its own Supabase queries, eliminating client/server divergence that caused false negatives. (`features/mobile/components/MobileShiftTracker.tsx`)
- Remove duplicate live job controls from the mobile focused job view: the new compact "Current Job State" card remains the single primary action surface and the legacy `JobPunchButton` block (and its duplicate Hold button in Operational actions) was removed so there is only one Finish/Hold/Resume control set. (`features/work-orders/mobile/MobileFocusedJob.tsx`)
- Minor safety: kept offline replay handlers and existing UX (pulsing cyan pill, compact styling) intact while simplifying control surfaces.

### Testing
- Ran targeted linter: `npx eslint app/api/mobile/shifts/route.ts features/mobile/components/MobileShiftTracker.tsx features/work-orders/mobile/MobileFocusedJob.tsx`; result: passes with warnings only (existing `no-explicit-any`, a React hook dependency warning, and an `img` optimization warning) and no new errors.
- Type-check: `npx tsc --noEmit` completed successfully with no type errors.
- After changes, verified the following by code review: `MobileShiftTracker` uses `/api/mobile/shifts` `GET` payload for display and actions continue to POST to `/api/mobile/shifts`; mobile WO page contains only the `Current Job State` primary action card and secondary operational tools (no duplicate Finish/Hold).

Files changed: `app/api/mobile/shifts/route.ts`, `features/mobile/components/MobileShiftTracker.tsx`, `features/work-orders/mobile/MobileFocusedJob.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a17fc2348328ba0ce18d15a62778)