### PR TITLE
Blocker A: Harden non-public API route guards

### DIFF
--- a/app/api/assistant/export/route.ts
+++ b/app/api/assistant/export/route.ts
@@ -1,11 +1,11 @@
 // app/api/assistant/export/route.ts
-export const runtime = "edge";
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
-import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -16,12 +16,6 @@ type Vehicle = {
 };
 
 type ChatMessage = { role: "user" | "assistant"; content: string };
-
-function getEnv(name: string): string {
-  const v = process.env[name];
-  if (!v) throw new Error(`Missing required env: ${name}`);
-  return v;
-}
 
 function normalizeMarkdown(s: string): string {
   let out = (s ?? "").trim();
@@ -35,6 +29,11 @@ function normalizeMarkdown(s: string): string {
 }
 
 export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) {
+    return access.response;
+  }
+
   try {
     const { vehicle, messages, workOrderLineId } = (await req.json()) as {
       vehicle?: Vehicle;
@@ -43,30 +42,24 @@ export async function POST(req: Request) {
     };
 
     if (!vehicle?.year || !vehicle?.make || !vehicle?.model) {
-      return NextResponse.json(
-        { error: "Missing vehicle info." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Missing vehicle info." }, { status: 400 });
     }
     if (!workOrderLineId) {
-      return NextResponse.json(
-        { error: "Missing work order line id." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Missing work order line id." }, { status: 400 });
     }
 
     const prompt = [
       `Vehicle: ${vehicle.year} ${vehicle.make} ${vehicle.model}`,
-      `You are preparing a concise work-order entry for a shop management system.`,
-      `From the conversation below, produce:`,
-      `- Cause: one or two sentences (this is the diagnosis / story of what you found).`,
-      `- Correction: short bullet list (1–5 bullets).`,
-      `- EstimatedLaborTime: a decimal number in hours when appropriate, else null.`,
-      ``,
-      `Conversation (latest last):`,
+      "You are preparing a concise work-order entry for a shop management system.",
+      "From the conversation below, produce:",
+      "- Cause: one or two sentences (this is the diagnosis / story of what you found).",
+      "- Correction: short bullet list (1–5 bullets).",
+      "- EstimatedLaborTime: a decimal number in hours when appropriate, else null.",
+      "",
+      "Conversation (latest last):",
       ...(messages ?? []).map((m) => `${m.role.toUpperCase()}: ${m.content}`),
-      ``,
-      `Return JSON with these exact keys: { "cause": string, "correction": string, "estimatedLaborTime": number | null }`,
+      "",
+      'Return JSON with these exact keys: { "cause": string, "correction": string, "estimatedLaborTime": number | null }',
     ].join("\n");
 
     const completion = await openai.chat.completions.create({
@@ -87,70 +80,45 @@ export async function POST(req: Request) {
     const cause = normalizeMarkdown(parsed.cause ?? "");
     const correction = normalizeMarkdown(parsed.correction ?? "");
     const estimatedLaborTime =
-      typeof parsed.estimatedLaborTime === "number"
-        ? parsed.estimatedLaborTime
-        : null;
+      typeof parsed.estimatedLaborTime === "number" ? parsed.estimatedLaborTime : null;
 
-    // We only *require* cause now; correction can be empty
     if (!cause) {
-      return NextResponse.json(
-        { error: "Model did not return a valid cause." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Model did not return a valid cause." }, { status: 500 });
     }
 
-    // 🔐 Supabase service client
-    const supabase = createClient<Database>(
-      getEnv("NEXT_PUBLIC_SUPABASE_URL"),
-      getEnv("SUPABASE_SERVICE_ROLE_KEY"),
-    );
-
-    // Optional: ensure line exists (nicer error)
-    const { data: line, error: lineErr } = await supabase
+    const { data: line, error: lineErr } = await access.supabase
       .from("work_order_lines")
       .select("id")
       .eq("id", workOrderLineId)
+      .eq("shop_id", access.profile.shop_id)
       .maybeSingle();
 
     if (lineErr) {
-      return NextResponse.json(
-        { error: "Failed to load work order line." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to load work order line." }, { status: 500 });
     }
     if (!line) {
-      return NextResponse.json(
-        { error: "Work order line not found." },
-        { status: 404 },
-      );
+      return NextResponse.json({ error: "Work order line not found." }, { status: 404 });
     }
 
-    // ✅ Only write cause + labor_time.
-    //    We DO NOT touch correction here, so tech keeps full control of that story.
-    const updates: Database["public"]["Tables"]["work_order_lines"]["Update"] =
-      {
-        cause,
-        labor_time: estimatedLaborTime,
-      };
+    const updates: Database["public"]["Tables"]["work_order_lines"]["Update"] = {
+      cause,
+      labor_time: estimatedLaborTime,
+    };
 
-    const { data: updated, error: updateErr } = await supabase
+    const { data: updated, error: updateErr } = await access.supabase
       .from("work_order_lines")
       .update(updates)
       .eq("id", workOrderLineId)
+      .eq("shop_id", access.profile.shop_id)
       .select("cause, correction, labor_time")
       .maybeSingle();
 
     if (updateErr) {
-      return NextResponse.json(
-        { error: "Failed to save story to work order line." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Failed to save story to work order line." }, { status: 500 });
     }
 
     return NextResponse.json({
       cause: updated?.cause ?? cause,
-      // Return whatever correction is currently on the line (or the AI suggestion),
-      // but we never overwrite it in this route.
       correction: updated?.correction ?? correction,
       estimatedLaborTime:
         typeof updated?.labor_time === "number"

--- a/app/api/debug/sendgrid-test/route.ts
+++ b/app/api/debug/sendgrid-test/route.ts
@@ -3,6 +3,8 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { sendDynamicTemplateEmail } from "@/features/email/server/sendDynamicTemplateEmail";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { requireNonProductionRoute } from "@/features/shared/lib/server/api-route-guard";
 
 type Body = {
   shopId?: string;
@@ -11,6 +13,16 @@ type Body = {
 };
 
 export async function POST(req: Request) {
+  const envGate = requireNonProductionRoute("debug/sendgrid-test");
+  if (!envGate.ok) {
+    return envGate.response;
+  }
+
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) {
+    return access.response;
+  }
+
   try {
     const body = (await req.json().catch(() => null)) as Body | null;
 
@@ -19,10 +31,11 @@ export async function POST(req: Request) {
     const templateKey = body?.templateKey ?? "portal_invite";
 
     if (!shopId || !to) {
-      return NextResponse.json(
-        { error: "shopId and to are required" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "shopId and to are required" }, { status: 400 });
+    }
+
+    if (shopId !== access.profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     await sendDynamicTemplateEmail({
@@ -73,8 +86,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ ok: true });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Unknown error";
+    const message = error instanceof Error ? error.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/diag/log/route.ts
+++ b/app/api/diag/log/route.ts
@@ -1,6 +1,20 @@
 import { NextResponse } from "next/server";
+import { requireInternalApiSecret } from "@/features/shared/lib/server/api-route-guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
+  const internalGate = requireInternalApiSecret({
+    request: req,
+    envSecretName: "DIAG_LOG_SECRET",
+    headerName: "x-diag-log-secret",
+    routeLabel: "diag/log",
+  });
+  if (!internalGate.ok) {
+    return internalGate.response;
+  }
+
   try {
     const body = await req.json().catch(() => ({}));
     console.log("[diag]", body.message, body.extra || "");

--- a/app/api/openai/realtime-token/route.ts
+++ b/app/api/openai/realtime-token/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -71,6 +72,11 @@ function extractToken(
 /* ----------------------------- Route ----------------------------- */
 
 export async function GET() {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) {
+    return access.response;
+  }
+
   try {
     const apiKey = process.env.OPENAI_API_KEY;
 

--- a/app/api/qb-route-test/route.ts
+++ b/app/api/qb-route-test/route.ts
@@ -1,8 +1,20 @@
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { requireNonProductionRoute } from "@/features/shared/lib/server/api-route-guard";
 
 export async function GET() {
+  const envGate = requireNonProductionRoute("qb-route-test");
+  if (!envGate.ok) {
+    return envGate.response;
+  }
+
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) {
+    return access.response;
+  }
+
   return NextResponse.json({
     ok: true,
     route: "qb-route-test",

--- a/features/shared/lib/server/api-route-guard.ts
+++ b/features/shared/lib/server/api-route-guard.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+export function isProductionRuntime(): boolean {
+  return process.env.NODE_ENV === "production" || process.env.VERCEL_ENV === "production";
+}
+
+export function requireNonProductionRoute(routeLabel: string):
+  | { ok: true }
+  | { ok: false; response: NextResponse } {
+  if (!isProductionRuntime()) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    response: NextResponse.json(
+      { error: `${routeLabel} is disabled in production` },
+      { status: 404 },
+    ),
+  };
+}
+
+export function requireInternalApiSecret(options: {
+  request: Request;
+  envSecretName: string;
+  headerName: string;
+  routeLabel: string;
+}):
+  | { ok: true }
+  | { ok: false; response: NextResponse } {
+  const configuredSecret = process.env[options.envSecretName];
+
+  if (!configuredSecret) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: `${options.routeLabel} is not configured` },
+        { status: 500 },
+      ),
+    };
+  }
+
+  const providedSecret = options.request.headers.get(options.headerName);
+
+  if (!providedSecret || providedSecret !== configuredSecret) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
### Motivation
- Close unauthenticated or weakly-guarded non-public API surfaces discovered in the recent audit so token-minting, export, debug, and diagnostic routes are not anonymously callable. 
- Use canonical server guards and explicit shop-scoping or secret gating to avoid ad-hoc checks and to preserve multi-tenant safety.

### Description
- Added a shared API guard helper `features/shared/lib/server/api-route-guard.ts` with `requireNonProductionRoute` and `requireInternalApiSecret` to centralize non-production and internal-secret gating.
- Hardened `/api/assistant/export` by requiring `requireShopScopedApiAccess`, switching to server-route runtime, and enforcing `shop_id` checks on `work_order_lines` select/update operations. 
- Hardened `/api/openai/realtime-token` by requiring `requireShopScopedApiAccess` so realtime token minting is authenticated and shop-scoped. 
- Locked `/api/debug/sendgrid-test` behind `requireNonProductionRoute` and `requireShopScopedApiAccess` (owner/admin) and enforced same-shop (`shopId === actor.shop_id`) validation. 
- Locked `/api/diag/log` behind `requireInternalApiSecret` which validates the `x-diag-log-secret` header against `DIAG_LOG_SECRET`. 
- Swept adjacent debug route `/api/qb-route-test` and gated it with `requireNonProductionRoute` + `requireShopScopedApiAccess` (`owner|admin`).

### Testing
- Ran `pnpm typecheck` and it passed (no new type errors introduced). 
- Ran `pnpm test` and it passed (5 files, 10 tests passed). 
- Ran `pnpm lint` which failed with pre-existing repo-wide issues unrelated to this patch (118 problems: 12 errors, 106 warnings); lint failures were not introduced by these guard additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b1c6ece88328b889d781061299ea)