### PR TITLE
Audit & harden ShopReel: command-center dashboard, config canonicalization, and delivery wiring fixes

### DIFF
--- a/app/api/shopreel/integration/route.ts
+++ b/app/api/shopreel/integration/route.ts
@@ -1,10 +1,13 @@
+import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
+import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "@/features/integrations/shopreel/server/shopreelConfig";
 
 type DB = Database;
+const ALLOWED_EVENT_TYPES = new Set<string>(DEFAULT_SHOPREEL_EVENT_TYPES);
 
 async function getOwnerShopContext() {
   const supabase = createRouteHandlerClient<DB>({ cookies });
@@ -66,17 +69,8 @@ export async function GET() {
       remoteShopId: data?.remote_shop_id ?? null,
       shopreelBaseUrl:
         data?.shopreel_base_url ??
-        process.env.SHOPREEL_BASE_URL ??
-        "https://shopreel.profixiq.com",
-      enabledEventTypes: data?.enabled_event_types ?? [
-        "inspection.completed",
-        "inspection.finding.flagged",
-        "inspection.media.captured",
-        "workorder.approved",
-        "workorder.completed",
-        "media.before_after.added",
-        "operations.signal",
-      ],
+        getShopReelBaseUrl(),
+      enabledEventTypes: data?.enabled_event_types ?? [...DEFAULT_SHOPREEL_EVENT_TYPES],
       lastTestedAt: data?.last_tested_at ?? null,
       lastSuccessAt: data?.last_success_at ?? null,
       lastErrorAt: data?.last_error_at ?? null,
@@ -93,7 +87,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { supabase, user, shopId } = context;
-  const body = await request.json();
+  const body = await request.json().catch(() => ({}));
 
   const enabled = Boolean(body?.enabled);
   const remoteShopId =
@@ -103,18 +97,12 @@ export async function POST(request: NextRequest) {
   const shopreelBaseUrl =
     typeof body?.shopreelBaseUrl === "string" && body.shopreelBaseUrl.trim().length
       ? body.shopreelBaseUrl.trim()
-      : process.env.SHOPREEL_BASE_URL ?? "https://shopreel.profixiq.com";
+      : getShopReelBaseUrl();
   const enabledEventTypes = Array.isArray(body?.enabledEventTypes)
-    ? body.enabledEventTypes.filter((value: unknown): value is string => typeof value === "string")
-    : [
-        "inspection.completed",
-        "inspection.finding.flagged",
-        "inspection.media.captured",
-        "workorder.approved",
-        "workorder.completed",
-        "media.before_after.added",
-        "operations.signal",
-      ];
+    ? body.enabledEventTypes
+        .filter((value: unknown): value is string => typeof value === "string")
+        .filter((value: string) => ALLOWED_EVENT_TYPES.has(value))
+    : [...DEFAULT_SHOPREEL_EVENT_TYPES];
 
   const { data, error } = await supabase
     .from("shopreel_integrations")

--- a/app/api/shopreel/retry/route.ts
+++ b/app/api/shopreel/retry/route.ts
@@ -4,6 +4,7 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
 import { signShopReelPayload } from "@/features/integrations/shopreel/server/signShopReelPayload";
+import { getShopReelBaseUrl } from "@/features/integrations/shopreel/server/shopreelConfig";
 
 type DB = Database;
 
@@ -108,7 +109,7 @@ export async function POST(request: NextRequest) {
     typeof delivery.request_url === "string" && delivery.request_url.trim().length > 0
       ? delivery.request_url.trim()
       : `${
-          (integration.shopreel_base_url || process.env.SHOPREEL_BASE_URL || "https://shopreel.profixiq.com").replace(/\/+$/, "")
+          (integration.shopreel_base_url || getShopReelBaseUrl()).replace(/\/+$/, "")
         }/api/integrations/profixiq/events`;
 
   const payload = JSON.stringify({
@@ -159,7 +160,7 @@ export async function POST(request: NextRequest) {
     await admin
       .from("shopreel_integrations")
       .update({
-        last_success_at: response.ok ? new Date().toISOString() : null,
+        ...(response.ok ? { last_success_at: new Date().toISOString() } : {}),
         last_error_at: response.ok ? null : new Date().toISOString(),
         last_error_message: response.ok ? null : `ShopReel responded with ${response.status}`,
       })

--- a/app/dashboard/owner/marketing/page.tsx
+++ b/app/dashboard/owner/marketing/page.tsx
@@ -3,6 +3,7 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import OwnerMarketingSettingsCard from "@/features/integrations/shopreel/components/OwnerMarketingSettingsCard";
+import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "@/features/integrations/shopreel/server/shopreelConfig";
 
 type DB = Database;
 
@@ -64,16 +65,8 @@ export default async function OwnerMarketingPage() {
             remoteShopId: integration?.remote_shop_id ?? null,
             shopreelBaseUrl:
               integration?.shopreel_base_url ??
-              process.env.SHOPREEL_BASE_URL ??
-              "https://shopreel.profixiq.com",
-            enabledEventTypes: integration?.enabled_event_types ?? [
-              "inspection.completed",
-              "inspection.finding.flagged",
-              "inspection.media.captured",
-              "workorder.approved",
-              "workorder.completed",
-              "media.before_after.added",
-            ],
+              getShopReelBaseUrl(),
+            enabledEventTypes: integration?.enabled_event_types ?? [...DEFAULT_SHOPREEL_EVENT_TYPES],
             lastTestedAt: integration?.last_tested_at ?? null,
             lastSuccessAt: integration?.last_success_at ?? null,
             lastErrorAt: integration?.last_error_at ?? null,

--- a/features/integrations/shopreel/components/MarketingDashboardPage.tsx
+++ b/features/integrations/shopreel/components/MarketingDashboardPage.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+
 import PageShell from "@/features/shared/components/PageShell";
 import { getMarketingDashboardData } from "../server/getMarketingDashboardData";
 import RetryDeliveryButton from "./RetryDeliveryButton";
@@ -10,34 +11,44 @@ function formatDate(value: string | null) {
   return date.toLocaleString();
 }
 
+function statusBadge(status: "pending" | "success" | "failed") {
+  if (status === "success") {
+    return <span className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">Success</span>;
+  }
+
+  if (status === "failed") {
+    return <span className="rounded-md border border-rose-500/40 bg-rose-500/10 px-2 py-1 text-xs text-rose-200">Failed</span>;
+  }
+
+  return <span className="rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-xs text-amber-200">Pending</span>;
+}
+
 export default async function MarketingDashboardPage() {
   const data = await getMarketingDashboardData();
 
   if (!data.authorized) {
     return (
       <PageShell title="Marketing">
-        <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
-          {data.reason}
-        </div>
+        <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">{data.reason}</div>
       </PageShell>
     );
   }
 
-  const { integration, deliveries } = data;
+  const { integration, deliveries, kpis, sourceHealth, pipeline, needsAttention } = data;
 
   return (
     <PageShell title="Marketing">
       <div className="space-y-6">
-        <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
-          <div className="flex flex-wrap items-center justify-between gap-4">
+        <section className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+          <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-semibold">Marketing</h1>
+              <h1 className="text-2xl font-semibold">ShopReel Command Center</h1>
               <p className="mt-2 text-sm text-white/70">
-                Monitor ProFixIQ → ShopReel automation for your shop.
+                Operational visibility across ingest, content pipeline, publishing, and delivery reliability.
               </p>
             </div>
 
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-3">
               <Link
                 href="/dashboard/owner/marketing"
                 className="rounded-md border border-white/10 px-4 py-2 text-sm text-white hover:bg-white/5"
@@ -50,47 +61,151 @@ export default async function MarketingDashboardPage() {
                 rel="noreferrer"
                 className="rounded-md bg-white px-4 py-2 text-sm font-medium text-black"
               >
-                View in ShopReel
+                Open ShopReel
               </a>
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Integration</div>
-            <div className="mt-2 text-lg font-semibold">
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-6">
+          <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white xl:col-span-2">
+            <div className="text-sm text-white/60">Integration status</div>
+            <div className="mt-2 flex items-center gap-2 text-lg font-semibold">
               {integration.enabled ? "Enabled" : "Disabled"}
+              {integration.enabled ? (
+                <span className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">
+                  Live
+                </span>
+              ) : (
+                <span className="rounded-md border border-rose-500/40 bg-rose-500/10 px-2 py-1 text-xs text-rose-200">
+                  Action required
+                </span>
+              )}
             </div>
+            <div className="mt-3 text-xs text-white/60">Remote shop: {integration.remoteShopId ?? "Not configured"}</div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Last success</div>
-            <div className="mt-2 text-sm font-medium">
-              {formatDate(integration.lastSuccessAt)}
-            </div>
+            <div className="text-sm text-white/60">Delivery attempts</div>
+            <div className="mt-2 text-2xl font-semibold">{kpis.attempts}</div>
+            <div className="mt-1 text-xs text-white/60">Last 40 logged events</div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Last test</div>
-            <div className="mt-2 text-sm font-medium">
-              {formatDate(integration.lastTestedAt)}
-            </div>
+            <div className="text-sm text-white/60">Success rate</div>
+            <div className="mt-2 text-2xl font-semibold">{kpis.successRatePct == null ? "—" : `${kpis.successRatePct}%`}</div>
+            <div className="mt-1 text-xs text-white/60">{kpis.successCount} succeeded / {kpis.failedCount} failed</div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Last error</div>
-            <div className="mt-2 text-sm font-medium">
-              {formatDate(integration.lastErrorAt)}
+            <div className="text-sm text-white/60">Pending deliveries</div>
+            <div className="mt-2 text-2xl font-semibold">{kpis.pendingCount}</div>
+            <div className="mt-1 text-xs text-white/60">{kpis.stalePending} stale ({">"} 3h old)</div>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
+            <div className="text-sm text-white/60">Published content</div>
+            <div className="mt-2 text-2xl font-semibold">{pipeline.publicationsPublished}</div>
+            <div className="mt-1 text-xs text-white/60">{pipeline.publicationsScheduled} scheduled</div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-3">
+          <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white xl:col-span-2">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold">Needs attention</h2>
+              <Link href="/dashboard/owner/marketing" className="text-xs text-white/70 hover:text-white">
+                Resolve in settings
+              </Link>
+            </div>
+
+            {needsAttention.length ? (
+              <ul className="mt-4 space-y-2">
+                {needsAttention.map((item) => (
+                  <li key={item} className="rounded-lg border border-amber-400/30 bg-amber-500/5 px-3 py-2 text-sm text-amber-100">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="mt-4 rounded-lg border border-emerald-400/30 bg-emerald-500/5 px-3 py-3 text-sm text-emerald-100">
+                No urgent blockers detected. Ingest and publishing signals are currently healthy.
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+            <h2 className="text-lg font-semibold">Primary actions</h2>
+            <div className="mt-3 space-y-2 text-sm">
+              <Link href="/dashboard/owner/marketing" className="block rounded-md border border-white/10 px-3 py-2 hover:bg-white/5">
+                Configure integration and event types
+              </Link>
+              <div className="rounded-md border border-white/10 px-3 py-2">
+                <div className="text-white/90">Operational signal ingest endpoint</div>
+                <div className="mt-1 text-xs text-white/60">POST /api/shopreel/operational-signals (owner-authenticated) to push live operational opportunities.</div>
+              </div>
+              <a
+                href={integration.shopreelBaseUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="block rounded-md border border-white/10 px-3 py-2 hover:bg-white/5"
+              >
+                Open ShopReel workspace
+              </a>
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
-          <h2 className="text-lg font-semibold">Recent events sent</h2>
-          <p className="mt-1 text-sm text-white/60">
-            Latest delivery attempts from ProFixIQ into ShopReel.
-          </p>
+        <section className="grid gap-4 xl:grid-cols-2">
+          <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+            <h2 className="text-lg font-semibold">Source ingest health</h2>
+            <p className="mt-1 text-sm text-white/60">Signals below are computed from delivery logs grouped by ShopReel event type.</p>
+
+            <div className="mt-4 space-y-2">
+              {sourceHealth.map((eventHealth) => (
+                <div key={eventHealth.eventType} className="rounded-md border border-white/10 px-3 py-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-sm font-medium">{eventHealth.eventType}</div>
+                    {eventHealth.lastStatus ? statusBadge(eventHealth.lastStatus) : <span className="text-xs text-white/40">No signal yet</span>}
+                  </div>
+                  <div className="mt-1 text-xs text-white/60">
+                    {eventHealth.successes} success / {eventHealth.failures} failed / {eventHealth.attempts} attempts · last seen {formatDate(eventHealth.lastSeenAt)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+            <h2 className="text-lg font-semibold">Content and publish pipeline</h2>
+            <div className="mt-4 grid gap-2 text-sm">
+              <div className="flex items-center justify-between rounded-md border border-white/10 px-3 py-2">
+                <span>Publications queued / scheduled / publishing</span>
+                <span>{pipeline.publicationsQueued} / {pipeline.publicationsScheduled} / {pipeline.publicationsPublishing}</span>
+              </div>
+              <div className="flex items-center justify-between rounded-md border border-white/10 px-3 py-2">
+                <span>Publish jobs queued / running / failed</span>
+                <span>{pipeline.publishJobsQueued} / {pipeline.publishJobsRunning} / {pipeline.publishJobsFailed}</span>
+              </div>
+              <div className="flex items-center justify-between rounded-md border border-white/10 px-3 py-2">
+                <span>Manual assets (total / draft)</span>
+                <span>{pipeline.manualAssetsTotal} / {pipeline.manualAssetsDraft}</span>
+              </div>
+              <div className="flex items-center justify-between rounded-md border border-white/10 px-3 py-2">
+                <span>Active social connections</span>
+                <span>{pipeline.activeConnections}</span>
+              </div>
+              <div className="flex items-center justify-between rounded-md border border-white/10 px-3 py-2">
+                <span>Tokens expiring soon ({"<"}72h)</span>
+                <span>{pipeline.tokenExpiringSoon}</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+          <h2 className="text-lg font-semibold">Recent delivery activity</h2>
+          <p className="mt-1 text-sm text-white/60">Latest delivery attempts from ProFixIQ into ShopReel.</p>
 
           <div className="mt-4 overflow-x-auto">
             <table className="min-w-full text-left text-sm">
@@ -113,13 +228,11 @@ export default async function MarketingDashboardPage() {
                         <div className="font-medium text-white">{delivery.eventType}</div>
                         <div className="text-xs text-white/50">{delivery.eventKey}</div>
                       </td>
-                      <td className="py-3 pr-4">{delivery.status}</td>
+                      <td className="py-3 pr-4">{statusBadge(delivery.status)}</td>
                       <td className="py-3 pr-4">{delivery.httpStatus ?? "—"}</td>
                       <td className="py-3 pr-4">{formatDate(delivery.createdAt)}</td>
                       <td className="py-3 pr-4">{formatDate(delivery.deliveredAt)}</td>
-                      <td className="py-3 pr-4 text-xs text-white/60">
-                        {delivery.errorMessage ?? "—"}
-                      </td>
+                      <td className="py-3 pr-4 text-xs text-white/60">{delivery.errorMessage ?? "—"}</td>
                       <td className="py-3 pr-4">
                         {delivery.status === "failed" ? (
                           <RetryDeliveryButton deliveryId={delivery.id} />
@@ -132,29 +245,27 @@ export default async function MarketingDashboardPage() {
                 ) : (
                   <tr>
                     <td colSpan={7} className="py-6 text-center text-white/50">
-                      No ShopReel delivery attempts yet.
+                      No ShopReel delivery attempts yet. Start by enabling integration settings, then complete an inspection or work order event.
                     </td>
                   </tr>
                 )}
               </tbody>
             </table>
           </div>
-        </div>
+        </section>
 
-        <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
-          <h2 className="text-lg font-semibold">Sync status</h2>
-          <div className="mt-3 space-y-2 text-sm text-white/70">
+        <section className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+          <h2 className="text-lg font-semibold">Integration diagnostics</h2>
+          <div className="mt-3 grid gap-2 text-sm text-white/70">
             <div>Base URL: {integration.shopreelBaseUrl}</div>
             <div>Remote Shop ID: {integration.remoteShopId ?? "Not set"}</div>
-            <div>
-              Enabled event types:{" "}
-              {integration.enabledEventTypes.length
-                ? integration.enabledEventTypes.join(", ")
-                : "None selected"}
-            </div>
+            <div>Enabled event types: {integration.enabledEventTypes.length ? integration.enabledEventTypes.join(", ") : "None selected"}</div>
+            <div>Last tested: {formatDate(integration.lastTestedAt)}</div>
+            <div>Last success: {formatDate(integration.lastSuccessAt)}</div>
+            <div>Last error: {formatDate(integration.lastErrorAt)}</div>
             <div>Last error message: {integration.lastErrorMessage ?? "None"}</div>
           </div>
-        </div>
+        </section>
       </div>
     </PageShell>
   );

--- a/features/integrations/shopreel/components/OwnerMarketingSettingsCard.tsx
+++ b/features/integrations/shopreel/components/OwnerMarketingSettingsCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { DEFAULT_SHOPREEL_EVENT_TYPES } from "../server/shopreelConfig";
 
 type IntegrationState = {
   shopId: string;
@@ -15,15 +16,7 @@ type IntegrationState = {
   lastErrorMessage: string | null;
 };
 
-const DEFAULT_EVENT_TYPES = [
-  "inspection.completed",
-  "inspection.finding.flagged",
-  "inspection.media.captured",
-  "workorder.approved",
-  "workorder.completed",
-  "media.before_after.added",
-  "operations.signal",
-];
+const DEFAULT_EVENT_TYPES = [...DEFAULT_SHOPREEL_EVENT_TYPES];
 
 export default function OwnerMarketingSettingsCard({
   initialState,

--- a/features/integrations/shopreel/server/getMarketingDashboardData.ts
+++ b/features/integrations/shopreel/server/getMarketingDashboardData.ts
@@ -1,8 +1,57 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+
 import type { Database } from "@shared/types/types/supabase";
+import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "./shopreelConfig";
 
 type DB = Database;
+type DeliveryStatus = "pending" | "success" | "failed";
+
+type DeliveryRow = Pick<
+  DB["public"]["Tables"]["shopreel_event_deliveries"]["Row"],
+  "id" | "event_key" | "event_type" | "status" | "http_status" | "delivered_at" | "error_message" | "created_at"
+>;
+
+type PublicationRow = Pick<
+  DB["public"]["Tables"]["shopreel_publications"]["Row"],
+  "id" | "status"
+>;
+
+type PublishJobRow = Pick<
+  DB["public"]["Tables"]["shopreel_publish_jobs"]["Row"],
+  "id" | "status" | "error_message" | "run_after"
+>;
+
+type SocialConnectionRow = Pick<
+  DB["public"]["Tables"]["shopreel_social_connections"]["Row"],
+  "id" | "platform" | "connection_active" | "token_expires_at"
+>;
+
+type ManualAssetRow = Pick<
+  DB["public"]["Tables"]["shopreel_manual_assets"]["Row"],
+  "id" | "status" | "created_at"
+>;
+
+function parseDate(value: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function inPastHours(value: string, hours: number) {
+  const date = parseDate(value);
+  if (!date) return false;
+
+  const now = Date.now();
+  return now - date.getTime() <= hours * 60 * 60 * 1000;
+}
+
+function toDeliveryStatus(value: string): DeliveryStatus {
+  if (value === "success" || value === "failed" || value === "pending") {
+    return value;
+  }
+  return "pending";
+}
 
 export async function getMarketingDashboardData() {
   const supabase = createServerComponentClient<DB>({ cookies });
@@ -35,19 +84,121 @@ export async function getMarketingDashboardData() {
 
   const shopId = membership.shop_id;
 
-  const [{ data: integration }, { data: deliveries }] = await Promise.all([
-    supabase
-      .from("shopreel_integrations")
-      .select("*")
-      .eq("shop_id", shopId)
-      .maybeSingle(),
+  const [
+    { data: integration },
+    { data: deliveries },
+    { data: publications },
+    { data: publishJobs },
+    { data: socialConnections },
+    { data: manualAssets },
+  ] = await Promise.all([
+    supabase.from("shopreel_integrations").select("*").eq("shop_id", shopId).maybeSingle(),
     supabase
       .from("shopreel_event_deliveries")
       .select("id, event_key, event_type, status, http_status, delivered_at, error_message, created_at")
       .eq("shop_id", shopId)
       .order("created_at", { ascending: false })
-      .limit(15),
+      .limit(40),
+    supabase.from("shopreel_publications").select("id, status").eq("shop_id", shopId).limit(200),
+    supabase
+      .from("shopreel_publish_jobs")
+      .select("id, status, error_message, run_after")
+      .eq("shop_id", shopId)
+      .order("created_at", { ascending: false })
+      .limit(200),
+    supabase
+      .from("shopreel_social_connections")
+      .select("id, platform, connection_active, token_expires_at")
+      .eq("shop_id", shopId)
+      .limit(50),
+    supabase
+      .from("shopreel_manual_assets")
+      .select("id, status, created_at")
+      .eq("shop_id", shopId)
+      .order("created_at", { ascending: false })
+      .limit(100),
   ]);
+
+  const typedDeliveries = (deliveries ?? []) as DeliveryRow[];
+  const typedPublications = (publications ?? []) as PublicationRow[];
+  const typedPublishJobs = (publishJobs ?? []) as PublishJobRow[];
+  const typedSocialConnections = (socialConnections ?? []) as SocialConnectionRow[];
+  const typedManualAssets = (manualAssets ?? []) as ManualAssetRow[];
+
+  const successCount = typedDeliveries.filter((delivery) => toDeliveryStatus(delivery.status) === "success").length;
+  const failedCount = typedDeliveries.filter((delivery) => toDeliveryStatus(delivery.status) === "failed").length;
+  const pendingCount = typedDeliveries.filter((delivery) => toDeliveryStatus(delivery.status) === "pending").length;
+
+  const stalePending = typedDeliveries.filter(
+    (delivery) => toDeliveryStatus(delivery.status) === "pending" && !inPastHours(delivery.created_at, 3),
+  ).length;
+
+  const attempts = typedDeliveries.length;
+  const successRatePct = attempts > 0 ? Math.round((successCount / attempts) * 100) : null;
+
+  const deliveryByEventType = DEFAULT_SHOPREEL_EVENT_TYPES.map((eventType) => {
+    const matching = typedDeliveries.filter((delivery) => delivery.event_type === eventType);
+    const latest = matching[0] ?? null;
+
+    return {
+      eventType,
+      attempts: matching.length,
+      successes: matching.filter((delivery) => toDeliveryStatus(delivery.status) === "success").length,
+      failures: matching.filter((delivery) => toDeliveryStatus(delivery.status) === "failed").length,
+      lastSeenAt: latest?.created_at ?? null,
+      lastStatus: latest ? toDeliveryStatus(latest.status) : null,
+    };
+  });
+
+  const publicationsQueued = typedPublications.filter((item) => item.status === "queued").length;
+  const publicationsScheduled = typedPublications.filter((item) => item.status === "scheduled").length;
+  const publicationsPublishing = typedPublications.filter((item) => item.status === "publishing").length;
+  const publicationsPublished = typedPublications.filter((item) => item.status === "published").length;
+  const publicationsFailed = typedPublications.filter((item) => item.status === "failed").length;
+
+  const publishJobsRunning = typedPublishJobs.filter((item) => item.status === "running").length;
+  const publishJobsQueued = typedPublishJobs.filter((item) => item.status === "queued").length;
+  const publishJobsFailed = typedPublishJobs.filter((item) => item.status === "failed").length;
+
+  const activeConnections = typedSocialConnections.filter((item) => item.connection_active).length;
+  const tokenExpiringSoon = typedSocialConnections.filter((item) => {
+    const expiresAt = parseDate(item.token_expires_at);
+    if (!expiresAt) return false;
+
+    return expiresAt.getTime() - Date.now() <= 3 * 24 * 60 * 60 * 1000;
+  }).length;
+
+  const draftManualAssets = typedManualAssets.filter((item) => item.status === "draft").length;
+
+  const needsAttention: string[] = [];
+
+  if (!(integration?.enabled ?? false)) {
+    needsAttention.push("Integration is disabled. Enable ShopReel sync to start ingesting events.");
+  }
+
+  if (!integration?.remote_shop_id) {
+    needsAttention.push("Remote ShopReel shop ID is missing, so delivered events may not map to a destination shop.");
+  }
+
+  if (failedCount > 0) {
+    needsAttention.push(`${failedCount} recent delivery attempt${failedCount === 1 ? "" : "s"} failed and may need retry.`);
+  }
+
+  if (stalePending > 0) {
+    needsAttention.push(`${stalePending} delivery attempt${stalePending === 1 ? " is" : "s are"} stuck in pending status for more than 3 hours.`);
+  }
+
+  if (activeConnections === 0) {
+    needsAttention.push("No active social connections are configured for publishing.");
+  }
+
+  if (tokenExpiringSoon > 0) {
+    needsAttention.push(`${tokenExpiringSoon} social connection token${tokenExpiringSoon === 1 ? "" : "s"} expires within 72 hours.`);
+  }
+
+  if (publishJobsFailed > 0) {
+    needsAttention.push(`${publishJobsFailed} publish job${publishJobsFailed === 1 ? " has" : "s have"} failed.`);
+  }
 
   return {
     authorized: true,
@@ -65,8 +216,7 @@ export async function getMarketingDashboardData() {
         }
       : {
           enabled: false,
-          shopreelBaseUrl:
-            process.env.SHOPREEL_BASE_URL ?? "https://shopreel.profixiq.com",
+          shopreelBaseUrl: getShopReelBaseUrl(),
           remoteShopId: null,
           lastTestedAt: null,
           lastSuccessAt: null,
@@ -74,12 +224,36 @@ export async function getMarketingDashboardData() {
           lastErrorMessage: null,
           enabledEventTypes: [],
         },
+    kpis: {
+      attempts,
+      successCount,
+      failedCount,
+      pendingCount,
+      successRatePct,
+      stalePending,
+    },
+    sourceHealth: deliveryByEventType,
+    pipeline: {
+      publicationsQueued,
+      publicationsScheduled,
+      publicationsPublishing,
+      publicationsPublished,
+      publicationsFailed,
+      publishJobsQueued,
+      publishJobsRunning,
+      publishJobsFailed,
+      manualAssetsTotal: typedManualAssets.length,
+      manualAssetsDraft: draftManualAssets,
+      activeConnections,
+      tokenExpiringSoon,
+    },
+    needsAttention,
     deliveries:
-      deliveries?.map((delivery) => ({
+      typedDeliveries.map((delivery) => ({
         id: delivery.id,
         eventKey: delivery.event_key,
         eventType: delivery.event_type,
-        status: delivery.status,
+        status: toDeliveryStatus(delivery.status),
         httpStatus: delivery.http_status,
         deliveredAt: delivery.delivered_at,
         errorMessage: delivery.error_message,

--- a/features/integrations/shopreel/server/postStoryEventToShopReel.ts
+++ b/features/integrations/shopreel/server/postStoryEventToShopReel.ts
@@ -3,6 +3,7 @@ import { getShopReelIntegrationForShop } from "./getShopReelIntegrationForShop";
 import { createShopReelDeliveryLog, finalizeShopReelDeliveryLog } from "./recordShopReelDelivery";
 import { sanitizeProFixIQStoryEvent } from "./sanitizeProFixIQStoryEvent";
 import { signShopReelPayload } from "./signShopReelPayload";
+import { getShopReelBaseUrl } from "./shopreelConfig";
 import type { ProFixIQStoryEvent } from "../types";
 
 function buildIngestUrl(baseUrl: string) {
@@ -37,7 +38,7 @@ export async function postStoryEventToShopReel(
 
   const sanitized = sanitizeProFixIQStoryEvent(event);
   const requestUrl = buildIngestUrl(
-    integration.shopreel_base_url || process.env.SHOPREEL_BASE_URL || "https://shopreel.profixiq.com"
+    integration.shopreel_base_url || getShopReelBaseUrl()
   );
   const payload = JSON.stringify({
     ...sanitized,
@@ -81,7 +82,7 @@ export async function postStoryEventToShopReel(
     await supabase
       .from("shopreel_integrations")
       .update({
-        last_success_at: response.ok ? new Date().toISOString() : null,
+        ...(response.ok ? { last_success_at: new Date().toISOString() } : {}),
         last_error_at: response.ok ? null : new Date().toISOString(),
         last_error_message: response.ok ? null : `ShopReel responded with ${response.status}`,
       })

--- a/features/integrations/shopreel/server/shopreelConfig.ts
+++ b/features/integrations/shopreel/server/shopreelConfig.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_SHOPREEL_BASE_URL = "https://shopreel.profixiq.com";
+
+export const DEFAULT_SHOPREEL_EVENT_TYPES = [
+  "inspection.completed",
+  "inspection.finding.flagged",
+  "inspection.media.captured",
+  "workorder.approved",
+  "workorder.completed",
+  "media.before_after.added",
+  "operations.signal",
+] as const;
+
+export function getShopReelBaseUrl() {
+  return process.env.SHOPREEL_BASE_URL ?? DEFAULT_SHOPREEL_BASE_URL;
+}


### PR DESCRIPTION
### Motivation
- Improve operational trust and visibility by turning the Marketing dashboard into a real ShopReel command center backed by live data. 
- Remove duplicated defaults and drift across owner settings, API, and UI by introducing one canonical ShopReel config surface. 
- Harden end-to-end delivery wiring so event deliveries and retries preserve truthful success history and only accept safe event types. 
- Keep all changes tenant-scoped, owner-gated where appropriate, and incremental to avoid breaking existing flows.

### Description
- Introduced a canonical server config module (`features/integrations/shopreel/server/shopreelConfig.ts`) and replaced duplicated base-URL and default event-type constants across owner page, settings UI, and integration API. 
- Rebuilt the Marketing dashboard into an operational command center (`features/integrations/shopreel/components/MarketingDashboardPage.tsx`) and expanded the server loader (`features/integrations/shopreel/server/getMarketingDashboardData.ts`) to compute KPIs, source ingest health, pipeline status, needs-attention signals, and bounded recent activity from real `shopreel_*` tables. 
- Hardened integration API and settings: added `crypto` import to the integration route, guarded `request.json()` with `.catch()`, and whitelisted `enabledEventTypes` against the canonical list in `app/api/shopreel/integration/route.ts`. 
- Standardized base-URL fallbacks and prevented accidental erasure of `last_success_at` by only setting that timestamp on successful deliveries in both `postStoryEventToShopReel.ts` and the retry route (`app/api/shopreel/retry/route.ts`). 

### Testing
- Ran type-check: `npx tsc --noEmit` — succeeded. 
- Ran lint on touched files: `npx eslint` targeted files — succeeded with no introduced lint errors. 
- Manual validation performed by running the dashboard loader and verifying no TypeScript/runtime errors in touched routes (owner-auth gating preserved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b796a0c08328b9946b9f34476544)