### PR TITLE
Phase 1: Harden privileged API auth and remove public shops SELECT policy

### DIFF
--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -9,6 +9,7 @@ import { getActiveBrandForRender } from "@/features/branding/server/getActiveBra
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
 import { reviewWorkOrder } from "../../work-orders/[id]/_lib/reviewWorkOrder";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -231,6 +232,12 @@ function pickCustomerPhone(
 
 export async function POST(req: Request) {
   try {
+    const access = await requireShopScopedApiAccess({
+      requiredCapabilities: ["canManageWorkOrders", "canAuthorizeQuotes"],
+      allowRoles: ["owner", "admin", "manager", "advisor", "service"],
+    });
+    if (!access.ok) return access.response;
+
     const raw = (await req.json().catch(() => null)) as unknown;
 
     const parsed = parseRequestBody(raw);
@@ -276,6 +283,10 @@ export async function POST(req: Request) {
 
     if (!wo.shop_id) {
       return NextResponse.json({ error: "Work order is missing shop_id" }, { status: 400 });
+    }
+
+    if (wo.shop_id !== access.profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const status = String(wo.status ?? "").toLowerCase().replaceAll(" ", "_");

--- a/app/api/work-orders/update-status/[id]/route.ts
+++ b/app/api/work-orders/update-status/[id]/route.ts
@@ -1,19 +1,25 @@
-// app/api/workOrders/update-status/[id]/route.ts
-// app/api/workOrders/update-status/[id]/route.ts
-
 export const runtime = "nodejs";
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
-export async function GET(request: NextRequest) {
-  const url = new URL(request.url);
-  const id = url.pathname.split("/").pop();
+type RouteContext = {
+  params: { id: string };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = context.params;
 
   if (!id) {
     return NextResponse.json({ error: "Missing ID" }, { status: 400 });
@@ -23,9 +29,10 @@ export async function GET(request: NextRequest) {
     .from("work_orders")
     .select("*")
     .eq("id", id)
-    .single();
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
 
-  if (error) {
+  if (error || !data) {
     console.error("Failed to fetch work order:", error);
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/app/api/work-orders/update-status/list/route.ts
+++ b/app/api/work-orders/update-status/list/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -11,9 +12,15 @@ const supabase = createClient(
 
 export async function GET() {
   try {
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageWorkOrders",
+    });
+    if (!access.ok) return access.response;
+
     const { data, error } = await supabase
       .from("work_orders")
       .select("*")
+      .eq("shop_id", access.profile.shop_id)
       .order("appointment", { ascending: true });
 
     if (error) throw error;

--- a/db/sql/2026-04-20_phase1_authz_tenant_hardening.sql
+++ b/db/sql/2026-04-20_phase1_authz_tenant_hardening.sql
@@ -1,0 +1,5 @@
+-- Phase 1 hardening: remove global shop visibility.
+-- Broad public SELECT on shops enables cross-tenant metadata leakage.
+-- Keep existing authenticated shop-scoped policy in place.
+
+DROP POLICY IF EXISTS "shops_public_select" ON public.shops;

--- a/db/sql/schema.sql
+++ b/db/sql/schema.sql
@@ -6147,10 +6147,6 @@ CREATE POLICY "shops: only read my shop" ON "public"."shops" FOR SELECT TO "auth
 
 
 
-CREATE POLICY "shops_public_select" ON "public"."shops" FOR SELECT USING (true);
-
-
-
 CREATE POLICY "shops_staff_write" ON "public"."shops" USING ((EXISTS ( SELECT 1
    FROM "public"."profiles" "p"
   WHERE (("p"."id" = "auth"."uid"()) AND ("p"."shop_id" = "shops"."id") AND ("p"."role" = ANY (ARRAY['owner'::"text", 'admin'::"text", 'manager'::"text"])))))) WITH CHECK ((EXISTS ( SELECT 1

--- a/features/shared/lib/server/admin-access.ts
+++ b/features/shared/lib/server/admin-access.ts
@@ -46,6 +46,7 @@ export async function requireAdminPageAccess(options: AdminPageAccessOptions): P
 
 type ApiAccessOptions = {
   requiredCapability?: CapabilityKey;
+  requiredCapabilities?: CapabilityKey[];
   allowRoles?: CanonicalRole[];
   requireOwnerPin?: boolean;
   ownerPinRequest?: Request;
@@ -86,6 +87,16 @@ export async function requireShopScopedApiAccess(options: ApiAccessOptions = {})
 
   if (options.requiredCapability && !actor[options.requiredCapability]) {
     return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+
+  if (options.requiredCapabilities?.length) {
+    const hasAllRequiredCapabilities = options.requiredCapabilities.every(
+      (capability) => actor[capability],
+    );
+
+    if (!hasAllRequiredCapabilities) {
+      return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    }
   }
 
   if (options.requireOwnerPin) {


### PR DESCRIPTION
### Motivation
- Close launch-blocking authz and tenancy gaps that allowed unauthenticated or cross-tenant access to privileged endpoints and shop metadata.
- Centralize server-side actor/shop/role checks so privileged routes consistently verify authentication, shop membership, and capabilities before running service-role DB actions.
- Remove broad public visibility of `shops` rows to eliminate cross-tenant metadata leakage via the `shops_public_select` policy.

### Description
- Extended the canonical server helper `requireShopScopedApiAccess` to support `requiredCapabilities` (all required) so routes can demand compound privileges in a single call. (`features/shared/lib/server/admin-access.ts`)
- Replaced unauthenticated service-role reads with actor-checked flows in `app/api/work-orders/update-status/[id]/route.ts` by requiring `requireShopScopedApiAccess` and scoping reads to `access.profile.shop_id`. (`app/api/work-orders/update-status/[id]/route.ts`)
- Hardened listing endpoint `app/api/work-orders/update-status/list/route.ts` to require `requireShopScopedApiAccess` and filter work orders to the actor's shop. (`app/api/work-orders/update-status/list/route.ts`)
- Hardened `app/api/invoices/send/route.ts` to require actor auth and explicit role/capability checks via `requireShopScopedApiAccess`, and added a cross-shop guard to block sending invoices for work orders outside the actor's shop. (`app/api/invoices/send/route.ts`)
- Removed the permissive `shops_public_select` policy from the schema snapshot and added an explicit migration `db/sql/2026-04-20_phase1_authz_tenant_hardening.sql` to drop the policy in deployed databases. (`db/sql/schema.sql`, `db/sql/2026-04-20_phase1_authz_tenant_hardening.sql`)

### Testing
- Ran `npx tsc --noEmit` and it passed with no type errors.
- Ran `pnpm test` and unit tests passed (`2` test files, `2` tests total).
- Ran `pnpm lint` which failed due to pre-existing repository lint errors outside the scope of this security patch and unrelated to the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58b5b1ea08328831af46b643c6d22)