### PR TITLE
Restore canonical Remove Hold flow on mobile focused job

### DIFF
--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -1,7 +1,7 @@
 // /features/work-orders/mobile/MobileFocusedJob.tsx (FULL FILE REPLACEMENT)
 // ✅ UI/theme only: align to MobileTechHome (metal-panel / metal-card)
 // ✅ FIX: pass lineLabel + onSaveDraft into CauseCorrectionModal so “Save” shows
-// ❗ NO other logic/behavior changes
+// ✅ Restore canonical hold/remove-hold flow for focused mobile actions
 
 "use client";
 
@@ -758,13 +758,14 @@ export default function MobileFocusedJob(props: {
     (normalizedStatus === "in_progress" || hasActivePunch);
   const isAwaiting = !!line && !isActive && !isOnHold && !isCompleted;
   const canStartOrResume = !!line && canPunch(line) && !isCompleted;
+  const canPrimaryAction = isOnHold || (canStartOrResume && (isActive || isAwaiting));
   const needsApprovalGate =
     line?.status === "awaiting_approval" ||
     (line?.approval_state != null && line.approval_state !== "approved") ||
     line?.status === "declined";
 
   const primaryActionLabel = isOnHold
-    ? "Resume Job"
+    ? "Remove Hold"
     : isActive
       ? "Finish Job"
       : isAwaiting
@@ -926,11 +927,12 @@ export default function MobileFocusedJob(props: {
                     <div className="flex flex-col gap-2 sm:flex-row">
                       <button
                         type="button"
-                        disabled={busy || !canStartOrResume || isCompleted}
+                        disabled={busy || !canPrimaryAction}
                         onClick={() => {
                           if (!line || busy) return;
                           if (isOnHold) {
-                            void releaseHold();
+                            closeAllSubModals();
+                            setOpenHold(true);
                             return;
                           }
                           if (isActive) {
@@ -1396,8 +1398,8 @@ export default function MobileFocusedJob(props: {
           isOpen={openHold}
           onClose={() => setOpenHold(false)}
           onApply={applyHold}
-          onRelease={line.hold_reason ? releaseHold : undefined}
-          canRelease={!!line.hold_reason}
+          onRelease={isOnHold ? releaseHold : undefined}
+          canRelease={isOnHold}
           defaultReason={line.hold_reason || "Awaiting parts"}
         />
       )}


### PR DESCRIPTION
### Motivation
- A mobile UI cleanup accidentally changed the on-hold primary action to a direct “Resume Job” that bypassed the canonical hold-resolution modal and release flow, causing a behavioral regression.

### Description
- Restored the canonical on-hold mapping in `features/work-orders/mobile/MobileFocusedJob.tsx` so the primary label is `Remove Hold` and tapping it opens the existing `HoldModal` instead of calling `releaseHold()` directly.
- Added a small guard `canPrimaryAction` to ensure the primary button is enabled only when the canonical flow allows it and preserved existing `Start Job` / `Finish Job` behavior for awaiting/active states.
- Wired the `HoldModal` props to use the `isOnHold` condition (`onRelease` and `canRelease`) so the modal continues to own release behavior.
- No changes to schema, auth, tenant scoping, or other job-action logic were made; visuals and panel layout were left intact.

### Testing
- Ran `npx eslint features/work-orders/mobile/MobileFocusedJob.tsx` which completed with warnings and no errors.
- Ran `npx tsc --noEmit` which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b4ddf0c48328a19d813bf39a0166)