### PR TITLE
Complete dashboard-themed component-tree migration for Work Orders, Parts, and Billing surfaces

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -358,7 +358,7 @@ export default function BillingPage(): JSX.Element {
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/work-orders/view"
-                className="inline-flex items-center justify-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
+                className="inline-flex items-center justify-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
               >
                 Open work orders
               </Link>
@@ -564,7 +564,7 @@ export default function BillingPage(): JSX.Element {
                   <div className="mt-4 flex flex-wrap gap-2">
                     <Link
                       href={href}
-                      className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
+                      className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
                     >
                       Open WO
                     </Link>

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -101,7 +101,7 @@ function TextField(props: {
     <div>
       <div className="mb-1 text-xs text-neutral-400">{label}</div>
       <input
-        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
+        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
@@ -123,7 +123,7 @@ function NumberField(props: {
       <div className="mb-1 text-xs text-neutral-400">{label}</div>
       <input
         type="number"
-        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
+        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
         value={value === "" ? "" : value}
         min={min}
         step={step}
@@ -147,7 +147,7 @@ function SelectField(props: {
     <div>
       <div className="mb-1 text-xs text-neutral-400">{label}</div>
       <select
-        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[rgba(200,122,67,0.38)]"
+        className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-sky-500/30"
         value={value}
         onChange={(e) => onChange(e.target.value)}
       >
@@ -345,7 +345,7 @@ export default function InventoryPage(): JSX.Element {
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-semibold transition disabled:opacity-60";
   const btnGhost = `${btnBase} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
   const btnCopper = `${btnBase} border-[rgba(197,122,74,0.55)] ${ACCENT_TEXT} bg-[linear-gradient(135deg,rgba(197,122,74,0.22),rgba(197,122,74,0.12))] hover:bg-[linear-gradient(135deg,rgba(197,122,74,0.3),rgba(197,122,74,0.18))]`;
-  const btnBlue = `${btnBase} border-sky-500/30 bg-sky-950/25 text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25`;
+  const btnBlue = `${btnBase} border-sky-500/30 bg-sky-950/25 text-sky-100 hover:bg-sky-900/25`;
 
   const pillBase =
     "inline-flex items-center whitespace-nowrap rounded-full border px-3 py-1 text-xs font-semibold";

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -213,7 +213,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
   const btnBase =
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm transition disabled:opacity-60";
-  const btnGhost = `${btnBase} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
+  const btnGhost = `${btnBase} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]`;
   const btnCopper = `${btnBase} ${ACCENT_BORDER} ${ACCENT_TEXT} bg-neutral-950/20 ${ACCENT_HOVER_BG}`;
   const btnDanger = `${btnBase} border-red-900/60 bg-neutral-950/20 text-red-200 hover:bg-red-900/20`;
 

--- a/app/parts/requests/[id]/request-detail-components.tsx
+++ b/app/parts/requests/[id]/request-detail-components.tsx
@@ -12,7 +12,7 @@ const SUBCARD =
 const INPUT =
   "w-72 rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-2 text-xs text-white focus:outline-none focus:ring-2 focus:ring-sky-500/30";
 const LINK_BTN =
-  "rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-neutral-200 hover:bg-white/5";
+  "rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]";
 
 export function RequestStatusSummary({
   waiting,

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -120,7 +120,7 @@ export default function PartsRequestsPage(): JSX.Element {
   const SELECT = `w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white focus:outline-none ${ACCENT_FOCUS_RING}`;
   const BTN_BASE =
     "inline-flex items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium transition disabled:opacity-60";
-  const BTN_GHOST = `${BTN_BASE} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-white/5`;
+  const BTN_GHOST = `${BTN_BASE} border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]`;
   const BTN_ACCENT = `${BTN_BASE} ${ACCENT_BORDER} ${ACCENT_TEXT} bg-neutral-950/20 ${ACCENT_HOVER_BG}`;
   const BTN_DANGER = `${BTN_BASE} border-red-500/30 bg-red-950/25 text-red-200 hover:bg-red-950/40`;
 

--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -151,13 +151,13 @@ function ScannerPane({
   return (
     <div
       className={`space-y-3 ${
-        isBusy ? "ring-2 ring-orange-500 rounded-md animate-pulse" : ""
+        isBusy ? "ring-2 ring-cyan-500/60 rounded-md animate-pulse" : ""
       }`}
     >
       {isBusy && (
-        <div className="flex items-center gap-2 rounded border border-orange-500/60 bg-neutral-950 px-3 py-2">
-          <span className="inline-block h-4 w-4 rounded-full border-2 border-orange-500 border-t-transparent animate-spin" />
-          <span className="text-xs text-orange-300">
+        <div className="flex items-center gap-2 rounded border border-cyan-500/50 bg-[color:var(--desktop-item-bg)] px-3 py-2">
+          <span className="inline-block h-4 w-4 rounded-full border-2 border-cyan-400 border-t-transparent animate-spin" />
+          <span className="text-xs text-cyan-100">
             Decoding VIN… this can take a moment
           </span>
         </div>
@@ -174,7 +174,7 @@ function ScannerPane({
       </div>
 
       {error ? (
-        <div className="text-xs text-amber-300">{error}</div>
+        <div className="text-xs text-slate-200">{error}</div>
       ) : (
         <div className="text-xs text-neutral-400">
           {active
@@ -192,7 +192,7 @@ function ScannerPane({
           type="file"
           accept="image/*"
           disabled={isBusy}
-          className="block w-full text-xs text-neutral-300 file:mr-3 file:rounded file:border-0 file:bg-orange-500 file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-black hover:file:bg-orange-400 disabled:opacity-60"
+          className="block w-full text-xs text-neutral-300 file:mr-3 file:rounded file:border-0 file:bg-[linear-gradient(135deg,rgba(197,122,74,0.9),rgba(197,122,74,0.75))] file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-black hover:file:bg-[linear-gradient(135deg,rgba(197,122,74,1),rgba(197,122,74,0.85))] disabled:opacity-60"
           onChange={async (e) => {
             if (isBusy) return;
             const file = e.target.files?.[0];

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -36,7 +36,7 @@ function statusMeta(status: string | null | undefined): { label: string; classNa
 
   switch (s) {
     case "queued":
-      return { label: "Queued", className: "border-sky-400/55 bg-sky-500/10 text-[rgba(242,210,187,0.94)]" };
+      return { label: "Queued", className: "border-sky-400/55 bg-sky-500/10 text-sky-100" };
     case "awaiting_approval":
       return { label: "Awaiting approval", className: "border-sky-400/55 bg-sky-500/10 text-sky-100" };
     case "ready_to_invoice":

--- a/app/work-orders/view/[id]/page.tsx
+++ b/app/work-orders/view/[id]/page.tsx
@@ -19,12 +19,12 @@ function chipClass(status: string | null | undefined): string {
   if (s.includes("paid") || s.includes("completed"))
     return "border-emerald-400/60 bg-emerald-500/10 text-emerald-200";
   if (s.includes("invoice"))
-    return "border-orange-400/60 bg-orange-500/10 text-orange-200";
+    return "border-cyan-400/60 bg-cyan-500/10 text-cyan-100";
   if (s.includes("approval"))
     return "border-blue-400/60 bg-blue-500/10 text-blue-200";
   if (s.includes("hold"))
-    return "border-amber-400/60 bg-amber-500/10 text-amber-200";
-  return "border-white/15 bg-white/5 text-neutral-200";
+    return "border-slate-400/50 bg-slate-500/10 text-slate-200";
+  return "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-200";
 }
 
 function safeTrim(v: unknown): string {

--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -173,8 +173,8 @@ function CustomerAutocomplete({
         <div
           className="
             absolute z-20 mt-1 w-full overflow-hidden rounded-xl
-            border border-white/12
-            bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_76%,transparent)] backdrop-blur-xl
+            border border-[color:var(--desktop-border)]
+            bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl
             shadow-[0_18px_45px_rgba(0,0,0,0.70)]
           "
         >
@@ -299,8 +299,8 @@ function UnitNumberAutocomplete({
         <div
           className="
             absolute z-20 mt-1 w-full overflow-hidden rounded-xl
-            border border-white/12
-            bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_76%,transparent)] backdrop-blur-xl
+            border border-[color:var(--desktop-border)]
+            bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl
             shadow-[0_18px_45px_rgba(0,0,0,0.70)]
           "
         >
@@ -494,9 +494,9 @@ export default function CustomerVehicleForm({
   };
 
   const panelClass =
-    "rounded-2xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] shadow-[0_18px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl";
+    "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_18px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl";
   const chipClass =
-    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1 text-[11px] text-white/60";
+    "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[11px] text-white/60";
   const labelClass = "text-xs text-neutral-300";
 
   return (
@@ -932,7 +932,7 @@ export default function CustomerVehicleForm({
               onClick={onClear}
               className="
                 inline-flex items-center rounded-full
-                border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)]
+                border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]
                 px-3 py-1.5 text-xs sm:text-sm text-white/75
                 transition hover:border-red-400/60 hover:bg-red-950/35 hover:text-red-200
               "

--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -134,12 +134,12 @@ export default function CreateFlowMaintenanceSelector({
   if (!enabled) return null;
 
   const softButtonClass =
-    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_60%,transparent)] disabled:opacity-50";
+    "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)] disabled:opacity-50";
   const itemPanelClass =
-    "rounded-xl border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_70%,transparent)] px-3 py-3";
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-3";
 
   return (
-    <section className="rounded-2xl border border-[var(--theme-card-border,#334155)] bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_84%,transparent)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5">
+    <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5">
       <div className="mb-3 flex items-start justify-between gap-3 border-b border-white/10 pb-3">
         <div>
           <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-300">
@@ -182,7 +182,7 @@ export default function CreateFlowMaintenanceSelector({
       </div>
 
       {!canLoad ? (
-        <div className="rounded-xl border border-dashed border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-4 text-sm text-neutral-400">
+        <div className="rounded-xl border border-dashed border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-4 text-sm text-neutral-400">
           Save customer and vehicle first to load maintenance suggestions.
         </div>
       ) : error ? (
@@ -192,7 +192,7 @@ export default function CreateFlowMaintenanceSelector({
       ) : loading ? (
         <div className="text-sm text-neutral-400">Loading suggestions...</div>
       ) : rows.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-4 text-sm text-neutral-400">
+        <div className="rounded-xl border border-dashed border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-4 text-sm text-neutral-400">
           No active maintenance suggestions for this vehicle.
         </div>
       ) : (
@@ -215,7 +215,7 @@ export default function CreateFlowMaintenanceSelector({
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
                         <div className="text-sm font-semibold text-white">{item.label}</div>
-                        <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-neutral-300">
+                        <span className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-neutral-300">
                           {item.serviceCode}
                         </span>
                       </div>

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -40,7 +40,7 @@ const COPPER = "#C57A4A";
 
 const card =
   "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[var(--theme-shadow-medium,0_22px_52px_rgba(0,0,0,0.5))] backdrop-blur-xl";
-const divider = "border-white/10";
+const divider = "border-[color:var(--desktop-border)]";
 const sectionPanel =
   "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-soft,0_14px_32px_rgba(0,0,0,0.4))] sm:p-5";
 const childPanel =
@@ -1709,8 +1709,8 @@ useEffect(() => {
                         "relative inline-flex h-7 w-14 shrink-0 items-center rounded-full border transition",
                         isWaiter
                           ? "border-[color:var(--copper)]/70 bg-[color:var(--copper)]/20"
-                          : "border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_62%,transparent)]",
-                        loading ? "opacity-60" : "hover:bg-white/5",
+                          : "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]",
+                        loading ? "opacity-60" : "hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_82%,black)]",
                       ].join(" ")}
                     >
                       <span
@@ -1730,7 +1730,7 @@ useEffect(() => {
                         "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]",
                         isWaiter
                           ? "border-amber-400/50 bg-amber-500/10 text-amber-100"
-                          : "border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_65%,transparent)] text-neutral-400",
+                          : "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-neutral-400",
                       ].join(" ")}
                     >
                       {isWaiter ? "Waiter" : "Drop-off"}
@@ -1908,7 +1908,7 @@ useEffect(() => {
                   type="checkbox"
                   checked={sendInvite}
                   onChange={(e) => setSendInvite(e.target.checked)}
-                  className="h-4 w-4 rounded border-white/20 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_60%,transparent)]"
+                  className="h-4 w-4 rounded border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]"
                   disabled={loading}
                 />
                 Email a customer portal sign-up link
@@ -2144,7 +2144,7 @@ useEffect(() => {
             </section>
 
             {/* Footer actions */}
-            <div className="sticky bottom-3 z-10 rounded-2xl border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_85%,transparent)] p-3 backdrop-blur-xl">
+            <div className="sticky bottom-3 z-10 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-3 backdrop-blur-xl">
               <div className="flex flex-wrap items-center gap-3">
               <button
                 type="submit"
@@ -2220,7 +2220,7 @@ useEffect(() => {
                   <button
                     type="button"
                     onClick={dismissIntakeOnce}
-                    className="rounded-full border border-white/10 bg-black/50 px-3 py-2 text-sm font-semibold text-neutral-200 hover:bg-black/65"
+                    className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm font-semibold text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_78%,black)]"
                   >
                     Skip
                   </button>
@@ -2305,7 +2305,7 @@ useEffect(() => {
                       type="button"
                       onClick={dismissIntakeOnce}
                       disabled={intakeSaving}
-                      className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm font-semibold text-neutral-200 hover:bg-black/65 disabled:opacity-60"
+                      className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_78%,black)] disabled:opacity-60"
                     >
                       Skip for now
                     </button>
@@ -2314,7 +2314,7 @@ useEffect(() => {
                       type="button"
                       onClick={dismissIntakeForever}
                       disabled={intakeSaving}
-                      className="rounded-full border border-white/10 bg-black/50 px-4 py-2 text-sm font-semibold text-neutral-400 hover:text-neutral-200 hover:bg-black/65 disabled:opacity-60"
+                      className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-400 hover:text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_78%,black)] disabled:opacity-60"
                     >
                       Don’t ask again
                     </button>

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -695,14 +695,14 @@ export default function WorkOrdersView(): JSX.Element {
 
             <Link
               href="/agent/planner?planner=ops&allowCreate=0&goal=Review%20the%20current%20work%20order%20queue%20and%20suggest%20the%20best%20next%20actions"
-              className="inline-flex items-center justify-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3.5 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
+              className="inline-flex items-center justify-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3.5 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
             >
               Open Planner
             </Link>
 
             <Link
               href="/work-orders/create"
-              className="inline-flex items-center justify-center rounded-full bg-[var(--accent-copper)] px-3.5 py-1.5 text-sm font-semibold text-black transition hover:opacity-90"
+              className="inline-flex items-center justify-center rounded-full border border-[color:var(--accent-copper,#C57A4A)]/45 bg-[linear-gradient(135deg,rgba(197,122,74,0.35),rgba(197,122,74,0.18))] px-3.5 py-1.5 text-sm font-semibold text-[color:var(--theme-text-primary,#E2E8F0)] transition hover:border-[color:var(--accent-copper,#C57A4A)]/65"
             >
               <span className="mr-1.5 text-base leading-none">+</span>
               New work order
@@ -744,7 +744,7 @@ export default function WorkOrdersView(): JSX.Element {
               void load();
               setAssignVersion((v) => v + 1);
             }}
-            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
+            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
           >
             Refresh
           </button>
@@ -814,7 +814,7 @@ export default function WorkOrdersView(): JSX.Element {
             return (
               <div
                 key={r.id}
-                className={`rounded-2xl border bg-[color:var(--desktop-item-bg)] p-4 backdrop-blur transition hover:bg-white/5 ${accent.border}`}
+                className={`rounded-2xl border bg-[color:var(--desktop-item-bg)] p-4 backdrop-blur transition hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_82%,black)] ${accent.border}`}
                 style={{
                   boxShadow:
                     "0 0 0 1px rgba(255,255,255,0.04) inset, 0 0 24px rgba(0,0,0,0.22)",
@@ -913,7 +913,7 @@ export default function WorkOrdersView(): JSX.Element {
                 <div className="mt-4 flex flex-wrap gap-2">
                   <Link
                     href={href}
-                    className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-white/10"
+                    className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
                   >
                     Open
                   </Link>
@@ -1003,7 +1003,7 @@ export default function WorkOrdersView(): JSX.Element {
 
                           <button
                             onClick={() => void handleAssignAll(r.id)}
-                            className="rounded-full bg-[var(--accent-copper)] px-3 py-1.5 text-xs font-semibold text-black transition hover:opacity-90"
+                            className="rounded-full border border-[color:var(--accent-copper,#C57A4A)]/45 bg-[linear-gradient(135deg,rgba(197,122,74,0.35),rgba(197,122,74,0.18))] px-3 py-1.5 text-xs font-semibold text-[color:var(--theme-text-primary,#E2E8F0)] transition hover:border-[color:var(--accent-copper,#C57A4A)]/65"
                           >
                             Apply
                           </button>
@@ -1013,7 +1013,7 @@ export default function WorkOrdersView(): JSX.Element {
                               setAssigningFor(null);
                               setSelectedTechId("");
                             }}
-                            className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-white/10"
+                            className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
                           >
                             Cancel
                           </button>

--- a/features/work-orders/components/MenuQuickAdd.tsx
+++ b/features/work-orders/components/MenuQuickAdd.tsx
@@ -603,13 +603,13 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
 
   const currency: "CAD" | "USD" = shopDefaults?.country === "CA" ? "CAD" : "USD";
   const panelClass =
-    "rounded-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
   const chipClass =
-    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_68%,transparent)] px-2 py-0.5 text-[10px] text-neutral-300";
+    "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-0.5 text-[10px] text-neutral-300";
   const itemCardClass =
-    "flex flex-col rounded-lg border border-white/10 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_70%,transparent)] p-3 text-left text-sm hover:border-[color:var(--accent-copper,#C57A4A)]/50 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_63%,transparent)] disabled:opacity-60";
+    "flex flex-col rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-left text-sm hover:border-sky-400/45 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_82%,black)] disabled:opacity-60";
   const softActionClass =
-    "rounded-md border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1.5 text-xs sm:text-sm text-neutral-100 hover:border-[color:var(--accent-copper,#C57A4A)]/55 hover:bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_60%,transparent)]";
+    "rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs sm:text-sm text-neutral-100 hover:border-sky-400/55 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]";
 
   return (
     <div className="space-y-5 text-white">
@@ -708,14 +708,14 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
               value={menuQuery}
               onChange={(e) => setMenuQuery(e.target.value)}
               placeholder="Search menu items (e.g. brakes, alignment, oil)…"
-              className="w-full sm:w-[320px] rounded-md border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1.5 text-xs sm:text-sm text-white placeholder:text-neutral-500 focus:border-[color:var(--accent-copper,#C57A4A)] focus:outline-none"
+              className="w-full sm:w-[320px] rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-xs sm:text-sm text-white placeholder:text-neutral-500 focus:border-sky-400/70 focus:outline-none"
             />
             <label className="flex items-center gap-2 text-[11px] text-neutral-300">
               <input
                 type="checkbox"
                 checked={includeGlobal}
                 onChange={(e) => setIncludeGlobal(e.target.checked)}
-                className="h-4 w-4 rounded border-white/20 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_64%,transparent)]"
+                className="h-4 w-4 rounded border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]"
               />
               Include global services
             </label>
@@ -758,7 +758,7 @@ export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
                         GLOBAL
                       </span>
                     ) : (
-                      <span className="ml-2 rounded-full border border-orange-500/60 bg-orange-500/10 px-2 py-0.5 text-[10px] text-orange-200">
+                      <span className="ml-2 rounded-full border border-cyan-500/60 bg-cyan-500/10 px-2 py-0.5 text-[10px] text-cyan-100">
                         FIT
                       </span>
                     )}

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -106,11 +106,11 @@ export function NewWorkOrderLineForm(props: {
   const canSave = (lineType === "info" ? infoTitle.length > 0 : complaint.trim().length > 0) && !!workOrderId;
   const topRepairDefault = isTopRepairDefault(smartMatch);
   const formShellClass =
-    "rounded-xl border border-white/12 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_74%,transparent)] p-4 text-sm text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] sm:p-5";
+    "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 text-sm text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] sm:p-5";
   const controlClass =
-    "w-full rounded-md border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-[color:var(--accent-copper,#C57A4A)] focus:outline-none";
+    "w-full rounded-md border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-sky-400/70 focus:outline-none";
   const mutedPillClass =
-    "rounded-full border border-white/15 bg-[color:color-mix(in_srgb,var(--theme-card-bg,#111827)_66%,transparent)] px-3 py-1 text-[10px] text-neutral-300";
+    "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-[10px] text-neutral-300";
 
   function normalizeJobType(t: WOJobType | null): InsertLine["job_type"] {
     const allowed: WOJobType[] = [
@@ -268,7 +268,7 @@ export function NewWorkOrderLineForm(props: {
       return "border-emerald-500/40 bg-emerald-500/10 text-emerald-200";
     }
     if (status === "stale") {
-      return "border-amber-500/40 bg-amber-500/10 text-amber-200";
+      return "border-slate-500/40 bg-slate-500/10 text-slate-200";
     }
     return "border-red-500/40 bg-red-500/10 text-red-200";
   }
@@ -717,7 +717,7 @@ export function NewWorkOrderLineForm(props: {
         <button
           disabled={!canSave || busy}
           onClick={addLine}
-          className="btn btn-orange px-4 py-1.5 text-xs font-semibold disabled:opacity-60"
+          className="rounded-full border border-[color:var(--accent-copper,#C57A4A)]/45 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.14))] px-4 py-1.5 text-xs font-semibold text-[color:var(--theme-text-primary,#E2E8F0)] transition hover:border-[color:var(--accent-copper,#C57A4A)]/65 hover:bg-[linear-gradient(135deg,rgba(197,122,74,0.36),rgba(197,122,74,0.2))] disabled:opacity-60"
         >
           {busy
             ? "Adding…"

--- a/features/work-orders/quote-review/LearnedSuggestionCard.tsx
+++ b/features/work-orders/quote-review/LearnedSuggestionCard.tsx
@@ -23,10 +23,10 @@ export default function LearnedSuggestionCard(props: {
   const { suggestion, onApplyLabor, onAddAsJob, onDismiss } = props;
 
   return (
-    <div className="rounded-xl border border-slate-300/15 bg-slate-950/55 px-3 py-2.5">
+    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] px-3 py-2.5">
       <div className="flex flex-wrap items-start justify-between gap-2.5">
         <div className="min-w-0">
-          <div className="text-[11px] font-medium text-slate-200">
+          <div className="text-[11px] font-medium text-neutral-200">
             Suggested from prior similar jobs
             {suggestion.sourceCount > 0 ? ` • ${suggestion.sourceCount} similar` : ""}
             {suggestion.laborHours != null ? ` • ${suggestion.laborHours}h labor` : ""}
@@ -34,14 +34,14 @@ export default function LearnedSuggestionCard(props: {
 
           <div className="mt-1 truncate text-sm font-semibold text-white">{suggestion.title}</div>
           {suggestion.summary ? (
-            <details className="mt-1 text-[11px] text-slate-300/90">
-              <summary className="cursor-pointer text-slate-400 hover:text-slate-200">
+            <details className="mt-1 text-[11px] text-neutral-300/90">
+              <summary className="cursor-pointer text-neutral-400 hover:text-neutral-200">
                 Details
               </summary>
               <div className="mt-1">{suggestion.summary}</div>
             </details>
           ) : null}
-          <div className="mt-1 flex flex-wrap gap-3 text-[11px] text-slate-400">
+          <div className="mt-1 flex flex-wrap gap-3 text-[11px] text-neutral-400">
             {suggestion.parts.length > 0 ? <span>Parts: {partsLabel(suggestion.parts)}</span> : null}
             {suggestion.confidence != null ? (
               <span>
@@ -68,7 +68,7 @@ export default function LearnedSuggestionCard(props: {
           <button
             type="button"
             onClick={onAddAsJob}
-            className="rounded-full border border-white/10 bg-slate-900/70 px-3 py-1 text-xs font-semibold text-white hover:bg-slate-900"
+            className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-xs font-semibold text-white hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_82%,black)]"
           >
             Add as line
           </button>
@@ -76,7 +76,7 @@ export default function LearnedSuggestionCard(props: {
           <button
             type="button"
             onClick={onDismiss}
-            className="rounded-full border border-white/10 bg-black/35 px-3 py-1 text-xs text-neutral-300 hover:bg-black/50"
+            className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1 text-xs text-neutral-300 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"
           >
             Dismiss
           </button>

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -1031,7 +1031,7 @@ export default function QuoteReviewView(props: {
                   No lines yet.
                 </div>
               ) : (
-                <div className="divide-y divide-white/10">
+                <div className="divide-y divide-[color:var(--desktop-border)]">
                   {lines.map((l) => {
                     const la = lineAllocs.get(l.id) ?? [];
                     const laborHours = typeof l.labor_time === "number" ? l.labor_time : 0;


### PR DESCRIPTION
### Motivation
- Finish a deep UI/theme pass so page bodies and their nested components read as a single coherent dashboard surface rather than feature-local visual islands. 
- Apply the dashboard dark-navy/cool-accent contract across the requested Work Orders, Parts, and Billing areas without changing behavior, API, or workflows. 
- Follow the component tree downward (headers, toolbars, cards, lists, forms, drawers, pills, empty/loading states) so the pages feel visually complete. 

### Description
- Theme tokens and panel/input/button classes were aligned to the dashboard variables (e.g. `--desktop-border`, `--desktop-item-bg`, `--desktop-panel-bg-soft`, cool accent/focus rings) and warm/hazy styles were removed across Work Orders, Parts, and Billing surfaces. 
- Work Orders: migrated page + nested components so the create flow reads as one surface and the view/history/detail flows use consistent shells; files changed include `features/work-orders/app/work-orders/create/page.tsx`, `features/work-orders/app/work-orders/view/page.tsx`, `features/work-orders/components/MenuQuickAdd.tsx`, `features/work-orders/components/NewWorkOrderLineForm.tsx`, `features/work-orders/quote-review/QuoteReviewView.tsx`, `features/work-orders/quote-review/LearnedSuggestionCard.tsx`, `features/inspections/components/inspection/CustomerVehicleForm.tsx`, `features/maintenance/components/CreateFlowMaintenanceSelector.tsx`, and `app/vehicle/VinCaptureModal.tsx`. 
- Parts: updated requests, request-detail component shells, and inventory input/controls to match the dashboard theme; files changed include `app/parts/requests/page.tsx`, `app/parts/requests/[id]/page.tsx`, `app/parts/requests/[id]/request-detail-components.tsx`, and `app/parts/inventory/page.tsx`. 
- Billing: adjusted major visible action surfaces/secondary button hover treatment for dashboard consistency in `app/billing/page.tsx`, and made no functional changes anywhere in the codebase. 

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully. 
- Lint: ran `npm run lint` which surfaced pre-existing repo-wide issues; the lint run failed (repo has existing lint errors/warnings outside the scope of this UI/theme pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e3e19b648328b68db3227f0da9ea)