### PR TITLE
Align Shop Assistant to canonical answer pipeline with richer evidence and Planner handoff

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -5,8 +5,11 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
 import type { Database } from "@shared/types/types/supabase";
-import type { AssistantContext } from "@/features/assistant/types/assistant";
-import { runAssistant } from "@/features/assistant/server/runAssistant";
+import { answerAssistant } from "@/features/agent/assistant/server/answerAssistant";
+import type {
+  AssistantAskContext,
+  AssistantAskSession,
+} from "@/features/agent/assistant/types";
 
 type DB = Database;
 
@@ -57,11 +60,11 @@ export async function POST(req: Request) {
 
   const body = (await req.json().catch(() => ({}))) as {
     query?: unknown;
-    context?: AssistantContext;
+    context?: AssistantAskContext;
+    session?: AssistantAskSession;
   };
 
-  const query =
-    typeof body.query === "string" ? body.query.trim() : "";
+  const query = typeof body.query === "string" ? body.query.trim() : "";
 
   if (!query) {
     return NextResponse.json(
@@ -71,15 +74,85 @@ export async function POST(req: Request) {
   }
 
   try {
-    const result = await runAssistant({
+    const answer = await answerAssistant({
       shopId: profile.shopId,
       userId: user.id,
       role: profile.role,
-      query,
-      context: body.context,
+      request: {
+        question: query,
+        context: body.context,
+        session: body.session,
+      },
     });
 
-    return NextResponse.json(result);
+    return NextResponse.json({
+      summary: answer.summary,
+      bullets: answer.bullets,
+      actions: answer.actions.map((action) =>
+        action.type === "link"
+          ? {
+              kind: "link",
+              label: action.label,
+              href: action.href,
+            }
+          : {
+              kind: "planner",
+              label: action.label,
+              plannerPayload: {
+                goal: action.goal,
+                planner:
+                  action.context?.planner === "approvals" ||
+                  action.context?.planner === "fleet" ||
+                  action.context?.planner === "simple" ||
+                  action.context?.planner === "openai"
+                    ? action.context.planner
+                    : "ops",
+                customerQuery:
+                  typeof action.context?.customerQuery === "string"
+                    ? action.context.customerQuery
+                    : undefined,
+                customerId:
+                  typeof action.context?.customerId === "string"
+                    ? action.context.customerId
+                    : answer.resolvedContext?.customerId,
+                vehicleId:
+                  typeof action.context?.vehicleId === "string"
+                    ? action.context.vehicleId
+                    : answer.resolvedContext?.vehicleId,
+                bookingId:
+                  typeof action.context?.bookingId === "string"
+                    ? action.context.bookingId
+                    : answer.resolvedContext?.bookingId,
+                workOrderId:
+                  typeof action.context?.workOrderId === "string"
+                    ? action.context.workOrderId
+                    : answer.resolvedContext?.workOrderId,
+                allowCreate:
+                  typeof action.context?.allowCreate === "boolean"
+                    ? action.context.allowCreate
+                    : false,
+              },
+            },
+      ),
+      notifications: answer.entities.map((entity, idx) => ({
+        level: "info",
+        code: `entity_${idx + 1}`,
+        title: entity.label,
+        message: entity.type,
+        href: entity.href,
+        entityType: entity.type,
+        entityId: entity.id,
+      })),
+      relatedRecords: [
+        ...answer.links.map((link) => ({ label: link.label, href: link.href, type: "link" })),
+        ...answer.entities.map((entity) => ({
+          label: entity.label,
+          href: entity.href,
+          type: entity.type,
+        })),
+      ],
+      resolvedContext: answer.resolvedContext,
+    });
   } catch (error: unknown) {
     return NextResponse.json(
       {

--- a/features/agent/assistant/server/answerAssistant.ts
+++ b/features/agent/assistant/server/answerAssistant.ts
@@ -5,6 +5,8 @@ import { runGetShopCurrentStatus } from "../../tools/getShopCurrentStatus";
 import { runGetStalledWorkOrders } from "../../tools/getStalledWorkOrders";
 import { runGetTechCurrentWork } from "../../tools/getTechCurrentWork";
 import { runGetVehicleHistory } from "../../tools/getVehicleHistory";
+import { runGetWorkOrderStatusSummary } from "../../tools/getWorkOrderStatusSummary";
+import { toolListPendingApprovals } from "../../tools/listPendingApprovals";
 
 import type {
   AssistantAction,
@@ -12,6 +14,7 @@ import type {
   AssistantAskRequest,
   AssistantEntity,
   AssistantLink,
+  AssistantResolvedContext,
 } from "../types";
 
 type AskParams = {
@@ -24,6 +27,8 @@ type AskParams = {
 type Citation = {
   label?: string;
   href?: string;
+  id?: string;
+  type?: string;
 };
 
 function normalizeQuestion(question: string): string {
@@ -49,10 +54,10 @@ function extractNameLikeValue(question: string): string | null {
   );
   if (forMatch?.[1]) return forMatch[1].trim();
 
-  const lastTimeMatch = question.match(
-    /\b(?:customer|vehicle|tech|technician)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})/,
+  const whoMatch = question.match(
+    /\b(?:is|was)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})\s+(?:working|assigned)/,
   );
-  if (lastTimeMatch?.[1]) return lastTimeMatch[1].trim();
+  if (whoMatch?.[1]) return whoMatch[1].trim();
 
   return null;
 }
@@ -87,16 +92,43 @@ function toLinks(value: unknown): AssistantLink[] {
     seen.add(key);
 
     out.push({ label, href });
-    if (out.length >= 6) break;
+    if (out.length >= 8) break;
   }
 
   return out;
 }
 
-function firstSentence(value: string | null | undefined): string {
-  const text = (value ?? "").trim();
-  if (!text) return "";
-  return text;
+function toEntities(value: unknown): AssistantEntity[] {
+  if (!Array.isArray(value)) return [];
+
+  const out: AssistantEntity[] = [];
+
+  for (const item of value) {
+    const row = item as Citation;
+    const label = typeof row?.label === "string" ? row.label.trim() : "";
+    if (!label) continue;
+
+    out.push({
+      type:
+        row.type === "work_order" ||
+        row.type === "vehicle" ||
+        row.type === "customer" ||
+        row.type === "booking" ||
+        row.type === "inspection" ||
+        row.type === "invoice" ||
+        row.type === "fleet_unit" ||
+        row.type === "technician"
+          ? row.type
+          : "alert",
+      id: typeof row.id === "string" ? row.id : undefined,
+      label,
+      href: typeof row.href === "string" ? row.href : undefined,
+    });
+
+    if (out.length >= 8) break;
+  }
+
+  return out;
 }
 
 function buildAnswer(params: {
@@ -106,6 +138,7 @@ function buildAnswer(params: {
   links?: AssistantLink[];
   entities?: AssistantEntity[];
   actions?: AssistantAction[];
+  resolvedContext?: AssistantResolvedContext;
 }): AssistantAnswer {
   return {
     intent: params.intent,
@@ -114,7 +147,71 @@ function buildAnswer(params: {
     links: params.links ?? [],
     entities: params.entities ?? [],
     actions: params.actions ?? [],
+    resolvedContext: params.resolvedContext,
   };
+}
+
+function dedupeStrings(values: Array<string | null | undefined>, limit = 6): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    const clean = (value ?? "").trim();
+    if (!clean) continue;
+    const key = clean.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(clean);
+    if (out.length >= limit) break;
+  }
+
+  return out;
+}
+
+function isFollowUp(question: string): boolean {
+  const q = question.toLowerCase().trim();
+  return [
+    "who worked on it",
+    "open that",
+    "open it",
+    "open that work order",
+    "plan follow-up",
+    "plan follow up",
+    "what about this",
+    "what about that",
+  ].some((token) => q.includes(token));
+}
+
+function resolveContext(request: AssistantAskRequest): AssistantResolvedContext {
+  return {
+    workOrderId: request.context?.workOrderId ?? request.session?.workOrderId,
+    customerId: request.context?.customerId ?? request.session?.customerId,
+    vehicleId: request.context?.vehicleId ?? request.session?.vehicleId,
+    bookingId: request.context?.bookingId ?? request.session?.bookingId,
+  };
+}
+
+function extractIdFromHref(href: string, segment: string): string | undefined {
+  const match = href.match(new RegExp(`/${segment}/([^/?#]+)`, "i"));
+  return match?.[1];
+}
+
+function withResolvedContext(
+  resolvedContext: AssistantResolvedContext,
+  links: AssistantLink[],
+): AssistantResolvedContext {
+  const next = { ...resolvedContext };
+
+  for (const link of links) {
+    if (!next.workOrderId) {
+      next.workOrderId = extractIdFromHref(link.href, "work-orders") ?? next.workOrderId;
+    }
+    if (!next.bookingId) {
+      next.bookingId = extractIdFromHref(link.href, "bookings") ?? next.bookingId;
+    }
+  }
+
+  return next;
 }
 
 export async function answerAssistant({
@@ -131,44 +228,191 @@ export async function answerAssistant({
     userId,
   };
 
-  const customerName = extractNameLikeValue(question);
+  const nameCandidate = extractNameLikeValue(question);
   const plateOrVin = extractPlateOrVin(question);
+  const resolvedContext = resolveContext(request);
+
+  if (
+    questionIncludes(q, [
+      "approval",
+      "awaiting decision",
+      "awaiting customer",
+      "quote waiting",
+      "waiting on approval",
+    ])
+  ) {
+    const result = await toolListPendingApprovals.run({ limit: 20 }, ctx);
+
+    if (result.items.length === 0) {
+      return buildAnswer({
+        intent: "pending_approvals",
+        summary: "There are no work order lines awaiting approval right now.",
+        bullets: ["No pending advisor/customer approval lines were found in this shop."],
+        actions: [
+          {
+            type: "planner",
+            label: "Prepare approval follow-up",
+            goal: "Review approval queues and prepare customer follow-up",
+            context: {
+              planner: "approvals",
+            },
+          },
+        ],
+        resolvedContext,
+      });
+    }
+
+    const links = result.items.slice(0, 6).map((item) => ({
+      label: `${item.customId ? `WO #${item.customId}` : item.workOrderId.slice(0, 8)} • ${item.customerName ?? "Customer"} • ${item.lines.length} line(s) pending`,
+      href: `/work-orders/${item.workOrderId}/quote-review`,
+    }));
+
+    const bullets = dedupeStrings(
+      result.items.slice(0, 5).map((item) => {
+        const total = item.estimatedTotal != null ? ` • est $${item.estimatedTotal.toFixed(2)}` : "";
+        return `${item.customId ? `WO #${item.customId}` : item.workOrderId.slice(0, 8)} • ${item.vehicleSummary ?? "Vehicle unknown"}${total}`;
+      }),
+      5,
+    );
+
+    const nextContext = withResolvedContext(resolvedContext, links);
+
+    return buildAnswer({
+      intent: "pending_approvals",
+      summary: `There are ${result.items.length} work order(s) with pending approvals right now.`,
+      bullets,
+      links,
+      entities: links.map((link) => ({ type: "work_order", label: link.label, href: link.href })),
+      actions: [
+        {
+          type: "link",
+          label: "Open top approval",
+          href: links[0]?.href ?? "/work-orders",
+        },
+        {
+          type: "planner",
+          label: "Prepare advisor approval actions",
+          goal: "Prepare advisor approval actions for pending work orders",
+          context: {
+            planner: "approvals",
+            workOrderId: nextContext.workOrderId,
+          },
+        },
+      ],
+      resolvedContext: nextContext,
+    });
+  }
+
+  if (
+    resolvedContext.workOrderId &&
+    (questionIncludes(q, ["blocking", "blocked", "on hold", "this work order", "what happened on this work order"]) ||
+      (isFollowUp(question) && request.session?.lastIntent === "work_order_status"))
+  ) {
+    const result = await runGetWorkOrderStatusSummary(
+      { workOrderId: resolvedContext.workOrderId },
+      ctx,
+    );
+
+    const links = toLinks((result as { citations?: unknown }).citations);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...((result as { notifications?: Array<{ message?: string }> }).notifications ?? []).map(
+        (item) => item.message,
+      ),
+    ]);
+
+    return buildAnswer({
+      intent: "work_order_status",
+      summary:
+        (result as { summary?: string }).summary ??
+        "I checked that work order and found its current status.",
+      bullets,
+      links,
+      entities: toEntities((result as { citations?: unknown }).citations),
+      actions: [
+        links[0]
+          ? {
+              type: "link",
+              label: "Open related work order",
+              href: links[0].href,
+            }
+          : {
+              type: "link",
+              label: "Open work orders",
+              href: "/work-orders",
+            },
+        {
+          type: "planner",
+          label: "Plan next steps",
+          goal: "Plan follow-up for blockers on this work order",
+          context: {
+            workOrderId: resolvedContext.workOrderId,
+          },
+        },
+      ],
+      resolvedContext,
+    });
+  }
 
   if (
     questionIncludes(q, [
       "last time",
       "last visit",
       "customer history",
-      "when did",
+      "issue came back",
+      "what was repaired",
       "what did we do",
-    ]) &&
-    customerName
+    ])
   ) {
     const result = await runGetCustomerVisitHistory(
-      { customerQuery: customerName, limit: 5 },
+      {
+        customerId: resolvedContext.customerId,
+        customerQuery: nameCandidate ?? undefined,
+        plateOrVin: plateOrVin ?? undefined,
+        limit: 8,
+      },
       ctx,
     );
 
     const links = toLinks((result as { citations?: unknown }).citations);
-    const bullets = links.slice(0, 3).map((item) => item.label);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...links.slice(0, 4).map((item) => item.label),
+    ]);
+
+    const nextContext: AssistantResolvedContext = withResolvedContext(
+      {
+        ...resolvedContext,
+        customerId: (result as { customerId?: string }).customerId ?? resolvedContext.customerId,
+        vehicleId: (result as { vehicleId?: string }).vehicleId ?? resolvedContext.vehicleId,
+      },
+      links,
+    );
 
     return buildAnswer({
       intent: "customer_visit_history",
       summary:
-        firstSentence((result as { summary?: string }).summary) ||
-        `I found the recent visit history for ${customerName}.`,
+        (result as { summary?: string }).summary ??
+        "I found recent visit history for that customer.",
       bullets,
       links,
+      entities: toEntities((result as { citations?: unknown }).citations),
       actions: [
+        links[0]
+          ? { type: "link", label: "Open related work order", href: links[0].href }
+          : { type: "link", label: "See customer history", href: "/work-orders/history" },
         {
           type: "planner",
-          label: "Open in Ops Planner",
-          goal: `Review customer history for ${customerName} and prepare next action`,
+          label: "Plan follow-up for repeat issue",
+          goal: "Plan follow-up for this repeat customer complaint",
           context: {
-            customerQuery: customerName,
+            customerId: nextContext.customerId,
+            vehicleId: nextContext.vehicleId,
+            workOrderId: nextContext.workOrderId,
           },
         },
       ],
+      resolvedContext: nextContext,
     });
   }
 
@@ -178,12 +422,16 @@ export async function answerAssistant({
       "history for this vehicle",
       "show vehicle history",
       "what has been done to this vehicle",
-    ]) &&
-    (customerName || plateOrVin)
+      "fleet unit",
+      "unit history",
+    ]) ||
+    ((questionIncludes(q, ["who worked on it", "who worked last time"]) || isFollowUp(question)) &&
+      Boolean(resolvedContext.vehicleId || resolvedContext.customerId))
   ) {
     const result = await runGetVehicleHistory(
       {
-        customerQuery: customerName ?? undefined,
+        vehicleId: resolvedContext.vehicleId,
+        customerQuery: nameCandidate ?? undefined,
         plateOrVin: plateOrVin ?? undefined,
         limit: 8,
       },
@@ -191,37 +439,52 @@ export async function answerAssistant({
     );
 
     const links = toLinks((result as { citations?: unknown }).citations);
-    const bullets = links.slice(0, 4).map((item) => item.label);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...links.slice(0, 4).map((item) => item.label),
+    ]);
+
+    const nextContext: AssistantResolvedContext = withResolvedContext(
+      {
+        ...resolvedContext,
+        customerId: (result as { customerId?: string }).customerId ?? resolvedContext.customerId,
+        vehicleId: (result as { vehicleId?: string }).vehicleId ?? resolvedContext.vehicleId,
+      },
+      links,
+    );
 
     return buildAnswer({
       intent: "vehicle_history",
       summary:
-        firstSentence((result as { summary?: string }).summary) ||
-        "I found the vehicle history.",
+        (result as { summary?: string }).summary ?? "I found vehicle history for this unit.",
       bullets,
       links,
+      entities: toEntities((result as { citations?: unknown }).citations),
       actions: [
+        links[0]
+          ? { type: "link", label: "Open related work order", href: links[0].href }
+          : { type: "link", label: "Open vehicles", href: "/vehicles" },
         {
           type: "planner",
-          label: "Open in Ops Planner",
-          goal: "Review this vehicle history and suggest next steps",
+          label: "Create next-step work order",
+          goal: "Create next-step work order for this vehicle concern",
           context: {
-            customerQuery: customerName ?? undefined,
-            plateOrVin: plateOrVin ?? undefined,
+            vehicleId: nextContext.vehicleId,
+            customerId: nextContext.customerId,
           },
         },
       ],
+      resolvedContext: nextContext,
     });
   }
 
   if (
     questionIncludes(q, [
-      "what is",
+      "what job is",
       "working on",
-      "what's mike working on",
-      "what is mike working on",
       "what is this tech working on",
       "current work",
+      "assigned right now",
     ])
   ) {
     const techIdCandidate =
@@ -230,29 +493,38 @@ export async function answerAssistant({
         : undefined;
 
     const result = await runGetTechCurrentWork(
-      { techId: techIdCandidate },
+      { techId: techIdCandidate, techName: techIdCandidate ? undefined : nameCandidate ?? undefined },
       ctx,
     );
 
     const links = toLinks((result as { citations?: unknown }).citations);
-    const bullets = links.slice(0, 3).map((item) => item.label);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...links.slice(0, 4).map((item) => item.label),
+    ]);
 
     return buildAnswer({
       intent: "tech_current_work",
       summary:
-        firstSentence((result as { summary?: string }).summary) ||
-        "I checked the technician's current work.",
+        (result as { summary?: string }).summary || "I checked the technician's current work.",
       bullets,
       links,
+      entities: toEntities((result as { citations?: unknown }).citations),
       actions: links[0]
         ? [
             {
               type: "link",
-              label: "Open work order",
+              label: "Open related work order",
               href: links[0].href,
+            },
+            {
+              type: "planner",
+              label: "Plan next steps",
+              goal: "Plan next steps for this technician's active jobs",
             },
           ]
         : [],
+      resolvedContext: withResolvedContext(resolvedContext, links),
     });
   }
 
@@ -263,40 +535,51 @@ export async function answerAssistant({
       "waiting too long",
       "queued too long",
       "what needs attention",
+      "what is blocking",
       "stale work orders",
     ])
   ) {
     const result = await runGetStalledWorkOrders({}, ctx);
     const links = toLinks((result as { citations?: unknown }).citations);
-    const bullets = links.slice(0, 5).map((item) => item.label);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...links.slice(0, 5).map((item) => item.label),
+    ]);
+
+    const nextContext = withResolvedContext(resolvedContext, links);
 
     return buildAnswer({
       intent: "stalled_work_orders",
       summary:
-        firstSentence((result as { summary?: string }).summary) ||
+        (result as { summary?: string }).summary ||
         "I found work orders that need attention.",
       bullets,
       links,
+      entities: toEntities((result as { citations?: unknown }).citations),
       actions: links[0]
         ? [
             {
               type: "link",
-              label: "Open most urgent",
+              label: "Open most urgent work order",
               href: links[0].href,
             },
             {
               type: "planner",
-              label: "Fix in Ops Planner",
-              goal: "Review stalled work orders and suggest corrective actions",
+              label: "Plan corrective actions",
+              goal: "Review stalled work orders and create corrective next steps",
+              context: {
+                workOrderId: nextContext.workOrderId,
+              },
             },
           ]
         : [
             {
               type: "planner",
-              label: "Open in Ops Planner",
+              label: "Open in Planner",
               goal: "Review stalled work orders and suggest corrective actions",
             },
           ],
+      resolvedContext: nextContext,
     });
   }
 
@@ -306,28 +589,47 @@ export async function answerAssistant({
       "bookings",
       "what is booked",
       "what's booked",
-      "today's schedule",
-      "todays schedule",
+      "today",
+      "tomorrow",
+      "scheduled",
+      "appointment moved",
     ])
   ) {
-    const result = await runGetBookings({ limit: 10 }, ctx);
+    const result = await runGetBookings(
+      {
+        customerId: resolvedContext.customerId,
+        customerQuery: nameCandidate ?? undefined,
+        plateOrVin: plateOrVin ?? undefined,
+        limit: 10,
+      },
+      ctx,
+    );
+
     const links = toLinks((result as { citations?: unknown }).citations);
-    const bullets = links.slice(0, 5).map((item) => item.label);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...links.slice(0, 5).map((item) => item.label),
+    ]);
 
     return buildAnswer({
       intent: "bookings",
       summary:
-        firstSentence((result as { summary?: string }).summary) ||
-        "I checked the current bookings.",
+        (result as { summary?: string }).summary || "I checked the current bookings.",
       bullets,
       links,
+      entities: toEntities((result as { citations?: unknown }).citations),
       actions: [
         {
           type: "planner",
-          label: "Open in Ops Planner",
-          goal: "Review bookings and reschedule if needed",
+          label: "Reschedule and notify customer",
+          goal: "Reschedule this booking and notify the customer",
+          context: {
+            bookingId: resolvedContext.bookingId,
+            customerId: resolvedContext.customerId,
+          },
         },
       ],
+      resolvedContext: withResolvedContext(resolvedContext, links),
     });
   }
 
