### PR TITLE
Unify Work Orders + Parts desktop surfaces with shared ProFixIQ primitives

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -68,7 +68,7 @@
   --desktop-border-strong: rgba(124, 155, 191, 0.56);
   --desktop-shadow-panel: 0 24px 72px rgba(0, 0, 0, 0.62);
   --desktop-shadow-card: 0 18px 45px rgba(0, 0, 0, 0.54);
-  --desktop-focus-ring: color-mix(in srgb, var(--brand-primary) 40%, #60a5fa);
+  --desktop-focus-ring: color-mix(in srgb, #60a5fa 70%, var(--brand-primary));
 
   --app-shell-bg:
     radial-gradient(circle at top, var(--desktop-bg-tint), transparent 52%),
@@ -257,7 +257,7 @@ select {
     font-family: var(--font-blackops), var(--font-inter), system-ui, sans-serif;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: color-mix(in srgb, var(--brand-primary) 82%, #f3f4f6);
+    color: color-mix(in srgb, #dbeafe 82%, var(--brand-primary) 18%);
   }
 
   .desktop-toolbar-row {
@@ -299,15 +299,15 @@ select {
   }
 
   .desktop-pill-active {
-    border-color: color-mix(in srgb, var(--brand-primary) 66%, #facc15);
-    background: color-mix(in srgb, var(--brand-primary) 22%, rgba(6, 10, 19, 0.9));
+    border-color: color-mix(in srgb, #60a5fa 58%, var(--desktop-border));
+    background: color-mix(in srgb, #1d4ed8 20%, rgba(6, 10, 19, 0.9));
     color: #f8fafc;
   }
 
   .desktop-btn-primary {
     border-radius: 9999px;
-    border: 1px solid color-mix(in srgb, var(--brand-primary) 58%, #fbbf24);
-    background: linear-gradient(to right, color-mix(in srgb, var(--brand-primary) 88%, #f3f4f6), color-mix(in srgb, var(--brand-primary) 60%, #f59e0b));
+    border: 1px solid color-mix(in srgb, var(--brand-primary) 52%, #f59e0b);
+    background: linear-gradient(to right, color-mix(in srgb, var(--brand-primary) 78%, #f3f4f6), color-mix(in srgb, var(--brand-primary) 54%, #fb923c));
     color: #020617;
     text-transform: uppercase;
     letter-spacing: 0.16em;
@@ -321,6 +321,24 @@ select {
     color: #e5e7eb;
     text-transform: uppercase;
     letter-spacing: 0.16em;
+  }
+
+  .desktop-btn-danger {
+    border-radius: 9999px;
+    border: 1px solid color-mix(in srgb, #ef4444 68%, transparent);
+    background: color-mix(in srgb, #7f1d1d 35%, rgba(3, 8, 16, 0.78));
+    color: #fecaca;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+  }
+
+  .desktop-link-chip {
+    border-radius: 9999px;
+    border: 1px solid color-mix(in srgb, var(--desktop-border) 88%, transparent);
+    background: rgba(3, 8, 16, 0.72);
+    padding: 0.2rem 0.55rem;
+    font-size: 11px;
+    color: #d1d5db;
   }
 }
 

--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type Alloc = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
@@ -121,27 +123,25 @@ export default function AllocationsPage(): JSX.Element {
   }, [rows, search]);
 
   return (
-    <div className="space-y-4 p-6 text-white">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Traceability</div>
-          <h1 className="text-2xl font-bold">Allocations</h1>
-          <div className="text-sm text-neutral-400">Track inventory committed to work orders with upstream request and stock move context.</div>
-        </div>
-        <Link href="/parts" className="rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm">Parts</Link>
+    <PageShell
+      eyebrow="Parts · Traceability"
+      title="Allocations"
+      description="Track inventory committed to work orders with upstream request and stock move context."
+      actions={<Link href="/parts" className={ui.buttonSecondary}>Parts</Link>}
+    >
+      <div className="space-y-4 text-white">
+
+      <div className="desktop-toolbar-row p-3">
+        <input className={ui.input} placeholder="Search WO, part, source request, move kind..." value={search} onChange={(e) => setSearch(e.target.value)} />
       </div>
 
-      <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-3">
-        <input className="w-full rounded-lg border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm" placeholder="Search WO, part, source request, move kind..." value={search} onChange={(e) => setSearch(e.target.value)} />
-      </div>
-
-      {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-4 text-sm text-red-200">{err}</div> : (
-        <div className="overflow-hidden rounded-xl border border-white/10 bg-neutral-950/35">
+      {loading ? <div className={ui.loadingState}>Loading…</div> : err ? <div className="desktop-panel-soft border-red-500/30 bg-red-950/30 p-4 text-sm text-red-200">{err}</div> : (
+        <div className="desktop-panel-soft overflow-hidden">
           <table className="w-full text-sm">
             <thead><tr className="text-left text-neutral-400"><th className="p-3">WO</th><th className="p-3">Part</th><th className="p-3">Location</th><th className="p-3">Qty</th><th className="p-3">Upstream trace</th><th className="p-3">Created</th></tr></thead>
             <tbody>
               {filtered.map((r) => (
-                <tr key={String(r.a.id)} className="border-t border-white/10 align-top">
+                <tr key={String(r.a.id)} className="border-t border-[color:var(--desktop-border)] align-top">
                   <td className="p-3.5">{r.a.work_order_id ? <Link className="text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(String(r.a.work_order_id))}`}>{r.wo?.custom_id ?? "Work order"}</Link> : <span className="text-neutral-500">—</span>}</td>
                   <td className="p-3.5">
                     {(() => {
@@ -159,7 +159,7 @@ export default function AllocationsPage(): JSX.Element {
                   <td className="p-3.5">{r.loc?.code ?? "LOC"} <span className="text-xs text-neutral-500">{r.loc?.name ?? ""}</span></td>
                   <td className="p-3.5 tabular-nums text-neutral-200">{r.a.qty}</td>
                   <td className="p-3.5 text-xs text-neutral-300">
-                    {r.req?.request_id ? <span className="rounded border border-white/10 px-2 py-0.5">Linked request</span> : <span className="text-neutral-500">No request link</span>}
+                    {r.req?.request_id ? <span className="desktop-link-chip">Linked request</span> : <span className="text-neutral-500">No request link</span>}
                     <div className="mt-1 text-neutral-500">{String(r.move?.reference_kind ?? "—").replaceAll("_", " ")} · {movementReasonLabel(r.move?.reason)}</div>
                   </td>
                   <td className="p-3.5 text-xs text-neutral-500">{r.a.created_at ? new Date(r.a.created_at).toLocaleString() : "—"}</td>
@@ -170,6 +170,7 @@ export default function AllocationsPage(): JSX.Element {
         </div>
       )}
       {!shopId ? <div className="text-xs text-neutral-500">No shop detected for this user.</div> : null}
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type StockMove = DB["public"]["Tables"]["stock_moves"]["Row"];
@@ -115,19 +117,17 @@ export default function StockMovementsPage(): JSX.Element {
   useEffect(() => { void load(); }, []);
 
   return (
-    <div className="space-y-4 p-6 text-white">
-      <div className="flex items-start justify-between">
-        <div>
-          <div className="text-xs uppercase tracking-[0.22em] text-neutral-400">Parts · Traceability</div>
-          <h1 className="text-2xl font-bold">Stock movements</h1>
-          <div className="text-sm text-neutral-400">Ledger with direct source links for PO, request receive, and WO allocation context.</div>
-        </div>
-        <button onClick={() => void load()} className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm">Refresh</button>
-      </div>
+    <PageShell
+      eyebrow="Parts · Traceability"
+      title="Stock movements"
+      description="Ledger with direct source links for PO, request receive, and WO allocation context."
+      actions={<button onClick={() => void load()} className={ui.buttonSecondary}>Refresh</button>}
+    >
+      <div className="space-y-4 text-white">
 
-      {err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
-      {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : (
-        <div className="overflow-hidden rounded-xl border border-white/10 bg-neutral-950/35">
+      {err ? <div className="desktop-panel-soft border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
+      {loading ? <div className={ui.loadingState}>Loading…</div> : (
+        <div className="desktop-panel-soft overflow-hidden">
           <table className="w-full text-sm">
             <thead>
               <tr className="text-left text-neutral-400">
@@ -143,7 +143,7 @@ export default function StockMovementsPage(): JSX.Element {
                 const refId = String(m.reference_id ?? "");
                 const ctx = ctxMap[refId] ?? ctxMap[String(m.id)] ?? null;
                 return (
-                  <tr key={String(m.id)} className="border-t border-white/10 align-top">
+                  <tr key={String(m.id)} className="border-t border-[color:var(--desktop-border)] align-top">
                     <td className="p-3.5 text-xs text-neutral-400">{m.created_at ? new Date(m.created_at).toLocaleString() : "—"}</td>
                     <td className="p-3.5">
                       <div className="font-medium text-neutral-100">{partSummary?.name ?? "Unknown part"}</div>
@@ -156,8 +156,8 @@ export default function StockMovementsPage(): JSX.Element {
                     <td className="p-3.5"><div className="text-neutral-200">{ctx?.sourceLabel ?? sourceLabel(m.reference_kind, m.reason)}</div><div className="text-xs text-neutral-500">{reasonLabel(m.reason)}</div></td>
                     <td className="p-3.5 text-xs">
                       <div className="flex flex-wrap gap-2">
-                        {ctx?.workOrderId ? <Link className="rounded border border-white/10 px-2 py-0.5 text-neutral-200 hover:text-white" href={`/work-orders/${encodeURIComponent(ctx.workOrderId)}`}>WO {ctx.workOrderId.slice(0, 8)}</Link> : <span className="text-neutral-500">No WO</span>}
-                        {ctx?.requestItemId ? <span className="rounded border border-white/10 px-2 py-0.5 text-neutral-300">Req item {ctx.requestItemId.slice(0, 8)}</span> : null}
+                        {ctx?.workOrderId ? <Link className="desktop-link-chip hover:text-white" href={`/work-orders/${encodeURIComponent(ctx.workOrderId)}`}>WO {ctx.workOrderId.slice(0, 8)}</Link> : <span className="text-neutral-500">No WO</span>}
+                        {ctx?.requestItemId ? <span className="desktop-link-chip">Req item {ctx.requestItemId.slice(0, 8)}</span> : null}
                       </div>
                     </td>
                   </tr>
@@ -167,6 +167,7 @@ export default function StockMovementsPage(): JSX.Element {
           </table>
         </div>
       )}
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -13,6 +13,8 @@ import {
   trustLevelLabel,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type QuaggaResult = { codeResult?: { code?: string | null } | null };
 
@@ -274,12 +276,12 @@ export default function ReceivePage(): JSX.Element {
   const locLabel = locs.find((l) => l.id === selectedLoc)?.code ?? "LOC";
 
   return (
-    <div className="p-6 space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-white">Scan to Receive</h1>
-          <div className="text-sm text-neutral-400">Scan to Receive: fast intake via barcode/manual entry.</div>
-        </div>
+    <PageShell
+      eyebrow="Parts · Receiving"
+      title="Scan to Receive"
+      description="Fast intake via barcode or manual entry."
+    >
+      <div className="space-y-4">
 
         <div className="flex flex-wrap items-center gap-2">
           <Link
@@ -290,7 +292,7 @@ export default function ReceivePage(): JSX.Element {
           </Link>
           <Link
             href="/agent/planner?planner=ops&allowCreate=0&goal=Review%20scan-to-receive%20workflow%20and%20suggest%20the%20best%20next%20actions"
-            className="rounded border border-white/10 bg-neutral-950/40 px-3 py-2 text-sm text-neutral-200 hover:border-sky-500/30 hover:text-sky-200"
+            className={ui.buttonSecondary}
           >
             Open Planner
           </Link>
@@ -301,11 +303,11 @@ export default function ReceivePage(): JSX.Element {
         Shop: <span className="text-neutral-300">{shopId ? shopId.slice(0, 8) : "—"}</span>
       </div>
 
-      <div className="rounded border border-neutral-800 bg-neutral-900 p-3 grid gap-3 sm:grid-cols-3">
+      <div className="desktop-toolbar-row grid gap-3 p-3 sm:grid-cols-3">
         <div className="sm:col-span-1">
           <div className="text-xs text-neutral-400 mb-1">Purchase Order (optional)</div>
           <select
-            className="w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-white"
+            className={ui.input}
             value={selectedPo}
             onChange={(e) => setSelectedPo(e.target.value)}
           >
@@ -321,7 +323,7 @@ export default function ReceivePage(): JSX.Element {
         <div>
           <div className="text-xs text-neutral-400 mb-1">Location</div>
           <select
-            className="w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-white"
+            className={ui.input}
             value={selectedLoc}
             onChange={(e) => setSelectedLoc(e.target.value)}
           >
@@ -339,7 +341,7 @@ export default function ReceivePage(): JSX.Element {
             type="number"
             min={0.01}
             step="0.01"
-            className="w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-white"
+            className={ui.input}
             value={qty}
             onChange={(e) => setQty(Math.max(0.01, Number(e.target.value || 1)))}
           />
@@ -347,7 +349,7 @@ export default function ReceivePage(): JSX.Element {
       </div>
 
       {/* Result panel */}
-      <div className="rounded border border-neutral-800 bg-neutral-950 p-3">
+      <div className="desktop-panel-soft p-3">
         <div className="text-xs uppercase tracking-[0.18em] text-neutral-500 mb-2">
           Last receive
         </div>
@@ -379,7 +381,7 @@ export default function ReceivePage(): JSX.Element {
         )}
       </div>
 
-      <div className="rounded border border-neutral-800 bg-neutral-900 p-3">
+      <div className="desktop-panel-soft p-3">
         <div className="mb-2 flex items-center gap-2">
           {!scanning ? (
             <button
@@ -407,6 +409,6 @@ export default function ReceivePage(): JSX.Element {
           className="aspect-video w-full overflow-hidden rounded border border-neutral-800 bg-black"
         />
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/features/parts/lib/trust-signals";
 import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 import type { ReceiveDrawerItem } from "@/features/parts/components/ReceiveDrawer";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
@@ -227,26 +229,24 @@ export default function ReceivingInboxPage(): JSX.Element {
   const poOptions = pos.map((po) => ({ value: String(po.id), label: `${String(po.id).slice(0, 8)} • ${String(po.status ?? "draft")}` }));
 
   return (
-    <div className="p-6 space-y-4 text-white">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-neutral-400">Parts · Receiving Lens</div>
-          <h1 className="text-2xl font-bold">Receiving Inbox</h1>
-          <div className="text-sm text-neutral-400">Shared receive flow for request items with consistent status and trust context.</div>
-        </div>
-        <button onClick={() => void load(page)} className="rounded-lg border border-white/10 bg-neutral-950/40 px-4 py-2 text-sm hover:bg-white/5">Refresh</button>
-      </div>
+    <PageShell
+      eyebrow="Parts · Receiving lens"
+      title="Receiving Inbox"
+      description="Shared receive flow for request items with consistent status and trust context."
+      actions={<button onClick={() => void load(page)} className={ui.buttonSecondary}>Refresh</button>}
+    >
+      <div className="space-y-4 text-white">
 
       <div className="text-xs text-neutral-500">
         Last updated <span className="text-neutral-300">{lastUpdated ? lastUpdated.toLocaleTimeString() : "—"}</span> · {lastUpdated && nowTs - lastUpdated.getTime() > 120000 ? <span className="text-neutral-300">stale</span> : <span className="text-emerald-300">fresh</span>}
       </div>
 
-      <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4">
+      <div className="desktop-toolbar-row p-4">
         <div className="grid gap-3 md:grid-cols-3">
-          <select className="rounded-lg border border-white/10 bg-neutral-950/40 p-2" value={selectedLoc} onChange={(e) => setSelectedLoc(e.target.value)}>
+          <select className={ui.input} value={selectedLoc} onChange={(e) => setSelectedLoc(e.target.value)}>
             {locs.map((l) => <option key={String(l.id)} value={String(l.id)}>{l.code ?? "LOC"} — {l.name ?? ""}</option>)}
           </select>
-          <select className="rounded-lg border border-white/10 bg-neutral-950/40 p-2" value={selectedPo} onChange={(e) => setSelectedPo(e.target.value)}>
+          <select className={ui.input} value={selectedPo} onChange={(e) => setSelectedPo(e.target.value)}>
             <option value="">PO optional</option>
             {pos.map((po) => <option key={String(po.id)} value={String(po.id)}>{String(po.id).slice(0, 8)} • {String(po.status ?? "draft")}</option>)}
           </select>
@@ -254,12 +254,12 @@ export default function ReceivingInboxPage(): JSX.Element {
         </div>
       </div>
 
-      {err ? <div className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
-      {loading ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">Loading…</div> : null}
+      {err ? <div className="desktop-panel-soft border-red-500/30 bg-red-950/30 p-3 text-sm text-red-200">{err}</div> : null}
+      {loading ? <div className={ui.loadingState}>Loading…</div> : null}
 
       {!loading && items.length > 0 ? (
-        <div className="rounded-xl border border-white/10 bg-neutral-950/35 overflow-hidden">
-          <div className="border-b border-white/10 px-4 py-3 text-xs text-neutral-500">{items.length} of {totalCount} rows loaded · page {page}</div>
+        <div className="desktop-panel-soft overflow-hidden">
+          <div className="border-b border-[color:var(--desktop-border)] px-4 py-3 text-xs text-neutral-500">{items.length} of {totalCount} rows loaded · page {page}</div>
           <table className="w-full text-sm">
             <thead><tr className="text-left text-neutral-400"><th className="p-3">Part / Context</th><th className="p-3">Receive state</th><th className="p-3">Qty</th><th className="p-3"/></tr></thead>
             <tbody>
@@ -270,7 +270,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                 const itemState = toItemFlowDisplay({ rawStatus: it.status, qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 const recvState = toReceiveProgressDisplay({ qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 return (
-                  <tr key={it.id} className="border-t border-white/10 align-top">
+                  <tr key={it.id} className="border-t border-[color:var(--desktop-border)] align-top">
                     <td className="p-3.5">
                       <div className="font-semibold text-neutral-100">{partSummary?.name ?? it.description}</div>
                       <div className="mt-1 text-[11px] text-neutral-500">
@@ -280,7 +280,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                       {trust && trust.reasons.length > 0 ? <div className={`mt-1 text-[11px] ${trustReasonTone(trust.level)}`}>{trust.reasons.slice(0,2).join(" · ")}</div> : null}
                     </td>
                     <td className="p-3.5">
-                      <span className="inline-flex rounded-full border border-white/10 bg-black/40 px-2 py-1 text-xs">{receiveProgressLabel(recvState)}</span>
+                      <span className="desktop-link-chip">{receiveProgressLabel(recvState)}</span>
                       {trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trustLevelLabel(trust.level)}</span> : null}
                     </td>
                     <td className="p-3.5 tabular-nums text-neutral-200">{it.qty_received} / {it.qty_approved} <span className="text-neutral-500">({it.qty_remaining} rem)</span></td>
@@ -290,13 +290,14 @@ export default function ReceivingInboxPage(): JSX.Element {
               })}
             </tbody>
           </table>
-          <div className="flex justify-between border-t border-white/10 p-3 text-xs"><button className="rounded border border-white/10 px-2 py-1" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Previous</button><button className="rounded border border-white/10 px-2 py-1" disabled={items.length < pageSize} onClick={() => setPage((p) => p + 1)}>Next</button></div>
+          <div className="flex justify-between border-t border-[color:var(--desktop-border)] p-3 text-xs"><button className="desktop-link-chip" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Previous</button><button className="desktop-link-chip" disabled={items.length < pageSize} onClick={() => setPage((p) => p + 1)}>Next</button></div>
         </div>
       ) : null}
 
-      {!loading && items.length === 0 ? <div className="rounded-xl border border-white/10 bg-neutral-950/35 p-4 text-sm text-neutral-400">No outstanding receive items.</div> : null}
+      {!loading && items.length === 0 ? <div className={ui.emptyState}>No outstanding receive items.</div> : null}
 
       <ReceiveDrawer open={drawerOpen} item={drawerItem} onClose={() => { setDrawerOpen(false); setDrawerItem(null); void load(); }} locations={locOptions} defaultLocationId={selectedLoc || locOptions[0]?.value || ""} purchaseOrders={poOptions} defaultPoId={selectedPo || ""} />
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/features/shared/components/ui/StatusBadge.tsx
+++ b/features/shared/components/ui/StatusBadge.tsx
@@ -25,7 +25,7 @@ const variantClasses: Record<StatusBadgeVariant, string> = {
     "border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-surface-2,#0B1220)_84%,transparent)] text-[var(--theme-text-secondary,#94A3B8)]",
   info: "border-sky-500/40 bg-sky-500/10 text-sky-200",
   active:
-    "border-[color:var(--accent-copper-soft,#fdba74)]/70 bg-[color:color-mix(in_srgb,var(--accent-copper,#f97316)_20%,transparent)] text-[color:var(--accent-copper-light,#fdba74)]",
+    "border-sky-400/60 bg-sky-500/10 text-sky-100",
   warning: "border-amber-500/60 bg-amber-500/10 text-amber-200",
   success: "border-emerald-500/60 bg-emerald-500/10 text-emerald-200",
   danger: "border-rose-500/60 bg-rose-500/10 text-rose-200",

--- a/features/work-orders/app/work-orders/queue/page.tsx
+++ b/features/work-orders/app/work-orders/queue/page.tsx
@@ -24,7 +24,7 @@ const STATUS_LABELS: Record<RollupStatus, string> = {
 
 const STATUS_STYLES: Record<RollupStatus, string> = {
   awaiting:
-    `${ui.itemCard} hover:border-[color:var(--brand-accent,#E39A6E)] data-[active=true]:border-[color:var(--brand-accent,#E39A6E)] data-[active=true]:bg-[color:color-mix(in_srgb,var(--brand-primary,#C97A3D)_12%,transparent)]`,
+    `${ui.itemCard} hover:border-sky-400/55 data-[active=true]:border-sky-400/60 data-[active=true]:bg-sky-500/10`,
   in_progress:
     `${ui.itemCard} hover:border-sky-400/60 data-[active=true]:border-sky-400/60 data-[active=true]:bg-sky-500/10`,
   on_hold:

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -60,10 +60,10 @@ const ASSIGN_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 const STATUS_PICKER_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 
 const INPUT_DARK =
-  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-light)] focus:ring-2 focus:ring-[var(--accent-copper)]/35";
+  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30";
 
 const SELECT_DARK =
-  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[var(--accent-copper-light)] focus:ring-2 focus:ring-[var(--accent-copper)]/35";
+  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30";
 
 function isStatusKey(x: string): x is StatusKey {
   return (
@@ -105,8 +105,8 @@ function stageAccent(status: string | null | undefined): {
   if (key === "in_progress") {
     return {
       badge:
-        "border-[var(--accent-copper-light)]/70 bg-[var(--accent-copper)]/15 text-[var(--accent-copper-light)]",
-      border: "border-[var(--accent-copper)]/30",
+        "border-sky-400/60 bg-sky-500/10 text-sky-100",
+      border: "border-sky-500/30",
       progress: "bg-[linear-gradient(90deg,#f59e0b,#c57a4a)]",
     };
   }
@@ -168,7 +168,7 @@ function stageAccent(status: string | null | undefined): {
 
 function techRollupChip(rollup: TechRollup): string {
   if (rollup === "in_progress") {
-    return "border-[var(--accent-copper-light)]/70 bg-[var(--accent-copper)]/15 text-[var(--accent-copper-light)]";
+    return "border-sky-400/60 bg-sky-500/10 text-sky-100";
   }
   if (rollup === "on_hold") {
     return "border-amber-400/70 bg-amber-500/10 text-amber-100";
@@ -695,7 +695,7 @@ export default function WorkOrdersView(): JSX.Element {
 
             <Link
               href="/agent/planner?planner=ops&allowCreate=0&goal=Review%20the%20current%20work%20order%20queue%20and%20suggest%20the%20best%20next%20actions"
-              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-3.5 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15"
+              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-3.5 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/65 hover:bg-sky-500/10"
             >
               Open Planner
             </Link>
@@ -744,7 +744,7 @@ export default function WorkOrdersView(): JSX.Element {
               void load();
               setAssignVersion((v) => v + 1);
             }}
-            className="rounded-xl border border-white/10 bg-black/25 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15"
+            className="rounded-xl border border-white/10 bg-black/25 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/65 hover:bg-sky-500/10"
           >
             Refresh
           </button>
@@ -825,7 +825,7 @@ export default function WorkOrdersView(): JSX.Element {
                     <div className="flex flex-wrap items-center gap-2">
                       <Link
                         href={href}
-                        className="text-sm font-extrabold text-white hover:text-[var(--accent-copper-light)]"
+                        className="text-sm font-extrabold text-white hover:text-sky-200"
                       >
                         {r.custom_id ?? `#${r.id.slice(0, 8)}`}
                       </Link>
@@ -913,7 +913,7 @@ export default function WorkOrdersView(): JSX.Element {
                 <div className="mt-4 flex flex-wrap gap-2">
                   <Link
                     href={href}
-                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/20"
+                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-sky-500/10"
                   >
                     Open
                   </Link>
@@ -952,7 +952,7 @@ export default function WorkOrdersView(): JSX.Element {
                       disabled={!reviewedOk}
                       className={
                         reviewedOk
-                          ? "rounded-full border border-[var(--accent-copper-light)] bg-[var(--accent-copper)]/15 px-3 py-1.5 text-xs font-semibold text-[var(--accent-copper-light)] transition hover:bg-[var(--accent-copper)]/25"
+                          ? "rounded-full border border-sky-400/60 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
                           : "rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-500 opacity-60"
                       }
                     >


### PR DESCRIPTION
### Motivation
- Continue the desktop visual rollout to bring all Work Order and Parts desktop surfaces into the canonical Inspection Templates visual language (premium dark, cool/blue undertone, restrained copper emphasis). 
- Use shared primitives (`PageShell`, `desktopPrimitives`) so Work Orders and Parts feel like one cohesive product family without changing workflows or data contracts. 

### Description
- Tuned global desktop primitives in `app/globals.css` (focus ring, title/pill active tones) and added `desktop-btn-danger` and `desktop-link-chip` to support consistent action and link treatments. 
- Normalized the `active` badge variant in `features/shared/components/ui/StatusBadge.tsx` from a copper tone to a cool/semantic blue to align status language across surfaces. 
- Rebalanced Work Orders visuals by adjusting queue/status card styles and input/select focus language in `features/work-orders/app/work-orders/queue/page.tsx` and `features/work-orders/app/work-orders/view/page.tsx` so status chips and actions use the shared cool/semantic treatment. 
- Migrated Parts operational pages (`app/parts/movements/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/receiving/page.tsx`, `app/parts/receive/page.tsx`) into `PageShell` and rewired headers, toolbar rows, inputs, panels, link chips, loading/empty states to the `desktopPrimitives` grammar for consistent cards/panels/buttons. 
- Files changed: `app/globals.css`, `features/shared/components/ui/StatusBadge.tsx`, `features/work-orders/app/work-orders/queue/page.tsx`, `features/work-orders/app/work-orders/view/page.tsx`, `app/parts/movements/page.tsx`, `app/parts/allocations/page.tsx`, `app/parts/receiving/page.tsx`, `app/parts/receive/page.tsx`.

### Testing
- Ran ESLint on touched files with `npx eslint <files>` which passed but emitted existing non-blocking `react-hooks/exhaustive-deps` warnings in receiving/movements load effects. 
- Ran TypeScript typecheck with `npx tsc --noEmit` which passed with no type errors. 
- No runtime/API/workflow logic was changed in this pass, so no behavioral tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e301ae31388328b7d2499eef892b62)