### PR TITLE
Harden owner PIN verification with signed actor-bound tokens

### DIFF
--- a/app/api/branding/assets/[id]/activate/route.ts
+++ b/app/api/branding/assets/[id]/activate/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireBrandShopWriteAccess } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 export async function POST(
   req: Request,
@@ -21,7 +21,11 @@ export async function POST(
   const pinCheck = await requireOwnerPinVerified(
     req,
     auth.supabase as never,
-    auth.shopId,
+    {
+      shopId: auth.shopId,
+      userId: auth.userId,
+      allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+    },
   );
 
   if (!pinCheck.ok) {

--- a/app/api/branding/assets/[id]/archive/route.ts
+++ b/app/api/branding/assets/[id]/archive/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireBrandShopWriteAccess } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -14,7 +14,11 @@ export async function POST(req: Request, { params }: Params) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, auth.shopId);
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
   if (!pinCheck.ok) return pinCheck.response;
 
   const body = (await req.json().catch(() => ({}))) as { archived?: boolean };

--- a/app/api/branding/assets/[id]/delete/route.ts
+++ b/app/api/branding/assets/[id]/delete/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireBrandShopWriteAccess } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -14,7 +14,11 @@ export async function POST(req: Request, { params }: Params) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, auth.shopId);
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
   if (!pinCheck.ok) return pinCheck.response;
 
   const { data: asset, error: assetErr } = await auth.supabase

--- a/app/api/branding/assets/[id]/favorite/route.ts
+++ b/app/api/branding/assets/[id]/favorite/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireBrandShopWriteAccess } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -14,7 +14,11 @@ export async function POST(req: Request, { params }: Params) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, auth.shopId);
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
   if (!pinCheck.ok) return pinCheck.response;
 
   const body = (await req.json().catch(() => ({}))) as { isFavorite?: boolean };

--- a/app/api/branding/assets/route.ts
+++ b/app/api/branding/assets/route.ts
@@ -4,7 +4,7 @@ import {
   requireBrandShopReadAccess,
   requireBrandShopWriteAccess,
 } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 type BrandAssetKind = DB["public"]["Enums"]["brand_asset_kind"];
@@ -74,7 +74,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, auth.shopId);
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
   if (!pinCheck.ok) {
     return pinCheck.response;
   }

--- a/app/api/branding/assets/upload/route.ts
+++ b/app/api/branding/assets/upload/route.ts
@@ -4,7 +4,7 @@ import {
   requireBrandShopWriteAccess,
   safeFilePart,
 } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 type BrandAssetKind = DB["public"]["Enums"]["brand_asset_kind"];
@@ -27,7 +27,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, auth.shopId);
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
   if (!pinCheck.ok) {
     return pinCheck.response;
   }

--- a/app/api/branding/generate/route.ts
+++ b/app/api/branding/generate/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import { requireBrandShopWriteAccess, safeFilePart } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 import { buildLogoPrompt, getOpenAIClient } from "@/features/branding/server/logo-generation";
 
 type DB = Database;
@@ -27,7 +27,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, auth.shopId);
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
   if (!pinCheck.ok) {
     return pinCheck.response;
   }

--- a/app/api/branding/profile/route.ts
+++ b/app/api/branding/profile/route.ts
@@ -5,7 +5,7 @@ import {
   requireBrandShopWriteAccess,
   normalizeHexColor,
 } from "@/features/branding/server/brand";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 
