### PR TITLE
Refine Quote Review UX: compact queue, evidence-first cards, inline send-blocker repair

### DIFF
--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -6,13 +6,8 @@ import { useParams, useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import QuoteApprovalActions from "@/features/portal/components/QuoteApprovalActions";
-import DecisionTimeline, {
-  type DecisionTimelineStage,
-} from "@/features/shared/components/ui/DecisionTimeline";
-import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
-import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
-import { deriveEventsFromQuote } from "@/features/shared/lib/decisionEvents";
+import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import {
   calculateTax,
   getTaxAmount,
@@ -28,6 +23,7 @@ type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type InspectionPhotoRow = DB["public"]["Tables"]["inspection_photos"]["Row"];
 
 type ParamsShape = Record<string, string | string[] | undefined>;
 
@@ -72,6 +68,7 @@ type LineView = {
     total: number;
     meta: string | null;
   }>;
+  evidencePhotos: string[];
 };
 
 function paramToString(value: string | string[] | undefined): string | null {
@@ -127,6 +124,27 @@ function getPartMeta(parts: AllocationWithPart["parts"]): string | null {
   const pn = safeTrim((source as { part_number?: unknown }).part_number);
   const sku = safeTrim((source as { sku?: unknown }).sku);
   return [pn, sku].filter(Boolean).join(" • ") || null;
+}
+
+function findEvidencePhotos(
+  line: Pick<QuoteLineRow, "description" | "complaint">,
+  photos: Array<Pick<InspectionPhotoRow, "image_url" | "item_name">>,
+): string[] {
+  if (photos.length === 0) return [];
+  const text = [safeTrim(line.description), safeTrim(line.complaint)]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  if (!text) return [];
+
+  return photos
+    .filter((photo) => {
+      const itemName = safeTrim(photo.item_name).toLowerCase();
+      return itemName && (text.includes(itemName) || itemName.includes(text.slice(0, 20)));
+    })
+    .map((photo) => safeTrim(photo.image_url))
+    .filter(Boolean)
+    .slice(0, 3);
 }
 
 export default function QuotePageClient(): JSX.Element {
@@ -219,6 +237,18 @@ export default function QuotePageClient(): JSX.Element {
       allocRows = (allocs ?? []) as AllocationWithPart[];
     }
 
+    let inspectionPhotos: Array<Pick<InspectionPhotoRow, "image_url" | "item_name">> = [];
+    const inspectionId = safeTrim((wo as { inspection_id?: unknown } | null)?.inspection_id);
+    if (inspectionId) {
+      const { data: photos } = await supabase
+        .from("inspection_photos")
+        .select("image_url,item_name")
+        .eq("inspection_id", inspectionId)
+        .order("created_at", { ascending: false })
+        .limit(100);
+      inspectionPhotos = (photos ?? []) as Array<Pick<InspectionPhotoRow, "image_url" | "item_name">>;
+    }
+
     const byLine = new Map<string, AllocationWithPart[]>();
     for (const a of allocRows) {
       const lineId = safeTrim(a.work_order_line_id);
@@ -270,6 +300,7 @@ export default function QuotePageClient(): JSX.Element {
         createdAt: line.created_at ?? null,
         updatedAt: line.updated_at ?? null,
         parts,
+        evidencePhotos: findEvidencePhotos(line, inspectionPhotos),
       };
     });
 
@@ -303,56 +334,12 @@ export default function QuotePageClient(): JSX.Element {
   const taxRes = provinceCode ? calculateTax(subtotal, provinceCode) : null;
   const taxAmount = taxRes ? getTaxAmount(taxRes) : 0;
   const grandTotal = subtotal + taxAmount;
-  const timelineStages: DecisionTimelineStage[] = [
-    { key: "inspection", label: "Inspection completed", state: "past" },
-    {
-      key: "recommendation",
-      label: "Recommendation issued",
-      state: lines.length > 0 ? "past" : "future",
-    },
-    {
-      key: "approval",
-      label: "Awaiting approval",
-      state: lines.some((line) => resolveDecisionStatus({ approvalState: line.approvalState }) === "awaiting_approval")
-        ? "current"
-        : lines.some((line) => resolveDecisionStatus({ approvalState: line.approvalState }) === "approved")
-          ? "past"
-          : "future",
-    },
-    {
-      key: "execution",
-      label: "Work started",
-      state: lines.some((line) => resolveDecisionStatus({ workStatus: line.status }) === "in_progress")
-        ? "current"
-        : lines.some((line) => resolveDecisionStatus({ workStatus: line.status }) === "completed")
-          ? "past"
-          : "future",
-    },
-  ];
-  const decisionEvents = useMemo(
-    () =>
-      deriveEventsFromQuote({
-        workOrder,
-        lines: lines.map((line) => ({
-          id: line.id,
-          line_no: line.lineNo,
-          description: line.title,
-          approval_state: line.approvalState,
-          status: line.status,
-          created_at: line.createdAt,
-          updated_at: line.updatedAt,
-        })),
-        actorLabel: "Shop team",
-      }),
-    [workOrder, lines],
-  );
-
   return (
     <div
       className="
         min-h-screen px-4 text-foreground
         bg-background
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
+        bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.1),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
       "
     >
       <div className="mx-auto flex min-h-screen max-w-4xl flex-col justify-center py-10">
@@ -360,7 +347,7 @@ export default function QuotePageClient(): JSX.Element {
           className="
             w-full rounded-3xl border
             border-[color:var(--metal-border-soft,#1f2937)]
-            bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.18),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]
+            bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.12),transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.98),#020617_82%)]
             shadow-[0_32px_80px_rgba(0,0,0,0.95)]
             px-6 py-7 sm:px-8 sm:py-9
           "
@@ -390,11 +377,9 @@ export default function QuotePageClient(): JSX.Element {
               {titleLabel}
             </h1>
             <p className="text-xs text-neutral-400 sm:text-sm">
-              Review each recommendation with pricing context, then decide what should proceed.
+              Review the finding, supporting photo, and price for each recommendation.
             </p>
           </div>
-          <DecisionTimeline stages={timelineStages} className="mb-6" />
-          <DecisionEventFeed events={decisionEvents} className="mb-6" compact maxVisible={5} />
 
           <div className="mb-6 grid gap-4 sm:grid-cols-4">
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
@@ -432,9 +417,7 @@ export default function QuotePageClient(): JSX.Element {
                 <div key={line.id} className="rounded-2xl border border-white/10 bg-black/40 px-4 py-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">
-                        Recommendation
-                      </div>
+                      <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Recommendation</div>
                       <div className="text-sm font-semibold text-white">
                         {line.lineNo ? `#${line.lineNo} • ` : ""}{line.title}
                       </div>
@@ -467,9 +450,35 @@ export default function QuotePageClient(): JSX.Element {
                     </div>
                   </div>
 
+                  <div className="mt-4 rounded-xl border border-white/10 bg-slate-950/50 p-3">
+                    <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Evidence photo</div>
+                    {line.evidencePhotos.length > 0 ? (
+                      <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                        {line.evidencePhotos.map((photo, idx) => (
+                          <a
+                            key={`${line.id}-photo-${idx}`}
+                            href={photo}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="overflow-hidden rounded-lg border border-white/10 bg-black/30"
+                          >
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                              src={photo}
+                              alt={`Evidence ${idx + 1}`}
+                              className="h-24 w-full object-cover"
+                            />
+                          </a>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="mt-2 text-xs text-neutral-400">No photo evidence attached.</div>
+                    )}
+                  </div>
+
                   <div className="mt-4 grid gap-3 sm:grid-cols-3">
                     <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Labor evidence</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Labor</div>
                       <div className="mt-1 text-sm font-medium text-white">{formatCurrency(line.laborAmount)}</div>
                       <div className="mt-1 text-xs text-neutral-400">{line.laborHours.toFixed(1)} hr</div>
                     </div>

--- a/features/shared/quote/QuoteLineCard.tsx
+++ b/features/shared/quote/QuoteLineCard.tsx
@@ -29,6 +29,7 @@ export function QuoteLineCard(props: {
 
   issueText?: string | null;
   photoUrl?: string | null;
+  photoUrls?: string[] | null;
 
   recommendedText?: string | null;
 
@@ -40,7 +41,7 @@ export function QuoteLineCard(props: {
   onDecline?: () => void;
   onDefer?: () => void;
 
-  footerNote?: string | null; // optional tiny footer line
+  footerNote?: string | null;
   whyRecommended?: string[];
   supportingEvidence?: string[];
   deferredConsequence?: string | null;
@@ -51,6 +52,7 @@ export function QuoteLineCard(props: {
     statusTone = "bad",
     issueText,
     photoUrl,
+    photoUrls,
     recommendedText,
     partsTotal,
     laborTotal,
@@ -65,6 +67,9 @@ export function QuoteLineCard(props: {
   } = props;
 
   const total = partsTotal + laborTotal;
+  const imageList = Array.from(
+    new Set([photoUrl, ...(Array.isArray(photoUrls) ? photoUrls : [])].filter(Boolean)),
+  ) as string[];
 
   const dotCls =
     statusTone === "bad"
@@ -76,22 +81,18 @@ export function QuoteLineCard(props: {
           : "bg-neutral-500";
 
   const card =
-    "rounded-2xl border border-white/10 bg-black/40 shadow-[0_24px_70px_rgba(0,0,0,0.65)]";
+    "rounded-2xl border border-slate-300/15 bg-slate-950/55 shadow-[0_20px_48px_rgba(2,6,23,0.65)]";
   const codeBox =
-    "mt-2 rounded-xl border border-white/10 bg-black/55 px-4 py-3 text-sm text-neutral-200 whitespace-pre-wrap";
+    "mt-2 rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-neutral-200 whitespace-pre-wrap";
 
   return (
     <div className={card} style={{ ["--copper" as never]: COPPER }}>
-      <div className="px-5 pt-5">
-        <div className="text-xs uppercase tracking-[0.18em] text-neutral-400">
-          Customer portal:
-        </div>
+      <div className="px-4 pt-4 sm:px-5 sm:pt-5">
+        <div className="text-xl font-semibold text-white">{title}</div>
 
-        <div className="mt-2 text-2xl font-semibold text-white">{title}</div>
-
-        <div className="mt-3 flex items-center gap-2">
+        <div className="mt-2 flex items-center gap-2">
           <span className={`h-3.5 w-3.5 rounded-full ${dotCls}`} />
-          <div className="text-xl font-semibold text-white">{statusLabel}</div>
+          <div className="text-sm font-semibold text-white">{statusLabel}</div>
         </div>
 
         {/* Issue found */}
@@ -100,23 +101,32 @@ export function QuoteLineCard(props: {
           <div className={codeBox}>{safeTrim(issueText) || "—"}</div>
         </div>
 
-        {/* Photo */}
         <div className="mt-4">
-          <div className="text-sm font-semibold text-neutral-200">
-            📷 Inspection Photo
-          </div>
-          <div className="mt-2 rounded-xl border border-white/10 bg-black/55 p-3">
-            {photoUrl ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={photoUrl}
-                alt="Inspection"
-                className="h-auto w-full rounded-lg object-cover"
-              />
-            ) : (
-              <div className="text-sm text-neutral-400">(image)</div>
-            )}
-          </div>
+          <div className="text-sm font-semibold text-neutral-200">Evidence photo</div>
+          {imageList.length > 0 ? (
+            <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {imageList.slice(0, 3).map((url, idx) => (
+                <a
+                  key={`${url}-${idx}`}
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="overflow-hidden rounded-xl border border-white/10 bg-slate-900/70"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={url}
+                    alt={`Evidence ${idx + 1}`}
+                    className="h-28 w-full object-cover"
+                  />
+                </a>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-2 rounded-xl border border-dashed border-white/10 bg-slate-950/50 px-3 py-2 text-xs text-neutral-400">
+              No photo attached for this recommendation.
+            </div>
+          )}
         </div>
 
         {/* Recommended */}
@@ -168,9 +178,7 @@ export function QuoteLineCard(props: {
 
         {showActions ? (
           <div className="mt-5">
-            <div className="text-sm font-semibold text-neutral-200">
-              Approve / Decline
-            </div>
+            <div className="text-sm font-semibold text-neutral-200">Decision</div>
             <div className="mt-3 flex flex-wrap gap-2">
               <button
                 type="button"
@@ -199,11 +207,11 @@ export function QuoteLineCard(props: {
       </div>
 
       {footerNote ? (
-        <div className="mt-5 border-t border-white/10 px-5 py-3 text-xs text-neutral-500">
+        <div className="mt-4 border-t border-white/10 px-4 py-2.5 text-xs text-neutral-500 sm:px-5">
           {footerNote}
         </div>
       ) : (
-        <div className="h-5" />
+        <div className="h-4" />
       )}
     </div>
   );

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -31,7 +31,7 @@ type WorkOrderWithMeta = WorkOrder & {
 const COPPER = "#C57A4A";
 
 const INPUT_DARK =
-  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-light)] focus:ring-2 focus:ring-[var(--accent-copper)]/35";
+  "w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-sky-300/50 focus:ring-2 focus:ring-sky-300/20";
 
 function safeTrim(x: unknown): string {
   return typeof x === "string" ? x.trim() : "";
@@ -55,6 +55,15 @@ function queueAccent(waitingForParts: boolean): {
     border: "border-emerald-500/25",
     progress: "bg-emerald-400",
   };
+}
+
+function approvalProgress(lines: WorkOrderWithMeta["work_order_lines"] | undefined): number {
+  if (!Array.isArray(lines) || lines.length === 0) return 0;
+  const decided = lines.filter((line) => {
+    const state = safeTrim(line.approval_state).toLowerCase();
+    return state === "approved" || state === "declined" || state === "deferred";
+  }).length;
+  return Math.round((decided / lines.length) * 100);
 }
 
 function ApprovalsList(): JSX.Element {
@@ -284,23 +293,15 @@ function ApprovalsList(): JSX.Element {
 
   return (
     <section className="space-y-4">
-      <div className="overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(197,122,74,0.12),rgba(0,0,0,0.92)_38%,rgba(2,6,23,0.98)_100%)] shadow-[0_0_60px_rgba(0,0,0,0.8)]">
-        <div className="border-b border-white/8 px-5 py-5 sm:px-6">
+      <div className="overflow-hidden rounded-[24px] border border-slate-300/15 bg-slate-950/65 shadow-[0_0_40px_rgba(2,6,23,0.75)]">
+        <div className="border-b border-white/8 px-5 py-4 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
                 Work Orders
               </div>
-              <h1
-                className="mt-2 text-3xl text-white"
-                style={{ fontFamily: "var(--font-blackops)" }}
-              >
-                Quote Review
-              </h1>
-              <p className="mt-2 max-w-2xl text-sm text-neutral-300">
-                Review work orders that are waiting for approval, see which ones
-                are still waiting on parts, and jump directly into the quote flow.
-              </p>
+              <h1 className="mt-1 text-2xl font-semibold text-white">Quote Review Queue</h1>
+              <p className="mt-1 text-sm text-neutral-400">Triage records ready for advisor review.</p>
 
               <div className="mt-4 flex flex-wrap gap-2">
                 <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
@@ -323,12 +324,6 @@ function ApprovalsList(): JSX.Element {
                 Open work orders
               </Link>
 
-              <Link
-                href="/billing"
-                className="inline-flex items-center justify-center rounded-full border border-[var(--accent-copper-light)]/35 bg-[var(--accent-copper)]/12 px-4 py-2 text-sm font-semibold text-[var(--accent-copper-light)] transition hover:bg-[var(--accent-copper)]/20"
-              >
-                Billing
-              </Link>
             </div>
           </div>
         </div>
@@ -340,7 +335,7 @@ function ApprovalsList(): JSX.Element {
                 value={q}
                 onChange={(e) => setQ(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && void load()}
-                placeholder="Search work order, shop, status, or queue state..."
+                placeholder="Search WO, customer, vehicle, or status..."
                 className={INPUT_DARK}
               />
             </div>
@@ -358,12 +353,12 @@ function ApprovalsList(): JSX.Element {
         </div>
       </div>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {rows.map((w) => {
           const quoteHref = `/quote-review/${w.id}`;
           const woHref = `/work-orders/${w.id}`;
           const accent = queueAccent(Boolean(w.waiting_for_parts));
-          const progressValue = w.waiting_for_parts ? 45 : 78;
+          const progressValue = approvalProgress(w.work_order_lines);
           const decisionEvents = deriveEventsFromQuote({
             workOrder: w,
             lines: w.work_order_lines ?? [],
@@ -373,16 +368,13 @@ function ApprovalsList(): JSX.Element {
           return (
             <div
               key={w.id}
-              className={[
-                "overflow-hidden rounded-[24px] border bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(255,255,255,0.01))] shadow-[0_0_40px_rgba(0,0,0,0.55)]",
-                accent.border,
-              ].join(" ")}
+              className={["overflow-hidden rounded-[18px] border bg-slate-950/65 shadow-[0_10px_30px_rgba(2,6,23,0.65)]", accent.border].join(" ")}
             >
-              <div className="border-b border-white/8 px-4 py-4">
+              <div className="border-b border-white/8 px-4 py-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <div className="text-2xl font-semibold text-white">
+                      <div className="text-lg font-semibold text-white">
                         {w.custom_id ? w.custom_id : `#${w.id.slice(0, 8)}`}
                       </div>
 
@@ -396,14 +388,11 @@ function ApprovalsList(): JSX.Element {
                       </StatusBadge>
                     </div>
 
-                    <div className="mt-3 text-base font-semibold text-white">
-                      {w.shops?.name || "Shop"}
+                    <div className="mt-2 truncate text-sm font-semibold text-white">
+                      {w.shops?.name || "Work order"}
                     </div>
-                    <div className="mt-1 text-sm text-neutral-300">
+                    <div className="mt-1 text-xs text-neutral-400">
                       {formatDecisionStatus({ workStatus: w.status }).label}
-                      {typeof w.labor_hours === "number"
-                        ? ` • ${w.labor_hours.toFixed(1)}h`
-                        : ""}
                     </div>
                   </div>
 
@@ -418,9 +407,9 @@ function ApprovalsList(): JSX.Element {
                 </div>
               </div>
 
-              <div className="px-4 py-4">
+              <div className="px-4 py-3">
                 <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.16em] text-neutral-500">
-                  <span>Approval progress</span>
+                  <span>Decision progress</span>
                   <span>{progressValue}%</span>
                 </div>
                 <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/10">
@@ -430,26 +419,31 @@ function ApprovalsList(): JSX.Element {
                   />
                 </div>
 
-                <div className="mt-4 grid grid-cols-2 gap-3">
+                <div className="mt-3 grid grid-cols-2 gap-2">
                   <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
                     <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-                      Work order
-                    </div>
-                    <div className="mt-1 text-sm font-semibold text-white">
-                      {w.custom_id ? `#${w.custom_id}` : `#${w.id.slice(0, 8)}`}
-                    </div>
-                  </div>
-
-                  <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
-                    <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-                      Labor hours
+                      Labor
                     </div>
                     <div className="mt-1 text-sm font-semibold text-white">
                       {typeof w.labor_hours === "number" ? `${w.labor_hours.toFixed(1)}h` : "—"}
                     </div>
                   </div>
+
+                  <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                      Created
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-white">
+                      {w.created_at ? new Date(w.created_at).toLocaleDateString() : "—"}
+                    </div>
+                  </div>
                 </div>
-                <DecisionEventFeed events={decisionEvents} compact className="mt-4" maxVisible={5} />
+                <details className="mt-3">
+                  <summary className="cursor-pointer text-xs font-medium text-neutral-400 hover:text-neutral-200">
+                    Decision history
+                  </summary>
+                  <DecisionEventFeed events={decisionEvents} compact className="mt-2" maxVisible={4} />
+                </details>
 
                 <div className="mt-4 flex flex-wrap gap-2">
                   <Link
@@ -491,7 +485,7 @@ export default function QuoteReviewIndexPage(): JSX.Element {
     <div
       className="
         min-h-screen px-4 py-6 text-foreground
-        bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
+        bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.1),transparent_52%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
       "
       style={{ ["--copper" as never]: COPPER }}
     >

--- a/features/work-orders/quote-review/LearnedSuggestionCard.tsx
+++ b/features/work-orders/quote-review/LearnedSuggestionCard.tsx
@@ -23,58 +23,32 @@ export default function LearnedSuggestionCard(props: {
   const { suggestion, onApplyLabor, onAddAsJob, onDismiss } = props;
 
   return (
-    <div className="rounded-2xl border border-[color:var(--copper,#C57A4A)]/25 bg-[color:var(--copper,#C57A4A)]/8 p-3">
-      <div className="flex flex-wrap items-start justify-between gap-2">
+    <div className="rounded-xl border border-slate-300/15 bg-slate-950/55 px-3 py-2.5">
+      <div className="flex flex-wrap items-start justify-between gap-2.5">
         <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="text-sm font-semibold text-white">
-              {suggestion.title}
-            </div>
-
-            <span className="rounded-full border border-[color:var(--copper,#C57A4A)]/35 bg-black/35 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--copper,#C57A4A)]">
-              Based on previous jobs
-            </span>
-
-            {suggestion.sourceCount > 0 ? (
-              <span className="text-[11px] text-neutral-400">
-                {suggestion.sourceCount} similar
-              </span>
-            ) : null}
+          <div className="text-[11px] font-medium text-slate-200">
+            Suggested from prior similar jobs
+            {suggestion.sourceCount > 0 ? ` • ${suggestion.sourceCount} similar` : ""}
+            {suggestion.laborHours != null ? ` • ${suggestion.laborHours}h labor` : ""}
           </div>
 
+          <div className="mt-1 truncate text-sm font-semibold text-white">{suggestion.title}</div>
           {suggestion.summary ? (
-            <div className="mt-1 text-xs text-neutral-300">
-              {suggestion.summary}
-            </div>
+            <details className="mt-1 text-[11px] text-slate-300/90">
+              <summary className="cursor-pointer text-slate-400 hover:text-slate-200">
+                Details
+              </summary>
+              <div className="mt-1">{suggestion.summary}</div>
+            </details>
           ) : null}
-
-          <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-neutral-400">
-            {suggestion.laborHours != null ? (
-              <span>
-                Labor:{" "}
-                <span className="text-neutral-200">
-                  {suggestion.laborHours} hr
-                </span>
-              </span>
-            ) : null}
-
-            {suggestion.parts.length > 0 ? (
-              <span>
-                Parts:{" "}
-                <span className="text-neutral-200">
-                  {partsLabel(suggestion.parts)}
-                </span>
-              </span>
-            ) : null}
-
+          <div className="mt-1 flex flex-wrap gap-3 text-[11px] text-slate-400">
+            {suggestion.parts.length > 0 ? <span>Parts: {partsLabel(suggestion.parts)}</span> : null}
             {suggestion.confidence != null ? (
               <span>
-                Confidence:{" "}
-                <span className="text-neutral-200">
-                  {suggestion.confidence > 1
-                    ? `${Math.round(suggestion.confidence)}%`
-                    : `${Math.round(suggestion.confidence * 100)}%`}
-                </span>
+                Confidence{" "}
+                {suggestion.confidence > 1
+                  ? `${Math.round(suggestion.confidence)}%`
+                  : `${Math.round(suggestion.confidence * 100)}%`}
               </span>
             ) : null}
           </div>
@@ -85,7 +59,7 @@ export default function LearnedSuggestionCard(props: {
             <button
               type="button"
               onClick={onApplyLabor}
-              className="rounded-full border border-[color:var(--copper,#C57A4A)]/45 bg-[color:var(--copper,#C57A4A)]/12 px-3 py-1 text-xs font-semibold text-[color:var(--copper,#C57A4A)] hover:bg-[color:var(--copper,#C57A4A)]/18"
+              className="rounded-full border border-[color:var(--copper,#C57A4A)]/45 bg-[color:var(--copper,#C57A4A)]/10 px-3 py-1 text-xs font-semibold text-[color:var(--copper,#C57A4A)] hover:bg-[color:var(--copper,#C57A4A)]/18"
             >
               Apply labor
             </button>
@@ -94,9 +68,9 @@ export default function LearnedSuggestionCard(props: {
           <button
             type="button"
             onClick={onAddAsJob}
-            className="rounded-full border border-white/10 bg-black/45 px-3 py-1 text-xs font-semibold text-white hover:bg-black/60"
+            className="rounded-full border border-white/10 bg-slate-900/70 px-3 py-1 text-xs font-semibold text-white hover:bg-slate-900"
           >
-            Add as job
+            Add as line
           </button>
 
           <button

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -34,6 +34,7 @@ type AllocationUpdate =
   DB["public"]["Tables"]["work_order_part_allocations"]["Update"];
 
 type Part = DB["public"]["Tables"]["parts"]["Row"];
+type InspectionPhoto = DB["public"]["Tables"]["inspection_photos"]["Row"];
 
 type AllocationWithPart = Allocation & {
   parts?: Pick<Part, "name" | "sku"> | null;
@@ -99,6 +100,40 @@ function deriveComplaintFromNotes(notes: unknown): string | null {
 
   // Strip trailing punctuation that makes it look weird in an input
   return derived.replace(/[.\s]+$/, "");
+}
+
+function isValidEmail(v: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+}
+
+function toSearchable(value: unknown): string {
+  return safeTrim(value).toLowerCase();
+}
+
+function collectLinePhotoUrls(
+  line: Pick<Line, "description" | "complaint" | "cause" | "correction">,
+  photos: Array<Pick<InspectionPhoto, "image_url" | "item_name">>,
+): string[] {
+  if (photos.length === 0) return [];
+  const haystack = [
+    toSearchable(line.description),
+    toSearchable(line.complaint),
+    toSearchable(line.cause),
+    toSearchable(line.correction),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (!haystack) return [];
+
+  return photos
+    .filter((photo) => {
+      const label = toSearchable(photo.item_name);
+      return label && (haystack.includes(label) || label.includes(haystack.slice(0, 24)));
+    })
+    .map((photo) => safeTrim(photo.image_url))
+    .filter(Boolean)
+    .slice(0, 4);
 }
 
 type EditableLine = Line & { _dirty?: boolean };
@@ -253,7 +288,7 @@ function partsToPaste(parts: Array<{ name: string; qty: number }>): string {
 }
 
 const card =
-  "rounded-2xl border border-white/10 bg-black/40 shadow-[0_24px_70px_rgba(0,0,0,0.65)]";
+  "rounded-2xl border border-slate-300/15 bg-slate-950/55 shadow-[0_20px_48px_rgba(2,6,23,0.65)]";
 const divider = "border-white/10";
 const inputBase =
   "mt-1 w-full rounded-lg border border-white/10 bg-black/60 px-2.5 py-2 text-sm text-white placeholder:text-neutral-500 outline-none";
@@ -281,6 +316,10 @@ export default function QuoteReviewView(props: {
 
   const [saving, setSaving] = useState(false);
   const [sending, setSending] = useState(false);
+  const [savingCustomerEmail, setSavingCustomerEmail] = useState(false);
+  const [pendingCustomerEmail, setPendingCustomerEmail] = useState("");
+  const [sendBlocker, setSendBlocker] = useState<string | null>(null);
+  const [linePhotos, setLinePhotos] = useState<Record<string, string[]>>({});
 
   const [delOpen, setDelOpen] = useState(false);
   const [delLineId, setDelLineId] = useState<string | null>(null);
@@ -445,11 +484,14 @@ export default function QuoteReviewView(props: {
       if (custErr) {
         toast.error(custErr.message);
         setCustomer(null);
+        setPendingCustomerEmail("");
       } else {
         setCustomer((custRow as Customer | null) ?? null);
+        setPendingCustomerEmail(safeTrim(custRow?.email ?? ""));
       }
     } else {
       setCustomer(null);
+      setPendingCustomerEmail("");
     }
 
     // lines
@@ -462,6 +504,7 @@ export default function QuoteReviewView(props: {
     if (lineErr) {
       toast.error(lineErr.message);
       setLines([]);
+      setLinePhotos({});
     } else {
       const mapped = (lineRows ?? []).map((l) => {
         const existingComplaint = safeTrim(l.complaint);
@@ -476,6 +519,29 @@ export default function QuoteReviewView(props: {
       });
 
       setLines(mapped);
+
+      const inspectionId = safeTrim((woRow as { inspection_id?: unknown } | null)?.inspection_id);
+      if (inspectionId) {
+        const { data: photosRaw } = await supabase
+          .from("inspection_photos")
+          .select("image_url,item_name")
+          .eq("inspection_id", inspectionId)
+          .order("created_at", { ascending: false })
+          .limit(120);
+
+        const photos =
+          ((photosRaw ?? []) as Array<Pick<InspectionPhoto, "image_url" | "item_name">>)
+            .filter((photo) => safeTrim(photo.image_url).length > 0);
+
+        const nextPhotoMap: Record<string, string[]> = {};
+        for (const line of mapped) {
+          const matched = collectLinePhotoUrls(line, photos);
+          if (matched.length > 0) nextPhotoMap[line.id] = matched;
+        }
+        setLinePhotos(nextPhotoMap);
+      } else {
+        setLinePhotos({});
+      }
     }
 
     // allocations
@@ -699,6 +765,34 @@ export default function QuoteReviewView(props: {
     await reload();
   }
 
+  async function saveCustomerEmailInline() {
+    if (!wo?.customer_id) {
+      toast.error("No customer linked to this work order.");
+      return;
+    }
+    const nextEmail = safeTrim(pendingCustomerEmail);
+    if (!nextEmail || !isValidEmail(nextEmail)) {
+      toast.error("Enter a valid customer email.");
+      return;
+    }
+
+    setSavingCustomerEmail(true);
+    try {
+      const { error } = await supabase
+        .from("customers")
+        .update({ email: nextEmail })
+        .eq("id", wo.customer_id);
+      if (error) throw error;
+      setSendBlocker(null);
+      toast.success("Customer email saved.");
+      await reload();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Failed to save customer email.");
+    } finally {
+      setSavingCustomerEmail(false);
+    }
+  }
+
   async function sendQuoteToCustomer() {
     if (!woId) return;
     if (sending) return;
@@ -716,10 +810,15 @@ export default function QuoteReviewView(props: {
       const json: { ok?: boolean; error?: string } = await res.json();
 
       if (!res.ok || !json.ok) {
-        toast.error(json.error ?? "Failed to send quote.");
+        const message = safeTrim(json.error ?? "Failed to send quote.");
+        if (message.toLowerCase().includes("missing customer email")) {
+          setSendBlocker("Customer email required to send quote");
+        }
+        toast.error(message);
         return;
       }
 
+      setSendBlocker(null);
       toast.success("Quote sent to customer (email + portal notification).");
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : "Failed to send quote.");
@@ -735,6 +834,7 @@ export default function QuoteReviewView(props: {
 
   const phoneRaw = safeTrim(customer?.phone ?? "");
   const emailRaw = safeTrim(customer?.email ?? "");
+  const missingCustomerEmail = !emailRaw;
   const tel = normalizePhoneForTel(phoneRaw);
 
   // ✅ Embedded mode sizing + padding
@@ -742,7 +842,7 @@ export default function QuoteReviewView(props: {
     ? "min-h-full w-full px-0 py-0 text-foreground"
     : `
       min-h-screen px-4 py-6 text-foreground
-      bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
+      bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.08),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
     `;
 
   const containerCls = embedded ? "mx-auto w-full max-w-none" : "mx-auto max-w-7xl";
@@ -890,7 +990,7 @@ export default function QuoteReviewView(props: {
                   {emailRaw ? (
                     <a
                       href={`mailto:${emailRaw}`}
-                      className="truncate text-sm font-semibold text-[color:var(--copper)] hover:underline"
+                      className="block break-all text-sm font-semibold leading-tight text-[color:var(--copper)] hover:underline"
                       title="Email customer"
                     >
                       {emailRaw}
@@ -968,15 +1068,11 @@ export default function QuoteReviewView(props: {
                       "—";
 
                     const whyRecommended = [
-                      safeTrim(l.correction) ? "Corrective action maps directly to the identified issue." : "Recommendation is tied to the current finding.",
-                      laborHours > 0 ? `Labor time estimate recorded at ${laborHours.toFixed(2)}h.` : null,
-                      partsAmt > 0 ? `Parts are already scoped (${fmt(partsAmt)}).` : null,
-                    ].filter((item): item is string => Boolean(item));
+                      safeTrim(l.correction) || "Recommended repair linked to this finding.",
+                    ];
 
                     const supportingEvidence = [
-                      safeTrim(l.cause) ? `Finding detail: ${safeTrim(l.cause)}` : null,
-                      safeTrim(l.status) ? `Line status: ${statusLabel(l.status)}` : null,
-                      safeTrim(l.approval_state) ? `Decision state: ${statusLabel(l.approval_state)}` : null,
+                      safeTrim(l.cause) || safeTrim(l.notes) || safeTrim(l.complaint),
                     ].filter((item): item is string => Boolean(item));
 
                     const deferredConsequence =
@@ -986,13 +1082,14 @@ export default function QuoteReviewView(props: {
 
                     return (
                       <div key={l.id} className={`${padX} py-4`}>
-                        <div className="rounded-[24px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(197,122,74,0.10),rgba(0,0,0,0.88)_42%,rgba(2,6,23,0.96)_100%)] p-3 shadow-[0_24px_70px_rgba(0,0,0,0.65)]">
+                        <div className="rounded-[20px] border border-slate-300/15 bg-slate-950/60 p-2.5 shadow-[0_18px_48px_rgba(2,6,23,0.7)]">
                           <QuoteLineCard
                             title={title}
                             statusLabel="Issue Found"
                             statusTone={tone}
                             issueText={issueText}
-                            photoUrl={null}
+                            photoUrl={(linePhotos[l.id] ?? [])[0] ?? null}
+                            photoUrls={linePhotos[l.id] ?? []}
                             recommendedText={recText}
                             partsTotal={partsAmt}
                             laborTotal={laborAmt}
@@ -1000,7 +1097,7 @@ export default function QuoteReviewView(props: {
                             onApprove={() => void setDecision(l.id, "approve")}
                             onDecline={() => void setDecision(l.id, "decline")}
                             onDefer={() => void setDecision(l.id, "defer")}
-                            footerNote={`approval_state=${l.approval_state ?? "null"} • status=${l.status ?? "null"}`}
+                            footerNote={null}
                             whyRecommended={whyRecommended}
                             supportingEvidence={supportingEvidence}
                             deferredConsequence={deferredConsequence}
@@ -1358,15 +1455,45 @@ export default function QuoteReviewView(props: {
                 Send to customer
               </div>
               <div className={`${padX} py-4 text-sm text-neutral-400`}>
-                Sends an email and creates a portal notification with the quote link.
+                Send quote email + portal notification.
+                {(missingCustomerEmail || sendBlocker) ? (
+                  <div className="mt-3 rounded-xl border border-amber-400/35 bg-amber-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">
+                      Blocked
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-amber-100">
+                      {sendBlocker ?? "Customer email required to send quote"}
+                    </div>
+                    <p className="mt-1 text-xs text-amber-100/80">
+                      Add the missing email here, save it, then retry send.
+                    </p>
+                    <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                      <input
+                        type="email"
+                        value={pendingCustomerEmail}
+                        onChange={(e) => setPendingCustomerEmail(e.target.value)}
+                        placeholder="customer@email.com"
+                        className="w-full rounded-lg border border-white/15 bg-slate-900/70 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-amber-300/70"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => void saveCustomerEmailInline()}
+                        disabled={savingCustomerEmail}
+                        className="rounded-lg border border-amber-300/45 bg-amber-400/15 px-3 py-2 text-sm font-semibold text-amber-100 hover:bg-amber-400/20 disabled:opacity-60"
+                      >
+                        {savingCustomerEmail ? "Saving…" : "Save email"}
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
                 <div className="mt-3">
                   <button
                     onClick={() => void sendQuoteToCustomer()}
-                    disabled={sending}
+                    disabled={sending || savingCustomerEmail}
                     className="
-                      w-full rounded-xl border border-white/10 bg-black/55
+                      w-full rounded-xl border border-white/10 bg-slate-900/80
                       px-4 py-2 text-sm font-semibold text-white
-                      hover:bg-black/70 disabled:opacity-60
+                      hover:bg-slate-900 disabled:opacity-60
                     "
                   >
                     {sending ? "Sending…" : "Send Quote"}


### PR DESCRIPTION
### Motivation
- Make Quote Review a compact, premium, evidence-forward approval workspace with stronger scanability and reduced decorative wording.  
- Surface technician inspection photos clearly on both internal review and customer-facing approval pages.  
- Remove noisy AI prose from the primary decision flow and provide a subordinate, actionable suggestion strip.  
- Provide repair-in-place for blocked send actions (e.g. missing customer email) so users can save and retry without leaving the page.

### Description
- Compact queue & header: tightened hero and list cards, switched to cooler blue/steel visual accents, added `approvalProgress` calculation and moved decision history behind a collapsed `<details>` disclosure for quieter triage.  
- Evidence-forward detail cards: `QuoteReviewView` now fetches `inspection_photos`, matches photos to individual lines, and passes `photoUrl`/`photoUrls` into the shared `QuoteLineCard` so each recommendation shows thumbnail evidence; card prose is simplified and hierarchy reduced.  
- Inline send-blocker repair: added send-blocker detection and right-rail inline email input + `saveCustomerEmailInline` flow and retry logic so missing customer email no longer forces navigation away from the review.  
- Quieter AI suggestions: `LearnedSuggestionCard` refactored to a concise strip with compact metadata, collapsed details, and direct actions (`Apply labor`, `Add as line`, `Dismiss`) so suggestions assist without overwhelming.  
- Customer portal adjustments: `QuotePageClient` loads inspection photos and surfaces evidence thumbnails per recommendation and reduces timeline/event framing for clearer customer view.  
- Visual & shared component updates: `QuoteLineCard` restyled and extended to accept multiple photos and show compact thumbnail treatment; several color/background adjustments to align with cool operational language.  
- Files changed: `features/work-orders/app/work-orders/quote-review/page.tsx`, `features/work-orders/quote-review/QuoteReviewView.tsx`, `features/shared/quote/QuoteLineCard.tsx`, `features/work-orders/quote-review/LearnedSuggestionCard.tsx`, `features/portal/app/quotes/[id]/QuotePageClient.tsx`.

### Testing
- Ran ESLint on the touched files: `npx eslint features/work-orders/app/work-orders/quote-review/page.tsx features/work-orders/quote-review/QuoteReviewView.tsx features/work-orders/quote-review/LearnedSuggestionCard.tsx features/shared/quote/QuoteLineCard.tsx features/portal/app/quotes/[id]/QuotePageClient.tsx` — completed (no blocking errors reported).  
- Type-check: `npx tsc --noEmit` — completed successfully (no type errors introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f27ba12c832894dfd80e980379d8)