### PR TITLE
Harden portal booking start: atomic RPC, idempotency, and DB constraints

### DIFF
--- a/app/api/portal/request/start/route.ts
+++ b/app/api/portal/request/start/route.ts
@@ -12,10 +12,15 @@ type Body = {
   vehicleId?: string | null;
   visitType: "waiter" | "drop_off";
   notes?: string | null;
+  startsAt?: string | null;
+  durationMins?: number | null;
+  idempotencyKey?: string | null;
+};
 
-  // Selected slot start from the "when" page
-  startsAt?: string | null; // ISO string
-  durationMins?: number | null; // default 60
+type StartRpcRow = {
+  work_order_id: string;
+  booking_id: string;
+  deduped: boolean;
 };
 
 function bad(msg: string, status = 400) {
@@ -31,6 +36,15 @@ function addMinsIso(startIso: string, mins: number): string {
   const d = new Date(startIso);
   d.setMinutes(d.getMinutes() + mins);
   return d.toISOString();
+}
+
+function normalizeIdempotencyKey(v: unknown): string {
+  if (typeof v !== "string") return "";
+  return v.trim().toLowerCase().slice(0, 120);
+}
+
+function isDuplicateKeyError(err: { code?: string | null; message?: string | null } | null): boolean {
+  return err?.code === "23505" || (err?.message ?? "").toLowerCase().includes("duplicate key");
 }
 
 export async function POST(req: Request) {
@@ -59,16 +73,15 @@ export async function POST(req: Request) {
     const startsAtRaw =
       typeof body.startsAt === "string" ? body.startsAt.trim() : "";
     if (!startsAtRaw) return bad("Missing startsAt (ISO) from selected slot.");
-    if (!isIsoDateString(startsAtRaw))
+    if (!isIsoDateString(startsAtRaw)) {
       return bad("startsAt must be a valid ISO date string.");
+    }
 
     const duration =
-      typeof body.durationMins === "number" &&
-      Number.isFinite(body.durationMins)
+      typeof body.durationMins === "number" && Number.isFinite(body.durationMins)
         ? Math.max(15, Math.min(180, Math.trunc(body.durationMins)))
         : 60;
 
-    // Basic safety: don't allow bookings in the past
     const startsAtDate = new Date(startsAtRaw);
     if (Number.isNaN(startsAtDate.getTime())) return bad("Invalid startsAt");
     if (startsAtDate.getTime() < Date.now() - 60_000) {
@@ -78,7 +91,6 @@ export async function POST(req: Request) {
     const startsAt = startsAtDate.toISOString();
     const endsAt = addMinsIso(startsAt, duration);
 
-    // Portal customer by auth user
     const { data: customer, error: custErr } = await supabase
       .from("customers")
       .select("id, shop_id")
@@ -87,78 +99,106 @@ export async function POST(req: Request) {
 
     if (custErr) return bad(custErr.message, 500);
     if (!customer?.id) return bad("Customer profile not found", 404);
-    if (!customer.shop_id)
+    if (!customer.shop_id) {
       return bad("Customer is not linked to a shop", 400);
-
-    // ✅ Overlap check BEFORE inserting booking (no .or() string parsing)
-    const { data: overlaps, error: ovErr } = await supabase
-      .from("bookings")
-      .select("id")
-      .eq("shop_id", customer.shop_id)
-      .lt("starts_at", endsAt)
-      .gt("ends_at", startsAt)
-      .limit(1);
-
-    if (ovErr) return bad("Failed to check availability", 500);
-    if (overlaps && overlaps.length > 0) {
-      return bad("This time overlaps an existing booking", 409);
     }
 
-    // 1) Create work order (draft/request shell)
-    const insertWo: DB["public"]["Tables"]["work_orders"]["Insert"] = {
-      shop_id: customer.shop_id,
-      customer_id: customer.id,
-      vehicle_id: body.vehicleId ?? null,
+    const normalizedKey = normalizeIdempotencyKey(body.idempotencyKey ?? null);
+    const sourceRowId = normalizedKey
+      ? `portal_start:${customer.id}:${normalizedKey}`
+      : null;
 
-      status: "awaiting_approval",
-      approval_state: "pending",
-      is_waiter: visitType === "waiter",
-      scheduled_at: startsAt,
-      notes: (body.notes ?? "").trim() || null,
+    // Fast-path replay: return existing created pair for the same idempotency key.
+    if (sourceRowId) {
+      const { data: existingWo, error: existingWoErr } = await supabase
+        .from("work_orders")
+        .select("id")
+        .eq("shop_id", customer.shop_id)
+        .eq("customer_id", customer.id)
+        .eq("source_row_id", sourceRowId)
+        .maybeSingle();
+
+      if (existingWoErr) return bad("Failed to verify request replay", 500);
+
+      if (existingWo?.id) {
+        const { data: existingBooking, error: existingBookingErr } = await supabase
+          .from("bookings")
+          .select("id")
+          .eq("work_order_id", existingWo.id)
+          .maybeSingle();
+
+        if (existingBookingErr) return bad("Failed to verify existing booking", 500);
+        if (existingBooking?.id) {
+          return NextResponse.json(
+            { workOrderId: existingWo.id, bookingId: existingBooking.id, replayed: true },
+            { status: 200 },
+          );
+        }
+      }
+    }
+
+    const rpcPayload = {
+      p_shop_id: customer.shop_id,
+      p_customer_id: customer.id,
+      p_vehicle_id: body.vehicleId ?? null,
+      p_starts_at: startsAt,
+      p_ends_at: endsAt,
+      p_visit_type: visitType,
+      p_notes: (body.notes ?? "").trim() || null,
+      p_source_row_id: sourceRowId,
     };
 
-    const { data: createdWo, error: woErr } = await supabase
-      .from("work_orders")
-      .insert(insertWo)
-      .select(
-        "id, shop_id, customer_id, vehicle_id, status, approval_state, is_waiter, created_at",
-      )
-      .single();
+    const { data: created, error: createErr } = await (supabase as never as {
+      rpc: (
+        fn: "portal_request_start_atomic",
+        args: typeof rpcPayload,
+      ) => Promise<{ data: StartRpcRow[] | null; error: { code?: string; message?: string } | null }>;
+    }).rpc("portal_request_start_atomic", rpcPayload);
 
-    if (woErr || !createdWo?.id) return bad("Failed to create work order", 500);
+    if (createErr) {
+      if (isDuplicateKeyError(createErr) && sourceRowId) {
+        const { data: fallbackWo } = await supabase
+          .from("work_orders")
+          .select("id")
+          .eq("shop_id", customer.shop_id)
+          .eq("customer_id", customer.id)
+          .eq("source_row_id", sourceRowId)
+          .maybeSingle();
 
-    // 2) Reserve the booking slot now (Option B)
-    const insertBooking: DB["public"]["Tables"]["bookings"]["Insert"] = {
-      shop_id: customer.shop_id,
-      customer_id: customer.id,
-      vehicle_id: body.vehicleId ?? null,
-      work_order_id: createdWo.id,
-      starts_at: startsAt,
-      ends_at: endsAt,
-      status: "pending",
-      notes: (body.notes ?? "").trim() || null,
-    };
+        if (fallbackWo?.id) {
+          const { data: fallbackBooking } = await supabase
+            .from("bookings")
+            .select("id")
+            .eq("work_order_id", fallbackWo.id)
+            .maybeSingle();
 
-    const { data: createdBooking, error: bErr } = await supabase
-      .from("bookings")
-      .insert(insertBooking)
-      .select("id, starts_at, ends_at, status")
-      .single();
+          if (fallbackBooking?.id) {
+            return NextResponse.json(
+              { workOrderId: fallbackWo.id, bookingId: fallbackBooking.id, replayed: true },
+              { status: 200 },
+            );
+          }
+        }
+      }
 
-    if (bErr || !createdBooking?.id) {
-      // Roll back the WO if booking fails
-      await supabase.from("work_orders").delete().eq("id", createdWo.id);
-      return bad(bErr?.message ?? "Failed to create booking", 500);
+      if (createErr.code === "P0001" || createErr.code === "23P01") {
+        return bad(createErr.message || "This time overlaps an existing booking", 409);
+      }
+      return bad(createErr.message || "Failed to start request", 500);
+    }
+
+    const row = Array.isArray(created) ? created[0] : null;
+    if (!row?.work_order_id || !row.booking_id) {
+      return bad("Failed to create work order and booking", 500);
     }
 
     return NextResponse.json(
       {
-        workOrderId: createdWo.id,
-        bookingId: createdBooking.id,
-        workOrder: createdWo,
-        booking: createdBooking,
+        workOrderId: row.work_order_id,
+        bookingId: row.booking_id,
+        replayed: Boolean(row.deduped),
       },
-      { status: 201 },
+      { status: row.deduped ? 200 : 201 },
     );
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/app/api/portal/request/submit/route.ts
+++ b/app/api/portal/request/submit/route.ts
@@ -115,7 +115,7 @@ export async function POST(req: Request) {
     // Load WO + ensure ownership
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
-      .select("id, shop_id, customer_id, notes")
+      .select("id, shop_id, customer_id, notes, portal_submitted_at")
       .eq("id", workOrderId)
       .maybeSingle();
 
@@ -126,13 +126,23 @@ export async function POST(req: Request) {
     // Load booking + ensure same shop
     const { data: booking, error: bErr } = await supabase
       .from("bookings")
-      .select("id, shop_id, starts_at, ends_at, status")
+      .select("id, shop_id, customer_id, work_order_id, starts_at, ends_at, status")
       .eq("id", bookingId)
       .maybeSingle();
 
     if (bErr) return bad("Failed to load booking", 500);
     if (!booking) return bad("Booking not found", 404);
     if (booking.shop_id !== wo.shop_id) return bad("Not allowed", 403);
+    if (booking.customer_id !== customer.id) return bad("Not allowed", 403);
+
+    const alreadySubmitted = Boolean(wo.portal_submitted_at);
+    const alreadyFinalized = booking.status === "confirmed" && booking.work_order_id === wo.id;
+    if (alreadySubmitted && alreadyFinalized) {
+      return NextResponse.json(
+        { ok: true, workOrderId: wo.id, bookingId: booking.id, partsRequestId: null, replayed: true },
+        { status: 200 },
+      );
+    }
 
     // Optional sanity: booking not in the past
     const startT = Date.parse(String(booking.starts_at ?? ""));
@@ -147,6 +157,7 @@ export async function POST(req: Request) {
     const woUpdate: DB["public"]["Tables"]["work_orders"]["Update"] = {
       customer_approval_at: customerAgreedAt,
       customer_approval_signature_url: customerSignatureUrl,
+      portal_submitted_at: wo.portal_submitted_at ?? new Date().toISOString(),
     };
 
     const { error: woUpdErr } = await supabase.from("work_orders").update(woUpdate).eq("id", wo.id);

--- a/app/portal/request/when/page.tsx
+++ b/app/portal/request/when/page.tsx
@@ -1,7 +1,7 @@
 // app/portal/request/when/page.tsx
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Toaster, toast } from "sonner";
@@ -353,9 +353,16 @@ export default function PortalRequestWhenPage() {
     return out;
   }, [date, shopHours]);
 
+  const startAttemptKeyRef = useRef<string>("");
+
   useEffect(() => {
     setSelectedSlotIso("");
+    startAttemptKeyRef.current = "";
   }, [date]);
+
+  useEffect(() => {
+    startAttemptKeyRef.current = "";
+  }, [selectedSlotIso, vehicleId, visitType]);
 
   const canStart = Boolean(customer?.id && shop?.id && vehicleId && selectedSlotIso);
 
@@ -364,12 +371,17 @@ export default function PortalRequestWhenPage() {
 
     setStarting(true);
     try {
+      if (!startAttemptKeyRef.current) {
+        startAttemptKeyRef.current = crypto.randomUUID();
+      }
+
       // ✅ Matches /api/portal/request/start expectations
       const payload = {
         vehicleId,
         startsAt: selectedSlotIso,
         durationMins: 60,
         visitType,
+        idempotencyKey: startAttemptKeyRef.current,
       };
 
       const r = await postJson<{ workOrderId?: string; bookingId?: string }>(
@@ -389,6 +401,8 @@ export default function PortalRequestWhenPage() {
         toast.error("Start failed: missing work order id or booking id.");
         return;
       }
+
+      startAttemptKeyRef.current = "";
 
       // ✅ Option B: carry bookingId into build page (NOT startsAt)
       router.push(

--- a/db/sql/2026-04-20_phase5_portal_booking_transaction_safety.sql
+++ b/db/sql/2026-04-20_phase5_portal_booking_transaction_safety.sql
@@ -1,0 +1,196 @@
+-- Phase 5: booking/request transaction safety
+-- Adds DB-backed guarantees for portal request start flow under concurrent/replay submits.
+
+create extension if not exists btree_gist;
+
+-- 1) Keep exactly one booking row per work order when linked.
+create unique index if not exists bookings_work_order_id_unique
+  on public.bookings (work_order_id)
+  where work_order_id is not null;
+
+-- 2) Idempotency key uniqueness for portal request start path (stored in work_orders.source_row_id).
+create unique index if not exists work_orders_portal_start_source_row_id_unique
+  on public.work_orders (source_row_id)
+  where source_row_id is not null
+    and source_row_id like 'portal_start:%';
+
+-- 3) Active booking slot overlap prevention at DB level.
+alter table public.bookings
+  drop constraint if exists bookings_no_active_overlap;
+
+alter table public.bookings
+  add constraint bookings_no_active_overlap
+  exclude using gist (
+    shop_id with =,
+    tstzrange(starts_at, ends_at, '[)') with &&
+  )
+  where (
+    shop_id is not null
+    and status in ('pending', 'confirmed')
+  );
+
+-- 4) Atomic portal request start helper: creates work order + linked booking in one transaction.
+create or replace function public.portal_request_start_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_vehicle_id uuid,
+  p_starts_at timestamptz,
+  p_ends_at timestamptz,
+  p_visit_type text,
+  p_notes text,
+  p_source_row_id text default null
+)
+returns table (
+  work_order_id uuid,
+  booking_id uuid,
+  deduped boolean
+)
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_work_order_id uuid;
+  v_booking_id uuid;
+  v_existing_work_order_id uuid;
+  v_existing_booking_id uuid;
+  v_normalized_visit_type text;
+begin
+  v_normalized_visit_type := case
+    when p_visit_type = 'waiter' then 'waiter'
+    when p_visit_type = 'drop_off' then 'drop_off'
+    else null
+  end;
+
+  if p_shop_id is null or p_customer_id is null then
+    raise exception 'Missing shop/customer for portal request start';
+  end if;
+
+  if p_starts_at is null or p_ends_at is null or p_ends_at <= p_starts_at then
+    raise exception 'Invalid booking window';
+  end if;
+
+  if v_normalized_visit_type is null then
+    raise exception 'visitType must be waiter or drop_off';
+  end if;
+
+  if p_source_row_id is not null and length(trim(p_source_row_id)) > 0 then
+    select w.id
+      into v_existing_work_order_id
+    from public.work_orders w
+    where w.shop_id = p_shop_id
+      and w.customer_id = p_customer_id
+      and w.source_row_id = p_source_row_id
+    order by w.created_at desc nulls last
+    limit 1;
+
+    if v_existing_work_order_id is not null then
+      select b.id
+        into v_existing_booking_id
+      from public.bookings b
+      where b.work_order_id = v_existing_work_order_id
+      order by b.created_at desc
+      limit 1;
+
+      if v_existing_booking_id is not null then
+        return query
+        select v_existing_work_order_id, v_existing_booking_id, true;
+        return;
+      end if;
+    end if;
+  end if;
+
+  -- Work order shell is created first, booking second, inside one DB transaction boundary.
+  insert into public.work_orders (
+    shop_id,
+    customer_id,
+    vehicle_id,
+    status,
+    approval_state,
+    is_waiter,
+    scheduled_at,
+    notes,
+    source_row_id
+  )
+  values (
+    p_shop_id,
+    p_customer_id,
+    p_vehicle_id,
+    'awaiting_approval',
+    'pending',
+    (v_normalized_visit_type = 'waiter'),
+    p_starts_at,
+    nullif(trim(coalesce(p_notes, '')), ''),
+    nullif(trim(coalesce(p_source_row_id, '')), '')
+  )
+  returning id into v_work_order_id;
+
+  insert into public.bookings (
+    shop_id,
+    customer_id,
+    vehicle_id,
+    work_order_id,
+    starts_at,
+    ends_at,
+    status,
+    notes
+  )
+  values (
+    p_shop_id,
+    p_customer_id,
+    p_vehicle_id,
+    v_work_order_id,
+    p_starts_at,
+    p_ends_at,
+    'pending',
+    nullif(trim(coalesce(p_notes, '')), '')
+  )
+  returning id into v_booking_id;
+
+  return query
+  select v_work_order_id, v_booking_id, false;
+exception
+  when unique_violation then
+    if p_source_row_id is not null and length(trim(p_source_row_id)) > 0 then
+      select w.id
+        into v_existing_work_order_id
+      from public.work_orders w
+      where w.shop_id = p_shop_id
+        and w.customer_id = p_customer_id
+        and w.source_row_id = p_source_row_id
+      order by w.created_at desc nulls last
+      limit 1;
+
+      if v_existing_work_order_id is not null then
+        select b.id
+          into v_existing_booking_id
+        from public.bookings b
+        where b.work_order_id = v_existing_work_order_id
+        order by b.created_at desc
+        limit 1;
+
+        if v_existing_booking_id is not null then
+          return query
+          select v_existing_work_order_id, v_existing_booking_id, true;
+          return;
+        end if;
+      end if;
+    end if;
+
+    raise;
+  when exclusion_violation then
+    raise exception 'This time overlaps an existing booking'
+      using errcode = 'P0001';
+end;
+$$;
+
+grant execute on function public.portal_request_start_atomic(
+  uuid,
+  uuid,
+  uuid,
+  timestamptz,
+  timestamptz,
+  text,
+  text,
+  text
+) to authenticated;

--- a/features/portal/server/createPortalBooking.ts
+++ b/features/portal/server/createPortalBooking.ts
@@ -202,7 +202,12 @@ export async function createPortalBooking({
     .select("*")
     .single();
 
-  if (insErr || !created) return { ok: false, error: "Failed to create booking", status: 500 };
+  if (insErr || !created) {
+    if (insErr?.code === "23P01") {
+      return { ok: false, error: "This time overlaps an existing booking", status: 409 };
+    }
+    return { ok: false, error: "Failed to create booking", status: 500 };
+  }
 
   const cameFromPortal = !hasExplicitCustomer && !hasInlineCustomerFields;
   if (cameFromPortal && !customerShopId) {

--- a/phase5-summary.md
+++ b/phase5-summary.md
@@ -1,0 +1,62 @@
+# Phase 5 Summary — Booking Transaction Safety
+
+## What was fixed
+- Replaced the portal request start route’s race-prone check-then-insert flow with a single RPC-backed atomic create path that creates work order + booking in one transaction.
+- Added idempotency propagation from the portal “when” UI (`idempotencyKey`) through `/api/portal/request/start` into `work_orders.source_row_id` as `portal_start:<customer_id>:<key>`.
+- Added replay handling so duplicate/retry submissions return the existing `workOrderId` + `bookingId` instead of creating duplicates.
+- Hardened portal submit flow ownership checks (`booking.customer_id`), and added replay-safe short-circuit when the request was already submitted/finalized.
+- Hardened generic portal booking create helper to map DB overlap violations to a stable 409 overlap response.
+
+## Canonical integrity protections now enforced
+- constraints
+  - `bookings_work_order_id_unique` (one linked booking per work order).
+  - `work_orders_portal_start_source_row_id_unique` for `portal_start:%` idempotency keys.
+  - `bookings_no_active_overlap` exclusion constraint for active booking statuses (`pending`,`confirmed`).
+- idempotency keys
+  - Client-generated `idempotencyKey` on portal start, persisted via `work_orders.source_row_id`.
+  - Replay path returns prior IDs instead of creating additional records.
+- transactional helpers / RPCs
+  - `public.portal_request_start_atomic(...)` now performs the work order + booking create sequence in one DB transaction boundary.
+- route truth path
+  - `/api/portal/request/start` now calls `portal_request_start_atomic` as the authoritative create path.
+
+## Files changed
+- app/api/portal/request/start/route.ts
+- app/api/portal/request/submit/route.ts
+- app/portal/request/when/page.tsx
+- features/portal/server/createPortalBooking.ts
+- db/sql/2026-04-20_phase5_portal_booking_transaction_safety.sql
+- phase5-summary.md
+
+## Migrations added
+- `db/sql/2026-04-20_phase5_portal_booking_transaction_safety.sql`
+  - Adds booking/work-order invariants and portal start atomic RPC.
+- manual SQL apply required
+  - This migration was generated only; it has not been applied automatically.
+- regenerate Supabase types after apply
+  - After applying SQL manually, regenerate Supabase types so typed RPC/function signatures are current.
+
+## Behavior changes
+- Portal request start now deduplicates replayed submissions with the same idempotency key and returns existing IDs.
+- Concurrent overlapping active bookings are now blocked at DB level (409 semantics in app paths).
+- Portal submit now rejects cross-customer booking linkage attempts and safely returns success for already-submitted finalized requests.
+
+## Risks resolved
+- Race-prone booking creation path (`app/api/portal/request/start/route.ts`)
+  - Resolved: moved to atomic RPC + DB exclusion + idempotency uniqueness.
+- Directly related booking/request/work-order check-then-insert duplicate/partial-write risk
+  - Resolved for portal start authority path and replay semantics.
+  - Mitigated for portal booking helper overlap handling and portal submit replay/ownership checks.
+
+## Remaining related risks not fixed in this phase
+- Existing historical data that already violates the new overlap constraint must be cleaned before migration apply if constraint creation fails.
+- Parts request creation in submit flow remains best-effort/non-transactional with downstream RPC call, but booking/work-order linkage and replay safety were addressed in this phase.
+
+## Validation run
+- `npx tsc --noEmit`
+  - pass
+- `npm run lint`
+  - fails with pre-existing repo-wide lint errors outside this phase’s touched scope.
+
+## Notes for next phase
+- Run a repo-wide cleanup and launch-readiness sweep focused on pre-existing lint violations, and consider extending submit-path idempotency to downstream parts-request generation metadata for fully replay-stable post-submit side effects.


### PR DESCRIPTION
### Motivation
- Fix a race-prone booking creation path that used check-then-insert logic and could produce duplicate or partial records under concurrent submissions.
- Ensure portal request start is exact-one (work order + booking) and safe for retries/replays while preserving existing UX semantics.
- Enforce DB-backed invariants to minimize partial writes and keep linked work-order/booking state consistent.

### Description
- Replaced the fragile start flow with an authoritative DB RPC `public.portal_request_start_atomic(...)` and updated `/api/portal/request/start` to call it atomically, returning replayed results when appropriate.
- Added idempotency propagation from the portal UI by generating an `idempotencyKey` in `app/portal/request/when/page.tsx` and persisting it as `work_orders.source_row_id = portal_start:<customer_id>:<key>` for replay/dedupe handling.
- Hardened related paths by adding ownership/replay checks in `/api/portal/request/submit`, mapping DB overlap/exclusion violations to 409 responses in `features/portal/server/createPortalBooking.ts`, and short-circuiting already-submitted finalization.
- Added a SQL migration `db/sql/2026-04-20_phase5_portal_booking_transaction_safety.sql` that creates unique indexes (`bookings_work_order_id_unique`, `work_orders_portal_start_source_row_id_unique`), an exclusion constraint `bookings_no_active_overlap` for active slot overlaps, and the `portal_request_start_atomic` function; note manual apply required and Supabase types must be regenerated after applying.

### Testing
- Ran `npx tsc --noEmit` and the typecheck passed.
- Ran `npm run lint` and linting failed with pre-existing repo-wide issues outside this change (no new phase-specific lint breakage introduced).
- Local validation: compiled TypeScript successfully after edits and the new SQL migration file was generated at `db/sql/2026-04-20_phase5_portal_booking_transaction_safety.sql` (migration not applied automatically and must be applied manually, then run Supabase type regeneration).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59e0fe27883289df419882b81313d)