### PR TITLE
Tighten inventory identifier persistence/search checks and clean parts metadata UI

### DIFF
--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 type Alloc = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
@@ -102,7 +102,22 @@ export default function AllocationsPage(): JSX.Element {
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
     if (!q) return rows;
-    return rows.filter((r) => [r.part?.name, r.part?.sku, r.loc?.code, r.wo?.custom_id, r.a.work_order_id, r.req?.request_id, r.move?.reference_kind].join(" ").toLowerCase().includes(q));
+    return rows
+      .filter((r) =>
+        [
+          r.part?.name,
+          r.part?.sku,
+          r.part?.part_number,
+          r.loc?.code,
+          r.wo?.custom_id,
+          r.a.work_order_id,
+          r.req?.request_id,
+          r.move?.reference_kind,
+        ]
+          .join(" ")
+          .toLowerCase()
+          .includes(q),
+      );
   }, [rows, search]);
 
   return (
@@ -127,17 +142,16 @@ export default function AllocationsPage(): JSX.Element {
             <tbody>
               {filtered.map((r) => (
                 <tr key={String(r.a.id)} className="border-t border-white/10 align-top">
-                  <td className="p-3.5">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? String(r.a.work_order_id).slice(0, 8)}</Link> : <span className="text-neutral-500">—</span>}</td>
+                  <td className="p-3.5">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? "Work order"}</Link> : <span className="text-neutral-500">—</span>}</td>
                   <td className="p-3.5">
                     {(() => {
                       const summary = r.part ? toPartDisplaySummary(r.part) : null;
                       return (
                         <>
                           <div className="font-medium text-neutral-100">{summary?.name ?? "Unknown part"}</div>
-                          <div className="text-xs text-neutral-500">
-                            {summary ? (summary.sku ? `SKU ${summary.sku}` : "No SKU") : ""}
-                            {summary?.partNumber ? ` · Part # ${summary.partNumber}` : ""}
-                          </div>
+                          {summary && summary.labeledIdentifiers.length > 0 ? (
+                            <div className="text-xs text-neutral-500">{partIdentifierLabel(summary)}</div>
+                          ) : null}
                         </>
                       );
                     })()}
@@ -145,7 +159,7 @@ export default function AllocationsPage(): JSX.Element {
                   <td className="p-3.5">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td>
                   <td className="p-3.5 tabular-nums text-neutral-200">{r.a.qty}</td>
                   <td className="p-3.5 text-xs text-neutral-300">
-                    {r.req?.request_id ? <span className="rounded border border-white/10 px-2 py-0.5">Request {String(r.req.request_id).slice(0, 8)}</span> : <span className="text-neutral-500">No request link</span>}
+                    {r.req?.request_id ? <span className="rounded border border-white/10 px-2 py-0.5">Linked request</span> : <span className="text-neutral-500">No request link</span>}
                     <div className="mt-1 text-neutral-500">{String(r.move?.reference_kind ?? "—").replaceAll("_", " ")} · {movementReasonLabel(r.move?.reason)}</div>
                   </td>
                   <td className="p-3.5 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td>

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -858,8 +858,8 @@ export default function InventoryPage(): JSX.Element {
               <thead className="bg-white/5 text-neutral-400">
                 <tr className="text-left">
                   <th className="p-3">Name</th>
-                  <th className="p-3">SKU</th>
-                  <th className="p-3">Part #</th>
+                  <th className="w-40 p-3">SKU</th>
+                  <th className="w-40 p-3">Part #</th>
                   <th className="p-3">Category</th>
                   <th className="p-3">Trust</th>
                   <th className="p-3">Price</th>
@@ -880,8 +880,8 @@ export default function InventoryPage(): JSX.Element {
                         {/* Previously this subtitle rendered String(p.id).slice(0, 8), which exposed internal ids as unlabeled metadata. */}
                         <div className="mt-0.5 text-xs text-neutral-500">Record ID in Edit modal</div>
                       </td>
-                      <td className="p-3">{summary.sku ?? "No SKU"}</td>
-                      <td className="p-3">{summary.partNumber ?? "—"}</td>
+                      <td className="p-3 font-mono text-xs text-neutral-300">{summary.sku ?? "—"}</td>
+                      <td className="p-3 font-mono text-xs text-neutral-300">{summary.partNumber ?? "—"}</td>
                       <td className="p-3">{summary.category ?? "—"}</td>
                       <td className="p-3">
                         <div className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold ${trustBadgeTone(trust.level)}`}>

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 type StockMove = DB["public"]["Tables"]["stock_moves"]["Row"];
@@ -147,7 +147,9 @@ export default function StockMovementsPage(): JSX.Element {
                     <td className="p-3.5 text-xs text-neutral-400">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td>
                     <td className="p-3.5">
                       <div className="font-medium text-neutral-100">{partSummary?.name ?? "Unknown part"}</div>
-                      <div className="text-xs text-neutral-500">{partSummary?.sku ? `SKU ${partSummary.sku}` : "No SKU"}</div>
+                      {partSummary && partSummary.labeledIdentifiers.length > 0 ? (
+                        <div className="text-xs text-neutral-500">{partIdentifierLabel(partSummary)}</div>
+                      ) : null}
                     </td>
                     <td className="p-3.5 text-neutral-300">{loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{loc?.name ?? ""}</span></td>
                     <td className="p-3.5"><span className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${qty >= 0 ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-200" : "border-rose-500/30 bg-rose-950/20 text-rose-200"}`}>{qty >= 0 ? "+" : ""}{qty}</span></td>

--- a/app/parts/po/[id]/page.tsx
+++ b/app/parts/po/[id]/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
-import { partOptionLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import { partIdentifierLabel, partOptionLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type DB = Database;
 
@@ -90,7 +90,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
     const m = new Map<string, string>();
     for (const s of suppliers) {
       const id = String(s.id);
-      const nm = typeof s.name === "string" && s.name.trim() ? s.name.trim() : id.slice(0, 8);
+      const nm = typeof s.name === "string" && s.name.trim() ? s.name.trim() : "Unnamed supplier";
       m.set(id, nm);
     }
     return m;
@@ -142,7 +142,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
     return {
       ...row,
-      ui_part_name: p?.name ? String(p.name) : partId ? partId.slice(0, 8) : "—",
+      ui_part_name: p?.name ? String(p.name) : "Unnamed part",
       ui_sku: p?.sku ? String(p.sku) : "",
       ui_ordered: ordered,
       ui_received: received,
@@ -238,7 +238,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
       return {
         ...r,
-        ui_part_name: p?.name ? String(p.name) : pid ? pid.slice(0, 8) : "—",
+        ui_part_name: p?.name ? String(p.name) : "Unnamed part",
         ui_sku: p?.sku ? String(p.sku) : "",
         ui_ordered: ordered,
         ui_received: received,
@@ -434,7 +434,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
   }
 
   const poSupplierId = supplierId || ((po.supplier_id as string | null) ?? "");
-  const supplierName = poSupplierId ? supplierNameById.get(poSupplierId) ?? poSupplierId.slice(0, 8) : "—";
+  const supplierName = poSupplierId ? supplierNameById.get(poSupplierId) ?? "Unnamed supplier" : "—";
   const poStatus = (status || (po.status as string | null) || "open").toLowerCase();
 
   return (
@@ -482,7 +482,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
                   <option value="">— select —</option>
                   {suppliers.map((s) => (
                     <option key={String(s.id)} value={String(s.id)}>
-                      {String(s.name ?? String(s.id).slice(0, 8))}
+                      {String(s.name ?? "Unnamed supplier")}
                     </option>
                   ))}
                 </select>
@@ -608,12 +608,22 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
               {linePartId ? (
                 <div className="md:col-span-4 text-[11px] text-neutral-500">
-                  SKU: <span className="text-neutral-200">{String(partById.get(linePartId)?.sku ?? "—")}</span>
-                  <span className="mx-2 text-neutral-600">·</span>
-                  Part #: <span className="text-neutral-200">{String(partById.get(linePartId)?.part_number ?? "—")}</span>
-                  <span className="mx-2 text-neutral-600">·</span>
-                  Name:{" "}
-                  <span className="text-neutral-200">{String(partById.get(linePartId)?.name ?? "—")}</span>
+                  {(() => {
+                    const part = partById.get(linePartId);
+                    if (!part) return <span className="text-neutral-400">Part selected</span>;
+                    const summary = toPartDisplaySummary(part);
+                    return (
+                      <>
+                        {summary.labeledIdentifiers.length > 0 ? (
+                          <>
+                            <span className="text-neutral-300">{partIdentifierLabel(summary)}</span>
+                            <span className="mx-2 text-neutral-600">·</span>
+                          </>
+                        ) : null}
+                        Name: <span className="text-neutral-200">{summary.name}</span>
+                      </>
+                    );
+                  })()}
                 </div>
               ) : null}
             </div>

--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -20,6 +20,7 @@ import {
   trustReasonTone,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
+import { partOptionLabel, partSearchText, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 
 type QuaggaResult = { codeResult?: { code?: string | null } | null };
 
@@ -428,7 +429,7 @@ export default function PoReceivePage(): JSX.Element {
   };
 
   const poStatus = String(po?.status ?? "—");
-  const supplierName = supplier?.name ?? (po?.supplier_id ? String(po.supplier_id).slice(0, 8) : "—");
+  const supplierName = supplier?.name ?? (po?.supplier_id ? "Unknown supplier" : "—");
 
   const totalOrdered = useMemo(() => lines.reduce((sum, l) => sum + n(l.qty), 0), [lines]);
   const totalReceived = useMemo(() => lines.reduce((sum, l) => sum + n(l.received_qty), 0), [lines]);
@@ -438,12 +439,7 @@ export default function PoReceivePage(): JSX.Element {
     const term = manualSearch.trim().toLowerCase();
     if (!term) return parts.slice(0, 180);
     return parts
-      .filter((p) => {
-        const name = String(p.name ?? "").toLowerCase();
-        const sku = String(p.sku ?? "").toLowerCase();
-        const cat = String(p.category ?? "").toLowerCase();
-        return name.includes(term) || sku.includes(term) || cat.includes(term);
-      })
+      .filter((p) => partSearchText(toPartDisplaySummary(p)).includes(term))
       .slice(0, 180);
   }, [manualSearch, parts]);
 
@@ -625,7 +621,7 @@ export default function PoReceivePage(): JSX.Element {
                   <option value="">— select —</option>
                   {filteredParts.map((p) => (
                     <option key={String(p.id)} value={String(p.id)}>
-                      {p.name ?? "Unnamed"} {p.sku ? `• ${p.sku}` : ""} {p.category ? `• ${p.category}` : ""}
+                      {partOptionLabel(toPartDisplaySummary(p))}
                     </option>
                   ))}
                 </select>
@@ -688,9 +684,7 @@ export default function PoReceivePage(): JSX.Element {
                     return (
                       <tr key={String(ln.id)} className="border-t border-white/5 hover:bg-white/5">
                         <td className="p-3">
-                          <div className="font-mono text-xs text-neutral-300">
-                            {ln.part_id ? String(ln.part_id).slice(0, 8) : "—"}
-                          </div>
+                          <div className="font-mono text-xs text-neutral-300">{ln.part_id ? "Linked part" : "Unmapped part"}</div>
                           <div className="text-xs text-neutral-500">{ln.description ?? "—"}</div>
                           <div className="mt-1 flex items-center gap-2">
                             <span className="text-[11px] text-neutral-400">{receiveProgressLabel(recvState)}</span>

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -18,7 +18,7 @@ import {
   trustReasonTone,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
-import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 import type { ReceiveDrawerItem } from "@/features/parts/components/ReceiveDrawer";
 
 type DB = Database;
@@ -274,11 +274,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                     <td className="p-3.5">
                       <div className="font-semibold text-neutral-100">{partSummary?.name ?? it.description}</div>
                       <div className="mt-1 text-[11px] text-neutral-500">
-                        {partSummary
-                          ? partSummary.sku
-                            ? `SKU ${partSummary.sku} • `
-                            : "No SKU • "
-                          : ""}
+                        {partSummary && partSummary.labeledIdentifiers.length > 0 ? `${partIdentifierLabel(partSummary)} · ` : ""}
                         {itemFlowLabel(itemState)} · {receiveProgressLabel(recvState)} {it.work_order_id ? <>· <Link className="text-neutral-300 hover:text-white" href={`/work-orders/${encodeURIComponent(it.work_order_id)}`}>WO {it.work_order_id.slice(0,8)}</Link></> : null}
                       </div>
                       {trust && trust.reasons.length > 0 ? <div className={`mt-1 text-[11px] ${trustReasonTone(trust.level)}`}>{trust.reasons.slice(0,2).join(" · ")}</div> : null}

--- a/features/parts/lib/part-display.ts
+++ b/features/parts/lib/part-display.ts
@@ -34,7 +34,7 @@ export function toPartDisplaySummary(part: Pick<PartRow, "id" | "name" | "sku" |
     partNumber,
     category: clean(part.category),
     price: typeof part.price === "number" ? part.price : null,
-    internalRecordLabel: `Record ${String(part.id).slice(0, 8)}`,
+    internalRecordLabel: "Record",
     labeledIdentifiers,
   };
 }
@@ -43,6 +43,10 @@ export function partOptionLabel(summary: PartDisplaySummary): string {
   if (summary.sku) return `${summary.sku} — ${summary.name}`;
   if (summary.partNumber) return `${summary.partNumber} — ${summary.name}`;
   return summary.name;
+}
+
+export function partIdentifierLabel(summary: PartDisplaySummary): string {
+  return summary.labeledIdentifiers.map((item) => `${item.label} ${item.value}`).join(" · ");
 }
 
 export function partSearchText(summary: PartDisplaySummary): string {


### PR DESCRIPTION
### Motivation
- Ensure part identifiers are persisted and normalized consistently for create/update flows while avoiding noisy UI fallbacks.  
- Preserve existing inventory search behavior (match `name`, `sku`, `part_number`, `category`) while including identifier fields in all relevant search surfaces.  
- Remove accidental internal-id leakage and consolidate ad hoc identifier formatting into a canonical helper so user-facing rows only show identifiers when they exist.

### Description
- Added `partIdentifierLabel` to `features/parts/lib/part-display.ts` and reused it across parts surfaces for compact identifier chips (SKU / Part #).  
- Replaced ad-hoc identifier rendering on: `app/parts/allocations/page.tsx`, `app/parts/movements/page.tsx`, `app/parts/receiving/page.tsx`, `app/parts/po/[id]/page.tsx`, and `app/parts/po/[id]/receive/page.tsx` to use the canonical helper and only render when values exist.  
- Tightened inventory table layout in `app/parts/inventory/page.tsx` by constraining SKU / Part # column widths and rendering them in compact monospace cells for better desktop scanability while keeping the new Part # column.  
- Reduced internal-id subtitle/fallback leakage by removing `String(id).slice(0,8)` and other id fallbacks from primary user-facing rows and replacing them with stable, friendly labels (internal ids remain available in edit/admin contexts via the modal).  
- Preserved inventory persistence contract: create and edit payloads continue to include both `sku` and `part_number`, with consistent empty-string normalization (use `trim() ? value : undefined` or `value || undefined`) so null/empty values render cleanly.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully.  
- Verified search/query contract in `app/parts/inventory/page.tsx` still uses `name.ilike`, `sku.ilike`, `part_number.ilike` and `category.ilike`, preserving existing behavior.  
- Ran targeted grep checks for remaining id-slice and noisy identifier patterns and validated the touched surfaces no longer render unlabeled internal id snippets or forced "No SKU" noisy labels.  
- Files modified in this pass: `features/parts/lib/part-display.ts`, `app/parts/inventory/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/movements/page.tsx`, `app/parts/receiving/page.tsx`, `app/parts/po/[id]/page.tsx`, and `app/parts/po/[id]/receive/page.tsx` and TypeScript validation passed for the changeset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24bd1793c8328992ecd2de9044090)