### PR TITLE
Fix Shop Boost real fixture parsing for customers and staff suggestions

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -1196,9 +1196,14 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         [first ?? "", last ?? ""].filter(Boolean).join(" ");
       const normalizedName = normalizeNameKey(name);
 
-      const business = pick(row, [/business/, /company/, /fleet/]);
-
-      const isFleet = !!business || lower(pick(row, [/is fleet/, /fleet\?/]) ?? "") === "true";
+      const customerType = lower(
+        pick(row, [/^customer[_\s-]*type$/, /^type$/, /account type/, /customer class/, /segment/]) ?? "",
+      );
+      const business = pick(row, [/^company[_\s-]*name$/, /^business[_\s-]*name$/, /^company$/, /^business$/]);
+      const isFleet =
+        customerType === "fleet" ||
+        customerType === "commercial" ||
+        lower(pick(row, [/^is[_\s-]*fleet$/, /^fleet\?$/, /^fleet$/]) ?? "") === "true";
 
       const external_id = sourceCustomerId
         ? sourceExternalId("customer", sourceCustomerId)
@@ -1240,7 +1245,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           sourceFile: "customers",
           sourceRowIndex: i + 1,
           rawPayload: row,
-          normalizedPayload: { email, phone, name, business, isFleet },
+          normalizedPayload: { email, phone, name, business, isFleet, customerType },
           targetDomain: "customer",
           matchStatus: "matched_existing",
           matchConfidence: "medium",
@@ -1279,7 +1284,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           sourceFile: "customers",
           sourceRowIndex: i + 1,
           rawPayload: row,
-          normalizedPayload: { email, phone, name, business, isFleet, sourceCustomerId },
+          normalizedPayload: { email, phone, name, business, isFleet, customerType, sourceCustomerId },
           targetDomain: "customer",
           matchStatus: "matched_existing",
           matchConfidence: sourceCustomerId || email || phone ? "high" : "medium",
@@ -1315,7 +1320,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           sourceFile: "customers",
           sourceRowIndex: i + 1,
           rawPayload: row,
-          normalizedPayload: { email, phone, name, business, isFleet },
+          normalizedPayload: { email, phone, name, business, isFleet, customerType },
           targetDomain: "customer",
           matchStatus: "invalid",
           matchConfidence: "low",
@@ -1362,7 +1367,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           sourceFile: "customers",
           sourceRowIndex: i + 1,
           rawPayload: row,
-          normalizedPayload: { email, phone, name, business, isFleet, sourceCustomerId },
+          normalizedPayload: { email, phone, name, business, isFleet, customerType, sourceCustomerId },
           targetDomain: "customer",
           matchStatus: "created_new",
           matchConfidence: email || phone ? "high" : "medium",
@@ -1389,7 +1394,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           sourceFile: "customers",
           sourceRowIndex: i + 1,
           rawPayload: row,
-          normalizedPayload: { email, phone, name, business, isFleet },
+          normalizedPayload: { email, phone, name, business, isFleet, customerType },
           targetDomain: "customer",
           matchStatus: "unmatched",
           matchConfidence: "low",
@@ -1655,16 +1660,23 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const row = rows[i];
 
       // Handles messy headers because pick() normalizes keys with lower(trim)
+      const firstName = pick(row, [/^first[_\s-]*name$/, /^first$/]) ?? null;
+      const lastName = pick(row, [/^last[_\s-]*name$/, /^last$/]) ?? null;
+      const displayName = pick(row, [/^display[_\s-]*name$/, /^preferred[_\s-]*name$/]) ?? null;
+      const fallbackJoinedName = [firstName ?? "", lastName ?? ""].filter(Boolean).join(" ").trim();
       const fullName =
         pick(row, [
           /^full[_\s-]*name$/, // Full_Name, full_name, full-name, full name
           /^name$/,
           /employee name/,
           /staff name/,
-        ]) ?? null;
+        ]) ??
+        displayName ??
+        (fallbackJoinedName || null);
 
       const emailRaw = pick(row, [/^email$/, /e-mail/, /mail/]);
       const email = emailRaw && emailRaw.includes("@") ? emailRaw.trim() : null;
+      const phone = normalizePhone(pick(row, [/^phone$/, /mobile/, /cell/, /phone number/]));
 
       // ✅ ROLE PATCH (use schema enum + mapping, including accounting->admin)
       const roleRaw = pick(row, [/^role$/, /position/, /job/, /title/]);
@@ -1675,6 +1687,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
       const notes = pick(row, [/reason/, /note/, /notes/, /comment/]) ?? "Imported from staff CSV";
       const externalUserId = pickSourceId(row, [/^external[_\s-]*user[_\s-]*id$/, /^user[_\s-]*id$/, /^employee[_\s-]*id$/]);
+      const normalizedIdentity = normalizeText(email ?? fullName ?? "").replace(/\s+/g, ".");
+      const username = externalUserId ?? (normalizedIdentity || null);
 
       // Deterministic-ish external id to prevent duplicates on reruns
       const external_id = `import:${intakeId}:staff:${sha1(
@@ -1688,6 +1702,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           role,
           full_name: fullName,
           email,
+          phone: phone || null,
+          username,
           count_suggested: 1,
           notes,
           external_id,


### PR DESCRIPTION
### Motivation
- Real fixture CSVs use `customer_type`, `company_name`, and `display_name` / split `first_name` + `last_name` shapes that the importer was not handling deterministically. 
- The importer was sometimes over-eagerly inferring `is_fleet` from freeform business/tags and under-populating staff suggestion identity fields, causing linkage/review noise. 

### Description
- Tighten customer parsing so `customer_type` and explicit fleet flags drive `is_fleet`, and `company_name`/`business_name` headers are used for business mapping instead of broad `/fleet/` pattern matching. 
- Extend staff suggestion parsing to consume `display_name` plus `first_name` and `last_name` fallbacks, normalize `phone`, derive a deterministic `username` from `external_user_id` or normalized identity, and persist `phone` and `username` into `staff_invite_suggestions`. 
- Changes are non-breaking, scope-limited to the existing Shop Boost import pipeline and preserve the suggestion-first staff flow and shop-scoped behavior. 
- Files changed: `features/integrations/imports/runFullImport.ts` (single-file patch). 

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully. 
- Lint/targeted check: ran `npx eslint features/integrations/imports/runFullImport.ts` and it completed successfully. 
- I verified real fixture shapes prior to changes by inspecting files under `/workspace/ProFixIQ/shop-boost-fixtures` to guide the minimal fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d0ba803083288027695e43cf88ca)