### PR TITLE
Harden chat message authorization parity across API routes and helpers

### DIFF
--- a/app/api/chat/delete-message/route.ts
+++ b/app/api/chat/delete-message/route.ts
@@ -1,26 +1,25 @@
 // app/api/chat/delete-message/route.ts
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
 /**
- * Delete a message if the authenticated user is its sender.
+ * Delete a message if the authenticated user is its sender and can access the parent conversation.
  * Body: { id: string }
  */
 export async function POST(req: Request): Promise<NextResponse> {
-  const supabase = createServerSupabaseRoute();
+  const userClient = createServerSupabaseRoute();
 
-  // 1) make sure we're logged in
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = await userClient.auth.getUser();
 
   if (!user) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  // 2) read message id from body
   const body = (await req.json().catch(() => null)) as { id?: string } | null;
   const messageId = body?.id;
 
@@ -28,10 +27,10 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: "Message ID required" }, { status: 400 });
   }
 
-  // 3) fetch the message so we can check ownership
-  const { data: message, error: fetchError } = await supabase
+  const admin = createAdminSupabase();
+  const { data: message, error: fetchError } = await admin
     .from("messages")
-    .select("id, sender_id")
+    .select("id, sender_id, conversation_id")
     .eq("id", messageId)
     .maybeSingle();
 
@@ -43,12 +42,25 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: "Message not found" }, { status: 404 });
   }
 
