### PR TITLE
Unify desktop theming across Work Orders, Quote Review and Parts dashboard

### DIFF
--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -7,6 +7,8 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import SuggestedActionsPanel from "@/features/assistant/components/SuggestedActionsPanel";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
@@ -33,8 +35,7 @@ function Sparkline({ points, width = 120, height = 28 }: { points: number[]; wid
 
 function OverviewCard({ title, value, href, hint }: { title: string; value: React.ReactNode; href?: string; hint?: string }) {
   const content = (
-    <div className="group relative overflow-hidden rounded-xl border border-white/10 bg-white/[0.04] px-4 py-4 shadow-card backdrop-blur-md transition hover:border-sky-400/50 hover:shadow-glow">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.14),transparent_58%)] opacity-0 transition-opacity group-hover:opacity-100" />
+    <div className={`${ui.itemCard} group px-4 py-4 transition hover:border-[color:var(--brand-accent,#E39A6E)]`}>
       <p className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">{title}</p>
       <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
       {hint ? <div className="mt-1 text-xs text-neutral-500">{hint}</div> : null}
@@ -49,8 +50,8 @@ function ActionButton({ href, children, emphasis }: { href: string; children: Re
       href={href}
       className={`inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium text-white transition ${
         emphasis
-          ? "border-sky-400/45 bg-sky-950/35 hover:border-sky-300 hover:bg-sky-900/30"
-          : "border-white/10 bg-white/[0.03] hover:bg-white/[0.08]"
+          ? ui.buttonPrimary
+          : ui.buttonSecondary
       }`}
     >
       {children}
@@ -158,23 +159,19 @@ export default function PartsDashboardPage(): JSX.Element {
   const hasOpenRequests = (openRequestsCount ?? 0) > 0;
 
   return (
-    <div className="relative space-y-4 p-5 text-white fade-in md:space-y-5 md:p-6">
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.09),transparent_56%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.92),#020617_72%)]" />
-
-      <section className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-4 shadow-card backdrop-blur-md">
-        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(130deg,rgba(148,163,184,0.1),rgba(15,23,42,0.03)_45%,transparent_70%)]" />
-        <div className="relative flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <div className="text-[10px] uppercase tracking-[0.2em] text-neutral-400">Parts command center</div>
-            <h1 className="mt-1 text-2xl font-semibold md:text-3xl">Start your parts day with clear signals</h1>
-            <p className="mt-2 max-w-2xl text-sm text-neutral-300">Prioritize open requests, receiving, and recent movement from one operational surface.</p>
-          </div>
+    <div className="relative p-5 text-white fade-in md:p-6">
+      <PageShell
+        title="Parts Dashboard"
+        eyebrow="Parts command center"
+        description="Prioritize open requests, receiving, and recent movement from one operational surface."
+        actions={
           <div className="flex flex-wrap gap-2">
             <ActionButton href="/parts/requests" emphasis>Open requests</ActionButton>
             <ActionButton href="/parts/receiving">Receiving inbox</ActionButton>
           </div>
-        </div>
-      </section>
+        }
+      >
+      <div className="space-y-4 md:space-y-5">
 
       <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <OverviewCard title="SKUs in catalog" value={loading ? "…" : skuTotal.toLocaleString()} href="/parts/inventory" />
@@ -184,7 +181,7 @@ export default function PartsDashboardPage(): JSX.Element {
       </section>
 
       <section className="grid gap-3 lg:grid-cols-[1.5fr_1fr]">
-        <div className="rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 shadow-[0_0_24px_rgba(15,23,42,0.24)]">
+        <div className="desktop-panel-soft px-4 py-3">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-300">Operational bottleneck</div>
@@ -194,7 +191,7 @@ export default function PartsDashboardPage(): JSX.Element {
           </div>
         </div>
 
-        <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+        <div className="desktop-panel-soft p-4">
           <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-400">Primary actions</div>
           <div className="mt-3 grid grid-cols-2 gap-2">
             <ActionButton href="/parts/po" emphasis>Create PO</ActionButton>
@@ -219,7 +216,7 @@ export default function PartsDashboardPage(): JSX.Element {
           hideDescription
         />
 
-        <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4 shadow-card backdrop-blur-md">
+        <div className="desktop-panel-soft px-4 py-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-neutral-300">Operational insights</h2>
@@ -228,22 +225,22 @@ export default function PartsDashboardPage(): JSX.Element {
             <Sparkline points={moves30Spark} />
           </div>
           <div className="mt-3 grid gap-2 text-sm">
-            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Receive queue</span><span className="font-semibold">{loading ? "…" : (receiveQueueCount ?? 0).toLocaleString()}</span></div>
-            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Open purchase orders</span><span className="font-semibold">{loading ? "…" : (openPoCount ?? 0).toLocaleString()}</span></div>
-            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Low-trust catalog records</span><span className="font-semibold text-rose-200">{loading ? "…" : trustSummary.lowTrust.toLocaleString()}</span></div>
-            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Review-needed imports</span><span className="font-semibold text-sky-200">{loading ? "…" : trustSummary.reviewStaging.toLocaleString()}</span></div>
-            <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/20 px-3 py-2"><span className="text-neutral-300">Ambiguous match candidates</span><span className="font-semibold text-sky-200">{loading ? "…" : trustSummary.ambiguousCandidates.toLocaleString()}</span></div>
+            <div className="desktop-item-card flex items-center justify-between px-3 py-2"><span className="text-neutral-300">Receive queue</span><span className="font-semibold">{loading ? "…" : (receiveQueueCount ?? 0).toLocaleString()}</span></div>
+            <div className="desktop-item-card flex items-center justify-between px-3 py-2"><span className="text-neutral-300">Open purchase orders</span><span className="font-semibold">{loading ? "…" : (openPoCount ?? 0).toLocaleString()}</span></div>
+            <div className="desktop-item-card flex items-center justify-between px-3 py-2"><span className="text-neutral-300">Low-trust catalog records</span><span className="font-semibold text-rose-200">{loading ? "…" : trustSummary.lowTrust.toLocaleString()}</span></div>
+            <div className="desktop-item-card flex items-center justify-between px-3 py-2"><span className="text-neutral-300">Review-needed imports</span><span className="font-semibold text-sky-200">{loading ? "…" : trustSummary.reviewStaging.toLocaleString()}</span></div>
+            <div className="desktop-item-card flex items-center justify-between px-3 py-2"><span className="text-neutral-300">Ambiguous match candidates</span><span className="font-semibold text-sky-200">{loading ? "…" : trustSummary.ambiguousCandidates.toLocaleString()}</span></div>
           </div>
         </div>
       </section>
 
-      <section className="rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-4 shadow-card backdrop-blur-md">
+      <section className="desktop-panel-soft px-5 py-4">
         <div className="mb-2 flex items-center justify-between gap-4">
           <div>
             <h2 className="text-lg font-semibold">Recent stock moves</h2>
             <p className="text-xs text-neutral-400">Most recent inventory movement with source traceability.</p>
           </div>
-          <Link href="/parts/movements" className="text-xs uppercase tracking-[0.14em] text-sky-300 hover:text-sky-200">View ledger</Link>
+          <Link href="/parts/movements" className={ui.buttonSecondary}>View ledger</Link>
         </div>
 
         {loading ? (
@@ -268,6 +265,8 @@ export default function PartsDashboardPage(): JSX.Element {
           </ul>
         )}
       </section>
+      </div>
+      </PageShell>
     </div>
   );
 }

--- a/features/work-orders/app/work-orders/editor/page.tsx
+++ b/features/work-orders/app/work-orders/editor/page.tsx
@@ -8,6 +8,7 @@ import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import { cn } from "@shared/lib/utils";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type MenuItem = DB["public"]["Tables"]["menu_items"]["Row"];
@@ -30,8 +31,7 @@ type LineDraft = {
   job_type?: "maintenance" | "diagnosis" | "inspection";
 };
 
-const fieldClass =
-  "w-full rounded-lg border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_75%,transparent)] px-3 py-2 text-sm text-[var(--theme-text-primary,#E2E8F0)] placeholder:text-[var(--theme-text-muted,#64748B)] focus:border-[var(--brand-accent,#E39A6E)] focus:outline-none focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_45%,transparent)]";
+const fieldClass = ui.input;
 
 export default function WorkOrderEditorPage() {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
@@ -202,7 +202,7 @@ export default function WorkOrderEditorPage() {
         <Button
           onClick={saveToWorkOrder}
           disabled={saving}
-          className="px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em]"
+          className={ui.buttonPrimary}
         >
           {saving ? "Saving…" : "Save to selected work order"}
         </Button>
@@ -219,7 +219,7 @@ export default function WorkOrderEditorPage() {
                 Compose and stage work-order lines
               </h2>
             </div>
-            <Button type="button" variant="outline" size="sm" onClick={addEmptyLine}>
+            <Button type="button" variant="outline" size="sm" onClick={addEmptyLine} className={ui.buttonSecondary}>
               + Add line
             </Button>
           </div>
@@ -240,7 +240,7 @@ export default function WorkOrderEditorPage() {
                   <button
                     type="button"
                     onClick={() => removeLine(idx)}
-                    className="text-xs font-medium text-rose-300 hover:text-rose-200"
+                    className="desktop-pill border-rose-500/40 bg-rose-500/10 px-2 py-1 text-xs font-medium normal-case tracking-[0.08em] text-rose-200 hover:border-rose-400/60"
                   >
                     Remove
                   </button>
@@ -340,7 +340,7 @@ export default function WorkOrderEditorPage() {
                   <li key={mi.id}>
                     <button
                       type="button"
-                      className="w-full rounded-md border border-[var(--theme-card-border,#334155)] bg-black/20 px-2.5 py-2 text-left text-xs text-[var(--theme-text-secondary,#94A3B8)] hover:border-[var(--brand-accent,#E39A6E)]/70"
+                    className="desktop-panel-soft w-full rounded-md px-2.5 py-2 text-left text-xs text-[var(--theme-text-secondary,#94A3B8)] hover:border-[var(--brand-accent,#E39A6E)]/70"
                       onClick={() => addFromMenu(mi)}
                     >
                       {(mi.name ?? mi.complaint ?? "Untitled")}

--- a/features/work-orders/app/work-orders/queue/page.tsx
+++ b/features/work-orders/app/work-orders/queue/page.tsx
@@ -7,6 +7,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import Link from "next/link";
 import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type Line = DB["public"]["Tables"]["work_order_lines"]["Row"];
@@ -23,13 +24,13 @@ const STATUS_LABELS: Record<RollupStatus, string> = {
 
 const STATUS_STYLES: Record<RollupStatus, string> = {
   awaiting:
-    "border-neutral-800 bg-neutral-950/70 hover:border-orange-400 data-[active=true]:border-orange-400 data-[active=true]:bg-orange-500/10",
+    `${ui.itemCard} hover:border-[color:var(--brand-accent,#E39A6E)] data-[active=true]:border-[color:var(--brand-accent,#E39A6E)] data-[active=true]:bg-[color:color-mix(in_srgb,var(--brand-primary,#C97A3D)_12%,transparent)]`,
   in_progress:
-    "border-neutral-800 bg-neutral-950/70 hover:border-orange-400 data-[active=true]:border-orange-400 data-[active=true]:bg-orange-500/10",
+    `${ui.itemCard} hover:border-sky-400/60 data-[active=true]:border-sky-400/60 data-[active=true]:bg-sky-500/10`,
   on_hold:
-    "border-neutral-800 bg-neutral-950/70 hover:border-orange-400 data-[active=true]:border-orange-400 data-[active=true]:bg-orange-500/10",
+    `${ui.itemCard} hover:border-amber-400/60 data-[active=true]:border-amber-400/60 data-[active=true]:bg-amber-500/10`,
   completed:
-    "border-neutral-800 bg-neutral-950/70 hover:border-orange-400 data-[active=true]:border-orange-400 data-[active=true]:bg-orange-500/10",
+    `${ui.itemCard} hover:border-emerald-400/60 data-[active=true]:border-emerald-400/60 data-[active=true]:bg-emerald-500/10`,
 };
 
 function rollupStatus(lines: Line[]): RollupStatus {
@@ -250,7 +251,7 @@ export default function QueuePage() {
         title="Job Queue"
         description="Live job queue for technicians, grouped by work order."
       >
-        <div className="rounded-xl border border-neutral-800 bg-neutral-950/60 px-4 py-6 text-sm text-neutral-300">
+        <div className={ui.loadingState}>
           Loading queue…
         </div>
       </PageShell>
@@ -263,7 +264,7 @@ export default function QueuePage() {
         title="Job Queue"
         description="Live job queue for technicians, grouped by work order."
       >
-        <div className="rounded-xl border border-red-500/40 bg-red-900/20 px-4 py-6 text-sm text-red-200">
+        <div className="desktop-panel-soft border-red-500/40 bg-red-900/20 px-4 py-6 text-sm text-red-200">
           {err}
         </div>
       </PageShell>
@@ -281,8 +282,8 @@ export default function QueuePage() {
       <div className="space-y-6">
 
         {/* Header row / top summary */}
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 px-3 py-2 text-xs text-neutral-300">
+        <div className={ui.toolbarRow}>
+          <div className="desktop-panel-soft px-3 py-2 text-xs text-neutral-300">
             <div className="text-[10px] uppercase tracking-wide text-neutral-500">
               Active work orders (last 30 days)
             </div>
@@ -291,13 +292,13 @@ export default function QueuePage() {
             </div>
           </div>
 
-          <div className="flex items-center gap-3 rounded-lg border border-neutral-800 bg-neutral-950/70 px-3 py-2 text-xs text-neutral-300">
+          <div className="desktop-panel-soft flex items-center gap-3 px-3 py-2 text-xs text-neutral-300">
             <label className="inline-flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
                 checked={showMineOnly}
                 onChange={(e) => setShowMineOnly(e.target.checked)}
-                className="h-4 w-4 rounded border-neutral-700 bg-neutral-900 text-orange-500"
+                className="h-4 w-4 rounded border-[color:var(--desktop-border)] bg-black/60 text-[var(--brand-primary,#C97A3D)]"
               />
               <span>
                 Show only jobs assigned to{" "}
@@ -309,14 +310,14 @@ export default function QueuePage() {
           <div className="ml-auto flex items-center gap-2">
             <Link
               href="/assistant?pageType=work_order_queue&pageTitle=Work%20Order%20Queue"
-              className="rounded border border-orange-400/40 bg-orange-500/10 px-3 py-1.5 text-[11px] text-orange-200 hover:bg-orange-500/15"
+              className={ui.buttonPrimary}
             >
               Ask Assistant
             </Link>
 
             <Link
               href="/agent/planner?planner=ops&allowCreate=0&goal=Review%20the%20current%20work%20order%20queue%20and%20suggest%20the%20best%20next%20actions"
-              className="rounded border border-neutral-700 bg-neutral-950 px-3 py-1.5 text-[11px] text-neutral-300 hover:border-orange-400 hover:text-orange-300"
+              className={ui.buttonSecondary}
             >
               Open Planner
             </Link>
@@ -324,7 +325,7 @@ export default function QueuePage() {
             <button
               type="button"
               onClick={() => setShowDebug((v) => !v)}
-              className="rounded border border-neutral-700 bg-neutral-950 px-3 py-1.5 text-[11px] text-neutral-300 hover:border-orange-400 hover:text-orange-300"
+              className={ui.buttonSecondary}
             >
               {showDebug ? "Hide debug" : "Show debug"}
             </button>
@@ -333,7 +334,7 @@ export default function QueuePage() {
 
         {/* Optional debug block */}
         {showDebug && (
-          <div className="rounded-xl border border-neutral-800 bg-neutral-950/80 px-4 py-3 text-xs text-neutral-300">
+          <div className="desktop-panel-soft px-4 py-3 text-xs text-neutral-300">
             <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-orange-400">
               Debug
             </div>
@@ -381,7 +382,7 @@ export default function QueuePage() {
                 key={s}
                 type="button"
                 onClick={() => setActiveFilter(isActive ? null : s)}
-                className={`rounded-xl border px-3 py-3 text-left text-sm text-neutral-100 transition ${STATUS_STYLES[s]}`}
+                className={`px-3 py-3 text-left text-sm text-neutral-100 transition ${STATUS_STYLES[s]}`}
                 data-active={isActive ? "true" : "false"}
               >
                 <div className="text-[10px] uppercase tracking-wide text-neutral-400">
@@ -425,7 +426,7 @@ export default function QueuePage() {
               <Link
                 key={wo.id}
                 href={`/work-orders/${slug}?mode=tech`}
-                className="block rounded-lg border border-neutral-800 bg-neutral-950/70 px-3 py-3 text-sm text-neutral-100 transition hover:border-orange-500 hover:bg-neutral-900"
+                className="desktop-item-card block px-3 py-3 text-sm text-neutral-100 transition hover:border-[color:var(--brand-accent,#E39A6E)]"
               >
                 <div className="flex items-center justify-between gap-3">
                   <div className="min-w-0">
@@ -449,7 +450,7 @@ export default function QueuePage() {
                   </div>
 
                   <div className="flex flex-col items-end gap-2">
-                    <span className="rounded-full border border-neutral-700 px-2.5 py-1 text-[11px] capitalize text-neutral-300">
+                    <span className={`${ui.pill} !normal-case !tracking-[0.08em] px-2.5 py-1 text-[11px] text-neutral-300`}>
                       {status.replace("_", " ")}
                     </span>
 
@@ -465,7 +466,7 @@ export default function QueuePage() {
           })}
 
           {filteredWos.length === 0 && (
-            <div className="rounded-lg border border-neutral-800 bg-neutral-950/70 p-4 text-sm text-neutral-400">
+            <div className={ui.emptyState}>
               No work orders in this bucket.
             </div>
           )}

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -9,6 +9,8 @@ import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import DecisionEventFeed from "@/features/shared/components/ui/DecisionEventFeed";
 import { deriveEventsFromQuote } from "@/features/shared/lib/decisionEvents";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 
@@ -28,10 +30,7 @@ type WorkOrderWithMeta = WorkOrder & {
   waiting_for_parts?: boolean;
 };
 
-const COPPER = "#C57A4A";
-
-const INPUT_DARK =
-  "w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-sky-300/50 focus:ring-2 focus:ring-sky-300/20";
+const INPUT_DARK = ui.input;
 
 function safeTrim(x: unknown): string {
   return typeof x === "string" ? x.trim() : "";
@@ -293,8 +292,8 @@ function ApprovalsList(): JSX.Element {
 
   return (
     <section className="space-y-4">
-      <div className="overflow-hidden rounded-[24px] border border-slate-300/15 bg-slate-950/65 shadow-[0_0_40px_rgba(2,6,23,0.75)]">
-        <div className="border-b border-white/8 px-5 py-4 sm:px-6">
+      <div className={`${ui.panel} overflow-hidden`}>
+        <div className="border-b border-[color:var(--desktop-border)] px-5 py-4 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
@@ -304,13 +303,13 @@ function ApprovalsList(): JSX.Element {
               <p className="mt-1 text-sm text-neutral-400">Triage records ready for advisor review.</p>
 
               <div className="mt-4 flex flex-wrap gap-2">
-                <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                <div className={ui.pill}>
                   Total: <span className="text-white">{rows.length}</span>
                 </div>
-                <div className="rounded-full border border-sky-500/20 bg-sky-500/5 px-3 py-1 text-[11px] font-semibold text-sky-100">
+                <div className={`${ui.pill} border-sky-500/30 bg-sky-500/10 text-sky-100`}>
                   Waiting for parts: <span className="text-white">{waitingCount}</span>
                 </div>
-                <div className="rounded-full border border-emerald-500/20 bg-emerald-500/5 px-3 py-1 text-[11px] font-semibold text-emerald-100">
+                <div className={`${ui.pill} border-emerald-500/30 bg-emerald-500/10 text-emerald-100`}>
                   Quotes ready: <span className="text-white">{readyCount}</span>
                 </div>
               </div>
@@ -319,7 +318,7 @@ function ApprovalsList(): JSX.Element {
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/work-orders/view"
-                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15"
+                className={ui.buttonSecondary}
               >
                 Open work orders
               </Link>
@@ -344,7 +343,7 @@ function ApprovalsList(): JSX.Element {
               <button
                 type="button"
                 onClick={() => void load()}
-                className="rounded-xl border border-white/10 bg-black/25 px-4 py-2 text-sm font-semibold text-white transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/10"
+                className={ui.buttonSecondary}
               >
                 Refresh
               </button>
@@ -368,9 +367,9 @@ function ApprovalsList(): JSX.Element {
           return (
             <div
               key={w.id}
-              className={["overflow-hidden rounded-[18px] border bg-slate-950/65 shadow-[0_10px_30px_rgba(2,6,23,0.65)]", accent.border].join(" ")}
+              className={["desktop-item-card overflow-hidden", accent.border].join(" ")}
             >
-              <div className="border-b border-white/8 px-4 py-3">
+              <div className="border-b border-[color:var(--desktop-border)] px-4 py-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
@@ -420,7 +419,7 @@ function ApprovalsList(): JSX.Element {
                 </div>
 
                 <div className="mt-3 grid grid-cols-2 gap-2">
-                  <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
+                  <div className="desktop-panel-soft px-3 py-3">
                     <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
                       Labor
                     </div>
@@ -429,7 +428,7 @@ function ApprovalsList(): JSX.Element {
                     </div>
                   </div>
 
-                  <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
+                  <div className="desktop-panel-soft px-3 py-3">
                     <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
                       Created
                     </div>
@@ -449,8 +448,7 @@ function ApprovalsList(): JSX.Element {
                   <Link
                     href={quoteHref}
                     prefetch={false}
-                    className="rounded-full border border-[color:var(--copper)]/70 bg-[color:var(--copper)]/10 px-3 py-1.5 text-sm font-semibold text-[color:var(--copper)] transition hover:bg-[color:var(--copper)]/15"
-                    style={{ ["--copper" as never]: COPPER }}
+                    className={ui.buttonPrimary}
                   >
                     Review
                   </Link>
@@ -458,7 +456,7 @@ function ApprovalsList(): JSX.Element {
                   <Link
                     href={woHref}
                     prefetch={false}
-                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15"
+                    className={ui.buttonSecondary}
                   >
                     Open WO
                   </Link>
@@ -482,24 +480,21 @@ export default function QuoteReviewIndexPage(): JSX.Element {
   }, [woId, router]);
 
   return (
-    <div
-      className="
-        min-h-screen px-4 py-6 text-foreground
-        bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.1),transparent_52%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
-      "
-      style={{ ["--copper" as never]: COPPER }}
+    <div className="px-4 py-6 text-foreground"
     >
       <div className="mx-auto max-w-7xl">
-        <div className="mb-4">
-          <button
-            onClick={() => router.back()}
-            className="text-sm text-[color:var(--copper)] hover:underline"
-          >
-            ← Back
-          </button>
-        </div>
-
-        <ApprovalsList />
+        <PageShell
+          title="Quote Review Queue"
+          eyebrow="Work Orders"
+          description="Triage records ready for advisor review."
+          actions={
+            <button onClick={() => router.back()} className={ui.buttonSecondary}>
+              Back
+            </button>
+          }
+        >
+          <ApprovalsList />
+        </PageShell>
       </div>
     </div>
   );

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -19,6 +19,7 @@ import {
   isProvinceCode,
   type ProvinceCode,
 } from "@/features/integrations/tax";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 
@@ -287,13 +288,12 @@ function partsToPaste(parts: Array<{ name: string; qty: number }>): string {
   return parts.map((p) => `${p.qty}x ${p.name}`).join("\n");
 }
 
-const card =
-  "rounded-2xl border border-slate-300/15 bg-slate-950/55 shadow-[0_20px_48px_rgba(2,6,23,0.65)]";
-const divider = "border-white/10";
+const card = ui.panel;
+const divider = "border-[color:var(--desktop-border)]";
 const inputBase =
-  "mt-1 w-full rounded-lg border border-white/10 bg-black/60 px-2.5 py-2 text-sm text-white placeholder:text-neutral-500 outline-none";
+  "mt-1 w-full desktop-input px-2.5 py-2 text-sm text-white placeholder:text-neutral-500 outline-none";
 const inputFocus =
-  "focus:border-[color:var(--copper,#C57A4A)]/60 focus:ring-2 focus:ring-[color:var(--copper,#C57A4A)]/15";
+  "focus:border-[color:var(--brand-accent,#E39A6E)]/60 focus:ring-2 focus:ring-[color:var(--brand-accent,#E39A6E)]/15";
 const inputCls = `${inputBase} ${inputFocus}`;
 
 export default function QuoteReviewView(props: {
@@ -840,10 +840,7 @@ export default function QuoteReviewView(props: {
   // ✅ Embedded mode sizing + padding
   const outerCls = embedded
     ? "min-h-full w-full px-0 py-0 text-foreground"
-    : `
-      min-h-screen px-4 py-6 text-foreground
-      bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.08),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)]
-    `;
+    : "min-h-screen px-4 py-6 text-foreground";
 
   const containerCls = embedded ? "mx-auto w-full max-w-none" : "mx-auto max-w-7xl";
   const padX = embedded ? "px-3" : "px-5";
@@ -856,12 +853,12 @@ export default function QuoteReviewView(props: {
 
   // ✅ Smaller action buttons when embedded
   const actionBtnCls = embedded
-    ? "rounded-full border border-white/10 bg-black/50 px-3 py-1.5 text-xs font-semibold text-white hover:bg-black/65 disabled:opacity-60"
-    : "rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm font-semibold text-white hover:bg-black/65 disabled:opacity-60";
+    ? `${ui.buttonSecondary} px-3 py-1.5 text-xs disabled:opacity-60`
+    : `${ui.buttonSecondary} px-4 py-2 text-sm disabled:opacity-60`;
 
   const saveBtnCls = embedded
-    ? "rounded-full border border-[color:var(--copper)]/70 bg-[color:var(--copper)]/10 px-3 py-1.5 text-xs font-semibold text-[color:var(--copper)] hover:bg-[color:var(--copper)]/15 disabled:opacity-60"
-    : "rounded-full border border-[color:var(--copper)]/70 bg-[color:var(--copper)]/10 px-4 py-2 text-sm font-semibold text-[color:var(--copper)] hover:bg-[color:var(--copper)]/15 disabled:opacity-60";
+    ? `${ui.buttonPrimary} px-3 py-1.5 text-xs disabled:opacity-60`
+    : `${ui.buttonPrimary} px-4 py-2 text-sm disabled:opacity-60`;
 
   return (
     <div className={outerCls} style={{ ["--copper" as never]: COPPER }}>
@@ -906,9 +903,8 @@ export default function QuoteReviewView(props: {
               <a
                 href={`/work-orders/${woId}`}
                 className="
-                  rounded-full border border-white/10 bg-black/40
+                  desktop-btn-secondary rounded-full
                   px-4 py-2 text-sm font-semibold text-neutral-200
-                  hover:bg-black/55
                 "
                 title="Open the work order"
               >
@@ -952,10 +948,7 @@ export default function QuoteReviewView(props: {
 
             {/* middle */}
             <div
-              className={`
-                w-full rounded-2xl border border-white/10 bg-black/35
-                px-4 py-3
-              `}
+              className="desktop-panel-soft w-full px-4 py-3"
             >
               <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-500">
                 Customer contact
@@ -1082,7 +1075,7 @@ export default function QuoteReviewView(props: {
 
                     return (
                       <div key={l.id} className={`${padX} py-4`}>
-                        <div className="rounded-[20px] border border-slate-300/15 bg-slate-950/60 p-2.5 shadow-[0_18px_48px_rgba(2,6,23,0.7)]">
+                        <div className="desktop-panel-soft p-2.5">
                           <QuoteLineCard
                             title={title}
                             statusLabel="Issue Found"
@@ -1172,17 +1165,15 @@ export default function QuoteReviewView(props: {
                               setOpenDetails((p) => ({ ...p, [l.id]: !p[l.id] }))
                             }
                             className="
-                              w-full rounded-2xl border border-white/10 bg-black/45
+                              desktop-btn-secondary w-full rounded-2xl
                               px-4 py-2.5 text-sm font-semibold text-neutral-200
-                              shadow-[0_12px_35px_rgba(0,0,0,0.45)]
-                              hover:bg-black/55
                             "
                           >
                             {openDetails[l.id] ? "Hide details" : "Show details"}
                           </button>
 
                           {openDetails[l.id] ? (
-                            <div className="mt-3 rounded-[24px] border border-white/10 bg-black/40 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.45)]">
+                            <div className="desktop-panel-soft mt-3 p-4">
                               {/* line editor */}
                               <div className={embedded ? "grid gap-3" : "grid gap-3 md:grid-cols-2"}>
                                 <label className="text-xs text-neutral-400">
@@ -1250,7 +1241,7 @@ export default function QuoteReviewView(props: {
                               </div>
 
                               {/* parts editor */}
-                              <div className="mt-4 rounded-2xl border border-white/10 bg-black/45 p-4">
+                              <div className="desktop-panel-soft mt-4 p-4">
                                 <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-neutral-400">
                                   Parts
                                 </div>
@@ -1281,7 +1272,7 @@ export default function QuoteReviewView(props: {
                                           key={a.id}
                                           className="
                                             flex flex-wrap items-center justify-between gap-3
-                                            rounded-2xl border border-white/10 bg-black/55 px-3 py-3
+                                            desktop-panel-soft rounded-2xl px-3 py-3
                                           "
                                         >
                                           <div className="min-w-0">
@@ -1338,9 +1329,8 @@ export default function QuoteReviewView(props: {
                                   type="button"
                                   onClick={() => openDeleteForLine(l.id)}
                                   className="
-                                    rounded-xl border border-white/15 bg-black/50
+                                    desktop-btn-secondary rounded-xl
                                     px-4 py-2 text-sm font-semibold text-neutral-200
-                                    hover:bg-black/65 hover:text-white
                                   "
                                 >
                                   Delete / Void
@@ -1380,9 +1370,8 @@ export default function QuoteReviewView(props: {
                       })
                     }
                     className="
-                      w-full rounded-xl border border-[color:var(--copper)]/70 bg-[color:var(--copper)]/10
-                      px-4 py-2 text-sm font-semibold text-[color:var(--copper)]
-                      hover:bg-[color:var(--copper)]/15
+                      desktop-btn-primary w-full rounded-xl
+                      px-4 py-2 text-sm font-semibold
                     "
                   >
                     + Add job line
@@ -1437,9 +1426,8 @@ export default function QuoteReviewView(props: {
                     onClick={() => void saveAllDirty()}
                     disabled={saving}
                     className="
-                      w-full rounded-xl border border-[color:var(--copper)]/70 bg-[color:var(--copper)]/10
-                      px-4 py-2 text-sm font-semibold text-[color:var(--copper)]
-                      hover:bg-[color:var(--copper)]/15 disabled:opacity-60
+                      desktop-btn-primary w-full rounded-xl
+                      px-4 py-2 text-sm font-semibold disabled:opacity-60
                     "
                   >
                     {saving ? "Saving…" : "Save changes"}
@@ -1491,9 +1479,9 @@ export default function QuoteReviewView(props: {
                     onClick={() => void sendQuoteToCustomer()}
                     disabled={sending || savingCustomerEmail}
                     className="
-                      w-full rounded-xl border border-white/10 bg-slate-900/80
+                      desktop-btn-secondary w-full rounded-xl
                       px-4 py-2 text-sm font-semibold text-white
-                      hover:bg-slate-900 disabled:opacity-60
+                      disabled:opacity-60
                     "
                   >
                     {sending ? "Sending…" : "Send Quote"}


### PR DESCRIPTION
### Motivation
- Continue the desktop visual rollout by aligning high-traffic operational surfaces to the canonical Inspection Templates theme and shared primitives. 
- Remove one-off panel/card/button/input styles that cause visual drift while preserving existing workflows and data flows. 
- Prefer `PageShell` and `desktopPrimitives` to ensure a single, maintainable desktop grammar across pages.

### Description
- Replaced page-local styling with shared primitives from `desktopPrimitives` and introduced `PageShell` on key pages to normalize headers, toolbars, panels, cards, pills and buttons. 
- Work Orders: migrated the Job Queue and Work Order Editor to use `ui.toolbarRow`, `ui.itemCard`, `ui.pill`, `ui.input`, `ui.buttonPrimary` / `ui.buttonSecondary`, and `ui.loadingState` while keeping existing rollup/filter/save logic intact. 
- Quote Review: normalized the Queue list and the `QuoteReviewView` detail surface to use `ui.panel`/`ui.itemCard`/`ui.pill`/`ui.input` and swapped bespoke copper/gradient chrome for the canonical treatments; preserved all approval/send/save behaviors. 
- Parts: moved the Parts Dashboard into `PageShell` and replaced many one-off cards and actions with `ui.itemCard`, `ui.panel`, `ui.button*` and consistent small item cards. 
- Files changed: `features/work-orders/app/work-orders/queue/page.tsx`, `features/work-orders/app/work-orders/editor/page.tsx`, `features/work-orders/app/work-orders/quote-review/page.tsx`, `features/work-orders/quote-review/QuoteReviewView.tsx`, `app/parts/page.tsx`.

### Testing
- Ran ESLint on touched files with: `npx eslint features/work-orders/app/work-orders/queue/page.tsx features/work-orders/app/work-orders/editor/page.tsx features/work-orders/app/work-orders/quote-review/page.tsx features/work-orders/quote-review/QuoteReviewView.tsx app/parts/page.tsx` and it completed without error. 
- Type-check: `npx tsc --noEmit` completed successfully with no new type errors. 
- No behavioral or routing changes were introduced and all existing business logic was preserved; visual-only composition changes were tested via local type/lint validation and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2fba840fc83288075b41a40902956)