@@ -109,7 +109,11 @@ export async function POST(req: Request) {
   const pinCheck = await requireOwnerPinVerified(
     req,
     auth.supabase as never,
-    auth.shopId,
+    {
+      shopId: auth.shopId,
+      userId: auth.userId,
+      allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+    },
   );
   if (!pinCheck.ok) {
     return pinCheck.response;

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
-import { setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 
@@ -134,7 +134,11 @@ export async function POST(req: Request) {
     }
 
     const res = NextResponse.json({ ok: true, shop_id: shop.id }, { status: 200 });
-    return setOwnerPinVerifiedCookie(res, shop.id);
+    return setOwnerPinVerifiedCookie(res, {
+      userId: user.id,
+      shopId: shop.id,
+      purpose: OWNER_PIN_PURPOSES.PRIVILEGED,
+    });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected server error";
     return NextResponse.json({ msg }, { status: 500 });

--- a/app/api/settings/hours/route.ts
+++ b/app/api/settings/hours/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 type HourInput = {
   weekday?: number;
@@ -54,6 +55,7 @@ export async function POST(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 

--- a/app/api/settings/pricing-valid-days/route.ts
+++ b/app/api/settings/pricing-valid-days/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 function clamp(v: number): number {
   if (!Number.isFinite(v)) return 30;
@@ -33,6 +34,7 @@ export async function POST(req: Request) {
     allowRoles: ["owner", "admin"],
     requireOwnerPin: true,
     ownerPinRequest: req,
+    ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
   });
   if (!access.ok) return access.response;
 

--- a/app/api/settings/time-off/route.ts
+++ b/app/api/settings/time-off/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 type TimeOffRow = {
   id?: string;
@@ -59,6 +60,7 @@ export async function POST(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 
@@ -110,6 +112,7 @@ export async function DELETE(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 

--- a/app/api/settings/update/route.ts
+++ b/app/api/settings/update/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 // Whitelist fields that can be updated from Settings
 const ALLOWED_FIELDS = new Set([
@@ -59,6 +60,7 @@ export async function POST(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 

--- a/app/api/shop/owner-pin/set/route.ts
+++ b/app/api/shop/owner-pin/set/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { getRouteHandlerCookies, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
+import {
+  getRouteHandlerCookies,
+  OWNER_PIN_PURPOSES,
+  setOwnerPinVerifiedCookie,
+} from "@/features/shared/lib/server/owner-pin";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 
@@ -75,7 +79,11 @@ export async function POST(req: Request) {
     }
 
     const res = NextResponse.json({ ok: true });
-    return setOwnerPinVerifiedCookie(res, shopId);
+    return setOwnerPinVerifiedCookie(res, {
+      userId: user.id,
+      shopId,
+      purpose: OWNER_PIN_PURPOSES.PRIVILEGED,
+    });
   } catch (err) {
     console.error("owner-pin.set error", err);
     return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/app/api/shop/owner-pin/verify/route.ts
+++ b/app/api/shop/owner-pin/verify/route.ts
@@ -3,6 +3,8 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import {
   getRouteHandlerCookies,
+  OWNER_PIN_PURPOSES,
+  type OwnerPinPurpose,
   setOwnerPinVerifiedCookie,
 } from "@/features/shared/lib/server/owner-pin";
 import { normalizeOwnerPin, verifyOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
@@ -12,7 +14,10 @@ type DB = Database;
 type Body = {
   shopId?: string;
   pin?: string;
+  purpose?: string;
 };
+
+const OWNER_PIN_PURPOSE_VALUES = new Set<OwnerPinPurpose>(Object.values(OWNER_PIN_PURPOSES));
 
 export async function POST(req: Request) {
   try {
@@ -30,6 +35,10 @@ export async function POST(req: Request) {
     const body = (await req.json().catch(() => ({}))) as Body;
     const shopId = body.shopId?.trim() ?? "";
     const pin = normalizeOwnerPin(body.pin ?? "");
+    const requestedPurpose = (body.purpose ?? "").trim();
+    const purpose = OWNER_PIN_PURPOSE_VALUES.has(requestedPurpose as OwnerPinPurpose)
+      ? (requestedPurpose as OwnerPinPurpose)
+      : OWNER_PIN_PURPOSES.PRIVILEGED;
 
     if (!shopId || !pin) {
       return NextResponse.json({ error: "shopId and pin required" }, { status: 400 });
@@ -65,7 +74,11 @@ export async function POST(req: Request) {
     }
 
     const res = NextResponse.json({ ok: true });
-    return setOwnerPinVerifiedCookie(res, shopId);
+    return setOwnerPinVerifiedCookie(res, {
+      userId: user.id,
+      shopId,
+      purpose,
+    });
   } catch (err) {
     console.error("owner-pin.verify error", err);
     return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -6,6 +6,7 @@ import Stripe from "stripe";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 
@@ -118,6 +119,7 @@ export async function POST(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.BILLING, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -6,6 +6,7 @@ import Stripe from "stripe";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 type DB = Database;
 
@@ -76,6 +77,7 @@ export async function POST(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.BILLING, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 

--- a/app/api/stripe/session/route.ts
+++ b/app/api/stripe/session/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
@@ -15,6 +16,7 @@ export async function GET(req: Request) {
       allowRoles: ["owner", "admin"],
       requireOwnerPin: true,
       ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.BILLING, OWNER_PIN_PURPOSES.PRIVILEGED],
     });
     if (!access.ok) return access.response;
 

--- a/features/shared/lib/server/admin-access.ts
+++ b/features/shared/lib/server/admin-access.ts
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import type { Database } from "@shared/types/types/supabase";
 import { createServerSupabaseRSC, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { canonicalizeRole, getActorCapabilities, type ActorCapabilities, type CanonicalRole } from "@/features/shared/lib/rbac";
-import { requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { OWNER_PIN_PURPOSES, type OwnerPinPurpose, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 import { NextResponse } from "next/server";
 
 type DB = Database;
@@ -50,6 +50,7 @@ type ApiAccessOptions = {
   allowRoles?: CanonicalRole[];
   requireOwnerPin?: boolean;
   ownerPinRequest?: Request;
+  ownerPinAllowedPurposes?: OwnerPinPurpose[];
 };
 
 export async function requireShopScopedApiAccess(options: ApiAccessOptions = {}): Promise<
@@ -103,7 +104,11 @@ export async function requireShopScopedApiAccess(options: ApiAccessOptions = {})
     if (!options.ownerPinRequest) {
       return { ok: false, response: NextResponse.json({ error: "Owner PIN request context missing" }, { status: 500 }) };
     }
-    const pinCheck = await requireOwnerPinVerified(options.ownerPinRequest, supabase as never, profile.shop_id);
+    const pinCheck = await requireOwnerPinVerified(options.ownerPinRequest, supabase as never, {
+      shopId: profile.shop_id,
+      userId: user.id,
+      allowedPurposes: options.ownerPinAllowedPurposes ?? [OWNER_PIN_PURPOSES.PRIVILEGED],
+    });
     if (!pinCheck.ok) return { ok: false, response: pinCheck.response };
   }
 

--- a/features/shared/lib/server/owner-pin.ts
+++ b/features/shared/lib/server/owner-pin.ts
@@ -1,13 +1,36 @@
 import { cookies as nextCookies } from "next/headers";
 import { NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 
 export const OWNER_PIN_COOKIE_NAME = "pfq_owner_pin_shop";
 export const OWNER_PIN_TTL_SECONDS = 60 * 30;
+export const OWNER_PIN_TOKEN_SECRET_ENV = "OWNER_PIN_TOKEN_SECRET";
+
+export const OWNER_PIN_PURPOSES = {
+  PRIVILEGED: "owner_pin:privileged",
+  SETTINGS: "owner_pin:settings",
+  BILLING: "owner_pin:billing",
+  BRANDING: "owner_pin:branding",
+} as const;
+
+export type OwnerPinPurpose = (typeof OWNER_PIN_PURPOSES)[keyof typeof OWNER_PIN_PURPOSES];
+
+type OwnerPinTokenClaims = {
+  sub: string;
+  shop_id: string;
+  purpose: OwnerPinPurpose;
+  iat: number;
+  exp: number;
+  ver: 1;
+};
 
 type SupabaseLike = {
+  auth: {
+    getUser: () => Promise<{ data: { user: { id: string } | null }; error: unknown }>;
+  };
   from: (table: keyof DB["public"]["Tables"] | string) => {
     select: (columns: string) => {
       eq: (column: string, value: string) => {
@@ -16,6 +39,93 @@ type SupabaseLike = {
     };
   };
 };
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function getOwnerPinTokenSecret(): string | null {
+  const secret = process.env[OWNER_PIN_TOKEN_SECRET_ENV]?.trim();
+  return secret ? secret : null;
+}
+
+function signOwnerPinToken(unsignedValue: string, secret: string): string {
+  return createHmac("sha256", secret).update(unsignedValue).digest("base64url");
+}
+
+function safeEqualString(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function createOwnerPinToken(args: {
+  userId: string;
+  shopId: string;
+  purpose: OwnerPinPurpose;
+  ttlSeconds?: number;
+  nowSeconds?: number;
+}): string {
+  const secret = getOwnerPinTokenSecret();
+  if (!secret) {
+    throw new Error(`${OWNER_PIN_TOKEN_SECRET_ENV} is required`);
+  }
+
+  const now = args.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const payload: OwnerPinTokenClaims = {
+    sub: args.userId,
+    shop_id: args.shopId,
+    purpose: args.purpose,
+    iat: now,
+    exp: now + (args.ttlSeconds ?? OWNER_PIN_TTL_SECONDS),
+    ver: 1,
+  };
+  const encodedHeader = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const unsigned = `${encodedHeader}.${encodedPayload}`;
+  const signature = signOwnerPinToken(unsigned, secret);
+  return `${unsigned}.${signature}`;
+}
+
+export function verifyOwnerPinToken(token: string): { ok: true; claims: OwnerPinTokenClaims } | { ok: false } {
+  try {
+    const secret = getOwnerPinTokenSecret();
+    if (!secret) return { ok: false };
+
+    const parts = token.split(".");
+    if (parts.length !== 3) return { ok: false };
+
+    const [encodedHeader, encodedPayload, signature] = parts;
+    const unsigned = `${encodedHeader}.${encodedPayload}`;
+    const expectedSignature = signOwnerPinToken(unsigned, secret);
+    if (!safeEqualString(signature, expectedSignature)) return { ok: false };
+
+    const parsedHeader = JSON.parse(base64UrlDecode(encodedHeader)) as { alg?: string; typ?: string };
+    if (parsedHeader.alg !== "HS256" || parsedHeader.typ !== "JWT") return { ok: false };
+
+    const claims = JSON.parse(base64UrlDecode(encodedPayload)) as Partial<OwnerPinTokenClaims>;
+    if (
+      claims.ver !== 1 ||
+      typeof claims.sub !== "string" ||
+      typeof claims.shop_id !== "string" ||
+      typeof claims.purpose !== "string" ||
+      typeof claims.iat !== "number" ||
+      typeof claims.exp !== "number"
+    ) {
+      return { ok: false };
+    }
+
+    if (claims.exp <= Math.floor(Date.now() / 1000)) return { ok: false };
+    return { ok: true, claims: claims as OwnerPinTokenClaims };
+  } catch {
+    return { ok: false };
+  }
+}
 
 export function getOwnerPinCookieFromRequest(req: Request): string | null {
   const cookieHeader = req.headers.get("cookie") ?? "";
@@ -29,8 +139,13 @@ export function getOwnerPinCookieFromRequest(req: Request): string | null {
   return decodeURIComponent(value || "");
 }
 
-export function setOwnerPinVerifiedCookie(res: NextResponse, shopId: string) {
-  res.cookies.set(OWNER_PIN_COOKIE_NAME, shopId, {
+export function setOwnerPinVerifiedCookie(
+  res: NextResponse,
+  args: { userId: string; shopId: string; purpose: OwnerPinPurpose }
+) {
+  const token = createOwnerPinToken(args);
+
+  res.cookies.set(OWNER_PIN_COOKIE_NAME, token, {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
@@ -56,21 +171,55 @@ export function clearOwnerPinVerifiedCookie(res: NextResponse) {
 export async function requireOwnerPinVerified(
   req: Request,
   supabase: SupabaseLike,
-  shopId: string
+  args: {
+    shopId: string;
+    userId: string;
+    allowedPurposes: OwnerPinPurpose[];
+  }
 ): Promise<{ ok: true } | { ok: false; response: NextResponse }> {
-  const cookieShopId = getOwnerPinCookieFromRequest(req);
+  const cookieToken = getOwnerPinCookieFromRequest(req);
 
-  if (!cookieShopId || cookieShopId !== shopId) {
+  if (!cookieToken) {
     return {
       ok: false,
       response: NextResponse.json({ error: "Owner PIN required" }, { status: 401 }),
     };
   }
 
+  const verification = verifyOwnerPinToken(cookieToken);
+  if (!verification.ok) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Owner PIN required" }, { status: 401 }),
+    };
+  }
+
+  if (verification.claims.sub !== args.userId || verification.claims.shop_id !== args.shopId) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Owner PIN required" }, { status: 401 }),
+    };
+  }
+
+  if (!args.allowedPurposes.includes(verification.claims.purpose)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Owner PIN purpose not allowed" }, { status: 403 }),
+    };
+  }
+
+  const { data: currentUser, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !currentUser.user || currentUser.user.id !== args.userId) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    };
+  }
+
   const { data: shop, error } = await supabase
     .from("shops")
     .select("id")
-    .eq("id", shopId)
+    .eq("id", args.shopId)
     .single();
 
   if (error || !shop) {

--- a/tests/owner-pin-token.test.ts
+++ b/tests/owner-pin-token.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  OWNER_PIN_COOKIE_NAME,
+  OWNER_PIN_PURPOSES,
+  clearOwnerPinVerifiedCookie,
+  createOwnerPinToken,
+  requireOwnerPinVerified,
+  verifyOwnerPinToken,
+} from "../features/shared/lib/server/owner-pin";
+import { NextResponse } from "next/server";
+
+const SECRET_ENV = "OWNER_PIN_TOKEN_SECRET";
+
+type MockSupabase = {
+  auth: {
+    getUser: () => Promise<{ data: { user: { id: string } | null }; error: unknown }>;
+  };
+  from: () => {
+    select: () => {
+      eq: () => {
+        single: () => Promise<{ data: { id: string } | null; error: unknown }>;
+      };
+    };
+  };
+};
+
+function makeRequestWithCookie(cookie: string): Request {
+  return new Request("http://localhost/api/test", {
+    headers: {
+      cookie,
+    },
+  });
+}
+
+function makeSupabase(userId = "user-1"): MockSupabase {
+  return {
+    auth: {
+      getUser: async () => ({ data: { user: { id: userId } }, error: null }),
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { id: "shop-1" }, error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+beforeEach(() => {
+  process.env[SECRET_ENV] = "unit-test-owner-pin-secret";
+});
+
+afterEach(() => {
+  delete process.env[SECRET_ENV];
+});
+
+describe("owner pin signed token", () => {
+  it("accepts a valid token", () => {
+    const token = createOwnerPinToken({
+      userId: "user-1",
+      shopId: "shop-1",
+      purpose: OWNER_PIN_PURPOSES.SETTINGS,
+      ttlSeconds: 600,
+    });
+
+    const verified = verifyOwnerPinToken(token);
+    expect(verified.ok).toBe(true);
+    if (verified.ok) {
+      expect(verified.claims.sub).toBe("user-1");
+      expect(verified.claims.shop_id).toBe("shop-1");
+      expect(verified.claims.purpose).toBe(OWNER_PIN_PURPOSES.SETTINGS);
+    }
+  });
+
+  it("rejects an expired token", async () => {
+    const token = createOwnerPinToken({
+      userId: "user-1",
+      shopId: "shop-1",
+      purpose: OWNER_PIN_PURPOSES.SETTINGS,
+      ttlSeconds: -1,
+    });
+
+    const req = makeRequestWithCookie(`${OWNER_PIN_COOKIE_NAME}=${encodeURIComponent(token)}`);
+    const result = await requireOwnerPinVerified(req, makeSupabase(), {
+      userId: "user-1",
+      shopId: "shop-1",
+      allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("rejects wrong user", async () => {
+    const token = createOwnerPinToken({
+      userId: "user-1",
+      shopId: "shop-1",
+      purpose: OWNER_PIN_PURPOSES.SETTINGS,
+    });
+
+    const req = makeRequestWithCookie(`${OWNER_PIN_COOKIE_NAME}=${encodeURIComponent(token)}`);
+    const result = await requireOwnerPinVerified(req, makeSupabase("user-2"), {
+      userId: "user-2",
+      shopId: "shop-1",
+      allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("rejects wrong shop", async () => {
+    const token = createOwnerPinToken({
+      userId: "user-1",
+      shopId: "shop-1",
+      purpose: OWNER_PIN_PURPOSES.SETTINGS,
+    });
+
+    const req = makeRequestWithCookie(`${OWNER_PIN_COOKIE_NAME}=${encodeURIComponent(token)}`);
+    const result = await requireOwnerPinVerified(req, makeSupabase(), {
+      userId: "user-1",
+      shopId: "shop-2",
+      allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("rejects wrong purpose", async () => {
+    const token = createOwnerPinToken({
+      userId: "user-1",
+      shopId: "shop-1",
+      purpose: OWNER_PIN_PURPOSES.BILLING,
+    });
+
+    const req = makeRequestWithCookie(`${OWNER_PIN_COOKIE_NAME}=${encodeURIComponent(token)}`);
+    const result = await requireOwnerPinVerified(req, makeSupabase(), {
+      userId: "user-1",
+      shopId: "shop-1",
+      allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+    }
+  });
+
+  it("rejects after clear cookie", async () => {
+    const res = NextResponse.json({ ok: true });
+    clearOwnerPinVerifiedCookie(res);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`${OWNER_PIN_COOKIE_NAME}=`);
+
+    const req = makeRequestWithCookie("");
+    const result = await requireOwnerPinVerified(req, makeSupabase(), {
+      userId: "user-1",
+      shopId: "shop-1",
+      allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the weak plaintext shopId cookie trust model used for owner PIN-protected actions with a cryptographically signed, actor-bound token to close several audit findings. 
- Ensure privileged actions require proof that is tied to the current authenticated user, current shop context, expiration, and a purpose scope so copied cookies or cross-shop reuse fail.

### Description
- Introduce an HMAC-signed owner PIN token model and helpers `createOwnerPinToken`, `verifyOwnerPinToken`, and `requireOwnerPinVerified` that validate signature, expiry, `sub` (user), `shop_id`, and token `purpose`, and fail safely when `OWNER_PIN_TOKEN_SECRET` is missing. 
- Replace cookie issuance to store the signed token in the existing cookie name `pfq_owner_pin_shop` and add `OWNER_PIN_PURPOSES` constants (`privileged`, `settings`, `billing`, `branding`) to scope verification per route. 
- Canonicalize verification by updating `requireShopScopedApiAccess` to pass `userId`, `shopId`, and `ownerPinAllowedPurposes` into `requireOwnerPinVerified` and propagate allowed-purpose checks to settings, billing, and branding endpoints. 
- Update owner PIN issuance paths (`/api/shop/owner-pin/verify`, `/api/shop/owner-pin/set`, onboarding bootstrap) to mint signed tokens bound to actor/shop/purpose and add unit tests exercising valid token, wrong user, wrong shop, expired, wrong purpose, and cleared cookie scenarios.

### Testing
- Ran typecheck: `pnpm -s tsc --noEmit` — passed. 
- Run unit tests: `pnpm -s vitest run tests/owner-pin-crypto.test.ts tests/owner-pin-token.test.ts` — passed (2 files, 9 tests). 
- Lint: `pnpm -s lint` — reported existing repo-wide issues unrelated to this change (pre-existing warnings/errors), not introduced by this patch. 
- No SQL migrations were added as this change is backend proof-model hardening only and does not alter schema; note that `OWNER_PIN_TOKEN_SECRET` environment variable must be set in deployment for issuance/verification to work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b4ecf78c832897ebb1c130f7ad5a)