### PR TITLE
Canonicalize parts display (SKU / Part #), remove unlabeled internal id, and normalize inventory header styling

### DIFF
--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -4,10 +4,11 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 type Alloc = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
-type PartLite = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku">;
+type PartLite = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku" | "part_number" | "category" | "price">;
 type LocLite = Pick<DB["public"]["Tables"]["stock_locations"]["Row"], "id" | "code" | "name">;
 type WoLite = Pick<DB["public"]["Tables"]["work_orders"]["Row"], "id" | "custom_id">;
 type ReqItemLite = Pick<DB["public"]["Tables"]["part_request_items"]["Row"], "id" | "request_id" | "po_id">;
@@ -67,7 +68,9 @@ export default function AllocationsPage(): JSX.Element {
         const moveIds = [...new Set(list.map((a) => String(a.stock_move_id ?? "")).filter(Boolean))];
 
         const [parts, locs, wos, reqItems, moves] = await Promise.all([
-          partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as PartLite[] }),
+          partIds.length
+            ? supabase.from("parts").select("id,name,sku,part_number,category,price").in("id", partIds)
+            : Promise.resolve({ data: [] as PartLite[] }),
           locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as LocLite[] }),
           woIds.length ? supabase.from("work_orders").select("id,custom_id").in("id", woIds) : Promise.resolve({ data: [] as WoLite[] }),
           reqItemIds.length ? supabase.from("part_request_items").select("id,request_id,po_id").in("id", reqItemIds) : Promise.resolve({ data: [] as ReqItemLite[] }),
