### PR TITLE
Standardize desktop inspection-template theme into shared primitives

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,9 +58,21 @@
   --theme-shadow-medium: 0 18px 45px rgba(0, 0, 0, 0.45);
   --theme-shadow-strong: 0 24px 70px rgba(0, 0, 0, 0.5);
 
+  --desktop-bg-base: #030711;
+  --desktop-bg-secondary: #02050d;
+  --desktop-bg-tint: rgba(71, 104, 150, 0.16);
+  --desktop-panel-bg: linear-gradient(160deg, rgba(8, 13, 24, 0.92), rgba(3, 7, 16, 0.94));
+  --desktop-panel-bg-soft: rgba(5, 10, 20, 0.84);
+  --desktop-item-bg: rgba(7, 12, 24, 0.78);
+  --desktop-border: rgba(110, 137, 170, 0.34);
+  --desktop-border-strong: rgba(124, 155, 191, 0.56);
+  --desktop-shadow-panel: 0 24px 72px rgba(0, 0, 0, 0.62);
+  --desktop-shadow-card: 0 18px 45px rgba(0, 0, 0, 0.54);
+  --desktop-focus-ring: color-mix(in srgb, var(--brand-primary) 40%, #60a5fa);
+
   --app-shell-bg:
-    radial-gradient(circle at top, rgba(249, 115, 22, 0.18), transparent 55%),
-    radial-gradient(circle at bottom, rgba(15, 23, 42, 0.96), #020617 70%);
+    radial-gradient(circle at top, var(--desktop-bg-tint), transparent 52%),
+    radial-gradient(circle at bottom, color-mix(in srgb, var(--desktop-bg-base) 86%, #020617), var(--desktop-bg-secondary) 76%);
 }
 
 html {
@@ -210,6 +222,106 @@ select {
   border: 1px solid var(--theme-card-border);
   box-shadow: var(--theme-shadow-medium);
   border-radius: var(--theme-radius-xl);
+}
+
+@layer components {
+  .desktop-backdrop {
+    background:
+      radial-gradient(circle at top, var(--desktop-bg-tint), transparent 56%),
+      radial-gradient(circle at bottom, color-mix(in srgb, var(--desktop-bg-base) 88%, #020617), var(--desktop-bg-secondary) 78%);
+  }
+
+  .desktop-panel {
+    border-radius: 1rem;
+    border: 1px solid var(--desktop-border);
+    background: var(--desktop-panel-bg);
+    box-shadow: var(--desktop-shadow-panel);
+    backdrop-filter: blur(16px);
+  }
+
+  .desktop-panel-soft {
+    border-radius: 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 92%, transparent);
+    background: var(--desktop-panel-bg-soft);
+    box-shadow: var(--desktop-shadow-card);
+  }
+
+  .desktop-item-card {
+    border-radius: 1rem;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 90%, transparent);
+    background: var(--desktop-item-bg);
+    box-shadow: 0 16px 34px rgba(0, 0, 0, 0.42);
+  }
+
+  .desktop-title {
+    font-family: var(--font-blackops), var(--font-inter), system-ui, sans-serif;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--brand-primary) 82%, #f3f4f6);
+  }
+
+  .desktop-toolbar-row {
+    border-radius: 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 85%, transparent);
+    background: rgba(4, 9, 18, 0.62);
+    padding: 0.65rem;
+  }
+
+  .desktop-input {
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 92%, transparent);
+    background: rgba(3, 8, 16, 0.82);
+    color: var(--theme-text-primary);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .desktop-input::placeholder {
+    color: color-mix(in srgb, var(--theme-text-secondary) 84%, #9ca3af);
+  }
+
+  .desktop-input:focus-visible {
+    border-color: color-mix(in srgb, var(--brand-primary) 66%, #93c5fd);
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--brand-primary) 62%, transparent),
+      0 0 0 3px color-mix(in srgb, var(--desktop-focus-ring) 30%, transparent);
+  }
+
+  .desktop-pill {
+    border-radius: 9999px;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 90%, transparent);
+    background: rgba(5, 10, 18, 0.68);
+    color: #d4d4d8;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 10px;
+    padding: 0.375rem 0.75rem;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+  }
+
+  .desktop-pill-active {
+    border-color: color-mix(in srgb, var(--brand-primary) 66%, #facc15);
+    background: color-mix(in srgb, var(--brand-primary) 22%, rgba(6, 10, 19, 0.9));
+    color: #f8fafc;
+  }
+
+  .desktop-btn-primary {
+    border-radius: 9999px;
+    border: 1px solid color-mix(in srgb, var(--brand-primary) 58%, #fbbf24);
+    background: linear-gradient(to right, color-mix(in srgb, var(--brand-primary) 88%, #f3f4f6), color-mix(in srgb, var(--brand-primary) 60%, #f59e0b));
+    color: #020617;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    box-shadow: 0 0 20px color-mix(in srgb, var(--brand-primary) 40%, transparent);
+  }
+
+  .desktop-btn-secondary {
+    border-radius: 9999px;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 92%, transparent);
+    background: rgba(3, 8, 16, 0.72);
+    color: #e5e7eb;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+  }
 }
 
 

--- a/features/fleet/components/FleetUnitsPage.tsx
+++ b/features/fleet/components/FleetUnitsPage.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import type { FleetUnitListItem } from "app/api/fleet/units/route";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type Props = {
   shopId?: string | null;
@@ -22,10 +23,6 @@ export default function FleetUnitsPage({
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [fleetFilter, setFleetFilter] = useState<string>("all");
-
-  const card =
-    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
 
   useEffect(() => {
     let cancelled = false;
@@ -107,35 +104,20 @@ export default function FleetUnitsPage({
   }, [units, search, fleetFilter]);
 
   return (
-    <div className="px-4 py-6 text-white">
-      <div className="mx-auto w-full max-w-6xl space-y-5">
-        {/* Copper wash */}
-        <div
-          aria-hidden
-          className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.16),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]"
-        />
+    <div className={ui.page}>
+      <div className={ui.container}>
+        <div aria-hidden className={ui.backdrop} />
 
         {/* Header */}
-        <div className={card + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 -top-10 h-24 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),transparent_65%)]"
-          />
-          <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className={`${ui.panel} ${ui.panelPadding} relative overflow-hidden`}>
+          <div className={ui.headerTop}>
             <div>
-              <h1
-                className="text-xl font-bold tracking-[0.22em] text-sky-300 md:text-2xl uppercase"
-                style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}
-              >
-                Fleet Units
-              </h1>
-              <p className="mt-1 text-xs text-neutral-300">
+              <h1 className={ui.title}>Fleet Units</h1>
+              <p className={ui.subtitle}>
                 Master list of tractors, trailers, buses and other HD assets
                 enrolled in fleet programs.
               </p>
-              <p className="mt-1 text-[11px] text-neutral-500">
-                Actor surface: {uiContext.actorLabel}
-              </p>
+              <p className={ui.note}>Actor surface: {uiContext.actorLabel}</p>
             </div>
 
             <div className="flex flex-col gap-2 md:items-end">
@@ -145,7 +127,7 @@ export default function FleetUnitsPage({
               <select
                 value={fleetFilter}
                 onChange={(e) => setFleetFilter(e.target.value)}
-                className="min-w-[180px] rounded-xl border border-white/10 bg-black/60 px-3 py-2 text-xs text-white shadow-card backdrop-blur-xl"
+                className={`${ui.input} min-w-[180px] text-xs`}
               >
                 <option value="all">All fleets</option>
                 {fleets.map((f) => (
@@ -158,13 +140,13 @@ export default function FleetUnitsPage({
           </div>
 
           {/* Search */}
-          <div className="relative mt-4 flex flex-col gap-2 md:flex-row md:items-center">
+          <div className={ui.toolbarRow}>
             <div className="relative flex-1">
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by unit, plate, VIN, location…"
-                className="w-full rounded-xl border border-white/10 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 shadow-card backdrop-blur-xl focus:outline-none focus:ring-2 focus:ring-sky-400/40"
+                className={ui.input}
               />
             </div>
 
@@ -175,7 +157,7 @@ export default function FleetUnitsPage({
         </div>
 
         {/* Content */}
-        <div className={card + " px-4 py-4 md:px-6 md:py-5"}>
+        <div className={`${ui.panel} ${ui.panelPadding}`}>
           {error && (
             <div className="rounded-xl border border-red-700 bg-red-900/30 px-4 py-3 text-xs text-red-200">
               {error}

--- a/features/fleet/components/PretripReportsPage.tsx
+++ b/features/fleet/components/PretripReportsPage.tsx
@@ -3,10 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
-
-const card =
-  "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-  "bg-black/70 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type PretripStatus = "open" | "reviewed" | "archived" | "all";
 
@@ -111,32 +108,18 @@ export default function PretripReportsPage({
   }, [reports, statusFilter, defectFilter, search]);
 
   return (
-    <div className="px-4 py-6 text-white">
-      <div className="mx-auto w-full max-w-6xl space-y-5">
-        <div
-          aria-hidden
-          className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.16),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]"
-        />
+    <div className={ui.page}>
+      <div className={ui.container}>
+        <div aria-hidden className={ui.backdrop} />
 
-        <div className={card + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 -top-10 h-24 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),transparent_65%)]"
-          />
-          <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className={`${ui.panel} ${ui.panelPadding} relative overflow-hidden`}>
+          <div className={ui.headerTop}>
             <div>
-              <h1
-                className="text-xl font-bold tracking-[0.22em] text-sky-300 md:text-2xl uppercase"
-                style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}
-              >
-                Pre-trip Reports
-              </h1>
-              <p className="mt-1 text-xs text-neutral-300">
+              <h1 className={ui.title}>Pre-trip Reports</h1>
+              <p className={ui.subtitle}>
                 View and audit daily DVIR / pre-trip reports coming in from drivers.
               </p>
-              <p className="mt-1 text-[11px] text-neutral-500">
-                Actor surface: {uiContext.actorLabel}
-              </p>
+              <p className={ui.note}>Actor surface: {uiContext.actorLabel}</p>
             </div>
 
             <div className="flex flex-wrap gap-2 text-[11px] text-neutral-400">
@@ -149,13 +132,13 @@ export default function PretripReportsPage({
             </div>
           </div>
 
-          <div className="relative mt-4 flex flex-col gap-2 md:flex-row md:items-center">
+          <div className={ui.toolbarRow}>
             <div className="relative flex-1">
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by unit, plate, driver, status…"
-                className="w-full rounded-xl border border-white/10 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 shadow-card backdrop-blur-xl focus:outline-none focus:ring-2 focus:ring-sky-400/40"
+                className={ui.input}
               />
             </div>
 
@@ -172,7 +155,7 @@ export default function PretripReportsPage({
           </div>
         </div>
 
-        <div className={card + " px-4 py-4 md:px-6 md:py-5"}>
+        <div className={`${ui.panel} ${ui.panelPadding}`}>
           <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-wrap gap-2 text-[11px]">
               {(["all", "open", "reviewed", "archived"] as const).map((st) => (

--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -1,4 +1,3 @@
-// features/inspections/app/inspection/templates/page.tsx (FULL FILE REPLACEMENT)
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
@@ -6,6 +5,7 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import FleetFormImportCard from "@/features/inspections/components/FleetFormImportCard";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type Template = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -27,12 +27,10 @@ export default function InspectionTemplatesPage() {
     (async () => {
       setLoading(true);
 
-      // get current user
       const { data: auth } = await supabase.auth.getUser();
       const uid = auth?.user?.id ?? null;
       setUserId(uid);
 
-      // resolve shop_id for this user (if any)
       let resolvedShopId: string | null = null;
       if (uid) {
         const byUser = await supabase
@@ -56,7 +54,6 @@ export default function InspectionTemplatesPage() {
       }
       setShopId(resolvedShopId);
 
-      // "My" templates (optionally scoped to shop)
       const minePromise = uid
         ? (() => {
             let q = supabase
@@ -74,7 +71,6 @@ export default function InspectionTemplatesPage() {
             error: null,
           });
 
-      // Shared/public templates (optionally scoped to shop)
       const sharedPromise = (() => {
         let q = supabase
           .from("inspection_templates")
@@ -107,7 +103,6 @@ export default function InspectionTemplatesPage() {
     } else if (scope === "shared") {
       pool = shared;
     } else {
-      // "all" — merge by id to avoid duplicates if a template is both mine + shared
       const byId = new Map<string, Template>();
       for (const t of [...mine, ...shared]) {
         if (!t.id) continue;
@@ -150,7 +145,6 @@ export default function InspectionTemplatesPage() {
       setMine((prev) => prev.filter((t) => t.id !== id));
       setShared((prev) => prev.filter((t) => t.id !== id));
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error("Delete failed:", e);
       alert("Failed to delete template.");
     } finally {
@@ -158,80 +152,29 @@ export default function InspectionTemplatesPage() {
     }
   }
 
-  const headerCard =
-    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
-
-  const listCard =
-    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_20px_70px_rgba(0,0,0,0.95)] backdrop-blur-xl";
-
-  const pillBase =
-    "px-3 py-1 text-[10px] uppercase tracking-[0.16em] rounded-full border " +
-    "transition-colors";
-
-  // copper palette (replaces all orange usage)
-  const COPPER_18 = "rgba(200,122,67,0.18)";
-  const COPPER_20 = "rgba(200,122,67,0.20)";
-  const COPPER_14 = "rgba(200,122,67,0.14)";
-  const COPPER_90 = "rgba(200,122,67,0.90)";
-  const COPPER_70 = "rgba(200,122,67,0.70)";
-  const COPPER_65 = "rgba(200,122,67,0.65)";
-  const COPPER_55 = "rgba(200,122,67,0.55)";
-  const COPPER_SHADOW_60 = "rgba(200,122,67,0.60)";
-  const COPPER_SHADOW_80 = "rgba(200,122,67,0.80)";
-
   return (
-    <div className="px-4 py-6 text-white">
-      <div className="mx-auto w-full max-w-6xl space-y-5">
-        {/* Copper wash (was orange) */}
-        <div
-          aria-hidden
-          className={`
-            pointer-events-none fixed inset-0 -z-10
-            bg-[radial-gradient(circle_at_top,${COPPER_18},transparent_55%),radial-gradient(circle_at_bottom,rgba(15,23,42,0.96),#020617_78%)]
-          `}
-        />
+    <div className={ui.page}>
+      <div className={ui.container}>
+        <div aria-hidden className={ui.backdrop} />
 
-        {/* Header + filters */}
-        <div className={headerCard + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
-          <div
-            aria-hidden
-            className={`
-              pointer-events-none absolute inset-x-0 -top-10 h-24
-              bg-[radial-gradient(circle_at_top,${COPPER_20},transparent_65%)]
-            `}
-          />
-
-          <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <section className={`${ui.panel} ${ui.panelPadding} relative overflow-hidden`}>
+          <div className={ui.headerTop}>
             <div>
-              <h1
-                className={`text-xl font-bold tracking-[0.22em] text-[${COPPER_90}] md:text-2xl uppercase`}
-                style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}
-              >
-                Inspection Templates
-              </h1>
-              <p className="mt-1 text-xs text-neutral-300">
+              <h1 className={ui.title}>Inspection Templates</h1>
+              <p className={ui.subtitle}>
                 Build, import, and manage inspection templates for your shop and fleets.
               </p>
             </div>
 
             <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
-              {/* Scope pills */}
-              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-black/60">
+              <div className="flex overflow-hidden rounded-full border border-[color:var(--desktop-border)] bg-black/50">
                 {(["mine", "shared", "all"] as Scope[]).map((s) => {
                   const isActive = scope === s;
                   return (
                     <button
                       key={s}
                       onClick={() => setScope(s)}
-                      className={
-                        pillBase +
-                        " " +
-                        (isActive
-                          ? `border-[${COPPER_70}] bg-[rgba(15,23,42,0.95)] text-[rgba(248,250,252,0.95)]`
-                          : "border-transparent bg-transparent text-neutral-400 hover:bg-zinc-900/80")
-                      }
+                      className={isActive ? ui.pillActive : ui.pill}
                     >
                       {s === "mine" ? "My Templates" : s === "shared" ? "Shared" : "All"}
                     </button>
@@ -239,55 +182,35 @@ export default function InspectionTemplatesPage() {
                 })}
               </div>
 
-              {/* New template CTA (was orange gradient + orange glow) */}
-              <Link
-                href="/inspections/custom-inspection"
-                className={`
-                  mt-1 inline-flex items-center justify-center rounded-full
-                  bg-[linear-gradient(to_right,rgba(200,122,67,0.85),rgba(200,122,67,0.55))]
-                  px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-black
-                  shadow-[0_0_22px_${COPPER_SHADOW_60}] hover:shadow-[0_0_30px_${COPPER_SHADOW_80}]
-                  md:mt-0
-                `}
-              >
+              <Link href="/inspections/custom-inspection" className={ui.buttonPrimary}>
                 New Template
               </Link>
             </div>
           </div>
 
-          {/* Search */}
-          <div className="relative mt-4 flex flex-col gap-2 md:flex-row md:items-center">
+          <div className={ui.toolbarRow}>
             <div className="relative flex-1">
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by name, description, or tags…"
-                className={`
-                  w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70
-                  px-3 py-2 text-sm text-white placeholder:text-neutral-500
-                  focus:outline-none focus:ring-2 focus:ring-[${COPPER_55}]
-                `}
+                className={ui.input}
               />
             </div>
 
             <div className="text-[11px] text-neutral-500 md:pl-3">
-              <span className="hidden md:inline">Tip:</span>{" "}
-              Use fleet imports to match customer forms exactly.
+              <span className="hidden md:inline">Tip:</span> Use fleet imports to match customer forms exactly.
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Fleet import card */}
         <FleetFormImportCard />
 
-        {/* Templates list */}
-        <div className={listCard + " px-4 py-4 md:px-6 md:py-5"}>
+        <section className={`${ui.panel} ${ui.panelPadding}`}>
           {loading ? (
-            <div className="rounded-xl border border-neutral-800 bg-black/60 px-4 py-4 text-sm text-neutral-300">
-              Loading templates…
-            </div>
+            <div className={ui.loadingState}>Loading templates…</div>
           ) : rows.length === 0 ? (
-            <div className="rounded-xl border border-neutral-800 bg-black/60 px-4 py-6 text-center text-sm text-neutral-300">
+            <div className={ui.emptyState}>
               <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
                 No templates found
               </div>
@@ -300,9 +223,7 @@ export default function InspectionTemplatesPage() {
               {rows.map((t) => {
                 const mineOwned = canEditOrDelete(t);
                 const encodedName = encodeURIComponent(t.template_name ?? "Custom Inspection");
-
                 const createdAt = t.created_at ? new Date(t.created_at).toLocaleDateString() : "—";
-
                 const tags = Array.isArray(t.tags) ? t.tags : [];
                 const lowerTags = tags.map((tag) => tag.toLowerCase());
 
@@ -315,7 +236,6 @@ export default function InspectionTemplatesPage() {
                       "border-[rgba(56,189,248,0.55)] bg-[rgba(8,47,73,0.7)] text-sky-100",
                   });
                 }
-
                 if (
                   lowerTags.includes("dvir") ||
                   lowerTags.includes("pre-trip") ||
@@ -328,7 +248,6 @@ export default function InspectionTemplatesPage() {
                       "border-[rgba(45,212,191,0.6)] bg-[rgba(6,78,59,0.7)] text-emerald-100",
                   });
                 }
-
                 if (
                   lowerTags.includes("pm") ||
                   lowerTags.includes("preventive maintenance") ||
@@ -340,8 +259,6 @@ export default function InspectionTemplatesPage() {
                       "border-[rgba(196,181,253,0.6)] bg-[rgba(49,46,129,0.7)] text-violet-100",
                   });
                 }
-
-                // Fallback "Custom" chip if no special type detected
                 if (chips.length === 0) {
                   chips.push({
                     label: "Custom",
@@ -351,20 +268,8 @@ export default function InspectionTemplatesPage() {
                 }
 
                 return (
-                  <li
-                    key={t.id}
-                    className="relative overflow-hidden rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.95)]"
-                  >
-                    <div
-                      aria-hidden
-                      className={`
-                        pointer-events-none absolute inset-x-0 -top-10 h-20
-                        bg-[radial-gradient(circle_at_top,${COPPER_14},transparent_70%)]
-                      `}
-                    />
-
+                  <li key={t.id} className={ui.itemCard}>
                     <div className="relative flex flex-col gap-2">
-                      {/* Title + scope + chips */}
                       <div className="flex items-start justify-between gap-2">
                         <div>
                           <div className="text-sm font-semibold text-neutral-50">
@@ -392,7 +297,7 @@ export default function InspectionTemplatesPage() {
                               <span
                                 key={chip.label}
                                 className={
-                                  "rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] " +
+                                  "rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] border " +
                                   chip.className
                                 }
                               >
@@ -403,7 +308,6 @@ export default function InspectionTemplatesPage() {
                         </div>
                       </div>
 
-                      {/* Tags + meta */}
                       <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-neutral-500">
                         <span>{createdAt}</span>
                         {tags.length > 0 && (
@@ -413,61 +317,40 @@ export default function InspectionTemplatesPage() {
                               {tags.slice(0, 4).map((tag) => (
                                 <span
                                   key={tag}
-                                  className="rounded-full border border-neutral-700 bg-black/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-neutral-300"
+                                  className="rounded-full border border-[color:var(--desktop-border)] bg-black/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-neutral-300"
                                 >
                                   {tag}
                                 </span>
                               ))}
                               {tags.length > 4 && (
-                                <span className="text-[10px] text-neutral-500">
-                                  +{tags.length - 4} more
-                                </span>
+                                <span className="text-[10px] text-neutral-500">+{tags.length - 4} more</span>
                               )}
                             </div>
                           </>
                         )}
                       </div>
 
-                      {/* Actions */}
                       <div className="mt-3 flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2">
-                          {/* Use Template / run */}
-                          <Link
-                            href={`/inspections/run?templateId=${t.id}`}
-                            className={`
-                              rounded-full border border-[color:var(--metal-border-soft,#374151)]
-                              bg-black/70 px-3 py-1.5 text-[11px] uppercase tracking-[0.16em]
-                              text-neutral-100 hover:border-[${COPPER_65}] hover:bg-black/80
-                            `}
-                          >
+                          <Link href={`/inspections/run?templateId=${t.id}`} className={ui.buttonSecondary}>
                             Use
                           </Link>
 
-                          {/* Edit -> go to custom draft */}
                           {mineOwned && (
                             <Link
                               href={`/inspections/custom-draft?templateId=${t.id}&template=${encodedName}`}
-                              className={`
-                                rounded-full border border-[color:var(--metal-border-soft,#374151)]
-                                bg-black/70 px-3 py-1.5 text-[11px] uppercase tracking-[0.16em]
-                                text-neutral-100 hover:border-[${COPPER_65}] hover:bg-black/80
-                              `}
+                              className={ui.buttonSecondary}
                             >
                               Edit
                             </Link>
                           )}
                         </div>
 
-                        {/* Delete */}
                         {mineOwned && (
                           <button
                             onClick={() => handleDelete(t.id)}
                             disabled={deletingId === t.id}
-                            className="
-                              rounded-full border border-red-700/80 bg-red-900/30
-                              px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em]
-                              text-red-200 hover:bg-red-900/50 disabled:opacity-60
-                            "
+                            className="rounded-full border border-red-700/80 bg-red-900/30 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-200 hover:bg-red-900/50 disabled:opacity-60"
                             title="Delete template"
                           >
                             {deletingId === t.id ? "Deleting…" : "Delete"}
@@ -480,7 +363,7 @@ export default function InspectionTemplatesPage() {
               })}
             </ul>
           )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/features/inspections/components/FleetFormImportCard.tsx
+++ b/features/inspections/components/FleetFormImportCard.tsx
@@ -476,16 +476,9 @@ export default function FleetFormImportCard() {
       <form
         onSubmit={handleSubmit}
         className="
-          relative rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)]
-          bg-black/65 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl p-5
+          desktop-panel relative p-5
         "
       >
-        {/* Copper glow wash */}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_65%)]"
-        />
-
         <div className="mb-3 flex items-center justify-between">
           <div>
             <div className="text-[11px] font-blackops uppercase tracking-[0.18em] text-neutral-400">
@@ -512,8 +505,7 @@ export default function FleetFormImportCard() {
               multiple
               onChange={handleFileChange}
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white
+                desktop-input px-3 py-2 text-xs text-white
                 file:mr-2 file:rounded-lg file:border file:border-[color:var(--metal-border-soft,#374151)]
                 file:bg-black/50 file:px-3 file:py-1.5 file:text-[10px] file:uppercase
                 file:tracking-[0.18em] file:text-neutral-300
@@ -533,8 +525,7 @@ export default function FleetFormImportCard() {
               onChange={(e) => setTitleHint(e.target.value)}
               placeholder="ABC Logistics – Daily Truck Inspection"
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white placeholder:text-neutral-500
+                desktop-input px-3 py-2 text-xs text-white placeholder:text-neutral-500
               "
             />
           </label>
@@ -583,8 +574,7 @@ export default function FleetFormImportCard() {
               value={vehicleType}
               onChange={(e) => setVehicleType(e.target.value)}
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white
+                desktop-input px-3 py-2 text-xs text-white
               "
             >
               <option value="">Not specified</option>
@@ -602,8 +592,7 @@ export default function FleetFormImportCard() {
               value={dutyClass}
               onChange={(e) => setDutyClass(e.target.value as DutyClass | "")}
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white
+                desktop-input px-3 py-2 text-xs text-white
               "
             >
               <option value="">Not specified</option>
@@ -622,9 +611,7 @@ export default function FleetFormImportCard() {
               disabled={loading}
               onClick={openCamera}
               className="
-                w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
-                text-neutral-200 hover:bg-black/80 hover:border-neutral-500
+                w-full desktop-btn-secondary px-4 py-2 text-[11px]
                 disabled:opacity-50
               "
             >
@@ -637,9 +624,7 @@ export default function FleetFormImportCard() {
               type="submit"
               disabled={!canSubmit}
               className="
-                w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
-                text-neutral-200 hover:bg-black/80 hover:border-neutral-500
+                w-full desktop-btn-secondary px-4 py-2 text-[11px]
                 disabled:opacity-50
               "
             >

--- a/features/shared/components/PageShell.tsx
+++ b/features/shared/components/PageShell.tsx
@@ -7,6 +7,7 @@ type PageShellProps = {
   description?: string;
   eyebrow?: string;
   actions?: ReactNode;
+  toolbar?: ReactNode;
   children: ReactNode;
 };
 
@@ -15,49 +16,40 @@ export default function PageShell({
   description,
   eyebrow,
   actions,
+  toolbar,
   children,
 }: PageShellProps) {
   return (
     <div className="space-y-6">
-      <header
-        className="flex flex-wrap items-center justify-between gap-4 border px-4 py-4 backdrop-blur-xl md:px-5"
-        style={{
-          borderColor: "var(--theme-card-border,#334155)",
-          background: "var(--theme-card-bg,#111827)",
-          borderRadius: "var(--theme-radius-xl,1rem)",
-          boxShadow: "var(--theme-shadow-medium,0_18px_45px_rgba(0,0,0,0.45))",
-        }}
-      >
-        <div>
-          {eyebrow ? (
-            <p
-              className="text-[10px] font-semibold uppercase tracking-[0.2em]"
-              style={{ color: "var(--theme-text-muted,#64748B)" }}
-            >
-              {eyebrow}
-            </p>
-          ) : null}
+      <header className="desktop-panel px-4 py-4 md:px-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            {eyebrow ? (
+              <p
+                className="text-[10px] font-semibold uppercase tracking-[0.2em]"
+                style={{ color: "var(--theme-text-muted,#64748B)" }}
+              >
+                {eyebrow}
+              </p>
+            ) : null}
 
-          <h1
-            className="text-xl font-semibold tracking-[0.03em]"
-            style={{
-              color: "var(--theme-text-primary,#E2E8F0)",
-            }}
-          >
-            {title}
-          </h1>
+            <h1 className="desktop-title text-xl font-semibold tracking-[0.03em] md:text-2xl">
+              {title}
+            </h1>
 
-          {description ? (
-            <p
-              className="mt-1 max-w-2xl text-sm"
-              style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
-            >
-              {description}
-            </p>
-          ) : null}
+            {description ? (
+              <p
+                className="mt-1 max-w-2xl text-sm"
+                style={{ color: "var(--theme-text-secondary,#94A3B8)" }}
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+
+          {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
         </div>
-
-        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+        {toolbar ? <div className="desktop-toolbar-row mt-4">{toolbar}</div> : null}
       </header>
 
       <div className="rounded-[var(--theme-radius-xl,1rem)]">{children}</div>

--- a/features/shared/components/ui/Button.tsx
+++ b/features/shared/components/ui/Button.tsx
@@ -26,22 +26,22 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 const base =
   "inline-flex items-center justify-center rounded-[var(--theme-radius-md,0.5rem)] font-semibold transition duration-150 ease-in-out " +
   "backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-offset-2 " +
-  "focus:ring-[var(--brand-primary,#C97A3D)] focus:ring-offset-black";
+  "focus:ring-[var(--desktop-focus-ring,var(--brand-primary,#C97A3D))] focus:ring-offset-black";
 
 const variantClasses: Record<Exclude<Variant, "copper">, string> = {
   default: clsx(
     "border",
-    "text-[var(--theme-button-primary-text,#000000)]",
-    "border-[var(--theme-card-border,#334155)]",
-    "bg-[var(--theme-button-primary-bg,var(--brand-primary,#C97A3D))]",
-    "hover:brightness-110",
+    "text-[#020617]",
+    "border-[color:color-mix(in_srgb,var(--brand-primary,#C97A3D)_58%,#fbbf24)]",
+    "bg-[linear-gradient(to_right,color-mix(in_srgb,var(--brand-primary,#C97A3D)_88%,#f3f4f6),color-mix(in_srgb,var(--brand-primary,#C97A3D)_60%,#f59e0b))]",
+    "hover:brightness-105",
   ),
   secondary: clsx(
     "border",
     "text-[var(--theme-button-secondary-text,#FFFFFF)]",
-    "border-[var(--theme-card-border,#334155)]",
-    "bg-[var(--theme-button-secondary-bg,var(--theme-card-bg,#111827))]",
-    "hover:brightness-110",
+    "border-[color:var(--desktop-border,var(--theme-card-border,#334155))]",
+    "bg-[color:rgba(3,8,16,0.72)]",
+    "hover:bg-[rgba(3,8,16,0.84)]",
   ),
   destructive: clsx(
     "text-white",
@@ -52,14 +52,13 @@ const variantClasses: Record<Exclude<Variant, "copper">, string> = {
   ghost: clsx(
     "border",
     "text-[var(--theme-text-primary,#FFFFFF)]",
-    "border-[var(--theme-card-border,#334155)]",
-    "bg-transparent",
-    "hover:bg-white/5",
+    "border-[color:var(--desktop-border,var(--theme-card-border,#334155))]",
+    "bg-transparent hover:bg-white/5",
   ),
   outline: clsx(
     "border",
     "text-[var(--theme-text-primary,#FFFFFF)]",
-    "border-[var(--theme-card-border,#334155)]",
+    "border-[color:var(--desktop-border,var(--theme-card-border,#334155))]",
     "bg-transparent",
     "hover:bg-white/5",
   ),
@@ -67,10 +66,10 @@ const variantClasses: Record<Exclude<Variant, "copper">, string> = {
 
 const copperClass = clsx(
   "border",
-  "text-[var(--theme-button-primary-text,#000000)]",
-  "bg-[var(--theme-button-primary-bg,var(--brand-primary,#C97A3D))]",
-  "border-[var(--theme-card-border,#334155)]",
-  "hover:brightness-110",
+  "text-[#020617]",
+  "bg-[linear-gradient(to_right,color-mix(in_srgb,var(--brand-primary,#C97A3D)_88%,#f3f4f6),color-mix(in_srgb,var(--brand-primary,#C97A3D)_60%,#f59e0b))]",
+  "border-[color:color-mix(in_srgb,var(--brand-primary,#C97A3D)_58%,#fbbf24)]",
+  "hover:brightness-105",
   "shadow-[var(--theme-shadow-soft,0_0_0_1px_rgba(193,102,59,0.12),0_0_16px_rgba(193,102,59,0.18))]",
 );
 

--- a/features/shared/components/ui/Card.tsx
+++ b/features/shared/components/ui/Card.tsx
@@ -14,10 +14,10 @@ export default function Card({ children, onClick, className }: CardProps) {
       onClick={onClick}
       className={cn(
         "rounded-[var(--theme-radius-xl,1rem)] border px-6 py-5 backdrop-blur-sm transition duration-200",
-        "border-[var(--theme-card-border,#334155)]",
-        "bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_94%,transparent)]",
+        "border-[color:var(--desktop-border,var(--theme-card-border,#334155))]",
+        "bg-[var(--desktop-panel-bg,var(--theme-card-bg,#111827))]",
         "text-[var(--theme-text-primary,#FFFFFF)]",
-        "shadow-[var(--theme-shadow-soft,0_14px_30px_rgba(0,0,0,0.35))]",
+        "shadow-[var(--desktop-shadow-card,var(--theme-shadow-soft,0_14px_30px_rgba(0,0,0,0.35)))]",
         onClick
           ? "cursor-pointer hover:-translate-y-[1px] hover:brightness-105"
           : "",

--- a/features/shared/components/ui/badge.tsx
+++ b/features/shared/components/ui/badge.tsx
@@ -13,10 +13,10 @@ export function Badge({
     <span
       className={cn(
         "inline-flex items-center rounded-full border px-2.5 py-1",
-        "border-[var(--theme-card-border,#334155)]",
-        "bg-[var(--theme-surface-2,#0B1220)]",
+        "border-[color:var(--desktop-border,var(--theme-card-border,#334155))]",
+        "bg-[color:rgba(5,10,20,0.84)]",
         "text-[10px] font-semibold uppercase tracking-[0.16em]",
-        "text-[var(--theme-text-primary,#FFFFFF)]",
+        "text-[var(--theme-text-secondary,#E5E7EB)]",
         className,
       )}
     >

--- a/features/shared/components/ui/desktopPrimitives.ts
+++ b/features/shared/components/ui/desktopPrimitives.ts
@@ -1,0 +1,25 @@
+export const desktopPrimitives = {
+  page: "px-4 py-6 text-white",
+  container: "mx-auto w-full max-w-6xl space-y-5",
+  backdrop: "pointer-events-none fixed inset-0 -z-10 desktop-backdrop",
+  panel: "desktop-panel border-[color:var(--desktop-border,var(--metal-border-soft,#1f2937))]",
+  panelPadding: "px-4 py-4 md:px-6 md:py-5",
+  headerTop: "relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between",
+  title: "desktop-title text-xl font-bold md:text-2xl",
+  subtitle: "mt-1 text-xs text-neutral-300",
+  note: "mt-1 text-[11px] text-neutral-500",
+  toolbarRow: "desktop-toolbar-row mt-4 flex flex-col gap-2 md:flex-row md:items-center",
+  input: "desktop-input w-full px-3 py-2 text-sm",
+  pill: "desktop-pill",
+  pillActive: "desktop-pill desktop-pill-active",
+  itemCard:
+    "desktop-item-card relative overflow-hidden border-[color:var(--desktop-border,var(--metal-border-soft,#1f2937))] p-4",
+  emptyState: "desktop-panel-soft px-4 py-6 text-center text-sm text-neutral-300",
+  loadingState: "desktop-panel-soft px-4 py-4 text-sm text-neutral-300",
+  buttonPrimary:
+    "desktop-btn-primary inline-flex items-center justify-center px-4 py-2 text-[11px] font-semibold",
+  buttonSecondary:
+    "desktop-btn-secondary inline-flex items-center justify-center px-3 py-1.5 text-[11px] font-semibold",
+};
+
+export type DesktopPrimitiveKey = keyof typeof desktopPrimitives;

--- a/features/shared/components/ui/input.tsx
+++ b/features/shared/components/ui/input.tsx
@@ -11,14 +11,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref={ref}
         className={cn(
           "h-10 w-full rounded-[var(--theme-radius-md,0.5rem)] border px-3 py-2 text-sm",
-          "border-[var(--theme-input-border,#334155)]",
-          "bg-[var(--theme-input-bg,#0B1220)]",
+          "border-[color:var(--desktop-border,var(--theme-input-border,#334155))]",
+          "bg-[color:rgba(3,8,16,0.82)]",
           "text-[var(--theme-input-text,#FFFFFF)]",
           "placeholder:text-[var(--theme-text-secondary,#94A3B8)]",
           "backdrop-blur-sm",
           "focus:outline-none focus:ring-2",
-          "focus:ring-[var(--brand-primary,#C97A3D)]",
-          "focus:border-[var(--brand-accent,#E2A164)]",
+          "focus:ring-[var(--desktop-focus-ring,var(--brand-primary,#C97A3D))]",
+          "focus:border-[color:color-mix(in_srgb,var(--brand-primary,#C97A3D)_66%,#93c5fd)]",
           "transition-all duration-200 ease-in-out",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className,


### PR DESCRIPTION
### Motivation
- Extract the visual language used by the Inspection Templates page into a shared, canonical desktop theme to avoid ad-hoc page-specific styling and competing accents. 
- Provide a single source of desktop tokens/primitives (backdrop, panels, cards, headers, toolbar rows, inputs, pills, buttons) so future pages can adopt the same premium dark/steel/copper system. 
- Roll out the primitives conservatively by updating shared building blocks and migrating 1–2 high-value surfaces as proofs without changing behavior. 

### Description
- Introduced desktop tokens and CSS utility classes in `app/globals.css` (`--desktop-*` variables and `desktop-*` classes) to codify backdrop, panel, card, input, pill, and button contracts. 
- Added a small primitives map `features/shared/components/ui/desktopPrimitives.ts` that exports reusable class presets (page/container/backdrop/panel/header/toolbar/input/pills/buttons). 
- Updated shared UI building blocks to consume the new contract: `features/shared/components/PageShell.tsx` (desktop header + toolbar slot), `features/shared/components/ui/Button.tsx`, `features/shared/components/ui/input.tsx`, `features/shared/components/ui/badge.tsx`, and `features/shared/components/ui/Card.tsx`. 
- Refactored the canonical surface `features/inspections/app/inspection/templates/page.tsx` to use the new primitives (removed page-local magic colors/shadows/pills). 
- Aligned `features/inspections/components/FleetFormImportCard.tsx` to the primitives and migrated two fleet desktop pages as rollout proofs: `features/fleet/components/FleetUnitsPage.tsx` and `features/fleet/components/PretripReportsPage.tsx`. 

### Testing
- Ran ESLint on all touched TypeScript/TSX files: `npx eslint features/shared/components/ui/desktopPrimitives.ts features/shared/components/PageShell.tsx features/shared/components/ui/Button.tsx features/shared/components/ui/input.tsx features/shared/components/ui/badge.tsx features/shared/components/ui/Card.tsx features/inspections/app/inspection/templates/page.tsx features/inspections/components/FleetFormImportCard.tsx features/fleet/components/FleetUnitsPage.tsx features/fleet/components/PretripReportsPage.tsx` and it succeeded. 
- Attempted to lint `app/globals.css` with ESLint which produced a parse error because raw CSS is not an ESLint target in this repo, so CSS was validated by inspection and Tailwind at runtime instead of ESLint. 
- Ran type-checking: `npx tsc --noEmit` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f5fa28e88328aa2b04c089356aaf)