@@ -338,47 +640,58 @@ export async function answerAssistant({
       "what is going on",
       "what's going on",
       "give me status",
+      "vehicles are in the shop",
       "shop snapshot",
     ])
   ) {
     const result = await runGetShopCurrentStatus({}, ctx);
     const links = toLinks((result as { citations?: unknown }).citations);
-    const bullets = links.slice(0, 5).map((item) => item.label);
+    const bullets = dedupeStrings([
+      (result as { summary?: string }).summary,
+      ...links.slice(0, 5).map((item) => item.label),
+    ]);
 
     return buildAnswer({
       intent: "shop_status",
       summary:
-        firstSentence((result as { summary?: string }).summary) ||
-        "I pulled the current shop status.",
+        (result as { summary?: string }).summary || "I pulled the current shop status.",
       bullets,
       links,
+      entities: toEntities((result as { citations?: unknown }).citations),
       actions: [
         {
           type: "planner",
-          label: "Open in Ops Planner",
-          goal: "Review current shop status and suggest next actions",
+          label: "Plan next steps",
+          goal: "Review current shop status and plan next operational actions",
         },
       ],
+      resolvedContext: withResolvedContext(resolvedContext, links),
     });
   }
 
   return buildAnswer({
     intent: "unknown",
     summary:
-      "I can help with customer visit history, vehicle history, bookings, shop status, stalled work orders, and technician work. Try asking a more specific shop question.",
+      "I can answer shop operations questions across work orders, approvals, bookings, technician activity, and customer or vehicle history. Ask a specific operational question and I will ground it in current records.",
     bullets: [
-      '“When was the last time John Smith visited?”',
-      '“Give me vehicle history for plate 8ABC123.”',
-      '“What is Mike working on right now?”',
-      '“What work orders are on hold too long?”',
+      '"What job is Lucas working on right now?"',
+      '"What is blocking this work order?"',
+      '"What did we do last time on this vehicle?"',
+      '"What approvals are waiting right now?"',
     ],
-    links: [],
     actions: [
       {
         type: "planner",
         label: "Open in Ops Planner",
         goal: question || "Review current shop operations",
+        context: {
+          workOrderId: resolvedContext.workOrderId,
+          customerId: resolvedContext.customerId,
+          vehicleId: resolvedContext.vehicleId,
+          bookingId: resolvedContext.bookingId,
+        },
       },
     ],
+    resolvedContext,
   });
 }