@@ -125,7 +128,20 @@ export default function AllocationsPage(): JSX.Element {
               {filtered.map((r) => (
                 <tr key={String(r.a.id)} className="border-t border-white/10 align-top">
                   <td className="p-3.5">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0, 8)}</Link> : <span className="text-neutral-500">—</span>}</td>
-                  <td className="p-3.5"><div className="font-medium text-neutral-100">{r.part?.name ?? String(r.a.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{r.part?.sku ?? ""}</div></td>
+                  <td className="p-3.5">
+                    {(() => {
+                      const summary = r.part ? toPartDisplaySummary(r.part) : null;
+                      return (
+                        <>
+                          <div className="font-medium text-neutral-100">{summary?.name ?? "Unknown part"}</div>
+                          <div className="text-xs text-neutral-500">
+                            {summary ? (summary.sku ? `SKU ${summary.sku}` : "No SKU") : ""}
+                            {summary?.partNumber ? ` · Part # ${summary.partNumber}` : ""}
+                          </div>
+                        </>
+                      );
+                    })()}
+                  </td>
                   <td className="p-3.5">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td>
                   <td className="p-3.5 tabular-nums text-neutral-200">{r.a.qty}</td>
                   <td className="p-3.5 text-xs text-neutral-300">

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -12,6 +12,7 @@ import {
   trustLevelLabel,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
+import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 /* ----------------------------- Types ----------------------------- */
 
@@ -298,6 +299,7 @@ export default function InventoryPage(): JSX.Element {
   const [sku, setSku] = useState<string>("");
   const [category, setCategory] = useState<string>("");
   const [price, setPrice] = useState<number | "">("");
+  const [partNumber, setPartNumber] = useState<string>("");
 
   // initial receive (optional) for Add
   const [initLoc, setInitLoc] = useState<string>("");
@@ -310,6 +312,7 @@ export default function InventoryPage(): JSX.Element {
   const [editSku, setEditSku] = useState<string>("");
   const [editCategory, setEditCategory] = useState<string>("");
   const [editPrice, setEditPrice] = useState<number | "">("");
+  const [editPartNumber, setEditPartNumber] = useState<string>("");
 
   // receive modal (standalone quick receive)
   const [recvOpen, setRecvOpen] = useState<boolean>(false);
@@ -334,8 +337,7 @@ export default function InventoryPage(): JSX.Element {
   const pageWrap = "space-y-4 p-6 text-white";
   const glassCard =
     "rounded-xl border border-white/10 bg-neutral-950/35 backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
-  const glassHeader =
-    "bg-gradient-to-b from-white/5 to-transparent border-b border-white/10";
+  const glassHeader = "bg-slate-950/55 border-b border-white/10";
 
   const inputBase =
     `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-white/10 focus:outline-none ${ACCENT_FOCUS_RING}`;
@@ -392,7 +394,14 @@ export default function InventoryPage(): JSX.Element {
       const q = search.trim();
 
       const { data, error } = await (q
-        ? base.or([`name.ilike.%${q}%`, `sku.ilike.%${q}%`, `category.ilike.%${q}%`].join(","))
+        ? base.or(
+            [
+              `name.ilike.%${q}%`,
+              `sku.ilike.%${q}%`,
+              `part_number.ilike.%${q}%`,
+              `category.ilike.%${q}%`,
+            ].join(","),
+          )
         : base);
 
       const partRows = (!error && (data as Part[])) || [];
@@ -558,6 +567,7 @@ export default function InventoryPage(): JSX.Element {
       shop_id: shopId,
       name: name.trim(),
       sku: sku.trim() ? sku.trim() : undefined,
+      part_number: partNumber.trim() ? partNumber.trim() : undefined,
       category: category.trim() ? category.trim() : undefined,
       price: typeof price === "number" ? price : undefined,
     };
@@ -587,6 +597,7 @@ export default function InventoryPage(): JSX.Element {
     setAddOpen(false);
     setName("");
     setSku("");
+    setPartNumber("");
     setCategory("");
     setPrice("");
     setInitQty("");
@@ -597,6 +608,7 @@ export default function InventoryPage(): JSX.Element {
     setEditPart(p);
     setEditName(p.name ?? "");
     setEditSku(p.sku ?? "");
+    setEditPartNumber(p.part_number ?? "");
     setEditCategory(p.category ?? "");
     setEditPrice(typeof p.price === "number" ? p.price : "");
     setEditOpen(true);
@@ -608,6 +620,7 @@ export default function InventoryPage(): JSX.Element {
     const patch: PartUpdate = {
       name: editName.trim() ? editName.trim() : undefined,
       sku: editSku.trim() ? editSku.trim() : undefined,
+      part_number: editPartNumber.trim() ? editPartNumber.trim() : undefined,
       category: editCategory.trim() ? editCategory.trim() : undefined,
       price: typeof editPrice === "number" ? editPrice : undefined,
     };
@@ -800,18 +813,18 @@ export default function InventoryPage(): JSX.Element {
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <Link href="/assistant?pageType=parts_inventory&pageTitle=Parts%20Inventory" className={btnCopper}>
+              <Link href="/assistant?pageType=parts_inventory&pageTitle=Parts%20Inventory" className={btnBlue}>
                 Ask Assistant
               </Link>
 
               <input
                 className={`${inputBase} w-72`}
-                placeholder="Search name / SKU / category"
+                placeholder="Search name / SKU / part # / category"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
               />
 
-              <button className={btnCopper} onClick={() => setAddOpen(true)} disabled={!shopId}>
+              <button className={btnBlue} onClick={() => setAddOpen(true)} disabled={!shopId}>
                 Add Part
               </button>
 
@@ -846,6 +859,7 @@ export default function InventoryPage(): JSX.Element {
                 <tr className="text-left">
                   <th className="p-3">Name</th>
                   <th className="p-3">SKU</th>
+                  <th className="p-3">Part #</th>
                   <th className="p-3">Category</th>
                   <th className="p-3">Trust</th>
                   <th className="p-3">Price</th>
@@ -855,19 +869,20 @@ export default function InventoryPage(): JSX.Element {
               </thead>
               <tbody>
                 {visibleParts.map((p) => {
+                  const summary = toPartDisplaySummary(p);
                   const total = onHand[p.id] ?? 0;
                   const onHandPill = total > 0 ? pillOk : pillZero;
                   const trust = trustByPartId[p.id] ?? { level: "high", reasons: [] as string[] };
                   return (
                     <tr key={p.id} className="border-t border-white/10">
                       <td className="p-3">
-                        <div className="font-medium text-white">{p.name}</div>
-                        <div className="mt-0.5 text-xs text-neutral-500">
-                          {p.id ? `#${String(p.id).slice(0, 8)}` : ""}
-                        </div>
+                        <div className="font-medium text-white">{summary.name}</div>
+                        {/* Previously this subtitle rendered String(p.id).slice(0, 8), which exposed internal ids as unlabeled metadata. */}
+                        <div className="mt-0.5 text-xs text-neutral-500">Record ID in Edit modal</div>
                       </td>
-                      <td className="p-3">{p.sku ?? "—"}</td>
-                      <td className="p-3">{p.category ?? "—"}</td>
+                      <td className="p-3">{summary.sku ?? "No SKU"}</td>
+                      <td className="p-3">{summary.partNumber ?? "—"}</td>
+                      <td className="p-3">{summary.category ?? "—"}</td>
                       <td className="p-3">
                         <div className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold ${trustBadgeTone(trust.level)}`}>
                           {trustLevelLabel(trust.level)}
@@ -934,6 +949,12 @@ export default function InventoryPage(): JSX.Element {
             <TextField label="Name*" value={name} onChange={setName} placeholder="Part name" />
           </div>
           <TextField label="SKU" value={sku} onChange={setSku} placeholder="Optional" />
+          <TextField
+            label="Part Number"
+            value={partNumber}
+            onChange={setPartNumber}
+            placeholder="Manufacturer or internal part #"
+          />
           <TextField label="Category" value={category} onChange={setCategory} placeholder="Optional" />
           <NumberField label="Price" value={price} onChange={(v) => setPrice(v === "" ? "" : v)} />
         </div>
@@ -987,8 +1008,12 @@ export default function InventoryPage(): JSX.Element {
             <TextField label="Name*" value={editName} onChange={setEditName} />
           </div>
           <TextField label="SKU" value={editSku} onChange={setEditSku} />
+          <TextField label="Part Number" value={editPartNumber} onChange={setEditPartNumber} />
           <TextField label="Category" value={editCategory} onChange={setEditCategory} />
           <NumberField label="Price" value={editPrice} onChange={(v) => setEditPrice(v === "" ? "" : v)} />
+          <div className="sm:col-span-2 text-xs text-neutral-500">
+            {editPart?.id ? `Internal record id: ${editPart.id}` : ""}
+          </div>
         </div>
       </Modal>
 

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -4,10 +4,11 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 type StockMove = DB["public"]["Tables"]["stock_moves"]["Row"];
-type PartLite = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku">;
+type PartLite = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku" | "part_number" | "category" | "price">;
 type LocLite = Pick<DB["public"]["Tables"]["stock_locations"]["Row"], "id" | "code" | "name">;
 type RequestItemLite = Pick<DB["public"]["Tables"]["part_request_items"]["Row"], "id" | "work_order_id">;
 type AllocationLite = Pick<DB["public"]["Tables"]["work_order_part_allocations"]["Row"], "stock_move_id" | "work_order_id" | "source_request_item_id">;
@@ -84,7 +85,9 @@ export default function StockMovementsPage(): JSX.Element {
     const stockMoveRefs = [...new Set(rows.filter((r) => String(r.reference_kind ?? "") === "work_order" && r.reference_id).map((r) => String(r.reference_id)))];
 
     const [pr, lr, reqItems, allocs] = await Promise.all([
-      partIds.length ? supabase.from("parts").select("id,name,sku").in("id", partIds) : Promise.resolve({ data: [] as PartLite[] }),
+      partIds.length
+        ? supabase.from("parts").select("id,name,sku,part_number,category,price").in("id", partIds)
+        : Promise.resolve({ data: [] as PartLite[] }),
       locIds.length ? supabase.from("stock_locations").select("id,code,name").in("id", locIds) : Promise.resolve({ data: [] as LocLite[] }),
       requestItemRefs.length ? supabase.from("part_request_items").select("id,work_order_id").in("id", requestItemRefs) : Promise.resolve({ data: [] as RequestItemLite[] }),
       stockMoveRefs.length ? supabase.from("work_order_part_allocations").select("stock_move_id,work_order_id,source_request_item_id").in("stock_move_id", stockMoveRefs) : Promise.resolve({ data: [] as AllocationLite[] }),
@@ -134,6 +137,7 @@ export default function StockMovementsPage(): JSX.Element {
             <tbody>
               {moves.map((m) => {
                 const part = parts[String(m.part_id)];
+                const partSummary = part ? toPartDisplaySummary(part) : null;
                 const loc = locs[String(m.location_id)];
                 const qty = n(m.qty_change);
                 const refId = String(m.reference_id ?? "");
@@ -141,7 +145,10 @@ export default function StockMovementsPage(): JSX.Element {
                 return (
                   <tr key={String(m.id)} className="border-t border-white/10 align-top">
                     <td className="p-3.5 text-xs text-neutral-400">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td>
-                    <td className="p-3.5"><div className="font-medium text-neutral-100">{part?.name ?? String(m.part_id).slice(0, 8)}</div><div className="text-xs text-neutral-500">{part?.sku ?? ""}</div></td>
+                    <td className="p-3.5">
+                      <div className="font-medium text-neutral-100">{partSummary?.name ?? "Unknown part"}</div>
+                      <div className="text-xs text-neutral-500">{partSummary?.sku ? `SKU ${partSummary.sku}` : "No SKU"}</div>
+                    </td>
                     <td className="p-3.5 text-neutral-300">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td>
                     <td className="p-3.5"><span className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${qty >= 0 ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-200" : "border-rose-500/30 bg-rose-950/20 text-rose-200"}`}>{qty >= 0 ? "+" : ""}{qty}</span></td>
                     <td className="p-3.5"><div className="text-neutral-200">{ctx?.sourceLabel ?? sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{reasonLabel(m.reason)}</div></td>

--- a/app/parts/po/[id]/page.tsx
+++ b/app/parts/po/[id]/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
+import { partOptionLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 
@@ -575,7 +576,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
                   <option value="">— select —</option>
                   {parts.map((p) => (
                     <option key={String(p.id)} value={String(p.id)}>
-                      {p.sku ? `${String(p.sku)} — ${String(p.name)}` : String(p.name ?? String(p.id).slice(0, 8))}
+                      {partOptionLabel(toPartDisplaySummary(p))}
                     </option>
                   ))}
                 </select>
@@ -607,7 +608,9 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
               {linePartId ? (
                 <div className="md:col-span-4 text-[11px] text-neutral-500">
-                  Part #: <span className="text-neutral-200">{String(partById.get(linePartId)?.sku ?? "—")}</span>
+                  SKU: <span className="text-neutral-200">{String(partById.get(linePartId)?.sku ?? "—")}</span>
+                  <span className="mx-2 text-neutral-600">·</span>
+                  Part #: <span className="text-neutral-200">{String(partById.get(linePartId)?.part_number ?? "—")}</span>
                   <span className="mx-2 text-neutral-600">·</span>
                   Name:{" "}
                   <span className="text-neutral-200">{String(partById.get(linePartId)?.name ?? "—")}</span>

--- a/app/parts/po/page.tsx
+++ b/app/parts/po/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
+import { partOptionLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 
@@ -540,9 +541,7 @@ export default function PurchaseOrdersPage(): JSX.Element {
                                     <option value="">— select —</option>
                                     {parts.map((p) => (
                                       <option key={String(p.id)} value={String(p.id)}>
-                                        {p.sku
-                                          ? `${String(p.sku)} — ${String(p.name ?? "")}`
-                                          : String(p.name ?? String(p.id).slice(0, 8))}
+                                        {partOptionLabel(toPartDisplaySummary(p))}
                                       </option>
                                     ))}
                                   </select>
@@ -642,9 +641,7 @@ export default function PurchaseOrdersPage(): JSX.Element {
                                 <option value="">— select —</option>
                                 {parts.map((p) => (
                                   <option key={String(p.id)} value={String(p.id)}>
-                                    {p.sku
-                                      ? `${String(p.sku)} — ${String(p.name ?? "")}`
-                                      : String(p.name ?? String(p.id).slice(0, 8))}
+                                    {partOptionLabel(toPartDisplaySummary(p))}
                                   </option>
                                 ))}
                               </select>

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -18,6 +18,7 @@ import {
   trustReasonTone,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
+import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
 import type { ReceiveDrawerItem } from "@/features/parts/components/ReceiveDrawer";
 
 type DB = Database;
@@ -264,14 +265,22 @@ export default function ReceivingInboxPage(): JSX.Element {
             <tbody>
               {items.map((it) => {
                 const p = it.part_id ? partsMap[it.part_id] : null;
+                const partSummary = p ? toPartDisplaySummary(p) : null;
                 const trust = it.part_id ? trustByPartId[it.part_id] : undefined;
                 const itemState = toItemFlowDisplay({ rawStatus: it.status, qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 const recvState = toReceiveProgressDisplay({ qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 return (
                   <tr key={it.id} className="border-t border-white/10 align-top">
                     <td className="p-3.5">
-                      <div className="font-semibold text-neutral-100">{p?.name ? String(p.name) : it.description}</div>
-                      <div className="mt-1 text-[11px] text-neutral-500">{p?.sku ? `${p.sku} • ` : ""}{itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}</div>
+                      <div className="font-semibold text-neutral-100">{partSummary?.name ?? it.description}</div>
+                      <div className="mt-1 text-[11px] text-neutral-500">
+                        {partSummary
+                          ? partSummary.sku
+                            ? `SKU ${partSummary.sku} • `
+                            : "No SKU • "
+                          : ""}
+                        {itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}
+                      </div>
                       {trust && trust.reasons.length > 0 ? <div className={`mt-1 text-[11px] ${trustReasonTone(trust.level)}`}>{trust.reasons.slice(0,2).join(" · ")}</div> : null}
                     </td>
                     <td className="p-3.5">
@@ -279,7 +288,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                       {trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trustLevelLabel(trust.level)}</span> : null}
                     </td>
                     <td className="p-3.5 tabular-nums text-neutral-200">{it.qty_received} / {it.qty_approved} <span className="text-neutral-500">({it.qty_remaining} rem)</span></td>
-                    <td className="p-3.5"><button onClick={() => {setDrawerItem({ ...it, part_name: p?.name ?? null, sku: p?.sku ?? null, trust_level: trust?.level, trust_reasons: trust?.reasons ?? [] }); setDrawerOpen(true);}} className="rounded-lg border border-sky-500/35 px-3 py-1 text-sky-200">Receive</button></td>
+                    <td className="p-3.5"><button onClick={() => {setDrawerItem({ ...it, part_name: partSummary?.name ?? null, sku: partSummary?.sku ?? null, trust_level: trust?.level, trust_reasons: trust?.reasons ?? [] }); setDrawerOpen(true);}} className="rounded-lg border border-sky-500/35 px-3 py-1 text-sky-200">Receive</button></td>
                   </tr>
                 );
               })}

--- a/features/parts/components/PartPicker.tsx
+++ b/features/parts/components/PartPicker.tsx
@@ -14,6 +14,7 @@ import {
   useAiPartSuggestions,
   type AiPartSuggestion,
 } from "@/features/parts/hooks/useAiPartSuggestions";
+import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 type UUID = string;
@@ -235,7 +236,7 @@ export function PartPicker({
         const term = search.trim();
         if (term) {
           q = q.or(
-            `name.ilike.%${term}%,sku.ilike.%${term}%,category.ilike.%${term}%`,
+            `name.ilike.%${term}%,sku.ilike.%${term}%,part_number.ilike.%${term}%,category.ilike.%${term}%`,
           );
         }
 
@@ -523,6 +524,7 @@ export function PartPicker({
                   ) : (
                     parts.map((p) => {
                       const pid = p.id as UUID;
+                      const summary = toPartDisplaySummary(p);
                       const active = selectedPartId === pid;
                       return (
                         <button
@@ -546,10 +548,10 @@ export function PartPicker({
                           type="button"
                         >
                           <div className="truncate text-sm font-semibold text-neutral-50">
-                            {p.name ?? "Unnamed part"}
+                            {summary.name}
                           </div>
                           <div className="truncate text-xs text-neutral-500">
-                            {p.sku ?? "—"} • {p.category ?? "Uncategorized"}
+                            {summary.sku ?? "No SKU"} • {summary.partNumber ? `Part # ${summary.partNumber}` : "No part #"} • {summary.category ?? "Uncategorized"}
                           </div>
                         </button>
                       );

--- a/features/parts/lib/part-display.ts
+++ b/features/parts/lib/part-display.ts
@@ -1,0 +1,52 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type PartRow = Database["public"]["Tables"]["parts"]["Row"];
+
+export type PartDisplaySummary = {
+  id: string;
+  name: string;
+  sku: string | null;
+  partNumber: string | null;
+  category: string | null;
+  price: number | null;
+  internalRecordLabel: string;
+  labeledIdentifiers: Array<{ label: "SKU" | "Part #"; value: string }>;
+};
+
+function clean(v: string | null | undefined): string | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+export function toPartDisplaySummary(part: Pick<PartRow, "id" | "name" | "sku" | "part_number" | "category" | "price">): PartDisplaySummary {
+  const sku = clean(part.sku);
+  const partNumber = clean(part.part_number);
+
+  const labeledIdentifiers: PartDisplaySummary["labeledIdentifiers"] = [];
+  if (sku) labeledIdentifiers.push({ label: "SKU", value: sku });
+  if (partNumber) labeledIdentifiers.push({ label: "Part #", value: partNumber });
+
+  return {
+    id: String(part.id),
+    name: clean(part.name) ?? "Unnamed part",
+    sku,
+    partNumber,
+    category: clean(part.category),
+    price: typeof part.price === "number" ? part.price : null,
+    internalRecordLabel: `Record ${String(part.id).slice(0, 8)}`,
+    labeledIdentifiers,
+  };
+}
+
+export function partOptionLabel(summary: PartDisplaySummary): string {
+  if (summary.sku) return `${summary.sku} — ${summary.name}`;
+  if (summary.partNumber) return `${summary.partNumber} — ${summary.name}`;
+  return summary.name;
+}
+
+export function partSearchText(summary: PartDisplaySummary): string {
+  return [summary.name, summary.sku ?? "", summary.partNumber ?? "", summary.category ?? ""]
+    .join(" ")
+    .toLowerCase();
+}


### PR DESCRIPTION
### Motivation
- Inventory UI was showing an unlabeled shortened internal `parts.id` under part names which could be mistaken for a business part number. 
- Parts identifier semantics were inconsistent across inventory, receiving, PO, allocations, movements, and pickers and needed a single, safe display contract. 
- The inventory header had a warm/copper visual drift that diverged from the cooler operational Parts styling and needed to be normalized. 

### Description
- Added a canonical mapper `toPartDisplaySummary` and helpers in `features/parts/lib/part-display.ts` that produce a normalized `PartDisplaySummary` shape (name, sku, partNumber, category, price, labeled identifiers, internalRecordLabel). 
- Inventory page (`app/parts/inventory/page.tsx`) now uses the mapper, removes the unlabeled `id.slice(0,8)` subtitle from primary rows, adds a dedicated `Part #` column, exposes `part_number` on Add/Edit forms, and includes `part_number` in search. 
- Propagated the normalized display usage to consumers so they no longer rely on unlabeled id fallbacks: `app/parts/receiving/page.tsx`, `app/parts/po/page.tsx`, `app/parts/po/[id]/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/movements/page.tsx`, and `features/parts/components/PartPicker.tsx` now render labeled SKU and Part # (where present) and use `partOptionLabel` for select labels. 
- Styling: replaced the warm header gradient with a cooler slate/neutral header `bg-slate-950/55` and adjusted inventory top action button tone to the blue operational style for consistency; preserved existing glass/dark card primitives. 
- No schema changes or migrations were added and no new data paths were introduced; `parts.part_number` (existing column) is used where applicable. 

Files changed (key):
- Added: `features/parts/lib/part-display.ts` 
- Modified: `app/parts/inventory/page.tsx`, `app/parts/receiving/page.tsx`, `app/parts/po/page.tsx`, `app/parts/po/[id]/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/movements/page.tsx`, `features/parts/components/PartPicker.tsx` 

### Testing
- Ran TypeScript check: `npx tsc --noEmit` and it passed (run after changes). 
- No unit or integration tests were modified; changes are UI/data-shape focused and rely on existing DB fields only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e241c72d0c83289cd994acbff127e8)