### PR TITLE
Fix blank-state regressions after desktop mutation refreshes

### DIFF
--- a/app/parts/po/[id]/page.tsx
+++ b/app/parts/po/[id]/page.tsx
@@ -63,6 +63,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
   const [loading, setLoading] = useState<boolean>(true);
+  const [loadedOnce, setLoadedOnce] = useState<boolean>(false);
 
   const [po, setPo] = useState<PurchaseOrderRow | null>(null);
   const [suppliers, setSuppliers] = useState<SupplierRow[]>([]);
@@ -159,15 +160,19 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
     if (poErr) {
       toast.error(poErr.message);
-      setPo(null);
-      setLines([]);
+      if (!loadedOnce) {
+        setPo(null);
+        setLines([]);
+      }
       setLoading(false);
       return;
     }
 
     if (!poRow) {
-      setPo(null);
-      setLines([]);
+      if (!loadedOnce) {
+        setPo(null);
+        setLines([]);
+      }
       setLoading(false);
       return;
     }
@@ -249,6 +254,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
     setLines(mapped);
 
     setLoading(false);
+    setLoadedOnce(true);
   }
 
   useEffect(() => {
@@ -414,7 +420,7 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
   const btnCopper = `${btnBase} border-sky-500/35 text-sky-200 bg-neutral-950/20 hover:bg-sky-900/20`;
   const btnDanger = `${btnBase} border-red-900/60 bg-neutral-950/20 text-red-200 hover:bg-red-900/20`;
 
-  if (loading) {
+  if (loading && !loadedOnce) {
     return (
       <div className="p-6 text-white">
         <div className={`${panel} p-4 text-neutral-300`}>Loading…</div>
@@ -439,6 +445,9 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
   return (
     <div className="space-y-4 p-6 text-white">
+      {loading ? (
+        <div className={`${panel} p-3 text-xs text-neutral-300`}>Refreshing purchase order…</div>
+      ) : null}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <button className={btnGhost} onClick={() => router.back()} type="button">

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -192,6 +192,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const [allocsByLine, setAllocsByLine] = useState<Record<string, AllocationRow[]>>({});
   const [stagedPartsByLine, setStagedPartsByLine] = useState<Record<string, WorkOrderPartRow[]>>({});
   const [loading, setLoading] = useState<boolean>(false);
+  const [loadedOnce, setLoadedOnce] = useState<boolean>(false);
   const [viewError, setViewError] = useState<string | null>(null);
 
   const [currentUserId, setCurrentUserId] = useTabState<string | null>("wo:id:uid", null);
@@ -461,14 +462,16 @@ export default function WorkOrderIdClient(): JSX.Element {
             return fetchAll(retry + 1);
           }
           setViewError("Work order not visible / not found.");
-          setWo(null);
-          setLines([]);
-          setQuoteLines([]);
-          setVehicle(null);
-          setCustomer(null);
-          setAllocsByLine({});
-          setStagedPartsByLine({});
-          setLineTechsByLine({});
+          if (!loadedOnce) {
+            setWo(null);
+            setLines([]);
+            setQuoteLines([]);
+            setVehicle(null);
+            setCustomer(null);
+            setAllocsByLine({});
+            setStagedPartsByLine({});
+            setLineTechsByLine({});
+          }
 
           // ✅ reset review state
           setReviewChecked(true);
@@ -607,6 +610,7 @@ export default function WorkOrderIdClient(): JSX.Element {
         console.error("[WO id page] load error:", e);
       } finally {
         setLoading(false);
+        setLoadedOnce(true);
       }
     },
     [
@@ -618,6 +622,7 @@ export default function WorkOrderIdClient(): JSX.Element {
       setVehicle,
       setCustomer,
       fetchLatestReview,
+      loadedOnce,
       setReviewChecked,
     ],
   );
@@ -1306,7 +1311,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           </section>
         )}
 
-        {loading ? (
+        {loading && !loadedOnce ? (
           <div className="mt-1 grid gap-4">
             <Skeleton className="h-24" />
             <Skeleton className="h-40" />
@@ -1316,6 +1321,11 @@ export default function WorkOrderIdClient(): JSX.Element {
           <div className="mt-2 text-sm text-red-400">Work order not found.</div>
         ) : (
           <div className={cn("space-y-2.5", supportFullyCollapsed && "space-y-2")}>
+            {loading ? (
+              <div className="rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/50 px-3 py-2 text-xs text-muted-foreground">
+                Refreshing work order data…
+              </div>
+            ) : null}
             <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
               <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">
                   <div className={cn(cardInner, "p-2")}>

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -307,6 +307,7 @@ export default function QuoteReviewView(props: {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
   const [loading, setLoading] = useState(true);
+  const [loadedOnce, setLoadedOnce] = useState(false);
   const [wo, setWo] = useState<WorkOrder | null>(null);
   const [shop, setShop] = useState<Shop | null>(null);
   const [customer, setCustomer] = useState<Customer | null>(null);
@@ -450,11 +451,13 @@ export default function QuoteReviewView(props: {
 
     if (woErr) {
       toast.error(woErr.message);
-      setWo(null);
-      setShop(null);
-      setCustomer(null);
-      setLines([]);
-      setAllocs([]);
+      if (!loadedOnce) {
+        setWo(null);
+        setShop(null);
+        setCustomer(null);
+        setLines([]);
+        setAllocs([]);
+      }
       setLoading(false);
       return;
     }
@@ -560,7 +563,8 @@ export default function QuoteReviewView(props: {
     }
 
     setLoading(false);
-  }, [supabase, woId]);
+    setLoadedOnce(true);
+  }, [loadedOnce, supabase, woId]);
 
   useEffect(() => {
     void reload();
@@ -829,7 +833,7 @@ export default function QuoteReviewView(props: {
 
   if (!woId)
     return <div className="p-6 text-red-300">Missing work order id.</div>;
-  if (loading) return <div className="p-6 text-neutral-300">Loading…</div>;
+  if (loading && !loadedOnce) return <div className="p-6 text-neutral-300">Loading…</div>;
   if (!wo) return <div className="p-6 text-red-300">Work order not found.</div>;
 
   const phoneRaw = safeTrim(customer?.phone ?? "");
@@ -863,6 +867,11 @@ export default function QuoteReviewView(props: {
   return (
     <div className={outerCls} style={{ ["--copper" as never]: COPPER }}>
       <div className={containerCls}>
+        {loading ? (
+          <div className="mb-2 rounded-xl border border-[color:var(--desktop-border)] bg-black/35 px-3 py-2 text-xs text-neutral-300">
+            Refreshing quote review data…
+          </div>
+        ) : null}
         {/* top row */}
         <div
           className={


### PR DESCRIPTION
### Motivation
- Recent UI/theme refactors caused pages to use the same `loading` flag for initial hydration and post-mutation reloads, allowing mutation-triggered reloads to blank the main content area.
- The change preserves UX stability by preventing full-content remounts during background revalidation while keeping success toasts and mutation flows intact.

### Description
- Added a `loadedOnce` guard to distinguish initial hydration from subsequent background reloads in `app/work-orders/[id]/Client.tsx`, `features/work-orders/quote-review/QuoteReviewView.tsx`, and `app/parts/po/[id]/page.tsx`.
- Constrained destructive clear-to-empty fallback behavior to pre-hydration only so transient fetch errors during a background refresh do not wipe visible content.
- Kept existing optimistic/local updates and revalidation calls but replaced full-page skeletons on every `loading` cycle with lightweight non-blocking “Refreshing…” banners during post-mutation reloads.
- Files changed: `app/work-orders/[id]/Client.tsx`, `features/work-orders/quote-review/QuoteReviewView.tsx`, `app/parts/po/[id]/page.tsx`.

### Testing
- Ran ESLint against the modified files with `npx eslint app/work-orders/[id]/Client.tsx features/work-orders/quote-review/QuoteReviewView.tsx app/parts/po/[id]/page.tsx` and it completed without introducing new lint failures.
- Ran type-checking with `npx tsc --noEmit` and the build passed with no type errors.
- Manual verification notes: mutation flows (approve/assign/save/send/add line) now keep the shell and last-known content visible while showing a scoped “Refreshing…” indicator during background reloads (no visual blanking observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31339c840832885ef9a68db245676)