### PR TITLE
Unify participant management under canonical conversation lifecycle authorization

### DIFF
--- a/app/api/chat/participants/route.ts
+++ b/app/api/chat/participants/route.ts
@@ -1,0 +1,402 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import {
+  authorizeConversationCreate,
+  authorizeConversationLifecycleAction,
+} from "@/features/ai/lib/chat/authorization";
+
+export const dynamic = "force-dynamic";
+
+type ParticipantRow = {
+  id: string;
+  conversation_id: string | null;
+  user_id: string | null;
+  role: string | null;
+  added_at: string | null;
+};
+
+function normalizeParticipantIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value
+        .filter((id): id is string => typeof id === "string")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+async function getAuthenticatedUserId(): Promise<string | null> {
+  const userClient = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
+
+  return user?.id ?? null;
+}
+
+export async function GET(req: Request): Promise<NextResponse> {
+  const actorUserId = await getAuthenticatedUserId();
+  if (!actorUserId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const conversationId = searchParams.get("conversationId")?.trim();
+
+  if (!conversationId) {
+    return NextResponse.json({ error: "conversationId required" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const access = await authorizeConversationLifecycleAction({
+    supabase: admin,
+    conversationId,
+    actorUserId,
+    action: "read_participants",
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const { data: participantRows, error: participantError } = await admin
+    .from("conversation_participants")
+    .select("id, conversation_id, user_id, role, added_at")
+    .eq("conversation_id", conversationId);
+
+  if (participantError) {
+    return NextResponse.json({ error: participantError.message }, { status: 500 });
+  }
+
+  const userIds = Array.from(
+    new Set(
+      (participantRows ?? [])
+        .map((row) => row.user_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+
+  const { data: profiles, error: profileError } = userIds.length
+    ? await admin
+        .from("profiles")
+        .select("id, user_id, full_name, email, avatar_url")
+        .or(userIds.map((id) => `user_id.eq.${id},id.eq.${id}`).join(","))
+    : { data: [], error: null };
+
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 500 });
+  }
+
+  const profileByUserId = new Map<string, { full_name: string | null; email: string | null; avatar_url: string | null }>();
+  (profiles ?? []).forEach((profile) => {
+    const resolvedUserId = profile.user_id ?? profile.id;
+    if (!resolvedUserId) return;
+
+    profileByUserId.set(resolvedUserId, {
+      full_name: profile.full_name,
+      email: profile.email,
+      avatar_url: profile.avatar_url ?? null,
+    });
+  });
+
+  const payload = (participantRows ?? []).map((row) => {
+    const profile = row.user_id ? profileByUserId.get(row.user_id) : undefined;
+    return {
+      id: row.id,
+      conversation_id: row.conversation_id,
+      user_id: row.user_id,
+      role: row.role,
+      added_at: row.added_at,
+      full_name: profile?.full_name ?? null,
+      email: profile?.email ?? null,
+      avatar_url: profile?.avatar_url ?? null,
+    };
+  });
+
+  return NextResponse.json(payload, { status: 200 });
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const actorUserId = await getAuthenticatedUserId();
+  if (!actorUserId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as
+    | {
+        conversationId?: string;
+        participant_ids?: unknown;
+        role?: string | null;
+      }
+    | null;
+
+  const conversationId = body?.conversationId?.trim();
+  const participantIds = normalizeParticipantIds(body?.participant_ids);
+
+  if (!conversationId || participantIds.length === 0) {
+    return NextResponse.json(
+      { error: "conversationId and participant_ids are required" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminSupabase();
+
+  const access = await authorizeConversationLifecycleAction({
+    supabase: admin,
+    conversationId,
+    actorUserId,
+    action: "manage_participants",
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const createAccess = await authorizeConversationCreate({
+    supabase: admin,
+    actorUserId,
+    participantUserIds: participantIds,
+  });
+
+  if (!createAccess.ok) {
+    return NextResponse.json({ error: createAccess.error }, { status: createAccess.status });
+  }
+
+  const requestedUserIds = new Set(createAccess.recipientUserIds);
+  const existingUserIds = new Set(access.participantUserIds);
+
+  const newUserIds = Array.from(requestedUserIds).filter(
+    (userId) => !existingUserIds.has(userId),
+  );
+
+  if (newUserIds.length === 0) {
+    return NextResponse.json({ inserted: 0 }, { status: 200 });
+  }
+
+  const insertRows = newUserIds.map((userId) => ({
+    id: randomUUID(),
+    conversation_id: conversationId,
+    user_id: userId,
+    role: body?.role ?? null,
+  }));
+
+  const { error: insertError } = await admin
+    .from("conversation_participants")
+    .insert(insertRows);
+
+  if (insertError) {
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ inserted: insertRows.length }, { status: 200 });
+}
+
+export async function PATCH(req: Request): Promise<NextResponse> {
+  const actorUserId = await getAuthenticatedUserId();
+  if (!actorUserId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as
+    | {
+        conversationId?: string;
+        participantId?: string;
+        role?: string | null;
+        user_id?: string;
+      }
+    | null;
+
+  const conversationId = body?.conversationId?.trim();
+  const participantId = body?.participantId?.trim();
+  const nextUserId = body?.user_id?.trim();
+
+  if (!conversationId || !participantId) {
+    return NextResponse.json({ error: "conversationId and participantId are required" }, { status: 400 });
+  }
+
+  if (body?.role === undefined && !nextUserId) {
+    return NextResponse.json({ error: "No participant updates provided" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const access = await authorizeConversationLifecycleAction({
+    supabase: admin,
+    conversationId,
+    actorUserId,
+    action: "manage_participants",
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const { data: existingRow, error: existingError } = await admin
+    .from("conversation_participants")
+    .select("id, conversation_id, user_id, role, added_at")
+    .eq("id", participantId)
+    .eq("conversation_id", conversationId)
+    .maybeSingle();
+
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 500 });
+  }
+
+  if (!existingRow) {
+    return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+  }
+
+  const updatePayload: { role?: string | null; user_id?: string } = {};
+
+  if (body?.role !== undefined) {
+    updatePayload.role = body.role;
+  }
+
+  if (nextUserId && nextUserId !== existingRow.user_id) {
+    const createAccess = await authorizeConversationCreate({
+      supabase: admin,
+      actorUserId,
+      participantUserIds: [nextUserId],
+    });
+
+    if (!createAccess.ok) {
+      return NextResponse.json({ error: createAccess.error }, { status: createAccess.status });
+    }
+
+    const validatedNextUserId = createAccess.recipientUserIds[0];
+    if (!validatedNextUserId) {
+      return NextResponse.json({ error: "No valid in-shop recipient found" }, { status: 400 });
+    }
+
+    const { data: duplicateParticipant } = await admin
+      .from("conversation_participants")
+      .select("id")
+      .eq("conversation_id", conversationId)
+      .eq("user_id", validatedNextUserId)
+      .neq("id", participantId)
+      .maybeSingle();
+
+    if (duplicateParticipant) {
+      return NextResponse.json(
+        { error: "User is already a participant in this conversation" },
+        { status: 409 },
+      );
+    }
+
+    updatePayload.user_id = validatedNextUserId;
+  }
+
+  const { data: updatedRow, error: updateError } = await admin
+    .from("conversation_participants")
+    .update(updatePayload)
+    .eq("id", participantId)
+    .eq("conversation_id", conversationId)
+    .select("id, conversation_id, user_id, role, added_at")
+    .maybeSingle();
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  if (!updatedRow) {
+    return NextResponse.json({ error: "Participant not found after update" }, { status: 404 });
+  }
+
+  return NextResponse.json(updatedRow satisfies ParticipantRow, { status: 200 });
+}
+
+export async function DELETE(req: Request): Promise<NextResponse> {
+  const actorUserId = await getAuthenticatedUserId();
+  if (!actorUserId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as
+    | {
+        conversationId?: string;
+        participantId?: string;
+        participantUserId?: string;
+      }
+    | null;
+
+  const conversationId = body?.conversationId?.trim();
+  const participantId = body?.participantId?.trim();
+  const participantUserId = body?.participantUserId?.trim();
+
+  if (!conversationId || (!participantId && !participantUserId)) {
+    return NextResponse.json(
+      { error: "conversationId and participantId or participantUserId are required" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminSupabase();
+  const access = await authorizeConversationLifecycleAction({
+    supabase: admin,
+    conversationId,
+    actorUserId,
+    action: "manage_participants",
+  });
+
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  if (participantUserId && participantUserId === access.conversation.created_by) {
+    return NextResponse.json(
+      { error: "Conversation creator cannot be removed" },
+      { status: 400 },
+    );
+  }
+
+  if (!participantUserId) {
+    const { data: targetRow, error: targetError } = await admin
+      .from("conversation_participants")
+      .select("user_id")
+      .eq("id", participantId as string)
+      .eq("conversation_id", conversationId)
+      .maybeSingle();
+
+    if (targetError) {
+      return NextResponse.json({ error: targetError.message }, { status: 500 });
+    }
+
+    if (!targetRow) {
+      return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+    }
+
+    if (targetRow.user_id && targetRow.user_id === access.conversation.created_by) {
+      return NextResponse.json(
+        { error: "Conversation creator cannot be removed" },
+        { status: 400 },
+      );
+    }
+  }
+
+  const deleteQuery = admin
+    .from("conversation_participants")
+    .delete()
+    .eq("conversation_id", conversationId);
+
+  if (participantId) {
+    deleteQuery.eq("id", participantId);
+  }
+
+  if (participantUserId) {
+    deleteQuery.eq("user_id", participantUserId);
+  }
+
+  const { data: deletedRows, error: deleteError } = await deleteQuery.select("id");
+
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ removed: deletedRows?.length ?? 0 }, { status: 200 });
+}

--- a/features/ai/components/chat/NewChatModal.tsx
+++ b/features/ai/components/chat/NewChatModal.tsx
@@ -8,7 +8,6 @@ import {
   useCallback,
   useRef,
 } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { toast } from "sonner";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
@@ -85,7 +84,6 @@ export default function NewChatModal({
   isOpen,
   onClose,
   onCreated,
-  created_by,
   context_type = null,
   context_id = null,
   activeConversationId: forcedConversationId = null,
@@ -451,61 +449,43 @@ export default function NewChatModal({
     async (participantIds: string[]): Promise<string | null> => {
       if (activeConvoId) return activeConvoId;
 
-      let creatorId = created_by ?? currentUserId;
-      if (!creatorId) {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        creatorId = user?.id ?? null;
-      }
-      if (!creatorId) {
-        toast.error("No authenticated user.");
-        return null;
-      }
+      try {
+        const res = await fetch("/api/chat/start-conversation", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            participant_ids: participantIds,
+            context_type,
+            context_id,
+          }),
+        });
 
-      const newId = uuidv4();
-      const { error: convErr } = await supabase.from("conversations").insert({
-        id: newId,
-        created_by: creatorId,
-        context_type,
-        context_id,
-      });
-      if (convErr) {
-        console.error("conversation insert failed:", convErr);
+        const json = (await res.json().catch(() => null)) as
+          | { id?: string; error?: string }
+          | null;
+
+        if (!res.ok || !json?.id) {
+          console.error("conversation create failed:", json?.error ?? `HTTP ${res.status}`);
+          toast.error(json?.error ?? "Could not create conversation");
+          return null;
+        }
+
+        const newId = json.id;
+        setActiveConvoId(newId);
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(LOCAL_ACTIVE_KEY, newId);
+        }
+        onCreated?.(newId);
+        upsertRecent(newId);
+        return newId;
+      } catch (error) {
+        console.error("conversation create failed:", error);
         toast.error("Could not create conversation");
         return null;
       }
-
-      const setIds = new Set(participantIds);
-      setIds.add(creatorId);
-
-      const rows = Array.from(setIds).map((user_id) => ({
-        id: uuidv4(),
-        conversation_id: newId,
-        user_id, // auth UID
-      }));
-
-      const { error: partErr } = await supabase
-        .from("conversation_participants")
-        .insert(rows);
-      if (partErr) {
-        console.error("participants insert failed:", partErr);
-      }
-
-      setActiveConvoId(newId);
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem(LOCAL_ACTIVE_KEY, newId);
-      }
-      onCreated?.(newId);
-      upsertRecent(newId);
-
-      return newId;
     },
     [
       activeConvoId,
-      created_by,
-      currentUserId,
-      supabase,
       context_type,
       context_id,
       onCreated,
@@ -585,22 +565,26 @@ export default function NewChatModal({
     async (convoId: string) => {
       if (!convoId || recentLabels[convoId]) return;
       try {
-        const { data: parts, error: partsErr } = await supabase
-          .from("conversation_participants")
-          .select("user_id")
-          .eq("conversation_id", convoId);
+        const res = await fetch(
+          `/api/chat/participants?conversationId=${encodeURIComponent(convoId)}`,
+          {
+            method: "GET",
+            credentials: "include",
+          },
+        );
 
-        if (partsErr || !parts?.length) return;
+        if (!res.ok) return;
 
-        const ids = parts.map((p) => p.user_id).filter(Boolean);
-        const { data: profs } = await supabase
-          .from("profiles")
-          .select("full_name,user_id")
-          .in("user_id", ids as string[]);
+        const participants = (await res.json().catch(() => [])) as Array<{
+          user_id: string | null;
+          full_name: string | null;
+        }>;
 
-        const others = (profs ?? [])
-          .filter((p) => p.user_id !== currentUserId)
-          .map((p) => p.full_name || "Unknown");
+        if (!participants.length) return;
+
+        const others = participants
+          .filter((participant) => participant.user_id !== currentUserId)
+          .map((participant) => participant.full_name || "Unknown");
 
         const label =
           others.length <= 2
@@ -612,7 +596,7 @@ export default function NewChatModal({
         // ignore
       }
     },
-    [supabase, currentUserId, recentLabels],
+    [currentUserId, recentLabels],
   );
 
   useEffect(() => {

--- a/next-blocker-summary-participant-management-authorization-parity.md
+++ b/next-blocker-summary-participant-management-authorization-parity.md
@@ -1,0 +1,49 @@
+# Next Blocker Summary — Participant Management Authorization Parity
+
+## What was fixed
+- Added a canonical participant-management API entrypoint at `/api/chat/participants` with `GET`, `POST`, `PATCH`, and `DELETE` handlers.
+- Wired participant list reads (`GET`) to canonical lifecycle authorization using `authorizeConversationLifecycleAction(action="read_participants")`.
+- Wired participant add/remove/update mutations (`POST`/`PATCH`/`DELETE`) to canonical lifecycle authorization using `authorizeConversationLifecycleAction(action="manage_participants")`.
+- Added in-shop validation for participant additions and participant user reassignment using existing `authorizeConversationCreate` recipient validation.
+- Migrated `NewChatModal` conversation creation away from direct client-side inserts to canonical `/api/chat/start-conversation`.
+- Migrated `NewChatModal` recent participant label reads away from direct `conversation_participants` table access to canonical `/api/chat/participants` read path.
+
+## Canonical authorization model now enforced
+- `app/api/chat/participants/route.ts::GET` -> `read_participants` rule via `authorizeConversationLifecycleAction`.
+- `app/api/chat/participants/route.ts::POST` -> `manage_participants` rule via `authorizeConversationLifecycleAction` + in-shop recipient validation via `authorizeConversationCreate`.
+- `app/api/chat/participants/route.ts::PATCH` -> `manage_participants` rule via `authorizeConversationLifecycleAction` + in-shop reassignment validation via `authorizeConversationCreate`.
+- `app/api/chat/participants/route.ts::DELETE` -> `manage_participants` rule via `authorizeConversationLifecycleAction`.
+- `features/ai/components/chat/NewChatModal.tsx::ensureConversation` -> canonical conversation/participant creation now flows through `/api/chat/start-conversation` (which already uses canonical create authorization helper).
+- `features/ai/components/chat/NewChatModal.tsx::buildRecentLabel` -> participant list reads now flow through `/api/chat/participants` (`read_participants`) instead of direct client table reads.
+
+## Files changed
+- `app/api/chat/participants/route.ts`
+- `features/ai/components/chat/NewChatModal.tsx`
+- `next-blocker-summary-participant-management-authorization-parity.md`
+
+## Migrations added
+- None.
+- manual SQL apply required: no (no SQL migration in this phase)
+- regenerate Supabase types after apply: not required in this phase (no schema change)
+
+## Behavior changes
+- Participant reads used by the recent label builder now fail closed unless the actor passes canonical `read_participants` authorization.
+- Conversation creation in `NewChatModal` no longer relies on direct browser inserts to `conversations`/`conversation_participants`; it now uses the existing canonical server route.
+- New participant mutation entrypoint now enforces creator-only participant management (`manage_participants`) consistently for add/remove/update operations.
+- Participant removal now explicitly blocks removing the conversation creator from the participant table through the canonical participant management route.
+
+## Risks resolved
+- Canonical lifecycle auth includes participant rules but participant endpoints/callers were not unified -> Resolved by adding canonical `/api/chat/participants` entrypoint and migrating modal participant reads/mutations to canonical server paths.
+- Existing participant mutation call sites may rely on local assumptions/direct helper/database access -> Resolved for identified UI mutation/read call sites in this phase (`NewChatModal` direct inserts/reads removed).
+
+## Remaining adjacent risks not fixed in this phase
+- `app/api/chat/my-conversations` still performs participant aggregation using service-role reads based on actor conversation-id derivation helper, rather than invoking `read_participants` per conversation explicitly.
+- Other potential non-UI/internal callers (if introduced later) must be held to `/api/chat/participants` or canonical helper usage to prevent future drift.
+
+## Validation run
+- `npx tsc --noEmit` -> pass
+- `npm run lint` -> fail (pre-existing repository lint errors/warnings outside this change scope)
+- `npx eslint app/api/chat/participants/route.ts features/ai/components/chat/NewChatModal.tsx` -> pass (warnings only)
+
+## Notes for next phase
+- Next highest adjacent blocker: unify `my-conversations` participant read aggregation under an explicit canonical `read_participants` path (or helper wrapper) so participant-list reads are consistently authorized through the same lifecycle surface across list and detail fetches.


### PR DESCRIPTION
### Motivation
- Consolidate participant add/read/update/remove paths to use the existing canonical conversation lifecycle authorization helper so participant operations cannot bypass lifecycle rules or cross shop boundaries.
- Enforce explicit `manage_participants` and `read_participants` rules uniformly for server-backed participant entry points and migrate client callers away from direct table access.
- Preserve existing UX while applying least-privilege controls (creator-only management baseline, in-shop validation for additions/reassignments).

### Description
- Added a canonical participant-management API route `app/api/chat/participants/route.ts` implementing `GET`, `POST`, `PATCH`, and `DELETE` handlers that all call `authorizeConversationLifecycleAction` with `read_participants` or `manage_participants` as appropriate.
- Reused `authorizeConversationCreate` to validate in-shop recipient IDs for `POST` and to validate reassignment targets in `PATCH`, and explicitly prevent removing the conversation creator in `DELETE`.
- Migrated UI callers in `features/ai/components/chat/NewChatModal.tsx` to use the canonical server surfaces: conversation creation now goes through `/api/chat/start-conversation` (which already uses canonical create checks), and recent participant label reads use `/api/chat/participants` instead of direct client-side table queries.
- Added `next-blocker-summary-participant-management-authorization-parity.md` containing the required blocker summary report.

### Testing
- Ran typecheck: `npx tsc --noEmit` — passed.
- Ran repository lint: `npm run lint` — failed due to pre-existing repository lint errors outside the scope of these changes (not introduced by this PR).
- Ran targeted lint for touched files: `npx eslint app/api/chat/participants/route.ts features/ai/components/chat/NewChatModal.tsx` — passed with warnings only.
- No SQL migrations were required or added in this phase (no schema changes); therefore manual SQL apply and Supabase type regeneration are not required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6376dba90832881db650429326b5b)