### PR TITLE
Align mobile work-order cards with desktop style and unify canonical shift reads

### DIFF
--- a/app/mobile/tech/performance/page.tsx
+++ b/app/mobile/tech/performance/page.tsx
@@ -177,6 +177,9 @@ export default function MobileTechPerformancePage() {
           <div className="text-[0.7rem] uppercase tracking-[0.25em] text-neutral-500">ProFixIQ • Tech</div>
           <h1 className="font-blackops text-lg uppercase tracking-[0.16em] text-sky-300">My Performance</h1>
           <p className="text-[0.8rem] text-neutral-400">Jobs, hours and efficiency for your chosen time range.</p>
+          <p className="text-[0.68rem] text-neutral-500">
+            Productivity view: clocked hours are from labor segments (with timecard fallback), not attendance shift punches.
+          </p>
         </header>
 
         <section className="mobile-tech-panel space-y-2 px-3 py-3">

--- a/app/tech/performance/page.tsx
+++ b/app/tech/performance/page.tsx
@@ -330,6 +330,9 @@ export default function TechPerformancePage() {
               )}
             </div>
           </div>
+          <p className="mt-2 text-xs text-neutral-500">
+            Productivity model: clocked hours come from labor segments (fallback payroll timecards), not attendance shift punches.
+          </p>
 
           {/* Quick compare row */}
           {!loading && !error && myRow && (

--- a/features/mobile/components/MobileShiftTracker.tsx
+++ b/features/mobile/components/MobileShiftTracker.tsx
@@ -8,8 +8,10 @@ import {
   subscribeOfflineMutations,
   type PendingMutation,
 } from "@/features/shared/lib/offline/mutations";
-
-type Mode = "none" | "shift" | "break" | "lunch" | "ended";
+import {
+  fetchMobileShiftState,
+  type MobileShiftMode as Mode,
+} from "@/features/mobile/shifts/client";
 
 type PunchEventType =
   | "start_shift"
@@ -79,28 +81,24 @@ export default function MobileShiftTracker({ userId }: Props) {
     if (!userId) return;
     setErr(null);
 
-    const res = await fetch("/api/mobile/shifts", { cache: "no-store" });
-    const body = (await res.json().catch(() => null)) as
-      | { ok?: boolean; error?: string; shiftId?: string | null; startTime?: string | null; mode?: Mode }
-      | null;
-    if (!res.ok || !body?.ok) {
-      setErr(body?.error ?? "Failed to load shift state");
+    try {
+      const shiftState = await fetchMobileShiftState();
+      if (!shiftState.shiftId) {
+        setShiftId(null);
+        setStartTime(null);
+        setMode("none");
+        return;
+      }
+
+      setShiftId(shiftState.shiftId);
+      setStartTime(shiftState.startTime ?? null);
+      setMode(shiftState.mode ?? "shift");
+    } catch (error) {
+      setErr(error instanceof Error ? error.message : "Failed to load shift state");
       setShiftId(null);
       setStartTime(null);
       setMode("none");
-      return;
     }
-
-    if (!body.shiftId) {
-      setShiftId(null);
-      setStartTime(null);
-      setMode("none");
-      return;
-    }
-
-    setShiftId(body.shiftId);
-    setStartTime(body.startTime ?? null);
-    setMode(body.mode ?? "shift");
   }, [userId]);
 
   useEffect(() => {

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
+import { fetchMobileShiftState } from "@/features/mobile/shifts/client";
 
 type DB = Database;
 
@@ -108,47 +109,14 @@ export function MobileTechHome({
         setShiftStart(null);
         return;
       }
-
-      // Latest shift for this user
-      const { data: latestShift, error: sErr } = await supabase
-        .from("tech_shifts")
-        .select("id, start_time, end_time, status")
-        .eq("user_id", id)
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (sErr || !latestShift) {
-        setShiftStatus("none");
-        setShiftStart(null);
-        return;
-      }
-
-      setShiftStart(latestShift.start_time ?? null);
-
-      // If shift is closed, mark ended
-      if (latestShift.end_time != null) {
-        setShiftStatus("ended");
-        return;
-      }
-
-      // Open shift – use last punch_event to decide active/break/lunch
-      const { data: lastPunch } = await supabase
-        .from("punch_events")
-        .select("event_type")
-        .eq("shift_id", latestShift.id)
-        .order("timestamp", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      const t = lastPunch?.event_type;
-      let computed: ShiftStatus = "active";
-
-      if (t === "break_start") computed = "break";
-      else if (t === "lunch_start") computed = "lunch";
-      else if (t === "end_shift") computed = "ended";
-
-      setShiftStatus(computed);
+      const canonical = await fetchMobileShiftState();
+      setShiftStart(canonical.startTime ?? null);
+      if (canonical.mode === "shift") setShiftStatus("active");
+      else setShiftStatus(canonical.mode);
+    } catch (error) {
+      console.error("[MobileTechHome] shift state refresh failed:", error);
+      setShiftStatus("none");
+      setShiftStart(null);
     } finally {
       setLoadingShift(false);
     }
@@ -159,7 +127,7 @@ export function MobileTechHome({
     void refreshShiftState();
   }, [refreshShiftState]);
 
-  // realtime: follow tech_shifts for this user so it matches bottom nav punches
+  // realtime: follow canonical shift persistence tables for this user
   useEffect(() => {
     if (!userId) return;
 
@@ -187,6 +155,17 @@ export function MobileTechHome({
       }
     };
   }, [supabase, userId, refreshShiftState]);
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      void refreshShiftState();
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [supabase, refreshShiftState]);
 
   /* ---------------------------------------------------------------------- */
   /* Current job – job the tech is punched in on                            */

--- a/features/mobile/shifts/client.ts
+++ b/features/mobile/shifts/client.ts
@@ -1,0 +1,33 @@
+"use client";
+
+export type MobileShiftMode = "none" | "shift" | "break" | "lunch" | "ended";
+
+export type MobileShiftState = {
+  shiftId: string | null;
+  startTime: string | null;
+  mode: MobileShiftMode;
+};
+
+type ShiftResponse =
+  | {
+      ok?: boolean;
+      error?: string;
+      shiftId?: string | null;
+      startTime?: string | null;
+      mode?: MobileShiftMode;
+    }
+  | null;
+
+export async function fetchMobileShiftState(): Promise<MobileShiftState> {
+  const res = await fetch("/api/mobile/shifts", { cache: "no-store" });
+  const body = (await res.json().catch(() => null)) as ShiftResponse;
+  if (!res.ok || !body?.ok) {
+    throw new Error(body?.error ?? "Failed to load shift state");
+  }
+
+  return {
+    shiftId: body.shiftId ?? null,
+    startTime: body.startTime ?? null,
+    mode: body.mode ?? "none",
+  };
+}

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -33,6 +33,16 @@ function dateDiffMinutes(start: string, end: string): number {
   return Math.max(0, Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000));
 }
 
+function clampIso(iso: string, minIso: string, maxIso: string): string {
+  const v = new Date(iso).getTime();
+  const min = new Date(minIso).getTime();
+  const max = new Date(maxIso).getTime();
+  if (!Number.isFinite(v) || !Number.isFinite(min) || !Number.isFinite(max)) return iso;
+  if (v < min) return minIso;
+  if (v > max) return maxIso;
+  return iso;
+}
+
 export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) {
   const admin = createAdminSupabase() as any;
   const today = new Date();
@@ -147,6 +157,32 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
   if (shiftsErr) throw new Error(shiftsErr.message);
   if (jobsErr) throw new Error(jobsErr.message);
 
+  const shiftIds = (shifts ?? []).map((s: { id: string }) => s.id).filter(Boolean);
+  const { data: punchEvents, error: punchEventsErr } = shiftIds.length
+    ? await admin
+        .from("punch_events")
+        .select("shift_id, event_type, timestamp")
+        .in("shift_id", shiftIds)
+        .order("timestamp", { ascending: true })
+    : { data: [], error: null };
+
+  if (punchEventsErr) throw new Error(punchEventsErr.message);
+
+  const punchEventsByShift = new Map<
+    string,
+    Array<{ event_type: string | null; timestamp: string | null }>
+  >();
+  for (const event of punchEvents ?? []) {
+    const sid = event.shift_id as string | null;
+    if (!sid) continue;
+    const current = punchEventsByShift.get(sid) ?? [];
+    current.push({
+      event_type: (event.event_type as string | null) ?? null,
+      timestamp: (event.timestamp as string | null) ?? null,
+    });
+    punchEventsByShift.set(sid, current);
+  }
+
   const rowsByKey = new Map<string, {
     user_id: string;
     work_date: string;
@@ -180,11 +216,36 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
     const endTime = shift.end_time ?? new Date().toISOString();
     const duration = dateDiffMinutes(shift.start_time, endTime);
 
-    if (shift.type === "shift") {
-      row.attendance_minutes += duration;
-    }
-    if (shift.type === "break" || shift.type === "lunch") {
-      row.unpaid_break_minutes += duration;
+    row.attendance_minutes += duration;
+
+    const events = punchEventsByShift.get(shift.id) ?? [];
+    if (events.length > 0) {
+      let activeBreakStart: string | null = null;
+
+      for (const event of events) {
+        const eventType = String(event.event_type ?? "").toLowerCase();
+        if (!event.timestamp) continue;
+        const eventTs = clampIso(event.timestamp, shift.start_time, endTime);
+
+        if (eventType === "break_start" || eventType === "lunch_start") {
+          if (activeBreakStart) {
+            row.unpaid_break_minutes += dateDiffMinutes(activeBreakStart, eventTs);
+          }
+          activeBreakStart = eventTs;
+          continue;
+        }
+
+        if (eventType === "break_end" || eventType === "lunch_end") {
+          if (activeBreakStart) {
+            row.unpaid_break_minutes += dateDiffMinutes(activeBreakStart, eventTs);
+            activeBreakStart = null;
+          }
+        }
+      }
+
+      if (activeBreakStart) {
+        row.unpaid_break_minutes += dateDiffMinutes(activeBreakStart, endTime);
+      }
     }
 
     const ids = Array.isArray(row.source_snapshot.shift_ids)
@@ -192,6 +253,11 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       : [];
     ids.push(shift.id);
     row.source_snapshot.shift_ids = ids;
+    row.source_snapshot = {
+      ...row.source_snapshot,
+      break_source: events.length > 0 ? "punch_events" : "none_recorded",
+      punch_event_count: events.length,
+    };
 
     if (!shift.end_time) {
       const openIds = Array.isArray(row.source_snapshot.open_shift_ids)

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -24,7 +24,7 @@ import type { Database } from "@shared/types/types/supabase";
 import PreviousPageButton from "@shared/components/ui/PreviousPageButton";
 import VoiceContextSetter from "@/features/shared/voice/VoiceContextSetter";
 import { useTabState } from "@/features/shared/hooks/useTabState";
-import { JobCard } from "@/features/work-orders/mobile/MobileJobCard";
+import { JobCard } from "@/features/work-orders/components/JobCard";
 import MobileFocusedJob from "@/features/work-orders/mobile/MobileFocusedJob";
 import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
@@ -132,48 +132,6 @@ const chip = (s: string | null | undefined): string => {
     .replaceAll(" ", "_") as KnownStatus;
   return `${BASE_BADGE} ${BADGE[key] ?? BADGE.awaiting}`;
 };
-
-/* ------------------------ Line status → card styles ------------------------ */
-
-type LineRollupStatus = "awaiting" | "in_progress" | "on_hold" | "completed";
-
-const LINE_STATUS_LABELS: Record<LineRollupStatus, string> = {
-  awaiting: "Awaiting",
-  in_progress: "In progress",
-  on_hold: "On hold",
-  completed: "Completed",
-};
-
-const LINE_CARD_STYLES: Record<LineRollupStatus, string> = {
-  awaiting: "border-[var(--metal-border-soft)] bg-black/30",
-  in_progress:
-    "border-[var(--accent-copper-soft)] bg-[radial-gradient(circle_at_top,_rgba(212,118,49,0.18),rgba(15,23,42,0.96))] shadow-[0_0_26px_rgba(212,118,49,0.55)]",
-  on_hold:
-    "border-amber-500/70 bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.14),rgba(15,23,42,0.98))]",
-  completed:
-    "border-emerald-500/60 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.14),rgba(15,23,42,0.97))]",
-};
-
-const LINE_PILL_STYLES: Record<LineRollupStatus, string> = {
-  awaiting:
-    "border-slate-500/70 bg-slate-900/60 text-slate-200",
-  in_progress:
-    "border-[var(--accent-copper-soft)] bg-[rgba(212,118,49,0.16)] text-[var(--accent-copper-light)] shadow-[0_0_20px_rgba(212,118,49,0.55)]",
-  on_hold:
-    "border-amber-400/70 bg-amber-500/12 text-amber-100",
-  completed:
-    "border-emerald-400/70 bg-emerald-500/12 text-emerald-100",
-};
-
-function toLineBucket(status: string | null | undefined): LineRollupStatus {
-  const s = (status ?? "").toLowerCase();
-  if (s === "in_progress") return "in_progress";
-  if (s === "on_hold") return "on_hold";
-  if (s === "completed" || s === "ready_to_invoice" || s === "invoiced") {
-    return "completed";
-  }
-  return "awaiting";
-}
 
 // roles allowed to approve / decline
 const APPROVAL_ROLES = new Set([
@@ -781,12 +739,25 @@ export default function MobileWorkOrderClient({
 
   const operationalPills = useMemo(
     () => [
-      { title: "In progress", targetLineId: firstInProgressLineId },
-      { title: "On hold", targetLineId: firstOnHoldLineId },
-      { title: "Parts waiting", targetLineId: firstPartsWaitingLineId },
-      { title: "Unassigned", targetLineId: firstUnassignedLineId },
+      { title: "In progress", count: inProgressCount, targetLineId: firstInProgressLineId },
+      {
+        title: "On hold",
+        count: lines.filter((l) => (l.status ?? "").toLowerCase() === "on_hold").length,
+        targetLineId: firstOnHoldLineId,
+      },
+      { title: "Parts waiting", count: awaitingPartsCount, targetLineId: firstPartsWaitingLineId },
+      { title: "Unassigned", count: unassignedCount, targetLineId: firstUnassignedLineId },
     ],
-    [firstInProgressLineId, firstOnHoldLineId, firstPartsWaitingLineId, firstUnassignedLineId],
+    [
+      awaitingPartsCount,
+      firstInProgressLineId,
+      firstOnHoldLineId,
+      firstPartsWaitingLineId,
+      firstUnassignedLineId,
+      inProgressCount,
+      lines,
+      unassignedCount,
+    ],
   );
 
   /* ----------------------- line & quote actions ----------------------- */
@@ -1061,13 +1032,16 @@ export default function MobileWorkOrderClient({
                       jumpToElement(lineRefs.current[pill.targetLineId] ?? null);
                     }}
                     className={[
-                      "inline-flex shrink-0 items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]",
+                      "inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]",
                       disabled
                         ? "cursor-not-allowed border-slate-700/80 bg-slate-900/40 text-slate-500"
                         : "border-slate-500/70 bg-slate-900/70 text-slate-100 active:bg-slate-800/90",
                     ].join(" ")}
                   >
                     {pill.title}
+                    <span className="rounded-full border border-current/30 px-1.5 py-0.5 text-[9px] leading-none">
+                      {pill.count}
+                    </span>
                   </button>
                 );
               })}
@@ -1418,67 +1392,35 @@ export default function MobileWorkOrderClient({
                     setFocusedOpen(true);
                   };
 
-                  const assignedTechName = ln.assigned_tech_id
-                    ? techNamesById[ln.assigned_tech_id] ?? "Assigned tech"
-                    : null;
-
-                  const bucket = toLineBucket(ln.status);
-                  const cardColor = LINE_CARD_STYLES[bucket];
-                  const pillColor = LINE_PILL_STYLES[bucket];
-                  const statusLabel = LINE_STATUS_LABELS[bucket];
+                  const lineTechnicians = ln.assigned_tech_id
+                    ? [
+                        {
+                          id: ln.assigned_tech_id,
+                          full_name: techNamesById[ln.assigned_tech_id] ?? "Assigned tech",
+                        },
+                      ]
+                    : [];
 
                   return (
                     <div
                       key={ln.id}
                       ref={setLineRef(ln.id)}
-                      className={[
-                        "scroll-mt-24 space-y-1 rounded-2xl border p-2 transition-shadow",
-                        cardColor,
-                        punchedIn ? "ring-2 ring-emerald-500/80" : "ring-0",
-                        bucket === "completed" ? "opacity-70" : "",
-                      ].join(" ")}
+                      className="scroll-mt-24"
                     >
-                      {/* header row with status pill on the right */}
-                      <div className="mb-1 flex items-center justify-between gap-2 px-1">
-                        <div className="text-[11px] text-neutral-400">
-                          {idx + 1}.{" "}
-                          {String(ln.job_type ?? "job").replaceAll(
-                            "_",
-                            " ",
-                          )}
-                        </div>
-                        <span
-                          className={[
-                            "inline-flex items-center rounded-full border px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em]",
-                            pillColor,
-                          ].join(" ")}
-                        >
-                          {statusLabel}
-                        </span>
-                      </div>
-
-                      <div className="metal-card rounded-2xl border border-[var(--metal-border-soft)] bg-black/35">
-                        <JobCard
-                          index={idx}
-                          line={ln}
-                          parts={[]} // stripped-down: no parts list on main mobile view
-                          technicians={[]} // assignment handled in focused view / desktop
-                          canAssign={canAssign}
-                          isPunchedIn={punchedIn}
-                          onOpen={openFocused}
-                          onAssign={undefined}
-                          onOpenInspection={() => openInspection(ln)}
-                          onAddPart={undefined}
-                        />
-                      </div>
-
-                      {/* Assigned tech pill */}
-                      <div className="pl-2 pt-1 text-[11px] text-neutral-400">
-                        Assigned to:{" "}
-                        <span className="font-medium text-neutral-200">
-                          {assignedTechName ?? "Unassigned"}
-                        </span>
-                      </div>
+                      <JobCard
+                        index={idx}
+                        line={ln}
+                        parts={[]} // stripped-down: no parts list on main mobile view
+                        technicians={lineTechnicians}
+                        canAssign={canAssign}
+                        isPunchedIn={punchedIn}
+                        onOpen={openFocused}
+                        onAssign={undefined}
+                        onOpenInspection={() => openInspection(ln)}
+                        onAddPart={undefined}
+                        compact
+                        hideExecutionStageCompletenessPills
+                      />
                     </div>
                   );
                 })}


### PR DESCRIPTION
### Motivation
- Make the mobile work-order client feel and read like the main app by reusing the desktop job-card grammar instead of a mobile-only card skin. 
- Ensure mobile shift status is authoritative and durable across reloads, sign-out/sign-in, and navigation by unifying read paths to a canonical API-backed source. 
- Reduce payroll/break drift by preferring punch_event boundaries for unpaid break/lunch derivation where available, without schema changes.

### Description
- Mobile job cards: switched the mobile list to render the shared desktop `JobCard` in compact mode and removed duplicated mobile-only card shells so status rails, badges, muted/completed treatments, and card hierarchy match desktop (file: `features/work-orders/mobile/MobileWorkOrderClient.tsx`).
- Top pills: preserved the top operational pills (`In progress`, `On hold`, `Parts waiting`, `Unassigned`) and upgraded them to section navigators with visible counts that jump to the first matching line anchor using stored refs and `scrollIntoView` (file: `features/work-orders/mobile/MobileWorkOrderClient.tsx`).
- Canonical shift read helper: added `features/mobile/shifts/client.ts` exposing `fetchMobileShiftState()` that calls `/api/mobile/shifts` and returns `{ shiftId, startTime, mode }` for reuse across mobile surfaces.
- Unified mobile shift consumers: `MobileTechHome` and `MobileShiftTracker` now use the canonical helper instead of duplicate direct table queries, and `MobileTechHome` also refreshes on auth-state changes to restore persisted open-shift state after logout/login/reload (files: `features/mobile/dashboard/MobileTechHome.tsx`, `features/mobile/components/MobileShiftTracker.tsx`).
- Payroll break derivation: in `features/payroll-time/server/payrollTime.ts` added minimal-safe logic to fetch `punch_events` for shifts in the rebuild path and derive unpaid break/lunch minutes from punch boundaries when present, and included `break_source` metadata in `source_snapshot` (no schema changes).
- UX clarity: added copy clarifying that tech performance pages are productivity/labor-segment based (with timecard fallback) and not attendance punch totals (files: `app/mobile/tech/performance/page.tsx`, `app/tech/performance/page.tsx`).

### Testing
- Ran ESLint on touched files: `npx eslint features/mobile/shifts/client.ts features/mobile/components/MobileShiftTracker.tsx features/mobile/dashboard/MobileTechHome.tsx features/work-orders/mobile/MobileWorkOrderClient.tsx app/mobile/tech/performance/page.tsx app/tech/performance/page.tsx features/payroll-time/server/payrollTime.ts`; result: no errors, 9 `@typescript-eslint/no-explicit-any` warnings reported (pre-existing style/typing warnings only). 
- Ran TypeScript check: `npx tsc --noEmit`; result: success (no type errors).
- No automated UI snapshot/screenshots executed in this pass; changes are UI-consistent with existing desktop primitives and were kept visually compressed for mobile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ac60a6b88328a2fa73dca3f43273)