### PR TITLE
Restore Inspection Templates as canonical visual reference

### DIFF
--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import FleetFormImportCard from "@/features/inspections/components/FleetFormImportCard";
-import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type DB = Database;
 type Template = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -27,10 +26,12 @@ export default function InspectionTemplatesPage() {
     (async () => {
       setLoading(true);
 
+      // get current user
       const { data: auth } = await supabase.auth.getUser();
       const uid = auth?.user?.id ?? null;
       setUserId(uid);
 
+      // resolve shop_id for this user (if any)
       let resolvedShopId: string | null = null;
       if (uid) {
         const byUser = await supabase
@@ -54,6 +55,7 @@ export default function InspectionTemplatesPage() {
       }
       setShopId(resolvedShopId);
 
+      // "My" templates (optionally scoped to shop)
       const minePromise = uid
         ? (() => {
             let q = supabase
@@ -71,6 +73,7 @@ export default function InspectionTemplatesPage() {
             error: null,
           });
 
+      // Shared/public templates (optionally scoped to shop)
       const sharedPromise = (() => {
         let q = supabase
           .from("inspection_templates")
@@ -103,6 +106,7 @@ export default function InspectionTemplatesPage() {
     } else if (scope === "shared") {
       pool = shared;
     } else {
+      // "all" — merge by id to avoid duplicates if a template is both mine + shared
       const byId = new Map<string, Template>();
       for (const t of [...mine, ...shared]) {
         if (!t.id) continue;
@@ -145,6 +149,7 @@ export default function InspectionTemplatesPage() {
       setMine((prev) => prev.filter((t) => t.id !== id));
       setShared((prev) => prev.filter((t) => t.id !== id));
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error("Delete failed:", e);
       alert("Failed to delete template.");
     } finally {
@@ -152,29 +157,80 @@ export default function InspectionTemplatesPage() {
     }
   }
 
-  return (
-    <div className={ui.page}>
-      <div className={ui.container}>
-        <div aria-hidden className={ui.backdrop} />
+  const headerCard =
+    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
+    "bg-black/70 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
 
-        <section className={`${ui.panel} ${ui.panelPadding} relative overflow-hidden`}>
-          <div className={ui.headerTop}>
+  const listCard =
+    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
+    "bg-black/70 shadow-[0_20px_70px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+
+  const pillBase =
+    "px-3 py-1 text-[10px] uppercase tracking-[0.16em] rounded-full border " +
+    "transition-colors";
+
+  // copper palette (replaces all orange usage)
+  const COPPER_18 = "rgba(200,122,67,0.18)";
+  const COPPER_20 = "rgba(200,122,67,0.20)";
+  const COPPER_14 = "rgba(200,122,67,0.14)";
+  const COPPER_90 = "rgba(200,122,67,0.90)";
+  const COPPER_70 = "rgba(200,122,67,0.70)";
+  const COPPER_65 = "rgba(200,122,67,0.65)";
+  const COPPER_55 = "rgba(200,122,67,0.55)";
+  const COPPER_SHADOW_60 = "rgba(200,122,67,0.60)";
+  const COPPER_SHADOW_80 = "rgba(200,122,67,0.80)";
+
+  return (
+    <div className="px-4 py-6 text-white">
+      <div className="mx-auto w-full max-w-6xl space-y-5">
+        {/* Copper wash (was orange) */}
+        <div
+          aria-hidden
+          className={`
+            pointer-events-none fixed inset-0 -z-10
+            bg-[radial-gradient(circle_at_top,${COPPER_18},transparent_55%),radial-gradient(circle_at_bottom,rgba(15,23,42,0.96),#020617_78%)]
+          `}
+        />
+
+        {/* Header + filters */}
+        <div className={headerCard + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
+          <div
+            aria-hidden
+            className={`
+              pointer-events-none absolute inset-x-0 -top-10 h-24
+              bg-[radial-gradient(circle_at_top,${COPPER_20},transparent_65%)]
+            `}
+          />
+
+          <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
-              <h1 className={ui.title}>Inspection Templates</h1>
-              <p className={ui.subtitle}>
+              <h1
+                className={`text-xl font-bold tracking-[0.22em] text-[${COPPER_90}] md:text-2xl uppercase`}
+                style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}
+              >
+                Inspection Templates
+              </h1>
+              <p className="mt-1 text-xs text-neutral-300">
                 Build, import, and manage inspection templates for your shop and fleets.
               </p>
             </div>
 
             <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
-              <div className="flex overflow-hidden rounded-full border border-[color:var(--desktop-border)] bg-black/50">
+              {/* Scope pills */}
+              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-black/60">
                 {(["mine", "shared", "all"] as Scope[]).map((s) => {
                   const isActive = scope === s;
                   return (
                     <button
                       key={s}
                       onClick={() => setScope(s)}
-                      className={isActive ? ui.pillActive : ui.pill}
+                      className={
+                        pillBase +
+                        " " +
+                        (isActive
+                          ? `border-[${COPPER_70}] bg-[rgba(15,23,42,0.95)] text-[rgba(248,250,252,0.95)]`
+                          : "border-transparent bg-transparent text-neutral-400 hover:bg-zinc-900/80")
+                      }
                     >
                       {s === "mine" ? "My Templates" : s === "shared" ? "Shared" : "All"}
                     </button>
@@ -182,35 +238,55 @@ export default function InspectionTemplatesPage() {
                 })}
               </div>
 
-              <Link href="/inspections/custom-inspection" className={ui.buttonPrimary}>
+              {/* New template CTA (was orange gradient + orange glow) */}
+              <Link
+                href="/inspections/custom-inspection"
+                className={`
+                  mt-1 inline-flex items-center justify-center rounded-full
+                  bg-[linear-gradient(to_right,rgba(200,122,67,0.85),rgba(200,122,67,0.55))]
+                  px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-black
+                  shadow-[0_0_22px_${COPPER_SHADOW_60}] hover:shadow-[0_0_30px_${COPPER_SHADOW_80}]
+                  md:mt-0
+                `}
+              >
                 New Template
               </Link>
             </div>
           </div>
 
-          <div className={ui.toolbarRow}>
+          {/* Search */}
+          <div className="relative mt-4 flex flex-col gap-2 md:flex-row md:items-center">
             <div className="relative flex-1">
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by name, description, or tags…"
-                className={ui.input}
+                className={`
+                  w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70
+                  px-3 py-2 text-sm text-white placeholder:text-neutral-500
+                  focus:outline-none focus:ring-2 focus:ring-[${COPPER_55}]
+                `}
               />
             </div>
 
             <div className="text-[11px] text-neutral-500 md:pl-3">
-              <span className="hidden md:inline">Tip:</span> Use fleet imports to match customer forms exactly.
+              <span className="hidden md:inline">Tip:</span>{" "}
+              Use fleet imports to match customer forms exactly.
             </div>
           </div>
-        </section>
+        </div>
 
+        {/* Fleet import card */}
         <FleetFormImportCard />
 
-        <section className={`${ui.panel} ${ui.panelPadding}`}>
+        {/* Templates list */}
+        <div className={listCard + " px-4 py-4 md:px-6 md:py-5"}>
           {loading ? (
-            <div className={ui.loadingState}>Loading templates…</div>
+            <div className="rounded-xl border border-neutral-800 bg-black/60 px-4 py-4 text-sm text-neutral-300">
+              Loading templates…
+            </div>
           ) : rows.length === 0 ? (
-            <div className={ui.emptyState}>
+            <div className="rounded-xl border border-neutral-800 bg-black/60 px-4 py-6 text-center text-sm text-neutral-300">
               <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
                 No templates found
               </div>
@@ -223,7 +299,9 @@ export default function InspectionTemplatesPage() {
               {rows.map((t) => {
                 const mineOwned = canEditOrDelete(t);
                 const encodedName = encodeURIComponent(t.template_name ?? "Custom Inspection");
+
                 const createdAt = t.created_at ? new Date(t.created_at).toLocaleDateString() : "—";
+
                 const tags = Array.isArray(t.tags) ? t.tags : [];
                 const lowerTags = tags.map((tag) => tag.toLowerCase());
 
@@ -236,6 +314,7 @@ export default function InspectionTemplatesPage() {
                       "border-[rgba(56,189,248,0.55)] bg-[rgba(8,47,73,0.7)] text-sky-100",
                   });
                 }
+
                 if (
                   lowerTags.includes("dvir") ||
                   lowerTags.includes("pre-trip") ||
@@ -248,6 +327,7 @@ export default function InspectionTemplatesPage() {
                       "border-[rgba(45,212,191,0.6)] bg-[rgba(6,78,59,0.7)] text-emerald-100",
                   });
                 }
+
                 if (
                   lowerTags.includes("pm") ||
                   lowerTags.includes("preventive maintenance") ||
@@ -259,6 +339,8 @@ export default function InspectionTemplatesPage() {
                       "border-[rgba(196,181,253,0.6)] bg-[rgba(49,46,129,0.7)] text-violet-100",
                   });
                 }
+
+                // Fallback "Custom" chip if no special type detected
                 if (chips.length === 0) {
                   chips.push({
                     label: "Custom",
@@ -268,8 +350,20 @@ export default function InspectionTemplatesPage() {
                 }
 
                 return (
-                  <li key={t.id} className={ui.itemCard}>
+                  <li
+                    key={t.id}
+                    className="relative overflow-hidden rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.95)]"
+                  >
+                    <div
+                      aria-hidden
+                      className={`
+                        pointer-events-none absolute inset-x-0 -top-10 h-20
+                        bg-[radial-gradient(circle_at_top,${COPPER_14},transparent_70%)]
+                      `}
+                    />
+
                     <div className="relative flex flex-col gap-2">
+                      {/* Title + scope + chips */}
                       <div className="flex items-start justify-between gap-2">
                         <div>
                           <div className="text-sm font-semibold text-neutral-50">
@@ -297,7 +391,7 @@ export default function InspectionTemplatesPage() {
                               <span
                                 key={chip.label}
                                 className={
-                                  "rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] border " +
+                                  "rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] " +
                                   chip.className
                                 }
                               >
@@ -308,6 +402,7 @@ export default function InspectionTemplatesPage() {
                         </div>
                       </div>
 
+                      {/* Tags + meta */}
                       <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-neutral-500">
                         <span>{createdAt}</span>
                         {tags.length > 0 && (
@@ -317,40 +412,61 @@ export default function InspectionTemplatesPage() {
                               {tags.slice(0, 4).map((tag) => (
                                 <span
                                   key={tag}
-                                  className="rounded-full border border-[color:var(--desktop-border)] bg-black/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-neutral-300"
+                                  className="rounded-full border border-neutral-700 bg-black/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-neutral-300"
                                 >
                                   {tag}
                                 </span>
                               ))}
                               {tags.length > 4 && (
-                                <span className="text-[10px] text-neutral-500">+{tags.length - 4} more</span>
+                                <span className="text-[10px] text-neutral-500">
+                                  +{tags.length - 4} more
+                                </span>
                               )}
                             </div>
                           </>
                         )}
                       </div>
 
+                      {/* Actions */}
                       <div className="mt-3 flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2">
-                          <Link href={`/inspections/run?templateId=${t.id}`} className={ui.buttonSecondary}>
+                          {/* Use Template / run */}
+                          <Link
+                            href={`/inspections/run?templateId=${t.id}`}
+                            className={`
+                              rounded-full border border-[color:var(--metal-border-soft,#374151)]
+                              bg-black/70 px-3 py-1.5 text-[11px] uppercase tracking-[0.16em]
+                              text-neutral-100 hover:border-[${COPPER_65}] hover:bg-black/80
+                            `}
+                          >
                             Use
                           </Link>
 
+                          {/* Edit -> go to custom draft */}
                           {mineOwned && (
                             <Link
                               href={`/inspections/custom-draft?templateId=${t.id}&template=${encodedName}`}
-                              className={ui.buttonSecondary}
+                              className={`
+                                rounded-full border border-[color:var(--metal-border-soft,#374151)]
+                                bg-black/70 px-3 py-1.5 text-[11px] uppercase tracking-[0.16em]
+                                text-neutral-100 hover:border-[${COPPER_65}] hover:bg-black/80
+                              `}
                             >
                               Edit
                             </Link>
                           )}
                         </div>
 
+                        {/* Delete */}
                         {mineOwned && (
                           <button
                             onClick={() => handleDelete(t.id)}
                             disabled={deletingId === t.id}
-                            className="rounded-full border border-red-700/80 bg-red-900/30 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-200 hover:bg-red-900/50 disabled:opacity-60"
+                            className="
+                              rounded-full border border-red-700/80 bg-red-900/30
+                              px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em]
+                              text-red-200 hover:bg-red-900/50 disabled:opacity-60
+                            "
                             title="Delete template"
                           >
                             {deletingId === t.id ? "Deleting…" : "Delete"}
@@ -363,7 +479,7 @@ export default function InspectionTemplatesPage() {
               })}
             </ul>
           )}
-        </section>
+        </div>
       </div>
     </div>
   );

--- a/features/inspections/components/FleetFormImportCard.tsx
+++ b/features/inspections/components/FleetFormImportCard.tsx
@@ -1,4 +1,3 @@
-//features/inspections/components/FleetFormImportCard.tsx
 
 "use client";
 
@@ -476,9 +475,16 @@ export default function FleetFormImportCard() {
       <form
         onSubmit={handleSubmit}
         className="
-          desktop-panel relative p-5
+          relative rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)]
+          bg-black/65 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl p-5
         "
       >
+        {/* Copper glow wash */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_65%)]"
+        />
+
         <div className="mb-3 flex items-center justify-between">
           <div>
             <div className="text-[11px] font-blackops uppercase tracking-[0.18em] text-neutral-400">
@@ -505,7 +511,8 @@ export default function FleetFormImportCard() {
               multiple
               onChange={handleFileChange}
               className="
-                desktop-input px-3 py-2 text-xs text-white
+                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
+                bg-black/70 px-3 py-2 text-xs text-white
                 file:mr-2 file:rounded-lg file:border file:border-[color:var(--metal-border-soft,#374151)]
                 file:bg-black/50 file:px-3 file:py-1.5 file:text-[10px] file:uppercase
                 file:tracking-[0.18em] file:text-neutral-300
@@ -525,7 +532,8 @@ export default function FleetFormImportCard() {
               onChange={(e) => setTitleHint(e.target.value)}
               placeholder="ABC Logistics – Daily Truck Inspection"
               className="
-                desktop-input px-3 py-2 text-xs text-white placeholder:text-neutral-500
+                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
+                bg-black/70 px-3 py-2 text-xs text-white placeholder:text-neutral-500
               "
             />
           </label>
@@ -574,7 +582,8 @@ export default function FleetFormImportCard() {
               value={vehicleType}
               onChange={(e) => setVehicleType(e.target.value)}
               className="
-                desktop-input px-3 py-2 text-xs text-white
+                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
+                bg-black/70 px-3 py-2 text-xs text-white
               "
             >
               <option value="">Not specified</option>
@@ -592,7 +601,8 @@ export default function FleetFormImportCard() {
               value={dutyClass}
               onChange={(e) => setDutyClass(e.target.value as DutyClass | "")}
               className="
-                desktop-input px-3 py-2 text-xs text-white
+                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
+                bg-black/70 px-3 py-2 text-xs text-white
               "
             >
               <option value="">Not specified</option>
@@ -611,7 +621,9 @@ export default function FleetFormImportCard() {
               disabled={loading}
               onClick={openCamera}
               className="
-                w-full desktop-btn-secondary px-4 py-2 text-[11px]
+                w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)]
+                bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
+                text-neutral-200 hover:bg-black/80 hover:border-neutral-500
                 disabled:opacity-50
               "
             >
@@ -624,7 +636,9 @@ export default function FleetFormImportCard() {
               type="submit"
               disabled={!canSubmit}
               className="
-                w-full desktop-btn-secondary px-4 py-2 text-[11px]
+                w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)]
+                bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
+                text-neutral-200 hover:bg-black/80 hover:border-neutral-500
                 disabled:opacity-50
               "
             >


### PR DESCRIPTION
### Motivation
- A previous visual rollout unintentionally repainted the Inspection Templates page; this change restores it as the stable, canonical reference while continuing the rollout on other surfaces.

### Description
- Reverted page-local visual changes in `features/inspections/app/inspection/templates/page.tsx` and `features/inspections/components/FleetFormImportCard.tsx` so the Inspection Templates surface retains its original layout and rhythm.
- Preserved shared/global primitives and tokens (e.g. UI primitives, `app/globals.css`, `features/shared/components/ui/*`) and did not modify any server, API, DB, or workflow logic.
- Kept only behavior-neutral, broadly reusable styling improvements in the shared primitives; no inspection-template-specific styling or hierarchy was advanced in this pass.

### Testing
- Ran `npx eslint features/inspections/app/inspection/templates/page.tsx features/inspections/components/FleetFormImportCard.tsx` and the lint completed successfully. 
- Ran `npx tsc --noEmit` and TypeScript build checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30667522c83288acdb91695d6efa3)