### PR TITLE
Disable incomplete PO draft and intake attachment affordances

### DIFF
--- a/features/parts/lib/po.ts
+++ b/features/parts/lib/po.ts
@@ -6,11 +6,13 @@ export type PoDraft = {
 };
 
 export async function suggestReorder(): Promise<PoDraft[]> {
-  // TODO: compute from low_stock + recent usage
-  return [];
+  throw new Error(
+    "PO reorder suggestions are currently unavailable in production.",
+  );
 }
 
 export async function createPoDraft(_draft: PoDraft): Promise<string> {
-  // TODO: insert into purchase_orders + purchase_order_lines and return id
-  return "TODO-PO-ID";
+  throw new Error(
+    "PO draft creation from this flow is currently unavailable in production.",
+  );
 }

--- a/features/work-orders/intake/components/blocks/AttachmentsBlock.tsx
+++ b/features/work-orders/intake/components/blocks/AttachmentsBlock.tsx
@@ -15,7 +15,8 @@ export function AttachmentsBlock(props: {
     <div style={{ display: "grid", gap: 12 }}>
       <label style={{ fontWeight: 800 }}>Attachments (optional)</label>
       <div style={{ fontSize: 13, opacity: 0.75 }}>
-        Add photos/videos/documents (dash lights, leaks, noises). Upload UI can plug in later.
+        Attachments are currently unavailable in intake. Continue the intake flow
+        and add supporting media from the work-order record after intake.
       </div>
 
       {!!attachments.length ? (
@@ -32,10 +33,12 @@ export function AttachmentsBlock(props: {
 
       <button
         type="button"
-        onClick={() => props.onChange(attachments)}
-        style={{ padding: 12, borderRadius: 10 }}
+        disabled
+        aria-disabled="true"
+        title="Intake attachments are not yet available."
+        style={{ padding: 12, borderRadius: 10, opacity: 0.55, cursor: "not-allowed" }}
       >
-        Add attachment (coming soon)
+        Attachment upload unavailable
       </button>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Prevent operators from seeing or using UI/API affordances that appear live but are not end-to-end operational, specifically parts PO draft creation and intake attachments.
- Make incomplete surfaces explicit and non-actionable to preserve operator trust and avoid creating fake/placeholder artifacts in the system.

### Description
- Replaced the placeholder PO helpers in `features/parts/lib/po.ts` so `suggestReorder()` and `createPoDraft()` now throw explicit "unavailable in production" errors instead of returning a fake ID or empty arrays, preventing callers from receiving misleading success values.
- Updated intake attachments UI in `features/work-orders/intake/components/blocks/AttachmentsBlock.tsx` to show clear copy that intake attachments are unavailable, disabled the action button, and relabeled it as "Attachment upload unavailable" so it is non-interactive.
- Changes are scoped to incomplete surfaces and do not alter canonical PO server actions or intake persistence routes.

### Testing
- Ran `npx tsc --noEmit` which completed successfully (typecheck passed).
- Ran `pnpm test` which completed successfully (all tests passed).
- Ran `pnpm lint` which failed due to pre-existing repository-wide lint issues unrelated to these changes (no lint errors introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62ad033f083288eaacccf79b72fb3)