### PR TITLE
Fix auth/onboarding handoff to existing Shop Boost intake

### DIFF
--- a/features/auth/lib/postAuthRouting.ts
+++ b/features/auth/lib/postAuthRouting.ts
@@ -18,6 +18,37 @@ const PASSTHROUGH_KEYS = [
   "activationContext",
 ] as const;
 
+const SHOP_BOOST_ACTIVE_OR_ACTIONABLE_STATUSES = new Set([
+  "queued",
+  "pending",
+  "processing",
+  "failed",
+  "blocked",
+  "requires_review",
+  "review_needed",
+]);
+
+const SHOP_BOOST_RECENT_COMPLETED_STATUSES = new Set([
+  "completed",
+  "completed_clean",
+  "completed_with_review",
+  "completed_with_warnings",
+  "ready_for_go_live",
+]);
+
+function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
+  const normalized = String(role ?? "").trim().toLowerCase();
+  return normalized === "owner" || normalized === "admin";
+}
+
+function shouldRouteOwnerToShopBoost(status: string | null | undefined): boolean {
+  const normalized = String(status ?? "").trim().toLowerCase();
+  if (!normalized) return true;
+  if (SHOP_BOOST_ACTIVE_OR_ACTIONABLE_STATUSES.has(normalized)) return false;
+  if (SHOP_BOOST_RECENT_COMPLETED_STATUSES.has(normalized)) return false;
+  return false;
+}
+
 function collectPassthroughParams(sp: URLSearchParams | ReadonlyURLSearchParams) {
   const params = new URLSearchParams();
   for (const key of PASSTHROUGH_KEYS) {
@@ -39,6 +70,7 @@ export async function resolvePostAuthDestination(args: {
     isMobileMode = false,
     defaultDashboardHref = "/dashboard",
   } = args;
+  const activationContext = parseActivationContextFromSearchParams(searchParams);
 
   const {
     data: { user },
@@ -48,7 +80,7 @@ export async function resolvePostAuthDestination(args: {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("completed_onboarding, must_change_password")
+    .select("completed_onboarding, must_change_password, role, shop_id")
     .eq("id", user.id)
     .maybeSingle();
 
@@ -61,17 +93,34 @@ export async function resolvePostAuthDestination(args: {
   if (!isOnboarded) {
     const passthrough = collectPassthroughParams(searchParams);
     const onboardingHref = `/onboarding${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
-    const activationContext = parseActivationContextFromSearchParams(searchParams);
 
     return activationContext
       ? appendActivationContextToHref(onboardingHref, activationContext)
       : onboardingHref;
   }
 
+  if (isShopBoostOrchestratedRole(profile?.role) && profile?.shop_id) {
+    const { data: latestIntake } = await supabase
+      .from("shop_boost_intakes")
+      .select("status")
+      .eq("shop_id", profile.shop_id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<{ status: string | null }>();
+
+    if (shouldRouteOwnerToShopBoost(latestIntake?.status)) {
+      const passthrough = collectPassthroughParams(searchParams);
+      const shopBoostHref = `/onboarding/shop-boost${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
+
+      return activationContext
+        ? appendActivationContextToHref(shopBoostHref, activationContext)
+        : shopBoostHref;
+    }
+  }
+
   if (isMobileMode) return "/mobile";
 
   const redirect = searchParams.get("redirect")?.trim();
-  const activationContext = parseActivationContextFromSearchParams(searchParams);
   const destination = redirect || defaultDashboardHref;
 
   return activationContext

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,6 +30,11 @@ function safeRedirectPath(v: string | null): string | null {
 
 type PortalMode = "customer" | "fleet";
 
+function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
+  const normalized = String(role ?? "").trim().toLowerCase();
+  return normalized === "owner" || normalized === "admin";
+}
+
 async function resolvePortalModeServer(
   supabase: ReturnType<typeof createMiddlewareClient<Database>>,
   userId: string,
@@ -98,23 +103,44 @@ export async function middleware(req: NextRequest) {
     isLegacyPortalConfirm;
 
   let completed = false;
+  let needsShopBoostIntake = false;
   if (session?.user && !isPortal) {
     try {
       const { data: profile } = await supabase
         .from("profiles")
-        .select("completed_onboarding, shop_id")
+        .select("completed_onboarding, shop_id, role")
         .eq("id", session.user.id)
         .limit(1)
         .maybeSingle();
 
       completed = !!profile?.completed_onboarding || !!profile?.shop_id;
+
+      if (profile?.completed_onboarding && profile?.shop_id && isShopBoostOrchestratedRole(profile.role)) {
+        const { data: intake } = await supabase
+          .from("shop_boost_intakes")
+          .select("id")
+          .eq("shop_id", profile.shop_id)
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        needsShopBoostIntake = !intake?.id;
+      }
     } catch {
       completed = false;
+      needsShopBoostIntake = false;
     }
   }
 
   if (pathname === "/" && session?.user) {
-    const target = new URL(completed ? "/dashboard" : "/onboarding", req.url);
+    const target = new URL(
+      !completed
+        ? "/onboarding"
+        : needsShopBoostIntake
+          ? "/onboarding/shop-boost"
+          : "/dashboard",
+      req.url,
+    );
     return withSupabaseCookies(res, NextResponse.redirect(target));
   }
 
@@ -134,9 +160,11 @@ export async function middleware(req: NextRequest) {
           ? completed
             ? "/mobile"
             : "/onboarding"
-          : completed
-            ? "/dashboard"
-            : "/onboarding");
+          : !completed
+            ? "/onboarding"
+            : needsShopBoostIntake
+              ? "/onboarding/shop-boost"
+              : "/dashboard");
 
       const target = new URL(to, req.url);
       return withSupabaseCookies(res, NextResponse.redirect(target));


### PR DESCRIPTION
### Motivation
- Ensure the canonical signup → confirm → onboarding → Shop Boost intake → dashboard flow completes without skipping the existing Shop Boost intake step. 
- Stop owner/admin users who are onboarded with a `shop_id` but who have not started Shop Boost from being prematurely redirected to `/dashboard`.

### Description
- Added a Shop Boost intake presence check in `resolvePostAuthDestination` and route owners/admins without any intake to the existing `/onboarding/shop-boost` page instead of the dashboard when appropriate.
- Updated server middleware redirects so landing on `/`, `/sign-in`, or `/signup` routes applies the same logic and routes owner/admin users without an intake to `/onboarding/shop-boost` instead of `/dashboard`.
- Reused existing activation context passthrough and preserved all existing Shop Boost submission and dashboard behavior (no new routes or UI introduced).
- Files changed: `features/auth/lib/postAuthRouting.ts`, `middleware.ts`.
- No database changes, migrations, RPCs, triggers, policies, or Supabase configuration were modified.

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` — succeeded.
- Code-path/manual verification performed in code for these flows and locations: `signup` → `features/auth/app/signup/SignUpClient.tsx`, `auth callback` → `app/auth/callback/page.tsx` using `resolvePostAuthDestination`, onboarding submit/owner bootstrap → `features/auth/app/onboarding/OnboardingPage.tsx` and `app/api/onboarding/bootstrap-owner/route.ts`, Shop Boost intake page at `/onboarding/shop-boost` → `app/onboarding/shop-boost/page.tsx`, and dashboard Shop Boost status UI (`ShopBoostActivationPanel`) → `app/dashboard/_components/OperationsDashboardView.tsx` + `features/dashboard/components/ShopBoostActivationPanel.tsx`.
- Verified redirect/handoff behavior before vs after in code: before, onboarded owners/admins with `shop_id` could be sent to `/dashboard` even without an intake; after, those users are routed to `/onboarding/shop-boost` until an intake exists or Shop Boost processing/completion is underway.
- Confirmations: no DB changes, no new routes, and the existing Shop Boost intake page and existing dashboard Shop Boost status UI are used as-is.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d98347e08328b0648512f1681e87)