### PR TITLE
Harden Planner with explicit proposal classification and confirm/apply execution

### DIFF
--- a/app/agent/planner/page.tsx
+++ b/app/agent/planner/page.tsx
@@ -12,6 +12,10 @@ import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 import { WorkOrderPreviewTrigger } from "app/work-orders/components/WorkOrderPreviewTrigger";
 import { WorkOrderPreview } from "app/work-orders/components/WorkOrderPreview";
 import VinCaptureModal from "app/vehicle/VinCaptureModal";
+import type {
+  PlannerExecutionResult,
+  PlannerProposal,
+} from "@/features/agent/lib/plannerProposal";
 
 type OcrFields = {
   vin?: string | null;
@@ -41,7 +45,10 @@ type PlannerLane =
   | "fleet_follow_up"
   | "menu_item_draft"
   | "inspection_template_draft"
-  | "service_bundle_draft";
+  | "service_bundle_draft"
+  | "resolve_approval_queue"
+  | "reschedule_booking"
+  | "work_order_operations";
 
 const LANE_LABEL: Record<PlannerLane, string> = {
   parts_follow_up: "Parts follow-up",
@@ -50,6 +57,9 @@ const LANE_LABEL: Record<PlannerLane, string> = {
   menu_item_draft: "Menu item draft",
   inspection_template_draft: "Inspection template draft",
   service_bundle_draft: "Service bundle draft",
+  resolve_approval_queue: "Resolve approval queue",
+  reschedule_booking: "Reschedule booking",
+  work_order_operations: "Work-order operations",
 };
 
 type PlannerStartOut = {
@@ -59,18 +69,6 @@ type PlannerStartOut = {
 };
 
 type PlannerEvent = Record<string, unknown> & { kind?: string };
-type PlannerProposal = {
-  domain: "parts" | "menu_item_draft" | "inspection_template_draft";
-  lane: string;
-  title: string;
-  summary: string;
-  sections: Array<{ title: string; items: string[] }>;
-  warnings: string[];
-  affectedRecords: Array<{ type: string; id: string; href: string; label: string }>;
-  reviewActions: string[];
-  executionSummary: string;
-};
-
 type AnyObj = Record<string, unknown>;
 
 function isObj(v: unknown): v is AnyObj {
@@ -178,61 +176,75 @@ function extractNotifications(evt: PlannerEvent): Array<{
 function extractProposal(evt: PlannerEvent): PlannerProposal | null {
   const raw = getField(evt, "proposal");
   if (!isObj(raw)) return null;
-  const domain = asString(raw.domain);
+
+  const classification = asString(raw.classification);
   if (
-    domain !== "parts" &&
-    domain !== "menu_item_draft" &&
-    domain !== "inspection_template_draft"
+    classification !== "draft_only" &&
+    classification !== "confirmable_write" &&
+    classification !== "informational"
   ) {
     return null;
   }
 
-  const sections = Array.isArray(raw.sections)
-    ? raw.sections
-        .filter((item) => isObj(item))
-        .map((item) => ({
-          title: asString(item.title) ?? "Section",
-          items: Array.isArray(item.items)
-            ? item.items
-                .map((value: unknown) => asString(value))
-                .filter((value: string | null): value is string => Boolean(value))
-            : [],
-        }))
-    : [];
-
-  const warnings = Array.isArray(raw.warnings)
-    ? raw.warnings
-        .map((value) => asString(value))
-        .filter((value): value is string => Boolean(value))
-    : [];
-
-  const affectedRecords = Array.isArray(raw.affectedRecords)
-    ? raw.affectedRecords
-        .filter((item) => isObj(item))
-        .map((item) => ({
-          type: asString(item.type) ?? "record",
-          id: asString(item.id) ?? "",
-          href: asString(item.href) ?? "#",
-          label: asString(item.label) ?? "Record",
-        }))
-    : [];
-
-  const reviewActions = Array.isArray(raw.reviewActions)
-    ? raw.reviewActions
-        .map((value) => asString(value))
-        .filter((value): value is string => Boolean(value))
-    : [];
+  const stringList = (value: unknown) =>
+    Array.isArray(value)
+      ? value
+          .map((entry) => asString(entry))
+          .filter((entry): entry is string => Boolean(entry))
+      : [];
 
   return {
-    domain,
+    id: asString(raw.id) ?? crypto.randomUUID(),
     lane: asString(raw.lane) ?? "",
+    classification,
     title: asString(raw.title) ?? "Proposal",
     summary: asString(raw.summary) ?? "",
-    sections,
-    warnings,
-    affectedRecords,
-    reviewActions,
-    executionSummary: asString(raw.executionSummary) ?? "",
+    proposed_steps: stringList(raw.proposed_steps),
+    affected_records: Array.isArray(raw.affected_records)
+      ? raw.affected_records
+          .filter((item) => isObj(item))
+          .map((item) => ({
+            type: asString(item.type) ?? "record",
+            id: asString(item.id) ?? "",
+            href: asString(item.href) ?? "#",
+            label: asString(item.label) ?? "Record",
+          }))
+      : [],
+    warnings: stringList(raw.warnings),
+    review_actions: stringList(raw.review_actions),
+    duplicate_candidates: stringList(raw.duplicate_candidates),
+    source_rationale: stringList(raw.source_rationale),
+    confirmation_required: getField(raw, "confirmation_required") === true,
+    execution_available: getField(raw, "execution_available") === true,
+    execution_label: asString(raw.execution_label) ?? "Confirm and apply",
+    not_executable_reason: asString(raw.not_executable_reason) ?? undefined,
+    result_summary: asString(raw.result_summary) ?? undefined,
+    result_links: Array.isArray(raw.result_links)
+      ? raw.result_links
+          .filter((item) => isObj(item))
+          .map((item) => ({
+            href: asString(item.href) ?? "#",
+            label: asString(item.label) ?? "Result",
+          }))
+      : [],
+    audit: {
+      generated_at:
+        asString(getNested(raw, ["audit", "generated_at"])) ??
+        new Date().toISOString(),
+      run_id: asString(getNested(raw, ["audit", "run_id"])) ?? undefined,
+      event_step:
+        typeof getNested(raw, ["audit", "event_step"]) === "number"
+          ? (getNested(raw, ["audit", "event_step"]) as number)
+          : undefined,
+    },
+    execution_payload: isObj(raw.execution_payload)
+      ? {
+          lane: asString(raw.execution_payload.lane) ?? "",
+          action: asString(raw.execution_payload.action) ?? "",
+          data: isObj(raw.execution_payload.data) ? raw.execution_payload.data : {},
+        }
+      : undefined,
+    execution_result: undefined,
   };
 }
 
@@ -324,6 +336,11 @@ export default function PlannerPage() {
   const [runId, setRunId] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const [proposals, setProposals] = useState<PlannerProposal[]>([]);
+  const [applyConfirmations, setApplyConfirmations] = useState<Record<string, boolean>>({});
+  const [applyingProposalId, setApplyingProposalId] = useState<string | null>(null);
+  const [executionResults, setExecutionResults] = useState<
+    Record<string, PlannerExecutionResult>
+  >({});
 
   const esRef = useRef<EventSource | null>(null);
   const autoRanRef = useRef(false);
@@ -410,7 +427,10 @@ export default function PlannerPage() {
       laneParam === "fleet_follow_up" ||
       laneParam === "menu_item_draft" ||
       laneParam === "inspection_template_draft" ||
-      laneParam === "service_bundle_draft"
+      laneParam === "service_bundle_draft" ||
+      laneParam === "resolve_approval_queue" ||
+      laneParam === "reschedule_booking" ||
+      laneParam === "work_order_operations"
     ) {
       setLane(laneParam);
     }
@@ -594,6 +614,8 @@ export default function PlannerPage() {
     setSummary(null);
     setNotifications([]);
     setProposals([]);
+    setApplyConfirmations({});
+    setExecutionResults({});
     setRunId(null);
     setPreviewWoId(null);
     setPreviewOpen(false);
@@ -613,6 +635,8 @@ export default function PlannerPage() {
     setSummary(null);
     setNotifications([]);
     setProposals([]);
+    setApplyConfirmations({});
+    setExecutionResults({});
     esRef.current?.close();
     esRef.current = null;
 
@@ -829,6 +853,44 @@ export default function PlannerPage() {
     } catch (e: unknown) {
       appendStep(`Error: ${toMsg(e)}`);
       setRunning(false);
+    }
+  }
+
+  async function applyProposal(proposal: PlannerProposal) {
+    if (!runId) {
+      appendStep("Apply blocked: missing run id.");
+      return;
+    }
+    if (!applyConfirmations[proposal.id]) {
+      appendStep("Apply blocked: confirm review before apply.");
+      return;
+    }
+    setApplyingProposalId(proposal.id);
+    try {
+      const res = await fetch("/api/planner/apply", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          runId,
+          proposalId: proposal.id,
+          confirmationToken: "CONFIRM_APPLY",
+          applyKey: crypto.randomUUID(),
+        }),
+      });
+      const out = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        proposalId?: string;
+        result?: PlannerExecutionResult;
+      };
+      if (!res.ok || !out.result || !out.proposalId) {
+        throw new Error(out.error ?? `Apply failed (HTTP ${res.status})`);
+      }
+      setExecutionResults((prev) => ({ ...prev, [out.proposalId as string]: out.result as PlannerExecutionResult }));
+      appendStep(out.result.summary);
+    } catch (error: unknown) {
+      appendStep(`Apply failed: ${toMsg(error)}`);
+    } finally {
+      setApplyingProposalId(null);
     }
   }
 
@@ -1144,58 +1206,65 @@ export default function PlannerPage() {
         {proposals.length > 0 ? (
           <div className="mt-4 space-y-4">
             {proposals.map((proposal, index) => (
+              (() => {
+                const executionResult = executionResults[proposal.id];
+                const isDraft = proposal.classification === "draft_only";
+                const isConfirmable = proposal.classification === "confirmable_write";
+                const canApply =
+                  isConfirmable &&
+                  proposal.execution_available &&
+                  applyConfirmations[proposal.id] === true &&
+                  applyingProposalId !== proposal.id;
+
+                return (
               <div
-                key={`${proposal.domain}-${proposal.lane}-${index}`}
-                className="rounded-3xl border border-sky-400/30 bg-sky-950/20 p-4 shadow-[0_12px_35px_rgba(0,0,0,0.75)]"
+                key={`${proposal.id}-${proposal.lane}-${index}`}
+                className={`rounded-3xl p-4 shadow-[0_12px_35px_rgba(0,0,0,0.75)] ${
+                  isDraft
+                    ? "border border-violet-400/30 bg-violet-950/20"
+                    : "border border-sky-400/30 bg-sky-950/20"
+                }`}
               >
                 <div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-200">
-                  Review-first proposal
+                  {isDraft ? "Draft proposal" : isConfirmable ? "Review before apply" : "Informational plan"}
                 </div>
                 <div className="mt-1 text-lg font-semibold text-white">{proposal.title}</div>
                 <div className="mt-2 text-sm text-neutral-200">{proposal.summary}</div>
 
                 <div className="mt-4 grid gap-3 md:grid-cols-2">
-                  {proposal.sections.map((section) => (
-                    <div
-                      key={`${proposal.title}-${section.title}`}
-                      className="rounded-2xl border border-white/10 bg-black/35 p-3"
-                    >
-                      <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">
-                        {section.title}
-                      </div>
-                      <ul className="mt-2 space-y-1">
-                        {section.items.map((item, itemIdx) => (
-                          <li key={`${section.title}-${itemIdx}`} className="text-sm text-neutral-100">
-                            • {item}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-
-                {proposal.warnings.length > 0 ? (
-                  <div className="mt-3 rounded-2xl border border-amber-400/30 bg-amber-500/10 p-3">
-                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-amber-200">
-                      Warnings
+                  <div className="rounded-2xl border border-white/10 bg-black/35 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">
+                      Proposed plan
                     </div>
                     <ul className="mt-2 space-y-1">
-                      {proposal.warnings.map((warning, warningIdx) => (
-                        <li key={`${warningIdx}-${warning}`} className="text-sm text-amber-100">
-                          • {warning}
+                      {proposal.proposed_steps.map((item, itemIdx) => (
+                        <li key={`${proposal.id}-step-${itemIdx}`} className="text-sm text-neutral-100">
+                          • {item}
                         </li>
                       ))}
                     </ul>
                   </div>
-                ) : null}
+                  <div className="rounded-2xl border border-white/10 bg-black/35 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">
+                      Source rationale
+                    </div>
+                    <ul className="mt-2 space-y-1">
+                      {proposal.source_rationale.map((item, itemIdx) => (
+                        <li key={`${proposal.id}-source-${itemIdx}`} className="text-sm text-neutral-100">
+                          • {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
 
-                {proposal.affectedRecords.length > 0 ? (
+                {proposal.affected_records.length > 0 ? (
                   <div className="mt-3 rounded-2xl border border-white/10 bg-black/35 p-3">
                     <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">
                       Affected records
                     </div>
                     <div className="mt-2 flex flex-wrap gap-2">
-                      {proposal.affectedRecords.slice(0, 8).map((record) => (
+                      {proposal.affected_records.slice(0, 10).map((record) => (
                         <a
                           key={`${record.type}-${record.id}-${record.href}`}
                           href={record.href}
@@ -1208,13 +1277,43 @@ export default function PlannerPage() {
                   </div>
                 ) : null}
 
-                {proposal.reviewActions.length > 0 ? (
+                {proposal.warnings.length > 0 ? (
+                  <div className="mt-3 rounded-2xl border border-amber-400/30 bg-amber-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-amber-200">
+                      Warnings / validation checks
+                    </div>
+                    <ul className="mt-2 space-y-1">
+                      {proposal.warnings.map((warning, warningIdx) => (
+                        <li key={`${warningIdx}-${warning}`} className="text-sm text-amber-100">
+                          • {warning}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {proposal.duplicate_candidates.length > 0 ? (
+                  <div className="mt-3 rounded-2xl border border-rose-400/30 bg-rose-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-rose-200">
+                      Overlap / duplicate candidates
+                    </div>
+                    <ul className="mt-2 space-y-1">
+                      {proposal.duplicate_candidates.map((item, itemIdx) => (
+                        <li key={`${proposal.id}-dup-${itemIdx}`} className="text-sm text-rose-100">
+                          • {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {proposal.review_actions.length > 0 ? (
                   <div className="mt-3 rounded-2xl border border-white/10 bg-black/35 p-3">
                     <div className="text-xs font-semibold uppercase tracking-[0.12em] text-neutral-300">
                       Review actions
                     </div>
                     <ul className="mt-2 space-y-1">
-                      {proposal.reviewActions.map((action, actionIdx) => (
+                      {proposal.review_actions.map((action, actionIdx) => (
                         <li key={`${actionIdx}-${action}`} className="text-sm text-neutral-100">
                           • {action}
                         </li>
@@ -1223,12 +1322,90 @@ export default function PlannerPage() {
                   </div>
                 ) : null}
 
-                {proposal.executionSummary ? (
-                  <div className="mt-3 rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-3 text-sm text-emerald-100">
-                    {proposal.executionSummary}
+                {isConfirmable ? (
+                  <div className="mt-3 rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-emerald-200">
+                      Required confirmation
+                    </div>
+                    <label className="mt-2 flex items-center gap-2 text-sm text-neutral-100">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(applyConfirmations[proposal.id])}
+                        onChange={(e) =>
+                          setApplyConfirmations((prev) => ({
+                            ...prev,
+                            [proposal.id]: e.target.checked,
+                          }))
+                        }
+                      />
+                      I reviewed this plan and want to continue with apply.
+                    </label>
+                    {proposal.execution_available ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="mt-3"
+                        disabled={!canApply}
+                        isLoading={applyingProposalId === proposal.id}
+                        onClick={() => void applyProposal(proposal)}
+                      >
+                        {proposal.execution_label}
+                      </Button>
+                    ) : (
+                      <div className="mt-3 text-sm text-amber-100">
+                        {proposal.not_executable_reason ?? "Not yet executable"}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="mt-3 rounded-2xl border border-violet-400/25 bg-violet-500/10 p-3 text-sm text-violet-100">
+                    {proposal.not_executable_reason ?? "Not yet applied"}
+                  </div>
+                )}
+
+                {executionResult ? (
+                  <div className="mt-3 rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.12em] text-emerald-200">
+                      Execution result
+                    </div>
+                    <div className="mt-2 text-sm text-emerald-100">{executionResult.summary}</div>
+                    {executionResult.changed_records.length > 0 ? (
+                      <ul className="mt-2 space-y-1">
+                        {executionResult.changed_records.map((record) => (
+                          <li key={`${proposal.id}-changed-${record.id}`} className="text-sm text-emerald-50">
+                            • {record.label}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                    {executionResult.result_links.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {executionResult.result_links.map((link, linkIdx) => (
+                          <a
+                            key={`${proposal.id}-result-${linkIdx}`}
+                            href={link.href}
+                            className="rounded-full border border-emerald-300/40 px-3 py-1 text-xs text-emerald-100"
+                          >
+                            {link.label}
+                          </a>
+                        ))}
+                      </div>
+                    ) : null}
+                    {executionResult.audit_ref ? (
+                      <div className="mt-2 text-xs text-emerald-200/90">
+                        Audit reference: {executionResult.audit_ref}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : proposal.result_summary ? (
+                  <div className="mt-3 rounded-2xl border border-white/10 bg-black/35 p-3 text-sm text-neutral-200">
+                    {proposal.result_summary}
                   </div>
                 ) : null}
               </div>
+                );
+              })()
             ))}
           </div>
         ) : null}

--- a/app/api/planner/apply/route.ts
+++ b/app/api/planner/apply/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { z } from "zod";
+
+import type { Database } from "@shared/types/types/supabase";
+import type { PlannerProposal } from "@/features/agent/lib/plannerProposal";
+import { runRescheduleBooking, runSetLineApproval, runAddWorkOrderLine } from "@/features/agent/lib/toolRegistry";
+
+const ApplyBodySchema = z.object({
+  runId: z.string().uuid(),
+  proposalId: z.string().min(3),
+  confirmationToken: z.literal("CONFIRM_APPLY"),
+  applyKey: z.string().min(8),
+});
+
+type DB = Database;
+
+function asProposal(value: unknown): PlannerProposal | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { proposal?: unknown };
+  if (!candidate.proposal || typeof candidate.proposal !== "object") return null;
+  return candidate.proposal as PlannerProposal;
+}
+
+async function resolveShopId(
+  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  userId: string,
+): Promise<string | null> {
+  const { data } = await supabase.from("profiles").select("shop_id").eq("id", userId).maybeSingle();
+  return data?.shop_id ?? null;
+}
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient<DB>({ cookies });
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const shopId = await resolveShopId(supabase, user.id);
+  if (!shopId) return NextResponse.json({ error: "No shop found" }, { status: 400 });
+
+  const raw = await req.json().catch(() => null);
+  const parsed = ApplyBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Invalid body" }, { status: 400 });
+  }
+
+  const { runId, proposalId, applyKey } = parsed.data;
+
+  const { data: run } = await supabase
+    .from("planner_runs")
+    .select("id, shop_id, user_id")
+    .eq("id", runId)
+    .maybeSingle();
+
+  if (!run || run.shop_id !== shopId) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  const { data: existingApply } = await supabase
+    .from("planner_events")
+    .select("id")
+    .eq("run_id", runId)
+    .eq("kind", "proposal.apply")
+    .contains("content", { proposalId, applyKey })
+    .limit(1);
+
+  if ((existingApply ?? []).length > 0) {
+    return NextResponse.json({ error: "This apply key was already used." }, { status: 409 });
+  }
+
+  const { data: proposalEvents } = await supabase
+    .from("planner_events")
+    .select("step, content")
+    .eq("run_id", runId)
+    .eq("kind", "proposal")
+    .order("step", { ascending: false })
+    .limit(50);
+
+  const proposal = (proposalEvents ?? [])
+    .map((event) => asProposal(event.content))
+    .find((item) => item?.id === proposalId);
+
+  if (!proposal) {
+    return NextResponse.json({ error: "Proposal not found for run." }, { status: 404 });
+  }
+
+  if (proposal.classification !== "confirmable_write" || !proposal.execution_available) {
+    return NextResponse.json({ error: "This proposal is not executable." }, { status: 400 });
+  }
+
+  const payload = proposal.execution_payload;
+  if (!payload) {
+    return NextResponse.json({ error: "Execution payload missing." }, { status: 400 });
+  }
+
+  const changedRecords: PlannerProposal["affected_records"] = [];
+  const resultLinks: PlannerProposal["result_links"] = [];
+  const failures: string[] = [];
+
+  try {
+    if (payload.action === "set_line_approval") {
+      const lineId = String(payload.data.lineId ?? "");
+      const approvalAction = String(payload.data.approvalAction ?? "approve");
+      const state = approvalAction === "reject" ? "declined" : "approved";
+      await runSetLineApproval({ lineId, state }, { shopId, userId: user.id });
+      changedRecords.push({
+        type: "work_order_line",
+        id: lineId,
+        href: "#",
+        label: `Line ${lineId.slice(0, 8)} set ${state}`,
+      });
+    } else if (payload.action === "reschedule_booking") {
+      const bookingId = String(payload.data.bookingId ?? "");
+      const startsAt = String(payload.data.requestedStart ?? "");
+      const endsAt = payload.data.requestedEnd ? String(payload.data.requestedEnd) : undefined;
+      await runRescheduleBooking({ bookingId, startsAt, endsAt }, { shopId, userId: user.id });
+      changedRecords.push({
+        type: "booking",
+        id: bookingId,
+        href: `/calendar?bookingId=${bookingId}`,
+        label: `Booking ${bookingId.slice(0, 8)} moved`,
+      });
+      resultLinks.push({ href: `/calendar?bookingId=${bookingId}`, label: "Open booking" });
+    } else if (payload.action === "add_work_order_line") {
+      const workOrderId = String(payload.data.workOrderId ?? "");
+      const description = String(payload.data.lineDescription ?? "");
+      const jobType = String(payload.data.jobType ?? "repair") as "maintenance" | "repair" | "diagnosis" | "inspection";
+      const laborHours = Number(payload.data.laborHours ?? 1);
+      const created = await runAddWorkOrderLine(
+        {
+          workOrderId,
+          description,
+          jobType,
+          laborHours,
+        },
+        { shopId, userId: user.id },
+      );
+      changedRecords.push({
+        type: "work_order_line",
+        id: created.lineId,
+        href: `/work-orders/${workOrderId}`,
+        label: `Line ${created.lineId.slice(0, 8)} added`,
+      });
+      resultLinks.push({ href: `/work-orders/${workOrderId}`, label: "Open work order" });
+    } else {
+      return NextResponse.json({ error: "Unsupported execution action." }, { status: 400 });
+    }
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  }
+
+  const status = failures.length > 0 ? (changedRecords.length > 0 ? "partial" : "failed") : "success";
+  const summary =
+    status === "success"
+      ? `Execution result: ${changedRecords.length} change(s) applied.`
+      : status === "partial"
+        ? `Execution partially applied with ${failures.length} failure(s).`
+        : "Execution failed. No changes were confirmed.";
+
+  const executionResult = {
+    status,
+    summary,
+    changed_records: changedRecords,
+    result_links: resultLinks,
+    failures,
+    audit_ref: `${runId}:${proposalId}:${applyKey}`,
+    applied_at: new Date().toISOString(),
+  };
+
+  await supabase.from("planner_events").insert({
+    run_id: runId,
+    step: (proposalEvents?.[0]?.step ?? 0) + 1,
+    kind: "proposal.apply",
+    content: {
+      proposalId,
+      applyKey,
+      result: executionResult,
+    },
+  });
+
+  return NextResponse.json({
+    proposalId,
+    result: executionResult,
+  });
+}

--- a/features/agent/lib/plannerOpenAI.ts
+++ b/features/agent/lib/plannerOpenAI.ts
@@ -20,6 +20,10 @@ import {
   runGetStalledWorkOrders,
   runGetWorkOrderStatusSummary,
 } from "./toolRegistry";
+import type {
+  PlannerAffectedRecord,
+  PlannerProposal,
+} from "./plannerProposal";
 
 type PlannerEvent = {
   kind: string;
@@ -41,12 +45,7 @@ type NotificationItem = {
   entityId?: string;
 };
 
-type CitationItem = {
-  type: string;
-  id: string;
-  href: string;
-  label: string;
-};
+type CitationItem = PlannerAffectedRecord;
 
 
 type ParsedPlan = {
@@ -85,22 +84,9 @@ type ParsedPlan = {
   requestedEnd?: string;
 };
 
-type ProposalSection = {
-  title: string;
-  items: string[];
-};
-
-type PlannerProposal = {
-  domain: "parts" | "menu_item_draft" | "inspection_template_draft";
-  lane: string;
-  title: string;
-  summary: string;
-  sections: ProposalSection[];
-  warnings: string[];
-  affectedRecords: CitationItem[];
-  reviewActions: string[];
-  executionSummary: string;
-};
+function createProposalId(lane: string) {
+  return `${lane}:${crypto.randomUUID().slice(0, 8)}`;
+}
 
 function get<T>(obj: Record<string, unknown>, key: string): T | undefined {
   return (obj as Record<string, T | undefined>)[key];
@@ -430,42 +416,6 @@ async function buildPartsProposal(
     }),
   ];
 
-  const inventorySection: ProposalSection = {
-    title: "Low inventory candidates",
-    items:
-      lowStock.length > 0
-        ? lowStock.slice(0, 8).map(
-            (row) =>
-              `${row.name}: on-hand ${row.qty_on_hand}, threshold ${row.threshold}, proposed reorder ${row.suggested}`,
-          )
-        : ["No low-inventory parts crossed the current threshold in this snapshot."],
-  };
-
-  const receivingSection: ProposalSection = {
-    title: "Receiving / PO follow-up",
-    items:
-      pendingReceiving.length > 0
-        ? [
-            `${pendingReceiving.length} request item(s) still not fully received.`,
-            `${openPos.length} open purchase order(s) in draft/sent/receiving states.`,
-            ...openPos.slice(0, 4).map((po) => `PO ${po.id.slice(0, 8)} • ${po.status ?? "unknown"}${po.expected_at ? ` • expected ${po.expected_at.slice(0, 10)}` : ""}`),
-          ]
-        : ["No pending receiving deltas were found in the sampled request items."],
-  };
-
-  const blockersSection: ProposalSection = {
-    title: "Blocked or at-risk jobs",
-    items:
-      blockedWoIds.length > 0
-        ? blockedWoIds.slice(0, 6).map((woId) => {
-            const wo = workOrderById.get(woId);
-            return wo?.custom_id
-              ? `WO #${wo.custom_id} appears parts-constrained (${wo.status ?? "status unknown"}).`
-              : `WO ${woId.slice(0, 8)} appears parts-constrained (${wo?.status ?? "status unknown"}).`;
-          })
-        : ["No work orders are currently tied to partially received request items."],
-  };
-
   const vehicleContext = vehicleRes.data as
     | { year: string | null; make: string | null; model: string | null; vin: string | null; license_plate: string | null }
     | null;
@@ -477,8 +427,9 @@ async function buildPartsProposal(
     : null;
 
   return {
-    domain: "parts",
+    id: createProposalId(lane),
     lane,
+    classification: "confirmable_write",
     title:
       lane === "low_inventory_reorder"
         ? "Low-inventory reorder proposal"
@@ -487,34 +438,48 @@ async function buildPartsProposal(
       lane === "low_inventory_reorder"
         ? `Proposed reorder set includes ${lowStock.length} low-inventory part(s) with receiving and blocker checks.`
         : `Proposed parts follow-up covers ${pendingReceiving.length} pending receiving item(s) and ${blockedWoIds.length} potentially blocked job(s).`,
-    sections: [
-      inventorySection,
-      receivingSection,
-      blockersSection,
-      {
-        title: "Evidence source distinctions",
-        items: [
-          "Inventory availability derived from part_stock on-hand and threshold values.",
-          "Pending receiving derived from part_request_items approved vs received quantities.",
-          "Blocked-job risk inferred when a work order is tied to not-yet-received request items.",
-          vehicleLabel ? `Vehicle-specific context applied for ${vehicleLabel}.` : "No specific vehicle context provided; shop-wide evidence was used.",
-        ],
-      },
+    proposed_steps: [
+      "Review low-stock candidates and reorder thresholds.",
+      "Review receiving state and open purchase order dependencies.",
+      "Review linked work orders that may be parts-constrained.",
+      "Confirm follow-up scope before any apply action.",
+    ],
+    source_rationale: [
+      "Inventory availability derived from part_stock on-hand and threshold values.",
+      "Pending receiving derived from part_request_items approved vs received quantities.",
+      "Blocked-job risk inferred when a work order is tied to not-yet-received request items.",
+      vehicleLabel ? `Vehicle-specific context applied for ${vehicleLabel}.` : "No specific vehicle context provided; shop-wide evidence was used.",
+      lowStock.length > 0
+        ? `Top candidates: ${lowStock
+            .slice(0, 5)
+            .map((row) => `${row.name} (${row.qty_on_hand}/${row.threshold})`)
+            .join(", ")}`
+        : "No low-stock candidate crossed threshold in sampled rows.",
     ],
     warnings: [
       "This is a staged proposal only. No purchase orders or inventory quantities were modified.",
       "Fitment confidence is not auto-assumed from inventory. Validate fitment before ordering if vehicle context is present.",
     ],
-    affectedRecords,
-    reviewActions: [
+    affected_records: affectedRecords,
+    review_actions: [
       "Review reorder quantities against min/max policy and supplier constraints.",
       "Confirm blocked jobs to prioritize receiving follow-up.",
       "Send selected follow-up items to execution only after explicit confirmation.",
     ],
-    executionSummary:
+    duplicate_candidates: openPos.slice(0, 5).map((po) => `Open PO ${po.id.slice(0, 8)} • ${po.status ?? "unknown"}`),
+    confirmation_required: true,
+    execution_available: false,
+    execution_label: "Confirm and apply",
+    not_executable_reason:
+      "Apply path is not enabled for parts follow-up yet. Keep this in review-first mode.",
+    result_summary:
       lane === "low_inventory_reorder"
-        ? "When confirmed, Planner will execute only the approved reorder candidates and report PO/line outcomes."
-        : "When confirmed, Planner will execute only approved parts follow-up actions and report completed outreach/results.",
+        ? "Ready for explicit apply when reorder mutation path is enabled."
+        : "Ready for explicit apply when parts follow-up mutation path is enabled.",
+    result_links: [],
+    audit: {
+      generated_at: new Date().toISOString(),
+    },
   };
 }
 
@@ -652,92 +617,238 @@ async function buildAuthoringProposal(
       .slice(0, 62);
 
     return {
-      domain: "menu_item_draft",
+      id: createProposalId(lane),
       lane,
+      classification: "draft_only",
       title: "Menu item draft proposal",
       summary: `Draft menu item "${proposedName}" prepared from repeated custom work with duplicate checks and review-first controls.`,
-      sections: [
-        {
-          title: "Proposed draft",
-          items: [
-            `Title: ${proposedName}`,
-            `Customer-facing summary: Standardized service based on repeated custom lines for "${clusterLabel}".`,
-            `Likely category: ${nearDuplicateMenu[0]?.category ?? "General Repair"}`,
-            `Estimated labor: ${avgHours != null ? `${avgHours.toFixed(1)} hr` : "Needs advisor review"}`,
-            "Suggested line structure: Labor line + likely required parts from prior similar jobs.",
-          ],
-        },
-        {
-          title: "Source rationale",
-          items: [
-            `Repeated custom-line frequency: ${clusterStats.count} occurrence(s) in recent sample.`,
-            ...clusterStats.samples.slice(0, 3).map((sample) => `Observed line: ${sample}`),
-            nearDuplicateMenu.length > 0
-              ? `Near-duplicate menu candidates: ${nearDuplicateMenu
-                  .map((item) => item.name ?? item.id.slice(0, 8))
-                  .join(", ")}`
-              : "No near-duplicate menu candidates found in sampled catalog.",
-          ],
-        },
+      proposed_steps: [
+        `Draft menu item title: ${proposedName}`,
+        `Draft category: ${nearDuplicateMenu[0]?.category ?? "General Repair"}`,
+        `Draft labor estimate: ${avgHours != null ? `${avgHours.toFixed(1)} hr` : "Needs advisor review"}`,
+        "Review duplicates and overlap before considering creation.",
+      ],
+      source_rationale: [
+        `Repeated custom-line frequency: ${clusterStats.count} occurrence(s) in recent sample.`,
+        ...clusterStats.samples.slice(0, 3).map((sample) => `Observed line: ${sample}`),
       ],
       warnings: [
         "Draft only: no menu item was created.",
         "Duplicate candidates require manual review before any create action.",
       ],
-      affectedRecords,
-      reviewActions: [
+      affected_records: affectedRecords,
+      review_actions: [
         "Keep as draft and request advisor edits.",
         "Revise title, description, labor, and suggested parts.",
         "Send reviewed draft to Planner execution lane for explicit create confirmation.",
       ],
-      executionSummary:
-        "If confirmed in execution mode, Planner will create only the reviewed menu item draft and report created record id.",
+      duplicate_candidates: nearDuplicateMenu.map((item) => item.name ?? item.id.slice(0, 8)),
+      confirmation_required: false,
+      execution_available: false,
+      execution_label: "Not yet executable",
+      not_executable_reason:
+        "Creation route is not enabled in this lane. Keep this proposal in draft review.",
+      result_summary: "Not yet applied.",
+      result_links: [],
+      audit: {
+        generated_at: new Date().toISOString(),
+      },
     };
   }
 
   return {
-    domain: "inspection_template_draft",
+    id: createProposalId(lane),
     lane,
+    classification: "draft_only",
     title: "Inspection template draft proposal",
     summary: `Draft inspection template proposal generated from recurring findings/manual additions with overlap checks against existing templates.`,
-    sections: [
-      {
-        title: "Proposed template",
-        items: [
-          `Template name: ${clusterLabel
-            .split(" ")
-            .slice(0, 5)
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(" ")} Inspection`,
-          "Purpose: Standardize recurring manual checks into a reusable review workflow.",
-          ...sortedSections.map(([title, count]) => `Section: ${title} (${count} recurring item references)`),
-        ],
-      },
-      {
-        title: "Source rationale & overlap",
-        items: [
-          `Repeated custom-line/finding signal count: ${clusterStats.count}`,
-          nearDuplicateTemplates.length > 0
-            ? `Possible overlapping templates: ${nearDuplicateTemplates
-                .map((item) => item.template_name ?? item.id.slice(0, 8))
-                .join(", ")}`
-            : "No obvious overlapping templates were found in sampled template names.",
-          "Recurring manual items and findings were used as draft evidence; this does not auto-merge template domains.",
-        ],
-      },
+    proposed_steps: [
+      `Draft template name: ${clusterLabel
+        .split(" ")
+        .slice(0, 5)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ")} Inspection`,
+      "Review recurring sections and checklist coverage.",
+      ...sortedSections.map(([title, count]) => `Candidate section: ${title} (${count} references)`),
+    ],
+    source_rationale: [
+      `Repeated custom-line/finding signal count: ${clusterStats.count}`,
+      "Recurring manual items and findings were used as draft evidence; this does not auto-merge template domains.",
     ],
     warnings: [
       "Draft only: no inspection template was created.",
       "Potential template overlap detected; review section structure before create.",
     ],
-    affectedRecords,
-    reviewActions: [
+    affected_records: affectedRecords,
+    review_actions: [
       "Keep as draft and edit sections/items.",
       "Revise overlap and duplicate checks with service leads.",
       "Send reviewed template draft to Planner execution lane for explicit confirmation.",
     ],
-    executionSummary:
-      "If confirmed in execution mode, Planner will create only the reviewed inspection template draft and summarize created sections/items.",
+    duplicate_candidates: nearDuplicateTemplates.map(
+      (item) => item.template_name ?? item.id.slice(0, 8),
+    ),
+    confirmation_required: false,
+    execution_available: false,
+    execution_label: "Not yet executable",
+    not_executable_reason:
+      "Creation route is not enabled in this lane. Keep this proposal in draft review.",
+    result_summary: "Not yet applied.",
+    result_links: [],
+    audit: {
+      generated_at: new Date().toISOString(),
+    },
+  };
+}
+
+function buildOperationalProposal(
+  lane: "resolve_approval_queue" | "reschedule_booking" | "work_order_operations",
+  context: Record<string, unknown>,
+): PlannerProposal {
+  const bookingId = normalizeText(get<string>(context, "bookingId"));
+  const workOrderId = normalizeText(get<string>(context, "workOrderId"));
+  const lineId =
+    normalizeText(get<string>(context, "lineId")) ??
+    normalizeText(get<string>(context, "workOrderLineId"));
+  const requestedStart = normalizeText(get<string>(context, "requestedStart"));
+  const lineDescription = normalizeText(get<string>(context, "lineDescription"));
+  const approvalAction = normalizeText(get<string>(context, "approvalAction")) ?? "approve";
+
+  const affectedRecords: CitationItem[] = [];
+  if (bookingId) {
+    affectedRecords.push({
+      type: "booking",
+      id: bookingId,
+      href: `/calendar?bookingId=${bookingId}`,
+      label: `Booking ${bookingId.slice(0, 8)}`,
+    });
+  }
+  if (workOrderId) {
+    affectedRecords.push({
+      type: "work_order",
+      id: workOrderId,
+      href: `/work-orders/${workOrderId}`,
+      label: `Work order ${workOrderId.slice(0, 8)}`,
+    });
+  }
+  if (lineId) {
+    affectedRecords.push({
+      type: "work_order_line",
+      id: lineId,
+      href: workOrderId ? `/work-orders/${workOrderId}` : "#",
+      label: `Line ${lineId.slice(0, 8)}`,
+    });
+  }
+
+  const base: Omit<PlannerProposal, "title" | "summary" | "proposed_steps" | "execution_payload" | "execution_available" | "not_executable_reason" | "id"> = {
+    lane,
+    classification: "confirmable_write",
+    affected_records: affectedRecords,
+    warnings: ["No records are changed during Generate Plan. Review before apply."],
+    review_actions: [
+      "Verify affected records are correct.",
+      "Review warnings and duplicate/conflict checks.",
+      "Use Confirm and apply only when ready.",
+    ],
+    duplicate_candidates: [],
+    source_rationale: ["Proposal derived from planner goal and linked record identifiers."],
+    confirmation_required: true,
+    execution_label: "Confirm and apply",
+    result_summary: "Not yet applied.",
+    result_links: [],
+    audit: {
+      generated_at: new Date().toISOString(),
+    },
+  };
+
+  if (lane === "resolve_approval_queue") {
+    const executionAvailable = Boolean(lineId);
+    return {
+      id: createProposalId(lane),
+      ...base,
+      title: "Approval resolution proposal",
+      summary: lineId
+        ? `Planner will set line ${lineId.slice(0, 8)} to ${approvalAction} after confirmation.`
+        : "Planner identified approval resolution work, but no line id was provided.",
+      proposed_steps: [
+        "Review pending approval line.",
+        `Apply approval state: ${approvalAction}.`,
+        "Capture execution result and changed records.",
+      ],
+      duplicate_candidates: lineId ? [`Line ${lineId.slice(0, 8)} may have been recently updated.`] : [],
+      execution_available: executionAvailable,
+      not_executable_reason: executionAvailable ? undefined : "Missing line id for apply.",
+      execution_payload: executionAvailable
+        ? { lane, action: "set_line_approval", data: { lineId, approvalAction } }
+        : undefined,
+    };
+  }
+
+  if (lane === "reschedule_booking") {
+    const executionAvailable = Boolean(bookingId && requestedStart);
+    return {
+      id: createProposalId(lane),
+      ...base,
+      title: "Booking reschedule proposal",
+      summary: executionAvailable
+        ? `Planner will move booking ${bookingId?.slice(0, 8)} to ${requestedStart} after confirmation.`
+        : "Planner identified booking reschedule work, but booking id and requested start are required.",
+      proposed_steps: [
+        "Review requested booking time change.",
+        "Validate conflicts and dependencies.",
+        "Confirm and apply booking update.",
+      ],
+      duplicate_candidates: bookingId ? [`Booking ${bookingId.slice(0, 8)} may already be rescheduled.`] : [],
+      execution_available: executionAvailable,
+      not_executable_reason: executionAvailable
+        ? undefined
+        : "Missing booking id or requested start timestamp for apply.",
+      execution_payload: executionAvailable
+        ? {
+            lane,
+            action: "reschedule_booking",
+            data: {
+              bookingId,
+              requestedStart,
+              requestedEnd: normalizeText(get<string>(context, "requestedEnd")),
+            },
+          }
+        : undefined,
+    };
+  }
+
+  const executionAvailable = Boolean(workOrderId && lineDescription);
+  return {
+    id: createProposalId(lane),
+    ...base,
+    title: "Work-order operation proposal",
+    summary: executionAvailable
+      ? `Planner will add/update work-order operations on ${workOrderId?.slice(0, 8)} after confirmation.`
+      : "Planner identified work-order operations, but work order id and line description are required.",
+    proposed_steps: [
+      "Review target work order and operation details.",
+      "Validate duplicate line risk.",
+      "Confirm and apply work-order line change.",
+    ],
+    duplicate_candidates: lineDescription
+      ? [`Potential duplicate operation text: "${lineDescription.slice(0, 80)}"`]
+      : [],
+    execution_available: executionAvailable,
+    not_executable_reason: executionAvailable
+      ? undefined
+      : "Missing work order id or operation description for apply.",
+    execution_payload: executionAvailable
+      ? {
+          lane,
+          action: "add_work_order_line",
+          data: {
+            workOrderId,
+            lineDescription,
+            jobType: coerceJobType(get<string>(context, "jobType")),
+            laborHours: Number(get<number>(context, "laborHours") ?? 1),
+          },
+        }
+      : undefined,
   };
 }
 
@@ -761,11 +872,11 @@ export async function runOpenAIPlanner(
     await onEvent?.({
       kind: "final",
       text: proposal.summary,
-      citations: proposal.affectedRecords,
+      citations: proposal.affected_records,
     });
     return {
       summary: proposal.summary,
-      citations: proposal.affectedRecords,
+      citations: proposal.affected_records,
       notifications: proposal.warnings.map((warning, index) => ({
         level: "warning",
         code: `parts_proposal_warning_${index + 1}`,
@@ -784,15 +895,39 @@ export async function runOpenAIPlanner(
     await onEvent?.({
       kind: "final",
       text: proposal.summary,
-      citations: proposal.affectedRecords,
+      citations: proposal.affected_records,
     });
     return {
       summary: proposal.summary,
-      citations: proposal.affectedRecords,
+      citations: proposal.affected_records,
       notifications: proposal.warnings.map((warning, index) => ({
         level: "warning",
         code: `authoring_proposal_warning_${index + 1}`,
         title: "Review required",
+        message: warning,
+      })),
+    };
+  }
+
+  if (
+    lane === "resolve_approval_queue" ||
+    lane === "reschedule_booking" ||
+    lane === "work_order_operations"
+  ) {
+    const proposal = buildOperationalProposal(lane, context);
+    await onEvent?.({ kind: "proposal", proposal });
+    await onEvent?.({
+      kind: "final",
+      text: proposal.summary,
+      citations: proposal.affected_records,
+    });
+    return {
+      summary: proposal.summary,
+      citations: proposal.affected_records,
+      notifications: proposal.warnings.map((warning, index) => ({
+        level: "warning",
+        code: `operational_proposal_warning_${index + 1}`,
+        title: "Review before apply",
         message: warning,
       })),
     };

--- a/features/agent/lib/plannerProposal.ts
+++ b/features/agent/lib/plannerProposal.ts
@@ -1,0 +1,59 @@
+export type PlannerProposalClassification =
+  | "draft_only"
+  | "confirmable_write"
+  | "informational";
+
+export type PlannerAffectedRecord = {
+  type: string;
+  id: string;
+  href: string;
+  label: string;
+};
+
+export type PlannerResultLink = {
+  href: string;
+  label: string;
+};
+
+export type PlannerExecutionResult = {
+  status: "success" | "failed" | "partial";
+  summary: string;
+  changed_records: PlannerAffectedRecord[];
+  result_links: PlannerResultLink[];
+  failures: string[];
+  audit_ref?: string;
+  applied_at?: string;
+};
+
+export type PlannerExecutionPayload = {
+  lane: string;
+  action: string;
+  data: Record<string, unknown>;
+};
+
+export type PlannerProposal = {
+  id: string;
+  lane: string;
+  classification: PlannerProposalClassification;
+  title: string;
+  summary: string;
+  proposed_steps: string[];
+  affected_records: PlannerAffectedRecord[];
+  warnings: string[];
+  review_actions: string[];
+  duplicate_candidates: string[];
+  source_rationale: string[];
+  confirmation_required: boolean;
+  execution_available: boolean;
+  execution_label: string;
+  not_executable_reason?: string;
+  result_summary?: string;
+  result_links: PlannerResultLink[];
+  audit: {
+    run_id?: string;
+    event_step?: number;
+    generated_at: string;
+  };
+  execution_payload?: PlannerExecutionPayload;
+  execution_result?: PlannerExecutionResult;
+};


### PR DESCRIPTION
### Motivation
- Make Planner an explicit, auditable execution surface that never silently mutates records and follows a review → confirm → apply UX contract.
- Normalize planner outputs so every lane clearly states whether it is a draft, informational, or a confirmable write and provide the metadata needed for safe execution and auditing.
- Harden highest-value lanes first (parts follow-up / low-inventory reorder, approval/booking/work-order ops, and authoring drafts) so teams can rely on predictable, review-first behavior.

### Description
- Introduced a canonical proposal model (`features/agent/lib/plannerProposal.ts`) with explicit `classification` (`draft_only | confirmable_write | informational`), `proposed_steps`, `affected_records`, `warnings`, `review_actions`, `duplicate_candidates`, `source_rationale`, confirmation/execution flags, `execution_payload`, and structured `execution_result`/audit fields.
- Refactored planner generators in `features/agent/lib/plannerOpenAI.ts` to emit canonical proposals and to classify lanes as follows: `menu_item_draft` and `inspection_template_draft` → `draft_only`; `low_inventory_reorder` and `parts_follow_up` → `confirmable_write` (review-first, currently `execution_available: false`); `resolve_approval_queue`, `reschedule_booking`, `work_order_operations` → `confirmable_write` with execution payload and input guards.
- Added an explicit apply endpoint at `POST /api/planner/apply` that validates user/shop scope, finds the proposal attached to a run, enforces `classification === 'confirmable_write'` and `execution_available`, checks an idempotent `applyKey` guard, executes the concrete action (approval set, booking reschedule, add work order line), persists a `proposal.apply` planner event for auditing, and returns a structured execution result.
- Updated planner UI in `app/agent/planner/page.tsx` to be model-driven: proposals are visually distinct by classification (draft vs confirmable), render `Proposed plan`, `Affected records`, `Warnings/validation checks`, `Overlap/duplicate candidates`, explicit `Review actions`, require a confirmation checkbox for confirmable proposals, and call the new apply endpoint only after explicit confirm; execution results (summary, changed records, links, audit ref) are rendered after apply.
- Added id generation, audit metadata, and non-executable messaging for lanes where live mutation paths are intentionally disabled to preserve review-first semantics.
- Files changed: `features/agent/lib/plannerProposal.ts`, `features/agent/lib/plannerOpenAI.ts`, `app/api/planner/apply/route.ts`, `app/agent/planner/page.tsx`.

### Testing
- Ran linter: `npx eslint app/agent/planner/page.tsx features/agent/lib/plannerOpenAI.ts app/api/planner/apply/route.ts features/agent/lib/plannerProposal.ts` which passed with one existing React hook dependency warning in the planner page (non-blocking UX/hook note).
- Ran TypeScript validation: `npx tsc --noEmit` which completed successfully with no type errors.
- Verified planner/streaming integration points by ensuring the planner emits `proposal` events in the new canonical shape and that the UI extracts and renders proposal fields as intended (applies are guarded by confirmation and server-side checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e255de10708328bf73707acd26ef68)