### PR TITLE
Add pricing CTA acquisition checkout flow with demo/intake attribution and passthrough auth handling

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -21,6 +21,8 @@ type CheckoutPayload = {
   enableTrial?: boolean;
   trialDays?: number;
   applyFoundingDiscount?: boolean;
+  demoId?: string | null;
+  intakeId?: string | null;
 };
 
 type ShopScope = Pick<
@@ -118,7 +120,85 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
-    const onboardingHandoffSource = String(body.source ?? "").trim() === "onboarding_shop_boost";
+    const source = String(body.source ?? "").trim();
+    const isAcquisitionCheckout = source === "pricing_cta";
+    const onboardingHandoffSource = source === "onboarding_shop_boost";
+
+    const rawPrice = String(body.priceId ?? body.planKey ?? "").trim();
+    if (!rawPrice) {
+      return NextResponse.json({ error: "Missing price identifier" }, { status: 400 });
+    }
+
+    const priceId = await resolvePriceId(stripe, rawPrice);
+    if (!priceId) {
+      return NextResponse.json(
+        { error: `No active Stripe price found for "${rawPrice}"` },
+        { status: 400 },
+      );
+    }
+
+    const baseUrl = getBaseUrl();
+    const acquisitionSuccessPath = "/auth/callback?flow=acquisition&session_id={CHECKOUT_SESSION_ID}";
+    const acquisitionCancelPath = "/compare-plans";
+    const successUrl = `${baseUrl}${
+      body.successPath?.startsWith("/")
+        ? body.successPath
+        : isAcquisitionCheckout
+          ? acquisitionSuccessPath
+          : "/dashboard/owner/settings#billing"
+    }`;
+
+    const cancelUrl = `${baseUrl}${
+      body.cancelPath?.startsWith("/")
+        ? body.cancelPath
+        : isAcquisitionCheckout
+          ? acquisitionCancelPath
+          : "/dashboard/owner/settings#billing"
+    }`;
+
+    const enableTrial = body.enableTrial !== false;
+    const trialDays = clampTrialDays(body.trialDays, envTrialDays());
+
+    const couponId = String(process.env.STRIPE_FOUNDING_COUPON_ID ?? "").trim();
+    const applyFoundingDiscount =
+      Boolean(couponId) && body.applyFoundingDiscount !== false;
+
+    if (isAcquisitionCheckout) {
+      const session = await stripe.checkout.sessions.create({
+        mode: "subscription",
+        customer_creation: "always",
+        payment_method_types: ["card"],
+        line_items: [{ price: priceId, quantity: 1 }],
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        allow_promotion_codes: true,
+        ...(applyFoundingDiscount ? { discounts: [{ coupon: couponId }] } : {}),
+        subscription_data: {
+          ...(enableTrial ? { trial_period_days: trialDays } : {}),
+          metadata: {
+            purpose: "profixiq_acquisition",
+            source: "pricing_cta",
+            founding_discount_applied: applyFoundingDiscount ? "true" : "false",
+            trial_enabled: enableTrial ? "true" : "false",
+            trial_days: enableTrial ? String(trialDays) : "0",
+            demo_id: String(body.demoId ?? "").trim() || "",
+            intake_id: String(body.intakeId ?? "").trim() || "",
+          },
+        },
+        metadata: {
+          purpose: "profixiq_acquisition",
+          source: "pricing_cta",
+          demo_id: String(body.demoId ?? "").trim() || "",
+          intake_id: String(body.intakeId ?? "").trim() || "",
+        },
+        customer_update: {
+          address: "auto",
+          name: "auto",
+        },
+      });
+
+      return NextResponse.json({ ok: true, sessionId: session.id, url: session.url });
+    }
 
     const access = await requireShopScopedApiAccess({
       requiredCapability: "canManageBilling",
@@ -132,19 +212,6 @@ export async function POST(req: Request) {
     const requestedShopId = String(body.shopId ?? access.profile.shop_id).trim();
     if (!requestedShopId || requestedShopId !== access.profile.shop_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const rawPrice = String(body.priceId ?? body.planKey ?? "").trim();
-    if (!rawPrice) {
-      return NextResponse.json({ error: "Missing price identifier" }, { status: 400 });
-    }
-
-    const priceId = await resolvePriceId(stripe, rawPrice);
-    if (!priceId) {
-      return NextResponse.json(
-        { error: `No active Stripe price found for "${rawPrice}"` },
-        { status: 400 },
-      );
     }
 
     const { data: shop, error: shopError } = await access.supabase
@@ -162,26 +229,6 @@ export async function POST(req: Request) {
     }
 
     const customerId = await createCustomerIfMissing(stripe, access.supabase, shop);
-
-    const baseUrl = getBaseUrl();
-    const successUrl = `${baseUrl}${
-      body.successPath?.startsWith("/")
-        ? body.successPath
-        : "/dashboard/owner/settings#billing"
-    }?session_id={CHECKOUT_SESSION_ID}`;
-
-    const cancelUrl = `${baseUrl}${
-      body.cancelPath?.startsWith("/")
-        ? body.cancelPath
-        : "/dashboard/owner/settings#billing"
-    }`;
-
-    const enableTrial = body.enableTrial !== false;
-    const trialDays = clampTrialDays(body.trialDays, envTrialDays());
-
-    const couponId = String(process.env.STRIPE_FOUNDING_COUPON_ID ?? "").trim();
-    const applyFoundingDiscount =
-      Boolean(couponId) && body.applyFoundingDiscount !== false;
 
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",

--- a/app/api/stripe/session/route.ts
+++ b/app/api/stripe/session/route.ts
@@ -9,15 +9,6 @@ const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
 
 export async function GET(req: Request) {
   try {
-    const access = await requireShopScopedApiAccess({
-      requiredCapability: "canManageBilling",
-      allowRoles: ["owner", "admin"],
-      requireOwnerPin: true,
-      ownerPinRequest: req,
-      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.BILLING, OWNER_PIN_PURPOSES.PRIVILEGED],
-    });
-    if (!access.ok) return access.response;
-
     const url = new URL(req.url);
     const sessionId = (url.searchParams.get("session_id") ?? "").trim();
 
@@ -30,6 +21,31 @@ export async function GET(req: Request) {
     }
 
     const session = await stripe.checkout.sessions.retrieve(sessionId);
+    const metadataPurpose = String(session.metadata?.purpose ?? "").trim();
+
+    if (metadataPurpose === "profixiq_acquisition") {
+      let email: string | null = session.customer_details?.email ?? null;
+
+      if (!email && typeof session.customer === "string") {
+        const customer = await stripe.customers.retrieve(session.customer);
+
+        if (customer && !("deleted" in customer)) {
+          email = customer.email ?? null;
+        }
+      }
+
+      return NextResponse.json({ email }, { status: 200 });
+    }
+
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBilling",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.BILLING, OWNER_PIN_PURPOSES.PRIVILEGED],
+    });
+    if (!access.ok) return access.response;
+
     const { data: shop } = await access.supabase
       .from("shops")
       .select("id, stripe_customer_id")
@@ -41,7 +57,6 @@ export async function GET(req: Request) {
     }
 
     const metadataShopId = String(session.metadata?.shop_id ?? "").trim();
-    const metadataPurpose = String(session.metadata?.purpose ?? "").trim();
     const sessionCustomer = typeof session.customer === "string" ? session.customer : null;
     const shopCustomer = String(shop.stripe_customer_id ?? "").trim() || null;
 

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -49,10 +49,20 @@ export default function AuthCallbackPage() {
       } = await supabase.auth.getSession();
 
       if (!session?.user) {
-        router.replace("/sign-in");
+        const passthrough = new URLSearchParams();
+        const sessionId = sp.get("session_id")?.trim();
+        const flow = sp.get("flow")?.trim();
+        if (sessionId) passthrough.set("session_id", sessionId);
+        if (flow) passthrough.set("flow", flow);
+        const signInHref = `/sign-in${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
+
+        router.replace(signInHref);
         setTimeout(() => {
-          if (typeof window !== "undefined" && window.location.pathname !== "/sign-in") {
-            window.location.assign("/sign-in");
+          if (typeof window !== "undefined") {
+            const want = new URL(signInHref, window.location.origin).href;
+            if (window.location.href !== want) {
+              window.location.assign(signInHref);
+            }
           }
         }, 100);
         return;

--- a/app/compare-plans/page.tsx
+++ b/app/compare-plans/page.tsx
@@ -7,11 +7,9 @@ import { useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { Toaster, toast } from "sonner";
 import {
-  appendActivationContextToHref,
   parseActivationContextFromSearchParams,
   persistActivationContext,
 } from "@/features/integrations/shopBoost/activationContext";
-import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 import PricingSection from "@/features/shared/components/ui/PricingSection";
 
 type Interval = "monthly" | "yearly";
@@ -21,19 +19,6 @@ export default function ComparePlansPage() {
   const demoId = searchParams.get("demoId");
   const intakeId = searchParams.get("intakeId");
   const activationContext = parseActivationContextFromSearchParams(searchParams);
-  const comparePlansHref = activationContext
-    ? appendActivationContextToHref(
-        `/compare-plans?${new URLSearchParams({
-          ...(demoId ? { demoId } : {}),
-          ...(intakeId ? { intakeId } : {}),
-        }).toString()}`,
-        activationContext,
-      )
-    : `/compare-plans?${new URLSearchParams({
-        ...(demoId ? { demoId } : {}),
-        ...(intakeId ? { intakeId } : {}),
-      }).toString()}`;
-
   useEffect(() => {
     if (!activationContext) return;
     persistActivationContext(activationContext);
@@ -51,9 +36,10 @@ export default function ComparePlansPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          source: "pricing_cta",
           planKey: priceId,
           interval,
-          // Optional attribution for pre-signup Shop Boost analysis.
+          cancelPath: "/compare-plans",
           demoId: demoId ?? null,
           intakeId: intakeId ?? null,
         }),
@@ -62,22 +48,6 @@ export default function ComparePlansPage() {
       const data = await res.json().catch(() => ({}));
 
       if (!res.ok) {
-        if (res.status === 401 || res.status === 403) {
-          const next = comparePlansHref;
-          const signupHref = activationContext
-            ? appendActivationContextToHref(
-                `/signup?redirect=${encodeURIComponent(next)}${demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`,
-                activationContext,
-              )
-            : `/signup?redirect=${encodeURIComponent(next)}${demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
-          trackShopBoostEvent("cta_clicked", {
-            demoId: demoId ?? "unknown",
-            intakeId: intakeId ?? undefined,
-            source: "compare_plans_auth_required",
-          });
-          window.location.href = signupHref;
-          return;
-        }
         toast.error(data?.details || data?.error || "Checkout failed");
         return;
       }
@@ -152,30 +122,6 @@ export default function ComparePlansPage() {
               });
             }}
           />
-          {demoId ? (
-            <div className="mt-4">
-              <Link
-                href={
-                  activationContext
-                    ? appendActivationContextToHref(
-                        `/signup?redirect=${encodeURIComponent(comparePlansHref)}&demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`,
-                        activationContext,
-                      )
-                    : `/signup?redirect=${encodeURIComponent(comparePlansHref)}&demoId=${encodeURIComponent(demoId)}${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`
-                }
-                onClick={() =>
-                  trackShopBoostEvent("cta_clicked", {
-                    demoId,
-                    intakeId: intakeId ?? undefined,
-                    source: "compare_plans_signup",
-                  })
-                }
-                className="inline-flex items-center rounded-lg border border-white/15 bg-white/[0.04] px-4 py-2 text-xs font-semibold text-neutral-100 hover:bg-white/[0.08]"
-              >
-                Continue activation via signup
-              </Link>
-            </div>
-          ) : null}
         </div>
 
         <div className="mt-8 rounded-3xl border border-white/10 bg-black/25 p-5 backdrop-blur-xl">

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -260,7 +260,7 @@ export default function ShopBoostOnboardingPage() {
         window.localStorage.removeItem(UPLOAD_SESSION_STORAGE_KEY);
       }
 
-      router.replace("/dashboard/operations?setup=shop-boost");
+      router.replace("/dashboard?setup=shop-boost");
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unexpected error during upload.";
       setError(message);

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -625,6 +625,7 @@ export default function OnboardingPage() {
                     </p>
                   </div>
                 )}
