### PR TITLE
Deepen themed migration for Work Orders, Parts Requests, and Billing pages

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -318,9 +318,9 @@ export default function BillingPage(): JSX.Element {
   );
 
   return (
-    <div className="mx-auto max-w-7xl space-y-6 bg-background px-4 py-6 text-foreground">
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 text-foreground">
       <section className="overflow-hidden rounded-[28px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_0_50px_rgba(2,6,23,0.55)]">
-        <div className="border-b border-[color:var(--desktop-border)] px-5 py-5 sm:px-6">
+        <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(56,189,248,0.12),rgba(15,23,42,0.03))] px-5 py-5 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
@@ -469,7 +469,7 @@ export default function BillingPage(): JSX.Element {
               <div
                 key={r.id}
                 className={[
-                  "overflow-hidden rounded-[24px] border bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(255,255,255,0.01))] shadow-[0_0_40px_rgba(0,0,0,0.55)]",
+                  "overflow-hidden rounded-[24px] border bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] shadow-[0_20px_44px_rgba(2,6,23,0.58)]",
                   accent.border,
                 ].join(" ")}
               >
@@ -561,7 +561,7 @@ export default function BillingPage(): JSX.Element {
                     </div>
                   </div>
 
-                  <div className="mt-4 flex flex-wrap gap-2">
+                  <div className="mt-4 flex flex-wrap gap-2 border-t border-[color:var(--desktop-border)] pt-3">
                     <Link
                       href={href}
                       className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1.5 text-sm font-semibold text-neutral-100 transition hover:border-sky-400/60 hover:bg-[color:color-mix(in_srgb,var(--desktop-item-bg)_80%,black)]"

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -203,13 +203,13 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_12%,transparent)]";
   const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_35%,transparent)]";
 
-  const pageWrap = "space-y-3 p-4 text-white";
+  const pageWrap = "space-y-4 p-4 text-white";
   const glassCard =
     "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
   const glassHeader =
     "bg-[linear-gradient(180deg,rgba(148,163,184,0.08),rgba(15,23,42,0))] border-b border-[color:var(--desktop-border)]";
