### PR TITLE
Harden owner PIN storage and canonicalize PIN set/verify flows

### DIFF
--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
+import { setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 
@@ -45,7 +47,7 @@ export async function POST(req: Request) {
     const city = cleanStr(raw.city);
     const province = cleanStr(raw.province);
     const postal_code = cleanStr(raw.postal_code);
-    const pin = cleanStr(raw.pin);
+    const pin = normalizeOwnerPin(String(raw.pin ?? ""));
 
     // New NA fields (optional in step 1, but we seed safely)
     const country = NA_COUNTRIES.has(cleanUpper(raw.country))
@@ -60,6 +62,15 @@ export async function POST(req: Request) {
       );
     }
 
+
+    if (!isValidOwnerPin(pin)) {
+      return NextResponse.json(
+        { msg: "PIN must be 4 to 8 digits" },
+        { status: 400 },
+      );
+    }
+
+    const ownerPinHash = await hashOwnerPin(pin);
     // Insert shop (seed both address+street for legacy consistency)
     const shopInsert: DB["public"]["Tables"]["shops"]["Insert"] = {
       owner_id: user.id,
@@ -74,9 +85,9 @@ export async function POST(req: Request) {
       postal_code,
       country,
       timezone,
-      // owner_pin_hash: await hashPin(pin) // optional
-      owner_pin: pin, // you have both owner_pin + pin columns in schema; keep what you use
-      pin, // keep in sync if your app references pin
+      owner_pin_hash: ownerPinHash,
+      owner_pin: null,
+      pin: null,
     };
 
     const { data: shop, error: shopErr } = await supabase
@@ -122,7 +133,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ msg: profErr.message }, { status: 400 });
     }
 
-    return NextResponse.json({ ok: true, shop_id: shop.id }, { status: 200 });
+    const res = NextResponse.json({ ok: true, shop_id: shop.id }, { status: 200 });
+    return setOwnerPinVerifiedCookie(res, shop.id);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected server error";
     return NextResponse.json({ msg }, { status: 500 });

