### PR TITLE
Blocker E: Harden chat/log RLS policies and enforce actor checks on send-message

### DIFF
--- a/app/api/chat/send-message/route.ts
+++ b/app/api/chat/send-message/route.ts
@@ -22,14 +22,13 @@ export async function POST(req: Request): Promise<NextResponse> {
     | {
         conversationId?: string;
         content?: string;
-        senderId?: string;
         metadata?: Record<string, unknown>;
       }
     | null;
 
   const conversationId = body?.conversationId;
   const content = body?.content?.trim() ?? "";
-  const senderId = body?.senderId ?? user.id;
+  const senderId = user.id;
 
   if (!conversationId || !content) {
     return NextResponse.json(
@@ -65,6 +64,17 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   if (partsErr) {
     return NextResponse.json({ error: partsErr.message }, { status: 500 });
+  }
+
+  const allowed =
+    convo.created_by === user.id ||
+    (participants ?? []).some((participant) => participant.user_id === user.id);
+
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "You are not part of this conversation" },
+      { status: 403 },
+    );
   }
 
   // Recipients are all users in conversation except the sender

--- a/db/sql/2026-04-20_phase7_blocker_e_chat_log_rls_hardening.sql
+++ b/db/sql/2026-04-20_phase7_blocker_e_chat_log_rls_hardening.sql
@@ -1,0 +1,335 @@
+-- Blocker E: chat/log RLS hardening
+-- Tightens permissive chat/log policy posture and broad grants.
+-- Manual apply required.
+
+begin;
+
+-- Ensure target tables are RLS-protected.
+alter table if exists public.chats enable row level security;
+alter table if exists public.chat_participants enable row level security;
+alter table if exists public.conversations enable row level security;
+alter table if exists public.conversation_participants enable row level security;
+alter table if exists public.dtc_logs enable row level security;
+alter table if exists public.email_logs enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- chats: participant/creator scoped visibility, actor-scoped writes.
+-- ---------------------------------------------------------------------------
+drop policy if exists chats_insert_self on public.chats;
+drop policy if exists chats_select_visible on public.chats;
+drop policy if exists chats_member_select on public.chats;
+drop policy if exists chats_actor_insert on public.chats;
+drop policy if exists chats_creator_update on public.chats;
+drop policy if exists chats_creator_delete on public.chats;
+
+create policy chats_member_select
+  on public.chats
+  for select
+  to authenticated
+  using (
+    created_by = auth.uid()
+    or exists (
+      select 1
+      from public.chat_participants cp
+      where cp.chat_id = chats.id
+        and cp.profile_id = auth.uid()
+    )
+  );
+
+create policy chats_actor_insert
+  on public.chats
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    or created_by is null
+  );
+
+create policy chats_creator_update
+  on public.chats
+  for update
+  to authenticated
+  using (created_by = auth.uid())
+  with check (created_by = auth.uid());
+
+create policy chats_creator_delete
+  on public.chats
+  for delete
+  to authenticated
+  using (created_by = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- chat_participants: only conversation members can read; only chat creator writes.
+-- ---------------------------------------------------------------------------
+drop policy if exists chat_participants_member_select on public.chat_participants;
+drop policy if exists chat_participants_creator_insert on public.chat_participants;
+drop policy if exists chat_participants_creator_update on public.chat_participants;
+drop policy if exists chat_participants_creator_delete on public.chat_participants;
+
+create policy chat_participants_member_select
+  on public.chat_participants
+  for select
+  to authenticated
+  using (
+    profile_id = auth.uid()
+    or exists (
+      select 1
+      from public.chats c
+      where c.id = chat_participants.chat_id
+        and c.created_by = auth.uid()
+    )
+    or exists (
+      select 1
+      from public.chat_participants self_cp
+      where self_cp.chat_id = chat_participants.chat_id
+        and self_cp.profile_id = auth.uid()
+    )
+  );
+
+create policy chat_participants_creator_insert
+  on public.chat_participants
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.chats c
+      where c.id = chat_participants.chat_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+create policy chat_participants_creator_update
+  on public.chat_participants
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.chats c
+      where c.id = chat_participants.chat_id
+        and c.created_by = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.chats c
+      where c.id = chat_participants.chat_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+create policy chat_participants_creator_delete
+  on public.chat_participants
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.chats c
+      where c.id = chat_participants.chat_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- conversations: participant/creator scoped visibility, creator-scoped writes.
+-- ---------------------------------------------------------------------------
+drop policy if exists conversations_member_select on public.conversations;
+drop policy if exists conversations_actor_insert on public.conversations;
+drop policy if exists conversations_creator_update on public.conversations;
+drop policy if exists conversations_creator_delete on public.conversations;
+
+create policy conversations_member_select
+  on public.conversations
+  for select
+  to authenticated
+  using (
+    created_by = auth.uid()
+    or exists (
+      select 1
+      from public.conversation_participants cp
+      where cp.conversation_id = conversations.id
+        and cp.user_id = auth.uid()
+    )
+  );
+
+create policy conversations_actor_insert
+  on public.conversations
+  for insert
+  to authenticated
+  with check (created_by = auth.uid());
+
+create policy conversations_creator_update
+  on public.conversations
+  for update
+  to authenticated
+  using (created_by = auth.uid())
+  with check (created_by = auth.uid());
+
+create policy conversations_creator_delete
+  on public.conversations
+  for delete
+  to authenticated
+  using (created_by = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- conversation_participants: participant-scoped reads, creator-scoped writes.
+-- ---------------------------------------------------------------------------
+drop policy if exists conversation_participants_member_select on public.conversation_participants;
+drop policy if exists conversation_participants_creator_insert on public.conversation_participants;
+drop policy if exists conversation_participants_creator_update on public.conversation_participants;
+drop policy if exists conversation_participants_creator_delete on public.conversation_participants;
+
+create policy conversation_participants_member_select
+  on public.conversation_participants
+  for select
+  to authenticated
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1
+      from public.conversations c
+      where c.id = conversation_participants.conversation_id
+        and c.created_by = auth.uid()
+    )
+    or exists (
+      select 1
+      from public.conversation_participants self_cp
+      where self_cp.conversation_id = conversation_participants.conversation_id
+        and self_cp.user_id = auth.uid()
+    )
+  );
+
+create policy conversation_participants_creator_insert
+  on public.conversation_participants
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.conversations c
+      where c.id = conversation_participants.conversation_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+create policy conversation_participants_creator_update
+  on public.conversation_participants
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.conversations c
+      where c.id = conversation_participants.conversation_id
+        and c.created_by = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.conversations c
+      where c.id = conversation_participants.conversation_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+create policy conversation_participants_creator_delete
+  on public.conversation_participants
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.conversations c
+      where c.id = conversation_participants.conversation_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- dtc_logs: actor-owned rows only.
+-- ---------------------------------------------------------------------------
+drop policy if exists dtc_logs_self_select on public.dtc_logs;
+drop policy if exists dtc_logs_self_insert on public.dtc_logs;
+drop policy if exists dtc_logs_self_update on public.dtc_logs;
+drop policy if exists dtc_logs_self_delete on public.dtc_logs;
+
+create policy dtc_logs_self_select
+  on public.dtc_logs
+  for select
+  to authenticated
+  using (user_id = auth.uid());
+
+create policy dtc_logs_self_insert
+  on public.dtc_logs
+  for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+create policy dtc_logs_self_update
+  on public.dtc_logs
+  for update
+  to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy dtc_logs_self_delete
+  on public.dtc_logs
+  for delete
+  to authenticated
+  using (user_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- email_logs: shop-scoped read-only for authorized staff; service-role manages writes.
+-- ---------------------------------------------------------------------------
+drop policy if exists email_logs_shop_staff_select on public.email_logs;
+
+create policy email_logs_shop_staff_select
+  on public.email_logs
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = email_logs.shop_id
+        and lower(coalesce(p.role, '')) in ('owner', 'admin', 'manager', 'advisor')
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- Grant hardening: remove broad anon access and keep least-privilege grants.
+-- ---------------------------------------------------------------------------
+revoke all on table public.chats from anon;
+revoke all on table public.chat_participants from anon;
+revoke all on table public.conversations from anon;
+revoke all on table public.conversation_participants from anon;
+revoke all on table public.dtc_logs from anon;
+revoke all on table public.email_logs from anon;
+
+revoke all on table public.chats from authenticated;
+revoke all on table public.chat_participants from authenticated;
+revoke all on table public.conversations from authenticated;
+revoke all on table public.conversation_participants from authenticated;
+revoke all on table public.dtc_logs from authenticated;
+revoke all on table public.email_logs from authenticated;
+
+grant select, insert, update, delete on table public.chats to authenticated;
+grant select, insert, update, delete on table public.chat_participants to authenticated;
+grant select, insert, update, delete on table public.conversations to authenticated;
+grant select, insert, update, delete on table public.conversation_participants to authenticated;
+grant select, insert, update, delete on table public.dtc_logs to authenticated;
+grant select on table public.email_logs to authenticated;
+
+grant all on table public.chats to service_role;
+grant all on table public.chat_participants to service_role;
+grant all on table public.conversations to service_role;
+grant all on table public.conversation_participants to service_role;
+grant all on table public.dtc_logs to service_role;
+grant all on table public.email_logs to service_role;
+
+commit;


### PR DESCRIPTION
### Motivation
- Close audit-identified RLS gaps for chat/log-like tables by removing permissive policies and broad grants. 
- Enforce least-privilege access models tied to actor identity, participant membership, or shop-scoped staff roles. 
- Preserve service-role/internal flows while preventing unaffiliated users from reading/writing tenant chat/log rows.

### Description
- Added an additive SQL migration `db/sql/2026-04-20_phase7_blocker_e_chat_log_rls_hardening.sql` that drops permissive policies and creates explicit RLS policies for `chats`, `chat_participants`, `conversations`, `conversation_participants`, `dtc_logs`, and `email_logs`, and tightens grants (revokes `anon`, re-grants least-privilege to `authenticated`, preserves `service_role`).
- Replaced broad `USING (true)`-style and similar permissive chat policies with participant/creator-scoped predicates and explicit insert/update/delete checks.
- Implemented actor-scoped behavior for logs: `dtc_logs` rows are actor-owned (`user_id = auth.uid()`), and `email_logs` read access is limited to shop staff roles (`owner`, `admin`, `manager`, `advisor`) scoped to `shop_id` while writes remain service-role/internal.
- Updated the server route `app/api/chat/send-message/route.ts` to always use the authenticated user as `sender_id`, to remove `senderId` trust from client input, and to enforce membership/creator checks before inserting messages.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it passed.
- Lint: ran `pnpm lint`; lint failed with pre-existing unrelated repository errors (no new lint errors in the touched files were introduced by this change).
- No SQL was applied in this environment; migration is provided as additive SQL and must be applied manually in the target Supabase instance.

# Blocker E Summary — Chat/Log RLS Policy Hardening

## What was fixed
- Added an additive SQL migration that hardens RLS posture for the six target chat/log-like tables: `chats`, `chat_participants`, `conversations`, `conversation_participants`, `dtc_logs`, and `email_logs`.
- Removed permissive/broad legacy chat policy shapes (`chats_insert_self`, `chats_select_visible`) and replaced them with explicit member/creator-scoped policy logic.
- Added full explicit policy coverage for tables that previously had missing/partial policy intent (notably `conversation_participants`, `conversations`, `dtc_logs`, `email_logs`, and `chat_participants`).
- Hardened grants by revoking `anon` access for all targets, re-granting least-privilege authenticated access, and preserving service-role full access for internal/server flows.
- Updated chat send route to enforce actor identity (`sender_id` is always the authenticated caller) and membership checks before write.

## Canonical access model now enforced
- `chats` -> authenticated creator or participant can read; only actor/creator-controlled writes (with legacy-safe null `created_by` insert allowance).
- `chat_participants` -> members/creator can read participant list; only chat creator can insert/update/delete participant rows.
- `conversations` -> authenticated creator or explicit participant can read; only creator can insert/update/delete conversation rows.
- `conversation_participants` -> participant-scoped/member-scoped reads; only conversation creator can insert/update/delete participant rows.
- `dtc_logs` -> actor-owned rows only (`user_id = auth.uid()`) for select/insert/update/delete.
- `email_logs` -> authenticated staff read-only access scoped to same `shop_id` with allowed roles (`owner`, `admin`, `manager`, `advisor`); write paths remain internal via service-role.

## Files changed
- `db/sql/2026-04-20_phase7_blocker_e_chat_log_rls_hardening.sql`
- `app/api/chat/send-message/route.ts`

## Migrations added
- `db/sql/2026-04-20_phase7_blocker_e_chat_log_rls_hardening.sql` — Purpose: drop/replace permissive chat policies, add explicit policy coverage for all six target tables, and tighten grants to least privilege while preserving service-role operations.
- Manual SQL apply required.
- Regenerate Supabase types after apply (e.g. run `pnpm typegen`).

## Behavior changes
- Unaffiliated authenticated users are now blocked from reading/writing unrelated conversation/chat participant data through RLS policy logic (no `USING (true)` style access remains on the targeted chat tables).
- Authenticated anonymous-visitor posture is tightened because `anon` grants were revoked for all six tables.
- `email_logs` is now authenticated read-only at SQL grant level (plus shop+role scoped RLS), so authenticated clients cannot write directly even if they try.
- Chat message send endpoint now rejects non-member callers and no longer accepts caller-provided `senderId`, preventing impersonation in server-mediated writes.

## Risks resolved
- Permissive `USING (true)` style policy risk -> resolved by dropping/replacing broad `chats_*` policies with membership/creator predicates.
- RLS-enabled tables with missing/partial policy coverage -> resolved by adding explicit select/insert/update/delete policy coverage for target chat/log-like tables according to intended access model.
- Broad grants on log-like tables -> resolved by revoking `anon`, reducing `email_logs` authenticated grants to `SELECT` only, and retaining service-role internal management rights.

## Remaining adjacent risks not fixed in this phase
- This phase does not add new `shop_id` columns or schema redesign for chat tables (`conversations/chats`) since that would be a broader architectural/data migration; scoping remains participant/creator-based for now.
- Legacy `chats` model still allows `created_by is null` insert for compatibility with existing function/write patterns; this was kept as the safest non-breaking assumption and should be revisited if legacy paths are retired.

## Validation run
- `npx tsc --noEmit` — passed.
- `pnpm lint` — failed due to pre-existing unrelated lint errors elsewhere in the repo; no blocker-specific lint failures introduced.

## Notes for next phase
- Follow-up work: review all message read paths for consistent participant authorization, and consider long-term tenant-scoped schema (explicit `shop_id` on conversation/chat) if product intent requires tenant-level enforcement rather than participant-only models.

Manual steps required: apply `db/sql/2026-04-20_phase7_blocker_e_chat_log_rls_hardening.sql` in the target Supabase instance, then run `pnpm typegen` to regenerate types.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62d53daac83289c32b22e2692e595)