### PR TITLE
Implement canonical ShopReel lifecycle foundation and queue

### DIFF
--- a/app/api/shopreel/drafts/[id]/route.ts
+++ b/app/api/shopreel/drafts/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOwnerShopContext } from "@/features/integrations/shopreel/server/getOwnerShopContext";
+import { SHOPREEL_DRAFT_STATUSES } from "@/features/integrations/shopreel/types";
+
+const STATUS_SET = new Set<string>(SHOPREEL_DRAFT_STATUSES);
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const context = await getOwnerShopContext();
+
+  if ("error" in context) {
+    return NextResponse.json({ error: context.error }, { status: context.status });
+  }
+
+  const { supabase, user, shopId } = context;
+  const scopedSupabase = supabase as unknown as {
+    from: (table: string) => ReturnType<typeof supabase.from>
+  };
+  const body = await request.json().catch(() => ({}));
+
+  const patch: Record<string, string | null> = {
+    updated_by: user.id,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (typeof body?.title === "string") patch.title = body.title.trim();
+  if (typeof body?.angle === "string") patch.angle = body.angle.trim();
+  if (typeof body?.script === "string") patch.script = body.script;
+
+  if (typeof body?.status === "string") {
+    if (!STATUS_SET.has(body.status)) {
+      return NextResponse.json({ error: "Invalid draft status." }, { status: 400 });
+    }
+
+    patch.status = body.status;
+
+    if (body.status === "approved" || body.status === "in_review") {
+      patch.reviewed_by = user.id;
+      patch.reviewed_at = new Date().toISOString();
+    }
+  }
+
+  const { error } = await scopedSupabase
+    .from("shopreel_drafts")
+    .update(patch)
+    .eq("id", params.id)
+    .eq("shop_id", shopId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/shopreel/drafts/route.ts
+++ b/app/api/shopreel/drafts/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOwnerShopContext } from "@/features/integrations/shopreel/server/getOwnerShopContext";
+
+export async function POST(request: NextRequest) {
+  const context = await getOwnerShopContext();
+
+  if ("error" in context) {
+    return NextResponse.json({ error: context.error }, { status: context.status });
+  }
+
+  const { supabase, user, shopId } = context;
+  const scopedSupabase = supabase as unknown as {
+    from: (table: string) => ReturnType<typeof supabase.from>
+  };
+  const body = await request.json().catch(() => ({}));
+
+  const opportunityId = typeof body?.opportunityId === "string" ? body.opportunityId : "";
+
+  if (!opportunityId) {
+    return NextResponse.json({ error: "opportunityId is required." }, { status: 400 });
+  }
+
+  const { data: opportunity, error: opportunityError } = await scopedSupabase
+    .from("shopreel_opportunities")
+    .select("id, title, angle, summary, status")
+    .eq("id", opportunityId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (opportunityError) {
+    return NextResponse.json({ error: opportunityError.message }, { status: 500 });
+  }
+
+  if (!opportunity?.id) {
+    return NextResponse.json({ error: "Opportunity not found." }, { status: 404 });
+  }
+
+  if (opportunity.status !== "accepted" && opportunity.status !== "generated") {
+    return NextResponse.json({ error: "Only accepted opportunities can generate drafts." }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const { data: draft, error: draftError } = await scopedSupabase
+    .from("shopreel_drafts")
+    .upsert(
+      {
+        shop_id: shopId,
+        opportunity_id: opportunityId,
+        title: opportunity.title,
+        angle: opportunity.angle,
+        script: opportunity.summary,
+        status: "draft",
+        created_by: user.id,
+        updated_by: user.id,
+        updated_at: now,
+      },
+      { onConflict: "opportunity_id" },
+    )
+    .select("id")
+    .single();
+
+  if (draftError || !draft?.id) {
+    return NextResponse.json({ error: draftError?.message ?? "Failed to create draft." }, { status: 500 });
+  }
+
+  await scopedSupabase
+    .from("shopreel_opportunities")
+    .update({
+      status: "generated",
+      generated_at: now,
+      updated_at: now,
+      acted_by: user.id,
+    })
+    .eq("id", opportunityId)
+    .eq("shop_id", shopId);
+
+  await scopedSupabase.from("shopreel_opportunity_status_history").insert({
+    shop_id: shopId,
+    opportunity_id: opportunityId,
+    previous_status: opportunity.status,
+    next_status: "generated",
+    action: "generated",
+    changed_by: user.id,
+  });
+
+  return NextResponse.json({ ok: true, draftId: draft.id });
+}

--- a/app/api/shopreel/integration/route.ts
+++ b/app/api/shopreel/integration/route.ts
@@ -1,47 +1,10 @@
 import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
 import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "@/features/integrations/shopreel/server/shopreelConfig";
+import { getOwnerShopContext } from "@/features/integrations/shopreel/server/getOwnerShopContext";
 
-type DB = Database;
 const ALLOWED_EVENT_TYPES = new Set<string>(DEFAULT_SHOPREEL_EVENT_TYPES);
-
-async function getOwnerShopContext() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
-
-  if (userError || !user) {
-    return { error: "Unauthorized", status: 401 as const };
-  }
-
-  const { data: membership, error: membershipError } = await supabase
-    .from("shop_members")
-    .select("shop_id, role")
-    .eq("user_id", user.id)
-    .eq("role", "owner")
-    .limit(1)
-    .maybeSingle();
-
-  if (membershipError) {
-    return { error: membershipError.message, status: 500 as const };
-  }
-
-  if (!membership?.shop_id) {
-    return { error: "Owner shop membership not found.", status: 403 as const };
-  }
-
-  return {
-    supabase,
-    user,
-    shopId: membership.shop_id as string,
-  };
-}
 
 export async function GET() {
   const context = await getOwnerShopContext();

--- a/app/api/shopreel/opportunities/action/route.ts
+++ b/app/api/shopreel/opportunities/action/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOwnerShopContext } from "@/features/integrations/shopreel/server/getOwnerShopContext";
+import {
+  SHOPREEL_OPPORTUNITY_ACTIONS,
+  type ShopReelOpportunityAction,
+  type ShopReelOpportunityStatus,
+} from "@/features/integrations/shopreel/types";
+
+const ACTION_SET = new Set<string>(SHOPREEL_OPPORTUNITY_ACTIONS);
+
+function statusFromAction(action: ShopReelOpportunityAction): ShopReelOpportunityStatus {
+  if (action === "accepted") return "accepted";
+  if (action === "dismissed") return "dismissed";
+  return "generated";
+}
+
+export async function POST(request: NextRequest) {
+  const context = await getOwnerShopContext();
+
+  if ("error" in context) {
+    return NextResponse.json({ error: context.error }, { status: context.status });
+  }
+
+  const { supabase, user, shopId } = context;
+  const scopedSupabase = supabase as unknown as {
+    from: (table: string) => ReturnType<typeof supabase.from>
+  };
+  const body = await request.json().catch(() => ({}));
+
+  const opportunityId = typeof body?.opportunityId === "string" ? body.opportunityId : "";
+  const action = typeof body?.action === "string" ? body.action : "";
+
+  if (!opportunityId || !ACTION_SET.has(action)) {
+    return NextResponse.json({ error: "opportunityId and a valid action are required." }, { status: 400 });
+  }
+
+  const nextStatus = statusFromAction(action as ShopReelOpportunityAction);
+
+  const { data: opportunity, error: fetchError } = await scopedSupabase
+    .from("shopreel_opportunities")
+    .select("id, status")
+    .eq("id", opportunityId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (fetchError) {
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+
+  if (!opportunity?.id) {
+    return NextResponse.json({ error: "Opportunity not found." }, { status: 404 });
+  }
+
+  const now = new Date().toISOString();
+
+  const statusPatch: Record<string, string | null> = {
+    status: nextStatus,
+    acted_by: user.id,
+    updated_at: now,
+  };
+
+  if (nextStatus === "accepted") statusPatch.accepted_at = now;
+  if (nextStatus === "dismissed") statusPatch.dismissed_at = now;
+  if (nextStatus === "generated") statusPatch.generated_at = now;
+
+  const { error: updateError } = await scopedSupabase
+    .from("shopreel_opportunities")
+    .update(statusPatch)
+    .eq("id", opportunityId)
+    .eq("shop_id", shopId);
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  const { error: historyError } = await scopedSupabase.from("shopreel_opportunity_status_history").insert({
+    shop_id: shopId,
+    opportunity_id: opportunityId,
+    previous_status: opportunity.status,
+    next_status: nextStatus,
+    action,
+    changed_by: user.id,
+  });
+
+  if (historyError) {
+    return NextResponse.json({ error: historyError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, opportunityId, status: nextStatus });
+}

--- a/db/sql/2026-04-18_shopreel_lifecycle_foundation.sql
+++ b/db/sql/2026-04-18_shopreel_lifecycle_foundation.sql
@@ -1,0 +1,272 @@
+-- Canonical ShopReel lifecycle foundation: source ingestion -> opportunities -> drafts.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'shopreel_opportunity_status') THEN
+    CREATE TYPE public.shopreel_opportunity_status AS ENUM ('new', 'accepted', 'dismissed', 'generated');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'shopreel_opportunity_action') THEN
+    CREATE TYPE public.shopreel_opportunity_action AS ENUM ('accepted', 'dismissed', 'generated');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'shopreel_draft_status') THEN
+    CREATE TYPE public.shopreel_draft_status AS ENUM ('draft', 'in_review', 'approved');
+  END IF;
+END $$;
+
+create table if not exists public.shopreel_story_sources (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  event_key text not null,
+  event_type text not null,
+  occurred_at timestamptz not null,
+  payload jsonb not null default '{}'::jsonb,
+  ingest_status text not null default 'ingested',
+  ingested_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, event_key)
+);
+
+create index if not exists idx_shopreel_story_sources_shop_ingested
+  on public.shopreel_story_sources(shop_id, ingested_at desc);
+create index if not exists idx_shopreel_story_sources_event_type
+  on public.shopreel_story_sources(shop_id, event_type);
+
+create table if not exists public.shopreel_opportunities (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  story_source_id uuid not null references public.shopreel_story_sources(id) on delete cascade,
+  status public.shopreel_opportunity_status not null default 'new',
+  title text not null,
+  angle text,
+  summary text,
+  event_type text not null,
+  source_occurred_at timestamptz not null,
+  first_generated_at timestamptz,
+  dismissed_at timestamptz,
+  accepted_at timestamptz,
+  generated_at timestamptz,
+  acted_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (story_source_id)
+);
+
+create index if not exists idx_shopreel_opportunities_shop_status
+  on public.shopreel_opportunities(shop_id, status, created_at desc);
+
+create table if not exists public.shopreel_opportunity_status_history (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  opportunity_id uuid not null references public.shopreel_opportunities(id) on delete cascade,
+  previous_status public.shopreel_opportunity_status,
+  next_status public.shopreel_opportunity_status not null,
+  action public.shopreel_opportunity_action,
+  note text,
+  changed_by uuid references public.profiles(id) on delete set null,
+  changed_at timestamptz not null default now()
+);
+
+create index if not exists idx_shopreel_opportunity_history_shop
+  on public.shopreel_opportunity_status_history(shop_id, changed_at desc);
+
+create table if not exists public.shopreel_drafts (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  opportunity_id uuid not null references public.shopreel_opportunities(id) on delete cascade,
+  status public.shopreel_draft_status not null default 'draft',
+  title text not null,
+  angle text,
+  script text,
+  created_by uuid references public.profiles(id) on delete set null,
+  updated_by uuid references public.profiles(id) on delete set null,
+  reviewed_by uuid references public.profiles(id) on delete set null,
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (opportunity_id)
+);
+
+create index if not exists idx_shopreel_drafts_shop_status
+  on public.shopreel_drafts(shop_id, status, updated_at desc);
+
+alter table public.shopreel_story_sources enable row level security;
+alter table public.shopreel_opportunities enable row level security;
+alter table public.shopreel_opportunity_status_history enable row level security;
+alter table public.shopreel_drafts enable row level security;
+
+-- Service role management policies.
+DROP POLICY IF EXISTS "service-role-manage-shopreel-story-sources" ON public.shopreel_story_sources;
+CREATE POLICY "service-role-manage-shopreel-story-sources"
+  ON public.shopreel_story_sources
+  TO service_role
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "service-role-manage-shopreel-opportunities" ON public.shopreel_opportunities;
+CREATE POLICY "service-role-manage-shopreel-opportunities"
+  ON public.shopreel_opportunities
+  TO service_role
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "service-role-manage-shopreel-opportunity-history" ON public.shopreel_opportunity_status_history;
+CREATE POLICY "service-role-manage-shopreel-opportunity-history"
+  ON public.shopreel_opportunity_status_history
+  TO service_role
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "service-role-manage-shopreel-drafts" ON public.shopreel_drafts;
+CREATE POLICY "service-role-manage-shopreel-drafts"
+  ON public.shopreel_drafts
+  TO service_role
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Owner read/write policies for canonical lifecycle UI + APIs.
+DROP POLICY IF EXISTS "owner-read-shopreel-story-sources" ON public.shopreel_story_sources;
+CREATE POLICY "owner-read-shopreel-story-sources"
+  ON public.shopreel_story_sources
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_story_sources.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-read-shopreel-opportunities" ON public.shopreel_opportunities;
+CREATE POLICY "owner-read-shopreel-opportunities"
+  ON public.shopreel_opportunities
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_opportunities.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-update-shopreel-opportunities" ON public.shopreel_opportunities;
+CREATE POLICY "owner-update-shopreel-opportunities"
+  ON public.shopreel_opportunities
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_opportunities.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_opportunities.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-read-shopreel-opportunity-history" ON public.shopreel_opportunity_status_history;
+CREATE POLICY "owner-read-shopreel-opportunity-history"
+  ON public.shopreel_opportunity_status_history
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_opportunity_status_history.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-insert-shopreel-opportunity-history" ON public.shopreel_opportunity_status_history;
+CREATE POLICY "owner-insert-shopreel-opportunity-history"
+  ON public.shopreel_opportunity_status_history
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_opportunity_status_history.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-read-shopreel-drafts" ON public.shopreel_drafts;
+CREATE POLICY "owner-read-shopreel-drafts"
+  ON public.shopreel_drafts
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_drafts.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-insert-shopreel-drafts" ON public.shopreel_drafts;
+CREATE POLICY "owner-insert-shopreel-drafts"
+  ON public.shopreel_drafts
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_drafts.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );
+
+DROP POLICY IF EXISTS "owner-update-shopreel-drafts" ON public.shopreel_drafts;
+CREATE POLICY "owner-update-shopreel-drafts"
+  ON public.shopreel_drafts
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_drafts.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.shop_members sm
+      WHERE sm.shop_id = shopreel_drafts.shop_id
+        AND sm.user_id = auth.uid()
+        AND sm.role = 'owner'
+    )
+  );

