### PR TITLE
Restore Inspection Templates page visual atmosphere to flagship reference

### DIFF
--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -158,21 +158,23 @@ export default function InspectionTemplatesPage() {
   }
 
   const headerCard =
-    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+    "rounded-2xl border border-[rgba(120,88,66,0.38)] " +
+    "bg-[linear-gradient(180deg,rgba(14,14,16,0.92),rgba(5,5,7,0.96))] " +
+    "shadow-[0_30px_90px_rgba(0,0,0,0.95)] backdrop-blur-xl";
 
   const listCard =
-    "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_20px_70px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+    "rounded-2xl border border-[rgba(73,86,112,0.38)] " +
+    "bg-[linear-gradient(180deg,rgba(10,12,18,0.94),rgba(2,4,8,0.98))] " +
+    "shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
 
   const pillBase =
     "px-3 py-1 text-[10px] uppercase tracking-[0.16em] rounded-full border " +
     "transition-colors";
 
   // copper palette (replaces all orange usage)
-  const COPPER_18 = "rgba(200,122,67,0.18)";
-  const COPPER_20 = "rgba(200,122,67,0.20)";
-  const COPPER_14 = "rgba(200,122,67,0.14)";
+  const COPPER_22 = "rgba(200,122,67,0.22)";
+  const COPPER_26 = "rgba(200,122,67,0.26)";
+  const COPPER_16 = "rgba(200,122,67,0.16)";
   const COPPER_90 = "rgba(200,122,67,0.90)";
   const COPPER_70 = "rgba(200,122,67,0.70)";
   const COPPER_65 = "rgba(200,122,67,0.65)";
