### PR TITLE
Fix create-work-order manual line regressions and harden smart-match gating

### DIFF
--- a/app/api/inspections/smart-match/route.ts
+++ b/app/api/inspections/smart-match/route.ts
@@ -18,6 +18,7 @@ type Body = {
     engine?: string | null;
     drivetrain?: string | null;
     transmission?: string | null;
+    fuel_type?: string | null;
   } | null;
 };
 

--- a/app/api/work-orders/smart-repair-match/route.ts
+++ b/app/api/work-orders/smart-repair-match/route.ts
@@ -18,6 +18,7 @@ type Body = {
     engine?: string | null;
     drivetrain?: string | null;
     transmission?: string | null;
+    fuel_type?: string | null;
   } | null;
 };
 

--- a/features/inspections/server/findSmartInspectionMatch.ts
+++ b/features/inspections/server/findSmartInspectionMatch.ts
@@ -15,6 +15,7 @@ type MatchBody = {
     engine?: string | null;
     drivetrain?: string | null;
     transmission?: string | null;
+    fuel_type?: string | null;
   } | null;
 };
 
@@ -69,6 +70,26 @@ type MenuRepairItemRow = {
   engine: string | null;
   drivetrain: string | null;
   transmission: string | null;
+  fuel_type: string | null;
+};
+
+type MenuItemRow = {
+  id: string;
+  name: string | null;
+  description: string | null;
+  complaint: string | null;
+  cause: string | null;
+  correction: string | null;
+  labor_hours: number | null;
+  total_price: number | null;
+  category: string | null;
+  service_key: string | null;
+  vehicle_year: number | null;
+  vehicle_make: string | null;
+  vehicle_model: string | null;
+  drivetrain: string | null;
+  engine_type: string | null;
+  transmission_type: string | null;
 };
 
 type WorkOrderIntelRow = {
@@ -85,6 +106,11 @@ type WorkOrderIntelRow = {
 export type SmartInspectionMatch = {
   id: string;
   label: string;
+  sourceType?: "history_repair" | "catalog_menu";
+  sourceLabel?: string;
+  whyShown?: string | null;
+  compatibilitySummary?: string | null;
+  compatibilityStatus?: "compatible";
   complaint?: string | null;
   correction?: string | null;
   laborHours?: number | null;
@@ -101,6 +127,90 @@ export type SmartInspectionMatch = {
 
 function txt(v: unknown): string {
   return typeof v === "string" ? v.trim().toLowerCase() : "";
+}
+
+function includesAny(haystack: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function isBroadComplaint(noteText: string): boolean {
+  const text = txt(noteText);
+  return includesAny(text, [
+    "check engine",
+    "cel",
+    "no start",
+    "no-start",
+    "won't start",
+    "wont start",
+    "vibration",
+    "noise",
+    "front end noise",
+    "front-end noise",
+    "diagnose",
+    "diagnostic",
+  ]);
+}
+
+function isGenericCatalogCandidate(row: MenuItemRow): boolean {
+  const text = txt(
+    [
+      row.name ?? "",
+      row.description ?? "",
+      row.complaint ?? "",
+      row.category ?? "",
+      row.service_key ?? "",
+    ].join(" "),
+  );
+
+  return includesAny(text, [
+    "diag",
+    "diagnostic",
+    "inspection",
+    "investigate",
+    "troubleshoot",
+    "check engine",
+    "noise diagnosis",
+    "vibration diagnosis",
+  ]);
+}
+
+function getFuelFamily(value: unknown): "gasoline" | "diesel" | "other" | null {
+  const v = txt(value);
+  if (!v) return null;
+  if (v.includes("diesel")) return "diesel";
+  if (includesAny(v, ["gas", "gasoline", "petrol", "flex", "e85"])) return "gasoline";
+  return "other";
+}
+
+function compatibilityReasonParts(row: {
+  vehicle_year?: number | null;
+  vehicle_make?: string | null;
+  vehicle_model?: string | null;
+  engine?: string | null;
+  drivetrain?: string | null;
+  transmission?: string | null;
+  fuel_type?: string | null;
+}, body: MatchBody): string[] {
+  const reqYear =
+    typeof body?.vehicle?.year === "number"
+      ? body.vehicle.year
+      : Number(body?.vehicle?.year ?? 0) || null;
+  const reqMake = txt(body?.vehicle?.make);
+  const reqModel = txt(body?.vehicle?.model);
+  const reqEngine = txt(body?.vehicle?.engine);
+  const reqDrive = txt(body?.vehicle?.drivetrain);
+  const reqTrans = txt(body?.vehicle?.transmission);
+  const reqFuel = getFuelFamily(body?.vehicle?.fuel_type);
+
+  const reasons: string[] = [];
+  if (reqYear && row.vehicle_year === reqYear) reasons.push("year");
+  if (reqMake && txt(row.vehicle_make) === reqMake) reasons.push("make");
+  if (reqModel && txt(row.vehicle_model) === reqModel) reasons.push("model");
+  if (reqEngine && txt(row.engine) === reqEngine) reasons.push("engine");
+  if (reqDrive && txt(row.drivetrain) === reqDrive) reasons.push("drivetrain");
+  if (reqTrans && txt(row.transmission) === reqTrans) reasons.push("transmission");
+  if (reqFuel && getFuelFamily(row.fuel_type) === reqFuel) reasons.push("fuel type");
+  return reasons;
 }
 
 function computePricingStatusFromDate(validUntil: string | null | undefined): "fresh" | "stale" | "expired" {
@@ -172,6 +282,7 @@ function addVehicleScore(
     engine?: string | null;
     drivetrain?: string | null;
     transmission?: string | null;
+    fuel_type?: string | null;
   },
   body: MatchBody,
 ): number {
@@ -186,6 +297,7 @@ function addVehicleScore(
   const reqEngine = txt(body?.vehicle?.engine);
   const reqDrivetrain = txt(body?.vehicle?.drivetrain);
   const reqTransmission = txt(body?.vehicle?.transmission);
+  const reqFuel = getFuelFamily(body?.vehicle?.fuel_type);
 
   if (reqYear && row.vehicle_year === reqYear) next += 0.22;
   if (reqMake && txt(row.vehicle_make) === reqMake) next += 0.24;
@@ -193,8 +305,62 @@ function addVehicleScore(
   if (reqEngine && txt(row.engine) === reqEngine) next += 0.08;
   if (reqDrivetrain && txt(row.drivetrain) === reqDrivetrain) next += 0.06;
   if (reqTransmission && txt(row.transmission) === reqTransmission) next += 0.06;
+  if (reqFuel && getFuelFamily(row.fuel_type) === reqFuel) next += 0.08;
 
   return next;
+}
+
+function isCompatibleCandidate(args: {
+  body: MatchBody;
+  noteText: string;
+  candidateText: string;
+  row: {
+    vehicle_year?: number | null;
+    vehicle_make?: string | null;
+    vehicle_model?: string | null;
+    engine?: string | null;
+    drivetrain?: string | null;
+    transmission?: string | null;
+    fuel_type?: string | null;
+  };
+}): boolean {
+  const { body, noteText, candidateText, row } = args;
+
+  const requestedFuel = getFuelFamily(body?.vehicle?.fuel_type);
+  const candidateFuel = getFuelFamily(row.fuel_type);
+  const fullText = `${txt(noteText)} ${txt(candidateText)}`;
+
+  // Hard block: DEF/diesel terms must not be shown to known non-diesel vehicles.
+  const hasDefSignal = includesAny(fullText, [
+    "def",
+    "diesel exhaust fluid",
+    "urea",
+    "scr",
+    "dpf",
+    "regen",
+  ]);
+  if (requestedFuel === "gasoline" && (hasDefSignal || candidateFuel === "diesel")) {
+    return false;
+  }
+
+  // Hard block: explicit fuel mismatch when both sides are known.
+  if (requestedFuel && candidateFuel && requestedFuel !== candidateFuel) {
+    return false;
+  }
+
+  const reqMake = txt(body?.vehicle?.make);
+  const reqModel = txt(body?.vehicle?.model);
+  const reqYear =
+    typeof body?.vehicle?.year === "number"
+      ? body.vehicle.year
+      : Number(body?.vehicle?.year ?? 0) || null;
+
+  // Hard block: if candidate has explicit YMM tags that conflict.
+  if (reqMake && txt(row.vehicle_make) && txt(row.vehicle_make) !== reqMake) return false;
+  if (reqModel && txt(row.vehicle_model) && txt(row.vehicle_model) !== reqModel) return false;
+  if (reqYear && row.vehicle_year && row.vehicle_year !== reqYear) return false;
+
+  return true;
 }
 
 export async function findSmartInspectionMatch(args: {
@@ -202,9 +368,11 @@ export async function findSmartInspectionMatch(args: {
   shopId: string;
   body: MatchBody;
 }): Promise<SmartInspectionMatch | null> {
-  // NOTE: This matcher powers manual line-entry suggestions only.
-  // It intentionally ranks menu_repair_items + shop match feedback and does not
-  // feed the "From My Menu" catalog lane (menu_items).
+  // NOTE: This matcher powers complaint-stage manual line-entry suggestions.
+  // It uses separate lanes:
+  // - menu_repair_items / match history (learned specific repairs)
+  // - menu_items (authored catalog, diagnostic, generic services)
+  // and then applies safety-first ranking.
   const { supabase, shopId, body } = args;
 
   const noteText = [txt(body?.item), txt(body?.notes), txt(body?.section)]
@@ -262,7 +430,7 @@ export async function findSmartInspectionMatch(args: {
   const { data: repairItems } = await supabase
     .from("menu_repair_items")
     .select(
-      "id, name, complaint, correction, labor_hours, parts, confidence_score, vehicle_year, vehicle_make, vehicle_model, engine, drivetrain, transmission",
+      "id, name, complaint, correction, labor_hours, parts, confidence_score, vehicle_year, vehicle_make, vehicle_model, engine, drivetrain, transmission, fuel_type",
     )
     .eq("shop_id", shopId)
     .order("updated_at", { ascending: false })
@@ -292,6 +460,17 @@ export async function findSmartInspectionMatch(args: {
         .join(" ")
         .trim();
 
+      if (
+        !isCompatibleCandidate({
+          body,
+          noteText,
+          candidateText: haystack,
+          row,
+        })
+      ) {
+        return null;
+      }
+
       let score = tokenScore(noteText, haystack);
       score = addVehicleScore(score, row, body);
 
@@ -314,34 +493,11 @@ export async function findSmartInspectionMatch(args: {
 
       return { row, score };
     })
+    .filter((x): x is { row: MenuRepairItemRow; score: number } => Boolean(x))
     .filter((x) => x.score >= 0.45)
     .sort((a, b) => b.score - a.score);
 
   const bestRepairItem = rankedRepairItems[0];
-  if (bestRepairItem?.row?.id && (bestRepairItem.row.name || bestRepairItem.row.complaint)) {
-    const pricing = pricingMap.get(bestRepairItem.row.id);
-
-    return {
-      id: bestRepairItem.row.id,
-      label:
-        bestRepairItem.row.name ??
-        bestRepairItem.row.complaint ??
-        "Matched repair",
-      complaint: bestRepairItem.row.complaint ?? null,
-      correction: bestRepairItem.row.correction ?? null,
-      laborHours: bestRepairItem.row.labor_hours ?? null,
-      parts: normalizeParts(bestRepairItem.row.parts),
-      score: bestRepairItem.score,
-      confidence:
-        typeof bestRepairItem.row.confidence_score === "number"
-          ? bestRepairItem.row.confidence_score
-          : Math.min(0.97, 0.6 + bestRepairItem.score * 0.3),
-      menuRepairItemId: bestRepairItem.row.id,
-      menuItemId: null,
-      pricingStatus: computePricingStatusFromDate(pricing?.validUntil ?? null),
-      pricingValidUntil: pricing?.validUntil ?? null,
-    };
-  }
 
   const { data: smartHistory } = await supabase
     .from("inspection_smart_match_history")
@@ -364,6 +520,19 @@ export async function findSmartInspectionMatch(args: {
         .trim();
 
       let score = tokenScore(noteText, haystack);
+      if (
+        !isCompatibleCandidate({
+          body,
+          noteText,
+          candidateText: haystack,
+          row: {
+            ...row,
+            fuel_type: null,
+          },
+        })
+      ) {
+        return null;
+      }
       score = addVehicleScore(score, row, body);
 
       if (
@@ -392,14 +561,186 @@ export async function findSmartInspectionMatch(args: {
 
       return { row, score };
     })
+    .filter((x): x is { row: SmartHistoryRow; score: number } => Boolean(x))
     .filter((x) => x.score >= 0.35)
     .sort((a, b) => b.score - a.score);
 
   const bestHistory = rankedHistory[0];
+
+  const { data: menuItems } = await supabase
+    .from("menu_items")
+    .select(
+      "id, name, description, complaint, cause, correction, labor_hours, total_price, category, service_key, vehicle_year, vehicle_make, vehicle_model, drivetrain, engine_type, transmission_type",
+    )
+    .eq("shop_id", shopId)
+    .eq("is_active", true)
+    .order("updated_at", { ascending: false })
+    .limit(80);
+
+  const broadComplaint = isBroadComplaint(noteText);
+  const rankedCatalogItems = ((menuItems ?? []) as MenuItemRow[])
+    .map((row) => {
+      const haystack = [
+        row.name ?? "",
+        row.description ?? "",
+        row.complaint ?? "",
+        row.correction ?? "",
+        row.category ?? "",
+        row.service_key ?? "",
+      ]
+        .join(" ")
+        .trim();
+
+      if (
+        !isCompatibleCandidate({
+          body,
+          noteText,
+          candidateText: haystack,
+          row: {
+            vehicle_year: row.vehicle_year,
+            vehicle_make: row.vehicle_make,
+            vehicle_model: row.vehicle_model,
+            engine: row.engine_type,
+            drivetrain: row.drivetrain,
+            transmission: row.transmission_type,
+            fuel_type: null,
+          },
+        })
+      ) {
+        return null;
+      }
+
+      let score = tokenScore(noteText, haystack);
+      score = addVehicleScore(
+        score,
+        {
+          vehicle_year: row.vehicle_year,
+          vehicle_make: row.vehicle_make,
+          vehicle_model: row.vehicle_model,
+          engine: row.engine_type,
+          drivetrain: row.drivetrain,
+          transmission: row.transmission_type,
+          fuel_type: null,
+        },
+        body,
+      );
+
+      if (isGenericCatalogCandidate(row)) {
+        score += broadComplaint ? 0.2 : 0.1;
+      }
+
+      return { row, score };
+    })
+    .filter((x): x is { row: MenuItemRow; score: number } => Boolean(x))
+    .filter((x) => x.score >= 0.34)
+    .sort((a, b) => b.score - a.score);
+
+  const bestCatalogItem = rankedCatalogItems[0];
+  const topSpecificConfidence =
+    typeof bestRepairItem?.row?.confidence_score === "number"
+      ? bestRepairItem.row.confidence_score
+      : typeof bestHistory?.row?.confidence === "number"
+        ? bestHistory.row.confidence
+        : 0;
+
+  const hasStrongSpecificMatch =
+    Boolean(bestRepairItem && bestRepairItem.score >= 0.72 && topSpecificConfidence >= 0.82) ||
+    Boolean(bestHistory && bestHistory.score >= 0.68 && topSpecificConfidence >= 0.8);
+
+  if (bestRepairItem?.row?.id && (bestRepairItem.row.name || bestRepairItem.row.complaint) && hasStrongSpecificMatch) {
+    const pricing = pricingMap.get(bestRepairItem.row.id);
+    const reasons = compatibilityReasonParts(bestRepairItem.row, body);
+
+    return {
+      id: bestRepairItem.row.id,
+      label:
+        bestRepairItem.row.name ??
+        bestRepairItem.row.complaint ??
+        "Matched repair",
+      sourceType: "history_repair",
+      sourceLabel: "repair history",
+      whyShown: "Strong compatible historical repair match.",
+      compatibilityStatus: "compatible",
+      compatibilitySummary:
+        reasons.length > 0 ? `Matched on ${reasons.join(", ")}.` : "Passed compatibility safety filters.",
+      complaint: bestRepairItem.row.complaint ?? null,
+      correction: bestRepairItem.row.correction ?? null,
+      laborHours: bestRepairItem.row.labor_hours ?? null,
+      parts: normalizeParts(bestRepairItem.row.parts),
+      score: bestRepairItem.score,
+      confidence:
+        typeof bestRepairItem.row.confidence_score === "number"
+          ? bestRepairItem.row.confidence_score
+          : Math.min(0.97, 0.6 + bestRepairItem.score * 0.3),
+      menuRepairItemId: bestRepairItem.row.id,
+      menuItemId: null,
+      pricingStatus: computePricingStatusFromDate(pricing?.validUntil ?? null),
+      pricingValidUntil: pricing?.validUntil ?? null,
+    };
+  }
+
+  if (bestCatalogItem?.row?.id) {
+    const reasons = compatibilityReasonParts(
+      {
+        vehicle_year: bestCatalogItem.row.vehicle_year,
+        vehicle_make: bestCatalogItem.row.vehicle_make,
+        vehicle_model: bestCatalogItem.row.vehicle_model,
+        drivetrain: bestCatalogItem.row.drivetrain,
+        engine: bestCatalogItem.row.engine_type,
+        transmission: bestCatalogItem.row.transmission_type,
+      },
+      body,
+    );
+    const genericCandidate = isGenericCatalogCandidate(bestCatalogItem.row);
+
+    return {
+      id: bestCatalogItem.row.id,
+      label:
+        bestCatalogItem.row.name ??
+        bestCatalogItem.row.description ??
+        "Catalog service",
+      sourceType: "catalog_menu",
+      sourceLabel: "menu catalog",
+      whyShown: genericCandidate && broadComplaint
+        ? "Broad complaint detected; safer generic diagnostic catalog item prioritized."
+        : "Compatible authored menu item suggestion.",
+      compatibilityStatus: "compatible",
+      compatibilitySummary:
+        reasons.length > 0 ? `Matched on ${reasons.join(", ")}.` : "Passed compatibility safety filters.",
+      complaint: bestCatalogItem.row.complaint ?? bestCatalogItem.row.description ?? null,
+      correction: bestCatalogItem.row.correction ?? null,
+      laborHours: bestCatalogItem.row.labor_hours ?? null,
+      score: bestCatalogItem.score,
+      confidence: Math.min(0.89, 0.5 + bestCatalogItem.score * 0.33),
+      menuRepairItemId: null,
+      menuItemId: bestCatalogItem.row.id,
+      pricingStatus: "expired",
+      pricingValidUntil: null,
+    };
+  }
+
   if (bestHistory?.row?.matched_label) {
+    const reasons = compatibilityReasonParts(
+      {
+        vehicle_year: bestHistory.row.vehicle_year,
+        vehicle_make: bestHistory.row.vehicle_make,
+        vehicle_model: bestHistory.row.vehicle_model,
+        engine: bestHistory.row.engine,
+        drivetrain: bestHistory.row.drivetrain,
+        transmission: bestHistory.row.transmission,
+      },
+      body,
+    );
+
     return {
       id: bestHistory.row.id,
       label: bestHistory.row.matched_label,
+      sourceType: "history_repair",
+      sourceLabel: "repair history",
+      whyShown: "Compatible historical candidate found (lower confidence).",
+      compatibilityStatus: "compatible",
+      compatibilitySummary:
+        reasons.length > 0 ? `Matched on ${reasons.join(", ")}.` : "Passed compatibility safety filters.",
       complaint: bestHistory.row.note ?? bestHistory.row.item_label ?? null,
       correction: bestHistory.row.correction ?? null,
       laborHours: bestHistory.row.labor_hours ?? null,

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -25,6 +25,11 @@ type AllowedStatus = (typeof ALLOWED_STATUS)[number];
 type SmartRepairMatch = {
   id: string;
   label: string;
+  sourceType?: "history_repair" | "catalog_menu";
+  sourceLabel?: string;
+  whyShown?: string | null;
+  compatibilitySummary?: string | null;
+  compatibilityStatus?: "compatible";
   complaint?: string | null;
   correction?: string | null;
   laborHours?: number | null;
@@ -57,7 +62,14 @@ function isTopRepairDefault(match: SmartRepairMatch | null): boolean {
 
 type VehicleLite = Pick<
   DB["public"]["Tables"]["vehicles"]["Row"],
-  "id" | "year" | "make" | "model" | "engine" | "drivetrain" | "transmission"
+  | "id"
+  | "year"
+  | "make"
+  | "model"
+  | "engine"
+  | "drivetrain"
+  | "transmission"
+  | "fuel_type"
 >;
 
 export function NewWorkOrderLineForm(props: {
@@ -72,6 +84,7 @@ export function NewWorkOrderLineForm(props: {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
   const [complaint, setComplaint] = useState("");
+  const [infoNote, setInfoNote] = useState("");
   const [cause, setCause] = useState("");
   const [correction, setCorrection] = useState("");
   const [labor, setLabor] = useState<string>("");
@@ -89,7 +102,8 @@ export function NewWorkOrderLineForm(props: {
 
   const smartMatchTimer = useRef<number | null>(null);
 
-  const canSave = complaint.trim().length > 0 && !!workOrderId;
+  const infoTitle = complaint.trim();
+  const canSave = (lineType === "info" ? infoTitle.length > 0 : complaint.trim().length > 0) && !!workOrderId;
   const topRepairDefault = isTopRepairDefault(smartMatch);
   const formShellClass =
     "rounded-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] p-4 text-sm text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] sm:p-5";
@@ -130,7 +144,7 @@ export function NewWorkOrderLineForm(props: {
 
       const { data, error } = await supabase
         .from("vehicles")
-        .select("id, year, make, model, engine, drivetrain, transmission")
+        .select("id, year, make, model, engine, drivetrain, transmission, fuel_type")
         .eq("id", vehicleId)
         .maybeSingle<VehicleLite>();
 
@@ -158,7 +172,7 @@ export function NewWorkOrderLineForm(props: {
       smartMatchTimer.current = null;
     }
 
-    if (term.length < 5 || !workOrderId) {
+    if (lineType !== "job" || term.length < 5 || !workOrderId) {
       setSmartMatch(null);
       setSmartMatchLoading(false);
       return;
@@ -186,6 +200,7 @@ export function NewWorkOrderLineForm(props: {
                   engine: vehicle.engine,
                   drivetrain: vehicle.drivetrain,
                   transmission: vehicle.transmission,
+                  fuel_type: vehicle.fuel_type,
                 }
               : null,
           }),
@@ -234,7 +249,7 @@ export function NewWorkOrderLineForm(props: {
         smartMatchTimer.current = null;
       }
     };
-  }, [complaint, vehicle, workOrderId]);
+  }, [complaint, lineType, vehicle, workOrderId]);
 
   function applySmartMatch(match: SmartRepairMatch) {
     setComplaint(match.complaint?.trim() || match.label || "");
@@ -279,8 +294,8 @@ export function NewWorkOrderLineForm(props: {
     setErr(null);
 
     try {
-      // Prefer exact vehicle-specific repair if available
-      if (smartMatch?.menuRepairItemId) {
+      // Prefer exact vehicle-specific repair if available (job lines only)
+      if (lineType === "job" && smartMatch?.menuRepairItemId) {
         const repairRes = await fetch("/api/work-orders/lines/add-from-menu-repair", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -318,7 +333,19 @@ export function NewWorkOrderLineForm(props: {
         data: { user },
       } = await supabase.auth.getUser();
 
-      const payload: InsertLine = {
+      const payload: InsertLine = lineType === "info" ? {
+        work_order_id: workOrderId,
+        vehicle_id: vehicleId,
+        user_id: user?.id ?? null,
+        line_type: "info",
+        description: infoTitle,
+        complaint: infoTitle || null,
+        notes: infoNote.trim() || null,
+        status: "awaiting",
+        job_type: null,
+        assigned_tech_id: null,
+        shop_id: shopId,
+      } : {
         work_order_id: workOrderId,
         vehicle_id: vehicleId,
         user_id: user?.id ?? null,
@@ -327,10 +354,9 @@ export function NewWorkOrderLineForm(props: {
         correction: correction.trim() || null,
         labor_time: labor ? Number(labor) : null,
         status: normalizeStatus(status),
-        job_type: lineType === "info" ? null : normalizeJobType(jobType),
-        line_type: lineType,
-        punchable: lineType === "info" ? false : null,
-        assigned_tech_id: lineType === "info" ? null : undefined,
+        job_type: normalizeJobType(jobType),
+        line_type: "job",
+        assigned_tech_id: undefined,
 
         // IMPORTANT: keep shop_id explicit so all RLS/shop triggers stay deterministic
         shop_id: shopId,
@@ -365,6 +391,7 @@ export function NewWorkOrderLineForm(props: {
       }
 
       setComplaint("");
+      setInfoNote("");
       setCause("");
       setCorrection("");
       setLabor("");
@@ -389,10 +416,14 @@ export function NewWorkOrderLineForm(props: {
         <div>
           <h3 className="text-sm font-semibold text-neutral-100">Add work order line</h3>
           <p className="text-[11px] text-neutral-400">
-            Complaint is required. Cause / correction can be filled in later.
+            {lineType === "info"
+              ? "Add a concise info title and optional note."
+              : "Complaint is required. Cause / correction can be filled in later."}
           </p>
           <p className="mt-1 text-[10px] uppercase tracking-wide text-neutral-500">
-            Direct custom line entry with optional smart repair suggestions from complaint + history matching
+            {lineType === "info"
+              ? "Info lines are context-only and use a dedicated insert path."
+              : "Direct custom line entry with optional smart repair suggestions from complaint + history matching"}
           </p>
         </div>
         <div className={mutedPillClass}>
@@ -409,7 +440,7 @@ export function NewWorkOrderLineForm(props: {
             onChange={(e) => setLineType(e.target.value as WOLineType)}
             className={controlClass}
           >
-            <option value="job">Job line (punchable)</option>
+            <option value="job">Job line (technician action)</option>
             <option value="info">Info line (context only)</option>
           </select>
           <p className="text-[10px] text-neutral-500">
@@ -421,21 +452,26 @@ export function NewWorkOrderLineForm(props: {
 
         <div className="sm:col-span-2 space-y-1">
           <label className="mb-0.5 block text-xs text-neutral-300">
-            Complaint <span className="text-red-400">*</span>
+            {lineType === "info" ? "Info title" : "Complaint"}{" "}
+            <span className="text-red-400">*</span>
           </label>
           <textarea
             value={complaint}
             onChange={(e) => setComplaint(e.target.value)}
             className={`${controlClass} min-h-[60px]`}
-            placeholder="Describe the issue / customer concern"
+            placeholder={
+              lineType === "info"
+                ? "Short title shown on the work order"
+                : "Describe the issue / customer concern"
+            }
           />
         </div>
 
-        {smartMatchLoading ? (
+        {lineType === "job" && smartMatchLoading ? (
           <div className="sm:col-span-2 rounded-md border border-white/10 bg-white/5 px-3 py-2 text-xs text-neutral-300">
             Looking for a matching quoted repair…
           </div>
-        ) : smartMatch ? (
+        ) : lineType === "job" && smartMatch ? (
           <div className="sm:col-span-2 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-3">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
@@ -464,6 +500,16 @@ export function NewWorkOrderLineForm(props: {
                   {smartMatch.menuRepairItemId && (
                     <span className="rounded-full border border-emerald-400/30 px-2 py-0.5">
                       vehicle-specific repair
+                    </span>
+                  )}
+                  {smartMatch.sourceLabel && (
+                    <span className="rounded-full border border-emerald-400/30 px-2 py-0.5">
+                      source: {smartMatch.sourceLabel}
+                    </span>
+                  )}
+                  {smartMatch.compatibilityStatus && (
+                    <span className="rounded-full border border-emerald-400/30 px-2 py-0.5">
+                      {smartMatch.compatibilityStatus}
                     </span>
                   )}
                   {smartMatch.matchTier && (
@@ -496,6 +542,16 @@ export function NewWorkOrderLineForm(props: {
                     </span>
                   ) : null}
                 </div>
+                {smartMatch.whyShown && (
+                  <div className="mt-2 text-[11px] text-emerald-100/85">
+                    Why shown: {smartMatch.whyShown}
+                  </div>
+                )}
+                {smartMatch.compatibilitySummary && (
+                  <div className="mt-1 text-[11px] text-emerald-100/85">
+                    Fit check: {smartMatch.compatibilitySummary}
+                  </div>
+                )}
               </div>
 
               <div className="flex flex-wrap gap-2">
@@ -518,72 +574,86 @@ export function NewWorkOrderLineForm(props: {
           </div>
         ) : null}
 
-        <div className="space-y-1">
-          <label className="mb-0.5 block text-xs text-neutral-300">Cause</label>
-          <textarea
-            value={cause}
-            onChange={(e) => setCause(e.target.value)}
-            className={`${controlClass} min-h-[48px]`}
-            placeholder="Root cause (optional)"
-          />
-        </div>
+        {lineType === "info" ? (
+          <div className="space-y-1 sm:col-span-2">
+            <label className="mb-0.5 block text-xs text-neutral-300">Note/body</label>
+            <textarea
+              value={infoNote}
+              onChange={(e) => setInfoNote(e.target.value)}
+              className={`${controlClass} min-h-[72px]`}
+              placeholder="Additional context for advisors or technicians (optional)"
+            />
+          </div>
+        ) : (
+          <>
+            <div className="space-y-1">
+              <label className="mb-0.5 block text-xs text-neutral-300">Cause</label>
+              <textarea
+                value={cause}
+                onChange={(e) => setCause(e.target.value)}
+                className={`${controlClass} min-h-[48px]`}
+                placeholder="Root cause (optional)"
+              />
+            </div>
 
-        <div className="space-y-1">
-          <label className="mb-0.5 block text-xs text-neutral-300">Correction</label>
-          <textarea
-            value={correction}
-            onChange={(e) => setCorrection(e.target.value)}
-            className={`${controlClass} min-h-[48px]`}
-            placeholder="What to do / repair plan (optional)"
-          />
-        </div>
+            <div className="space-y-1">
+              <label className="mb-0.5 block text-xs text-neutral-300">Correction</label>
+              <textarea
+                value={correction}
+                onChange={(e) => setCorrection(e.target.value)}
+                className={`${controlClass} min-h-[48px]`}
+                placeholder="What to do / repair plan (optional)"
+              />
+            </div>
 
-        <div className="space-y-1">
-          <label className="mb-0.5 block text-xs text-neutral-300">Labor (hrs)</label>
-          <input
-            inputMode="decimal"
-            value={labor}
-            onChange={(e) => setLabor(e.target.value)}
-            className={controlClass}
-            placeholder="0.0"
-          />
-          <p className="text-[10px] text-neutral-500">
-            Flat-rate or estimated hours. Leave blank if unknown.
-          </p>
-        </div>
+            <div className="space-y-1">
+              <label className="mb-0.5 block text-xs text-neutral-300">Labor (hrs)</label>
+              <input
+                inputMode="decimal"
+                value={labor}
+                onChange={(e) => setLabor(e.target.value)}
+                className={controlClass}
+                placeholder="0.0"
+              />
+              <p className="text-[10px] text-neutral-500">
+                Flat-rate or estimated hours. Leave blank if unknown.
+              </p>
+            </div>
 
-        <div className="space-y-1">
-          <label className="mb-0.5 block text-xs text-neutral-300">Status</label>
-          <select
-            value={normalizeStatus(status)}
-            onChange={(e) => setStatus(e.target.value as InsertLine["status"])}
-            className={controlClass}
-          >
-            <option value="awaiting">Awaiting</option>
-            <option value="in_progress">In progress</option>
-            <option value="on_hold">On hold</option>
-            <option value="paused">Paused</option>
-            <option value="completed">Completed</option>
-          </select>
-        </div>
+            <div className="space-y-1">
+              <label className="mb-0.5 block text-xs text-neutral-300">Status</label>
+              <select
+                value={normalizeStatus(status)}
+                onChange={(e) => setStatus(e.target.value as InsertLine["status"])}
+                className={controlClass}
+              >
+                <option value="awaiting">Awaiting</option>
+                <option value="in_progress">In progress</option>
+                <option value="on_hold">On hold</option>
+                <option value="paused">Paused</option>
+                <option value="completed">Completed</option>
+              </select>
+            </div>
 
-        <div className="space-y-1">
-          <label className="mb-0.5 block text-xs text-neutral-300">Job type</label>
-          <select
-            value={jobType ?? ""}
-            onChange={(e) => setJobType((e.target.value || null) as WOJobType | null)}
-            className={controlClass}
-          >
-            <option value="">Unspecified</option>
-            <option value="diagnosis">Diagnosis</option>
-            <option value="inspection">Inspection</option>
-            <option value="maintenance">Maintenance</option>
-            <option value="repair">Repair</option>
-          </select>
-        </div>
+            <div className="space-y-1">
+              <label className="mb-0.5 block text-xs text-neutral-300">Job type</label>
+              <select
+                value={jobType ?? ""}
+                onChange={(e) => setJobType((e.target.value || null) as WOJobType | null)}
+                className={controlClass}
+              >
+                <option value="">Unspecified</option>
+                <option value="diagnosis">Diagnosis</option>
+                <option value="inspection">Inspection</option>
+                <option value="maintenance">Maintenance</option>
+                <option value="repair">Repair</option>
+              </select>
+            </div>
+          </>
+        )}
       </div>
 
-      {smartMatch && (
+      {lineType === "job" && smartMatch && (
         <div className="rounded-md border border-white/10 bg-neutral-900/60 px-3 py-3 text-xs text-neutral-200">
           <div className="flex flex-wrap items-center gap-2">
             <span className="font-semibold text-neutral-100">
@@ -651,7 +721,9 @@ export function NewWorkOrderLineForm(props: {
         >
           {busy
             ? "Adding…"
-            : smartMatch?.menuRepairItemId
+            : lineType === "info"
+              ? "Add info line"
+              : smartMatch?.menuRepairItemId
               ? "Add matched repair"
               : "Add line to work order"}
         </button>


### PR DESCRIPTION
### Motivation
- Restore manual work-order job-line creation that regressed due to explicit writes to the `punchable` column which now must be derived by the server/DB. 
- Make `info` lines a true separate insertion flow (compact title + body) so info-lines do not behave like job-lines. 
- Prevent obviously inapplicable smart repair suggestions (e.g. DEF/diesel repairs for known gasoline vehicles) and make broad complaints prefer diagnostic/catalog matches unless a very strong specific-history signal exists.

### Description
- Splits the UI/form in `NewWorkOrderLineForm.tsx` into real mode branches: `job` (full fields + smart-match) and `info` (title + note only), removes explicit `punchable` writes from manual payloads, and sends `fuel_type` in vehicle context to the matcher; also surfaces match explainability metadata in the suggestion card (fields like `sourceType`, `whyShown`, `compatibilitySummary`). (`features/work-orders/components/NewWorkOrderLineForm.tsx`)
- Hardens the server matcher in `findSmartInspectionMatch.ts` by adding a compatibility filter stage (fuel-family checks, DEF/diesel guard, explicit YMM gating) executed before ranking, separates candidate lanes (`menu_repair_items` history vs `menu_items` catalog), and implements broad-complaint behavior that prefers generic diagnostic/catalog items unless a high-confidence specific repair is present. (`features/inspections/server/findSmartInspectionMatch.ts`)
- Extended smart-match route typings to include `fuel_type` so compatibility checks are end-to-end. (`app/api/work-orders/smart-repair-match/route.ts`, `app/api/inspections/smart-match/route.ts`)
- Left unrelated flows intact (no billing/quote/invoice logic changed, no tenant/RLS changes, menu insertion flows preserved). 

### Testing
- Ran lint on touched files with `npx eslint` (targeting changed files) and the run completed successfully. 
- Ran TypeScript checks with `npx tsc --noEmit` and the run completed successfully. 
- No automated unit tests were added; changes were scoped to UI form behavior and server matching logic with the above static checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27fc80d488328b43453c96701669d)