--- a/features/integrations/shopreel/components/MarketingDashboardPage.tsx
+++ b/features/integrations/shopreel/components/MarketingDashboardPage.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import PageShell from "@/features/shared/components/PageShell";
 import { getMarketingDashboardData } from "../server/getMarketingDashboardData";
 import RetryDeliveryButton from "./RetryDeliveryButton";
+import ShopReelLifecycleQueue from "./ShopReelLifecycleQueue";
 
 function formatDate(value: string | null) {
   if (!value) return "—";
@@ -34,7 +35,7 @@ export default async function MarketingDashboardPage() {
     );
   }
 
-  const { integration, deliveries, kpis, sourceHealth, pipeline, needsAttention } = data;
+  const { integration, deliveries, sourceHealth, lifecycle, pipeline, needsAttention } = data;
 
   return (
     <PageShell title="Marketing">
@@ -86,27 +87,27 @@ export default async function MarketingDashboardPage() {
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Delivery attempts</div>
-            <div className="mt-2 text-2xl font-semibold">{kpis.attempts}</div>
-            <div className="mt-1 text-xs text-white/60">Last 40 logged events</div>
+            <div className="text-sm text-white/60">Story sources</div>
+            <div className="mt-2 text-2xl font-semibold">{lifecycle.sourceCount}</div>
+            <div className="mt-1 text-xs text-white/60">Ingested canonical source records</div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Success rate</div>
-            <div className="mt-2 text-2xl font-semibold">{kpis.successRatePct == null ? "—" : `${kpis.successRatePct}%`}</div>
-            <div className="mt-1 text-xs text-white/60">{kpis.successCount} succeeded / {kpis.failedCount} failed</div>
+            <div className="text-sm text-white/60">New opportunities</div>
+            <div className="mt-2 text-2xl font-semibold">{lifecycle.newOpportunities}</div>
+            <div className="mt-1 text-xs text-white/60">Awaiting queue action</div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Pending deliveries</div>
-            <div className="mt-2 text-2xl font-semibold">{kpis.pendingCount}</div>
-            <div className="mt-1 text-xs text-white/60">{kpis.stalePending} stale ({">"} 3h old)</div>
+            <div className="text-sm text-white/60">Dismissed / accepted</div>
+            <div className="mt-2 text-2xl font-semibold">{lifecycle.dismissedOpportunities} / {lifecycle.acceptedOpportunities}</div>
+            <div className="mt-1 text-xs text-white/60">Opportunity decisions</div>
           </div>
 
           <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-white">
-            <div className="text-sm text-white/60">Published content</div>
-            <div className="mt-2 text-2xl font-semibold">{pipeline.publicationsPublished}</div>
-            <div className="mt-1 text-xs text-white/60">{pipeline.publicationsScheduled} scheduled</div>
+            <div className="text-sm text-white/60">Drafts awaiting review</div>
+            <div className="mt-2 text-2xl font-semibold">{lifecycle.draftsAwaitingReview}</div>
+            <div className="mt-1 text-xs text-white/60">{lifecycle.approvedItems} approved</div>
           </div>
         </section>
 
@@ -156,10 +157,13 @@ export default async function MarketingDashboardPage() {
           </div>
         </section>
 
+
+
+        <ShopReelLifecycleQueue opportunities={lifecycle.opportunities} drafts={lifecycle.drafts} />
         <section className="grid gap-4 xl:grid-cols-2">
           <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
             <h2 className="text-lg font-semibold">Source ingest health</h2>
-            <p className="mt-1 text-sm text-white/60">Signals below are computed from delivery logs grouped by ShopReel event type.</p>
+            <p className="mt-1 text-sm text-white/60">Signals below are transport diagnostics from delivery logs grouped by ShopReel event type.</p>
 
             <div className="mt-4 space-y-2">
               {sourceHealth.map((eventHealth) => (

--- a/features/integrations/shopreel/components/ShopReelLifecycleQueue.tsx
+++ b/features/integrations/shopreel/components/ShopReelLifecycleQueue.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ShopReelDraftDto, ShopReelOpportunityDto } from "../types";
+
+type Props = {
+  opportunities: ShopReelOpportunityDto[];
+  drafts: ShopReelDraftDto[];
+};
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export default function ShopReelLifecycleQueue({ opportunities, drafts }: Props) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const draftByOpportunity = useMemo(() => {
+    return new Map(drafts.map((draft) => [draft.opportunityId, draft]));
+  }, [drafts]);
+
+  async function runOpportunityAction(opportunityId: string, action: "accepted" | "dismissed" | "generated") {
+    setBusyId(opportunityId);
+    try {
+      await fetch("/api/shopreel/opportunities/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ opportunityId, action }),
+      });
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function createDraft(opportunityId: string) {
+    setBusyId(opportunityId);
+    try {
+      await fetch("/api/shopreel/drafts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ opportunityId }),
+      });
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function updateDraft(draftId: string, payload: Record<string, string>) {
+    setBusyId(draftId);
+    try {
+      await fetch(`/api/shopreel/drafts/${draftId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <section className="grid gap-4 xl:grid-cols-2">
+      <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+        <h2 className="text-lg font-semibold">Opportunity queue</h2>
+        <p className="mt-1 text-sm text-white/60">Canonical lifecycle queue for source-derived opportunities.</p>
+
+        <div className="mt-4 space-y-3">
+          {opportunities.length ? (
+            opportunities.map((opportunity) => {
+              const linkedDraft = draftByOpportunity.get(opportunity.id) ?? null;
+
+              return (
+                <div key={opportunity.id} className="rounded-lg border border-white/10 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-semibold text-white">{opportunity.title}</div>
+                      <div className="mt-1 text-xs text-white/60">{opportunity.eventType} · status {opportunity.status}</div>
+                    </div>
+                    <div className="text-xs text-white/50">{formatDate(opportunity.sourceOccurredAt)}</div>
+                  </div>
+
+                  {opportunity.angle ? <div className="mt-2 text-sm text-white/70">Angle: {opportunity.angle}</div> : null}
+                  {opportunity.summary ? <div className="mt-1 text-xs text-white/60">{opportunity.summary}</div> : null}
+
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                    <button
+                      type="button"
+                      className="rounded-md border border-emerald-400/40 px-2 py-1 text-emerald-100 hover:bg-emerald-500/10 disabled:opacity-60"
+                      onClick={() => runOpportunityAction(opportunity.id, "accepted")}
+                      disabled={busyId === opportunity.id}
+                    >
+                      Accept
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-md border border-rose-400/40 px-2 py-1 text-rose-100 hover:bg-rose-500/10 disabled:opacity-60"
+                      onClick={() => runOpportunityAction(opportunity.id, "dismissed")}
+                      disabled={busyId === opportunity.id}
+                    >
+                      Dismiss
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-md border border-sky-400/40 px-2 py-1 text-sky-100 hover:bg-sky-500/10 disabled:opacity-60"
+                      onClick={() => createDraft(opportunity.id)}
+                      disabled={busyId === opportunity.id || (opportunity.status !== "accepted" && opportunity.status !== "generated")}
+                    >
+                      {linkedDraft ? "Open draft" : "Generate draft"}
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div className="rounded-md border border-white/10 p-3 text-sm text-white/60">No lifecycle opportunities yet.</div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-black/20 p-5 text-white">
+        <h2 className="text-lg font-semibold">Draft review</h2>
+        <p className="mt-1 text-sm text-white/60">Minimal build entity tied to accepted/generated opportunities.</p>
+
+        <div className="mt-4 space-y-3">
+          {drafts.length ? (
+            drafts.map((draft) => (
+              <form
+                key={draft.id}
+                className="space-y-2 rounded-lg border border-white/10 p-3"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  const formData = new FormData(event.currentTarget);
+                  updateDraft(draft.id, {
+                    title: String(formData.get("title") ?? ""),
+                    angle: String(formData.get("angle") ?? ""),
+                    script: String(formData.get("script") ?? ""),
+                    status: String(formData.get("status") ?? "draft"),
+                  });
+                }}
+              >
+                <div className="flex items-center justify-between gap-3 text-xs text-white/60">
+                  <span>Status: {draft.status}</span>
+                  <span>Updated: {formatDate(draft.updatedAt)}</span>
+                </div>
+
+                <input
+                  name="title"
+                  defaultValue={draft.title}
+                  className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1 text-sm text-white"
+                  placeholder="Draft title"
+                />
+                <input
+                  name="angle"
+                  defaultValue={draft.angle ?? ""}
+                  className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1 text-sm text-white"
+                  placeholder="Angle"
+                />
+                <textarea
+                  name="script"
+                  rows={3}
+                  defaultValue={draft.script ?? ""}
+                  className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1 text-sm text-white"
+                  placeholder="Script"
+                />
+                <select
+                  name="status"
+                  defaultValue={draft.status}
+                  className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1 text-sm text-white"
+                >
+                  <option value="draft">draft</option>
+                  <option value="in_review">in_review</option>
+                  <option value="approved">approved</option>
+                </select>
+                <button
+                  type="submit"
+                  disabled={busyId === draft.id}
+                  className="rounded-md border border-white/20 px-3 py-1 text-xs text-white hover:bg-white/10 disabled:opacity-60"
+                >
+                  Save draft
+                </button>
+              </form>
+            ))
+          ) : (
+            <div className="rounded-md border border-white/10 p-3 text-sm text-white/60">No drafts created yet.</div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/integrations/shopreel/server/getMarketingDashboardData.ts
+++ b/features/integrations/shopreel/server/getMarketingDashboardData.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 
 import type { Database } from "@shared/types/types/supabase";
 import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "./shopreelConfig";
+import type { ShopReelDraftDto, ShopReelOpportunityDto, ShopReelStorySourceDto } from "../types";
 
 type DB = Database;
 type DeliveryStatus = "pending" | "success" | "failed";
@@ -55,6 +56,9 @@ function toDeliveryStatus(value: string): DeliveryStatus {
 
 export async function getMarketingDashboardData() {
   const supabase = createServerComponentClient<DB>({ cookies });
+  const lifecycleSupabase = supabase as unknown as {
+    from: (table: string) => ReturnType<typeof supabase.from>
+  };
 
   const {
     data: { user },
@@ -91,6 +95,9 @@ export async function getMarketingDashboardData() {
     { data: publishJobs },
     { data: socialConnections },
     { data: manualAssets },
+    { data: storySources },
+    { data: opportunities },
+    { data: drafts },
   ] = await Promise.all([
     supabase.from("shopreel_integrations").select("*").eq("shop_id", shopId).maybeSingle(),
     supabase
@@ -117,6 +124,24 @@ export async function getMarketingDashboardData() {
       .eq("shop_id", shopId)
       .order("created_at", { ascending: false })
       .limit(100),
+    lifecycleSupabase
+      .from("shopreel_story_sources")
+      .select("id, event_key, event_type, occurred_at, ingested_at")
+      .eq("shop_id", shopId)
+      .order("ingested_at", { ascending: false })
+      .limit(120),
+    lifecycleSupabase
+      .from("shopreel_opportunities")
+      .select("id, story_source_id, status, title, angle, summary, event_type, source_occurred_at, created_at, updated_at, accepted_at, dismissed_at, generated_at")
+      .eq("shop_id", shopId)
+      .order("created_at", { ascending: false })
+      .limit(120),
+    lifecycleSupabase
+      .from("shopreel_drafts")
+      .select("id, opportunity_id, status, title, angle, script, updated_at, reviewed_at")
+      .eq("shop_id", shopId)
+      .order("updated_at", { ascending: false })
+      .limit(120),
   ]);
 
   const typedDeliveries = (deliveries ?? []) as DeliveryRow[];
@@ -168,6 +193,48 @@ export async function getMarketingDashboardData() {
     return expiresAt.getTime() - Date.now() <= 3 * 24 * 60 * 60 * 1000;
   }).length;
 
+  const typedStorySources = ((storySources ?? []) as Array<Record<string, unknown>>).map((item) => ({
+    id: String(item.id),
+    eventKey: String(item.event_key),
+    eventType: String(item.event_type),
+    occurredAt: String(item.occurred_at),
+    ingestedAt: String(item.ingested_at),
+  })) as ShopReelStorySourceDto[];
+
+  const typedOpportunities = ((opportunities ?? []) as Array<Record<string, unknown>>).map((item) => ({
+    id: String(item.id),
+    storySourceId: String(item.story_source_id),
+    status: String(item.status) as ShopReelOpportunityDto["status"],
+    title: String(item.title ?? ""),
+    angle: typeof item.angle === "string" ? item.angle : null,
+    summary: typeof item.summary === "string" ? item.summary : null,
+    eventType: String(item.event_type),
+    sourceOccurredAt: String(item.source_occurred_at),
+    createdAt: String(item.created_at),
+    updatedAt: String(item.updated_at),
+    acceptedAt: typeof item.accepted_at === "string" ? item.accepted_at : null,
+    dismissedAt: typeof item.dismissed_at === "string" ? item.dismissed_at : null,
+    generatedAt: typeof item.generated_at === "string" ? item.generated_at : null,
+  })) as ShopReelOpportunityDto[];
+
+  const typedDrafts = ((drafts ?? []) as Array<Record<string, unknown>>).map((item) => ({
+    id: String(item.id),
+    opportunityId: String(item.opportunity_id),
+    status: String(item.status) as ShopReelDraftDto["status"],
+    title: String(item.title ?? ""),
+    angle: typeof item.angle === "string" ? item.angle : null,
+    script: typeof item.script === "string" ? item.script : null,
+    updatedAt: String(item.updated_at),
+    reviewedAt: typeof item.reviewed_at === "string" ? item.reviewed_at : null,
+  })) as ShopReelDraftDto[];
+
+  const lifecycleSourceCount = typedStorySources.length;
+  const lifecycleNewOpportunities = typedOpportunities.filter((item) => item.status === "new").length;
+  const lifecycleDismissedOpportunities = typedOpportunities.filter((item) => item.status === "dismissed").length;
+  const lifecycleAcceptedOpportunities = typedOpportunities.filter((item) => item.status === "accepted").length;
+  const lifecycleDraftsAwaitingReview = typedDrafts.filter((item) => item.status === "in_review").length;
+  const lifecycleApprovedDrafts = typedDrafts.filter((item) => item.status === "approved").length;
+
   const draftManualAssets = typedManualAssets.filter((item) => item.status === "draft").length;
 
   const needsAttention: string[] = [];
@@ -198,6 +265,10 @@ export async function getMarketingDashboardData() {
 
   if (publishJobsFailed > 0) {
     needsAttention.push(`${publishJobsFailed} publish job${publishJobsFailed === 1 ? " has" : "s have"} failed.`);
+  }
+
+  if (lifecycleNewOpportunities > 0) {
+    needsAttention.push(`${lifecycleNewOpportunities} lifecycle opportunit${lifecycleNewOpportunities === 1 ? "y is" : "ies are"} waiting in the queue.`);
   }
 
   return {
@@ -233,6 +304,39 @@ export async function getMarketingDashboardData() {
       stalePending,
     },
     sourceHealth: deliveryByEventType,
+    lifecycle: {
+      sourceCount: lifecycleSourceCount,
+      newOpportunities: lifecycleNewOpportunities,
+      dismissedOpportunities: lifecycleDismissedOpportunities,
+      acceptedOpportunities: lifecycleAcceptedOpportunities,
+      draftsAwaitingReview: lifecycleDraftsAwaitingReview,
+      approvedItems: lifecycleApprovedDrafts,
+      opportunities: typedOpportunities.map((item) => ({
+        id: item.id,
+        storySourceId: item.storySourceId,
+        status: item.status,
+        title: item.title,
+        angle: item.angle,
+        summary: item.summary,
+        eventType: item.eventType,
+        sourceOccurredAt: item.sourceOccurredAt,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        acceptedAt: item.acceptedAt,
+        dismissedAt: item.dismissedAt,
+        generatedAt: item.generatedAt,
+      })),
+      drafts: typedDrafts.map((item) => ({
+        id: item.id,
+        opportunityId: item.opportunityId,
+        status: item.status,
+        title: item.title,
+        angle: item.angle,
+        script: item.script,
+        updatedAt: item.updatedAt,
+        reviewedAt: item.reviewedAt,
+      })),
+    },
     pipeline: {
       publicationsQueued,
       publicationsScheduled,

--- a/features/integrations/shopreel/server/getOwnerShopContext.ts
+++ b/features/integrations/shopreel/server/getOwnerShopContext.ts
@@ -1,0 +1,40 @@
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+export async function getOwnerShopContext() {
+  const supabase = createRouteHandlerClient<DB>({ cookies });
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return { error: "Unauthorized", status: 401 as const };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("shop_members")
+    .select("shop_id, role")
+    .eq("user_id", user.id)
+    .eq("role", "owner")
+    .limit(1)
+    .maybeSingle();
+
+  if (membershipError) {
+    return { error: membershipError.message, status: 500 as const };
+  }
+
+  if (!membership?.shop_id) {
+    return { error: "Owner shop membership not found.", status: 403 as const };
+  }
+
+  return {
+    supabase,
+    user,
+    shopId: membership.shop_id as string,
+  };
+}

--- a/features/integrations/shopreel/server/persistShopReelLifecycleSource.ts
+++ b/features/integrations/shopreel/server/persistShopReelLifecycleSource.ts
@@ -1,0 +1,66 @@
+import { createAdminClient } from "./createAdminClient";
+import type { ProFixIQStoryEvent } from "../types";
+
+function buildOpportunityTitle(event: ProFixIQStoryEvent) {
+  return (
+    event.storyData.headline?.trim() ||
+    event.storyData.summary?.trim() ||
+    `${event.eventType.replace(/\./g, " ")} opportunity`
+  );
+}
+
+function buildOpportunityAngle(event: ProFixIQStoryEvent) {
+  const serviceLabel = event.storyData.services?.[0]?.label?.trim();
+  const findingLabel = event.storyData.findings?.[0]?.label?.trim();
+
+  return serviceLabel || findingLabel || null;
+}
+
+export async function persistShopReelLifecycleSource(event: ProFixIQStoryEvent) {
+  const supabase = createAdminClient() as unknown as {
+    from: (table: string) => ReturnType<ReturnType<typeof createAdminClient>["from"]>
+  };
+
+  const { data: source, error: sourceError } = await supabase
+    .from("shopreel_story_sources")
+    .upsert(
+      {
+        shop_id: event.source.shopId,
+        event_key: event.eventId,
+        event_type: event.eventType,
+        occurred_at: event.occurredAt,
+        payload: event,
+        ingest_status: "ingested",
+        ingested_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "shop_id,event_key" },
+    )
+    .select("id, occurred_at")
+    .single();
+
+  if (sourceError || !source?.id) {
+    throw sourceError ?? new Error("Failed to persist ShopReel story source.");
+  }
+
+  const { error: opportunityError } = await supabase
+    .from("shopreel_opportunities")
+    .upsert(
+      {
+        shop_id: event.source.shopId,
+        story_source_id: source.id,
+        title: buildOpportunityTitle(event),
+        angle: buildOpportunityAngle(event),
+        summary: event.storyData.summary ?? null,
+        event_type: event.eventType,
+        source_occurred_at: source.occurred_at,
+        first_generated_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "story_source_id", ignoreDuplicates: true },
+    );
+
+  if (opportunityError) {
+    throw opportunityError;
+  }
+}

--- a/features/integrations/shopreel/server/postStoryEventToShopReel.ts
+++ b/features/integrations/shopreel/server/postStoryEventToShopReel.ts
@@ -3,6 +3,7 @@ import { getShopReelIntegrationForShop } from "./getShopReelIntegrationForShop";
 import { createShopReelDeliveryLog, finalizeShopReelDeliveryLog } from "./recordShopReelDelivery";
 import { sanitizeProFixIQStoryEvent } from "./sanitizeProFixIQStoryEvent";
 import { signShopReelPayload } from "./signShopReelPayload";
+import { persistShopReelLifecycleSource } from "./persistShopReelLifecycleSource";
 import { getShopReelBaseUrl } from "./shopreelConfig";
 import type { ProFixIQStoryEvent } from "../types";
 
@@ -13,6 +14,12 @@ function buildIngestUrl(baseUrl: string) {
 export async function postStoryEventToShopReel(
   event: ProFixIQStoryEvent
 ): Promise<{ skipped?: boolean; ok: boolean; status?: number; message?: string }> {
+  try {
+    await persistShopReelLifecycleSource(event);
+  } catch (error) {
+    console.error("[shopreel] failed to persist lifecycle source", error);
+  }
+
   const integration = await getShopReelIntegrationForShop(event.source.shopId);
 
   if (!integration || !integration.enabled) {

--- a/features/integrations/shopreel/types.ts
+++ b/features/integrations/shopreel/types.ts
@@ -103,3 +103,47 @@ export type OperationalStoryCandidate = {
   opportunityScore: number;
   tags: string[];
 };
+
+export const SHOPREEL_OPPORTUNITY_STATUSES = ["new", "accepted", "dismissed", "generated"] as const;
+export type ShopReelOpportunityStatus = (typeof SHOPREEL_OPPORTUNITY_STATUSES)[number];
+
+export const SHOPREEL_OPPORTUNITY_ACTIONS = ["accepted", "dismissed", "generated"] as const;
+export type ShopReelOpportunityAction = (typeof SHOPREEL_OPPORTUNITY_ACTIONS)[number];
+
+export const SHOPREEL_DRAFT_STATUSES = ["draft", "in_review", "approved"] as const;
+export type ShopReelDraftStatus = (typeof SHOPREEL_DRAFT_STATUSES)[number];
+
+export type ShopReelStorySourceDto = {
+  id: string;
+  eventKey: string;
+  eventType: string;
+  occurredAt: string;
+  ingestedAt: string;
+};
+
+export type ShopReelOpportunityDto = {
+  id: string;
+  storySourceId: string;
+  status: ShopReelOpportunityStatus;
+  title: string;
+  angle: string | null;
+  summary: string | null;
+  eventType: string;
+  sourceOccurredAt: string;
+  createdAt: string;
+  updatedAt: string;
+  acceptedAt: string | null;
+  dismissedAt: string | null;
+  generatedAt: string | null;
+};
+
+export type ShopReelDraftDto = {
+  id: string;
+  opportunityId: string;
+  status: ShopReelDraftStatus;
+  title: string;
+  angle: string | null;
+  script: string | null;
+  updatedAt: string;
+  reviewedAt: string | null;
+};


### PR DESCRIPTION
### Motivation
- Provide the first in-app canonical ShopReel lifecycle slice (source ingestion → opportunity queue → draft/build → review) so the app has persistent canonical truth for ShopReel events instead of deriving everything from delivery logs. 
- Keep the change additive and non-breaking: add safe types, tables, RLS policies, owner-scoped APIs, and a minimal UI surface to operate opportunities and drafts. 
- Preserve tenant isolation and existing ownership/auth patterns by using owner-scoped policies and `shop_id` boundaries for all new entities. 

### Description
- Added an additive DB migration that creates enum types and tables for `shopreel_story_sources`, `shopreel_opportunities`, `shopreel_opportunity_status_history`, and `shopreel_drafts`, plus indexes and RLS + owner/service-role policies (file: `db/sql/2026-04-18_shopreel_lifecycle_foundation.sql`).
- Introduced canonical TypeScript enums/DTOs and types used across API/UI, with status sets: opportunity status `new | accepted | dismissed | generated`, opportunity action `accepted | dismissed | generated`, and draft status `draft | in_review | approved` (file: `features/integrations/shopreel/types.ts`).
- Persist story source ingestion and auto-seed an opportunity from the existing ShopReel event pipeline by calling `persistShopReelLifecycleSource` from `postStoryEventToShopReel`, and added persistence helper and owner-context helper (files: `features/integrations/shopreel/server/persistShopReelLifecycleSource.ts`, `features/integrations/shopreel/server/getOwnerShopContext.ts`, `features/integrations/shopreel/server/postStoryEventToShopReel.ts`).
- Added owner-authenticated lifecycle APIs to act on opportunities and create/edit drafts, a minimal queue + review UI, and wired dashboard datapath to surface lifecycle KPIs and lists (files: `app/api/shopreel/opportunities/action/route.ts`, `app/api/shopreel/drafts/route.ts`, `app/api/shopreel/drafts/[id]/route.ts`, `features/integrations/shopreel/server/getMarketingDashboardData.ts`, `features/integrations/shopreel/components/ShopReelLifecycleQueue.tsx`, `features/integrations/shopreel/components/MarketingDashboardPage.tsx`).
- Exact files changed: `db/sql/2026-04-18_shopreel_lifecycle_foundation.sql`, `features/integrations/shopreel/types.ts`, `features/integrations/shopreel/server/persistShopReelLifecycleSource.ts`, `features/integrations/shopreel/server/postStoryEventToShopReel.ts`, `features/integrations/shopreel/server/getOwnerShopContext.ts`, `app/api/shopreel/integration/route.ts`, `app/api/shopreel/opportunities/action/route.ts`, `app/api/shopreel/drafts/route.ts`, `app/api/shopreel/drafts/[id]/route.ts`, `features/integrations/shopreel/server/getMarketingDashboardData.ts`, `features/integrations/shopreel/components/ShopReelLifecycleQueue.tsx`, and `features/integrations/shopreel/components/MarketingDashboardPage.tsx`.
- What remains (render/publish/campaign phases): canonical approved-draft → render job creation, publication scheduling, campaign orchestration and publish-attribution loops remain out of scope and should be layered on top of these entities in subsequent passes. 

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully with no introduced type errors. 
- Ran targeted ESLint checks on the new/modified ShopReel files (`npx eslint ...` on the listed API and component files) and resolved noisy warnings; final lint run produced no errors blocking merge. 
- Local integration smoke: new APIs and UI were wired to existing dashboard data fetch path and exercised by refreshing the marketing dashboard to ensure lifecycle objects are read and the queue UI renders (manual runtime verification during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c1acde1c832891727b0e870271ca)