### PR TITLE
Add review-first ops intelligence: Smart Match readiness + menu/inspection recommendation engines

### DIFF
--- a/app/agent/planner/page.tsx
+++ b/app/agent/planner/page.tsx
@@ -43,6 +43,9 @@ type PlannerLane =
   | "parts_follow_up"
   | "low_inventory_reorder"
   | "fleet_follow_up"
+  | "smart_match_readiness"
+  | "menu_item_efficiency_review"
+  | "inspection_template_efficiency_review"
   | "menu_item_draft"
   | "inspection_template_draft"
   | "service_bundle_draft"
@@ -54,6 +57,9 @@ const LANE_LABEL: Record<PlannerLane, string> = {
   parts_follow_up: "Parts follow-up",
   low_inventory_reorder: "Low inventory reorder",
   fleet_follow_up: "Fleet follow-up",
+  smart_match_readiness: "Smart Match readiness",
+  menu_item_efficiency_review: "Menu item efficiency review",
+  inspection_template_efficiency_review: "Inspection template efficiency review",
   menu_item_draft: "Menu item draft",
   inspection_template_draft: "Inspection template draft",
   service_bundle_draft: "Service bundle draft",
@@ -425,6 +431,9 @@ export default function PlannerPage() {
       laneParam === "parts_follow_up" ||
       laneParam === "low_inventory_reorder" ||
       laneParam === "fleet_follow_up" ||
+      laneParam === "smart_match_readiness" ||
+      laneParam === "menu_item_efficiency_review" ||
+      laneParam === "inspection_template_efficiency_review" ||
       laneParam === "menu_item_draft" ||
       laneParam === "inspection_template_draft" ||
       laneParam === "service_bundle_draft" ||

--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -135,6 +135,9 @@ export async function POST(req: Request) {
                   action.context?.lane === "parts_follow_up" ||
                   action.context?.lane === "low_inventory_reorder" ||
                   action.context?.lane === "fleet_follow_up" ||
+                  action.context?.lane === "smart_match_readiness" ||
+                  action.context?.lane === "menu_item_efficiency_review" ||
+                  action.context?.lane === "inspection_template_efficiency_review" ||
                   action.context?.lane === "menu_item_draft" ||
                   action.context?.lane === "inspection_template_draft" ||
                   action.context?.lane === "service_bundle_draft"

--- a/features/agent/assistant/server/answerAssistant.ts
+++ b/features/agent/assistant/server/answerAssistant.ts
@@ -8,6 +8,11 @@ import { runGetVehicleHistory } from "../../tools/getVehicleHistory";
 import { runGetWorkOrderStatusSummary } from "../../tools/getWorkOrderStatusSummary";
 import { toolListPendingApprovals } from "../../tools/listPendingApprovals";
 import { getServerSupabase } from "../../server/supabase";
+import {
+  buildInspectionTemplateEfficiencyRecommendations,
+  buildMenuItemEfficiencyRecommendations,
+  evaluateSmartMatchReadiness,
+} from "../../server/opsRecommendations";
 import { buildPartSuggestions } from "@/features/parts/server/buildPartSuggestions";
 
 import type {
@@ -269,6 +274,94 @@ function looksLikeAuthoringQuestion(q: string): boolean {
     "should this become",
     "similar menu",
   ]);
+}
+
+function looksLikeOpsIntelligenceQuestion(q: string): boolean {
+  return questionIncludes(q, [
+    "smart match",
+    "smart-match",
+    "ready for conservative",
+    "ready for full",
+    "menu items should we create",
+    "repeated work",
+    "repeated jobs",
+    "reusable menu",
+    "inspection templates should we add",
+    "should be templated",
+    "manual complaint lines",
+    "operational recommendations",
+  ]);
+}
+
+async function answerOpsIntelligenceDomain(args: {
+  shopId: string;
+  q: string;
+  resolvedContext: AssistantResolvedContext;
+}): Promise<AssistantAnswer | null> {
+  if (!looksLikeOpsIntelligenceQuestion(args.q)) return null;
+
+  const [smartMatch, menuItemRecs, inspectionTemplateRecs] = await Promise.all([
+    evaluateSmartMatchReadiness(args.shopId),
+    buildMenuItemEfficiencyRecommendations(args.shopId),
+    buildInspectionTemplateEfficiencyRecommendations(args.shopId),
+  ]);
+
+  const bullets = dedupeStrings([
+    smartMatch.summary,
+    ...smartMatch.evidence.slice(0, 4),
+    menuItemRecs[0]
+      ? `Top menu-item opportunity: ${menuItemRecs[0].suggestedTitle} (${menuItemRecs[0].sourceRecords.length} evidence record(s) in sample).`
+      : "No menu item opportunity passed the repeat threshold in the sampled window.",
+    inspectionTemplateRecs[0]
+      ? `Top inspection-template opportunity: ${inspectionTemplateRecs[0].suggestedTemplateTitle} (${inspectionTemplateRecs[0].sourceRecords.length} evidence record(s) in sample).`
+      : "No inspection-template opportunity passed the repeat threshold in the sampled window.",
+  ]);
+
+  const links: AssistantLink[] = [
+    { label: "Review in Planner: Smart Match readiness", href: "/agent/planner?planner=ops&lane=smart_match_readiness&allowCreate=0&goal=Review%20Smart%20Match%20readiness%20with%20evidence" },
+    { label: "Review in Planner: Menu item efficiency", href: "/agent/planner?planner=ops&lane=menu_item_efficiency_review&allowCreate=0&goal=Review%20repeated%20manual%20work%20for%20menu%20item%20drafts" },
+    { label: "Review in Planner: Inspection template efficiency", href: "/agent/planner?planner=ops&lane=inspection_template_efficiency_review&allowCreate=0&goal=Review%20repeated%20inspection%20patterns%20for%20template%20drafts" },
+  ];
+
+  return buildAnswer({
+    intent: "shop_status",
+    summary: `Operational intelligence is ready for review. Smart Match is currently ${smartMatch.state.replaceAll("_", " ")}; menu item opportunities: ${menuItemRecs.length}; inspection template opportunities: ${inspectionTemplateRecs.length}.`,
+    bullets,
+    links,
+    entities: [
+      ...menuItemRecs.slice(0, 2).map((item) => ({
+        type: "menu_item" as const,
+        label: `Candidate menu item: ${item.suggestedTitle}`,
+        href: "/menu",
+      })),
+      ...inspectionTemplateRecs.slice(0, 2).map((item) => ({
+        type: "inspection_template" as const,
+        label: `Candidate template: ${item.suggestedTemplateTitle}`,
+        href: "/inspection/templates",
+      })),
+    ],
+    actions: [
+      {
+        type: "planner",
+        label: "Review Smart Match readiness proposal",
+        goal: "Build Smart Match readiness recommendation with evidence and review warnings",
+        context: { planner: "ops", lane: "smart_match_readiness", allowCreate: false },
+      },
+      {
+        type: "planner",
+        label: "Review menu item efficiency proposals",
+        goal: "Build review-first menu item efficiency recommendations from repeated manual work",
+        context: { planner: "ops", lane: "menu_item_efficiency_review", allowCreate: false },
+      },
+      {
+        type: "planner",
+        label: "Review inspection template efficiency proposals",
+        goal: "Build review-first inspection template recommendations from repeated inspection behavior",
+        context: { planner: "ops", lane: "inspection_template_efficiency_review", allowCreate: false },
+      },
+    ],
+    resolvedContext: args.resolvedContext,
+  });
 }
 
 async function answerPartsDomain(args: {
@@ -891,6 +984,15 @@ export async function answerAssistant({
   });
   if (fleetAnswer) {
     return fleetAnswer;
+  }
+
+  const opsIntelligenceAnswer = await answerOpsIntelligenceDomain({
+    shopId,
+    q,
+    resolvedContext,
+  });
+  if (opsIntelligenceAnswer) {
+    return opsIntelligenceAnswer;
   }
 
   const authoringAnswer = await answerAuthoringDomain({

--- a/features/agent/lib/plannerOpenAI.ts
+++ b/features/agent/lib/plannerOpenAI.ts
@@ -2,6 +2,11 @@
 import type { ToolContext } from "./toolTypes";
 import { getServerSupabase } from "../server/supabase";
 import { buildPartSuggestions } from "@/features/parts/server/buildPartSuggestions";
+import {
+  buildInspectionTemplateEfficiencyRecommendations,
+  buildMenuItemEfficiencyRecommendations,
+  evaluateSmartMatchReadiness,
+} from "../server/opsRecommendations";
 
 import {
   runCreateWorkOrder,
@@ -716,6 +721,145 @@ async function buildAuthoringProposal(
   };
 }
 
+async function buildOpsIntelligenceProposal(
+  lane:
+    | "smart_match_readiness"
+    | "menu_item_efficiency_review"
+    | "inspection_template_efficiency_review",
+  ctx: ToolContext,
+): Promise<PlannerProposal> {
+  if (lane === "smart_match_readiness") {
+    const readiness = await evaluateSmartMatchReadiness(ctx.shopId);
+    return {
+      id: createProposalId(lane),
+      lane,
+      classification: "informational",
+      title: "Smart Match readiness proposal",
+      summary: readiness.summary,
+      proposed_steps: [
+        `Recommended state: ${readiness.state}`,
+        ...(readiness.nextAction ? [`Next action: ${readiness.nextAction}`] : []),
+      ],
+      affected_records: [],
+      warnings: readiness.reviewNotes,
+      review_actions: [
+        "Owner/admin reviews readiness evidence and false-match risk before changing Smart Match settings.",
+        "Do not auto-enable Smart Match from this proposal; use explicit settings action if approved.",
+      ],
+      duplicate_candidates: [],
+      source_rationale: readiness.evidence,
+      confirmation_required: false,
+      execution_available: false,
+      execution_label: "Review only",
+      not_executable_reason: "Readiness proposals are recommendation-only and never auto-enable Smart Match.",
+      result_summary: "No Smart Match mode changes were applied.",
+      result_links: [
+        { href: "/dashboard/owner/settings", label: "Open owner settings" },
+      ],
+      audit: {
+        generated_at: new Date().toISOString(),
+      },
+    };
+  }
+
+  if (lane === "menu_item_efficiency_review") {
+    const recs = await buildMenuItemEfficiencyRecommendations(ctx.shopId);
+    const top = recs[0];
+    return {
+      id: createProposalId(lane),
+      lane,
+      classification: "draft_only",
+      title: "Menu item efficiency review proposal",
+      summary: top
+        ? `Found ${recs.length} menu-item candidate(s) from repeated manual work. Top recommendation: ${top.suggestedTitle}.`
+        : "No menu-item recommendation met the evidence threshold in the sampled history.",
+      proposed_steps: top
+        ? [
+            `Proposed title: ${top.suggestedTitle}`,
+            `Suggested category: ${top.suggestedCategory}`,
+            `Labor baseline: ${top.suggestedLaborHours != null ? `${top.suggestedLaborHours.toFixed(1)} hr` : "Needs review"}`,
+            "Review overlap candidates and advisor workflow impact before drafting.",
+          ]
+        : ["Collect more repeated manual line history, then re-run this review lane."],
+      affected_records: top
+        ? top.sourceRecords.slice(0, 8).map((record) => ({
+            type: "work_order_line",
+            id: record.id,
+            href: record.href,
+            label: record.label,
+          }))
+        : [],
+      warnings: [
+        "Review-first only: no menu_items records were created from this proposal.",
+        ...(top?.overlapCandidates.length ? ["Potential catalog overlap detected; verify duplicates before drafting."] : []),
+      ],
+      review_actions: [
+        "Review proposed title/category/labor with advisors.",
+        "Confirm duplicate/overlap handling with existing menu_items.",
+        "If approved, create manually through existing menu item flows.",
+      ],
+      duplicate_candidates: top?.overlapCandidates ?? [],
+      source_rationale: top ? [top.rationale, ...top.evidenceBullets] : ["No candidate reached repeat threshold."],
+      confirmation_required: false,
+      execution_available: false,
+      execution_label: "Draft only",
+      not_executable_reason: "This lane only stages evidence-backed recommendations for review.",
+      result_summary: "No catalog records were created.",
+      result_links: [{ href: "/menu", label: "Open menu catalog" }],
+      audit: {
+        generated_at: new Date().toISOString(),
+      },
+    };
+  }
+
+  const recs = await buildInspectionTemplateEfficiencyRecommendations(ctx.shopId);
+  const top = recs[0];
+  return {
+    id: createProposalId(lane),
+    lane,
+    classification: "draft_only",
+    title: "Inspection template efficiency review proposal",
+    summary: top
+      ? `Found ${recs.length} inspection-template candidate(s) from repeated inspection behavior. Top recommendation: ${top.suggestedTemplateTitle}.`
+      : "No inspection-template recommendation met the evidence threshold in the sampled history.",
+    proposed_steps: top
+      ? [
+          `Proposed template: ${top.suggestedTemplateTitle}`,
+          `Suggested scope: ${top.suggestedScope}`,
+          "Review overlap and section structure before drafting any template.",
+        ]
+      : ["Collect more repeated inspection activity, then re-run this review lane."],
+    affected_records: top
+      ? top.sourceRecords.slice(0, 8).map((record) => ({
+          type: "work_order_line",
+          id: record.id,
+          href: record.href,
+          label: record.label,
+        }))
+      : [],
+    warnings: [
+      "Review-first only: no inspection_templates records were created from this proposal.",
+      ...(top?.overlapCandidates.length ? ["Potential template overlap detected; validate before authoring."] : []),
+    ],
+    review_actions: [
+      "Review candidate scope with service leads/technicians.",
+      "Confirm overlap handling with existing inspection_templates.",
+      "If approved, create manually through existing inspection template flows.",
+    ],
+    duplicate_candidates: top?.overlapCandidates ?? [],
+    source_rationale: top ? [top.rationale, ...top.evidenceBullets] : ["No candidate reached repeat threshold."],
+    confirmation_required: false,
+    execution_available: false,
+    execution_label: "Draft only",
+    not_executable_reason: "This lane only stages evidence-backed recommendations for review.",
+    result_summary: "No template records were created.",
+    result_links: [{ href: "/inspection/templates", label: "Open inspection templates" }],
+    audit: {
+      generated_at: new Date().toISOString(),
+    },
+  };
+}
+
 function buildOperationalProposal(
   lane: "resolve_approval_queue" | "reschedule_booking" | "work_order_operations",
   context: Record<string, unknown>,
@@ -922,6 +1066,37 @@ export async function runOpenAIPlanner(
         message: warning,
       })),
     };
+  }
+
+  if (
+    lane === "smart_match_readiness" ||
+    lane === "menu_item_efficiency_review" ||
+    lane === "inspection_template_efficiency_review"
+  ) {
+    const proposal = await buildOpsIntelligenceProposal(lane, ctx);
+    await onEvent?.({
+      kind: "proposal",
+      proposal,
+    });
+
+    await onEvent?.({
+      kind: "plan",
+      text: proposal.summary,
+      citations: proposal.affected_records,
+    });
+
+    await onEvent?.({
+      kind: "agent_result",
+      summary: proposal.summary,
+      citations: proposal.affected_records,
+      notifications: proposal.warnings.map((warning, index) => ({
+        level: "warning",
+        code: `ops_intel_warning_${index + 1}`,
+        title: "Review warning",
+        message: warning,
+      })),
+    });
+    return;
   }
 
   if (

--- a/features/agent/server/opsRecommendations.ts
+++ b/features/agent/server/opsRecommendations.ts
@@ -1,0 +1,475 @@
+import { getServerSupabase } from "./supabase";
+
+export type SmartMatchReadinessState =
+  | "not_ready"
+  | "ready_for_conservative"
+  | "ready_for_full";
+
+export type SourceRecord = {
+  id: string;
+  workOrderId?: string;
+  label: string;
+  href: string;
+  createdAt?: string | null;
+};
+
+export type SmartMatchReadinessRecommendation = {
+  state: SmartMatchReadinessState;
+  summary: string;
+  evidence: string[];
+  reviewNotes: string[];
+  nextAction?: string;
+  stats: {
+    completedRepairLines: number;
+    repeatedComplaintCorrectionPatterns: number;
+    linkedVehicleCount: number;
+    importedHistoryCount: number;
+    smartMatchEligibleHistoryCount: number;
+    acceptedSmartMatchCount: number;
+    dismissedSmartMatchCount: number;
+  };
+};
+
+export type MenuItemEfficiencyRecommendation = {
+  suggestedTitle: string;
+  suggestedCategory: string;
+  suggestedLaborHours: number | null;
+  rationale: string;
+  expectedOperationalBenefit: string;
+  overlapCandidates: string[];
+  evidenceBullets: string[];
+  sourceRecords: SourceRecord[];
+  explainabilityNotes: string[];
+};
+
+export type InspectionTemplateEfficiencyRecommendation = {
+  suggestedTemplateTitle: string;
+  suggestedScope: string;
+  rationale: string;
+  expectedOperationalBenefit: string;
+  overlapCandidates: string[];
+  evidenceBullets: string[];
+  sourceRecords: SourceRecord[];
+  explainabilityNotes: string[];
+};
+
+function norm(value: string | null | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function isCompletedStatus(value: string | null | undefined): boolean {
+  const v = (value ?? "").toLowerCase();
+  return ["completed", "complete", "closed", "invoiced", "done", "delivered"].some((token) =>
+    v.includes(token),
+  );
+}
+
+function isInspectionLike(value: string): boolean {
+  return [
+    "inspection",
+    "inspect",
+    "mpi",
+    "multi point",
+    "multi-point",
+    "check",
+    "checklist",
+    "diag",
+    "diagnostic",
+    "courtesy",
+    "safety",
+  ].some((token) => value.includes(token));
+}
+
+function avg(values: number[]): number | null {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export async function evaluateSmartMatchReadiness(
+  shopId: string,
+): Promise<SmartMatchReadinessRecommendation> {
+  const supabase = getServerSupabase();
+
+  const { data: woRows, error: woErr } = await supabase
+    .from("work_orders")
+    .select("id, status, vehicle_id")
+    .eq("shop_id", shopId)
+    .order("created_at", { ascending: false })
+    .limit(800);
+
+  if (woErr) {
+    throw new Error(woErr.message || "Failed to load work orders for Smart Match readiness");
+  }
+
+  const completedWorkOrders = (woRows ?? []).filter((row) => isCompletedStatus(row.status));
+  const completedWorkOrderIds = completedWorkOrders.map((row) => row.id);
+
+  const { data: lineRows, error: lineErr } = completedWorkOrderIds.length
+    ? await supabase
+        .from("work_order_lines")
+        .select(
+          "id, work_order_id, vehicle_id, menu_item_id, complaint, correction, description, source_row_id, source_intake_id, external_id",
+        )
+        .in("work_order_id", completedWorkOrderIds.slice(0, 700))
+        .limit(1500)
+    : { data: [], error: null };
+
+  if (lineErr) {
+    throw new Error(lineErr.message || "Failed to load work order lines for Smart Match readiness");
+  }
+
+  const { data: feedbackRows, error: feedbackErr } = await supabase
+    .from("inspection_smart_match_feedback")
+    .select("action")
+    .eq("shop_id", shopId)
+    .order("created_at", { ascending: false })
+    .limit(400);
+
+  if (feedbackErr) {
+    throw new Error(feedbackErr.message || "Failed to load Smart Match feedback");
+  }
+
+  const lines = lineRows ?? [];
+  const completedRepairLines = lines.length;
+
+  const patternCounts = new Map<string, number>();
+  for (const row of lines) {
+    const complaint = norm(row.complaint);
+    const correction = norm(row.correction ?? row.description);
+    if (!complaint || !correction) continue;
+    const key = `${complaint} -> ${correction}`;
+    patternCounts.set(key, (patternCounts.get(key) ?? 0) + 1);
+  }
+
+  const repeatedComplaintCorrectionPatterns = [...patternCounts.values()].filter((count) => count >= 3).length;
+  const linkedVehicleCount = new Set(completedWorkOrders.map((row) => row.vehicle_id).filter(Boolean)).size;
+  const importedHistoryCount = lines.filter((row) => row.source_row_id || row.source_intake_id || row.external_id).length;
+  const smartMatchEligibleHistoryCount = lines.filter((row) => row.menu_item_id || row.correction || row.description).length;
+
+  const acceptedSmartMatchCount = (feedbackRows ?? []).filter((row) => row.action === "accepted").length;
+  const dismissedSmartMatchCount = (feedbackRows ?? []).filter((row) => row.action === "dismissed").length;
+
+  const score =
+    (completedRepairLines >= 220 ? 2 : completedRepairLines >= 120 ? 1 : 0) +
+    (repeatedComplaintCorrectionPatterns >= 20 ? 2 : repeatedComplaintCorrectionPatterns >= 8 ? 1 : 0) +
+    (linkedVehicleCount >= 40 ? 2 : linkedVehicleCount >= 18 ? 1 : 0) +
+    (importedHistoryCount >= 80 ? 1 : 0) +
+    (smartMatchEligibleHistoryCount >= 130 ? 1 : 0) +
+    (acceptedSmartMatchCount >= 20 && dismissedSmartMatchCount <= acceptedSmartMatchCount * 0.4 ? 1 : 0);
+
+  const state: SmartMatchReadinessState =
+    score >= 7 ? "ready_for_full" : score >= 4 ? "ready_for_conservative" : "not_ready";
+
+  const summary =
+    state === "ready_for_full"
+      ? "Smart Match is ready for Full mode based on stable repeated repair patterns and cross-vehicle history."
+      : state === "ready_for_conservative"
+        ? "Smart Match is ready for Conservative mode based on meaningful repair history and repeated complaint/correction patterns."
+        : "Smart Match is not ready yet because the shop's usable repair history is still sparse for reliable matching.";
+
+  const evidence = [
+    `${completedRepairLines} completed repair line(s) sampled from recent closed/completed work orders.`,
+    `${repeatedComplaintCorrectionPatterns} repeated complaint→correction pattern cluster(s) met the minimum frequency threshold.`,
+    `${linkedVehicleCount} distinct vehicle(s) contribute to historical pattern coverage.`,
+    `${importedHistoryCount} line(s) include imported/source history indicators (external or mapped source references).`,
+    `${smartMatchEligibleHistoryCount} line(s) include signals useful for Smart Match eligibility.`,
+    `Feedback sample: ${acceptedSmartMatchCount} accepted and ${dismissedSmartMatchCount} dismissed Smart Match feedback event(s).`,
+  ];
+
+  return {
+    state,
+    summary,
+    evidence,
+    reviewNotes: [
+      "Recommendation only: Smart Match mode is not auto-enabled by this evaluator.",
+      "Owner/admin should review false-positive risk and sample matched recommendations before changing mode.",
+    ],
+    nextAction:
+      state === "not_ready"
+        ? "Keep Smart Match off, continue collecting completed repair lines, and re-run readiness after more repeated patterns accumulate."
+        : state === "ready_for_conservative"
+          ? "Enable Conservative mode only after owner/admin review and monitor accepted vs dismissed feedback weekly."
+          : "Consider enabling Full mode after owner/admin review and continue auditing weak-match dismissals.",
+    stats: {
+      completedRepairLines,
+      repeatedComplaintCorrectionPatterns,
+      linkedVehicleCount,
+      importedHistoryCount,
+      smartMatchEligibleHistoryCount,
+      acceptedSmartMatchCount,
+      dismissedSmartMatchCount,
+    },
+  };
+}
+
+export async function buildMenuItemEfficiencyRecommendations(
+  shopId: string,
+): Promise<MenuItemEfficiencyRecommendation[]> {
+  const supabase = getServerSupabase();
+
+  const since = new Date(Date.now() - 1000 * 60 * 60 * 24 * 90).toISOString();
+  const [menuRes, woRes, linesRes] = await Promise.all([
+    supabase
+      .from("menu_items")
+      .select("id, name, category")
+      .eq("shop_id", shopId)
+      .limit(250),
+    supabase
+      .from("work_orders")
+      .select("id, status")
+      .eq("shop_id", shopId)
+      .gte("created_at", since)
+      .limit(900),
+    supabase
+      .from("work_order_lines")
+      .select("id, work_order_id, description, complaint, correction, labor_time, menu_item_id, created_at")
+      .eq("shop_id", shopId)
+      .gte("created_at", since)
+      .order("created_at", { ascending: false })
+      .limit(1800),
+  ]);
+
+  if (menuRes.error || woRes.error || linesRes.error) {
+    throw new Error(
+      menuRes.error?.message ?? woRes.error?.message ?? linesRes.error?.message ?? "Failed to build menu item efficiency recommendations",
+    );
+  }
+
+  const completedIds = new Set((woRes.data ?? []).filter((row) => isCompletedStatus(row.status)).map((row) => row.id));
+
+  const clusters = new Map<
+    string,
+    {
+      count: number;
+      labor: number[];
+      complaints: Set<string>;
+      corrections: Set<string>;
+      sourceRecords: SourceRecord[];
+      distinctWorkOrders: Set<string>;
+    }
+  >();
+
+  for (const row of linesRes.data ?? []) {
+    if (!row.work_order_id || !completedIds.has(row.work_order_id)) continue;
+    if (row.menu_item_id) continue;
+
+    const lineText = norm(row.description || row.complaint || row.correction);
+    if (lineText.length < 8) continue;
+
+    const key = lineText;
+    const current =
+      clusters.get(key) ??
+      {
+        count: 0,
+        labor: [],
+        complaints: new Set<string>(),
+        corrections: new Set<string>(),
+        sourceRecords: [],
+        distinctWorkOrders: new Set<string>(),
+      };
+
+    current.count += 1;
+    current.distinctWorkOrders.add(row.work_order_id);
+    if (typeof row.labor_time === "number") current.labor.push(row.labor_time);
+
+    const complaint = norm(row.complaint);
+    const correction = norm(row.correction);
+    if (complaint) current.complaints.add(complaint);
+    if (correction) current.corrections.add(correction);
+
+    if (current.sourceRecords.length < 7) {
+      current.sourceRecords.push({
+        id: row.id,
+        workOrderId: row.work_order_id,
+        label: row.description ?? row.complaint ?? "Repeated manual line",
+        href: `/work-orders/${row.work_order_id}`,
+        createdAt: row.created_at,
+      });
+    }
+
+    clusters.set(key, current);
+  }
+
+  const menuItems = menuRes.data ?? [];
+
+  return [...clusters.entries()]
+    .filter(([, cluster]) => cluster.count >= 5 && cluster.distinctWorkOrders.size >= 3)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, 4)
+    .map(([key, cluster]) => {
+      const title = titleCase(key).slice(0, 70);
+      const overlapCandidates = menuItems
+        .filter((item) => norm(item.name).includes(key.slice(0, 20)) || key.includes(norm(item.name)))
+        .slice(0, 4)
+        .map((item) => item.name ?? item.id);
+      const suggestedLaborHours = avg(cluster.labor);
+
+      return {
+        suggestedTitle: title,
+        suggestedCategory:
+          overlapCandidates.length > 0
+            ? menuItems.find((item) => (item.name ?? "") === overlapCandidates[0])?.category ?? "General Repair"
+            : "General Repair",
+        suggestedLaborHours,
+        rationale: `This work pattern repeated ${cluster.count} time(s) across ${cluster.distinctWorkOrders.size} completed work order(s) and is currently being entered manually instead of selected from menu_items.`,
+        expectedOperationalBenefit:
+          "Reduces repeated manual entry, improves quote consistency, and speeds advisor workflow.",
+        overlapCandidates,
+        evidenceBullets: [
+          `${cluster.count} repeated manual line(s) in the last 90 days.`,
+          `${cluster.complaints.size} unique complaint phrasing cluster(s) and ${cluster.corrections.size} correction cluster(s).`,
+          suggestedLaborHours != null
+            ? `Observed labor baseline averages ${suggestedLaborHours.toFixed(1)} hour(s).`
+            : "Labor baseline could not be derived from recent lines; advisor review required.",
+        ],
+        sourceRecords: cluster.sourceRecords,
+        explainabilityNotes: [
+          "Deterministic clustering used normalized line text and completed-work-only evidence.",
+          "No menu_items record was created automatically.",
+        ],
+      } satisfies MenuItemEfficiencyRecommendation;
+    });
+}
+
+export async function buildInspectionTemplateEfficiencyRecommendations(
+  shopId: string,
+): Promise<InspectionTemplateEfficiencyRecommendation[]> {
+  const supabase = getServerSupabase();
+  const since = new Date(Date.now() - 1000 * 60 * 60 * 24 * 120).toISOString();
+
+  const [woRes, templateRes, linesRes] = await Promise.all([
+    supabase
+      .from("work_orders")
+      .select("id, status")
+      .eq("shop_id", shopId)
+      .gte("created_at", since)
+      .limit(900),
+    supabase
+      .from("inspection_templates")
+      .select("id, template_name")
+      .eq("shop_id", shopId)
+      .limit(250),
+    supabase
+      .from("work_order_lines")
+      .select("id, work_order_id, description, complaint, inspection_template_id, created_at")
+      .eq("shop_id", shopId)
+      .gte("created_at", since)
+      .order("created_at", { ascending: false })
+      .limit(1800),
+  ]);
+
+  if (woRes.error || templateRes.error || linesRes.error) {
+    throw new Error(
+      woRes.error?.message ?? templateRes.error?.message ?? linesRes.error?.message ?? "Failed to build inspection template efficiency recommendations",
+    );
+  }
+
+  const completedIds = new Set((woRes.data ?? []).filter((row) => isCompletedStatus(row.status)).map((row) => row.id));
+
+  const clusters = new Map<
+    string,
+    {
+      count: number;
+      sections: Map<string, number>;
+      sourceRecords: SourceRecord[];
+      distinctWorkOrders: Set<string>;
+    }
+  >();
+
+  for (const row of linesRes.data ?? []) {
+    if (!row.work_order_id || !completedIds.has(row.work_order_id)) continue;
+    if (row.inspection_template_id) continue;
+
+    const candidate = norm(row.description || row.complaint);
+    if (!candidate || !isInspectionLike(candidate)) continue;
+
+    const key = candidate;
+    const current =
+      clusters.get(key) ??
+      {
+        count: 0,
+        sections: new Map<string, number>(),
+        sourceRecords: [],
+        distinctWorkOrders: new Set<string>(),
+      };
+
+    current.count += 1;
+    current.distinctWorkOrders.add(row.work_order_id);
+
+    const sectionGuess =
+      candidate.includes("brake")
+        ? "Brakes"
+        : candidate.includes("suspension")
+          ? "Suspension"
+          : candidate.includes("engine")
+            ? "Engine"
+            : candidate.includes("cool")
+              ? "Cooling"
+              : "General Inspection";
+    current.sections.set(sectionGuess, (current.sections.get(sectionGuess) ?? 0) + 1);
+
+    if (current.sourceRecords.length < 7) {
+      current.sourceRecords.push({
+        id: row.id,
+        workOrderId: row.work_order_id,
+        label: row.description ?? row.complaint ?? "Repeated manual inspection line",
+        href: `/work-orders/${row.work_order_id}`,
+        createdAt: row.created_at,
+      });
+    }
+
+    clusters.set(key, current);
+  }
+
+  const templates = templateRes.data ?? [];
+
+  return [...clusters.entries()]
+    .filter(([, cluster]) => cluster.count >= 4 && cluster.distinctWorkOrders.size >= 3)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, 4)
+    .map(([key, cluster]) => {
+      const suggestedTemplateTitle = `${titleCase(key).slice(0, 48)} Inspection`;
+      const overlapCandidates = templates
+        .filter((template) => norm(template.template_name).includes(key.slice(0, 18)) || key.includes(norm(template.template_name)))
+        .slice(0, 4)
+        .map((template) => template.template_name ?? template.id);
+
+      const topSections = [...cluster.sections.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([name, count]) => `${name} (${count})`);
+
+      return {
+        suggestedTemplateTitle,
+        suggestedScope: topSections.length > 0 ? topSections.join(" • ") : "General inspection workflow",
+        rationale: `Inspection-like manual work was repeated ${cluster.count} time(s) across ${cluster.distinctWorkOrders.size} completed work order(s) without template backing.`,
+        expectedOperationalBenefit:
+          "Standardizes technician documentation and reduces repeated manual inspection setup.",
+        overlapCandidates,
+        evidenceBullets: [
+          `${cluster.count} repeated inspection-like manual line(s) in the sampled history.`,
+          `${cluster.distinctWorkOrders.size} distinct work order(s) show the same inspection behavior pattern.`,
+          topSections.length > 0
+            ? `Likely recurring section focus: ${topSections.join(", ")}.`
+            : "Section-level inspection patterning was limited in this sample.",
+        ],
+        sourceRecords: cluster.sourceRecords,
+        explainabilityNotes: [
+          "Deterministic pattern detection was used; recommendations are evidence-backed and review-first.",
+          "No inspection_templates record was created automatically.",
+        ],
+      } satisfies InspectionTemplateEfficiencyRecommendation;
+    });
+}

--- a/features/assistant/hooks/useAssistant.ts
+++ b/features/assistant/hooks/useAssistant.ts
@@ -126,6 +126,9 @@ function toPlannerPayload(
         context.lane === "parts_follow_up" ||
         context.lane === "low_inventory_reorder" ||
         context.lane === "fleet_follow_up" ||
+        context.lane === "smart_match_readiness" ||
+        context.lane === "menu_item_efficiency_review" ||
+        context.lane === "inspection_template_efficiency_review" ||
         context.lane === "menu_item_draft" ||
         context.lane === "inspection_template_draft" ||
         context.lane === "service_bundle_draft"

--- a/features/assistant/lib/buildPlannerHref.ts
+++ b/features/assistant/lib/buildPlannerHref.ts
@@ -14,6 +14,9 @@ export type PlannerPayload = {
     | "parts_follow_up"
     | "low_inventory_reorder"
     | "fleet_follow_up"
+    | "smart_match_readiness"
+    | "menu_item_efficiency_review"
+    | "inspection_template_efficiency_review"
     | "menu_item_draft"
     | "inspection_template_draft"
     | "service_bundle_draft";

--- a/features/assistant/types/assistant.ts
+++ b/features/assistant/types/assistant.ts
@@ -17,6 +17,9 @@ export type PlannerPayload = {
     | "parts_follow_up"
     | "low_inventory_reorder"
     | "fleet_follow_up"
+    | "smart_match_readiness"
+    | "menu_item_efficiency_review"
+    | "inspection_template_efficiency_review"
     | "menu_item_draft"
     | "inspection_template_draft"
     | "service_bundle_draft";


### PR DESCRIPTION
### Motivation
- Provide a deterministic, evidence-backed operations intelligence layer that helps shops decide when to enable Smart Match and when to promote repeated work into reusable menu items or inspection templates. 
- Keep everything review-first and admin-controlled: surface proposals and evidence, but do not auto-enable Smart Match or auto-create catalog/templates.

### Description
- Added a new server-side ops intelligence engine `features/agent/server/opsRecommendations.ts` implementing `evaluateSmartMatchReadiness`, `buildMenuItemEfficiencyRecommendations`, and `buildInspectionTemplateEfficiencyRecommendations`, each returning explicit evidence, rationale, and explainability notes.
- Wired ops intelligence into Assistant Q&A by updating `features/agent/assistant/server/answerAssistant.ts` to detect ops-intel questions and return direct answers with evidence bullets, linked source records, and Planner handoff actions (`smart_match_readiness`, `menu_item_efficiency_review`, `inspection_template_efficiency_review`).
- Added Planner proposal support in `features/agent/lib/plannerOpenAI.ts` via `buildOpsIntelligenceProposal` and handled the new lanes as review-only/draft proposals; no execution paths alter Smart Match or create catalog/template records.
- Propagated new planner lane types and UI labels through `app/agent/planner/page.tsx`, `features/assistant/lib/buildPlannerHref.ts`, `features/assistant/types/assistant.ts`, `features/assistant/hooks/useAssistant.ts`, and `app/api/assistant/route.ts` so assistant → planner handoff is typed and validated end-to-end.
- Explicitly preserved domain boundaries and review-first contract: proposals include warnings/notes that no auto-create / no auto-enable behavior occurs, and Planner proposals are non-executable or draft-only.

### Testing
- Ran ESLint on the touched files with `npx eslint features/agent/server/opsRecommendations.ts features/agent/assistant/server/answerAssistant.ts features/agent/lib/plannerOpenAI.ts app/agent/planner/page.tsx features/assistant/lib/buildPlannerHref.ts features/assistant/types/assistant.ts features/assistant/hooks/useAssistant.ts app/api/assistant/route.ts` which completed with 0 errors and 1 pre-existing `react-hooks/exhaustive-deps` warning in the planner page.
- Ran TypeScript validation with `npx tsc --noEmit` which passed with no type errors.
- No DB migrations were added or applied in this change (read-only data analysis only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ec8cf5548328908112595e29b54e)