@@ -183,13 +185,17 @@ export default function InspectionTemplatesPage() {
   return (
     <div className="px-4 py-6 text-white">
       <div className="mx-auto w-full max-w-6xl space-y-5">
-        {/* Copper wash (was orange) */}
+        {/* Atmospheric page wash */}
         <div
           aria-hidden
           className={`
             pointer-events-none fixed inset-0 -z-10
-            bg-[radial-gradient(circle_at_top,${COPPER_18},transparent_55%),radial-gradient(circle_at_bottom,rgba(15,23,42,0.96),#020617_78%)]
+            bg-[radial-gradient(circle_at_14%_8%,${COPPER_22},transparent_44%),radial-gradient(circle_at_82%_24%,rgba(28,60,112,0.18),transparent_40%),radial-gradient(circle_at_bottom,rgba(7,10,18,0.98),#010103_76%)]
           `}
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-0 -z-10 bg-[linear-gradient(180deg,rgba(2,4,9,0.25),rgba(0,0,0,0.78)_72%)]"
         />
 
         {/* Header + filters */}
@@ -197,9 +203,13 @@ export default function InspectionTemplatesPage() {
           <div
             aria-hidden
             className={`
-              pointer-events-none absolute inset-x-0 -top-10 h-24
-              bg-[radial-gradient(circle_at_top,${COPPER_20},transparent_65%)]
+              pointer-events-none absolute inset-x-0 -top-12 h-28
+              bg-[radial-gradient(circle_at_top,${COPPER_26},transparent_64%)]
             `}
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-[linear-gradient(160deg,rgba(9,10,14,0.05),rgba(2,2,4,0.35)_62%,rgba(1,1,2,0.62))]"
           />
 
           <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -217,7 +227,7 @@ export default function InspectionTemplatesPage() {
 
             <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
               {/* Scope pills */}
-              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-black/60">
+              <div className="flex overflow-hidden rounded-full border border-[rgba(120,88,66,0.42)] bg-[rgba(2,4,9,0.78)] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.45)]">
                 {(["mine", "shared", "all"] as Scope[]).map((s) => {
                   const isActive = scope === s;
                   return (
@@ -255,14 +265,14 @@ export default function InspectionTemplatesPage() {
           </div>
 
           {/* Search */}
-          <div className="relative mt-4 flex flex-col gap-2 md:flex-row md:items-center">
+          <div className="relative mt-4 flex flex-col gap-2 rounded-2xl border border-[rgba(120,88,66,0.28)] bg-[linear-gradient(180deg,rgba(5,8,14,0.88),rgba(2,2,4,0.95))] p-3 md:flex-row md:items-center">
             <div className="relative flex-1">
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by name, description, or tags…"
                 className={`
-                  w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70
+                  w-full rounded-xl border border-[rgba(111,120,140,0.55)] bg-[rgba(2,5,11,0.92)]
                   px-3 py-2 text-sm text-white placeholder:text-neutral-500
                   focus:outline-none focus:ring-2 focus:ring-[${COPPER_55}]
                 `}
@@ -352,13 +362,13 @@ export default function InspectionTemplatesPage() {
                 return (
                   <li
                     key={t.id}
-                    className="relative overflow-hidden rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.95)]"
+                    className="relative overflow-hidden rounded-2xl border border-[rgba(83,97,125,0.46)] bg-[linear-gradient(180deg,rgba(6,9,16,0.94),rgba(2,3,7,0.98))] p-4 shadow-[0_24px_70px_rgba(0,0,0,0.95)]"
                   >
                     <div
                       aria-hidden
                       className={`
                         pointer-events-none absolute inset-x-0 -top-10 h-20
-                        bg-[radial-gradient(circle_at_top,${COPPER_14},transparent_70%)]
+                        bg-[radial-gradient(circle_at_top,${COPPER_16},transparent_70%)]
                       `}
                     />
 

--- a/features/inspections/components/FleetFormImportCard.tsx
+++ b/features/inspections/components/FleetFormImportCard.tsx
@@ -475,14 +475,15 @@ export default function FleetFormImportCard() {
       <form
         onSubmit={handleSubmit}
         className="
-          relative rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)]
-          bg-black/65 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl p-5
+          relative rounded-2xl border border-[rgba(120,88,66,0.4)]
+          bg-[linear-gradient(180deg,rgba(13,11,10,0.92),rgba(7,7,8,0.96))]
+          shadow-[0_28px_90px_rgba(0,0,0,0.95)] backdrop-blur-xl p-5
         "
       >
         {/* Copper glow wash */}
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_65%)]"
+          className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_16%_10%,rgba(200,122,67,0.2),transparent_48%),radial-gradient(circle_at_84%_8%,rgba(64,84,120,0.14),transparent_42%)]"
         />
 
         <div className="mb-3 flex items-center justify-between">
@@ -511,12 +512,12 @@ export default function FleetFormImportCard() {
               multiple
               onChange={handleFileChange}
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white
-                file:mr-2 file:rounded-lg file:border file:border-[color:var(--metal-border-soft,#374151)]
-                file:bg-black/50 file:px-3 file:py-1.5 file:text-[10px] file:uppercase
+                rounded-xl border border-[rgba(125,134,153,0.56)]
+                bg-[rgba(3,6,11,0.9)] px-3 py-2 text-xs text-white
+                file:mr-2 file:rounded-lg file:border file:border-[rgba(120,88,66,0.5)]
+                file:bg-[rgba(12,12,14,0.78)] file:px-3 file:py-1.5 file:text-[10px] file:uppercase
                 file:tracking-[0.18em] file:text-neutral-300
-                hover:file:bg-black/70
+                hover:file:bg-[rgba(20,18,16,0.88)]
               "
             />
             <span className="mt-1 text-[10px] text-neutral-500">
@@ -532,8 +533,8 @@ export default function FleetFormImportCard() {
               onChange={(e) => setTitleHint(e.target.value)}
               placeholder="ABC Logistics – Daily Truck Inspection"
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white placeholder:text-neutral-500
+                rounded-xl border border-[rgba(125,134,153,0.56)]
+                bg-[rgba(3,6,11,0.9)] px-3 py-2 text-xs text-white placeholder:text-neutral-500
               "
             />
           </label>
@@ -541,7 +542,7 @@ export default function FleetFormImportCard() {
 
         {/* Selected files list */}
         {files.length > 0 && (
-          <div className="mb-4 rounded-xl border border-neutral-800 bg-black/50 p-3">
+          <div className="mb-4 rounded-xl border border-[rgba(84,96,122,0.5)] bg-[rgba(2,4,8,0.72)] p-3">
             <div className="mb-2 text-[11px] uppercase tracking-[0.16em] text-neutral-400">
               Selected pages ({files.length})
             </div>
@@ -549,7 +550,7 @@ export default function FleetFormImportCard() {
               {files.map((f, idx) => (
                 <li
                   key={`${f.name}-${idx}`}
-                  className="flex items-center justify-between gap-2 rounded-lg border border-neutral-800 bg-black/40 px-3 py-2"
+                  className="flex items-center justify-between gap-2 rounded-lg border border-[rgba(72,84,110,0.52)] bg-[rgba(1,2,4,0.7)] px-3 py-2"
                 >
                   <div className="min-w-0">
                     <div className="truncate text-xs text-neutral-200">
@@ -563,7 +564,7 @@ export default function FleetFormImportCard() {
                   <button
                     type="button"
                     onClick={() => handleRemove(idx)}
-                    className="rounded-full border border-neutral-700 bg-black/50 px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-neutral-300 hover:bg-black/70"
+                    className="rounded-full border border-[rgba(120,88,66,0.44)] bg-[rgba(8,8,11,0.74)] px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-neutral-300 hover:bg-[rgba(17,13,11,0.88)]"
                     aria-label={`Remove ${f.name}`}
                   >
                     Remove
@@ -582,8 +583,8 @@ export default function FleetFormImportCard() {
               value={vehicleType}
               onChange={(e) => setVehicleType(e.target.value)}
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white
+                rounded-xl border border-[rgba(125,134,153,0.56)]
+                bg-[rgba(3,6,11,0.9)] px-3 py-2 text-xs text-white
               "
             >
               <option value="">Not specified</option>
@@ -601,8 +602,8 @@ export default function FleetFormImportCard() {
               value={dutyClass}
               onChange={(e) => setDutyClass(e.target.value as DutyClass | "")}
               className="
-                rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-3 py-2 text-xs text-white
+                rounded-xl border border-[rgba(125,134,153,0.56)]
+                bg-[rgba(3,6,11,0.9)] px-3 py-2 text-xs text-white
               "
             >
               <option value="">Not specified</option>
@@ -621,9 +622,9 @@ export default function FleetFormImportCard() {
               disabled={loading}
               onClick={openCamera}
               className="
-                w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
-                text-neutral-200 hover:bg-black/80 hover:border-neutral-500
+                w-full rounded-xl border border-[rgba(120,88,66,0.45)]
+                bg-[rgba(10,11,15,0.82)] px-4 py-2 text-[11px] uppercase tracking-[0.16em]
+                text-neutral-200 hover:bg-[rgba(18,15,13,0.9)] hover:border-[rgba(181,130,93,0.62)]
                 disabled:opacity-50
               "
             >
@@ -636,9 +637,9 @@ export default function FleetFormImportCard() {
               type="submit"
               disabled={!canSubmit}
               className="
-                w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
-                text-neutral-200 hover:bg-black/80 hover:border-neutral-500
+                w-full rounded-xl border border-[rgba(120,88,66,0.45)]
+                bg-[rgba(10,11,15,0.82)] px-4 py-2 text-[11px] uppercase tracking-[0.16em]
+                text-neutral-200 hover:bg-[rgba(18,15,13,0.9)] hover:border-[rgba(181,130,93,0.62)]
                 disabled:opacity-50
               "
             >
@@ -667,15 +668,15 @@ export default function FleetFormImportCard() {
       {/* Camera modal (simple, dependency-free) */}
       {cameraOpen && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4">
-          <div className="w-full max-w-xl overflow-hidden rounded-2xl border border-neutral-800 bg-black/80 shadow-[0_30px_120px_rgba(0,0,0,0.95)]">
-            <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+          <div className="w-full max-w-xl overflow-hidden rounded-2xl border border-[rgba(110,119,138,0.55)] bg-[linear-gradient(180deg,rgba(8,10,16,0.96),rgba(4,5,8,0.98))] shadow-[0_30px_120px_rgba(0,0,0,0.95)]">
+            <div className="flex items-center justify-between border-b border-[rgba(110,119,138,0.45)] px-4 py-3">
               <div className="text-[11px] font-blackops uppercase tracking-[0.18em] text-neutral-300">
                 Camera Capture
               </div>
               <button
                 type="button"
                 onClick={closeCamera}
-                className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1 text-[10px] uppercase tracking-[0.16em] text-neutral-300 hover:bg-black/80"
+                className="rounded-full border border-[rgba(120,88,66,0.45)] bg-[rgba(8,9,12,0.8)] px-3 py-1 text-[10px] uppercase tracking-[0.16em] text-neutral-300 hover:bg-[rgba(18,15,13,0.88)]"
               >
                 Close
               </button>
@@ -690,7 +691,7 @@ export default function FleetFormImportCard() {
                 <>
                   <video
                     ref={videoRef}
-                    className="aspect-video w-full rounded-xl border border-neutral-800 bg-black"
+                    className="aspect-video w-full rounded-xl border border-[rgba(110,119,138,0.45)] bg-black"
                     playsInline
                     muted
                   />
@@ -701,9 +702,9 @@ export default function FleetFormImportCard() {
                       type="button"
                       onClick={handleCapture}
                       className="
-                        rounded-xl border border-[color:var(--metal-border-soft,#374151)]
-                        bg-black/70 px-4 py-2 text-[11px] uppercase tracking-[0.16em]
-                        text-neutral-200 hover:bg-black/80 hover:border-neutral-500
+                        rounded-xl border border-[rgba(120,88,66,0.45)]
+                        bg-[rgba(10,11,15,0.82)] px-4 py-2 text-[11px] uppercase tracking-[0.16em]
+                        text-neutral-200 hover:bg-[rgba(18,15,13,0.9)] hover:border-[rgba(181,130,93,0.62)]
                       "
                     >
                       Capture


### PR DESCRIPTION
### Motivation
- The Inspection Templates page drifted toward a flattened/cool visual treatment and needs to be restored to the original premium, dark, and slightly-warm flagship look used as the app’s canonical reference.  
- The goal is purely visual: bring back warmer copper accents, deeper panel interiors, and stronger surface contrast while preserving all existing behavior and layout.  
- Keep the change minimal and page-local so other routes and shared primitives are not affected.

### Description
- Adjusted page-local class composition and gradients in `features/inspections/app/inspection/templates/page.tsx` to restore a layered dark-first backdrop, warmer copper washes in the header, a more cinematic header card, a richer search/filter well, and higher-contrast template cards.  
- Updated the copper color tokens and replaced several flat `bg-black/*` fills with subtle linear/radial gradients and slightly darker border colors to reintroduce depth and premium atmosphere.  
- Restyled `features/inspections/components/FleetFormImportCard.tsx` (form shell, file input, selected-file rows, camera modal and action buttons) to restore the original warm/darker fill, copper wash accents, and elevated contrast without touching upload/capture/navigation logic.  
- All edits are CSS/class-level only; no state, query, filtering, action, or import logic was changed and no routes outside these two files were modified.

### Testing
- Ran `npx eslint features/inspections/app/inspection/templates/page.tsx features/inspections/components/FleetFormImportCard.tsx` and it completed successfully.  
- Ran `npx tsc --noEmit` and the TypeScript check completed successfully.  
- No UI or behavioral tests were modified because this is a visual-only restoration and no functional logic was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e313070ca48328a67eaa2546c8d818)