--- a/features/agent/assistant/types.ts
+++ b/features/agent/assistant/types.ts
@@ -5,6 +5,9 @@ export type AssistantEntityType =
   | "vehicle"
   | "customer"
   | "booking"
+  | "inspection"
+  | "invoice"
+  | "fleet_unit"
   | "technician"
   | "alert";
 
@@ -33,12 +36,20 @@ export type AssistantEntity = {
   href?: string;
 };
 
+export type AssistantResolvedContext = {
+  workOrderId?: string;
+  customerId?: string;
+  vehicleId?: string;
+  bookingId?: string;
+};
+
 export type AssistantAnswer = {
   summary: string;
   bullets: string[];
   links: AssistantLink[];
   entities: AssistantEntity[];
   actions: AssistantAction[];
+  resolvedContext?: AssistantResolvedContext;
   intent:
     | "customer_visit_history"
     | "vehicle_history"
@@ -46,11 +57,32 @@ export type AssistantAnswer = {
     | "stalled_work_orders"
     | "bookings"
     | "tech_current_work"
+    | "pending_approvals"
+    | "work_order_status"
     | "unknown";
+};
+
+export type AssistantAskContext = {
+  workOrderId?: string;
+  customerId?: string;
+  vehicleId?: string;
+  bookingId?: string;
+  pageType?: string;
+  pageTitle?: string;
+};
+
+export type AssistantAskSession = {
+  workOrderId?: string;
+  customerId?: string;
+  vehicleId?: string;
+  bookingId?: string;
+  lastIntent?: AssistantAnswer["intent"];
 };
 
 export type AssistantAskRequest = {
   question: string;
+  context?: AssistantAskContext;
+  session?: AssistantAskSession;
 };
 
 export type AssistantAskResponse =

--- a/features/assistant/components/AssistantResponseCard.tsx
+++ b/features/assistant/components/AssistantResponseCard.tsx
@@ -15,7 +15,7 @@ function normalizePlannerActionLabel(label: string): string {
   if (!lower || lower.includes("fix") || lower.includes("planner")) {
     return "Plan next steps";
   }
-  return "Open in Planner";
+  return label;
 }
 
 export default function AssistantResponseCard({ data }: Props) {
@@ -47,7 +47,28 @@ export default function AssistantResponseCard({ data }: Props) {
         </div>
       ) : null}
 
-      {data.notifications.length > 0 ? (
+      {data.relatedRecords && data.relatedRecords.length > 0 ? (
+        <div className="mt-4 space-y-2">
+          <div className="mb-2 text-xs text-neutral-400">Related records</div>
+          {data.relatedRecords.slice(0, 6).map((record, i) => (
+            <div
+              key={`${record.label}-${record.href ?? i}`}
+              className="rounded-xl border border-white/10 bg-black/40 p-3"
+            >
+              {record.href ? (
+                <Link href={record.href} className="text-sm font-semibold text-orange-200 hover:text-orange-100">
+                  {record.label}
+                </Link>
+              ) : (
+                <div className="text-sm font-semibold text-white">{record.label}</div>
+              )}
+              <div className="text-xs text-neutral-300">
+                {record.type ? record.type.replaceAll("_", " ") : "record"}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : data.notifications.length > 0 ? (
         <div className="mt-4 space-y-2">
           <div className="mb-2 text-xs text-neutral-400">Related records</div>
           {data.notifications.slice(0, 3).map((notification, i) => (

--- a/features/assistant/hooks/useAssistant.ts
+++ b/features/assistant/hooks/useAssistant.ts
@@ -4,7 +4,9 @@
 
 import { useState } from "react";
 import type {
+  AssistantAction,
   AssistantContext,
+  AssistantNotification,
   AssistantResponse,
 } from "../types/assistant";
 
@@ -12,23 +14,195 @@ type AssistantError = {
   error: string;
 };
 
+type ApiAnswerAction =
+  | {
+      type: "link";
+      label: string;
+      href: string;
+    }
+  | {
+      type: "planner";
+      label: string;
+      goal: string;
+      context?: Record<string, unknown>;
+    };
+
+type ApiAnswerLink = {
+  label: string;
+  href: string;
+};
+
+type ApiEntity = {
+  type: string;
+  id?: string;
+  label: string;
+  href?: string;
+};
+
+type ApiAnswer = {
+  summary: string;
+  bullets?: string[];
+  links?: ApiAnswerLink[];
+  entities?: ApiEntity[];
+  actions?: ApiAnswerAction[];
+  intent?: string;
+  resolvedContext?: {
+    workOrderId?: string;
+    customerId?: string;
+    vehicleId?: string;
+    bookingId?: string;
+  };
+};
+
+type AskResponse =
+  | {
+      ok: true;
+      answer: ApiAnswer;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type AssistantSession = {
+  workOrderId?: string;
+  vehicleId?: string;
+  customerId?: string;
+  bookingId?: string;
+  lastIntent?: string;
+};
+
+function notificationLevelFromType(type?: string): AssistantNotification["level"] {
+  if (type === "alert") return "warning";
+  return "info";
+}
+
+function toPlannerPayload(
+  action: Extract<ApiAnswerAction, { type: "planner" }>,
+  fallbackContext?: AssistantContext,
+): AssistantAction {
+  const context = action.context ?? {};
+
+  return {
+    kind: "planner",
+    label: action.label,
+    plannerPayload: {
+      planner:
+        context.planner === "openai" ||
+        context.planner === "simple" ||
+        context.planner === "fleet" ||
+        context.planner === "approvals"
+          ? context.planner
+          : "ops",
+      goal: action.goal,
+      workOrderId:
+        typeof context.workOrderId === "string"
+          ? context.workOrderId
+          : fallbackContext?.workOrderId,
+      bookingId:
+        typeof context.bookingId === "string"
+          ? context.bookingId
+          : fallbackContext?.bookingId,
+      customerId:
+        typeof context.customerId === "string"
+          ? context.customerId
+          : fallbackContext?.customerId,
+      vehicleId:
+        typeof context.vehicleId === "string"
+          ? context.vehicleId
+          : fallbackContext?.vehicleId,
+      customerQuery:
+        typeof context.customerQuery === "string" ? context.customerQuery : undefined,
+      plateOrVin: typeof context.plateOrVin === "string" ? context.plateOrVin : undefined,
+      allowCreate:
+        typeof context.allowCreate === "boolean" ? context.allowCreate : false,
+      emailInvoiceTo:
+        typeof context.emailInvoiceTo === "string" ? context.emailInvoiceTo : undefined,
+    },
+  };
+}
+
+function mapAnswerToResponse(answer: ApiAnswer, context?: AssistantContext): AssistantResponse {
+  const actions: AssistantAction[] = (answer.actions ?? [])
+    .map((action) => {
+      if (action.type === "planner") {
+        return toPlannerPayload(action, context);
+      }
+
+      return {
+        kind: "link" as const,
+        label: action.label,
+        href: action.href,
+      };
+    })
+    .slice(0, 6);
+
+  const relatedRecords = [
+    ...(answer.links ?? []).map((item) => ({
+      label: item.label,
+      href: item.href,
+      type: "link",
+    })),
+    ...(answer.entities ?? []).map((item) => ({
+      label: item.label,
+      href: item.href,
+      type: item.type,
+    })),
+  ].slice(0, 8);
+
+  const notifications: AssistantNotification[] = relatedRecords.slice(0, 6).map((item, idx) => ({
+    level: notificationLevelFromType(item.type),
+    code: `record_${idx + 1}`,
+    title: item.label,
+    message: item.type ? `Related ${item.type.replaceAll("_", " ")}` : "Related record",
+    href: item.href,
+    entityType: item.type,
+  }));
+
+  return {
+    summary: answer.summary,
+    bullets: (answer.bullets ?? []).filter(Boolean).slice(0, 6),
+    actions,
+    notifications,
+    relatedRecords,
+  };
+}
+
 export function useAssistant() {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<AssistantResponse | AssistantError | null>(null);
+  const [session, setSession] = useState<AssistantSession>({});
 
   async function ask(query: string, context?: AssistantContext) {
     setLoading(true);
     setData(null);
 
     try {
-      const res = await fetch("/api/assistant", {
+      const res = await fetch("/api/assistant/answer", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ query, context }),
+        body: JSON.stringify({
+          question: query,
+          context,
+          session,
+        }),
       });
 
-      const json = (await res.json()) as AssistantResponse | AssistantError;
-      setData(json);
+      const json = (await res.json()) as AskResponse;
+
+      if (!res.ok || !json.ok) {
+        setData({ error: json.ok ? "Assistant request failed" : json.error });
+        return;
+      }
+
+      const nextContext = json.answer.resolvedContext;
+      setSession((prev) => ({
+        ...prev,
+        ...nextContext,
+        lastIntent: json.answer.intent,
+      }));
+
+      setData(mapAnswerToResponse(json.answer, context));
     } catch {
       setData({ error: "Failed to fetch" });
     } finally {

--- a/features/assistant/types/assistant.ts
+++ b/features/assistant/types/assistant.ts
@@ -3,6 +3,8 @@
 export type PlannerPayload = {
   goal?: string;
   customerQuery?: string;
+  customerId?: string;
+  vehicleId?: string;
   plateOrVin?: string;
   emailInvoiceTo?: string;
   bookingId?: string;
@@ -42,9 +44,16 @@ export type AssistantNotification = {
   entityId?: string;
 };
 
+export type AssistantRelatedRecord = {
+  label: string;
+  href?: string;
+  type?: string;
+};
+
 export type AssistantResponse = {
   summary: string;
   bullets: string[];
   actions: AssistantAction[];
   notifications: AssistantNotification[];
+  relatedRecords?: AssistantRelatedRecord[];
 };


### PR DESCRIPTION
### Motivation
- Move the Shop Assistant from a summary-first path to the richer, tool-backed answer pipeline so assistant responses are system-wide, evidence-backed, and operationally useful.
- Preserve existing shop/user scoping and session-level safety while improving multi-turn follow-up and context carry-forward.
- Make Planner handoffs feel like a continuation by supplying clean operational goals and scoped record IDs instead of dumping raw assistant text.

### Description
- Route the compatibility endpoint `app/api/assistant` through the agent `answerAssistant` path and normalize its output to the Assistant UI shape, including converting agent actions into planner payloads with scoped IDs. (`app/api/assistant/route.ts`)
- Replace the client assistant hook to call `/api/assistant/answer`, add lightweight session state (`context` + `session`), persist `resolvedContext` across turns, and map API answers to UI responses. (`features/assistant/hooks/useAssistant.ts`)
- Expand `answerAssistant` with broader operational intents (pending approvals, work order status/blockers, customer/vehicle history, tech current work, stalled work orders, bookings, shop status), return structured summary + bullets + links/entities + actions, and expose `resolvedContext` for follow-up continuity. (`features/agent/assistant/server/answerAssistant.ts`, `features/agent/assistant/types.ts`)
- Improve UI rendering to surface related record links as first-class cards and retain planner/link action chips, and extend Assistant types for related records and planner payload IDs. (`features/assistant/components/AssistantResponseCard.tsx`, `features/assistant/types/assistant.ts`)

### Testing
- Ran linting on touched files with `npx eslint app/api/assistant/route.ts app/api/assistant/answer/route.ts features/assistant/hooks/useAssistant.ts features/assistant/components/AssistantResponseCard.tsx features/assistant/types/assistant.ts features/agent/assistant/server/answerAssistant.ts features/agent/assistant/types.ts` and it completed successfully.
- Ran type-checking with `npx tsc --noEmit` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23ea9a6ac8328acd47a50b49bc1b7)