### PR TITLE
Desktop: normalize Assistant and PO Receive views with PageShell and desktop primitives

### DIFF
--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 import { useAssistant } from "@/features/assistant/hooks/useAssistant";
 import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
@@ -57,8 +58,8 @@ export default function AssistantPage() {
       title="Shop Assistant"
       description="Your universal shop intelligence surface for questions, explanations, and cross-record history."
     >
-      <div className="metal-card rounded-3xl p-5">
-        <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+      <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
+        <div className="desktop-panel-soft p-4">
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
             Assistant scope
           </div>
@@ -66,10 +67,10 @@ export default function AssistantPage() {
             {contextChips.map((chip) => (
               <span
                 key={chip.label}
-                className={`rounded-full border px-3 py-1 text-xs ${
+                className={`desktop-pill px-3 py-1 text-xs ${
                   chip.active
-                    ? "border-orange-400/40 bg-orange-500/10 text-orange-300"
-                    : "border-white/15 bg-black/30 text-neutral-400"
+                    ? "border-[color:var(--brand-accent,#E39A6E)]/55 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_16%,transparent)] text-[color:var(--brand-accent,#E39A6E)]"
+                    : "text-neutral-400"
                 }`}
               >
                 {chip.label}
@@ -87,15 +88,15 @@ export default function AssistantPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Ask a shop question, request an explanation, or compare records..."
-          className="mt-4 w-full min-h-[120px] rounded-2xl bg-black/60 p-3 text-white"
+          className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-white"
         />
 
-        <div className="mt-3 flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2">
           {EXAMPLE_PROMPTS.map((example) => (
             <button
               key={example}
               type="button"
-              className="rounded-full border border-white/15 bg-black/30 px-3 py-1 text-xs text-neutral-300 hover:border-orange-400/40 hover:text-orange-200"
+              className="desktop-pill px-3 py-1 text-xs text-neutral-300 hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
               onClick={() => setQuery(example)}
             >
               {example}

--- a/app/parts/po/receive/page.tsx
+++ b/app/parts/po/receive/page.tsx
@@ -6,6 +6,9 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { receiveProgressLabel } from "@/features/parts/lib/status-display";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
+import { Button } from "@/features/shared/components/ui/Button";
 
 type DB = Database;
 
@@ -59,125 +62,107 @@ export default function ReceiveFromPOPage(): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const card =
-    "metal-card rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/60 shadow-[0_18px_40px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+  const toneForStatus = (status: string) => {
+    const normalized = status.toLowerCase();
+    if (normalized === "received") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-200";
+    if (normalized === "receiving") return "border-sky-500/40 bg-sky-500/10 text-sky-200";
+    if (normalized === "ordered" || normalized === "open" || normalized === "draft") {
+      return "border-indigo-500/40 bg-indigo-500/10 text-indigo-200";
+    }
+    if (normalized === "cancelled" || normalized === "canceled") return "border-rose-500/40 bg-rose-500/10 text-rose-200";
+    return "border-[color:var(--desktop-border)] bg-black/40 text-neutral-200";
+  };
+
+  const toolbar = (
+    <div className="flex w-full justify-end">
+      <Button type="button" variant="secondary" size="sm" onClick={() => void load()}>
+        Refresh
+      </Button>
+    </div>
+  );
 
   return (
-    <div className="p-6 space-y-4 text-white">
-      {/* Header */}
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-neutral-400">
-            Parts
-          </div>
-          <h1
-            className="text-2xl font-bold"
-            style={{ fontFamily: "var(--font-blackops), system-ui" }}
-          >
-            Receive from PO
-          </h1>
-          <div className="text-sm text-neutral-400">PO lens into the shared receiving workflow.</div>
-        </div>
+    <PageShell
+      title="Receive from PO"
+      eyebrow="Parts"
+      description="PO lens into the shared receiving workflow."
+      toolbar={toolbar}
+    >
+      <div className="space-y-4 text-white">
 
-        <button
-          onClick={() => void load()}
-          className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm text-neutral-100 hover:bg-white/5"
-        >
-          Refresh
-        </button>
+        {err ? <div className="desktop-panel-soft border-red-500/40 bg-red-900/20 p-3 text-sm text-red-200">{err}</div> : null}
+
+        {loading ? (
+          <div className={ui.loadingState}>Loading…</div>
+        ) : pos.length === 0 ? (
+          <div className={ui.emptyState}>No purchase orders found.</div>
+        ) : (
+          <div className={`${ui.panel} overflow-hidden`}>
+            <div className="border-b border-[color:var(--desktop-border)] px-4 py-3">
+              <div className="text-xs font-medium uppercase tracking-[0.18em] text-neutral-400">Purchase orders</div>
+              <div className="mt-1 text-[11px] text-neutral-500">Select a PO to open the receiving screen.</div>
+            </div>
+
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-neutral-400">
+                    <th className="p-3">PO</th>
+                    <th className="p-3">Status</th>
+                    <th className="p-3">Created</th>
+                    <th className="p-3">Vendor</th>
+                    <th className="p-3"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pos.map((po) => {
+                    const id = safeText(po.id);
+                    const status = safeText(po.status ?? "draft");
+
+                    const vendor =
+                      safeText((po as unknown as { vendor?: unknown }).vendor) ||
+                      safeText((po as unknown as { vendor_name?: unknown }).vendor_name) ||
+                      safeText((po as unknown as { vendor_id?: unknown }).vendor_id) ||
+                      "—";
+
+                    return (
+                      <tr key={id} className="border-t border-[color:var(--desktop-border)]">
+                        <td className="p-3">
+                          <div className="font-semibold text-neutral-100">{id ? id.slice(0, 8) : "—"}</div>
+                          <div className="text-[11px] text-neutral-500">{id ? id : ""}</div>
+                        </td>
+
+                        <td className="p-3">
+                          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs ${toneForStatus(status)}`}>
+                            {status}
+                          </span>
+                        </td>
+
+                        <td className="p-3 text-neutral-300">{fmtDate(po.created_at ?? null)}</td>
+
+                        <td className="p-3 text-neutral-300">{vendor}</td>
+
+                        <td className="p-3">
+                          <Link
+                            href={`/parts/po/${encodeURIComponent(id)}/receive`}
+                            className="desktop-btn-secondary inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold"
+                          >
+                            Open receive →
+                          </Link>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="border-t border-[color:var(--desktop-border)] px-4 py-3 text-[11px] text-neutral-500">
+              Tip: Shared receive language: {receiveProgressLabel("partial")} and {receiveProgressLabel("received")} apply across Inbox, PO, and Scan.
+            </div>
+          </div>
+        )}
       </div>
-
-      {/* Errors */}
-      {err ? (
-        <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">
-          {err}
-        </div>
-      ) : null}
-
-      {/* Main */}
-      {loading ? (
-        <div className={`${card} p-4 text-sm text-neutral-400`}>Loading…</div>
-      ) : pos.length === 0 ? (
-        <div className={`${card} p-4 text-sm text-neutral-400`}>
-          No purchase orders found.
-        </div>
-      ) : (
-        <div className={`${card} overflow-hidden`}>
-          <div className="border-b border-white/10 bg-gradient-to-r from-black/80 via-slate-950/80 to-black/80 px-4 py-3">
-            <div className="text-xs font-medium uppercase tracking-[0.18em] text-neutral-400">
-              Purchase Orders
-            </div>
-            <div className="mt-1 text-[11px] text-neutral-500">
-              Select a PO to open the receiving screen.
-            </div>
-          </div>
-
-          <div className="overflow-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-neutral-400">
-                  <th className="p-3">PO</th>
-                  <th className="p-3">Status</th>
-                  <th className="p-3">Created</th>
-                  <th className="p-3">Vendor</th>
-                  <th className="p-3"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {pos.map((po) => {
-                  const id = safeText(po.id);
-                  const status = safeText(po.status ?? "draft");
-
-                  // vendor is schema-dependent; we keep it defensive
-                  const vendor =
-                    safeText((po as unknown as { vendor?: unknown }).vendor) ||
-                    safeText((po as unknown as { vendor_name?: unknown }).vendor_name) ||
-                    safeText((po as unknown as { vendor_id?: unknown }).vendor_id) ||
-                    "—";
-
-                  return (
-                    <tr key={id} className="border-t border-white/10">
-                      <td className="p-3">
-                        <div className="font-semibold text-neutral-100">
-                          {id ? id.slice(0, 8) : "—"}
-                        </div>
-                        <div className="text-[11px] text-neutral-500">
-                          {id ? id : ""}
-                        </div>
-                      </td>
-
-                      <td className="p-3">
-                        <span className="inline-flex items-center rounded-full border border-white/10 bg-black/40 px-3 py-1 text-xs text-neutral-200">
-                          {status}
-                        </span>
-                      </td>
-
-                      <td className="p-3 text-neutral-300">
-                        {fmtDate(po.created_at ?? null)}
-                      </td>
-
-                      <td className="p-3 text-neutral-300">{vendor}</td>
-
-                      <td className="p-3">
-                        <Link
-                          href={`/parts/po/${encodeURIComponent(id)}/receive`}
-                          className="inline-flex items-center justify-center rounded-lg border border-sky-500/35 bg-neutral-950/20 px-4 py-2 text-sm font-semibold text-sky-200 hover:bg-sky-900/20"
-                        >
-                          Open receive →
-                        </Link>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="border-t border-white/10 px-4 py-3 text-[11px] text-neutral-500">
-            Tip: Shared receive language: {receiveProgressLabel("partial")} and {receiveProgressLabel("received")} apply across Inbox, PO, and Scan.
-          </div>
-        </div>
-      )}
-    </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Reduce visual drift by bringing high-traffic desktop surfaces into the canonical Inspection Templates theme and shared desktop primitives. 
- Target parts receiving and the Assistant surface because they visibly diverged from the shared panel/toolbar/card grammar. 
- Prefer reuse of existing `PageShell`/`desktopPrimitives` and shared `Button` to keep style consistent while making no business/API changes.

### Description
- Reworked `app/assistant/page.tsx` to use `PageShell`, `desktopPrimitives` styles, shared pill grammar, and the shared input/button primitives instead of the local metal-card chrome. 
- Reworked `app/parts/po/receive/page.tsx` to the `PageShell` pattern with an eyebrow/description/toolbar, replaced the local card chrome with `desktopPrimitives` for loading/empty/panel states, added a shared `Button` refresh in the toolbar, and normalized PO status badge tones. 
- No changes to data fetching, API calls, or business logic; the work is purely visual/compositional using existing shared primitives. 

### Testing
- Ran lint over the touched files with `npx eslint app/assistant/page.tsx app/parts/po/receive/page.tsx` and it completed successfully. 
- Ran type-checking with `npx tsc --noEmit` and it completed successfully. 
- Files changed: `app/assistant/page.tsx`, `app/parts/po/receive/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2fe35a07c8328aa34c0fd0d8b32ce)