+  if (!message.conversation_id) {
+    return NextResponse.json({ error: "Message has no conversation" }, { status: 400 });
+  }
+
+  const access = await authorizeConversationActor({
+    supabase: admin,
+    conversationId: message.conversation_id,
+    actorUserId: user.id,
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
   if (message.sender_id !== user.id) {
     return NextResponse.json({ error: "Not authorized" }, { status: 403 });
   }
 
-  // 4) delete it
-  const { error: deleteError } = await supabase
+  const { error: deleteError } = await admin
     .from("messages")
     .delete()
     .eq("id", messageId);

--- a/app/api/chat/get-messages/route.ts
+++ b/app/api/chat/get-messages/route.ts
@@ -1,21 +1,17 @@
-// app/api/chat/get-messages/route.ts
 import { NextResponse } from "next/server";
 import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
-type ConversationRow = DB["public"]["Tables"]["conversations"]["Row"];
-type ParticipantRow =
-  DB["public"]["Tables"]["conversation_participants"]["Row"];
 
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request): Promise<NextResponse> {
-  // 1) who is calling
   const userClient = createServerSupabaseRoute();
   const {
     data: { user },
@@ -37,63 +33,17 @@ export async function POST(req: Request): Promise<NextResponse> {
     );
   }
 
-  // 2) use admin so we always see fresh rows
   const admin = createAdminSupabase();
+  const access = await authorizeConversationActor({
+    supabase: admin,
+    conversationId,
+    actorUserId: user.id,
+  });
 
-  // 2a) make sure the conversation exists
-  const { data: convo, error: convoErr } = await admin
-    .from("conversations")
-    .select("*")
-    .eq("id", conversationId)
-    .maybeSingle<ConversationRow>();
-
-  if (convoErr) {
-    return NextResponse.json({ error: convoErr.message }, { status: 500 });
-  }
-  if (!convo) {
-    return NextResponse.json(
-      { error: "Conversation not found" },
-      { status: 404 },
-    );
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
   }
 
-  // 2b) load participants
-  const {
-    data: participants,
-    error: partsErr,
-  } = (await admin
-    .from("conversation_participants")
-    .select("*")
-    .eq("conversation_id", conversationId)) as {
-    data: ParticipantRow[] | null;
-    error: { message: string } | null;
-  };
-
-  if (partsErr) {
-    return NextResponse.json({ error: partsErr.message }, { status: 500 });
-  }
-
-  const hasParticipants = (participants?.length ?? 0) > 0;
-
-  // 2c) check access
-  let allowed = convo.created_by === user.id;
-  if (!allowed) {
-    if (hasParticipants) {
-      allowed = (participants ?? []).some((p) => p.user_id === user.id);
-    } else {
-      // convo exists but has no participants yet – let creator in
-      allowed = true;
-    }
-  }
-
-  if (!allowed) {
-    return NextResponse.json(
-      { error: "You are not part of this conversation" },
-      { status: 403 },
-    );
-  }
-
-  // 3) fetch messages – ONLY by conversation_id now
   const { data: messages, error: msgErr } = await admin
     .from("messages")
     .select("*")

--- a/app/api/chat/mark-read/route.ts
+++ b/app/api/chat/mark-read/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,16 @@ export async function POST(req: Request): Promise<NextResponse> {
   if (!body?.conversationId) return NextResponse.json({ error: "conversationId required" }, { status: 400 });
 
   const admin = createAdminSupabase();
+  const access = await authorizeConversationActor({
+    supabase: admin,
+    conversationId: body.conversationId,
+    actorUserId: user.id,
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
   const { error } = await admin
     .from("message_reads")
     .upsert({ user_id: user.id, conversation_id: body.conversationId, last_read_at: new Date().toISOString() }, { onConflict: "user_id,conversation_id" });

--- a/app/api/chat/my-conversations/route.ts
+++ b/app/api/chat/my-conversations/route.ts
@@ -4,6 +4,7 @@ import {
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorConversationIds } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
@@ -39,30 +40,14 @@ export async function GET(): Promise<NextResponse> {
 
   const admin = createAdminSupabase();
 
-  const { data: createdConvos, error: createdErr } = await admin
-    .from("conversations")
-    .select("id, created_at, created_by, context_type, context_id, is_group, title")
-    .eq("created_by", user.id);
+  const { ids: convoIds, error: accessErr } = await getActorConversationIds({
+    supabase: admin,
+    actorUserId: user.id,
+  });
 
-  if (createdErr) {
-    return NextResponse.json({ error: createdErr.message }, { status: 500 });
+  if (accessErr) {
+    return NextResponse.json({ error: accessErr }, { status: 500 });
   }
-
-  const { data: partRows, error: partsErr } = await admin
-    .from("conversation_participants")
-    .select("conversation_id, user_id")
-    .eq("user_id", user.id);
-
-  if (partsErr) {
-    return NextResponse.json({ error: partsErr.message }, { status: 500 });
-  }
-
-  const convoIds = Array.from(
-    new Set([
-      ...(createdConvos?.map((c) => c.id) ?? []),
-      ...(partRows?.map((p) => p.conversation_id) ?? []),
-    ]),
-  ).filter(Boolean) as string[];
 
   if (convoIds.length === 0) {
     return NextResponse.json<ConversationPayload[]>([], { status: 200 });

--- a/app/api/chat/send-message/route.ts
+++ b/app/api/chat/send-message/route.ts
@@ -1,9 +1,9 @@
-// app/api/chat/send-message/route.ts
 import { NextResponse } from "next/server";
 import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
@@ -28,7 +28,6 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   const conversationId = body?.conversationId;
   const content = body?.content?.trim() ?? "";
-  const senderId = user.id;
 
   if (!conversationId || !content) {
     return NextResponse.json(
@@ -38,57 +37,24 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 
   const admin = createAdminSupabase();
+  const access = await authorizeConversationActor({
+    supabase: admin,
+    conversationId,
+    actorUserId: user.id,
+  });
 
-  // Confirm conversation exists
-  const { data: convo, error: convoErr } = await admin
-    .from("conversations")
-    .select("id, created_by")
-    .eq("id", conversationId)
-    .maybeSingle();
-
-  if (convoErr) {
-    return NextResponse.json({ error: convoErr.message }, { status: 500 });
-  }
-  if (!convo) {
-    return NextResponse.json(
-      { error: "Conversation not found" },
-      { status: 404 },
-    );
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
   }
 
-  // Fetch participants to determine recipients
-  const { data: participants, error: partsErr } = await admin
-    .from("conversation_participants")
-    .select("user_id")
-    .eq("conversation_id", conversationId);
+  const recipients = access.participantUserIds.filter((id) => id !== user.id);
 
-  if (partsErr) {
-    return NextResponse.json({ error: partsErr.message }, { status: 500 });
-  }
-
-  const allowed =
-    convo.created_by === user.id ||
-    (participants ?? []).some((participant) => participant.user_id === user.id);
-
-  if (!allowed) {
-    return NextResponse.json(
-      { error: "You are not part of this conversation" },
-      { status: 403 },
-    );
-  }
-
-  // Recipients are all users in conversation except the sender
-  const recipients = (participants ?? [])
-    .map((p) => p.user_id)
-    .filter((id) => id !== senderId);
-
-  // Insert message
   const now = new Date().toISOString();
   const { data: inserted, error: insertErr } = await admin
     .from("messages")
     .insert({
       conversation_id: conversationId,
-      sender_id: senderId,
+      sender_id: user.id,
       recipients,
       content,
       sent_at: now,

--- a/features/ai/api/get-messages/route.ts
+++ b/features/ai/api/get-messages/route.ts
@@ -1,16 +1,46 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
-export async function POST(req: Request) {
-  const { conversationId } = await req.json();
+export async function POST(req: Request): Promise<NextResponse> {
+  const userClient = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
 
-  const supabase = createServerSupabaseRoute();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
 
-  const { data, error } = await supabase
+  const body = (await req.json().catch(() => null)) as {
+    conversationId?: string;
+  } | null;
+
+  const conversationId = body?.conversationId;
+  if (!conversationId) {
+    return NextResponse.json({ error: "conversationId required" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const access = await authorizeConversationActor({
+    supabase: admin,
+    conversationId,
+    actorUserId: user.id,
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const { data, error } = await admin
     .from("messages")
     .select("*")
     .eq("conversation_id", conversationId)
-    .order("sent_at", { ascending: true });
+    .order("sent_at", { ascending: true })
+    .order("created_at", { ascending: true });
 
   if (error) {
     console.error("Error fetching messages:", error);

--- a/features/ai/api/send-message/route.ts
+++ b/features/ai/api/send-message/route.ts
@@ -1,24 +1,58 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
-export async function POST(req: Request) {
-  const { conversationId, senderId, content } = await req.json();
+export async function POST(req: Request): Promise<NextResponse> {
+  const userClient = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
 
-  if (!conversationId || !senderId || !content?.trim()) {
+  if (!user) {
+    return NextResponse.json({ success: false, error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    conversationId?: string;
+    content?: string;
+  } | null;
+
+  const conversationId = body?.conversationId;
+  const content = body?.content?.trim() ?? "";
+
+  if (!conversationId || !content) {
     return NextResponse.json({ success: false, error: "Missing fields" }, { status: 400 });
   }
 
-  const supabase = createServerSupabaseRoute();
+  const admin = createAdminSupabase();
+  const access = await authorizeConversationActor({
+    supabase: admin,
+    conversationId,
+    actorUserId: user.id,
+  });
 
-  const { error } = await supabase.from("messages").insert({
+  if (!access.ok) {
+    return NextResponse.json({ success: false, error: access.error }, { status: access.status });
+  }
+
+  const recipients = access.participantUserIds.filter((id) => id !== user.id);
+
+  const { error } = await admin.from("messages").insert({
     conversation_id: conversationId,
-    sender_id: senderId,
+    sender_id: user.id,
+    recipients,
     content,
+    sent_at: new Date().toISOString(),
+    attachments: [],
+    metadata: {},
   });
 
   if (error) {
     console.error("Error sending message:", error);
-    return NextResponse.json({ success: false }, { status: 500 });
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
   }
 
   return NextResponse.json({ success: true });

--- a/features/ai/lib/chat/authorization.ts
+++ b/features/ai/lib/chat/authorization.ts
@@ -1,0 +1,102 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+type ConversationRow = Database["public"]["Tables"]["conversations"]["Row"];
+
+type AccessResult =
+  | {
+      ok: true;
+      conversation: ConversationRow;
+      participantUserIds: string[];
+    }
+  | {
+      ok: false;
+      status: 403 | 404 | 500;
+      error: string;
+    };
+
+export async function authorizeConversationActor({
+  supabase,
+  conversationId,
+  actorUserId,
+}: {
+  supabase: SupabaseClient<Database>;
+  conversationId: string;
+  actorUserId: string;
+}): Promise<AccessResult> {
+  const { data: conversation, error: conversationError } = await supabase
+    .from("conversations")
+    .select("id, created_by, context_type, context_id, is_group, title, created_at")
+    .eq("id", conversationId)
+    .maybeSingle();
+
+  if (conversationError) {
+    return { ok: false, status: 500, error: conversationError.message };
+  }
+
+  if (!conversation) {
+    return { ok: false, status: 404, error: "Conversation not found" };
+  }
+
+  const { data: participantRows, error: participantsError } = await supabase
+    .from("conversation_participants")
+    .select("user_id")
+    .eq("conversation_id", conversationId);
+
+  if (participantsError) {
+    return { ok: false, status: 500, error: participantsError.message };
+  }
+
+  const participantUserIds = (participantRows ?? [])
+    .map((row) => row.user_id)
+    .filter((userId): userId is string => Boolean(userId));
+
+  const isAllowed =
+    conversation.created_by === actorUserId ||
+    participantUserIds.includes(actorUserId);
+
+  if (!isAllowed) {
+    return {
+      ok: false,
+      status: 403,
+      error: "You are not part of this conversation",
+    };
+  }
+
+  return { ok: true, conversation, participantUserIds };
+}
+
+export async function getActorConversationIds({
+  supabase,
+  actorUserId,
+}: {
+  supabase: SupabaseClient<Database>;
+  actorUserId: string;
+}): Promise<{ ids: string[]; error: string | null }> {
+  const { data: createdConversations, error: createdError } = await supabase
+    .from("conversations")
+    .select("id")
+    .eq("created_by", actorUserId);
+
+  if (createdError) {
+    return { ids: [], error: createdError.message };
+  }
+
+  const { data: participantRows, error: participantError } = await supabase
+    .from("conversation_participants")
+    .select("conversation_id")
+    .eq("user_id", actorUserId);
+
+  if (participantError) {
+    return { ids: [], error: participantError.message };
+  }
+
+  const ids = Array.from(
+    new Set([
+      ...(createdConversations ?? []).map((row) => row.id),
+      ...(participantRows ?? []).map((row) => row.conversation_id),
+    ]),
+  ).filter((id): id is string => Boolean(id));
+
+  return { ids, error: null };
+}

--- a/features/ai/lib/chat/getMessages.ts
+++ b/features/ai/lib/chat/getMessages.ts
@@ -1,41 +1,44 @@
-// app/api/chat/get-messages/route.ts
-import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
-type DB = Database;
-type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
-
-export const dynamic = "force-dynamic";
-
-export async function POST(req: Request): Promise<NextResponse> {
-  const supabase = createServerSupabaseRoute();
+export async function getMessages({
+  supabase,
+  conversationId,
+}: {
+  supabase: SupabaseClient<Database>;
+  conversationId: string;
+}): Promise<Database["public"]["Tables"]["messages"]["Row"][]> {
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser();
 
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (authError || !user) {
+    return [];
   }
 
-  const { conversationId } = (await req.json()) as { conversationId: string };
+  const access = await authorizeConversationActor({
+    supabase,
+    conversationId,
+    actorUserId: user.id,
+  });
 
-  if (!conversationId) {
-    return NextResponse.json({ error: "conversationId required" }, { status: 400 });
+  if (!access.ok) {
+    return [];
   }
 
-  // simplest: pull the ones for that conversation_id
   const { data, error } = await supabase
     .from("messages")
     .select("*")
-    .or(
-      `conversation_id.eq.${conversationId},chat_id.eq.${conversationId}`
-    )
+    .eq("conversation_id", conversationId)
+    .order("sent_at", { ascending: true })
     .order("created_at", { ascending: true });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("Error fetching messages:", error);
+    return [];
   }
 
-  return NextResponse.json<MessageRow[]>(data ?? []);
+  return data ?? [];
 }

--- a/features/ai/lib/chat/getUserConversations.ts
+++ b/features/ai/lib/chat/getUserConversations.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { getActorConversationIds } from "@/features/ai/lib/chat/authorization";
 
 type Conversation = Database["public"]["Tables"]["conversations"]["Row"];
 type Message = Database["public"]["Tables"]["messages"]["Row"];
@@ -24,35 +25,15 @@ export async function getUserConversations(
 
   const myId = user.id;
 
-  // 2) conversations where I'm a participant
-  const { data: participantRows, error: participantErr } = await supabase
-    .from("conversation_participants")
-    .select("conversation_id")
-    .eq("user_id", myId);
+  const { ids: allConvoIds, error: conversationIdsError } = await getActorConversationIds({
+    supabase,
+    actorUserId: myId,
+  });
 
-  if (participantErr) {
-    console.error("[getUserConversations] participants error:", participantErr);
+  if (conversationIdsError) {
+    console.error("[getUserConversations] ids error:", conversationIdsError);
+    return [];
   }
-
-  const participantIds =
-    participantRows?.map((row) => row.conversation_id).filter(Boolean) ?? [];
-
-  // 3) conversations I created
-  const { data: createdRows, error: createdErr } = await supabase
-    .from("conversations")
-    .select("id")
-    .eq("created_by", myId);
-
-  if (createdErr) {
-    console.error("[getUserConversations] created error:", createdErr);
-  }
-
-  const createdIds = createdRows?.map((row) => row.id).filter(Boolean) ?? [];
-
-  // 4) union → final list of convo IDs
-  const allConvoIds = Array.from(
-    new Set<string>([...participantIds, ...createdIds]),
-  );
 
   if (allConvoIds.length === 0) {
     return [];

--- a/features/ai/lib/chat/helpers.ts
+++ b/features/ai/lib/chat/helpers.ts
@@ -1,62 +1,32 @@
-// lib/chat/helpers.ts
-
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@shared/types/types/supabase";
-
-const supabase = createServerComponentClient<Database>({ cookies });
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { getMessages as getMessagesWithAccess } from "@/features/ai/lib/chat/getMessages";
+import { sendMessage as sendMessageWithAccess } from "@/features/ai/lib/chat/sendMessage";
+import { getUserConversations } from "@/features/ai/lib/chat/getUserConversations";
 
 export async function getMessages(conversationId: string) {
-  const { data, error } = await supabase
-    .from("messages")
-    .select("*")
-    .eq("conversation_id", conversationId)
-    .order("sent_at", { ascending: true });
-
-  if (error) {
-    console.error("Error fetching messages:", error);
-    return [];
-  }
-
-  return data ?? [];
+  const supabase = createServerSupabaseRSC();
+  return getMessagesWithAccess({ supabase, conversationId });
 }
 
-export async function getUserConversations(userId: string) {
-  const { data, error } = await supabase
-    .from("conversation_participants")
-    .select("conversation_id, conversations(*)")
-    .eq("user_id", userId);
-
-  if (error) {
-    console.error("Error fetching user conversations:", error);
-    return [];
-  }
-
-  // Guard in case a row has no joined conversation
-  return (data ?? [])
-    .map((entry) => entry.conversations)
-    .filter(Boolean);
+export async function getMyConversations() {
+  const supabase = createServerSupabaseRSC();
+  return getUserConversations(supabase);
 }
 
 export async function sendMessage({
   conversationId,
-  senderId,
   content,
+  metadata,
 }: {
   conversationId: string;
-  senderId: string;
   content: string;
+  metadata?: Record<string, unknown>;
 }) {
-  const { error } = await supabase.from("messages").insert({
-    conversation_id: conversationId,
-    sender_id: senderId,
+  const supabase = createServerSupabaseRSC();
+  return sendMessageWithAccess({
+    supabase,
+    conversationId,
     content,
+    metadata,
   });
-
-  if (error) {
-    console.error("Error sending message:", error);
-    return false;
-  }
-
-  return true;
 }

--- a/features/ai/lib/chat/sendMessage.ts
+++ b/features/ai/lib/chat/sendMessage.ts
@@ -1,120 +1,63 @@
-// app/api/chat/send-message/route.ts
-import { NextResponse } from "next/server";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-type MessagesTable = DB["public"]["Tables"]["messages"];
-type MessageInsert = MessagesTable["Insert"];
-type ConversationsTable = DB["public"]["Tables"]["conversations"]["Row"];
-type ParticipantsTable =
-  DB["public"]["Tables"]["conversation_participants"]["Row"];
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(req: Request): Promise<NextResponse> {
-  // 1. get the user from the request cookie/session
-  const userClient = createServerSupabaseRoute();
+export async function sendMessage({
+  supabase,
+  conversationId,
+  content,
+  metadata,
+}: {
+  supabase: SupabaseClient<Database>;
+  conversationId: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
   const {
     data: { user },
-  } = await userClient.auth.getUser();
+    error: authError,
+  } = await supabase.auth.getUser();
 
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (authError || !user) {
+    return { ok: false, status: 401, error: "Not authenticated" };
   }
 
-  // 2. parse body
-  const body = (await req.json()) as {
-    conversationId: string;
-    content: string;
-    senderId?: string;
-    recipients?: string[];
-  };
-
-  const conversationId = body.conversationId;
-  const content = body.content?.trim() ?? "";
-  const senderId = body.senderId ?? user.id;
-
-  if (!conversationId || !content) {
-    return NextResponse.json(
-      { error: "conversationId and content are required" },
-      { status: 400 },
-    );
+  const trimmedContent = content.trim();
+  if (!trimmedContent) {
+    return {
+      ok: false,
+      status: 400,
+      error: "conversationId and content are required",
+    };
   }
 
-  // 3. use admin client to avoid RLS race, but still check user is allowed
-  const admin = createAdminSupabase();
+  const access = await authorizeConversationActor({
+    supabase,
+    conversationId,
+    actorUserId: user.id,
+  });
 
-  // 3a. make sure conversation exists
-  const {
-    data: convo,
-    error: convoErr,
-  } = await admin
-    .from("conversations")
-    .select("*")
-    .eq("id", conversationId)
-    .maybeSingle<ConversationsTable>();
-
-  if (convoErr) {
-    return NextResponse.json({ error: convoErr.message }, { status: 500 });
-  }
-  if (!convo) {
-    return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+  if (!access.ok) {
+    return { ok: false, status: access.status, error: access.error };
   }
 
-  // 3b. check the user is either the creator or a participant
-  const isCreator = convo.created_by === user.id;
+  const recipients = access.participantUserIds.filter((id) => id !== user.id);
 
-  let isParticipant = false;
-  if (!isCreator) {
-    const {
-      data: participant,
-      error: participantErr,
-    } = await admin
-      .from("conversation_participants")
-      .select("id")
-      .eq("conversation_id", conversationId)
-      .eq("user_id", user.id)
-      .maybeSingle<Pick<ParticipantsTable, "id">>();
-
-    if (participantErr) {
-      return NextResponse.json({ error: participantErr.message }, { status: 500 });
-    }
-    isParticipant = Boolean(participant);
-  }
-
-  if (!isCreator && !isParticipant) {
-    return NextResponse.json(
-      { error: "You are not part of this conversation" },
-      { status: 403 },
-    );
-  }
-
-  // 4. insert the message with admin client (so no RLS race)
-  const messagePayload: MessageInsert = {
+  const { error: insertError } = await supabase.from("messages").insert({
     conversation_id: conversationId,
-    // chat_id removed – column no longer exists in types
-    sender_id: senderId,
-    content,
-    recipients: Array.isArray(body.recipients) ? body.recipients : [],
+    sender_id: user.id,
+    recipients,
+    content: trimmedContent,
     sent_at: new Date().toISOString(),
-  };
+    attachments: [],
+    metadata: metadata ?? {},
+  });
 
-  const {
-    data: inserted,
-    error: insertErr,
-  } = await admin
-    .from("messages")
-    .insert(messagePayload)
-    .select()
-    .maybeSingle<MessagesTable>();
-
-  if (insertErr) {
-    return NextResponse.json({ error: insertErr.message }, { status: 500 });
+  if (insertError) {
+    return { ok: false, status: 500, error: insertError.message };
   }
 
-  return NextResponse.json(inserted ?? messagePayload, { status: 200 });
+  return { ok: true };
 }


### PR DESCRIPTION
### Motivation
- Close gaps where some message read/write entry points trusted caller-provided sender IDs or skipped participant checks.  
- Enforce a single canonical server-side actor model so sender identity is always derived from server auth and participant membership is consistently enforced.  
- Avoid RLS races by using admin/service clients only after server-side authorization decisions are made.

### Description
- Add a canonical authorization helper `authorizeConversationActor` and `getActorConversationIds` in `features/ai/lib/chat/authorization.ts` to centralize conversation membership and visibility logic.  
- Propagate the authorization helper to all message read/write entry points including `app/api/chat/*` routes (`send-message`, `get-messages`, `delete-message`, `mark-read`, `my-conversations`) and AI endpoints in `features/ai/api/*`, so all paths require server-derived actor identity and membership before DB reads/writes.  
- Harden helper functions under `features/ai/lib/chat/*` to call the canonical helpers and to derive the caller via `supabase.auth.getUser()` so payload-provided `senderId` can no longer spoof identity.  
- No schema changes or SQL migrations were added in this phase (authorization enforced at route/helper layer).

### Testing
- Ran typecheck with `npx tsc --noEmit` which completed successfully (no type errors).  
- Ran linter with `npm run lint` which failed due to pre-existing unrelated lint issues elsewhere in the repo (errors/warnings reported but not introduced by this patch).  
- No automated DB migrations were run because none were required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6306655c88328ba595c94e1a6d1ed)