### PR TITLE
Harden ShopReel lifecycle bridge, canonicalize event types, and add Phase 2 audit

### DIFF
--- a/app/api/shopreel/integration/route.ts
+++ b/app/api/shopreel/integration/route.ts
@@ -1,8 +1,12 @@
+import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
+import {
+  sanitizeShopReelEventTypes,
+} from "@/features/integrations/shopreel/constants";
 
 type DB = Database;
 
@@ -68,15 +72,7 @@ export async function GET() {
         data?.shopreel_base_url ??
         process.env.SHOPREEL_BASE_URL ??
         "https://shopreel.profixiq.com",
-      enabledEventTypes: data?.enabled_event_types ?? [
-        "inspection.completed",
-        "inspection.finding.flagged",
-        "inspection.media.captured",
-        "workorder.approved",
-        "workorder.completed",
-        "media.before_after.added",
-        "operations.signal",
-      ],
+      enabledEventTypes: sanitizeShopReelEventTypes(data?.enabled_event_types),
       lastTestedAt: data?.last_tested_at ?? null,
       lastSuccessAt: data?.last_success_at ?? null,
       lastErrorAt: data?.last_error_at ?? null,
@@ -104,17 +100,7 @@ export async function POST(request: NextRequest) {
     typeof body?.shopreelBaseUrl === "string" && body.shopreelBaseUrl.trim().length
       ? body.shopreelBaseUrl.trim()
       : process.env.SHOPREEL_BASE_URL ?? "https://shopreel.profixiq.com";
-  const enabledEventTypes = Array.isArray(body?.enabledEventTypes)
-    ? body.enabledEventTypes.filter((value: unknown): value is string => typeof value === "string")
-    : [
-        "inspection.completed",
-        "inspection.finding.flagged",
-        "inspection.media.captured",
-        "workorder.approved",
-        "workorder.completed",
-        "media.before_after.added",
-        "operations.signal",
-      ];
+  const enabledEventTypes = sanitizeShopReelEventTypes(body?.enabledEventTypes);
 
   const { data, error } = await supabase
     .from("shopreel_integrations")
@@ -143,7 +129,7 @@ export async function POST(request: NextRequest) {
       enabled: data.enabled,
       remoteShopId: data.remote_shop_id,
       shopreelBaseUrl: data.shopreel_base_url,
-      enabledEventTypes: data.enabled_event_types,
+      enabledEventTypes: sanitizeShopReelEventTypes(data.enabled_event_types),
       lastTestedAt: data.last_tested_at,
       lastSuccessAt: data.last_success_at,
       lastErrorAt: data.last_error_at,

--- a/app/api/shopreel/retry/route.ts
+++ b/app/api/shopreel/retry/route.ts
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
 
   const { data: integration, error: integrationError } = await admin
     .from("shopreel_integrations")
-    .select("id, remote_shop_id, shopreel_base_url, enabled")
+    .select("id, remote_shop_id, shopreel_base_url, enabled, last_success_at")
     .eq("shop_id", shopId)
     .maybeSingle();
 
@@ -88,6 +88,13 @@ export async function POST(request: NextRequest) {
   if (!integration?.id || !integration.remote_shop_id) {
     return NextResponse.json(
       { error: "ShopReel integration is missing a remote shop ID." },
+      { status: 400 }
+    );
+  }
+
+  if (!integration.enabled) {
+    return NextResponse.json(
+      { error: "Enable the ShopReel integration before retrying a delivery." },
       { status: 400 }
     );
   }
@@ -159,7 +166,7 @@ export async function POST(request: NextRequest) {
     await admin
       .from("shopreel_integrations")
       .update({
-        last_success_at: response.ok ? new Date().toISOString() : null,
+        last_success_at: response.ok ? new Date().toISOString() : integration.last_success_at,
         last_error_at: response.ok ? null : new Date().toISOString(),
         last_error_message: response.ok ? null : `ShopReel responded with ${response.status}`,
       })

--- a/app/dashboard/owner/marketing/page.tsx
+++ b/app/dashboard/owner/marketing/page.tsx
@@ -3,6 +3,7 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import OwnerMarketingSettingsCard from "@/features/integrations/shopreel/components/OwnerMarketingSettingsCard";
+import { getDefaultShopReelEventTypes } from "@/features/integrations/shopreel/constants";
 
 type DB = Database;
 
@@ -67,12 +68,7 @@ export default async function OwnerMarketingPage() {
               process.env.SHOPREEL_BASE_URL ??
               "https://shopreel.profixiq.com",
             enabledEventTypes: integration?.enabled_event_types ?? [
-              "inspection.completed",
-              "inspection.finding.flagged",
-              "inspection.media.captured",
-              "workorder.approved",
-              "workorder.completed",
-              "media.before_after.added",
+              ...getDefaultShopReelEventTypes(),
             ],
             lastTestedAt: integration?.last_tested_at ?? null,
             lastSuccessAt: integration?.last_success_at ?? null,

--- a/docs/shopreel-lifecycle-audit-phase2.md
+++ b/docs/shopreel-lifecycle-audit-phase2.md
@@ -1,0 +1,90 @@
+# ShopReel Lifecycle Audit — Phase 2 (Canonical System)
+
+## Snapshot
+
+This pass confirms that ProFixIQ currently implements **ShopReel integration observability + outbound event bridge**, not a complete in-app ShopReel product lifecycle.
+
+Canonical lifecycle currently implemented in-repo is:
+
+`ProFixIQ operational/work-order/inspection events -> sanitized ShopReel payload delivery -> delivery log + integration status`
+
+The following lifecycle stages are **not implemented as canonical in-app flows** (only schema hints exist):
+- story source management UI
+- opportunity queue with generated/dismissed lifecycle persistence
+- creator/build editor
+- draft/review workflow
+- render jobs
+- publish/schedule orchestration
+- campaign lifecycle management
+- autopilot orchestration state machine
+- first-class analytics rollups tied to publication/render tables
+
+## Canonical Route/File Map
+
+### Canonical user surfaces
+- `/dashboard/owner/marketing` (owner settings)
+- `/dashboard/marketing` (owner monitoring view)
+
+### Canonical API surfaces
+- `GET|POST|PUT /api/shopreel/integration`
+- `POST /api/shopreel/retry`
+- `POST /api/shopreel/operational-signals`
+
+### Canonical event source entry points
+- `POST /api/inspections/complete`
+- `POST /api/inspections/photos/upload`
+- `POST /api/work-orders/[id]/mark-ready`
+- `POST /api/work-orders/quotes/[id]/approval`
+
+### Canonical bridge runtime files
+- `features/integrations/shopreel/server/buildProFixIQStoryEvents.ts`
+- `features/integrations/shopreel/server/buildOperationalStoryCandidates.ts`
+- `features/integrations/shopreel/server/mapOperationalStoryCandidateToStoryEvent.ts`
+- `features/integrations/shopreel/server/postOperationalStoryCandidatesToShopReel.ts`
+- `features/integrations/shopreel/server/postStoryEventToShopReel.ts`
+- `features/integrations/shopreel/server/recordShopReelDelivery.ts`
+- `features/integrations/shopreel/server/sanitizeProFixIQStoryEvent.ts`
+
+## Partially Wired / Stale / Parallel Paths
+
+1. **Schema-forward but app-missing lifecycle tables**
+   - `shopreel_manual_assets`
+   - `shopreel_manual_asset_files`
+   - `shopreel_publications`
+   - `shopreel_publish_jobs`
+   - `shopreel_social_connections`
+
+   These exist in generated Supabase types, but no canonical App Router surfaces or API routes currently operate them in this repo.
+
+2. **Parallel type output trees**
+   - `shared/types/types/supabase.ts`
+   - `features/shared/types/types/supabase.ts`
+
+   Both advertise ShopReel lifecycle tables, which can cause confusion during audits if one path is treated as canonical source-of-truth by mistake.
+
+3. **Discoverability mismatch (resolved in this pass)**
+   - Admin role tile previously exposed `/dashboard/marketing` even though route access gates to owner membership only.
+
+## Phase 2 Fixes Implemented in This Pass
+
+1. Canonicalized allowed ShopReel event types into one source of truth.
+2. Added event-type sanitization so API persistence cannot drift with invalid event names.
+3. Fixed integration API test-event route compile/runtime issue (`crypto` import missing).
+4. Hardened outbound delivery lifecycle to surface missing `remote_shop_id` as integration error state instead of silent attempted lifecycle continuity.
+5. Preserved `last_success_at` on failed delivery/retry attempts (prevents trust regression in monitoring history).
+6. Blocked retry flow when integration is disabled (status consistency).
+7. Removed non-owner discoverability to Marketing tile (owner-only route now owner-only in navigation).
+
+## Remaining Gaps (Explicit)
+
+To become a true in-repo end-to-end ShopReel lifecycle system, this codebase still needs canonical implementations for:
+
+1. Opportunity persistence model (`generated`, `dismissed`, `accepted`, `expired`) with audit trail.
+2. Creator/build entities and edit session contracts.
+3. Draft/review approval state machine and reviewer attribution.
+4. Render job orchestration + durable state transitions (`queued -> rendering -> completed/failed`).
+5. Publication scheduler + status transitions tied to publish jobs and connections.
+6. Campaign/autopilot orchestration engine with explicit transitions and retry semantics.
+7. Analytics rollups derived from render/publication/campaign lifecycle tables (not inferred from delivery logs alone).
+8. Consolidation policy for duplicate generated Supabase type trees to avoid drift during future lifecycle work.
+

--- a/features/integrations/shopreel/components/OwnerMarketingSettingsCard.tsx
+++ b/features/integrations/shopreel/components/OwnerMarketingSettingsCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { SHOPREEL_EVENT_TYPES } from "../constants";
 
 type IntegrationState = {
   shopId: string;
@@ -14,16 +15,6 @@ type IntegrationState = {
   lastErrorAt: string | null;
   lastErrorMessage: string | null;
 };
-
-const DEFAULT_EVENT_TYPES = [
-  "inspection.completed",
-  "inspection.finding.flagged",
-  "inspection.media.captured",
-  "workorder.approved",
-  "workorder.completed",
-  "media.before_after.added",
-  "operations.signal",
-];
 
 export default function OwnerMarketingSettingsCard({
   initialState,
@@ -178,7 +169,7 @@ export default function OwnerMarketingSettingsCard({
       <div className="space-y-2">
         <div className="text-sm font-medium text-white">Enabled event types</div>
         <div className="grid gap-2">
-          {DEFAULT_EVENT_TYPES.map((eventType) => (
+          {SHOPREEL_EVENT_TYPES.map((eventType) => (
             <label
               key={eventType}
               className="flex items-center justify-between rounded-md border border-white/10 px-3 py-2 text-sm text-white"

--- a/features/integrations/shopreel/constants.ts
+++ b/features/integrations/shopreel/constants.ts
@@ -1,0 +1,37 @@
+import type { ProFixIQStoryEventType } from "./types";
+
+export const SHOPREEL_EVENT_TYPES = [
+  "inspection.completed",
+  "inspection.finding.flagged",
+  "inspection.media.captured",
+  "workorder.approved",
+  "workorder.completed",
+  "media.before_after.added",
+  "operations.signal",
+] as const satisfies readonly ProFixIQStoryEventType[];
+
+export const SHOPREEL_EVENT_TYPE_SET = new Set<string>(SHOPREEL_EVENT_TYPES);
+
+export function getDefaultShopReelEventTypes(): ProFixIQStoryEventType[] {
+  return [...SHOPREEL_EVENT_TYPES];
+}
+
+export function sanitizeShopReelEventTypes(values: unknown): ProFixIQStoryEventType[] {
+  if (!Array.isArray(values)) {
+    return getDefaultShopReelEventTypes();
+  }
+
+  const deduped = new Set<ProFixIQStoryEventType>();
+
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    if (!SHOPREEL_EVENT_TYPE_SET.has(value)) continue;
+    deduped.add(value as ProFixIQStoryEventType);
+  }
+
+  if (deduped.size === 0) {
+    return getDefaultShopReelEventTypes();
+  }
+
+  return [...deduped];
+}

--- a/features/integrations/shopreel/server/getMarketingDashboardData.ts
+++ b/features/integrations/shopreel/server/getMarketingDashboardData.ts
@@ -1,6 +1,10 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  getDefaultShopReelEventTypes,
+  sanitizeShopReelEventTypes,
+} from "../constants";
 
 type DB = Database;
 
@@ -61,7 +65,7 @@ export async function getMarketingDashboardData() {
           lastSuccessAt: integration.last_success_at,
           lastErrorAt: integration.last_error_at,
           lastErrorMessage: integration.last_error_message,
-          enabledEventTypes: integration.enabled_event_types ?? [],
+          enabledEventTypes: sanitizeShopReelEventTypes(integration.enabled_event_types),
         }
       : {
           enabled: false,
@@ -72,7 +76,7 @@ export async function getMarketingDashboardData() {
           lastSuccessAt: null,
           lastErrorAt: null,
           lastErrorMessage: null,
-          enabledEventTypes: [],
+          enabledEventTypes: getDefaultShopReelEventTypes(),
         },
     deliveries:
       deliveries?.map((delivery) => ({

--- a/features/integrations/shopreel/server/postStoryEventToShopReel.ts
+++ b/features/integrations/shopreel/server/postStoryEventToShopReel.ts
@@ -4,6 +4,7 @@ import { createShopReelDeliveryLog, finalizeShopReelDeliveryLog } from "./record
 import { sanitizeProFixIQStoryEvent } from "./sanitizeProFixIQStoryEvent";
 import { signShopReelPayload } from "./signShopReelPayload";
 import type { ProFixIQStoryEvent } from "../types";
+import { sanitizeShopReelEventTypes } from "../constants";
 
 function buildIngestUrl(baseUrl: string) {
   return `${baseUrl.replace(/\/+$/, "")}/api/integrations/profixiq/events`;
@@ -22,11 +23,31 @@ export async function postStoryEventToShopReel(
     };
   }
 
-  if (!integration.enabled_event_types.includes(event.eventType)) {
+  const enabledEventTypes = sanitizeShopReelEventTypes(integration.enabled_event_types);
+
+  if (!enabledEventTypes.includes(event.eventType)) {
     return {
       skipped: true,
       ok: true,
       message: "Event type is disabled for this shop.",
+    };
+  }
+
+  if (!integration.remote_shop_id) {
+    const message = "ShopReel integration is missing a remote shop ID.";
+    const supabase = createAdminClient();
+    await supabase
+      .from("shopreel_integrations")
+      .update({
+        last_error_at: new Date().toISOString(),
+        last_error_message: message,
+      })
+      .eq("id", integration.id);
+
+    return {
+      skipped: true,
+      ok: true,
+      message,
     };
   }
 
@@ -81,7 +102,7 @@ export async function postStoryEventToShopReel(
     await supabase
       .from("shopreel_integrations")
       .update({
-        last_success_at: response.ok ? new Date().toISOString() : null,
+        last_success_at: response.ok ? new Date().toISOString() : integration.last_success_at,
         last_error_at: response.ok ? null : new Date().toISOString(),
         last_error_message: response.ok ? null : `ShopReel responded with ${response.status}`,
       })

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -416,7 +416,7 @@ export const TILES: Tile[] = [
     href: "/dashboard/marketing",
     title: "Marketing",
     subtitle: "ShopReel sync & activity",
-    roles: ["owner", "admin"],
+    roles: ["owner"],
     scopes: ["management", "all"],
     section: "Admin",
   },


### PR DESCRIPTION
### Motivation
- Ensure ShopReel integration is a single canonical outbound bridge with stronger lifecycle truth (prevent silent failures or drift in stored integration state). 
- Centralize and validate allowed event types so the API/UI cannot persist invalid or divergent event names. 
- Surface and harden obvious lifecycle failure modes (missing remote mapping, disabled integration retries, and accidental clearing of historical success timestamps).

### Description
- Introduced a canonical event-types module `features/integrations/shopreel/constants.ts` with `SHOPREEL_EVENT_TYPES`, `sanitizeShopReelEventTypes`, and `getDefaultShopReelEventTypes`, and wired it into UI/API surfaces. (files: `features/integrations/shopreel/constants.ts`, `features/integrations/shopreel/components/OwnerMarketingSettingsCard.tsx`, `app/dashboard/owner/marketing/page.tsx`, `features/integrations/shopreel/server/getMarketingDashboardData.ts`)
- Hardened integration API at `app/api/shopreel/integration/route.ts` by importing `crypto` for test events and sanitizing `enabled_event_types` on read/write so persisted values follow the canonical contract. (file: `app/api/shopreel/integration/route.ts`)
- Tightened outbound delivery logic in `postStoryEventToShopReel` to sanitize enabled event types before sending, explicitly mark/record a missing `remote_shop_id` as an integration error (and skip delivery), and avoid clearing `last_success_at` when a delivery fails. (file: `features/integrations/shopreel/server/postStoryEventToShopReel.ts`)
- Hardened retry flow at `app/api/shopreel/retry/route.ts` by blocking retries when the integration is disabled and preserving `last_success_at` on failed retries. (file: `app/api/shopreel/retry/route.ts`)
- Reduced discoverability mismatch by making the Marketing tile owner-only to match route-level owner gating. (file: `features/shared/config/tiles.ts`)
- Added a Phase 2 audit document `docs/shopreel-lifecycle-audit-phase2.md` that maps canonical routes/files, enumerates partly wired and stale schema areas, lists implemented fixes, and states explicit remaining gaps for a full in-app lifecycle (creator/editor, render/publish/campaign lifecycle, analytics rollups). (file: `docs/shopreel-lifecycle-audit-phase2.md`)

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which succeeded.
- Ran ESLint on the touched files with `npx eslint <file list>` (targeted files in the Marketing/ShopReel integration paths), which succeeded.
- No new unit tests were added in this pass; changes focus on hardening behavior and documenting remaining work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bc3a91408328817d0c81db4a5ad4)