### PR TITLE
Align custom inspection flow with dashboard visual contract

### DIFF
--- a/features/inspections/app/inspection/custom-draft/page.tsx
+++ b/features/inspections/app/inspection/custom-draft/page.tsx
@@ -887,11 +887,15 @@ export default function CustomDraftPage() {
 
   return (
     <div className="px-4 py-6 text-white">
-      <div className="mx-auto w-full max-w-6xl rounded-2xl border border-white/10 bg-black/75 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl md:p-6">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(96,165,250,0.1),transparent_48%),radial-gradient(circle_at_bottom,rgba(3,7,18,0.96),#020617_80%)]"
+      />
+      <div className="mx-auto w-full max-w-6xl rounded-2xl border border-[var(--metal-border-soft,#334155)] bg-[linear-gradient(180deg,rgba(6,10,18,0.94),rgba(2,6,14,0.98))] p-4 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl md:p-6">
         {/* Header */}
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
           <h1
-            className="text-xl font-bold tracking-[0.18em] text-orange-400 sm:text-2xl"
+            className="text-xl font-bold tracking-[0.18em] text-slate-100 sm:text-2xl"
             style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}
           >
             Template Draft (Editable)
@@ -900,14 +904,14 @@ export default function CustomDraftPage() {
           <button
             type="button"
             onClick={() => router.back()}
-            className="rounded-full border border-neutral-600 bg-black/60 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-800"
+            className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-slate-900/80"
           >
             ← Back
           </button>
         </div>
 
         {/* Summary strip */}
-        <div className="mb-5 rounded-2xl border border-white/10 bg-black/70 px-3 py-3 text-xs text-neutral-200 md:flex md:items-center md:justify-between md:px-4">
+        <div className="mb-5 rounded-2xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-3 text-xs text-neutral-200 md:flex md:items-center md:justify-between md:px-4">
           <div className="space-y-1 md:space-y-0 md:flex md:flex-wrap md:items-center md:gap-x-4 md:gap-y-1">
             <span className="inline-flex items-center gap-1.5">
               <span className="text-[10px] uppercase tracking-[0.16em] text-neutral-400">
@@ -922,7 +926,7 @@ export default function CustomDraftPage() {
               <span className="text-[10px] uppercase tracking-[0.16em] text-neutral-400">
                 Duty
               </span>
-              <span className="rounded-full bg-orange-500/10 px-2 py-1 text-[11px] font-semibold text-orange-300">
+              <span className="rounded-full bg-[rgba(176,141,112,0.16)] px-2 py-1 text-[11px] font-semibold text-[rgba(221,194,166,0.95)]">
                 {dutyLabel}
               </span>
             </span>
@@ -931,7 +935,7 @@ export default function CustomDraftPage() {
               <span className="text-[10px] uppercase tracking-[0.16em] text-neutral-400">
                 Corner Grid
               </span>
-              <span className="rounded-full bg-emerald-500/10 px-2 py-1 text-[11px] font-semibold text-emerald-300">
+              <span className="rounded-full bg-indigo-500/10 px-2 py-1 text-[11px] font-semibold text-indigo-300">
                 {gridModeLabel}
               </span>
             </span>
@@ -940,7 +944,7 @@ export default function CustomDraftPage() {
               <span className="text-[10px] uppercase tracking-[0.16em] text-neutral-400">
                 Batteries
               </span>
-              <span className="rounded-full bg-sky-500/10 px-2 py-1 text-[11px] font-semibold text-sky-300">
+              <span className="rounded-full bg-indigo-500/10 px-2 py-1 text-[11px] font-semibold text-indigo-300">
                 {batteryPresent ? "Battery grid present" : "No battery grid"}
               </span>
             </span>
@@ -965,15 +969,15 @@ export default function CustomDraftPage() {
 
         {/* ✅ Create Menu Item panel */}
         {showMenuCreate ? (
-          <div className="mb-5 rounded-2xl border border-orange-500/20 bg-neutral-950/85 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.9)]">
+          <div className="mb-5 rounded-2xl border border-[rgba(100,116,139,0.4)] bg-slate-950/80 p-4 shadow-[0_18px_45px_rgba(0,0,0,0.9)]">
             <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-              <div className="text-sm font-semibold text-orange-300">
+              <div className="text-sm font-semibold text-slate-200">
                 Create Menu Item from this Draft
               </div>
               <button
                 type="button"
                 onClick={() => setShowMenuCreate(false)}
-                className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-800"
+                className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-slate-900/80"
               >
                 Close
               </button>
@@ -985,7 +989,7 @@ export default function CustomDraftPage() {
                   Menu item name
                 </span>
                 <input
-                  className="w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                  className="w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
                   value={menuName}
                   onChange={(e) => setMenuName(e.target.value)}
                   placeholder="e.g. Vibration at 100 km/h diagnostic inspection"
@@ -999,7 +1003,7 @@ export default function CustomDraftPage() {
                 <input
                   type="text"
                   inputMode="decimal"
-                  className="w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                  className="w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
                   value={laborHoursInput}
                   placeholder="e.g. 1.50"
                   onChange={(e) => setLaborHoursInput(e.target.value)}
@@ -1017,7 +1021,7 @@ export default function CustomDraftPage() {
                 Description (optional)
               </span>
               <textarea
-                className="min-h-[72px] w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                className="min-h-[72px] w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
                 value={menuDescription}
                 onChange={(e) => setMenuDescription(e.target.value)}
                 placeholder="Customer-facing: what you’ll inspect, what’s included, evidence trail, etc."
@@ -1033,7 +1037,7 @@ export default function CustomDraftPage() {
                 type="button"
                 onClick={createMenuItemFromDraft}
                 disabled={creatingMenu}
-                className="rounded-full bg-[linear-gradient(to_right,var(--accent-copper-soft,#e17a3e),var(--accent-copper,#f97316))] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black shadow-[0_0_18px_rgba(212,118,49,0.35)] hover:brightness-110 disabled:opacity-60"
+                className="rounded-full bg-[linear-gradient(to_right,rgba(191,141,99,0.82),rgba(160,116,82,0.76))] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black shadow-[0_0_18px_rgba(176,141,112,0.22)] hover:brightness-110 disabled:opacity-60"
               >
                 {creatingMenu ? "Creating…" : "Create Menu Item"}
               </button>
@@ -1046,7 +1050,7 @@ export default function CustomDraftPage() {
           <label className="flex flex-col gap-1">
             <span className="text-sm text-neutral-300">Template name</span>
             <input
-              className="rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+              className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
@@ -1055,7 +1059,7 @@ export default function CustomDraftPage() {
           <label className="flex flex-col gap-1">
             <span className="text-sm text-neutral-300">Vehicle type</span>
             <select
-              className="rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+              className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
               value={vehicleType ?? ""}
               onChange={(e) =>
                 setVehicleType(e.target.value ? (e.target.value as VehicleType) : null)
@@ -1072,7 +1076,7 @@ export default function CustomDraftPage() {
           <label className="flex flex-col gap-1">
             <span className="text-sm text-neutral-300">Duty class</span>
             <select
-              className="rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+              className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
               value={dutyClass ?? ""}
               onChange={(e) =>
                 setDutyClass(e.target.value ? (e.target.value as DutyClass) : null)
@@ -1090,7 +1094,7 @@ export default function CustomDraftPage() {
             <input
               type="text"
               inputMode="decimal"
-              className="w-40 rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+              className="w-40 rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
               value={laborHoursInput}
               placeholder="e.g. 2.50"
               onChange={(e) => setLaborHoursInput(e.target.value)}
@@ -1105,9 +1109,9 @@ export default function CustomDraftPage() {
 
         {/* Master section picker */}
         {showSectionPicker ? (
-          <div className="mb-5 rounded-2xl border border-neutral-800 bg-neutral-950/85 p-3">
+          <div className="mb-5 rounded-2xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 p-3">
             <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-              <div className="text-sm font-semibold text-orange-300">
+              <div className="text-sm font-semibold text-slate-200">
                 Add Section from Master List
               </div>
               <button
@@ -1116,14 +1120,14 @@ export default function CustomDraftPage() {
                   setShowSectionPicker(false);
                   setSectionSearch("");
                 }}
-                className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-800"
+                className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-slate-900/80"
               >
                 Close
               </button>
             </div>
 
             <input
-              className="mb-3 w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+              className="mb-3 w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
               placeholder="Search sections…"
               value={sectionSearch}
               onChange={(e) => setSectionSearch(e.target.value)}
@@ -1139,14 +1143,14 @@ export default function CustomDraftPage() {
                     setShowSectionPicker(false);
                     setSectionSearch("");
                   }}
-                  className="rounded-xl border border-neutral-800 bg-black/60 px-3 py-2 text-left text-sm text-neutral-100 hover:bg-black/70"
+                  className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-2 text-left text-sm text-neutral-100 hover:bg-slate-900/80"
                   title="Add section"
                 >
                   {t}
                 </button>
               ))}
               {filteredMasterSectionTitles.length > 60 ? (
-                <div className="rounded-xl border border-neutral-800 bg-black/30 px-3 py-2 text-xs text-neutral-400">
+                <div className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/40 px-3 py-2 text-xs text-neutral-400">
                   Showing first 60 results — refine your search to narrow down.
                 </div>
               ) : null}
@@ -1179,16 +1183,16 @@ export default function CustomDraftPage() {
             return (
               <div
                 key={`${sec.title}-${i}`}
-                className="rounded-2xl border border-neutral-800 bg-neutral-950/85 p-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)]"
+                className="rounded-2xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 p-3 shadow-[0_18px_45px_rgba(0,0,0,0.9)]"
               >
                 {/* Section header */}
                 <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="rounded-full bg-orange-500/15 px-2 py-[2px] text-[10px] font-semibold uppercase tracking-[0.16em] text-orange-300">
+                    <span className="rounded-full bg-slate-800/80 px-2 py-[2px] text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-200">
                       Section {i + 1}
                     </span>
                     <input
-                      className="min-w-[220px] max-w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-1.5 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                      className="min-w-[220px] max-w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-1.5 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
                       value={sec.title}
                       onChange={(e) => updateSectionTitle(i, e.target.value)}
                       placeholder="Section title"
@@ -1202,7 +1206,7 @@ export default function CustomDraftPage() {
                     <button
                       type="button"
                       onClick={() => moveSection(i, -1)}
-                      className="rounded-full border border-neutral-700 bg-black/60 px-2.5 py-1 text-[11px] text-neutral-200 hover:bg-neutral-800 disabled:opacity-40"
+                      className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-2.5 py-1 text-[11px] text-neutral-200 hover:bg-slate-900/80 disabled:opacity-40"
                       disabled={i === 0}
                       title="Move up"
                     >
@@ -1211,7 +1215,7 @@ export default function CustomDraftPage() {
                     <button
                       type="button"
                       onClick={() => moveSection(i, +1)}
-                      className="rounded-full border border-neutral-700 bg-black/60 px-2.5 py-1 text-[11px] text-neutral-200 hover:bg-neutral-800 disabled:opacity-40"
+                      className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-2.5 py-1 text-[11px] text-neutral-200 hover:bg-slate-900/80 disabled:opacity-40"
                       disabled={i === sections.length - 1}
                       title="Move down"
                     >
@@ -1220,7 +1224,7 @@ export default function CustomDraftPage() {
                     <button
                       type="button"
                       onClick={() => removeSection(i)}
-                      className="rounded-full border border-red-600 bg-red-900/30 px-3 py-1 text-[11px] font-semibold text-red-300 hover:bg-red-900/60"
+                      className="rounded-full border border-red-500/60 bg-red-950/30 px-3 py-1 text-[11px] font-semibold text-red-300 hover:bg-red-900/60"
                       title="Remove section"
                     >
                       Remove
@@ -1242,7 +1246,7 @@ export default function CustomDraftPage() {
                           setCustomItemText("");
                         }
                       }}
-                      className="rounded-full bg-neutral-800 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-100 hover:bg-neutral-700"
+                      className="rounded-full bg-slate-800 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-100 hover:bg-slate-700"
                     >
                       + Add Item
                     </button>
@@ -1250,7 +1254,7 @@ export default function CustomDraftPage() {
                     <button
                       type="button"
                       onClick={() => addItemBlank(i)}
-                      className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-800"
+                      className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-slate-900/80"
                       title="Add a blank item field"
                     >
                       Add blank
@@ -1264,15 +1268,15 @@ export default function CustomDraftPage() {
                   </div>
 
                   {addPanelOpen ? (
-                    <div className="mt-3 rounded-2xl border border-neutral-800 bg-black/40 p-3">
+                    <div className="mt-3 rounded-2xl border border-neutral-800 bg-slate-950/50 p-3">
                       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                        <div className="text-sm font-semibold text-orange-300">
+                        <div className="text-sm font-semibold text-slate-200">
                           Add items to “{sec.title || "Section"}”
                         </div>
                         <button
                           type="button"
                           onClick={closeAddItemPicker}
-                          className="rounded-full border border-neutral-700 bg-black/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-800"
+                          className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-slate-900/80"
                         >
                           Close
                         </button>
@@ -1281,14 +1285,14 @@ export default function CustomDraftPage() {
                       {masterItemsForThisSection.length ? (
                         <>
                           <input
-                            className="mb-3 w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                            className="mb-3 w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
                             placeholder="Search master items…"
                             value={itemSearch}
                             onChange={(e) => setItemSearch(e.target.value)}
                           />
 
                           {filteredMasterItems.length === 0 ? (
-                            <div className="rounded-xl border border-neutral-800 bg-black/30 px-3 py-2 text-xs text-neutral-400">
+                            <div className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/40 px-3 py-2 text-xs text-neutral-400">
                               No items available (either all are added already, or none match your search).
                             </div>
                           ) : (
@@ -1301,19 +1305,19 @@ export default function CustomDraftPage() {
                                     const added = addItemFromMaster(i, mi.item, mi.unit ?? null);
                                     if (added) setItemSearch("");
                                   }}
-                                  className="rounded-xl border border-neutral-800 bg-black/60 px-3 py-2 text-left text-sm text-neutral-100 hover:bg-black/70"
+                                  className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-2 text-left text-sm text-neutral-100 hover:bg-slate-900/80"
                                   title="Add item"
                                 >
                                   <div className="flex items-center justify-between gap-2">
                                     <span className="truncate">{mi.item}</span>
-                                    <span className="rounded-full bg-neutral-800 px-2 py-[2px] text-[10px] text-neutral-300">
+                                    <span className="rounded-full bg-slate-800 px-2 py-[2px] text-[10px] text-neutral-300">
                                       {mi.unit ?? "—"}
                                     </span>
                                   </div>
                                 </button>
                               ))}
                               {filteredMasterItems.length > 45 ? (
-                                <div className="rounded-xl border border-neutral-800 bg-black/30 px-3 py-2 text-xs text-neutral-400">
+                                <div className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/40 px-3 py-2 text-xs text-neutral-400">
                                   Showing first 45 results — refine your search.
                                 </div>
                               ) : null}
@@ -1324,13 +1328,13 @@ export default function CustomDraftPage() {
 
                       <div className="mt-3 grid gap-2 md:grid-cols-[1fr,140px,auto] md:items-center">
                         <input
-                          className="w-full rounded-xl border border-neutral-700 bg-neutral-900/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/70"
+                          className="w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
                           placeholder="Custom item label…"
                           value={customItemText}
                           onChange={(e) => setCustomItemText(e.target.value)}
                         />
                         <select
-                          className="rounded-xl border border-neutral-700 bg-neutral-900/80 px-2 py-2 text-sm text-white"
+                          className="rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-2 py-2 text-sm text-white"
                           value=""
                           onChange={(e) => {
                             const unit = e.target.value || null;
@@ -1353,7 +1357,7 @@ export default function CustomDraftPage() {
                             const added = addItemFromMaster(i, customItemText, null);
                             if (added) setCustomItemText("");
                           }}
-                          className="rounded-full bg-orange-600 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black hover:bg-orange-500"
+                          className="rounded-full bg-slate-700 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100 hover:bg-slate-600"
                         >
                           Add custom
                         </button>
@@ -1372,11 +1376,11 @@ export default function CustomDraftPage() {
                     return (
                       <div
                         key={it._key}
-                        className="grid grid-cols-1 gap-2 rounded-xl bg-black/55 p-2 sm:grid-cols-[minmax(0,1.4fr),140px,auto,auto] sm:items-center"
+                        className="grid grid-cols-1 gap-2 rounded-xl bg-slate-950/60 p-2 sm:grid-cols-[minmax(0,1.4fr),140px,auto,auto] sm:items-center"
                       >
                         {/* label */}
                         <input
-                          className="w-full rounded-lg border border-neutral-700 bg-neutral-900/80 px-3 py-1.5 text-sm text-white placeholder:text-neutral-500"
+                          className="w-full rounded-lg border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-1.5 text-sm text-white placeholder:text-neutral-500"
                           value={it.item ?? ""}
                           onChange={(e) => updateItemLabel(i, j, e.target.value)}
                           placeholder="Item label"
@@ -1384,7 +1388,7 @@ export default function CustomDraftPage() {
 
                         {/* unit */}
                         <select
-                          className="rounded-lg border border-neutral-700 bg-neutral-900/80 px-2 py-1.5 text-sm text-white"
+                          className="rounded-lg border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-2 py-1.5 text-sm text-white"
                           value={it.unit ?? ""}
                           onChange={(e) => updateItemUnit(i, j, e.target.value)}
                           title="Measurement unit"
@@ -1401,7 +1405,7 @@ export default function CustomDraftPage() {
                           <button
                             type="button"
                             onClick={() => moveItem(i, j, -1)}
-                            className="rounded-full border border-neutral-700 bg-neutral-900/80 px-2 py-1 text-[11px] text-neutral-100 hover:bg-neutral-800 disabled:opacity-40"
+                            className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-2 py-1 text-[11px] text-neutral-100 hover:bg-slate-900/80 disabled:opacity-40"
                             disabled={j === 0}
                             title="Move up"
                           >
@@ -1410,7 +1414,7 @@ export default function CustomDraftPage() {
                           <button
                             type="button"
                             onClick={() => moveItem(i, j, +1)}
-                            className="rounded-full border border-neutral-700 bg-neutral-900/80 px-2 py-1 text-[11px] text-neutral-100 hover:bg-neutral-800 disabled:opacity-40"
+                            className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-2 py-1 text-[11px] text-neutral-100 hover:bg-slate-900/80 disabled:opacity-40"
                             disabled={j === (sec.items?.length ?? 0) - 1}
                             title="Move down"
                           >
@@ -1422,7 +1426,7 @@ export default function CustomDraftPage() {
                         <button
                           type="button"
                           onClick={() => removeItem(i, j)}
-                          className="justify-self-start rounded-full border border-red-600 bg-red-900/30 px-2.5 py-1 text-[11px] font-semibold text-red-300 hover:bg-red-900/60 sm:justify-self-end"
+                          className="justify-self-start rounded-full border border-red-500/60 bg-red-950/30 px-2.5 py-1 text-[11px] font-semibold text-red-300 hover:bg-red-900/60 sm:justify-self-end"
                           title="Remove item"
                         >
                           Remove
@@ -1441,7 +1445,7 @@ export default function CustomDraftPage() {
           <button
             type="button"
             onClick={addSectionBlank}
-            className="rounded-full bg-neutral-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-white hover:bg-neutral-700"
+            className="rounded-full bg-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-white hover:bg-slate-700"
           >
             + Add Blank Section
           </button>
@@ -1449,7 +1453,7 @@ export default function CustomDraftPage() {
           <button
             type="button"
             onClick={() => setShowSectionPicker((v) => !v)}
-            className="rounded-full border border-neutral-700 bg-black/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-800"
+            className="rounded-full border border-[var(--metal-border-soft,#334155)] bg-slate-950/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-slate-900/80"
           >
             + Add Section from Master
           </button>
@@ -1467,7 +1471,7 @@ export default function CustomDraftPage() {
                 return next;
               });
             }}
-            className="rounded-full border border-orange-500/60 bg-orange-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-orange-200 hover:bg-orange-500/20"
+            className="rounded-full border border-[rgba(176,141,112,0.5)] bg-[rgba(176,141,112,0.14)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-[rgba(221,194,166,0.95)] hover:bg-[rgba(176,141,112,0.22)]"
             title="Package this draft into a Menu Item linked to the inspection template"
           >
             Create Menu Item
@@ -1478,7 +1482,7 @@ export default function CustomDraftPage() {
               type="button"
               onClick={saveChanges}
               disabled={savingExisting}
-              className="rounded-full bg-sky-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black hover:bg-sky-400 disabled:opacity-60"
+              className="rounded-full bg-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-950 hover:bg-slate-100 disabled:opacity-60"
             >
               {savingExisting ? "Saving…" : "Save Changes"}
             </button>
@@ -1488,7 +1492,7 @@ export default function CustomDraftPage() {
             type="button"
             onClick={saveTemplate}
             disabled={savingNew}
-            className="rounded-full bg-amber-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black hover:bg-amber-400 disabled:opacity-60"
+            className="rounded-full bg-[linear-gradient(to_right,rgba(191,141,99,0.82),rgba(160,116,82,0.76))] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black hover:brightness-110 disabled:opacity-60"
           >
             {savingNew ? "Saving…" : "Save as New Template"}
           </button>
@@ -1497,7 +1501,7 @@ export default function CustomDraftPage() {
             type="button"
             onClick={saveAndRun}
             disabled={running}
-            className="rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black hover:bg-emerald-400 disabled:opacity-60"
+            className="rounded-full bg-slate-700 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-100 hover:bg-slate-600 disabled:opacity-60"
             title="Stage this draft and open the Run page"
           >
             {running ? "Opening…" : "Save & Run"}

--- a/features/inspections/app/inspection/custom-inspection/page.tsx
+++ b/features/inspections/app/inspection/custom-inspection/page.tsx
@@ -743,18 +743,18 @@ export default function CustomBuilderPage() {
   /* ------------------------------------------------------------------ */
 
   // copper: slightly muted, avoids neon/orange pop
-  const COPPER = "rgba(224,174,130,0.88)";
-  const COPPER_55 = "rgba(224,174,130,0.46)";
-  const COPPER_GLOW_20 = "rgba(224,174,130,0.20)";
-  const COOL_WASH_20 = "rgba(56,189,248,0.10)";
+  const COPPER = "rgba(176,141,112,0.9)";
+  const COPPER_55 = "rgba(176,141,112,0.42)";
+  const COPPER_GLOW_20 = "rgba(176,141,112,0.18)";
+  const COOL_WASH_20 = "rgba(96,165,250,0.12)";
 
   const headerCard =
     "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+    "bg-slate-950/75 shadow-[0_24px_80px_rgba(0,0,0,0.95)] backdrop-blur-xl";
 
   const sectionCard =
     "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] " +
-    "bg-black/70 shadow-[0_20px_70px_rgba(0,0,0,0.95)] backdrop-blur-xl";
+    "bg-slate-950/75 shadow-[0_20px_70px_rgba(0,0,0,0.95)] backdrop-blur-xl";
 
   const pillBase =
     "px-3 py-1 text-[10px] uppercase tracking-[0.16em] rounded-full border transition-colors";
@@ -765,21 +765,21 @@ export default function CustomBuilderPage() {
   const pillInactive = "border-transparent bg-transparent text-neutral-400 hover:bg-zinc-900/80";
 
   const inputBase =
-    "w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 " +
+    "w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/75 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 " +
     `focus:ring-[${COPPER_55}]`;
 
   const selectBase =
-    "w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 " +
+    "w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/75 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 " +
     `focus:ring-[${COPPER_55}]`;
 
   const actionBtn =
     "rounded-full border border-[color:var(--metal-border-soft,#374151)] " +
-    "bg-black/70 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] " +
-    "text-neutral-100 hover:bg-black/80 " +
+    "bg-slate-950/75 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] " +
+    "text-neutral-100 hover:bg-slate-900/80 " +
     `hover:border-[${COPPER_55}]`;
 
   const primaryBtn =
-    "rounded-full bg-[linear-gradient(to_right,rgba(200,122,67,0.85),rgba(200,122,67,0.55))] " +
+    "rounded-full bg-[linear-gradient(to_right,rgba(191,141,99,0.82),rgba(160,116,82,0.76))] " +
     "px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-black " +
     `shadow-[0_0_18px_${COPPER_GLOW_20}] hover:shadow-[0_0_26px_${COPPER_GLOW_20}] disabled:opacity-60`;
 
@@ -791,7 +791,7 @@ export default function CustomBuilderPage() {
           aria-hidden
           className={cx(
             "pointer-events-none fixed inset-0 -z-10",
-            `bg-[radial-gradient(circle_at_top,${COOL_WASH_20},transparent_55%),radial-gradient(circle_at_bottom,rgba(15,23,42,0.96),#020617_78%)]`,
+            `bg-[radial-gradient(circle_at_top,${COOL_WASH_20},transparent_52%),radial-gradient(circle_at_bottom,rgba(10,15,28,0.97),#020617_80%)]`,
           )}
         />
 
@@ -816,7 +816,7 @@ export default function CustomBuilderPage() {
                 <span
                   key={c.k}
                   className={cx(
-                    "inline-flex items-center gap-2 rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/60 px-3 py-1 text-[11px]",
+                    "inline-flex items-center gap-2 rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/70 px-3 py-1 text-[11px]",
                     "text-neutral-200",
                   )}
                 >
@@ -864,7 +864,7 @@ export default function CustomBuilderPage() {
           {/* Toggles + corner grid (templates-style pill group) */}
           <div className="relative mt-5 space-y-3">
             <div className="flex flex-wrap items-center justify-center gap-2">
-              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-black/60">
+              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-slate-950/70">
                 <button
                   type="button"
                   onClick={() => setIncludeOil((v) => !v)}
@@ -896,11 +896,11 @@ export default function CustomBuilderPage() {
               </div>
 
               {includeOil && (
-                <div className="flex items-center gap-2 rounded-full border border-neutral-700/80 bg-black/60 px-3 py-1.5">
+                <div className="flex items-center gap-2 rounded-full border border-neutral-700/80 bg-slate-950/70 px-3 py-1.5">
                   <span className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">Engine</span>
                   <select
                     className={cx(
-                      "rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/70 px-3 py-1 text-[12px] text-white focus:outline-none focus:ring-2",
+                      "rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/75 px-3 py-1 text-[12px] text-white focus:outline-none focus:ring-2",
                       `focus:ring-[${COPPER_55}]`,
                     )}
                     value={oilEngineType}
@@ -915,7 +915,7 @@ export default function CustomBuilderPage() {
 
             <div className="flex flex-wrap items-center justify-center gap-2">
               <span className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">Corner grid</span>
-              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-black/60">
+              <div className="flex overflow-hidden rounded-full border border-neutral-700/80 bg-slate-950/70">
                 {gridModeButtons.map((opt) => {
                   const active = gridMode === opt.value;
                   return (
@@ -943,7 +943,7 @@ export default function CustomBuilderPage() {
             <div className="mb-1 text-center text-sm font-semibold" style={{ color: COPPER }}>
               Quick Build
             </div>
-            <p className="mb-4 text-center text-sm text-neutral-400">
+            <p className="mb-4 text-center text-sm text-slate-400">
               Deterministic build from your master list (keeps CVIP/spec codes).
             </p>
 
@@ -1013,7 +1013,7 @@ export default function CustomBuilderPage() {
             <div className="mb-1 text-center text-sm font-semibold" style={{ color: COPPER }}>
               Prompt Build
             </div>
-            <p className="mb-4 text-center text-sm text-neutral-400">
+            <p className="mb-4 text-center text-sm text-slate-400">
               Triggers auto-apply while typing (air/hydraulic, tires, batteries, grease, oil, “60 point”, etc).
             </p>
 
@@ -1052,7 +1052,7 @@ export default function CustomBuilderPage() {
 
             <textarea
               className={cx(
-                "mb-3 min-h-[90px] w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-black/70 p-3 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2",
+                "mb-3 min-h-[90px] w-full rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/75 p-3 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2",
                 `focus:ring-[${COPPER_55}]`,
               )}
               placeholder="e.g. brake inspection, hydraulic, include tires, 30 point"
@@ -1099,7 +1099,7 @@ export default function CustomBuilderPage() {
                 <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                   <div className="flex flex-wrap items-center gap-2">
                     <div className="font-semibold text-neutral-100">{sec.title}</div>
-                    <span className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-black/60 px-2 py-0.5 text-[11px] text-neutral-300">
+                    <span className="rounded-full border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/70 px-2 py-0.5 text-[11px] text-neutral-300">
                       {selectedCount}/{sec.items.length} selected
                     </span>
                   </div>
@@ -1127,7 +1127,7 @@ export default function CustomBuilderPage() {
                         <label
                           key={label}
                           className={cx(
-                            "flex items-center gap-2 rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-black/60 px-2 py-1 text-sm text-neutral-100",
+                            "flex items-center gap-2 rounded-lg border border-[color:var(--metal-border-soft,#374151)] bg-slate-950/70 px-2 py-1 text-sm text-neutral-100",
                             checked && `border-[${COPPER_55}]`,
                           )}
                         >

--- a/features/inspections/app/inspection/customer-vehicle/page.tsx
+++ b/features/inspections/app/inspection/customer-vehicle/page.tsx
@@ -125,188 +125,113 @@ export default function CustomerVehicleFormPage() {
     }
   };
 
+  const pageShell =
+    "mx-auto w-full max-w-5xl rounded-2xl border border-[var(--metal-border-soft,#334155)] " +
+    "bg-[linear-gradient(180deg,rgba(6,10,18,0.94),rgba(2,6,14,0.98))] p-4 shadow-[0_24px_80px_rgba(0,0,0,0.95)] md:p-6";
+  const panel =
+    "rounded-2xl border border-[var(--metal-border-soft,#334155)] " +
+    "bg-[linear-gradient(180deg,rgba(8,14,24,0.88),rgba(2,6,12,0.95))] p-4";
+  const inputBase =
+    "w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 " +
+    "focus:outline-none focus:ring-2 focus:ring-slate-500/40";
+  const selectBase =
+    "w-full rounded-xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-slate-100 " +
+    "focus:outline-none focus:ring-2 focus:ring-slate-500/40";
+
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-xl font-bold">Enter Customer &amp; Vehicle Info</h1>
+    <div className="px-4 py-6 text-slate-100">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.09),transparent_48%),radial-gradient(circle_at_bottom,rgba(3,7,18,0.96),#020617_80%)]"
+      />
 
-      {/* Customer Info */}
-      <div className="space-y-2">
-        <input
-          type="text"
-          name="first_name"
-          placeholder="First Name *"
-          value={customer.first_name}
-          onChange={(e) => handleChange(e, "customer")}
-          className="input"
-        />
-        <input
-          type="text"
-          name="last_name"
-          placeholder="Last Name *"
-          value={customer.last_name}
-          onChange={(e) => handleChange(e, "customer")}
-          className="input"
-        />
-        <input
-          type="text"
-          name="phone"
-          placeholder="Phone"
-          value={customer.phone}
-          onChange={(e) => handleChange(e, "customer")}
-          className="input"
-        />
-        <input
-          type="email"
-          name="email"
-          placeholder="Email"
-          value={customer.email}
-          onChange={(e) => handleChange(e, "customer")}
-          className="input"
-        />
+      <div className={pageShell}>
+        <header className="mb-5 rounded-2xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/60 px-4 py-4">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-slate-400">Inspection Intake</p>
+          <h1 className="mt-1 text-xl font-semibold text-slate-100 sm:text-2xl">
+            Customer &amp; Vehicle Information
+          </h1>
+          <p className="mt-2 text-sm text-slate-400">
+            Fill required fields to start the inspection flow.
+          </p>
+        </header>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <section className={panel}>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.14em] text-slate-300">Customer</h2>
+              <span className="rounded-full border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[11px] text-slate-400">
+                Required: name
+              </span>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <input type="text" name="first_name" placeholder="First Name *" value={customer.first_name} onChange={(e) => handleChange(e, "customer")} className={inputBase} />
+              <input type="text" name="last_name" placeholder="Last Name *" value={customer.last_name} onChange={(e) => handleChange(e, "customer")} className={inputBase} />
+              <input type="text" name="phone" placeholder="Phone" value={customer.phone} onChange={(e) => handleChange(e, "customer")} className={inputBase + " sm:col-span-2"} />
+              <input type="email" name="email" placeholder="Email" value={customer.email} onChange={(e) => handleChange(e, "customer")} className={inputBase + " sm:col-span-2"} />
+            </div>
+          </section>
+
+          <section className={panel}>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.14em] text-slate-300">Vehicle</h2>
+              <span className="rounded-full border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[11px] text-slate-400">
+                Required: make + model
+              </span>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <input type="text" name="unit_number" placeholder="Unit #" value={vehicle.unit_number} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <input type="text" name="year" placeholder="Year" value={vehicle.year} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} inputMode="numeric" />
+              <input type="text" name="make" placeholder="Make *" value={vehicle.make} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <input type="text" name="model" placeholder="Model *" value={vehicle.model} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <input type="text" name="vin" placeholder="VIN" value={vehicle.vin} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <input type="text" name="license_plate" placeholder="License Plate" value={vehicle.license_plate} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <input type="text" name="mileage" placeholder="Mileage" value={vehicle.mileage} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} inputMode="numeric" />
+              <input type="text" name="color" placeholder="Color" value={vehicle.color} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <input type="text" name="engine_hours" placeholder="Engine hours" value={vehicle.engine_hours} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} inputMode="numeric" />
+              <input type="text" name="engine" placeholder="Engine / Trim (e.g. 3.5L EcoBoost)" value={vehicle.engine} onChange={(e) => handleChange(e, "vehicle")} className={inputBase} />
+              <select name="transmission" value={vehicle.transmission} onChange={(e) => handleChange(e, "vehicle")} className={selectBase}>
+                <option value="">Select transmission</option>
+                <option value="automatic">Automatic</option>
+                <option value="manual">Manual</option>
+                <option value="cvt">CVT</option>
+                <option value="dct">Dual-clutch</option>
+                <option value="other">Other</option>
+              </select>
+              <select name="fuel_type" value={vehicle.fuel_type} onChange={(e) => handleChange(e, "vehicle")} className={selectBase}>
+                <option value="">Select fuel type</option>
+                <option value="gasoline">Gasoline</option>
+                <option value="diesel">Diesel</option>
+                <option value="hybrid">Hybrid</option>
+                <option value="phev">Plug-in hybrid</option>
+                <option value="ev">Electric (BEV)</option>
+                <option value="other">Other</option>
+              </select>
+              <select name="drivetrain" value={vehicle.drivetrain} onChange={(e) => handleChange(e, "vehicle")} className={selectBase}>
+                <option value="">Select drivetrain</option>
+                <option value="fwd">FWD</option>
+                <option value="rwd">RWD</option>
+                <option value="awd">AWD</option>
+                <option value="4x4">4x4</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[var(--metal-border-soft,#334155)] bg-slate-950/60 px-4 py-3">
+          <p className="text-xs text-slate-400">
+            {requiredMissing ? `Missing required field: ${requiredMissing}` : "All required fields complete."}
+          </p>
+          <button
+            type="button"
+            onClick={handleStart}
+            className="rounded-full bg-[linear-gradient(to_right,rgba(194,136,96,0.88),rgba(173,111,72,0.88))] px-5 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-black shadow-[0_0_18px_rgba(181,120,82,0.22)] hover:brightness-110"
+          >
+            Start Inspection
+          </button>
+        </div>
       </div>
-
-      {/* Vehicle Info */}
-      <div className="space-y-2">
-        {/* Optional but useful for fleets */}
-        <input
-          type="text"
-          name="unit_number"
-          placeholder="Unit #"
-          value={vehicle.unit_number}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-
-        <input
-          type="text"
-          name="year"
-          placeholder="Year"
-          value={vehicle.year}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-          inputMode="numeric"
-        />
-        <input
-          type="text"
-          name="make"
-          placeholder="Make *"
-          value={vehicle.make}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-        <input
-          type="text"
-          name="model"
-          placeholder="Model *"
-          value={vehicle.model}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-        <input
-          type="text"
-          name="vin"
-          placeholder="VIN"
-          value={vehicle.vin}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-        <input
-          type="text"
-          name="license_plate"
-          placeholder="License Plate"
-          value={vehicle.license_plate}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-        <input
-          type="text"
-          name="mileage"
-          placeholder="Mileage"
-          value={vehicle.mileage}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-          inputMode="numeric"
-        />
-        <input
-          type="text"
-          name="color"
-          placeholder="Color"
-          value={vehicle.color}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-
-        {/* ✅ added fields */}
-        <input
-          type="text"
-          name="engine_hours"
-          placeholder="Engine hours"
-          value={vehicle.engine_hours}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-          inputMode="numeric"
-        />
-
-        <input
-          type="text"
-          name="engine"
-          placeholder="Engine / Trim (e.g. 3.5L EcoBoost)"
-          value={vehicle.engine}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        />
-
-        <select
-          name="transmission"
-          value={vehicle.transmission}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        >
-          <option value="">Select transmission</option>
-          <option value="automatic">Automatic</option>
-          <option value="manual">Manual</option>
-          <option value="cvt">CVT</option>
-          <option value="dct">Dual-clutch</option>
-          <option value="other">Other</option>
-        </select>
-
-        <select
-          name="fuel_type"
-          value={vehicle.fuel_type}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        >
-          <option value="">Select fuel type</option>
-          <option value="gasoline">Gasoline</option>
-          <option value="diesel">Diesel</option>
-          <option value="hybrid">Hybrid</option>
-          <option value="phev">Plug-in hybrid</option>
-          <option value="ev">Electric (BEV)</option>
-          <option value="other">Other</option>
-        </select>
-
-        <select
-          name="drivetrain"
-          value={vehicle.drivetrain}
-          onChange={(e) => handleChange(e, "vehicle")}
-          className="input"
-        >
-          <option value="">Select drivetrain</option>
-          <option value="fwd">FWD</option>
-          <option value="rwd">RWD</option>
-          <option value="awd">AWD</option>
-          <option value="4x4">4x4</option>
-          <option value="other">Other</option>
-        </select>
-      </div>
-
-      <button
-        type="button"
-        onClick={handleStart}
-        className="bg-orange-500 hover:bg-orange-600 text-white text-lg font-bold px-6 py-3 rounded w-full"
-      >
-        Start Inspection
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The custom inspection flow used legacy, orange/copper-heavy, and standalone control styles that diverged from the repo-wide dashboard theme. 
- Visual inconsistency made the customer/vehicle intake and custom-draft surfaces read like a separate microsite instead of a first-class dashboard surface. 
- The goal is to bring these pages into the current navy/blue-black dashboard visual language while preserving behavior.

### Description
- Replaced page-local styling and ad-hoc classes with dashboard-themed shells, cards, and input/button patterns in three feature pages: `features/inspections/app/inspection/custom-inspection/page.tsx`, `features/inspections/app/inspection/custom-draft/page.tsx`, and `features/inspections/app/inspection/customer-vehicle/page.tsx`.
- Converted legacy orange-heavy accents to a restrained copper-primary + slate surfaces system, added subtle background wash, consistent thin borders, and unified `input/select`/card/button classes to match existing dashboard primitives.
- Rebuilt the customer/vehicle intake layout into a two-panel dashboard shell with grouped customer and vehicle cards and standardized inputs/selects while preserving all save/navigation handlers.
- Kept all business logic, API calls, route targets, and state handlers unchanged; only className/style and local UI structure were modified.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully.
- No other automated tests were added or modified as this PR is visual/styling-only and preserves existing runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e44c25599883289266dded5fc68330)