### PR TITLE
Clarify Shop Boost status/report visibility and staff invite staging

### DIFF
--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -197,6 +197,8 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
       : null;
 
   const intakeAge = overview?.intake_created_at ? timeAgo(overview.intake_created_at) : null;
+  const intakeStatus = overview?.intake_status ? String(overview.intake_status) : null;
+  const hasIntakeReport = Boolean(overview?.intake_id);
 
   const narrative = latest?.narrative_summary ?? null;
 
@@ -414,6 +416,21 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
               <MetaCard label="Latest snapshot" value={snapshotAge ?? "—"} />
               <MetaCard label="Source" value={overview?.intake_source ? String(overview.intake_source) : "—"} />
             </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-neutral-300">
+              <span className="rounded-full border border-white/10 bg-black/25 px-2.5 py-1">
+                Intake status: {intakeStatus ?? "unknown"}
+              </span>
+              {hasIntakeReport ? (
+                <button
+                  type="button"
+                  onClick={() => window.open(`/api/shop-boost/intakes/${overview?.intake_id}/report`, "_blank", "noopener,noreferrer")}
+                  className="rounded-full border border-white/15 bg-black/25 px-2.5 py-1 transition hover:bg-black/40"
+                >
+                  Open latest intake report JSON
+                </button>
+              ) : null}
+            </div>
           </section>
 
           {/* How to use this */}
@@ -494,6 +511,9 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
                 <h3 className={`mt-1 text-sm font-semibold ${titleText}`}>Setup checklist (menus, inspections, staff)</h3>
                 <p className={`mt-1 text-xs ${subtleText}`}>
                   Use “Open” to go to the right screen. “Create” now calls the accept-suggestion API.
+                </p>
+                <p className="mt-1 text-xs text-amber-200/90">
+                  Staff CSV imports are staged as invite suggestions first. Staff users are created only after accept.
                 </p>
               </div>
 


### PR DESCRIPTION
### Motivation
- Reduce owner confusion by surfacing intake status and an easy way to open the latest intake report, and explicitly communicate that staff CSV imports are staged as invite suggestions rather than immediately creating accounts.

### Description
- Updated `features/owner/reports/ReportsShopHealthPanel.tsx` to display an intake status chip and a button that opens the latest intake report JSON at `/api/shop-boost/intakes/:id/report` for quick access. 
- Added UI copy clarifying that staff CSV imports are staged into invite suggestions and that actual staff accounts are created only after accept/creation actions. 
- No schema changes, no new routes, and no changes to import materialization logic; this is a UI/wiring clarity patch only.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully. 
- Performed repository inspections to locate CSVs and DB credentials but the actual CSV files and Supabase environment were not present in this workspace, so full real-data verification was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8421a96848328bb4872ca80f5c97d)