### PR TITLE
Clarify Assistant vs Planner UX contract

### DIFF
--- a/app/agent/planner/page.tsx
+++ b/app/agent/planner/page.tsx
@@ -29,6 +29,12 @@ type OcrFields = {
 
 type PlannerKind = "simple" | "openai" | "ops" | "fleet" | "approvals";
 
+type PlannerPreset = {
+  id: PlannerKind;
+  label: string;
+  description: string;
+};
+
 type PlannerStartOut = {
   runId: string;
   alreadyExists: boolean;
@@ -194,6 +200,7 @@ function labelFor(evt: PlannerEvent): string | null {
 export default function PlannerPage() {
   const [goal, setGoal] = useState("");
   const [planner, setPlanner] = useState<PlannerKind>("ops");
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const [allowCreate, setAllowCreate] = useState(false);
 
@@ -734,22 +741,42 @@ export default function PlannerPage() {
     bookingId,
   ]);
 
-  const plannerModes: { id: PlannerKind; label: string }[] = [
-    { id: "ops", label: "Ops Assistant" },
-    { id: "openai", label: "OpenAI (rich)" },
-    { id: "simple", label: "Simple (rules)" },
-    { id: "fleet", label: "Fleet PM" },
-    { id: "approvals", label: "Advisor approvals" },
+  const plannerPresets: PlannerPreset[] = [
+    {
+      id: "ops",
+      label: "General Operations",
+      description: "Build an action plan for mixed shop operations.",
+    },
+    {
+      id: "fleet",
+      label: "Fleet Follow-up",
+      description: "Plan fleet-ready next steps and status follow-up.",
+    },
+    {
+      id: "approvals",
+      label: "Resolve Approval Queue",
+      description: "Prepare advisor actions for pending approvals.",
+    },
+    {
+      id: "simple",
+      label: "Quick Plan",
+      description: "Fast structured planning for straightforward requests.",
+    },
+    {
+      id: "openai",
+      label: "Deep Plan",
+      description: "Use richer planning when the request has extra nuance.",
+    },
   ];
 
   return (
     <PageShell
-      title="AI Planner"
-      description="Ask operational questions, create work orders, move bookings, summarize history, and surface shop alerts."
+      title="Planner"
+      description="Turn operational goals into reviewable action plans, then confirm and execute."
     >
       <div className="metal-card rounded-3xl p-5 shadow-[0_12px_35px_rgba(0,0,0,0.85)]">
         <div className="flex flex-wrap gap-2">
-          {plannerModes.map((m) => (
+          {plannerPresets.map((m) => (
             <Button
               key={m.id}
               variant={planner === m.id ? "outline" : "ghost"}
@@ -767,70 +794,107 @@ export default function PlannerPage() {
           ))}
         </div>
 
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-3 shadow-[0_10px_26px_rgba(0,0,0,0.55)]">
-          <div className="min-w-[220px]">
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
-              Data mode
-            </div>
-            <div className="mt-1 text-sm text-neutral-100">
-              {allowCreate
-                ? "Setup mode (allow auto-create)"
-                : "Existing DB mode (no auto-create)"}
-            </div>
+        <div className="mt-3 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4 shadow-[0_10px_26px_rgba(0,0,0,0.55)]">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
+            Active planner preset
           </div>
-
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              variant={allowCreate ? "ghost" : "outline"}
-              className={
-                allowCreate
-                  ? "opacity-80 hover:opacity-100"
-                  : "ring-2 ring-orange-400/60 bg-orange-500/10"
-              }
-              onClick={() => setAllowCreate(false)}
-              disabled={running}
-            >
-              Existing DB
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant={allowCreate ? "outline" : "ghost"}
-              className={
-                allowCreate
-                  ? "ring-2 ring-orange-400/60 bg-orange-500/10"
-                  : "opacity-80 hover:opacity-100"
-              }
-              onClick={() => setAllowCreate(true)}
-              disabled={running}
-            >
-              Setup
-            </Button>
+          <div className="mt-1 text-sm text-neutral-100">
+            {plannerPresets.find((preset) => preset.id === planner)?.description}
           </div>
-
-          {!allowCreate ? (
-            <div className="w-full text-xs text-neutral-400">
-              Existing DB mode is best for history lookups, bookings, status
-              questions, and live shop summaries.
-            </div>
-          ) : null}
+          <div className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-300">
+            <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1">Goal</span>
+            <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1">Proposed plan</span>
+            <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1">Affected records</span>
+            <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1">Review checks</span>
+            <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1">Execute / stage</span>
+          </div>
         </div>
+
+        <div className="mt-3 flex items-center justify-between rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/30 p-3">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
+              Advanced settings
+            </div>
+            <div className="mt-1 text-xs text-neutral-400">
+              Internal planner tuning and safe create behavior.
+            </div>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => setShowAdvanced((v) => !v)}
+          >
+            {showAdvanced ? "Hide" : "Show"}
+          </Button>
+        </div>
+
+        {showAdvanced ? (
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-3 shadow-[0_10px_26px_rgba(0,0,0,0.55)]">
+            <div className="min-w-[220px]">
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
+                Data mode
+              </div>
+              <div className="mt-1 text-sm text-neutral-100">
+                {allowCreate
+                  ? "Setup mode (allow auto-create)"
+                  : "Existing DB mode (no auto-create)"}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant={allowCreate ? "ghost" : "outline"}
+                className={
+                  allowCreate
+                    ? "opacity-80 hover:opacity-100"
+                    : "ring-2 ring-orange-400/60 bg-orange-500/10"
+                }
+                onClick={() => setAllowCreate(false)}
+                disabled={running}
+              >
+                Existing DB
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={allowCreate ? "outline" : "ghost"}
+                className={
+                  allowCreate
+                    ? "ring-2 ring-orange-400/60 bg-orange-500/10"
+                    : "opacity-80 hover:opacity-100"
+                }
+                onClick={() => setAllowCreate(true)}
+                disabled={running}
+              >
+                Setup
+              </Button>
+            </div>
+
+            {!allowCreate ? (
+              <div className="w-full text-xs text-neutral-400">
+                Existing DB mode is best for history lookups, bookings, status
+                questions, and live shop summaries.
+              </div>
+            ) : null}
+          </div>
+        ) : null}
 
         <div className="mt-3 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4 shadow-[0_10px_26px_rgba(0,0,0,0.55)]">
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
             What to do here
           </div>
           <div className="mt-2 text-sm leading-7 text-neutral-200">
-            Type the result you want, not the steps. Examples: “Resolve this hold job line”, “Show me what this customer approved last visit”, or “Create a work order for this vehicle”.
+            Describe the outcome you want Planner to produce. Planner will return proposed steps, affected records, and checks before execution.
           </div>
         </div>
 
         <textarea
           value={goal}
           onChange={(e) => setGoal(e.target.value)}
-          placeholder='e.g. "When was the last time John Smith visited?" or "What is Mike working on?" or "Reschedule booking 123 to tomorrow at 10am"'
+          placeholder='e.g. "Create a work order for this complaint", "Move this booking to tomorrow morning", or "Prepare advisor follow-up for pending approvals"'
           className="mt-3 min-h-[120px] w-full rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/60 p-3 text-sm text-neutral-100 placeholder:text-neutral-500 shadow-[0_10px_26px_rgba(0,0,0,0.6)] focus:outline-none focus:ring-2 focus:ring-orange-400/50"
         />
 
@@ -949,7 +1013,7 @@ export default function PlannerPage() {
         {summary ? (
           <div className="mt-4 rounded-3xl border border-orange-400/20 bg-orange-500/10 p-4 shadow-[0_12px_35px_rgba(0,0,0,0.75)]">
             <div className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-orange-300">
-              Summary
+              Proposed plan
             </div>
             <div className="text-sm text-neutral-100">{summary}</div>
           </div>
@@ -958,7 +1022,7 @@ export default function PlannerPage() {
         {notifications.length > 0 ? (
           <div className="mt-4 rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/60 p-4 shadow-[0_12px_35px_rgba(0,0,0,0.75)]">
             <div className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
-              Alerts
+              Affected records & alerts
             </div>
             <div className="space-y-2">
               {notifications.map((item, index) => (
@@ -985,10 +1049,10 @@ export default function PlannerPage() {
 
         <div className="mt-4 rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/60 p-4 shadow-[0_12px_35px_rgba(0,0,0,0.75)]">
           <div className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
-            Stream
+            Review checks & execution log
           </div>
           {steps.length === 0 ? (
-            <div className="text-sm text-neutral-400">Waiting for updates…</div>
+            <div className="text-sm text-neutral-400">Generate a plan to begin review checks.</div>
           ) : (
             <ul className="space-y-2">
               {steps.map((s, i) => (
@@ -1017,7 +1081,7 @@ export default function PlannerPage() {
             }
             className="min-w-[140px]"
           >
-            Run Assistant
+            Generate Plan
           </Button>
 
           <Button

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -11,6 +11,13 @@ import { useAssistant } from "@/features/assistant/hooks/useAssistant";
 import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
 import type { AssistantContext } from "@/features/assistant/types/assistant";
 
+const EXAMPLE_PROMPTS = [
+  "Which work orders are waiting on approvals right now?",
+  "Summarize open inspections with safety concerns from this week.",
+  "What changed today across bookings, invoices, and technician activity?",
+  "Show repeat issues for this vehicle and what we recommended last time.",
+];
+
 export default function AssistantPage() {
   const [query, setQuery] = useState("");
   const { ask, loading, data } = useAssistant();
@@ -34,18 +41,67 @@ export default function AssistantPage() {
     };
   }, [searchParams]);
 
+  const contextChips = useMemo(
+    () => [
+      { label: "Shop-wide", active: true },
+      { label: "Current page", active: Boolean(context.pageType || context.pageTitle) },
+      { label: "Current customer", active: Boolean(context.customerId) },
+      { label: "Current vehicle", active: Boolean(context.vehicleId) },
+      { label: "Current work order", active: Boolean(context.workOrderId) },
+    ],
+    [context],
+  );
+
   return (
     <PageShell
-      title="AI Assistant"
-      description="Ask anything about your shop"
+      title="Shop Assistant"
+      description="Your universal shop intelligence surface for questions, explanations, and cross-record history."
     >
       <div className="metal-card rounded-3xl p-5">
+        <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
+            Assistant scope
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {contextChips.map((chip) => (
+              <span
+                key={chip.label}
+                className={`rounded-full border px-3 py-1 text-xs ${
+                  chip.active
+                    ? "border-orange-400/40 bg-orange-500/10 text-orange-300"
+                    : "border-white/15 bg-black/30 text-neutral-400"
+                }`}
+              >
+                {chip.label}
+              </span>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-neutral-400">
+            Ask across work orders, customers, vehicles, inspections, approvals,
+            bookings, invoices, fleet, parts, and staff/shop activity. Current-page
+            context is applied when available.
+          </p>
+        </div>
+
         <textarea
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Ask anything about your shop..."
-          className="w-full min-h-[120px] rounded-2xl bg-black/60 p-3 text-white"
+          placeholder="Ask a shop question, request an explanation, or compare records..."
+          className="mt-4 w-full min-h-[120px] rounded-2xl bg-black/60 p-3 text-white"
         />
+
+        <div className="mt-3 flex flex-wrap gap-2">
+          {EXAMPLE_PROMPTS.map((example) => (
+            <button
+              key={example}
+              type="button"
+              className="rounded-full border border-white/15 bg-black/30 px-3 py-1 text-xs text-neutral-300 hover:border-orange-400/40 hover:text-orange-200"
+              onClick={() => setQuery(example)}
+            >
+              {example}
+            </button>
+          ))}
+        </div>
 
         <div className="mt-4 flex justify-center">
           <Button

--- a/features/assistant/components/AskAssistantEntry.tsx
+++ b/features/assistant/components/AskAssistantEntry.tsx
@@ -107,13 +107,13 @@ function getAssistantLabel(context: AssistantContext): string {
 function getPlannerLabel(context: AssistantContext): string {
   switch (context.pageType) {
     case "work_order":
-      return "Fix this WO";
+      return "Plan next steps";
     case "customer":
-      return "Plan for this customer";
+      return "Open in Planner";
     case "vehicle":
-      return "Plan for this vehicle";
+      return "Open in Planner";
     case "booking":
-      return "Plan this booking";
+      return "Open in Planner";
     default:
       return "Open Planner";
   }
@@ -122,15 +122,15 @@ function getPlannerLabel(context: AssistantContext): string {
 function getPlannerGoal(context: AssistantContext): string {
   switch (context.pageType) {
     case "work_order":
-      return "Help me review and take action on this work order";
+      return "Build next steps for this work order";
     case "customer":
-      return "Help me take action for this customer";
+      return "Build next steps for this customer";
     case "vehicle":
-      return "Help me take action for this vehicle";
+      return "Build next steps for this vehicle";
     case "booking":
-      return "Help me review and reschedule or act on this booking";
+      return "Build next steps for this booking";
     default:
-      return "Help me take action";
+      return "Build next operational plan";
   }
 }
 

--- a/features/assistant/components/AssistantResponseCard.tsx
+++ b/features/assistant/components/AssistantResponseCard.tsx
@@ -10,6 +10,14 @@ type Props = {
   data: AssistantResponse | { error: string } | null;
 };
 
+function normalizePlannerActionLabel(label: string): string {
+  const lower = label.trim().toLowerCase();
+  if (!lower || lower.includes("fix") || lower.includes("planner")) {
+    return "Plan next steps";
+  }
+  return "Open in Planner";
+}
+
 export default function AssistantResponseCard({ data }: Props) {
   if (!data) return null;
 
@@ -23,16 +31,12 @@ export default function AssistantResponseCard({ data }: Props) {
 
   return (
     <div className="mt-6 rounded-2xl border border-white/10 bg-black/40 p-5">
-      <div className="mb-2 text-xs uppercase text-neutral-400">
-        Summary
-      </div>
-      <div className="whitespace-pre-line text-sm text-white">
-        {data.summary}
-      </div>
+      <div className="mb-2 text-xs uppercase text-neutral-400">Direct answer</div>
+      <div className="whitespace-pre-line text-sm text-white">{data.summary}</div>
 
       {data.bullets.length > 0 ? (
         <div className="mt-4">
-          <div className="mb-2 text-xs text-neutral-400">Action Items</div>
+          <div className="mb-2 text-xs text-neutral-400">Supporting evidence & context</div>
           <ul className="space-y-1">
             {data.bullets.map((bullet, i) => (
               <li key={`${bullet}-${i}`} className="text-sm text-neutral-200">
@@ -43,45 +47,45 @@ export default function AssistantResponseCard({ data }: Props) {
         </div>
       ) : null}
 
-      {data.actions.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {data.actions.map((action, i) =>
-            action.kind === "planner" ? (
-              <Link
-                key={`${action.label}-${i}`}
-                href={buildPlannerHref(action.plannerPayload)}
-                className="rounded-full border border-orange-400/40 bg-orange-500/10 px-3 py-1 text-xs text-orange-300"
-              >
-                {action.label}
-              </Link>
-            ) : (
-              <Link
-                key={`${action.href}-${i}`}
-                href={action.href}
-                className="rounded-full border border-orange-400/40 px-3 py-1 text-xs text-orange-300"
-              >
-                {action.label}
-              </Link>
-            ),
-          )}
-        </div>
-      ) : null}
-
       {data.notifications.length > 0 ? (
         <div className="mt-4 space-y-2">
+          <div className="mb-2 text-xs text-neutral-400">Related records</div>
           {data.notifications.slice(0, 3).map((notification, i) => (
             <div
               key={`${notification.code}-${notification.entityId ?? i}`}
               className="rounded-xl border border-white/10 bg-black/40 p-3"
             >
-              <div className="text-sm font-semibold text-white">
-                {notification.title}
-              </div>
-              <div className="text-xs text-neutral-300">
-                {notification.message}
-              </div>
+              <div className="text-sm font-semibold text-white">{notification.title}</div>
+              <div className="text-xs text-neutral-300">{notification.message}</div>
             </div>
           ))}
+        </div>
+      ) : null}
+
+      {data.actions.length > 0 ? (
+        <div className="mt-4">
+          <div className="mb-2 text-xs text-neutral-400">Suggested next actions</div>
+          <div className="flex flex-wrap gap-2">
+            {data.actions.map((action, i) =>
+              action.kind === "planner" ? (
+                <Link
+                  key={`${action.label}-${i}`}
+                  href={buildPlannerHref(action.plannerPayload)}
+                  className="rounded-full border border-orange-400/40 bg-orange-500/10 px-3 py-1 text-xs text-orange-300"
+                >
+                  {normalizePlannerActionLabel(action.label)}
+                </Link>
+              ) : (
+                <Link
+                  key={`${action.href}-${i}`}
+                  href={action.href}
+                  className="rounded-full border border-orange-400/40 px-3 py-1 text-xs text-orange-300"
+                >
+                  {action.label}
+                </Link>
+              ),
+            )}
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
### Motivation
- Make it immediately clear in the UI that the Assistant is the universal shop Q&A surface and Planner is the operational action surface.
- Remove implementation jargon from primary views and make the Assistant→Planner handoff intentional and predictable.

### Description
- Updated the Assistant surface by renaming to `Shop Assistant`, adding visible scope chips, clearer subtitle copy, and a set of operational example prompts to show shop-wide coverage (`app/assistant/page.tsx`).
- Reframed assistant responses into a clear contract: `Direct answer` → `Supporting evidence & context` → `Related records` → `Suggested next actions`, and normalized planner handoff wording to friendlier labels like `Plan next steps` / `Open in Planner` (`features/assistant/components/AssistantResponseCard.tsx`).
- Changed embedded assistant entry handoff labels and prefill goals to action-oriented wording so Planner receives explicit outcome goals (`features/assistant/components/AskAssistantEntry.tsx`).
- Reworked Planner to read as a planner/action-builder by renaming page/title, adding user-facing planner presets (General Operations, Fleet Follow-up, Resolve Approval Queue, Quick Plan, Deep Plan), moving engine/data tuning behind an `Advanced settings` disclosure, updating prompt/placeholder examples to outcome-based language, and reframing outputs as `Proposed plan`, `Affected records & alerts`, and `Review checks & execution log` (`app/agent/planner/page.tsx`).
- Preserved existing handoff wiring and payloads via `buildPlannerHref(...)` so context/goals continue to prefill Planner without backend changes.

### Testing
- Ran `npx eslint app/assistant/page.tsx app/agent/planner/page.tsx features/assistant/components/AssistantResponseCard.tsx features/assistant/components/AskAssistantEntry.tsx`, which completed with one existing `react-hooks/exhaustive-deps` warning in `app/agent/planner/page.tsx`.
- Ran `npx tsc --noEmit`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e237ea5a1c832886a47d3f70235e11)