### PR TITLE
Migrate desktop feature pages to dashboard visual language

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -22,10 +22,10 @@ type Status = Exclude<WorkOrder["status"], null> | "ready_to_invoice" | "invoice
 const BILLING_STATUSES: Status[] = ["completed", "ready_to_invoice", "invoiced"];
 
 const INPUT_DARK =
-  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-light)] focus:ring-2 focus:ring-[var(--accent-copper)]/35";
+  "desktop-input w-full px-3 py-2 text-sm";
 
 const SELECT_DARK =
-  "w-full rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-white outline-none focus:border-[var(--accent-copper-light)] focus:ring-2 focus:ring-[var(--accent-copper)]/35";
+  "desktop-input w-full px-3 py-2 text-sm";
 
 function stageAccent(status: string | null | undefined): {
   badge: string;
@@ -36,9 +36,9 @@ function stageAccent(status: string | null | undefined): {
 
   if (key === "ready_to_invoice") {
     return {
-      badge: "border-amber-400/70 bg-amber-500/10 text-amber-100",
-      border: "border-amber-500/30",
-      progress: "bg-amber-400",
+      badge: "border-sky-400/45 bg-sky-500/10 text-sky-100",
+      border: "border-sky-500/25",
+      progress: "bg-sky-400",
     };
   }
 
@@ -75,7 +75,7 @@ function priorityChip(priority: number | null | undefined): string {
   if (priority === 4) {
     return "border-slate-500/40 bg-slate-500/10 text-slate-300";
   }
-  return "border-white/10 bg-white/5 text-neutral-300";
+  return "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-300";
 }
 
 function formatMoney(value: number | null | undefined): string {
@@ -339,7 +339,7 @@ export default function BillingPage(): JSX.Element {
 
               {!loading && !err ? (
                 <div className="mt-4 flex flex-wrap gap-2">
-                  <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                  <div className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-semibold text-neutral-200">
                     Total: <span className="text-white">{total}</span>
                   </div>
                   <div className="rounded-full border border-sky-500/20 bg-sky-500/5 px-3 py-1 text-[11px] font-semibold text-sky-100">
@@ -401,7 +401,7 @@ export default function BillingPage(): JSX.Element {
               <button
                 type="button"
                 onClick={() => void load()}
-                className="rounded-xl border border-white/10 bg-black/25 px-4 py-2 text-sm font-semibold text-white transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/10"
+                className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-white transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/10"
               >
                 Refresh
               </button>
@@ -426,7 +426,7 @@ export default function BillingPage(): JSX.Element {
           ))}
         </div>
       ) : rows.length === 0 ? (
-        <div className="rounded-[24px] border border-white/10 bg-black/25 p-6 text-sm text-neutral-400">
+        <div className="rounded-[24px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-6 text-sm text-neutral-400">
           No billing work orders match your current filters.
         </div>
       ) : (
@@ -533,7 +533,7 @@ export default function BillingPage(): JSX.Element {
                   </div>
 
                   <div className="mt-4 grid grid-cols-2 gap-3">
-                    <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-3">
                       <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
                         Labor
                       </div>
@@ -542,7 +542,7 @@ export default function BillingPage(): JSX.Element {
                       </div>
                     </div>
 
-                    <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-3">
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-3">
                       <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
                         Parts
                       </div>
@@ -551,7 +551,7 @@ export default function BillingPage(): JSX.Element {
                       </div>
                     </div>
 
-                    <div className="col-span-2 rounded-xl border border-white/10 bg-black/25 px-3 py-3">
+                    <div className="col-span-2 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-3">
                       <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
                         Invoice total
                       </div>

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -51,11 +51,11 @@ function Modal(props: {
   if (!open) return null;
 
   // ---- Theme (glass + neutral accent styling) ----
-  const ACCENT_BORDER = "border-[rgba(200,122,67,0.45)]";
-  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]";
+  const ACCENT_BORDER = "border-[color:var(--desktop-border-strong)]";
+  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
 
   const shell =
-    "rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 backdrop-blur-xl " +
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl " +
     "shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset] text-white";
 
   return (
@@ -73,7 +73,7 @@ function Modal(props: {
           <h2 className="text-lg font-semibold">{title}</h2>
           <button
             onClick={onClose}
-            className={`rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-2 py-1 text-sm hover:bg-white/5 focus:outline-none ${ACCENT_FOCUS_RING}`}
+            className={`rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-sm hover:bg-white/5 focus:outline-none ${ACCENT_FOCUS_RING}`}
             aria-label="Close"
           >
             ✕
@@ -101,7 +101,7 @@ function TextField(props: {
     <div>
       <div className="mb-1 text-xs text-neutral-400">{label}</div>
       <input
-        className="w-full rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
+        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
@@ -123,7 +123,7 @@ function NumberField(props: {
       <div className="mb-1 text-xs text-neutral-400">{label}</div>
       <input
         type="number"
-        className="w-full rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
+        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
         value={value === "" ? "" : value}
         min={min}
         step={step}
@@ -147,7 +147,7 @@ function SelectField(props: {
     <div>
       <div className="mb-1 text-xs text-neutral-400">{label}</div>
       <select
-        className="w-full rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
+        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
         value={value}
         onChange={(e) => onChange(e.target.value)}
       >
@@ -330,13 +330,13 @@ export default function InventoryPage(): JSX.Element {
   const [csvDefaultLoc, setCsvDefaultLoc] = useState<string>("");
 
   // ---- Theme (glass + neutral accent styling) ----
-  const ACCENT_TEXT = "text-[rgba(242,210,187,0.94)]";
-  const ACCENT_HOVER_BG = "hover:bg-[rgba(200,122,67,0.14)]";
-  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]";
+  const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
+  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
+  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
 
   const pageWrap = "space-y-4 p-6 text-white";
   const glassCard =
-    "rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
   const glassHeader = "bg-slate-950/55 border-b border-white/10";
 
   const inputBase =
@@ -344,7 +344,7 @@ export default function InventoryPage(): JSX.Element {
 
   const btnBase =
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-semibold transition disabled:opacity-60";
-  const btnGhost = `${btnBase} border-[color:var(--metal-border-soft,#374151)] bg-black/70 hover:bg-white/5`;
+  const btnGhost = `${btnBase} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
   const btnCopper = `${btnBase} border-white/10 ${ACCENT_TEXT} bg-neutral-950/20 ${ACCENT_HOVER_BG}`;
   const btnBlue = `${btnBase} border-sky-500/30 bg-sky-950/25 text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25`;
 
@@ -959,7 +959,7 @@ export default function InventoryPage(): JSX.Element {
           <NumberField label="Price" value={price} onChange={(v) => setPrice(v === "" ? "" : v)} />
         </div>
 
-        <div className="mt-4 rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-3">
+        <div className="mt-4 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
           <div className="mb-2 text-sm font-semibold text-white">
             Initial Stock <span className="text-xs font-normal text-neutral-400">(optional)</span>
           </div>
@@ -1067,7 +1067,7 @@ export default function InventoryPage(): JSX.Element {
         {ohLines.length === 0 ? (
           <div className="text-sm text-neutral-300">No movement found for this part.</div>
         ) : (
-          <div className="overflow-hidden rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70">
+          <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
             <table className="w-full text-sm">
               <thead className="bg-white/5 text-left text-neutral-400">
                 <tr>
@@ -1135,7 +1135,7 @@ export default function InventoryPage(): JSX.Element {
         }
       >
         <div className="grid gap-3">
-          <div className="rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-3 text-sm text-neutral-300">
+          <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-sm text-neutral-300">
             Expected headers (case-insensitive): <code className={ACCENT_TEXT}>name, sku, category, price, qty</code>.
             Extra columns are ignored.
           </div>
@@ -1173,7 +1173,7 @@ Spark Plug – Iridium,SP-IR-01,Ignition,9.95,24
           />
 
           {csvPreview && (
-            <div className="overflow-hidden rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70">
+            <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
               <table className="w-full text-sm">
                 <thead className="bg-white/5 text-left text-neutral-400">
                   <tr>

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -198,14 +198,14 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const [recvItem, setRecvItem] = useState<DrawerItem | null>(null);
 
   // ---- Theme (glass + neutral accent styling) ----
-  const ACCENT_BORDER = "border-[rgba(200,122,67,0.45)]";
-  const ACCENT_TEXT = "text-[rgba(242,210,187,0.94)]";
-  const ACCENT_HOVER_BG = "hover:bg-[rgba(200,122,67,0.14)]";
-  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]";
+  const ACCENT_BORDER = "border-[color:var(--desktop-border-strong)]";
+  const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
+  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
+  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
 
   const pageWrap = "space-y-3 p-4 text-white";
   const glassCard =
-    "rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
   const glassHeader =
     "bg-gradient-to-b from-white/5 to-transparent border-b border-white/10";
   const inputBase = `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-white/10 focus:outline-none ${ACCENT_FOCUS_RING}`;
@@ -213,7 +213,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
   const btnBase =
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm transition disabled:opacity-60";
-  const btnGhost = `${btnBase} border-[color:var(--metal-border-soft,#374151)] bg-black/70 hover:bg-white/5`;
+  const btnGhost = `${btnBase} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
   const btnCopper = `${btnBase} ${ACCENT_BORDER} ${ACCENT_TEXT} bg-neutral-950/20 ${ACCENT_HOVER_BG}`;
   const btnDanger = `${btnBase} border-red-900/60 bg-neutral-950/20 text-red-200 hover:bg-red-900/20`;
 
@@ -1469,7 +1469,7 @@ if (!lineId || !isUuid(lineId)) {
                                           ))}
                                         </select>
 
-                                        <details className="rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2">
+                                        <details className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2">
                                           <summary className="cursor-pointer select-none text-xs text-neutral-300">
                                             Create PO for supplier
                                           </summary>

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -107,20 +107,20 @@ export default function PartsRequestsPage(): JSX.Element {
   const [buckets, setBuckets] = useState<WoBucket[]>([]);
   const [deletingWoId, setDeletingWoId] = useState<string | null>(null);
 
-  const ACCENT_BORDER = "border-[rgba(200,122,67,0.45)]";
-  const ACCENT_TEXT = "text-[rgba(242,210,187,0.94)]";
-  const ACCENT_HOVER_BG = "hover:bg-[rgba(200,122,67,0.14)]";
-  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]";
+  const ACCENT_BORDER = "border-[color:var(--desktop-border-strong)]";
+  const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
+  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
+  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
 
   const PAGE = "w-full px-3 py-4 text-white sm:px-5 lg:px-8 xl:px-12";
   const CARD =
-    "rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
   const CARD_PAD = `${CARD} p-3`;
-  const INPUT = `w-full rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-4 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none ${ACCENT_FOCUS_RING}`;
-  const SELECT = `w-full rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2 text-sm text-white focus:outline-none ${ACCENT_FOCUS_RING}`;
+  const INPUT = `w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none ${ACCENT_FOCUS_RING}`;
+  const SELECT = `w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white focus:outline-none ${ACCENT_FOCUS_RING}`;
   const BTN_BASE =
     "inline-flex items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium transition disabled:opacity-60";
-  const BTN_GHOST = `${BTN_BASE} border-[color:var(--metal-border-soft,#374151)] bg-black/70 hover:bg-white/5`;
+  const BTN_GHOST = `${BTN_BASE} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
   const BTN_ACCENT = `${BTN_BASE} ${ACCENT_BORDER} ${ACCENT_TEXT} bg-neutral-950/20 ${ACCENT_HOVER_BG}`;
   const BTN_DANGER = `${BTN_BASE} border-red-500/30 bg-red-950/25 text-red-200 hover:bg-red-950/40`;
 
@@ -492,7 +492,7 @@ export default function PartsRequestsPage(): JSX.Element {
 
           <div className="md:col-span-3">
             <div className="mb-1 text-xs text-neutral-400">Showing</div>
-            <div className="rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2 text-sm text-neutral-200">
+            <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-neutral-200">
               <span className="font-semibold text-white">{filtered.length}</span>{" "}
               work order{filtered.length === 1 ? "" : "s"}
             </div>
@@ -562,7 +562,7 @@ export default function PartsRequestsPage(): JSX.Element {
                     <span>Completion</span>
                     <span className={ACCENT_TEXT}>{b.completionPct}%</span>
                   </div>
-                  <div className="mt-1 h-2 w-full overflow-hidden rounded-full border border-white/10 bg-black/40">
+                  <div className="mt-1 h-2 w-full overflow-hidden desktop-pill">
                     <div
                       className="h-full rounded-full bg-white/20"
                       style={{ width: `${b.completionPct}%` }}

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -242,12 +242,12 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
   }
 
   return (
-    <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top,_rgba(200,122,67,0.18),#020617_82%)] px-4 py-6 text-white">
-      <div className="mx-auto max-w-6xl rounded-2xl border border-[var(--metal-border-soft)] bg-[radial-gradient(circle_at_top,_#050910,_#020308_65%,_#000)] px-4 py-5 shadow-[0_24px_80px_rgba(0,0,0,0.95)] sm:px-6 sm:py-6">
+    <div className="min-h-[calc(100vh-4rem)] desktop-backdrop px-4 py-6 text-white">
+      <div className="mx-auto max-w-6xl desktop-panel px-4 py-5 sm:px-6 sm:py-6">
         {/* Header */}
         <div className="mb-5 flex flex-wrap items-center gap-3">
           <div className="space-y-1">
-            <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/70 px-3 py-1">
+            <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1">
               <span className="text-[0.7rem] font-blackops uppercase tracking-[0.22em] text-neutral-200">
                 Work Order History
               </span>
@@ -380,7 +380,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                       </Link>
 
                       {r.custom_id ? (
-                        <span className="rounded-full border border-white/10 bg-black/60 px-2 py-0.5 text-[10px] font-mono text-neutral-400">
+                        <span className="desktop-btn-secondary px-2 py-0.5 text-[10px] font-mono text-neutral-400">
                           #{r.id.slice(0, 6)}
                         </span>
                       ) : null}

--- a/app/work-orders/view/[id]/page.tsx
+++ b/app/work-orders/view/[id]/page.tsx
@@ -150,13 +150,13 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
   };
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(248,113,22,0.14),transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.96),#020617_78%)] px-4 py-6 text-white">
+    <div className="min-h-screen desktop-backdrop px-4 py-6 text-white">
       <div className="mx-auto max-w-4xl space-y-4">
         <div className="flex items-center justify-between gap-2">
           <button
             type="button"
             onClick={goBack}
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/60 px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] text-neutral-200 hover:bg-black/70"
+            className="inline-flex items-center gap-2 desktop-btn-secondary px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] text-neutral-200 hover:bg-black/70"
           >
             <span aria-hidden className="text-base leading-none">
               ←
@@ -169,7 +169,7 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-white/10 bg-black/35 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.9)]">
+        <div className="desktop-panel p-5">
           {loading ? (
             <div className="text-sm text-neutral-300">Loading…</div>
           ) : err ? (
@@ -212,13 +212,13 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
                   >
                     {String(wo.status ?? "—").replaceAll("_", " ")}
                   </span>
-                  <span className="rounded-full border border-white/10 bg-black/40 px-2 py-0.5 text-[10px] font-mono text-neutral-400">
+                  <span className="desktop-pill px-2 py-0.5 text-[10px] font-mono text-neutral-400">
                     {wo.id.slice(0, 8)}
                   </span>
                 </div>
               </div>
 
-              <div className="mt-5 rounded-2xl border border-white/10 bg-black/35 p-4">
+              <div className="mt-5 desktop-panel-soft p-4">
                 <div className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-300">
                   Jobs (Punchable)
                 </div>
@@ -242,7 +242,7 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
                       return (
                         <div
                           key={l.id}
-                          className="rounded-xl border border-white/10 bg-black/40 p-3"
+                          className="desktop-item-card p-3"
                         >
                           <div className="flex items-baseline justify-between gap-2">
                             <div className="min-w-0">
@@ -292,7 +292,7 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
                     {lines
                       .filter((line) => (line.line_type ?? "job") === "info")
                       .map((line) => (
-                        <div key={line.id} className="rounded-xl border border-white/10 bg-black/30 p-3">
+                        <div key={line.id} className="desktop-item-card p-3">
                           <div className="text-sm text-neutral-100">
                             {safeTrim(line.description) || safeTrim(line.complaint) || "Context line"}
                           </div>

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -39,16 +39,16 @@ const InspectionModal = dynamic(
 const COPPER = "#C57A4A";
 
 const card =
-  "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 shadow-[var(--theme-shadow-medium,0_22px_52px_rgba(0,0,0,0.5))] backdrop-blur-xl";
+  "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[var(--theme-shadow-medium,0_22px_52px_rgba(0,0,0,0.5))] backdrop-blur-xl";
 const divider = "border-white/10";
 const sectionPanel =
-  "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5";
+  "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5";
 const childPanel =
-  "rounded-2xl border border-[color:var(--metal-border-soft,#374151)] bg-black/65 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
+  "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
 const subtlePanel =
-  "rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/65";
+  "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]";
 const softButton =
-  "rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/65 text-neutral-200 hover:bg-black/75";
+  "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-200 hover:bg-black/75";
 
 /* =============================================================================
    Types & helpers
@@ -2200,7 +2200,7 @@ useEffect(() => {
                 className="absolute inset-0 bg-black/70 backdrop-blur-sm"
                 onClick={dismissIntakeOnce}
               />
-              <div className="relative w-full max-w-2xl rounded-3xl border border-white/10 bg-black/70 p-4 shadow-[0_0_40px_rgba(0,0,0,0.85)] backdrop-blur-md">
+              <div className="relative w-full max-w-2xl rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4 shadow-[0_0_40px_rgba(0,0,0,0.85)] backdrop-blur-md">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <div className="text-xs uppercase tracking-[0.25em] text-neutral-400">

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -60,10 +60,10 @@ const ASSIGN_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 const STATUS_PICKER_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 
 const INPUT_DARK =
-  "w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30";
+  "w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30";
 
 const SELECT_DARK =
-  "w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2 text-sm text-white outline-none focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30";
+  "w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white outline-none focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30";
 
 function isStatusKey(x: string): x is StatusKey {
   return (
@@ -129,9 +129,9 @@ function stageAccent(status: string | null | undefined): {
 
   if (key === "on_hold") {
     return {
-      badge: "border-amber-400/70 bg-amber-500/10 text-amber-100",
-      border: "border-amber-500/30",
-      progress: "bg-amber-400",
+      badge: "border-sky-400/45 bg-sky-500/10 text-sky-100",
+      border: "border-sky-500/25",
+      progress: "bg-sky-400",
     };
   }
 
@@ -171,7 +171,7 @@ function techRollupChip(rollup: TechRollup): string {
     return "border-sky-400/60 bg-sky-500/10 text-sky-100";
   }
   if (rollup === "on_hold") {
-    return "border-amber-400/70 bg-amber-500/10 text-amber-100";
+    return "border-sky-400/45 bg-sky-500/10 text-sky-100";
   }
   if (rollup === "completed") {
     return "border-emerald-400/70 bg-emerald-500/10 text-emerald-100";
@@ -197,7 +197,7 @@ function priorityChip(priority: number | null | undefined): string {
   if (priority === 4) {
     return "border-slate-500/40 bg-slate-500/10 text-slate-300";
   }
-  return "border-white/10 bg-white/5 text-neutral-300";
+  return "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-300";
 }
 
 export default function WorkOrdersView(): JSX.Element {
@@ -647,7 +647,7 @@ export default function WorkOrdersView(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 text-foreground">
-      <section className="rounded-3xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-4 backdrop-blur md:p-5">
+      <section className="rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 backdrop-blur md:p-5">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
@@ -665,20 +665,20 @@ export default function WorkOrdersView(): JSX.Element {
 
             {!loading && !err ? (
               <div className="mt-3 flex flex-wrap gap-2">
-                <div className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                <div className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-semibold text-neutral-200">
                   Active: <span className="text-white">{activeCount}</span>
                 </div>
-                <div className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                <div className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-semibold text-neutral-200">
                   Awaiting approval:{" "}
                   <span className="text-white">{awaitingApprovalCount}</span>
                 </div>
-                <div className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                <div className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-semibold text-neutral-200">
                   Waiters: <span className="text-white">{waiterCount}</span>
                 </div>
-                <div className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                <div className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-semibold text-neutral-200">
                   Urgent: <span className="text-white">{urgentCount}</span>
                 </div>
-                <div className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-1 text-[11px] font-semibold text-neutral-200">
+                <div className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-semibold text-neutral-200">
                   Total: <span className="text-white">{total}</span>
                 </div>
               </div>
@@ -711,7 +711,7 @@ export default function WorkOrdersView(): JSX.Element {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-4 backdrop-blur">
+      <section className="rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 backdrop-blur">
         <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto]">
           <input
             value={q}
@@ -744,7 +744,7 @@ export default function WorkOrdersView(): JSX.Element {
               void load();
               setAssignVersion((v) => v + 1);
             }}
-            className="rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-[rgba(200,122,67,0.62)] hover:bg-[rgba(200,122,67,0.15)]"
+            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-[rgba(200,122,67,0.62)] hover:bg-[rgba(200,122,67,0.15)]"
           >
             Refresh
           </button>
@@ -767,7 +767,7 @@ export default function WorkOrdersView(): JSX.Element {
           ))}
         </div>
       ) : rows.length === 0 ? (
-        <div className="rounded-2xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-6 text-sm text-neutral-300">
+        <div className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-6 text-sm text-neutral-300">
           No work orders match your current filters.
         </div>
       ) : (
@@ -969,7 +969,7 @@ export default function WorkOrdersView(): JSX.Element {
                 </div>
 
                 {canAssign ? (
-                  <div className="mt-4 rounded-xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/70 p-3">
+                  <div className="mt-4 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-3">
                     {!isAssigning ? (
                       <button
                         onClick={() => {


### PR DESCRIPTION
### Motivation
- Apply the established dashboard desktop visual language to real desktop feature pages (not only shared shells) so operational surfaces match the central design tokens and theme. 
- Replace feature-local warm-brown / glass haze wrappers with the desktop primitives while preserving existing behavior and business logic. 
- Keep the change focused and non-breaking: do not alter dashboard pages, RLS/auth, API shapes, or the work-order client job card logic.

### Description
- Migrated desktop surfaces for Work Orders, Billing and Parts by replacing local visual wrappers and class strings with desktop primitives such as `desktop-backdrop`, `desktop-panel`, `desktop-panel-soft`, `desktop-item-card`, `desktop-btn-secondary`, `desktop-pill`, and `desktop-input`, and by normalizing local accent/focus constants to use `--desktop-*` / brand tokens. 
- Pages migrated: Work Orders (`/work-orders/history`, `/work-orders/view/[id]`) plus supporting feature page style constants in `features/work-orders` (create/view); Billing (`/billing`); Parts (`/parts/requests`, `/parts/requests/[id]`, `/parts/inventory`). 
- Files changed: `app/work-orders/history/WorkOrdersHistoryClient.tsx`, `app/work-orders/view/[id]/page.tsx`, `features/work-orders/app/work-orders/create/page.tsx`, `features/work-orders/app/work-orders/view/page.tsx`, `app/billing/page.tsx`, `app/parts/requests/page.tsx`, `app/parts/requests/[id]/page.tsx`, `app/parts/inventory/page.tsx`. 
- Confirmations: dashboard visuals were not edited (no files under `app/dashboard/**` changed) and no edits were made to the work-order client job card logic or `app/work-orders/[id]/Client.tsx`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully. 
- Lint: ran `npm run lint`; lint failed with pre-existing, repo-wide issues unrelated to this patch (errors/warnings are outside the modified files). 
- Commit: changes were staged and committed as part of this PR (message: "Migrate desktop feature pages to dashboard visual language").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3db3a06708328bbdbe3c74dab5a54)