-  const inputBase = `rounded-lg border bg-neutral-950/40 px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
-  const selectBase = `rounded-lg border bg-neutral-950/40 px-2 py-2 text-xs text-white border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
+  const inputBase = `rounded-lg border bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white placeholder:text-neutral-500 border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
+  const selectBase = `rounded-lg border bg-[color:var(--desktop-item-bg)] px-2 py-2 text-xs text-white border-[color:var(--desktop-border)] focus:outline-none ${ACCENT_FOCUS_RING}`;
 
   const btnBase =
     "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm transition disabled:opacity-60";
@@ -1101,9 +1101,16 @@ if (!lineId || !isUuid(lineId)) {
 
   return (
     <div className={pageWrap}>
-      <button className={btnGhost} onClick={() => router.back()} type="button">
-        ← Back
-      </button>
+      <div className="sticky top-2 z-20 flex items-center justify-between gap-3 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)]/90 px-3 py-2 backdrop-blur">
+        <button className={btnGhost} onClick={() => router.back()} type="button">
+          ← Back
+        </button>
+        {woDisplay ? (
+          <div className="text-xs uppercase tracking-[0.16em] text-neutral-400">
+            Work order <span className="text-neutral-200">{woDisplay}</span>
+          </div>
+        ) : null}
+      </div>
 
       {loading ? (
         <div className={`${glassCard} p-4 text-neutral-300`}>Loading…</div>
@@ -1229,7 +1236,25 @@ if (!lineId || !isUuid(lineId)) {
                       </div>
                     </div>
 
-                    <div className="p-3 space-y-3">
+                    <div className="space-y-3 p-3">
+                      <div className="grid gap-2 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-xs text-neutral-400 md:grid-cols-3">
+                        <div>
+                          Request state:{" "}
+                          <span className="font-semibold text-neutral-200">
+                            {requestFlowLabel(requestState)}
+                          </span>
+                        </div>
+                        <div>
+                          Items:{" "}
+                          <span className="font-semibold text-neutral-200">{r.items.length}</span>
+                        </div>
+                        <div>
+                          Linked line:{" "}
+                          <span className="font-semibold text-neutral-200">
+                            {hasValidLineId ? lineId?.slice(0, 8) : "Not linked"}
+                          </span>
+                        </div>
+                      </div>
                       <RequestItemsTable>
                         <table className="w-full text-sm">
                           <thead className="bg-[color:var(--desktop-item-bg)] text-neutral-400">
@@ -1382,7 +1407,7 @@ if (!lineId || !isUuid(lineId)) {
                                           </div>
                                         ) : null}
                                         {trustMeta && trustMeta.reasons.length > 0 ? (
-                                          <div className="text-[11px] text-[rgba(242,210,187,0.94)]">
+                                          <div className="text-[11px] text-[var(--accent-copper-light)]/90">
                                             {trustMeta.reasons.slice(0, 2).join(" · ")}
                                           </div>
                                         ) : null}
@@ -1469,7 +1494,7 @@ if (!lineId || !isUuid(lineId)) {
                                           ))}
                                         </select>
 
-                                        <details className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2">
+                                        <details className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
                                           <summary className="cursor-pointer select-none text-xs text-neutral-300">
                                             Create PO for supplier
                                           </summary>

--- a/app/parts/requests/[id]/request-detail-components.tsx
+++ b/app/parts/requests/[id]/request-detail-components.tsx
@@ -6,9 +6,9 @@ import type { ReactNode } from "react";
 type Option = { value: string; label: string };
 
 const CARD =
-  "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
+  "rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_16px_42px_rgba(2,6,23,0.52)]";
 const SUBCARD =
-  "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]";
+  "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
 const INPUT =
   "w-72 rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-2 text-xs text-white focus:outline-none focus:ring-2 focus:ring-sky-500/30";
 const LINK_BTN =
@@ -55,7 +55,7 @@ export function RequestHeaderSection({
 }): JSX.Element {
   return (
     <div className={`${CARD} overflow-hidden`}>
-      <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(148,163,184,0.08),rgba(15,23,42,0))] px-4 py-3">
+      <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(56,189,248,0.12),rgba(15,23,42,0.02))] px-4 py-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="text-xl font-semibold tracking-wide text-white">{title}</div>
@@ -126,7 +126,7 @@ export function RequestReceivingPanel(): JSX.Element {
 
 export function RequestItemsTable({ children }: { children: ReactNode }): JSX.Element {
   return (
-    <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
+    <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
       {children}
     </div>
   );

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -112,10 +112,10 @@ export default function PartsRequestsPage(): JSX.Element {
   const ACCENT_HOVER_BG = "hover:bg-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_12%,transparent)]";
   const ACCENT_FOCUS_RING = "focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-accent,#38bdf8)_35%,transparent)]";
 
-  const PAGE = "w-full px-3 py-4 text-white sm:px-5 lg:px-8 xl:px-12";
+  const PAGE = "w-full space-y-4 px-3 py-4 text-white sm:px-5 lg:px-8 xl:px-12";
   const CARD =
     "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] backdrop-blur-xl shadow-[0_0_0_1px_rgba(255,255,255,0.03)_inset]";
-  const CARD_PAD = `${CARD} p-3`;
+  const CARD_PAD = `${CARD} p-4`;
   const INPUT = `w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none ${ACCENT_FOCUS_RING}`;
   const SELECT = `w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white focus:outline-none ${ACCENT_FOCUS_RING}`;
   const BTN_BASE =
@@ -428,8 +428,10 @@ export default function PartsRequestsPage(): JSX.Element {
 
   return (
     <div className={PAGE}>
-      <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div>
+      <section className="overflow-hidden rounded-[28px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_24px_60px_rgba(2,6,23,0.62)]">
+        <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(56,189,248,0.12),rgba(15,23,42,0.02))] px-4 py-5 sm:px-6">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
           <div className="text-[11px] uppercase tracking-[0.22em] text-neutral-400">
             Parts
           </div>
@@ -443,68 +445,70 @@ export default function PartsRequestsPage(): JSX.Element {
             One card per work order. Completion % is based on items with part + qty
             + price.
           </p>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Link href="/parts" className={BTN_ACCENT}>
-            Parts Dashboard
-          </Link>
-          <button
-            type="button"
-            className={BTN_GHOST}
-            onClick={() => void reload()}
-          >
-            Refresh
-          </button>
-        </div>
-      </div>
-
-      <div className={`${CARD_PAD} mb-4 space-y-3`}>
-        <div className="grid gap-3 md:grid-cols-12 md:items-center">
-          <div className="md:col-span-5">
-            <div className="mb-1 text-xs text-neutral-400">
-              Search (WO#, customer, vehicle, request id, part description)
             </div>
-            <input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search…"
-              className={INPUT}
-            />
-          </div>
 
-          <div className="md:col-span-4">
-            <div className="mb-1 text-xs text-neutral-400">Status</div>
-            <select
-              className={SELECT}
-              value={statusFilter}
-              onChange={(e) =>
-                setStatusFilter((e.target.value as typeof statusFilter) ?? "all")
-              }
-            >
-              <option value="all">All</option>
-              <option value="pending">Pending</option>
-              <option value="in_progress">In Progress</option>
-              <option value="ready">Ready</option>
-              <option value="complete">Complete</option>
-            </select>
-          </div>
-
-          <div className="md:col-span-3">
-            <div className="mb-1 text-xs text-neutral-400">Showing</div>
-            <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-neutral-200">
-              <span className="font-semibold text-white">{filtered.length}</span>{" "}
-              work order{filtered.length === 1 ? "" : "s"}
+            <div className="flex flex-wrap gap-2">
+              <Link href="/parts" className={BTN_ACCENT}>
+                Parts Dashboard
+              </Link>
+              <button
+                type="button"
+                className={BTN_GHOST}
+                onClick={() => void reload()}
+              >
+                Refresh
+              </button>
             </div>
           </div>
         </div>
-      </div>
+
+        <div className="px-4 py-4 sm:px-6">
+          <div className="grid gap-3 md:grid-cols-12 md:items-end">
+            <div className="md:col-span-6">
+              <div className="mb-1 text-xs uppercase tracking-[0.18em] text-neutral-400">
+                Search queue
+              </div>
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="WO#, customer, vehicle, request id, part description…"
+                className={INPUT}
+              />
+            </div>
+
+            <div className="md:col-span-3">
+              <div className="mb-1 text-xs uppercase tracking-[0.18em] text-neutral-400">Flow state</div>
+              <select
+                className={SELECT}
+                value={statusFilter}
+                onChange={(e) =>
+                  setStatusFilter((e.target.value as typeof statusFilter) ?? "all")
+                }
+              >
+                <option value="all">All</option>
+                <option value="pending">Pending</option>
+                <option value="in_progress">In Progress</option>
+                <option value="ready">Ready</option>
+                <option value="complete">Complete</option>
+              </select>
+            </div>
+
+            <div className="md:col-span-3">
+              <div className="mb-1 text-xs uppercase tracking-[0.18em] text-neutral-400">Visible cards</div>
+              <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-neutral-200">
+                <span className="font-semibold text-white">{filtered.length}</span>{" "}
+                work order{filtered.length === 1 ? "" : "s"}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
       {loading ? (
-        <div className={`${CARD_PAD} text-sm text-neutral-300`}>Loading…</div>
+        <div className={`${CARD_PAD} text-sm text-neutral-300`}>Loading active request buckets…</div>
       ) : filtered.length === 0 ? (
-        <div className={`${CARD_PAD} text-sm text-neutral-400`}>
-          No active parts requests.
+        <div className={`${CARD_PAD} border-dashed text-sm text-neutral-400`}>
+          No active parts requests match this filter.
         </div>
       ) : (
         <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
@@ -557,21 +561,21 @@ export default function PartsRequestsPage(): JSX.Element {
                   <span className={pillFor(b.status)}>{labelFor(b.status)}</span>
                 </div>
 
-                <div className="mt-3">
+                <div className="mt-4">
                   <div className="flex items-center justify-between text-[11px] text-neutral-400">
                     <span>Completion</span>
                     <span className={ACCENT_TEXT}>{b.completionPct}%</span>
                   </div>
-                  <div className="mt-1 h-2 w-full overflow-hidden desktop-pill">
+                  <div className="mt-1 h-2 w-full overflow-hidden rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
                     <div
-                      className="h-full rounded-full bg-white/20"
+                      className="h-full rounded-full bg-[linear-gradient(90deg,rgba(56,189,248,0.45),rgba(197,122,74,0.65))]"
                       style={{ width: `${b.completionPct}%` }}
                       aria-hidden="true"
                     />
                   </div>
                 </div>
 
-                <div className="mt-3 flex flex-wrap justify-end gap-2">
+                <div className="mt-4 flex flex-wrap justify-end gap-2 border-t border-[color:var(--desktop-border)] pt-3">
                   <button
                     type="button"
                     className={BTN_DANGER}

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -243,39 +243,42 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
 
   return (
     <div className="min-h-[calc(100vh-4rem)] desktop-backdrop px-4 py-6 text-white">
-      <div className="mx-auto max-w-6xl desktop-panel px-4 py-5 sm:px-6 sm:py-6">
+      <div className="mx-auto max-w-6xl space-y-4">
         {/* Header */}
-        <div className="mb-5 flex flex-wrap items-center gap-3">
-          <div className="space-y-1">
-            <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1">
-              <span className="text-[0.7rem] font-blackops uppercase tracking-[0.22em] text-neutral-200">
-                Work Order History
-              </span>
-            </div>
-            <p className="text-xs text-neutral-400">
-              All work orders for your shop (any status). Search, filter by date, export for reporting.
-            </p>
-          </div>
-
-          <div className="ml-auto text-right text-xs text-neutral-400">
-            <div>
-              <span className="font-mono text-sm font-semibold text-cyan-300">
-                {rows.length.toString().padStart(2, "0")}
-              </span>{" "}
-              <span className="uppercase tracking-[0.14em] text-neutral-500">Loaded</span>
-            </div>
-            {from || to ? (
-              <div className="mt-0.5 font-mono text-[11px] text-neutral-500">
-                Range: {from || "…"} → {to || "…"}
+        <section className="overflow-hidden rounded-[26px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_18px_48px_rgba(2,6,23,0.58)]">
+          <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(56,189,248,0.1),rgba(15,23,42,0.02))] px-4 py-4 sm:px-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="space-y-1">
+                <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-1">
+                  <span className="text-[0.7rem] font-blackops uppercase tracking-[0.22em] text-neutral-200">
+                    Work Order History
+                  </span>
+                </div>
+                <p className="text-xs text-neutral-400">
+                  All work orders for your shop (any status). Search, filter by date, export for reporting.
+                </p>
               </div>
-            ) : (
-              <div className="mt-0.5 text-[11px] text-neutral-500">Showing last {rows.length} records loaded</div>
-            )}
+
+              <div className="ml-auto text-right text-xs text-neutral-400">
+                <div>
+                  <span className="font-mono text-sm font-semibold text-cyan-300">
+                    {rows.length.toString().padStart(2, "0")}
+                  </span>{" "}
+                  <span className="uppercase tracking-[0.14em] text-neutral-500">Loaded</span>
+                </div>
+                {from || to ? (
+                  <div className="mt-0.5 font-mono text-[11px] text-neutral-500">
+                    Range: {from || "…"} → {to || "…"}
+                  </div>
+                ) : (
+                  <div className="mt-0.5 text-[11px] text-neutral-500">Showing last {rows.length} records loaded</div>
+                )}
+              </div>
+            </div>
           </div>
-        </div>
 
         {/* Filters bar */}
-        <div className="mb-5 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)] sm:p-4">
+        <div className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] sm:p-4">
           <div className="flex flex-wrap items-end gap-3">
             <div className="min-w-[220px] flex-1">
               <label className="mb-1 block text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-400">
@@ -337,6 +340,9 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
             </div>
           </div>
         </div>
+        </section>
+
+        <section className="desktop-panel px-4 py-5 sm:px-6 sm:py-6">
 
         {/* Error */}
         {err && (
@@ -440,6 +446,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
             })}
           </div>
         )}
+        </section>
       </div>
     </div>
   );

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -647,7 +647,8 @@ export default function WorkOrdersView(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 text-foreground">
-      <section className="rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 backdrop-blur md:p-5">
+      <section className="overflow-hidden rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_22px_52px_rgba(2,6,23,0.58)]">
+        <div className="bg-[linear-gradient(180deg,rgba(56,189,248,0.1),rgba(15,23,42,0.02))] p-4 md:p-5">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
@@ -688,7 +689,7 @@ export default function WorkOrdersView(): JSX.Element {
           <div className="flex flex-wrap items-center gap-3">
             <Link
               href="/assistant?pageType=work_orders&pageTitle=Work%20Orders"
-              className="inline-flex items-center justify-center rounded-full border border-[rgba(200,122,67,0.55)] bg-[rgba(200,122,67,0.16)] px-3.5 py-1.5 text-sm font-semibold text-[rgba(246,224,207,0.96)] transition hover:bg-[rgba(200,122,67,0.22)]"
+              className="inline-flex items-center justify-center rounded-full border border-[var(--accent-copper-light)]/35 bg-[var(--accent-copper)]/15 px-3.5 py-1.5 text-sm font-semibold text-[var(--accent-copper-light)] transition hover:bg-[var(--accent-copper)]/22"
             >
               Ask Assistant
             </Link>
@@ -709,9 +710,10 @@ export default function WorkOrdersView(): JSX.Element {
             </Link>
           </div>
         </div>
+        </div>
       </section>
 
-      <section className="rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 backdrop-blur">
+      <section className="rounded-3xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 backdrop-blur shadow-[0_16px_36px_rgba(2,6,23,0.5)]">
         <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto]">
           <input
             value={q}


### PR DESCRIPTION
### Motivation
- Finish the visual migration for the targeted flows so each page body and its major component tree read as a single, cohesive dashboard-themed surface rather than token-level wrappers. 
- Align the Work Orders, Parts Requests (list + detail), and Billing surfaces to the dashboard theme (dark navy panels, cool gradients, thin soft borders, low-noise cards, and copper primary accents) without changing business logic or data flows.

### Description
- Upgraded page-level header bands, section containers, toolbars, search/filter rows, card shells, progress rails, nested table/detail shells, sticky action strip, and action rails across the targeted areas to complete the visual migration. 
- Files changed: `app/billing/page.tsx`, `app/parts/requests/page.tsx`, `app/parts/requests/[id]/page.tsx`, `app/parts/requests/[id]/request-detail-components.tsx`, `app/work-orders/history/WorkOrdersHistoryClient.tsx`, and `features/work-orders/app/work-orders/view/page.tsx`. 
- Nested components updated: request detail header and panels in `app/parts/requests/[id]/request-detail-components.tsx` and the request detail page shell in `app/parts/requests/[id]/page.tsx`. 
- Visible body sections migrated include page header band, section headers, toolbars/action rows, search/filter rows, cards, nested list/row shells, detail panels, table shells, progress bars, pills/chips, empty/loading states, and sticky CTA/action rails; no API, workflow, or data logic was intentionally changed and the dashboard and work-order-client job cards were left untouched.

### Testing
- Ran type-checking with `npx tsc --noEmit`, which completed successfully. 
- No other automated tests were added or run as part of this surface-only migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e97d9f2083289d4bd065d177ea40)