### PR TITLE
Unify Stripe API version usage with shared client helper

### DIFF
--- a/app/api/portal/payments/checkout/route.ts
+++ b/app/api/portal/payments/checkout/route.ts
@@ -1,6 +1,6 @@
 // app/api/portal/payments/checkout/route.ts
 import { NextResponse } from "next/server";
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { cookies as nextCookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
@@ -13,9 +13,7 @@ import {
 
 type DB = Database;
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "", {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY ?? "");
 
 // 3% platform fee
 const PLATFORM_FEE_BPS = 300;

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
@@ -110,9 +111,7 @@ async function createCustomerIfMissing(
 
 export async function POST(req: Request) {
   try {
-    const stripe = new Stripe(mustEnv("STRIPE_SECRET_KEY"), {
-      apiVersion: "2022-11-15",
-    });
+    const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
 
     const access = await requireShopScopedApiAccess({
       requiredCapability: "canManageBilling",

--- a/app/api/stripe/connect/onboard/route.ts
+++ b/app/api/stripe/connect/onboard/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -52,9 +52,7 @@ function getShopDisplayName(shop: { shop_name?: string | null; name?: string | n
 
 export async function POST() {
   try {
-    const stripe = new Stripe(mustEnv("STRIPE_SECRET_KEY"), {
-      apiVersion: "2022-11-15",
-    });
+    const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
 
     const supabase = createRouteHandlerClient<DB>({ cookies });
 

--- a/app/api/stripe/payments/checkout/route.ts
+++ b/app/api/stripe/payments/checkout/route.ts
@@ -1,16 +1,14 @@
 //app/api/stripe/payments/checkout/route.ts
 
 import { NextResponse } from "next/server";
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { cookies as nextCookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "", {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY ?? "");
 
 const ADMIN_ROLES = new Set<string>(["owner", "admin", "manager", "advisor"]);
 

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
@@ -68,9 +69,7 @@ async function createCustomerIfMissing(
 
 export async function POST(req: Request) {
   try {
-    const stripe = new Stripe(mustEnv("STRIPE_SECRET_KEY"), {
-      apiVersion: "2022-11-15",
-    });
+    const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
 
     const access = await requireShopScopedApiAccess({
       requiredCapability: "canManageBilling",

--- a/app/api/stripe/session/route.ts
+++ b/app/api/stripe/session/route.ts
@@ -1,13 +1,11 @@
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
 
 export async function GET(req: Request) {
   try {

--- a/app/landing/actions.ts
+++ b/app/landing/actions.ts
@@ -1,10 +1,8 @@
 "use server";
 
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
 
 export async function fetchPlans() {
   try {

--- a/app/pay/success/page.tsx
+++ b/app/pay/success/page.tsx
@@ -1,12 +1,10 @@
 // app/pay/success/page.tsx
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import Link from "next/link";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "", {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY ?? "");
 
 function getStr(searchParams: SearchParams, key: string): string | null {
   const v = searchParams[key];

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -1,11 +1,9 @@
 //features/stripe/api/stripe/checkout/link-user/route.ts
 
 import { NextResponse } from "next/server";
-import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
 
 export async function POST(req: Request) {
   try {

--- a/features/stripe/api/stripe/webhook/route.ts
+++ b/features/stripe/api/stripe/webhook/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import {
@@ -322,9 +323,7 @@ export async function handleStripeWebhook(req: Request): Promise<Response> {
     return NextResponse.json({ error: "Missing Stripe signature" }, { status: 400 });
   }
 
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-    apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-  });
+  const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY);
 
   const supabase = createClient<DB>(
     process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/features/stripe/lib/getStripePlans.ts
+++ b/features/stripe/lib/getStripePlans.ts
@@ -2,11 +2,9 @@
 
 "use server";
 
-import Stripe from "stripe";
+import { createStripeClient } from "./stripe/client";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
 
 export async function getStripePlans() {
   try {

--- a/features/stripe/lib/stripe/client.ts
+++ b/features/stripe/lib/stripe/client.ts
@@ -1,0 +1,9 @@
+import Stripe from "stripe";
+
+export const STRIPE_API_VERSION = "2024-04-10";
+
+export function createStripeClient(secretKey: string): Stripe {
+  return new Stripe(secretKey, {
+    apiVersion: STRIPE_API_VERSION as Stripe.LatestApiVersion,
+  });
+}

--- a/features/stripe/lib/stripe/getPlans.ts
+++ b/features/stripe/lib/stripe/getPlans.ts
@@ -1,7 +1,7 @@
 // features/stripe/lib/stripe/getPlans.ts
 "use server";
 
-import Stripe from "stripe";
+import { createStripeClient } from "./client";
 import {
   PLAN_LOOKUP_KEYS,
   PLAN_LIMITS,
@@ -9,9 +9,7 @@ import {
   type PlanKey,
 } from "./constants";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2024-04-10" as Stripe.LatestApiVersion,
-});
+const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
 
 export type StripePlan = {
   key: PlanKey;

--- a/tests/stripe-api-version-unification.test.ts
+++ b/tests/stripe-api-version-unification.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import { STRIPE_API_VERSION } from "../features/stripe/lib/stripe/client";
+
+const BILLING_STRIPE_SURFACES = [
+  "app/api/stripe/checkout/route.ts",
+  "app/api/stripe/portal/route.ts",
+  "app/api/stripe/session/route.ts",
+  "app/api/stripe/payments/checkout/route.ts",
+  "app/api/portal/payments/checkout/route.ts",
+  "app/api/stripe/connect/onboard/route.ts",
+  "features/stripe/api/stripe/webhook/route.ts",
+  "features/stripe/api/stripe/checkout/link-user/route.ts",
+  "app/landing/actions.ts",
+  "app/pay/success/page.tsx",
+  "features/stripe/lib/getStripePlans.ts",
+  "features/stripe/lib/stripe/getPlans.ts",
+] as const;
+
+describe("stripe api version unification", () => {
+  it("uses one canonical Stripe API version string", () => {
+    expect(STRIPE_API_VERSION).toBe("2024-04-10");
+  });
+
+  it("keeps billing checkout/portal/session/webhook paths on the shared Stripe client", async () => {
+    for (const file of BILLING_STRIPE_SURFACES) {
+      const source = await readFile(file, "utf8");
+      expect(source).toContain("createStripeClient(");
+      expect(source).not.toContain("apiVersion:");
+      expect(source).not.toContain("new Stripe(");
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Eliminate mixed Stripe API versions observed across billing surfaces to prevent compatibility drift between checkout, webhook, portal, and session handlers.
- Centralize the Stripe API version so future changes are made in one place and accidental per-file overrides are prevented.
- Preserve existing billing behavior, metadata mappings, and shop-scoped security checks while adding focused validation that surfaces use the canonical client.

### Description
- Add a canonical Stripe client helper `features/stripe/lib/stripe/client.ts` exporting `STRIPE_API_VERSION = "2024-04-10"` and `createStripeClient(secretKey)` factory used to instantiate Stripe with the canonical version.
- Replace per-file `new Stripe(..., { apiVersion: ... })` usages across billing-related surfaces to call `createStripeClient(...)` instead in the following files: `app/api/stripe/checkout/route.ts`, `app/api/stripe/portal/route.ts`, `app/api/stripe/session/route.ts`, `app/api/stripe/connect/onboard/route.ts`, `app/api/stripe/payments/checkout/route.ts`, `app/api/portal/payments/checkout/route.ts`, `features/stripe/api/stripe/webhook/route.ts`, `features/stripe/api/stripe/checkout/link-user/route.ts`, `features/stripe/lib/getStripePlans.ts`, `features/stripe/lib/stripe/getPlans.ts`, `app/landing/actions.ts`, and `app/pay/success/page.tsx`.
- Add `tests/stripe-api-version-unification.test.ts` to assert the canonical version value and to ensure billing surfaces use `createStripeClient(...)` and do not contain inline `apiVersion:` or local `new Stripe(` constructors.
- Preserve all billing flows and metadata handling in webhook and checkout handlers; no schema or webhook ledger redesigns were introduced.

### Testing
- Ran focused unit/tests: `npm run -s test -- tests/stripe-webhook-hardening.test.ts tests/stripe-api-version-unification.test.ts` which completed successfully with both test files passing (2 files, 4 tests passed).
- Ran type check: `npx tsc --noEmit` which passed (typecheck successful; non-fatal npm env warning observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e642bc76008328892a911b07f46828)