### PR TITLE
Standardize non-dashboard shells to dashboard visual grammar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,6 +73,9 @@
   --app-shell-bg:
     radial-gradient(circle at top, var(--desktop-bg-tint), transparent 52%),
     radial-gradient(circle at bottom, color-mix(in srgb, var(--desktop-bg-base) 86%, #020617), var(--desktop-bg-secondary) 76%);
+  --app-shell-wash:
+    radial-gradient(1200px 680px at 50% -8%, rgba(59, 130, 246, 0.1), transparent 62%),
+    radial-gradient(950px 620px at 100% 100%, rgba(30, 64, 175, 0.08), transparent 64%);
 }
 
 html {
@@ -118,6 +121,7 @@ html[data-theme-mode="light"] {
 body {
   color: var(--theme-text-primary);
   background:
+    var(--app-shell-wash),
     linear-gradient(180deg, var(--theme-app-bg), var(--theme-app-bg-secondary));
   font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 }
@@ -213,15 +217,33 @@ select {
 }
 
 .metal-bar {
-  background-color: var(--theme-header-bg);
-  border-bottom: 1px solid var(--theme-card-border);
+  background:
+    linear-gradient(180deg, rgba(3, 8, 18, 0.96), rgba(2, 6, 15, 0.98));
+  border-bottom: 1px solid color-mix(in srgb, var(--desktop-border) 88%, transparent);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
 }
 
 .metal-card {
-  background-color: var(--theme-card-bg);
-  border: 1px solid var(--theme-card-border);
-  box-shadow: var(--theme-shadow-medium);
+  background: var(--desktop-panel-bg);
+  border: 1px solid color-mix(in srgb, var(--desktop-border) 90%, transparent);
+  box-shadow: var(--desktop-shadow-card);
   border-radius: var(--theme-radius-xl);
+}
+
+.app-metal-bg {
+  background:
+    radial-gradient(circle at 50% -8%, rgba(59, 130, 246, 0.12), transparent 56%),
+    radial-gradient(circle at 88% 90%, rgba(29, 78, 216, 0.08), transparent 60%),
+    linear-gradient(180deg, #030711, #02050d 72%);
+}
+
+.glass-card,
+.metal-panel {
+  border-radius: var(--theme-radius-xl);
+  border: 1px solid color-mix(in srgb, var(--desktop-border) 88%, transparent);
+  background: var(--desktop-panel-bg-soft);
+  box-shadow: var(--desktop-shadow-card);
+  backdrop-filter: blur(12px);
 }
 
 @layer components {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,7 +73,7 @@ export default async function RootLayout({
         className="min-h-screen antialiased"
         style={{
           backgroundImage:
-            "var(--app-shell-bg, radial-gradient(circle at top, rgba(249,115,22,0.18), transparent 55%), radial-gradient(circle at bottom, rgba(15,23,42,0.96), #020617 70%))",
+            "var(--app-shell-bg, radial-gradient(circle at top, rgba(59,130,246,0.12), transparent 56%), radial-gradient(circle at bottom, rgba(15,23,42,0.96), #020617 70%))",
         }}
       >
         <Providers initialSession={session ?? null}>

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -66,7 +66,7 @@ export function MobileShell({ children, title }: Props) {
             type="button"
             onClick={() => setSidebarOpen(true)}
             aria-label="Open menu"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/15 bg-black/40 hover:bg-black/70 active:scale-95"
+            className="desktop-btn-secondary inline-flex h-8 w-8 items-center justify-center rounded-full border active:scale-95"
           >
             <span className="sr-only">Open menu</span>
             <div className="flex flex-col gap-[3px]">
@@ -86,7 +86,7 @@ export function MobileShell({ children, title }: Props) {
           <button
             type="button"
             onClick={handleHome}
-            className="inline-flex items-center gap-1 rounded-full border border-white/18 bg-black/40 px-3 py-1 text-[0.7rem] text-neutral-100 hover:bg-black/70 active:scale-95"
+            className="desktop-btn-secondary inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[0.7rem] text-neutral-100 active:scale-95"
           >
             <span className="block h-[10px] w-[10px] rounded-[3px] border border-white/70 bg-white/10" />
             <span className="uppercase tracking-[0.16em]">Home</span>

--- a/features/portal/components/PortalShell.tsx
+++ b/features/portal/components/PortalShell.tsx
@@ -123,14 +123,14 @@ export default function PortalShell({
   };
 
   const ShellCard =
-    "rounded-3xl border border-white/10 bg-black/25 p-4 backdrop-blur-md shadow-card sm:p-6";
+    "desktop-panel-soft rounded-3xl border p-4 backdrop-blur-md shadow-card sm:p-6";
 
   // ✅ AUTH PAGES: allow the auth page to own the full viewport/background
   if (hideNav) {
     return (
       <div className="relative min-h-dvh app-metal-bg text-white overflow-hidden">
         <div className="pointer-events-none absolute inset-0">
-          <div className="absolute left-1/2 top-[-22%] h-[58rem] w-[58rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(197,122,74,0.18),transparent_60%)]" />
+          <div className="absolute left-1/2 top-[-22%] h-[58rem] w-[58rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.15),transparent_60%)]" />
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,rgba(15,23,42,0.88),transparent_68%)]" />
         </div>
 
@@ -151,7 +151,7 @@ export default function PortalShell({
           <button
             type="button"
             onClick={() => router.push("/portal")}
-            className="inline-flex items-center gap-1 rounded-full border border-white/18 bg-black/40 px-3 py-1 text-[0.7rem] text-neutral-100 hover:bg-black/70 active:scale-95"
+            className="desktop-btn-secondary inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[0.7rem] text-neutral-100 active:scale-95"
           >
             <span className="uppercase tracking-[0.16em]">Home</span>
           </button>
@@ -167,7 +167,7 @@ export default function PortalShell({
   return (
     <div className="relative min-h-dvh app-metal-bg text-white overflow-hidden">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-[6%] h-[80rem] w-[80rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(197,122,74,0.14),transparent_62%)]" />
+        <div className="absolute left-1/2 top-[6%] h-[80rem] w-[80rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.12),transparent_62%)]" />
         <div className="absolute right-[-18%] top-[28%] h-[46rem] w-[46rem] rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.06),transparent_60%)]" />
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,rgba(15,23,42,0.82),transparent_70%)]" />
       </div>
@@ -179,7 +179,7 @@ export default function PortalShell({
             type="button"
             onClick={() => setMobileOpen(true)}
             aria-label="Open menu"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/15 bg-black/40 hover:bg-black/70 active:scale-95 md:hidden"
+            className="desktop-btn-secondary inline-flex h-8 w-8 items-center justify-center rounded-full border active:scale-95 md:hidden"
           >
             <MenuIcon />
           </button>
@@ -188,7 +188,7 @@ export default function PortalShell({
             type="button"
             onClick={() => setDesktopOpen((v) => !v)}
             aria-label="Toggle sidebar"
-            className="hidden md:inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/15 bg-black/40 hover:bg-black/70 active:scale-95"
+            className="desktop-btn-secondary hidden h-8 w-8 items-center justify-center rounded-full border active:scale-95 md:inline-flex"
           >
             <MenuIcon />
           </button>
@@ -206,23 +206,23 @@ export default function PortalShell({
 
           <Link
             href="/portal/request/when"
-            className="inline-flex items-center rounded-full border border-white/18 bg-black/40 px-3 py-1 text-[0.7rem] font-semibold text-neutral-100 transition hover:bg-black/70 active:scale-95"
+            className="desktop-btn-primary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95"
           >
-            <span style={{ color: COPPER }}>Request</span>
+            <span>Request</span>
           </Link>
 
           <Link
             href="/portal/approvals"
-            className="inline-flex items-center rounded-full border border-white/18 bg-black/40 px-3 py-1 text-[0.7rem] font-semibold text-neutral-100 transition hover:bg-black/70 active:scale-95"
+            className="desktop-btn-secondary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95"
           >
-            <span style={{ color: COPPER }}>Approvals</span>
+            <span>Approvals</span>
           </Link>
 
           <button
             type="button"
             onClick={() => void signOut()}
             disabled={signingOut}
-            className="inline-flex items-center rounded-full border border-white/18 bg-black/40 px-3 py-1 text-[0.7rem] font-semibold text-neutral-100 transition hover:bg-black/70 active:scale-95 disabled:opacity-60"
+            className="desktop-btn-secondary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95 disabled:opacity-60"
             title="Sign out"
           >
             {signingOut ? "Signing out…" : "Sign out"}
@@ -233,7 +233,7 @@ export default function PortalShell({
       <div className="relative mx-auto flex min-h-[calc(100dvh-52px)] w-full max-w-6xl flex-col gap-4 px-3 py-4 md:flex-row md:gap-6 md:px-6">
         <aside
           className={cx(
-            "hidden overflow-hidden rounded-2xl border border-white/10 bg-black/25 backdrop-blur-md shadow-card md:flex md:flex-col transition-all duration-300",
+            "desktop-panel-soft hidden overflow-hidden rounded-2xl border backdrop-blur-md shadow-card transition-all duration-300 md:flex md:flex-col",
             desktopOpen
               ? "w-72"
               : "w-0 border-transparent bg-transparent shadow-none",
@@ -280,8 +280,8 @@ export default function PortalShell({
               className="absolute inset-0 bg-black/60"
               onClick={() => setMobileOpen(false)}
             />
-            <div className="absolute left-0 top-0 h-full w-[82vw] max-w-[360px] border-r border-white/10 bg-black/85 backdrop-blur-xl">
-              <div className="flex items-center justify-between border-b border-white/10 px-5 py-5">
+            <div className="absolute left-0 top-0 h-full w-[82vw] max-w-[360px] border-r border-white/10 bg-[#020611]/95 backdrop-blur-xl">
+              <div className="flex items-center justify-between border-b border-[color:var(--desktop-border)] px-5 py-5">
                 <div>
                   <div
                     className="font-blackops text-lg tracking-[0.16em]"
@@ -294,7 +294,7 @@ export default function PortalShell({
                   </div>
                 </div>
                 <button
-                  className="rounded-full border border-white/15 bg-black/40 px-3 py-1 text-xs text-neutral-100"
+                  className="desktop-btn-secondary rounded-full border px-3 py-1 text-xs text-neutral-100"
                   onClick={() => setMobileOpen(false)}
                 >
                   Close

--- a/features/shared/components/ButtonLink.tsx
+++ b/features/shared/components/ButtonLink.tsx
@@ -14,9 +14,8 @@ export default function ButtonLink({ href, children, className = "", prefetch = 
       href={href}
       prefetch={prefetch}
       className={[
-        "inline-flex items-center justify-center rounded-lg px-4 py-2",
-        "bg-surface text-accent shadow-card hover:shadow-lg transition",
-        "border border-neutral-800/20 dark:border-neutral-200/10",
+        "desktop-btn-secondary inline-flex items-center justify-center rounded-lg border px-4 py-2",
+        "text-sm font-medium text-[var(--theme-text-primary)] transition",
         className,
       ].join(" ")}
     >

--- a/features/shared/components/CreateWorkOrderForm.tsx
+++ b/features/shared/components/CreateWorkOrderForm.tsx
@@ -105,14 +105,14 @@ export default function CreateWorkOrderForm() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto mt-8 p-6 border border-orange-500 rounded-xl bg-black/60 backdrop-blur-md shadow-card text-white space-y-4">
-      <h2 className="text-3xl font-bold text-center text-yellow-400 font-blackops">
+    <div className="desktop-panel-soft mx-auto mt-8 max-w-2xl space-y-4 rounded-xl border p-6 text-white backdrop-blur-md shadow-card">
+      <h2 className="font-blackops text-center text-3xl font-bold text-[var(--theme-text-primary)]">
         Create Work Order
       </h2>
 
       {/* Customer Info */}
       <div>
-        <h3 className="text-xl font-semibold text-orange-400">
+        <h3 className="text-xl font-semibold text-[var(--theme-text-secondary)]">
           Customer Information
         </h3>
         <input
@@ -167,7 +167,7 @@ export default function CreateWorkOrderForm() {
 
       {/* Vehicle Info */}
       <div>
-        <h3 className="text-xl font-semibold text-orange-400">
+        <h3 className="text-xl font-semibold text-[var(--theme-text-secondary)]">
           Vehicle Information
         </h3>
         <div className="flex gap-2">
@@ -204,7 +204,7 @@ export default function CreateWorkOrderForm() {
 
       {/* Inspection Type */}
       <div>
-        <h3 className="text-xl font-semibold text-orange-400">Inspection</h3>
+        <h3 className="text-xl font-semibold text-[var(--theme-text-secondary)]">Inspection</h3>
         <select
           value={inspection}
           onChange={(e) => setInspection(e.target.value)}
@@ -219,7 +219,7 @@ export default function CreateWorkOrderForm() {
 
       {/* Concern Lines */}
       <div>
-        <h3 className="text-xl font-semibold text-orange-400">Concerns</h3>
+        <h3 className="text-xl font-semibold text-[var(--theme-text-secondary)]">Concerns</h3>
         {concerns.map((concern, index) => (
           <input
             key={index}
@@ -232,7 +232,7 @@ export default function CreateWorkOrderForm() {
         ))}
         <button
           onClick={handleAddConcern}
-          className="text-sm text-yellow-300 hover:underline mt-1"
+          className="mt-1 text-sm text-[var(--brand-accent)] hover:underline"
         >
           + Add Concern
         </button>
@@ -242,14 +242,14 @@ export default function CreateWorkOrderForm() {
       <button
         onClick={handleSubmit}
         disabled={loading}
-        className="w-full mt-4 py-3 font-blackops text-lg rounded bg-orange-600 hover:bg-orange-700 transition-all"
+        className="desktop-btn-primary mt-4 w-full rounded py-3 text-lg font-blackops transition-all"
       >
         {loading ? "Creating..." : "Create Work Order"}
       </button>
 
       {/* Message */}
       {message && (
-        <p className="text-center text-sm mt-2 text-yellow-300">{message}</p>
+        <p className="mt-2 text-center text-sm text-[var(--brand-accent)]">{message}</p>
       )}
     </div>
   );

--- a/shared/components/ui/dialog.tsx
+++ b/shared/components/ui/dialog.tsx
@@ -23,7 +23,7 @@ export const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-40 bg-black/70 backdrop-blur-sm transition-opacity data-[state=open]:opacity-100 data-[state=closed]:opacity-0",
+      "fixed inset-0 z-40 bg-black/75 backdrop-blur-sm transition-opacity data-[state=open]:opacity-100 data-[state=closed]:opacity-0",
       className
     )}
     {...props}
@@ -40,7 +40,12 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 w-[95%] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-xl border border-white/10 bg-black/80 p-6 shadow-xl backdrop-blur-xl",
+        "fixed left-1/2 top-1/2 z-50 w-[95%] max-w-lg -translate-x-1/2 -translate-y-1/2 border p-6 backdrop-blur-xl",
+        "rounded-[var(--theme-radius-xl,1rem)]",
+        "border-[var(--theme-card-border,#334155)]",
+        "bg-[var(--theme-card-bg,#111827)]",
+        "text-[var(--theme-text-primary,#FFFFFF)]",
+        "shadow-[var(--theme-shadow-strong,0_24px_70px_rgba(0,0,0,0.85))]",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         "data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
@@ -60,7 +65,8 @@ export const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col gap-1 border-b border-white/10 pb-3",
+      "flex flex-col gap-1 border-b pb-3",
+      "border-[var(--theme-card-border,#334155)]",
       className
     )}
     {...props}
@@ -74,7 +80,8 @@ export const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-blackops uppercase tracking-[0.18em] text-neutral-300",
+      "text-lg font-semibold uppercase tracking-[0.16em]",
+      "text-[var(--theme-text-primary,#FFFFFF)]",
       className
     )}
     {...props}
@@ -88,7 +95,7 @@ export const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-neutral-400", className)}
+    className={cn("text-sm text-[var(--theme-text-secondary,#94A3B8)]", className)}
     {...props}
   />
 ));
@@ -100,7 +107,8 @@ export const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "mt-4 flex w-full items-center justify-end gap-2 border-t border-white/10 pt-3",
+      "mt-4 flex w-full items-center justify-end gap-2 border-t pt-3",
+      "border-[var(--theme-card-border,#334155)]",
       className
     )}
     {...props}


### PR DESCRIPTION
### Motivation
- Align non-dashboard pages and shared primitives to the operations dashboard visual language and remove warm/brown background wash from non-dashboard surfaces. 
- Bring shared shells, panels, buttons and dialogs onto a single, restrained dark/cool theme without changing app logic, routes, or data flows. 
- Centralize reusable tokens and classes so future pages consume the same dashboard grammar instead of page-local visual systems.

### Description
- Introduced and adjusted theme tokens and shared surface styles in `app/globals.css`, including `--app-shell-wash`, `.app-metal-bg`, and standardized `metal-bar`, `metal-card`, `.glass-card`, `.metal-panel`, and desktop primitives like `.desktop-panel-soft`. 
- Updated root layout background in `app/layout.tsx` to use the cooler dashboard-backdrop instead of the warm orange fallback. 
- Migrated Portal shell in `features/portal/components/PortalShell.tsx` to use the dashboard primitives (`desktop-panel-soft`, `desktop-btn-primary`, `desktop-btn-secondary`) and replaced warm radial accents with cool gradients. 
- Normalized mobile header controls in `components/layout/MobileShell.tsx` to use shared `desktop-btn-secondary` styling. 
- Converted `features/shared/components/ButtonLink.tsx` to the shared secondary button contract (`desktop-btn-secondary`). 
- Restyled the example form in `features/shared/components/CreateWorkOrderForm.tsx` to use `desktop-panel-soft`, `desktop-btn-primary`, input/text color tokens and preserved all behavior and submission logic. 
- Harmonized modal/dialog surface contract in `shared/components/ui/dialog.tsx` to use theme variables for border, background, typography, and shadows.

### Testing
- Ran `pnpm eslint` targeted at the modified TypeScript/TSX files which passed after an initial lint attempt that failed because ESLint was invoked over a CSS file (CSS parsing is not applicable); the targeted run on code files produced no errors. 
- Ran `npx tsc --noEmit` to verify type correctness which completed successfully with no emitted errors. 
- No automated UI tests were changed and no runtime/behavioral changes were introduced by these visual-only updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d36404908328a6a644f0642a2fb2)