### PR TITLE
Migrate nested work orders, parts, and billing components to dashboard desktop theme

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -70,7 +70,7 @@ function priorityChip(priority: number | null | undefined): string {
     return "border-red-500/50 bg-red-500/15 text-red-200";
   }
   if (priority === 2) {
-    return "border-orange-500/50 bg-orange-500/15 text-orange-200";
+    return "border-sky-500/50 bg-sky-500/15 text-sky-100";
   }
   if (priority === 4) {
     return "border-slate-500/40 bg-slate-500/10 text-slate-300";
@@ -319,8 +319,8 @@ export default function BillingPage(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 bg-background px-4 py-6 text-foreground">
-      <section className="overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(197,122,74,0.12),rgba(0,0,0,0.92)_38%,rgba(2,6,23,0.98)_100%)] shadow-[0_0_60px_rgba(0,0,0,0.8)]">
-        <div className="border-b border-white/8 px-5 py-5 sm:px-6">
+      <section className="overflow-hidden rounded-[28px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_0_50px_rgba(2,6,23,0.55)]">
+        <div className="border-b border-[color:var(--desktop-border)] px-5 py-5 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
@@ -345,7 +345,7 @@ export default function BillingPage(): JSX.Element {
                   <div className="rounded-full border border-sky-500/20 bg-sky-500/5 px-3 py-1 text-[11px] font-semibold text-sky-100">
                     Completed: <span className="text-white">{completedCount}</span>
                   </div>
-                  <div className="rounded-full border border-amber-500/20 bg-amber-500/5 px-3 py-1 text-[11px] font-semibold text-amber-100">
+                  <div className="rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-[11px] font-semibold text-sky-100">
                     Ready: <span className="text-white">{readyCount}</span>
                   </div>
                   <div className="rounded-full border border-emerald-500/20 bg-emerald-500/5 px-3 py-1 text-[11px] font-semibold text-emerald-100">
@@ -358,7 +358,7 @@ export default function BillingPage(): JSX.Element {
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/work-orders/view"
-                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15"
+                className="inline-flex items-center justify-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
               >
                 Open work orders
               </Link>
@@ -421,7 +421,7 @@ export default function BillingPage(): JSX.Element {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="h-64 animate-pulse rounded-[24px] border border-white/10 bg-white/5"
+              className="h-64 animate-pulse rounded-[24px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]"
             />
           ))}
         </div>
@@ -473,7 +473,7 @@ export default function BillingPage(): JSX.Element {
                   accent.border,
                 ].join(" ")}
               >
-                <div className="border-b border-white/8 px-4 py-4">
+                <div className="border-b border-[color:var(--desktop-border)] px-4 py-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
@@ -564,7 +564,7 @@ export default function BillingPage(): JSX.Element {
                   <div className="mt-4 flex flex-wrap gap-2">
                     <Link
                       href={href}
-                      className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15"
+                      className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
                     >
                       Open WO
                     </Link>
@@ -582,7 +582,7 @@ export default function BillingPage(): JSX.Element {
                       type="button"
                       onClick={() => void handleMarkReady(r.id)}
                       disabled={r.status === "invoiced" || r.status === "ready_to_invoice"}
-                      className="rounded-full border border-amber-400/70 bg-amber-500/10 px-3 py-1.5 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded-full border border-sky-400/60 bg-sky-500/10 px-3 py-1.5 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50"
                       title="Mark ready to invoice"
                     >
                       Mark Ready

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -83,7 +83,7 @@ function Modal(props: {
         <div>{children}</div>
 
         {footer ? (
-          <div className={`mt-4 border-t border-white/10 pt-3 ${ACCENT_BORDER}`}>{footer}</div>
+          <div className={`mt-4 border-t border-[color:var(--desktop-border)] pt-3 ${ACCENT_BORDER}`}>{footer}</div>
         ) : null}
       </div>
     </div>
@@ -331,21 +331,20 @@ export default function InventoryPage(): JSX.Element {
 
   // ---- Theme (glass + neutral accent styling) ----
   const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
-  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
   const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
 
   const pageWrap = "space-y-4 p-6 text-white";
   const glassCard =
     "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
-  const glassHeader = "bg-slate-950/55 border-b border-white/10";
+  const glassHeader = "bg-[linear-gradient(180deg,rgba(148,163,184,0.08),rgba(15,23,42,0))] border-b border-[color:var(--desktop-border)]";
 
   const inputBase =
-    `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-white/10 focus:outline-none ${ACCENT_FOCUS_RING}`;
+    `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
 
   const btnBase =
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-semibold transition disabled:opacity-60";
   const btnGhost = `${btnBase} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
-  const btnCopper = `${btnBase} border-white/10 ${ACCENT_TEXT} bg-neutral-950/20 ${ACCENT_HOVER_BG}`;
+  const btnCopper = `${btnBase} border-[rgba(197,122,74,0.55)] ${ACCENT_TEXT} bg-[linear-gradient(135deg,rgba(197,122,74,0.22),rgba(197,122,74,0.12))] hover:bg-[linear-gradient(135deg,rgba(197,122,74,0.3),rgba(197,122,74,0.18))]`;
   const btnBlue = `${btnBase} border-sky-500/30 bg-sky-950/25 text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25`;
 
   const pillBase =
@@ -855,7 +854,7 @@ export default function InventoryPage(): JSX.Element {
         <div className={`${glassCard} overflow-hidden`}>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-white/5 text-neutral-400">
+              <thead className="bg-[color:var(--desktop-item-bg)] text-neutral-400">
                 <tr className="text-left">
                   <th className="p-3">Name</th>
                   <th className="w-40 p-3">SKU</th>
@@ -874,7 +873,7 @@ export default function InventoryPage(): JSX.Element {
                   const onHandPill = total > 0 ? pillOk : pillZero;
                   const trust = trustByPartId[p.id] ?? { level: "high", reasons: [] as string[] };
                   return (
-                    <tr key={p.id} className="border-t border-white/10">
+                    <tr key={p.id} className="border-t border-[color:var(--desktop-border)]">
                       <td className="p-3">
                         <div className="font-medium text-white">{summary.name}</div>
                         {/* Previously this subtitle rendered String(p.id).slice(0, 8), which exposed internal ids as unlabeled metadata. */}
@@ -922,7 +921,7 @@ export default function InventoryPage(): JSX.Element {
             </table>
           </div>
 
-          <div className="border-t border-white/10 px-5 py-3 text-xs text-neutral-500">
+          <div className="border-t border-[color:var(--desktop-border)] px-5 py-3 text-xs text-neutral-500">
             Tip: Click on-hand to see locations. {suspectCount} row(s) currently flagged for trust review.
           </div>
         </div>
@@ -1077,7 +1076,7 @@ export default function InventoryPage(): JSX.Element {
               </thead>
               <tbody>
                 {ohLines.map((l, i) => (
-                  <tr key={i} className="border-t border-white/10">
+                  <tr key={i} className="border-t border-[color:var(--desktop-border)]">
                     <td className="p-3">{l.location}</td>
                     <td className="p-3 tabular-nums">{l.qty}</td>
                   </tr>
@@ -1186,7 +1185,7 @@ Spark Plug – Iridium,SP-IR-01,Ignition,9.95,24
                 </thead>
                 <tbody>
                   {csvRows.map((r, i) => (
-                    <tr key={i} className="border-t border-white/10">
+                    <tr key={i} className="border-t border-[color:var(--desktop-border)]">
                       <td className="p-3">{r.name}</td>
                       <td className="p-3">{r.sku ?? "—"}</td>
                       <td className="p-3">{r.category ?? "—"}</td>

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -200,16 +200,16 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   // ---- Theme (glass + neutral accent styling) ----
   const ACCENT_BORDER = "border-[color:var(--desktop-border-strong)]";
   const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
-  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
-  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
+  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_12%,transparent)]";
+  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_35%,transparent)]";
 
   const pageWrap = "space-y-3 p-4 text-white";
   const glassCard =
     "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
   const glassHeader =
-    "bg-gradient-to-b from-white/5 to-transparent border-b border-white/10";
-  const inputBase = `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-white/10 focus:outline-none ${ACCENT_FOCUS_RING}`;
-  const selectBase = `rounded-lg border bg-neutral-950/40 px-2 py-2 text-xs text-white border-white/10 focus:outline-none ${ACCENT_FOCUS_RING}`;
+    "bg-[linear-gradient(180deg,rgba(148,163,184,0.08),rgba(15,23,42,0))] border-b border-[color:var(--desktop-border)]";
+  const inputBase = `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
+  const selectBase = `rounded-lg border bg-neutral-950/40 px-2 py-2 text-xs text-white border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
 
   const btnBase =
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm transition disabled:opacity-60";
@@ -221,7 +221,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     "inline-flex items-center whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium";
   const pillNeedsQuote = `${pillBase} border-red-500/35 bg-red-950/35 text-red-200`;
   const pillQuoted = `${pillBase} border-teal-500/35 bg-teal-950/25 text-teal-200`;
-  const pillProgress = `${pillBase} border-[rgba(200,122,67,0.45)] bg-sky-950/25 text-[rgba(242,210,187,0.94)]`;
+  const pillProgress = `${pillBase} border-sky-500/45 bg-sky-950/25 text-sky-100`;
   const pillComplete = `${pillBase} border-emerald-500/35 bg-emerald-950/25 text-emerald-200`;
 
   const supplierNameById = useMemo(() => {
@@ -1232,7 +1232,7 @@ if (!lineId || !isUuid(lineId)) {
                     <div className="p-3 space-y-3">
                       <RequestItemsTable>
                         <table className="w-full text-sm">
-                          <thead className="bg-white/5 text-neutral-400">
+                          <thead className="bg-[color:var(--desktop-item-bg)] text-neutral-400">
                             <tr>
                               <th className="px-3 py-2 text-left">Requested part</th>
                               <th className="px-3 py-2 text-right">Qty</th>
@@ -1245,7 +1245,7 @@ if (!lineId || !isUuid(lineId)) {
 
                           <tbody>
                             {r.items.length === 0 ? (
-                              <tr className="border-t border-white/10">
+                              <tr className="border-t border-[color:var(--desktop-border)]">
                                 <td
                                   className="p-4 text-sm text-neutral-500"
                                   colSpan={6}
@@ -1296,7 +1296,7 @@ if (!lineId || !isUuid(lineId)) {
                                 return (
                                   <tr
                                     key={String(it.id)}
-                                    className="border-t border-white/10"
+                                    className="border-t border-[color:var(--desktop-border)]"
                                   >
                                     {/* ✅ Bigger request description ABOVE stock-part selector */}
                                     <td className="px-3 py-2 align-top">

--- a/app/parts/requests/[id]/request-detail-components.tsx
+++ b/app/parts/requests/[id]/request-detail-components.tsx
@@ -5,6 +5,15 @@ import type { ReactNode } from "react";
 
 type Option = { value: string; label: string };
 
+const CARD =
+  "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
+const SUBCARD =
+  "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]";
+const INPUT =
+  "w-72 rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-2 text-xs text-white focus:outline-none focus:ring-2 focus:ring-sky-500/30";
+const LINK_BTN =
+  "rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-neutral-200 hover:bg-white/5";
+
 export function RequestStatusSummary({
   waiting,
   ordered,
@@ -17,7 +26,7 @@ export function RequestStatusSummary({
   complete: number;
 }): JSX.Element {
   const pill =
-    "rounded-lg border border-white/10 bg-neutral-950/30 px-3 py-2 text-xs text-neutral-300";
+    "rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-xs text-neutral-300";
 
   return (
     <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -45,18 +54,18 @@ export function RequestHeaderSection({
   statusSummary: ReactNode;
 }): JSX.Element {
   return (
-    <div className="rounded-xl border border-white/10 bg-neutral-950/35 backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset] overflow-hidden">
-      <div className="bg-gradient-to-b from-white/5 to-transparent border-b border-white/10 px-4 py-3">
+    <div className={`${CARD} overflow-hidden`}>
+      <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(148,163,184,0.08),rgba(15,23,42,0))] px-4 py-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <div className="text-xl font-semibold tracking-wide">{title}</div>
+            <div className="text-xl font-semibold tracking-wide text-white">{title}</div>
             <div className="mt-1 text-sm text-neutral-400">{subtitle}</div>
           </div>
 
           <div className="flex items-center gap-2">
             <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">PO</div>
             <select
-              className="w-72 rounded-lg border border-white/10 bg-neutral-950/40 px-2 py-2 text-xs text-white focus:outline-none"
+              className={INPUT}
               value={selectedPo}
               onChange={(e) => onSelectedPoChange(e.target.value)}
               title="Optional: choose PO to apply receiving against"
@@ -79,16 +88,16 @@ export function RequestHeaderSection({
 
 export function RequestProcurementPanel(): JSX.Element {
   return (
-    <div className="rounded-xl border border-white/10 bg-neutral-950/25 p-3">
+    <div className={`${SUBCARD} p-3`}>
       <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Procurement</div>
       <p className="mt-2 text-xs text-neutral-400">
         Supplier selection, PO creation/reuse, and PO assignment happen per item row.
       </p>
       <div className="mt-3 flex flex-wrap gap-2 text-xs">
-        <Link href="/parts/po" className="rounded border border-white/10 px-2 py-1 text-neutral-200 hover:bg-white/5">
+        <Link href="/parts/po" className={LINK_BTN}>
           → Open PO list
         </Link>
-        <Link href="/parts/po/receive" className="rounded border border-white/10 px-2 py-1 text-neutral-200 hover:bg-white/5">
+        <Link href="/parts/po/receive" className={LINK_BTN}>
           → Receive from PO
         </Link>
       </div>
@@ -98,16 +107,16 @@ export function RequestProcurementPanel(): JSX.Element {
 
 export function RequestReceivingPanel(): JSX.Element {
   return (
-    <div className="rounded-xl border border-white/10 bg-neutral-950/25 p-3">
+    <div className={`${SUBCARD} p-3`}>
       <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Receiving</div>
       <p className="mt-2 text-xs text-neutral-400">
         Use item-level Receive actions to open the Receive Drawer for partial or full intake.
       </p>
       <div className="mt-3 flex flex-wrap gap-2 text-xs">
-        <Link href="/parts/receiving" className="rounded border border-white/10 px-2 py-1 text-neutral-200 hover:bg-white/5">
+        <Link href="/parts/receiving" className={LINK_BTN}>
           → View Request Inbox
         </Link>
-        <Link href="/parts/receive" className="rounded border border-white/10 px-2 py-1 text-neutral-200 hover:bg-white/5">
+        <Link href="/parts/receive" className={LINK_BTN}>
           → Scan to Receive
         </Link>
       </div>
@@ -116,5 +125,9 @@ export function RequestReceivingPanel(): JSX.Element {
 }
 
 export function RequestItemsTable({ children }: { children: ReactNode }): JSX.Element {
-  return <div className="overflow-hidden rounded-xl border border-white/10 bg-neutral-950/20">{children}</div>;
+  return (
+    <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
+      {children}
+    </div>
+  );
 }

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -109,8 +109,8 @@ export default function PartsRequestsPage(): JSX.Element {
 
   const ACCENT_BORDER = "border-[color:var(--desktop-border-strong)]";
   const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
-  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)]";
-  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_35%,transparent)]";
+  const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_12%,transparent)]";
+  const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_35%,transparent)]";
 
   const PAGE = "w-full px-3 py-4 text-white sm:px-5 lg:px-8 xl:px-12";
   const CARD =
@@ -128,7 +128,7 @@ export default function PartsRequestsPage(): JSX.Element {
     "inline-flex items-center whitespace-nowrap rounded-full border px-3 py-1 text-xs font-semibold";
   const PILL_NEEDS = `${PILL_BASE} border-red-500/35 bg-red-950/35 text-red-200`;
   const PILL_QUOTED = `${PILL_BASE} border-teal-500/35 bg-teal-950/25 text-teal-200`;
-  const PILL_APPROVED = `${PILL_BASE} border-[rgba(200,122,67,0.45)] bg-sky-950/25 text-[rgba(242,210,187,0.94)]`;
+  const PILL_APPROVED = `${PILL_BASE} border-sky-500/45 bg-sky-950/25 text-sky-100`;
   const PILL_FULFILLED = `${PILL_BASE} border-emerald-500/35 bg-emerald-950/25 text-emerald-200`;
 
   function pillFor(status: BucketStatus): string {

--- a/app/work-orders/[id]/focused-job/_components/FocusedJobSplitView.tsx
+++ b/app/work-orders/[id]/focused-job/_components/FocusedJobSplitView.tsx
@@ -14,7 +14,7 @@ export default function FocusedJobSplitView(props: {
   right: ReactNode;
 }): JSX.Element {
   return (
-    <div className="min-h-screen w-full bg-background text-foreground">
+    <div className="min-h-screen w-full desktop-backdrop text-foreground">
       <div className="mx-auto max-w-[1800px] px-3 py-4 sm:px-6 lg:px-8">
         <div className="grid min-h-0 gap-4 lg:grid-cols-12">
           {/* Left column */}

--- a/app/work-orders/[id]/quote-review/_components/QuoteReviewPanelClient.tsx
+++ b/app/work-orders/[id]/quote-review/_components/QuoteReviewPanelClient.tsx
@@ -15,9 +15,9 @@ export default function QuoteReviewPanelClient(props: {
   const router = useRouter();
 
   return (
-    <div className={cn(PANEL_VARIANTS.secondary, "flex h-full min-h-0 flex-col p-2")}>
+    <div className={cn(PANEL_VARIANTS.secondary, "flex h-full min-h-0 flex-col rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-2")}>
       <div className="flex items-center justify-between gap-2 px-2 py-1">
-        <div className="flex items-center gap-2 text-sm font-semibold text-white">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
           Quote Review
           <StatusBadge variant="info">
             (WO {props.workOrderLabel ?? props.workOrderId.slice(0, 8)}…)
@@ -26,7 +26,7 @@ export default function QuoteReviewPanelClient(props: {
 
         <button
           type="button"
-          className="rounded-md border border-[var(--theme-card-border,#334155)] bg-transparent px-2 py-1 text-xs text-neutral-200 hover:bg-white/5"
+          className="rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-xs text-neutral-200 hover:bg-white/5"
           onClick={() =>
             router.push(`/work-orders/${props.workOrderLabel ?? props.workOrderId}`)
           }
@@ -37,7 +37,7 @@ export default function QuoteReviewPanelClient(props: {
       </div>
 
       {/* ✅ THIS is the key: allow scrolling in the panel */}
-      <div className={cn(PANEL_VARIANTS.passive, "mt-2 min-h-0 flex-1 overflow-auto rounded-xl")}>
+      <div className={cn(PANEL_VARIANTS.passive, "mt-2 min-h-0 flex-1 overflow-auto rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]")}>
         <div className="p-2">
           <QuoteReviewView workOrderId={props.workOrderId} embedded />
         </div>

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -38,9 +38,9 @@ function statusMeta(status: string | null | undefined): { label: string; classNa
     case "queued":
       return { label: "Queued", className: "border-sky-400/55 bg-sky-500/10 text-[rgba(242,210,187,0.94)]" };
     case "awaiting_approval":
-      return { label: "Awaiting approval", className: "border-amber-400/55 bg-amber-500/10 text-amber-200" };
+      return { label: "Awaiting approval", className: "border-sky-400/55 bg-sky-500/10 text-sky-100" };
     case "ready_to_invoice":
-      return { label: "Ready to invoice", className: "border-orange-400/55 bg-orange-500/10 text-orange-200" };
+      return { label: "Ready to invoice", className: "border-cyan-400/55 bg-cyan-500/10 text-cyan-100" };
     case "invoiced":
       return { label: "Invoiced", className: "border-indigo-400/55 bg-indigo-500/10 text-indigo-200" };
     case "paid":
@@ -48,7 +48,7 @@ function statusMeta(status: string | null | undefined): { label: string; classNa
     case "completed":
       return { label: "Completed", className: "border-emerald-400/55 bg-emerald-500/10 text-emerald-200" };
     default:
-      return { label: status ? String(status) : "—", className: "border-white/15 bg-white/5 text-neutral-200" };
+      return { label: status ? String(status) : "—", className: "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-200" };
   }
 }
 
@@ -259,7 +259,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
 
           <div className="ml-auto text-right text-xs text-neutral-400">
             <div>
-              <span className="font-mono text-sm font-semibold text-orange-400">
+              <span className="font-mono text-sm font-semibold text-cyan-300">
                 {rows.length.toString().padStart(2, "0")}
               </span>{" "}
               <span className="uppercase tracking-[0.14em] text-neutral-500">Loaded</span>
@@ -275,7 +275,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
         </div>
 
         {/* Filters bar */}
-        <div className="mb-5 rounded-2xl border border-[var(--metal-border-soft)] bg-black/60 p-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)] sm:p-4">
+        <div className="mb-5 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)] sm:p-4">
           <div className="flex flex-wrap items-end gap-3">
             <div className="min-w-[220px] flex-1">
               <label className="mb-1 block text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-400">
@@ -286,7 +286,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                 onChange={(e) => setQ(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && load()}
                 placeholder="ID, custom ID, status, name, VIN, plate, YMM…"
-                className="w-full rounded-lg border border-neutral-800 bg-black/70 px-3 py-1.5 text-sm text-neutral-100 outline-none ring-0 transition-colors focus:border-orange-400 focus:ring-1 focus:ring-orange-500/70"
+                className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm text-neutral-100 outline-none ring-0 transition-colors focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30"
               />
             </div>
 
@@ -296,7 +296,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                 type="date"
                 value={from}
                 onChange={(e) => setFrom(e.target.value)}
-                className="rounded-lg border border-neutral-800 bg-black/70 px-3 py-1.5 text-sm text-neutral-100 outline-none ring-0 focus:border-orange-400 focus:ring-1 focus:ring-orange-500/70"
+                className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm text-neutral-100 outline-none ring-0 focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30"
                 aria-label="From date"
               />
             </div>
@@ -307,7 +307,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                 type="date"
                 value={to}
                 onChange={(e) => setTo(e.target.value)}
-                className="rounded-lg border border-neutral-800 bg-black/70 px-3 py-1.5 text-sm text-neutral-100 outline-none ring-0 focus:border-orange-400 focus:ring-1 focus:ring-orange-500/70"
+                className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm text-neutral-100 outline-none ring-0 focus:border-sky-400/70 focus:ring-2 focus:ring-sky-500/30"
                 aria-label="To date"
               />
             </div>
@@ -316,14 +316,14 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
               <button
                 type="button"
                 onClick={load}
-                className="rounded-full border border-[var(--metal-border-soft)] bg-black/70 px-3 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-neutral-100 hover:border-orange-400 hover:bg-black/80"
+                className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-neutral-100 hover:border-sky-400/60 hover:bg-white/10"
               >
                 Apply
               </button>
               <button
                 type="button"
                 onClick={() => window.print()}
-                className="rounded-full border border-neutral-700 bg-black/70 px-3 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900"
+                className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900"
               >
                 Print
               </button>
@@ -347,11 +347,11 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
 
         {/* Content */}
         {loading ? (
-          <div className="rounded-2xl border border-dashed border-[var(--metal-border-soft)] bg-black/60 p-6 text-sm text-neutral-400">
+          <div className="rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-6 text-sm text-neutral-400">
             Loading work orders…
           </div>
         ) : rows.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-[var(--metal-border-soft)] bg-black/60 p-6 text-sm text-neutral-400">
+          <div className="rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-6 text-sm text-neutral-400">
             No work orders found for this shop and date range.
           </div>
         ) : (
@@ -368,13 +368,13 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
               return (
                 <div
                   key={r.id}
-                  className="flex flex-col gap-2 rounded-2xl border border-[var(--metal-border-soft)] bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.24),_#020617_75%)]/90 p-3 shadow-[0_14px_38px_rgba(0,0,0,0.9)] sm:flex-row sm:items-center"
+                  className="flex flex-col gap-2 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-3 shadow-[0_14px_38px_rgba(0,0,0,0.9)] sm:flex-row sm:items-center"
                 >
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
                       <Link
                         href={`/work-orders/view/${r.id}`}
-                        className="font-mono text-sm text-orange-300 underline decoration-transparent underline-offset-2 hover:decoration-orange-400"
+                        className="font-mono text-sm text-cyan-200 underline decoration-transparent underline-offset-2 hover:decoration-cyan-300"
                       >
                         {r.custom_id ? r.custom_id : `#${r.id.slice(0, 8)}`}
                       </Link>
@@ -405,7 +405,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                   <div className="flex flex-wrap items-center justify-end gap-2">
                     <Link
                       href={`/work-orders/invoice/${r.id}`}
-                      className="rounded-full border border-[var(--metal-border-soft)] bg-black/70 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-100 hover:border-orange-400 hover:bg-black/80"
+                      className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-100 hover:border-sky-400/60 hover:bg-white/10"
                       title="Open invoice inside ProFixIQ (staff view)"
                     >
                       View Invoice
@@ -416,7 +416,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                         href={r.invoice_url}
                         target="_blank"
                         rel="noreferrer"
-                        className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-300 hover:bg-black/80"
+                        className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-300 hover:bg-white/10"
                         title="Open customer portal invoice link"
                       >
                         Portal Link
@@ -426,7 +426,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                         href={r.quote_url}
                         target="_blank"
                         rel="noreferrer"
-                        className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-300 hover:bg-black/80"
+                        className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-300 hover:bg-white/10"
                         title="Open quote link"
                       >
                         Open Quote

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -267,7 +267,7 @@ function ApprovalsList(): JSX.Element {
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className="h-56 animate-pulse rounded-[24px] border border-white/10 bg-white/5"
+            className="h-56 animate-pulse rounded-[24px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]"
           />
         ))}
       </div>
@@ -284,7 +284,7 @@ function ApprovalsList(): JSX.Element {
 
   if (rows.length === 0) {
     return (
-      <div className="rounded-[24px] border border-white/10 bg-black/25 p-6 text-sm text-neutral-400">
+      <div className="rounded-[24px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-6 text-sm text-neutral-400">
         No work orders waiting for approval.
       </div>
     );

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -107,7 +107,7 @@ function stageAccent(status: string | null | undefined): {
       badge:
         "border-sky-400/60 bg-sky-500/10 text-sky-100",
       border: "border-sky-500/30",
-      progress: "bg-[linear-gradient(90deg,#f59e0b,#c57a4a)]",
+      progress: "bg-[linear-gradient(90deg,#0ea5e9,#c57a4a)]",
     };
   }
 
@@ -192,10 +192,10 @@ function priorityChip(priority: number | null | undefined): string {
     return "border-red-500/50 bg-red-500/15 text-red-200";
   }
   if (priority === 2) {
-    return "border-orange-500/50 bg-orange-500/15 text-orange-200";
+    return "border-sky-500/50 bg-sky-500/15 text-sky-100";
   }
   if (priority === 4) {
-    return "border-slate-500/40 bg-slate-500/10 text-slate-300";
+    return "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-slate-300";
   }
   return "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-300";
 }
@@ -695,7 +695,7 @@ export default function WorkOrdersView(): JSX.Element {
 
             <Link
               href="/agent/planner?planner=ops&allowCreate=0&goal=Review%20the%20current%20work%20order%20queue%20and%20suggest%20the%20best%20next%20actions"
-              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-3.5 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-[rgba(200,122,67,0.62)] hover:bg-[rgba(200,122,67,0.15)]"
+              className="inline-flex items-center justify-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3.5 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
             >
               Open Planner
             </Link>
@@ -744,7 +744,7 @@ export default function WorkOrdersView(): JSX.Element {
               void load();
               setAssignVersion((v) => v + 1);
             }}
-            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-[rgba(200,122,67,0.62)] hover:bg-[rgba(200,122,67,0.15)]"
+            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
           >
             Refresh
           </button>
@@ -762,7 +762,7 @@ export default function WorkOrdersView(): JSX.Element {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="h-64 animate-pulse rounded-2xl border border-white/10 bg-white/5"
+              className="h-64 animate-pulse rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]"
             />
           ))}
         </div>
@@ -814,7 +814,7 @@ export default function WorkOrdersView(): JSX.Element {
             return (
               <div
                 key={r.id}
-                className={`rounded-2xl border bg-black/25 p-4 backdrop-blur transition hover:bg-black/30 ${accent.border}`}
+                className={`rounded-2xl border bg-[color:var(--desktop-item-bg)] p-4 backdrop-blur transition hover:bg-white/5 ${accent.border}`}
                 style={{
                   boxShadow:
                     "0 0 0 1px rgba(255,255,255,0.04) inset, 0 0 24px rgba(0,0,0,0.22)",
@@ -845,7 +845,7 @@ export default function WorkOrdersView(): JSX.Element {
                       </span>
 
                       {r.is_waiter ? (
-                        <span className="rounded-full border border-amber-400/50 bg-amber-500/15 px-2 py-0.5 text-[11px] font-bold text-amber-100">
+                        <span className="rounded-full border border-sky-400/50 bg-sky-500/15 px-2 py-0.5 text-[11px] font-bold text-sky-100">
                           Waiting
                         </span>
                       ) : null}
@@ -866,7 +866,7 @@ export default function WorkOrdersView(): JSX.Element {
                             Reviewed ✓
                           </span>
                         ) : (
-                          <span className="rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-[11px] font-bold text-amber-200">
+                          <span className="rounded-full border border-sky-500/50 bg-sky-500/10 px-2 py-0.5 text-[11px] font-bold text-sky-100">
                             Issues: {issueCount}
                           </span>
                         )
@@ -913,7 +913,7 @@ export default function WorkOrdersView(): JSX.Element {
                 <div className="mt-4 flex flex-wrap gap-2">
                   <Link
                     href={href}
-                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:border-[var(--accent-copper-light)] hover:bg-sky-500/10"
+                    className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
                   >
                     Open
                   </Link>
@@ -953,7 +953,7 @@ export default function WorkOrdersView(): JSX.Element {
                       className={
                         reviewedOk
                           ? "rounded-full border border-sky-400/60 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
-                          : "rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-500 opacity-60"
+                          : "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-500 opacity-60"
                       }
                     >
                       Invoice
@@ -1013,7 +1013,7 @@ export default function WorkOrdersView(): JSX.Element {
                               setAssigningFor(null);
                               setSelectedTechId("");
                             }}
-                            className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-white/10"
+                            className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-white/10"
                           >
                             Cancel
                           </button>

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -868,7 +868,7 @@ export default function QuoteReviewView(props: {
     <div className={outerCls} style={{ ["--copper" as never]: COPPER }}>
       <div className={containerCls}>
         {loading ? (
-          <div className="mb-2 rounded-xl border border-[color:var(--desktop-border)] bg-black/35 px-3 py-2 text-xs text-neutral-300">
+          <div className="mb-2 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-xs text-neutral-300">
             Refreshing quote review data…
           </div>
         ) : null}
@@ -1454,14 +1454,14 @@ export default function QuoteReviewView(props: {
               <div className={`${padX} py-4 text-sm text-neutral-400`}>
                 Send quote email + portal notification.
                 {(missingCustomerEmail || sendBlocker) ? (
-                  <div className="mt-3 rounded-xl border border-amber-400/35 bg-amber-500/10 p-3">
-                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">
+                  <div className="mt-3 rounded-xl border border-sky-400/35 bg-sky-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-sky-100">
                       Blocked
                     </div>
-                    <div className="mt-1 text-sm font-semibold text-amber-100">
+                    <div className="mt-1 text-sm font-semibold text-sky-100">
                       {sendBlocker ?? "Customer email required to send quote"}
                     </div>
-                    <p className="mt-1 text-xs text-amber-100/80">
+                    <p className="mt-1 text-xs text-sky-100/80">
                       Add the missing email here, save it, then retry send.
                     </p>
                     <div className="mt-2 flex flex-col gap-2 sm:flex-row">
@@ -1470,13 +1470,13 @@ export default function QuoteReviewView(props: {
                         value={pendingCustomerEmail}
                         onChange={(e) => setPendingCustomerEmail(e.target.value)}
                         placeholder="customer@email.com"
-                        className="w-full rounded-lg border border-white/15 bg-slate-900/70 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-amber-300/70"
+                        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-sky-300/70"
                       />
                       <button
                         type="button"
                         onClick={() => void saveCustomerEmailInline()}
                         disabled={savingCustomerEmail}
-                        className="rounded-lg border border-amber-300/45 bg-amber-400/15 px-3 py-2 text-sm font-semibold text-amber-100 hover:bg-amber-400/20 disabled:opacity-60"
+                        className="rounded-lg border border-amber-300/45 bg-amber-400/15 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-amber-400/20 disabled:opacity-60"
                       >
                         {savingCustomerEmail ? "Saving…" : "Save email"}
                       </button>


### PR DESCRIPTION
### Motivation
- Finish the desktop theme migration by updating the actual feature components and nested surfaces so pages read as a single dashboard system, not only outer wrappers. 
- Target the surface layers used inside Work Orders, Parts, and Billing pages (panels, cards, tables, filters, pills, inputs, modals, and split panels). 
- Preserve all business logic, behavior, and multi-tenant protections while removing remaining warm/brown treatments in favor of the dark navy dashboard primitives. 
- Ensure the work-order-client job cards and dashboard architecture remain unchanged while aligning surrounding surfaces visually.

### Description
- Work Orders: updated inner board and list surfaces, status/priority pills, chips, loading/empty shells, and the quote-review embedded panel; key files include `features/work-orders/app/work-orders/view/page.tsx`, `features/work-orders/quote-review/QuoteReviewView.tsx`, `app/work-orders/history/WorkOrdersHistoryClient.tsx`, `app/work-orders/[id]/quote-review/_components/QuoteReviewPanelClient.tsx`, and `app/work-orders/[id]/focused-job/_components/FocusedJobSplitView.tsx`. Changes are styling/class updates to use `--desktop-*` variables, dashboard panel/card primitives, and updated hover/focus accents. 
- Parts: migrated request and inventory nested surfaces and controls, including request header/status summary, procurement/receiving panels, table shells, select/input/button language; key files changed: `app/parts/requests/page.tsx`, `app/parts/requests/[id]/page.tsx`, `app/parts/requests/[id]/request-detail-components.tsx`, and `app/parts/inventory/page.tsx`. All edits are theming only (classes/constants, card/background/border adjustments). 
- Billing: migrated billing page inner panels, chip/tone adjustments, cards and action buttons to dashboard palette and primitives; primary file: `app/billing/page.tsx`. 
- Utilities and UI primitives usage: normalized many local theme constants to `var(--desktop-*)` colors and `desktop`-style input/button/card classes (no changes to API calls, hooks, or DB access). 
- Safety notes: no business logic, API, schema, or workflow sequencing changes were made; the `work-order-client` job card components were not modified; dashboard architecture and widget system were left intact.

### Testing
- Ran TypeScript check: `npx tsc --noEmit` and it passed successfully. 
- No other automated tests were added or required for this UI-only pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3de4690ec8328a02bf7ee02069580)