--- a/app/api/shop/owner-pin/set/route.ts
+++ b/app/api/shop/owner-pin/set/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import bcrypt from "bcryptjs";
 import type { Database } from "@shared/types/types/supabase";
 import { getRouteHandlerCookies, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 
 type DB = Database;
 
@@ -11,14 +11,6 @@ type Body = {
   shopId?: string;
   pin?: string;
 };
-
-function normalizePin(pin: string): string {
-  return pin.trim();
-}
-
-function isValidPin(pin: string): boolean {
-  return /^\d{4,8}$/.test(pin);
-}
 
 export async function POST(req: Request) {
   try {
@@ -35,13 +27,13 @@ export async function POST(req: Request) {
 
     const body = (await req.json().catch(() => ({}))) as Body;
     const shopId = body.shopId?.trim() ?? "";
-    const pin = normalizePin(body.pin ?? "");
+    const pin = normalizeOwnerPin(body.pin ?? "");
 
     if (!shopId || !pin) {
       return NextResponse.json({ error: "shopId and pin are required" }, { status: 400 });
     }
 
-    if (!isValidPin(pin)) {
+    if (!isValidOwnerPin(pin)) {
       return NextResponse.json(
         { error: "PIN must be 4 to 8 digits" },
         { status: 400 }
@@ -67,7 +59,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Only owner/admin can set PIN" }, { status: 403 });
     }
 
-    const hash = await bcrypt.hash(pin, 10);
+    const hash = await hashOwnerPin(pin);
 
     const { error: updateErr } = await supabase
       .from("shops")

--- a/app/api/shop/owner-pin/verify/route.ts
+++ b/app/api/shop/owner-pin/verify/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import bcrypt from "bcryptjs";
 import type { Database } from "@shared/types/types/supabase";
 import {
   getRouteHandlerCookies,
   setOwnerPinVerifiedCookie,
 } from "@/features/shared/lib/server/owner-pin";
+import { normalizeOwnerPin, verifyOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 
 type DB = Database;
 
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
 
     const body = (await req.json().catch(() => ({}))) as Body;
     const shopId = body.shopId?.trim() ?? "";
-    const pin = body.pin?.trim() ?? "";
+    const pin = normalizeOwnerPin(body.pin ?? "");
 
     if (!shopId || !pin) {
       return NextResponse.json({ error: "shopId and pin required" }, { status: 400 });
@@ -59,7 +59,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Owner PIN not set" }, { status: 400 });
     }
 
-    const ok = await bcrypt.compare(pin, shop.owner_pin_hash);
+    const ok = await verifyOwnerPin(pin, shop.owner_pin_hash);
     if (!ok) {
       return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
     }

--- a/db/sql/2026-04-20_phase2_owner_pin_hardening.sql
+++ b/db/sql/2026-04-20_phase2_owner_pin_hardening.sql
@@ -1,0 +1,51 @@
+-- Phase 2: Owner PIN hardening
+-- Canonical source of truth is shops.owner_pin_hash.
+-- Legacy plaintext columns (shops.owner_pin, shops.pin) are backfilled then disabled.
+
+begin;
+
+create extension if not exists pgcrypto;
+
+update public.shops
+set owner_pin_hash = case
+  when owner_pin_hash is null
+    and owner_pin is not null
+    and btrim(owner_pin) ~ '^[0-9]{4,8}$'
+    then crypt(btrim(owner_pin), gen_salt('bf'))
+  when owner_pin_hash is null
+    and pin is not null
+    and btrim(pin) ~ '^[0-9]{4,8}$'
+    then crypt(btrim(pin), gen_salt('bf'))
+  else owner_pin_hash
+end
+where owner_pin_hash is null
+  and (
+    (owner_pin is not null and btrim(owner_pin) ~ '^[0-9]{4,8}$')
+    or (pin is not null and btrim(pin) ~ '^[0-9]{4,8}$')
+  );
+
+update public.shops
+set owner_pin = null,
+    pin = null
+where owner_pin is not null
+   or pin is not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'shops_owner_pin_plaintext_unused_chk'
+      and conrelid = 'public.shops'::regclass
+  ) then
+    alter table public.shops
+      add constraint shops_owner_pin_plaintext_unused_chk
+      check (owner_pin is null and pin is null) not valid;
+  end if;
+end;
+$$;
+
+alter table public.shops
+  validate constraint shops_owner_pin_plaintext_unused_chk;
+
+commit;

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -206,8 +206,8 @@ export default function OnboardingPage() {
     }
 
     if (asOwner) {
-      if (!ownerPin || ownerPin.length < 4) {
-        setError("Please provide an Owner PIN (min 4 characters).");
+      if (!/^\d{4,8}$/.test(ownerPin)) {
+        setError("Please provide a 4 to 8 digit Owner PIN.");
         setLoading(false);
         return;
       }
@@ -604,12 +604,15 @@ export default function OnboardingPage() {
                   <div className="space-y-1">
                     <label className="text-xs text-neutral-300">
                       Owner PIN{" "}
-                      <span className="text-neutral-400">(min 4 chars)</span>
+                      <span className="text-neutral-400">(4-8 digits)</span>
                     </label>
                     <input
                       type="password"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      maxLength={8}
                       value={ownerPin}
-                      onChange={(e) => setOwnerPin(e.target.value)}
+                      onChange={(e) => setOwnerPin(e.target.value.replace(/\D/g, ""))}
                       className={fieldClassName}
                       required
                     />

--- a/features/shared/lib/server/owner-pin-crypto.ts
+++ b/features/shared/lib/server/owner-pin-crypto.ts
@@ -1,0 +1,19 @@
+import bcrypt from "bcryptjs";
+
+export const OWNER_PIN_PATTERN = /^\d{4,8}$/;
+
+export function normalizeOwnerPin(pin: string): string {
+  return pin.trim();
+}
+
+export function isValidOwnerPin(pin: string): boolean {
+  return OWNER_PIN_PATTERN.test(pin);
+}
+
+export async function hashOwnerPin(pin: string): Promise<string> {
+  return bcrypt.hash(pin, 10);
+}
+
+export async function verifyOwnerPin(pin: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(pin, hash);
+}

--- a/phase2-owner-pin-hardening-summary.md
+++ b/phase2-owner-pin-hardening-summary.md
@@ -1,0 +1,64 @@
+# Phase 2 Summary — Owner PIN Hardening
+
+## What was fixed
+- Replaced onboarding plaintext PIN writes with canonical hashed writes to `shops.owner_pin_hash` and explicitly nulled legacy plaintext columns (`owner_pin`, `pin`).
+- Added shared server PIN crypto helper (`normalize`, `validate`, `hash`, `verify`) and refactored PIN set + verify APIs to use it.
+- Kept owner PIN session behavior canonical by setting the owner PIN verified cookie on successful onboarding owner bootstrap as well as set/verify.
+- Added an additive SQL hardening migration to backfill hashes from legacy plaintext columns, clear plaintext values, and enforce non-usage of plaintext owner PIN columns with a validated check constraint.
+- Tightened onboarding UI validation to 4–8 numeric digits, matching backend/API contracts.
+- Added automated tests for PIN normalization, validation, hashing, and verification helper behavior.
+
+## Canonical PIN model now enforced
+- storage field(s)
+  - `public.shops.owner_pin_hash` is canonical.
+  - `public.shops.owner_pin` and `public.shops.pin` are no longer valid truth sources and are constrained to remain `NULL`.
+- verification helper(s)
+  - `normalizeOwnerPin`, `isValidOwnerPin`, `hashOwnerPin`, `verifyOwnerPin` in `features/shared/lib/server/owner-pin-crypto.ts`.
+- route(s) used
+  - `/api/shop/owner-pin/set` for set/update.
+  - `/api/shop/owner-pin/verify` for verification.
+  - `/api/shop/owner-pin/clear` for clearing verified session cookie.
+  - `/api/onboarding/bootstrap-owner` now writes owner PIN in canonical hashed form during shop creation.
+- expiry/session behavior
+  - Owner PIN verification remains cookie-based via `pfq_owner_pin_shop` with a 30-minute TTL (`OWNER_PIN_TTL_SECONDS = 60 * 30`), unchanged in semantics.
+
+## Files changed
+- `app/api/onboarding/bootstrap-owner/route.ts`
+- `app/api/shop/owner-pin/set/route.ts`
+- `app/api/shop/owner-pin/verify/route.ts`
+- `features/auth/app/onboarding/OnboardingPage.tsx`
+- `features/shared/lib/server/owner-pin-crypto.ts`
+- `db/sql/2026-04-20_phase2_owner_pin_hardening.sql`
+- `tests/owner-pin-crypto.test.ts`
+- `phase2-owner-pin-hardening-summary.md`
+
+## Migrations added
+- `db/sql/2026-04-20_phase2_owner_pin_hardening.sql`
+  - Backfills `owner_pin_hash` from legacy plaintext PIN columns when possible.
+  - Clears legacy plaintext PIN columns.
+  - Adds and validates `shops_owner_pin_plaintext_unused_chk` to prevent future plaintext storage.
+
+## Behavior changes
+- Onboarding owner bootstrap now succeeds only with a 4–8 digit PIN and stores only a hash.
+- PIN verify checks only `owner_pin_hash` using bcrypt compare via shared helper.
+- PIN set/update always writes hash and clears legacy plaintext fields.
+- Existing shops with plaintext PINs are migrated to hash (when valid 4–8 numeric PIN present) and plaintext values are removed.
+- Future writes attempting to persist plaintext `owner_pin`/`pin` now fail due to DB check constraint.
+
+## Risks resolved
+- Plaintext owner PIN writes during onboarding (`app/api/onboarding/bootstrap-owner/route.ts`) → **Resolved**.
+- Owner PIN system canonicalization across set/verify flows → **Resolved** (shared crypto helper + single hashed storage source).
+- Sensitive settings consistency relying on verified owner PIN pattern → **Resolved for audited routes** (`settings/update`, `settings/hours`, `settings/time-off`, `settings/pricing-valid-days` already use `requireOwnerPin`; this phase preserved and aligned backend PIN truth model those checks depend on).
+- Duplicate plaintext columns causing ambiguity (`shops.owner_pin`, `shops.pin`) → **Resolved as active truth sources** (backfilled/cleared + constrained).
+
+## Remaining related risks not fixed in this phase
+- The legacy plaintext columns still physically exist in schema for compatibility; they are now constrained to null. Full column removal can be done in a later phase if desired with coordinated type regeneration and rollout.
+
+## Validation run
+- `npx tsc --noEmit`
+  - pass (exit code 0; npm emitted non-blocking env warning: `Unknown env config "http-proxy"`).
+- `pnpm test`
+  - pass (`3` test files, `5` tests passed).
+
+## Notes for next phase
+- For billing/webhook canonicalization, apply the same pattern used here: establish one canonical source of truth per sensitive state transition, migrate/deprecate legacy write paths, and enforce at DB + route guard layers together.

--- a/tests/owner-pin-crypto.test.ts
+++ b/tests/owner-pin-crypto.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashOwnerPin,
+  isValidOwnerPin,
+  normalizeOwnerPin,
+  verifyOwnerPin,
+} from "../features/shared/lib/server/owner-pin-crypto";
+
+describe("owner pin crypto", () => {
+  it("normalizes owner pins", () => {
+    expect(normalizeOwnerPin(" 1234 ")).toBe("1234");
+  });
+
+  it("accepts only 4-8 numeric digits", () => {
+    expect(isValidOwnerPin("1234")).toBe(true);
+    expect(isValidOwnerPin("12345678")).toBe(true);
+    expect(isValidOwnerPin("123")).toBe(false);
+    expect(isValidOwnerPin("123456789")).toBe(false);
+    expect(isValidOwnerPin("12ab")).toBe(false);
+  });
+
+  it("hashes and verifies correctly", async () => {
+    const pin = "987654";
+    const hash = await hashOwnerPin(pin);
+
+    expect(hash).not.toEqual(pin);
+    await expect(verifyOwnerPin(pin, hash)).resolves.toBe(true);
+    await expect(verifyOwnerPin("1111", hash)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Eliminate plaintext Owner PIN writes during onboarding and remove ambiguity from duplicate plaintext columns used as truth sources. 
- Ensure a single, secure canonical PIN storage and verification model is used across onboarding and runtime PIN-protected flows. 
- Keep sensitive owner settings consistently gated by the same verified PIN/session semantics used elsewhere in the app. 

### Description
- Add a shared server helper `features/shared/lib/server/owner-pin-crypto.ts` with `normalizeOwnerPin`, `isValidOwnerPin`, `hashOwnerPin`, and `verifyOwnerPin` to centralize PIN validation and bcrypt hashing/verification. 
- Refactor `/api/shop/owner-pin/set` and `/api/shop/owner-pin/verify` to use the new helper and to always store/compare hashed PINs (`shops.owner_pin_hash`), and clear legacy plaintext fields (`owner_pin`, `pin`). 
- Harden onboarding (`app/api/onboarding/bootstrap-owner/route.ts`) to validate 4–8 digit PINs, persist only the hashed PIN into `owner_pin_hash`, null the plaintext columns, and set the canonical owner-PIN verified cookie on success. 
- Add an additive DB migration `db/sql/2026-04-20_phase2_owner_pin_hardening.sql` to backfill `owner_pin_hash` from valid legacy plaintext values, clear plaintext columns, and add/validate a check constraint preventing future plaintext PIN storage. 
- Align onboarding UI validation and input to digits-only 4–8 behavior and add unit tests for normalization/validation/hash/verify helpers (`tests/owner-pin-crypto.test.ts`). 

### Testing
- Ran TypeScript check with `npx tsc --noEmit` which completed successfully. 
- Ran tests with `pnpm test` and all tests passed (3 test files, 5 tests total), including new `owner-pin-crypto` tests. 
- Manual review of changed routes and helpers ensured the owner-PIN verified cookie behavior (30-minute TTL) remains unchanged and is set by onboarding, set, and verify flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58ecf68888328b559fcfa848f043e)