### PR TITLE
Fix Next.js dynamic params typing in Shopreel draft PATCH route

### DIFF
--- a/app/api/shopreel/drafts/[id]/route.ts
+++ b/app/api/shopreel/drafts/[id]/route.ts
@@ -4,7 +4,11 @@ import { SHOPREEL_DRAFT_STATUSES } from "@/features/integrations/shopreel/types"
 
 const STATUS_SET = new Set<string>(SHOPREEL_DRAFT_STATUSES);
 
-export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
   const context = await getOwnerShopContext();
 
   if ("error" in context) {
@@ -42,7 +46,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   const { error } = await scopedSupabase
     .from("shopreel_drafts")
     .update(patch)
-    .eq("id", params.id)
+    .eq("id", id)
     .eq("shop_id", shopId);
 
   if (error) {


### PR DESCRIPTION
### Motivation
- The Next.js build failed due to an invalid `PATCH` route export signature in `app/api/shopreel/drafts/[id]/route.ts`, so the handler was updated to match the current Next.js dynamic route handler docs and avoid relying on `RouteContext` or an unsupported second-argument shape.

### Description
- Updated `app/api/shopreel/drafts/[id]/route.ts` to use the supported signature `export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> })`, awaited `params` with `const { id } = await params`, and replaced direct `params.id` usages with the awaited `id` while leaving business/auth/Supabase/response logic unchanged.

### Testing
- Searched for the old invalid pattern with `rg --no-ignore -n "{\s*params\s*}:\s*{\s*params\s*:\s*{" app --glob '**/route.ts'` and only `app/api/shopreel/drafts/[id]/route.ts` matched; ran `pnpm build` which no longer surfaced the PATCH typing error but the overall build is currently blocked in this environment by external Google Fonts fetch failures (network) rather than by route-handler typings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ed27ad088328998598a6dc02acba)