### PR TITLE
Harden authz on /api/quotes/send-for-approval and add tests

### DIFF
--- a/app/api/quotes/send-for-approval/route.ts
+++ b/app/api/quotes/send-for-approval/route.ts
@@ -1,9 +1,10 @@
-// /app/api/quotes/send-for-approval/route.ts (FULL FILE REPLACEMENT)
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
 import type { Database } from "@shared/types/types/supabase";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 
 function isUuid(v: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
@@ -26,10 +27,16 @@ function toStringArray(x: unknown): string[] | null {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const access = await requireShopScopedApiAccess({
+    requiredCapabilities: ["canManageWorkOrders", "canAuthorizeQuotes"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "service"],
+  });
+
+  if (!access.ok) {
+    return access.response;
+  }
+
+  const { supabase, profile } = access;
 
   let workOrderId: string | null = null;
   let lineIds: string[] | null = null;
@@ -54,7 +61,6 @@ export async function POST(req: Request) {
     );
   }
 
-  // ✅ Catch the classic “pattern” error early (custom_id passed instead of UUID)
   if (!isUuid(workOrderId)) {
     return NextResponse.json(
       {
@@ -66,7 +72,6 @@ export async function POST(req: Request) {
     );
   }
 
-  // ✅ line ids must also be UUIDs
   const badLineIds = lineIds.filter((id) => !isUuid(id));
   if (badLineIds.length > 0) {
     return NextResponse.json(
@@ -75,6 +80,41 @@ export async function POST(req: Request) {
         detail: { badLineIds },
       },
       { status: 400 },
+    );
+  }
+
+  const { data: workOrder, error: workOrderError } = await supabase
+    .from("work_orders")
+    .select("id")
+    .eq("id", workOrderId)
+    .eq("shop_id", profile.shop_id)
+    .maybeSingle<Pick<WorkOrderRow, "id">>();
+
+  if (workOrderError) {
+    return NextResponse.json({ error: workOrderError.message }, { status: 400 });
+  }
+
+  if (!workOrder) {
+    return NextResponse.json(
+      { error: "Work order is not accessible in actor shop" },
+      { status: 403 },
+    );
+  }
+
+  const { data: scopedLines, error: scopedLinesError } = await supabase
+    .from("work_order_lines")
+    .select("id")
+    .eq("work_order_id", workOrderId)
+    .in("id", lineIds);
+
+  if (scopedLinesError) {
+    return NextResponse.json({ error: scopedLinesError.message }, { status: 400 });
+  }
+
+  if (!scopedLines || scopedLines.length !== lineIds.length) {
+    return NextResponse.json(
+      { error: "One or more lineIds are not accessible for this work order" },
+      { status: 403 },
     );
   }
 
@@ -99,7 +139,7 @@ export async function POST(req: Request) {
   await logOperationalEvent({
     supabase,
     event: "work_order_sent_for_approval",
-    actorId: user?.id ?? null,
+    actorId: profile.id,
     entityType: "work_order",
     entityId: workOrderId,
     details: {

--- a/tests/quotes-send-for-approval-route.test.ts
+++ b/tests/quotes-send-for-approval-route.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const WORK_ORDER_ID = "11111111-1111-4111-8111-111111111111";
+const LINE_ID_1 = "22222222-2222-4222-8222-222222222222";
+const LINE_ID_2 = "33333333-3333-4333-8333-333333333333";
+
+type AccessResult =
+  | { ok: false; response: NextResponse }
+  | {
+      ok: true;
+      profile: { id: string; role: string; shop_id: string };
+      canonicalRole: "advisor";
+      supabase: ReturnType<typeof createSupabaseMock>;
+    };
+
+const state = {
+  accessResult: null as AccessResult | null,
+  workOrderFound: true,
+  scopedLineCount: 2,
+};
+
+function createSupabaseMock() {
+  const rpc = vi.fn(async () => ({ error: null }));
+
+  const from = vi.fn((table: string) => {
+    if (table === "work_orders") {
+      const query: any = {};
+      query.select = vi.fn(() => query);
+      query.eq = vi.fn(() => query);
+      query.maybeSingle = vi.fn(async () => ({
+        data: state.workOrderFound ? { id: WORK_ORDER_ID } : null,
+        error: null,
+      }));
+      return query;
+    }
+
+    if (table === "work_order_lines") {
+      const query: any = {};
+      query.select = vi.fn(() => query);
+      query.eq = vi.fn(() => query);
+      query.in = vi.fn(async () => ({
+        data: Array.from({ length: state.scopedLineCount }, (_, i) => ({
+          id: i === 0 ? LINE_ID_1 : LINE_ID_2,
+        })),
+        error: null,
+      }));
+      return query;
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  return { from, rpc };
+}
+
+const requireShopScopedApiAccessMock = vi.fn(async () => state.accessResult);
+const logOperationalEventMock = vi.fn(async () => undefined);
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: requireShopScopedApiAccessMock,
+}));
+
+vi.mock("@/features/work-orders/server/logOperationalEvent", () => ({
+  logOperationalEvent: logOperationalEventMock,
+}));
+
+describe("POST /api/quotes/send-for-approval", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    state.workOrderFound = true;
+    state.scopedLineCount = 2;
+    state.accessResult = {
+      ok: true,
+      profile: { id: "actor-id", role: "advisor", shop_id: "shop-a" },
+      canonicalRole: "advisor",
+      supabase: createSupabaseMock(),
+    };
+  });
+
+  it("rejects anonymous callers and never invokes RPC", async () => {
+    state.accessResult = {
+      ok: false,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    };
+
+    const { POST } = await import("../app/api/quotes/send-for-approval/route");
+    const response = await POST(
+      new Request("http://localhost/api/quotes/send-for-approval", {
+        method: "POST",
+        body: JSON.stringify({ workOrderId: WORK_ORDER_ID, lineIds: [LINE_ID_1] }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    const supabase = (state.accessResult as any).supabase;
+    expect(supabase?.rpc).toBeUndefined();
+  });
+
+  it("rejects wrong-role callers and never invokes RPC", async () => {
+    state.accessResult = {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+
+    const { POST } = await import("../app/api/quotes/send-for-approval/route");
+    const response = await POST(
+      new Request("http://localhost/api/quotes/send-for-approval", {
+        method: "POST",
+        body: JSON.stringify({ workOrderId: WORK_ORDER_ID, lineIds: [LINE_ID_1] }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    const supabase = (state.accessResult as any).supabase;
+    expect(supabase?.rpc).toBeUndefined();
+  });
+
+  it("rejects cross-shop work order access and never invokes RPC", async () => {
+    state.workOrderFound = false;
+
+    const { POST } = await import("../app/api/quotes/send-for-approval/route");
+    const response = await POST(
+      new Request("http://localhost/api/quotes/send-for-approval", {
+        method: "POST",
+        body: JSON.stringify({ workOrderId: WORK_ORDER_ID, lineIds: [LINE_ID_1] }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+
+    const supabase = (state.accessResult as Extract<AccessResult, { ok: true }>).supabase;
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("allows authorized callers in the same shop and invokes RPC", async () => {
+    const { POST } = await import("../app/api/quotes/send-for-approval/route");
+    const response = await POST(
+      new Request("http://localhost/api/quotes/send-for-approval", {
+        method: "POST",
+        body: JSON.stringify({
+          workOrderId: WORK_ORDER_ID,
+          lineIds: [LINE_ID_1, LINE_ID_2],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+
+    const supabase = (state.accessResult as Extract<AccessResult, { ok: true }>).supabase;
+    expect(supabase.rpc).toHaveBeenCalledTimes(1);
+    expect(supabase.rpc).toHaveBeenCalledWith("send_for_approval", {
+      _wo: WORK_ORDER_ID,
+      _line_ids: [LINE_ID_1, LINE_ID_2],
+      _set_wo_status: true,
+    });
+    expect(logOperationalEventMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix an authorization gap where the route could reach `send_for_approval` without an explicit authenticated/shop-scoped capability check.
- Prevent anonymous, wrong-role, and cross-shop callers from invoking the trusted RPC boundary.
- Preserve existing approval-send behavior for legitimately authorized actors in the same shop.

### Description
- Enforce canonical route access by calling `requireShopScopedApiAccess` at the start of `POST` with `requiredCapabilities: ["canManageWorkOrders","canAuthorizeQuotes"]` and `allowRoles: ["owner","admin","manager","advisor","service"]`.
- Verify the target work order belongs to the actor shop by querying `work_orders` with `.eq("id", workOrderId).eq("shop_id", profile.shop_id)` before any RPC call.
- Validate that all provided `lineIds` belong to that work order via `.from("work_order_lines").eq("work_order_id", workOrderId).in("id", lineIds)` and reject if any are missing.
- Invoke `send_for_approval` RPC only after the above checks and use `profile.id` as the actor when calling `logOperationalEvent`.

### Testing
- Ran `npx tsc --noEmit` and it passed with exit 0.
- Ran `npx vitest run tests/quotes-send-for-approval-route.test.ts` and the test file passed (4 tests) verifying anonymous, wrong-role, cross-shop rejections and authorized same-shop success.
- Tests assert that no RPC is invoked before authz/ownership checks and that the RPC is called exactly once for an authorized request.
- No database migrations were required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e641095fd48328865737e6ae95c5a7)