### PR TITLE
Fix workforce navigation, appointments UUID mismatch, and targeted theme alignment

### DIFF
--- a/app/api/optimization/apply/route.ts
+++ b/app/api/optimization/apply/route.ts
@@ -55,6 +55,10 @@ function toNonEmptyString(value: unknown): string | null {
   return v.length > 0 ? v : null;
 }
 
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
 function safePayload(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   return value as Record<string, unknown>;
@@ -263,7 +267,8 @@ export async function POST(req: Request) {
 
     if (type === "inspection") {
       const templateRaw = safePayload(payload.inspectionTemplate);
-      const templateId = toNonEmptyString(templateRaw.templateId) ?? opportunity?.targetRefs?.inspectionTemplateId ?? null;
+      const rawTemplateId = toNonEmptyString(templateRaw.templateId) ?? opportunity?.targetRefs?.inspectionTemplateId ?? null;
+      const templateId = rawTemplateId && isUuid(rawTemplateId) ? rawTemplateId : null;
       const menuItemId = toNonEmptyString(payload.menuItemId) ?? opportunity?.targetRefs?.menuItemId ?? undefined;
       const templateName =
         toNonEmptyString(templateRaw.templateName) ||

--- a/app/dashboard/admin/employees/page.tsx
+++ b/app/dashboard/admin/employees/page.tsx
@@ -1,7 +1,7 @@
-import { redirect } from "next/navigation";
+import EmployeesClient from "@/features/dashboard/app/dashboard/admin/EmployeesClient";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
 export default async function Page() {
   await requireAdminPageAccess({ allow: ["owner", "admin"] });
-  redirect("/dashboard/admin/people?view=workforce");
+  return <EmployeesClient />;
 }

--- a/features/admin/components/InviteCandidatesList.tsx
+++ b/features/admin/components/InviteCandidatesList.tsx
@@ -34,12 +34,12 @@ const T = {
   glass:
     "bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02))] bg-black/35 backdrop-blur-md",
   glassStrong:
-    "bg-[radial-gradient(900px_520px_at_18%_0%,rgba(197,106,47,0.12),transparent_55%),linear-gradient(180deg,rgba(0,0,0,0.62),rgba(0,0,0,0.42))] backdrop-blur-md",
+    "bg-[radial-gradient(900px_520px_at_18%_0%,rgba(56,189,248,0.08),transparent_55%),linear-gradient(180deg,rgba(2,6,23,0.92),rgba(2,6,23,0.72))] backdrop-blur-md",
   shadow: "shadow-[0_18px_40px_rgba(0,0,0,0.85)]",
   panel: "rounded-2xl border",
   label: "block text-[0.7rem] uppercase tracking-[0.12em] text-neutral-400",
   input:
-    "w-full rounded-md border bg-black/50 px-3 py-2 text-sm text-neutral-100 outline-none transition " +
+    "w-full rounded-md border bg-slate-950/70 px-3 py-2 text-sm text-neutral-100 outline-none transition " +
     "placeholder:text-neutral-500 focus:ring-1 focus:ring-[color:var(--accent-copper-soft,#e7a36c)] " +
     "focus:border-[color:var(--accent-copper,#c56a2f)]",
   chip:

--- a/features/admin/components/UsersList.tsx
+++ b/features/admin/components/UsersList.tsx
@@ -141,7 +141,7 @@ export default function UsersList(): JSX.Element {
           title="Workflow Purpose"
           description="Users covers account governance. Use Employees for workforce posture and activity review."
           action={
-            <Link href="/dashboard/admin/employees" className="text-xs font-medium text-orange-300 hover:text-orange-200">
+            <Link href="/dashboard/admin/employees" className="text-xs font-medium text-[var(--accent-copper-soft)] hover:text-[var(--accent-copper)]">
               Open Employees →
             </Link>
           }
@@ -169,7 +169,7 @@ export default function UsersList(): JSX.Element {
         <AdminToolbar>
           <AdminField label="Search" className="flex-1">
             <input
-              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-orange-400/70"
+              className="w-full rounded-lg border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)]"
               placeholder="Search name, email, or phone…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -177,7 +177,7 @@ export default function UsersList(): JSX.Element {
           </AdminField>
           <AdminField label="Role" className="w-full md:w-52">
             <select
-              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-orange-400/70"
+              className="w-full rounded-lg border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-[var(--accent-copper-soft)]"
               value={roleFilter}
               onChange={(e) => setRoleFilter(e.target.value as UserRole | "all")}
             >
@@ -199,10 +199,10 @@ export default function UsersList(): JSX.Element {
           description="Edit or remove account records. Review role and identity context before changes."
           action={
             <div className="flex items-center gap-3 text-xs">
-              <Link href="/dashboard/admin/employees" className="font-medium text-orange-300 hover:text-orange-200">
+              <Link href="/dashboard/admin/employees" className="font-medium text-[var(--accent-copper-soft)] hover:text-[var(--accent-copper)]">
                 Workforce posture →
               </Link>
-              <Link href="/dashboard/admin/payroll-time" className="font-medium text-orange-300 hover:text-orange-200">
+              <Link href="/dashboard/admin/payroll-time" className="font-medium text-[var(--accent-copper-soft)] hover:text-[var(--accent-copper)]">
                 Payroll review →
               </Link>
             </div>

--- a/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
@@ -33,7 +33,7 @@ const CANONICAL_ADMIN_ROUTES = [
     nextStep: "Open person workspace and manage sections",
   },
   {
-    href: "/dashboard/admin/people?view=workforce",
+    href: "/dashboard/admin/employees",
     label: "Workforce Readiness View",
     description: "Filtered workforce posture view sourced from canonical People records.",
     nextStep: "Close onboarding/certification gaps",

--- a/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   AdminBadge,
   AdminEmptyState,
@@ -58,11 +59,19 @@ function certificationPosture(row: PersonRow) {
 }
 
 export default function PeoplePageClient() {
+  const searchParams = useSearchParams();
   const [rows, setRows] = useState<PersonRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive" | "on_leave">("all");
   const [actionFilter, setActionFilter] = useState<"all" | "needs_action" | "payroll_issues" | "cert_expiry">("all");
+
+  useEffect(() => {
+    const view = searchParams.get("view");
+    if (view === "workforce") {
+      setActionFilter("needs_action");
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     (async () => {

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -195,7 +195,7 @@ export default function PayrollTimeClient() {
           description="Payroll review stays aligned with employee identity/workforce posture."
         />
         <div className="flex flex-wrap items-center gap-3 p-4 text-xs">
-          <Link href="/dashboard/admin/people?view=workforce" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
+          <Link href="/dashboard/admin/employees" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
             Open People & Staff
           </Link>
           <Link href="/dashboard/admin/people" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -21,6 +21,10 @@ type CreatePayload = {
 };
 
 const COPPER = "#C57A4A";
+const PANEL_CLASS =
+  "rounded-2xl border border-[color:var(--metal-border-soft,#334155)] bg-[linear-gradient(180deg,rgba(2,6,23,0.92),rgba(2,6,23,0.8))] p-4 backdrop-blur-md shadow-[0_22px_60px_rgba(0,0,0,0.72)] sm:p-6";
+const INPUT_CLASS =
+  "w-full rounded-lg border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--metal-border-strong,#64748b)]";
 
 export default function CreateUserPage(): JSX.Element {
   const router = useRouter();
@@ -199,7 +203,7 @@ export default function CreateUserPage(): JSX.Element {
       {/* top 2-column content */}
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         {/* LEFT: create user */}
-        <div className="space-y-4 rounded-2xl border border-white/12 bg-black/25 p-4 backdrop-blur-md shadow-[0_28px_80px_rgba(0,0,0,0.85)] sm:p-6">
+        <div className={`space-y-4 ${PANEL_CLASS}`}>
           <div className="space-y-1">
             <h2 className="text-lg font-semibold text-white">New team member</h2>
             <p className="text-sm text-neutral-400">
@@ -247,7 +251,7 @@ export default function CreateUserPage(): JSX.Element {
                 Full name
               </label>
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="Full name"
                 value={form.full_name ?? ""}
                 onChange={(e) =>
@@ -261,7 +265,7 @@ export default function CreateUserPage(): JSX.Element {
                 Phone
               </label>
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="Phone"
                 value={form.phone ?? ""}
                 onChange={(e) => setForm({ ...form, phone: e.target.value })}
@@ -273,7 +277,7 @@ export default function CreateUserPage(): JSX.Element {
                 Username <span className="text-red-400">*</span>
               </label>
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="e.g. jsmith"
                 value={form.username}
                 onChange={(e) =>
@@ -290,7 +294,7 @@ export default function CreateUserPage(): JSX.Element {
                 Temporary password <span className="text-red-400">*</span>
               </label>
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="Temporary password"
                 type="password"
                 value={form.password}
@@ -307,7 +311,7 @@ export default function CreateUserPage(): JSX.Element {
                 Role
               </label>
               <select
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 value={form.role ?? ""}
                 onChange={(e) =>
                   setForm({ ...form, role: e.target.value as UserRole })
@@ -340,7 +344,7 @@ export default function CreateUserPage(): JSX.Element {
                 </span>
               </label>
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="Shop ID"
                 value={form.shop_id ?? ""}
                 onChange={(e) =>
@@ -380,7 +384,7 @@ export default function CreateUserPage(): JSX.Element {
         {/* RIGHT: recents + internal reset */}
         <div className="space-y-6">
           {/* recently created */}
-          <div className="rounded-2xl border border-white/12 bg-black/25 p-4 backdrop-blur-md shadow-[0_20px_50px_rgba(0,0,0,0.75)] sm:p-6">
+          <div className={PANEL_CLASS}>
             <h2 className="mb-2 text-lg font-semibold text-white">
               Recently created
             </h2>
@@ -393,7 +397,7 @@ export default function CreateUserPage(): JSX.Element {
                 {recentUsers.map((u) => (
                   <li
                     key={u.username}
-                    className="flex items-center justify-between gap-2 rounded-xl border border-white/8 bg-black/60 px-3 py-2"
+                    className="flex items-center justify-between gap-2 rounded-xl border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/75 px-3 py-2"
                   >
                     <div>
                       <div className="font-medium text-white">
@@ -403,7 +407,7 @@ export default function CreateUserPage(): JSX.Element {
                         @{u.username} • {u.role ?? "mechanic"}
                       </div>
                     </div>
-                    <span className="rounded-full border border-white/16 bg-black/60 px-2 py-0.5 text-[11px] text-neutral-200">
+                    <span className="rounded-full border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/75 px-2 py-0.5 text-[11px] text-neutral-200">
                       temp set
                     </span>
                   </li>
@@ -415,7 +419,7 @@ export default function CreateUserPage(): JSX.Element {
                 Latest person record:{" "}
                 <button
                   type="button"
-                  className="text-orange-300 hover:text-orange-200"
+                  className="text-[var(--accent-copper-soft)] hover:text-[var(--accent-copper)]"
                   onClick={() => router.push(`/dashboard/admin/people/${createdUserId}?from=create-user`)}
                 >
                   Open workspace
@@ -425,7 +429,7 @@ export default function CreateUserPage(): JSX.Element {
           </div>
 
           {/* reset */}
-          <div className="rounded-2xl border border-white/12 bg-black/25 p-4 backdrop-blur-md shadow-[0_20px_50px_rgba(0,0,0,0.75)] sm:p-6">
+          <div className={PANEL_CLASS}>
             <h2 className="mb-2 text-lg font-semibold text-white">
               Reset password (internal)
             </h2>
@@ -436,13 +440,13 @@ export default function CreateUserPage(): JSX.Element {
             </p>
             <div className="space-y-2 text-sm">
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="Username to reset"
                 value={resetUsername}
                 onChange={(e) => setResetUsername(e.target.value)}
               />
               <input
-                className="w-full rounded-lg border border-white/12 bg-black/60 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--accent-copper-soft)]"
+                className={INPUT_CLASS}
                 placeholder="New temporary password"
                 type="password"
                 value={resetPass}
@@ -465,7 +469,7 @@ export default function CreateUserPage(): JSX.Element {
       </div>
 
       {/* PENDING INVITES */}
-      <div className="mt-6 rounded-2xl border border-white/12 bg-black/25 p-4 backdrop-blur-md shadow-[0_24px_70px_rgba(0,0,0,0.85)] sm:p-6">
+      <div className={`mt-6 ${PANEL_CLASS}`}>
         <h2 className="mb-3 text-lg font-semibold text-white">Pending invites</h2>
         <p className="mb-3 text-xs text-neutral-500">
           These are staff invite candidates (imported or staged). Create the user + send the invite email.
@@ -474,7 +478,7 @@ export default function CreateUserPage(): JSX.Element {
       </div>
 
       {/* USERS LIST (full width, own card) */}
-      <div className="mt-6 rounded-2xl border border-white/12 bg-black/25 p-4 backdrop-blur-md shadow-[0_24px_70px_rgba(0,0,0,0.85)] sm:p-6">
+      <div className={`mt-6 ${PANEL_CLASS}`}>
         <h2 className="mb-3 text-lg font-semibold text-white">All users</h2>
         <p className="mb-3 text-xs text-neutral-500">
           This is the full list of users for your shop. New accounts appear here automatically.

--- a/features/inspections/app/inspection/custom-inspection/page.tsx
+++ b/features/inspections/app/inspection/custom-inspection/page.tsx
@@ -745,8 +745,8 @@ export default function CustomBuilderPage() {
   // copper: slightly muted, avoids neon/orange pop
   const COPPER = "rgba(224,174,130,0.88)";
   const COPPER_55 = "rgba(224,174,130,0.46)";
-  const COPPER_20 = "rgba(59,130,246,0.14)";
-  const COPPER_14 = "rgba(59,130,246,0.10)";
+  const COPPER_GLOW_20 = "rgba(224,174,130,0.20)";
+  const COOL_WASH_20 = "rgba(56,189,248,0.10)";
 
   const headerCard =
     "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
@@ -781,7 +781,7 @@ export default function CustomBuilderPage() {
   const primaryBtn =
     "rounded-full bg-[linear-gradient(to_right,rgba(200,122,67,0.85),rgba(200,122,67,0.55))] " +
     "px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-black " +
-    `shadow-[0_0_18px_${COPPER_20}] hover:shadow-[0_0_26px_${COPPER_20}] disabled:opacity-60`;
+    `shadow-[0_0_18px_${COPPER_GLOW_20}] hover:shadow-[0_0_26px_${COPPER_GLOW_20}] disabled:opacity-60`;
 
   return (
     <div className="px-4 py-6 text-white">
@@ -791,20 +791,12 @@ export default function CustomBuilderPage() {
           aria-hidden
           className={cx(
             "pointer-events-none fixed inset-0 -z-10",
-            `bg-[radial-gradient(circle_at_top,${COPPER_20},transparent_55%),radial-gradient(circle_at_bottom,rgba(15,23,42,0.96),#020617_78%)]`,
+            `bg-[radial-gradient(circle_at_top,${COOL_WASH_20},transparent_55%),radial-gradient(circle_at_bottom,rgba(15,23,42,0.96),#020617_78%)]`,
           )}
         />
 
         {/* Header */}
         <div className={headerCard + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
-          <div
-            aria-hidden
-            className={cx(
-              "pointer-events-none absolute inset-x-0 -top-10 h-24",
-              `bg-[radial-gradient(circle_at_top,${COPPER_20},transparent_65%)]`,
-            )}
-          />
-
           <div className="relative flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div className="text-center md:text-left">
               <h1
@@ -947,14 +939,6 @@ export default function CustomBuilderPage() {
 
         {/* Quick build */}
         <div className={sectionCard + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
-          <div
-            aria-hidden
-            className={cx(
-              "pointer-events-none absolute inset-x-0 -top-10 h-20",
-              `bg-[radial-gradient(circle_at_top,${COPPER_14},transparent_70%)]`,
-            )}
-          />
-
           <div className="relative">
             <div className="mb-1 text-center text-sm font-semibold" style={{ color: COPPER }}>
               Quick Build
@@ -1025,14 +1009,6 @@ export default function CustomBuilderPage() {
 
         {/* Prompt build */}
         <div className={sectionCard + " relative overflow-hidden px-4 py-4 md:px-6 md:py-5"}>
-          <div
-            aria-hidden
-            className={cx(
-              "pointer-events-none absolute inset-x-0 -top-10 h-20",
-              `bg-[radial-gradient(circle_at_top,${COPPER_14},transparent_70%)]`,
-            )}
-          />
-
           <div className="relative">
             <div className="mb-1 text-center text-sm font-semibold" style={{ color: COPPER }}>
               Prompt Build

--- a/features/shared/components/RoleHubTiles/tiles.ts
+++ b/features/shared/components/RoleHubTiles/tiles.ts
@@ -228,7 +228,7 @@ export const TILES: Tile[] = [
     scopes: ["management", "all"],
   },
   {
-    href: "/dashboard/admin/people?view=workforce",
+    href: "/dashboard/admin/employees",
     title: "Workforce View",
     subtitle: "Filtered workforce readiness from People records",
     roles: ["owner", "admin"],

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -365,7 +365,7 @@ export const TILES: Tile[] = [
     section: "Admin",
   },
   {
-    href: "/dashboard/admin/people?view=workforce",
+    href: "/dashboard/admin/employees",
     title: "Workforce View",
     subtitle: "Workforce posture, onboarding, and payroll readiness filters",
     roles: ["owner", "admin"],


### PR DESCRIPTION
### Motivation
- Resolve functional breakages first: the Workforce View navigation button was not resolving to an actual rendered page and the Appointments flow raised a Postgres UUID parse error (`invalid input syntax for type uuid: "inspection:general_service"`).
- Finish a targeted theme migration so the Inspection Builder and Create User pages match the dashboard dark/cool styling and remove residual warm/orange haze without changing behavior.
- Keep changes narrowly scoped to routing, the appointments UUID source, and visual surface polish for the specified pages/components.

### Description
- Guard inspection template IDs before querying `inspection_templates` by adding an `isUuid()` validator and treating non-UUID symbolic keys as `null` so the apply flow falls back to creation/linkage paths; change made in `app/api/optimization/apply/route.ts` (normalize `rawTemplateId` → validate/`templateId`).
- Restore a proper rendered Workforce page and update navigation wiring by returning the `EmployeesClient` from `app/dashboard/admin/employees/page.tsx`, adding `?view=workforce` compatibility in `features/dashboard/app/dashboard/admin/PeoplePageClient.tsx`, and switching nav tiles/links to the canonical `/dashboard/admin/employees` route (updates in `features/shared/*` and `features/dashboard/*`).
- Finish targeted theme migration for the Inspection Builder by removing legacy radial warm-haze overlays and introducing a cool wash variable on the rendered body/panels while preserving all builder controls and behavior in `features/inspections/app/inspection/custom-inspection/page.tsx`.
- Align Create User surfaces and nested admin components with the dashboard theme by introducing `PANEL_CLASS`/`INPUT_CLASS` and updating nested lists and invite UIs to cool dark panels and thin borders while preserving all page behavior (`features/dashboard/app/dashboard/owner/create-user/page.tsx`, `features/admin/components/UsersList.tsx`, `features/admin/components/InviteCandidatesList.tsx`).
- Minor link/text polish across admin landing and payroll-time clients to point to the canonical employees route (files updated include `features/dashboard/app/dashboard/admin/AdminLandingClient.tsx` and `features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx`).

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully with no introduced type errors.
- No additional automated tests were present for the visual adjustments; changes were limited to markup/CSS classes and runtime-safe routing/validation logic only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e437285e708328883754f910355dd2)