### PR TITLE
Restore Black Ops One title & keep shared backdrop on Custom Inspection Builder

### DIFF
--- a/features/inspections/app/inspection/custom-inspection/page.tsx
+++ b/features/inspections/app/inspection/custom-inspection/page.tsx
@@ -786,7 +786,10 @@ export default function CustomBuilderPage() {
           <div className="relative flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div className="text-center md:text-left">
               <p className="text-[10px] uppercase tracking-[0.16em] text-slate-400">Inspections</p>
-              <h1 className="mt-1 text-2xl font-semibold tracking-tight text-slate-100 md:text-3xl">
+              <h1
+                className="mt-1 text-2xl uppercase tracking-[0.2em] text-slate-100 md:text-3xl"
+                style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}
+              >
                 Custom Inspection Builder
               </h1>
               <p className="mt-1 text-sm text-neutral-400">


### PR DESCRIPTION
### Motivation
- Ensure the Custom Inspection Builder header returns to the inspection-tools brand treatment (Black Ops One) and confirm the page uses the shared cool navy/blue-black app shell backdrop without any page-local warm/copper atmospheric wash.

### Description
- Updated the page title in `features/inspections/app/inspection/custom-inspection/page.tsx` to an uppercase tracked heading and applied `style={{ fontFamily: "Black Ops One, system-ui, sans-serif" }}`, while keeping existing `headerCard`/`sectionCard` surface tokens and deliberately not adding or changing any page-level radial gradients or overlay layers.

### Testing
- Ran `npx tsc --noEmit` which completed successfully, and verified via a code search that there are no page-local atmospheric layers (no `radial-gradient`, full-page `fixed inset-0` overlays, or `-z-10` backdrop wash) in the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e583daa3d08328a629602fa76db312)