+
               </div>
             </section>
 

--- a/features/auth/app/signup/SignUpClient.tsx
+++ b/features/auth/app/signup/SignUpClient.tsx
@@ -41,19 +41,15 @@ export default function SignUpClient() {
     const params = new URLSearchParams();
 
     const redirect = sp.get("redirect");
-    const priceId = sp.get("priceId");
-    const interval = sp.get("interval");
-    const trial = sp.get("trial");
-    const founding = sp.get("founding");
+    const sessionId = sp.get("session_id");
+    const flow = sp.get("flow");
     const demoIdParam = sp.get("demoId");
     const intakeIdParam = sp.get("intakeId");
     const activationContextRaw = sp.get("activationContext");
 
     if (redirect) params.set("redirect", redirect);
-    if (priceId) params.set("priceId", priceId);
-    if (interval) params.set("interval", interval);
-    if (trial) params.set("trial", trial);
-    if (founding) params.set("founding", founding);
+    if (sessionId) params.set("session_id", sessionId);
+    if (flow) params.set("flow", flow);
     if (demoIdParam) params.set("demoId", demoIdParam);
     if (intakeIdParam) params.set("intakeId", intakeIdParam);
     if (activationContextRaw) {
@@ -147,17 +143,9 @@ export default function SignUpClient() {
     const redirect = sp.get("redirect");
     const params = new URLSearchParams();
 
-    const priceId = sp.get("priceId");
-    const interval = sp.get("interval");
-    const trial = sp.get("trial");
-    const founding = sp.get("founding");
     const demoIdParam = sp.get("demoId");
     const intakeIdParam = sp.get("intakeId");
 
-    if (priceId) params.set("priceId", priceId);
-    if (interval) params.set("interval", interval);
-    if (trial) params.set("trial", trial);
-    if (founding) params.set("founding", founding);
     if (demoIdParam) params.set("demoId", demoIdParam);
     if (intakeIdParam) params.set("intakeId", intakeIdParam);
 

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -38,9 +38,15 @@ export default function AuthPage() {
   }, []);
 
   const emailRedirectTo = useMemo(() => {
+    const params = new URLSearchParams();
     const redirect = sp.get("redirect");
-    const tail = redirect ? `?redirect=${encodeURIComponent(redirect)}` : "";
-    return `${origin}/auth/callback${tail}`;
+    const sessionId = sp.get("session_id");
+    const flow = sp.get("flow");
+    if (redirect) params.set("redirect", redirect);
+    if (sessionId) params.set("session_id", sessionId);
+    if (flow) params.set("flow", flow);
+    const tail = params.toString();
+    return `${origin}/auth/callback${tail ? `?${tail}` : ""}`;
   }, [origin, sp]);
 
   const goLanding = () => {
@@ -155,7 +161,12 @@ export default function AuthPage() {
       return;
     }
 
-    await go("/onboarding");
+    const destination = await resolvePostAuthDestination({
+      supabase,
+      searchParams: sp,
+      isMobileMode,
+    });
+    await go(destination);
     setLoading(false);
   };
 

--- a/features/auth/lib/postAuthRouting.ts
+++ b/features/auth/lib/postAuthRouting.ts
@@ -8,10 +8,6 @@ import {
 
 export const PASSTHROUGH_KEYS = [
   "redirect",
-  "priceId",
-  "interval",
-  "trial",
-  "founding",
   "session_id",
   "demoId",
   "intakeId",
@@ -56,10 +52,6 @@ export function collectPassthroughParams(sp: URLSearchParams | ReadonlyURLSearch
     if (value) params.set(key, value);
   }
   return params;
-}
-
-export function hasBillingIntentParams(sp: URLSearchParams | ReadonlyURLSearchParams): boolean {
-  return !!sp.get("priceId");
 }
 
 export async function resolvePostAuthDestination(args: {
@@ -113,15 +105,6 @@ export async function resolvePostAuthDestination(args: {
       .maybeSingle<{ status: string | null }>();
 
     if (shouldRouteOwnerToShopBoost(latestIntake?.status)) {
-      const passthrough = collectPassthroughParams(searchParams);
-      const shopBoostHref = `/onboarding/shop-boost${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
-
-      return activationContext
-        ? appendActivationContextToHref(shopBoostHref, activationContext)
-        : shopBoostHref;
-    }
-
-    if (hasBillingIntentParams(searchParams)) {
       const passthrough = collectPassthroughParams(searchParams);
       const shopBoostHref = `/onboarding/shop-boost${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
 

--- a/features/shared/components/ProFixIQLanding.tsx
+++ b/features/shared/components/ProFixIQLanding.tsx
@@ -51,6 +51,28 @@ export default function ProFixIQLanding() {
     window.location.href = "/";
   };
 
+  const startCheckout = async ({ priceId, interval }: { priceId: string; interval: Interval }) => {
+    const res = await fetch("/api/stripe/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        source: "pricing_cta",
+        planKey: priceId,
+        interval,
+        enableTrial: true,
+        applyFoundingDiscount: true,
+        cancelPath: "/compare-plans",
+      }),
+    });
+
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data?.url) {
+      throw new Error(String(data?.error ?? data?.details ?? "Unable to start checkout"));
+    }
+
+    window.location.href = data.url;
+  };
+
   return (
     <div className="relative min-h-screen text-white">
       <Toaster position="top-center" />
@@ -251,22 +273,10 @@ export default function ProFixIQLanding() {
                 priceId: string;
                 interval: Interval;
               }) => {
-                const params = new URLSearchParams({
-                  priceId,
-                  interval,
-                  trial: "1",
-                  founding: "1",
-                });
-
-                window.location.href = `/signup?${params.toString()}`;
+                await startCheckout({ priceId, interval });
               }}
               onStartFree={() => {
-                const params = new URLSearchParams({
-                  trial: "1",
-                  founding: "1",
-                });
-
-                window.location.href = `/signup?${params.toString()}`;
+                window.location.href = "/compare-plans";
               }}
             />
           </div>


### PR DESCRIPTION
### Motivation

- Allow visitors to start a subscription from the public pricing CTA (acquisition) without an existing shop account or owner PIN.
- Carry demo/intake attribution through checkout and auth flows so purchases started from previews or Shop Boost can be associated back to those contexts.
- Simplify post-auth routing and session handling to support acquisition checkout sessions and preserve session passthrough params across sign-in/sign-up.

### Description

- Added `demoId` and `intakeId` to the checkout payload and implemented a new acquisition branch in `app/api/stripe/checkout/route.ts` that creates a Stripe Checkout session with `customer_creation: "always"`, stores attribution in session metadata, and returns the session id and URL without requiring shop-scoped access.
- Updated `app/api/stripe/session/route.ts` to detect acquisition sessions by `metadata.purpose === "profixiq_acquisition"` and return the purchaser email without requiring shop-scoped access; preserved shop-scoped validation for subscription flows.
- Propagated `session_id`/`flow` passthrough handling through auth redirects and client flows by updating `app/auth/callback/page.tsx`, `features/auth/app/signup/SignUpClient.tsx`, `features/auth/components/SignIn.tsx`, and `features/auth/lib/postAuthRouting.ts` to collect and preserve passthrough params and route appropriately after auth.
- Updated front-end entry points to start acquisition checkouts: `app/compare-plans/page.tsx` now sends `source: "pricing_cta"` and `demoId`/`intakeId` when starting checkout, `features/shared/components/ProFixIQLanding.tsx` adds a `startCheckout` helper to initiate acquisition sessions, and removed legacy billing-intent passthrough logic.
- Adjusted onboarding redirect in `app/onboarding/shop-boost/page.tsx` to go to `/dashboard?setup=shop-boost` after queueing migrations and removed obsolete billing intent routing checks from `postAuthRouting.ts`.

### Testing

- Ran TypeScript type checking (`tsc --noEmit`) and a Next.js production build (`next build`), both of which completed without errors.
- Exercised the new pricing CTA acquisition flow via a local dev run to confirm that `/api/stripe/checkout` returns a checkout URL for `source: "pricing_cta"` and that `/api/stripe/session` returns the email for an acquisition session; these smoke checks succeeded.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a3c9308c8328b15c848dabfa2f6c)