### PR TITLE
Reconcile Shop Boost suggestion/canonical drift in customer & staff surfaces

### DIFF
--- a/app/mobile/customers/[id]/page.tsx
+++ b/app/mobile/customers/[id]/page.tsx
@@ -83,10 +83,46 @@ export default function MobileCustomerProfilePage() {
         setCustomer(cRes.data ?? null);
 
         if (vRes.error) throw vRes.error;
-        setVehicles(vRes.data ?? []);
+        const directVehicles = vRes.data ?? [];
+        const directVehicleIds = directVehicles.map((v) => v.id).filter(Boolean);
 
         if (woRes.error) throw woRes.error;
-        setWorkOrders(woRes.data ?? []);
+        const fallbackWosRes = directVehicleIds.length
+          ? await supabase
+              .from("work_orders")
+              .select("*")
+              .in("vehicle_id", directVehicleIds)
+              .order("created_at", { ascending: false })
+          : { data: [], error: null };
+
+        if (fallbackWosRes.error) throw fallbackWosRes.error;
+
+        const allWorkOrders = [...(woRes.data ?? []), ...(fallbackWosRes.data ?? [])];
+        const workOrdersById = new Map<string, WorkOrder>();
+        for (const wo of allWorkOrders) {
+          if (!wo?.id) continue;
+          workOrdersById.set(wo.id, wo);
+        }
+        const mergedWorkOrders = Array.from(workOrdersById.values()).sort(
+          (a, b) => new Date(String(b.created_at ?? "")).getTime() - new Date(String(a.created_at ?? "")).getTime(),
+        );
+
+        const fallbackVehicleIds = Array.from(
+          new Set(
+            mergedWorkOrders
+              .map((wo) => wo.vehicle_id)
+              .filter((id): id is string => typeof id === "string" && id.length > 0),
+          ),
+        ).filter((id) => !directVehicleIds.includes(id));
+
+        const fallbackVehiclesRes = fallbackVehicleIds.length
+          ? await supabase.from("vehicles").select("*").in("id", fallbackVehicleIds)
+          : { data: [], error: null };
+
+        if (fallbackVehiclesRes.error) throw fallbackVehiclesRes.error;
+
+        setVehicles([...(directVehicles as Vehicle[]), ...((fallbackVehiclesRes.data ?? []) as Vehicle[])]);
+        setWorkOrders(mergedWorkOrders);
       } catch (e) {
         const msg =
           e instanceof Error ? e.message : "Failed to load customer profile.";

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -376,7 +376,52 @@ export default function CustomerProfilePage(): JSX.Element {
 
         if (vsErr) throw vsErr;
 
-        const vrows = (vs ?? []) as Vehicle[];
+        const directVehicles = (vs ?? []) as Vehicle[];
+        const directVehicleIds = directVehicles.map((v) => v.id).filter(Boolean);
+
+        const { data: directWos, error: directWoErr } = await supabase
+          .from("work_orders")
+          .select("*")
+          .eq("customer_id", customerId)
+          .order("created_at", { ascending: false });
+
+        if (directWoErr) throw directWoErr;
+
+        const fallbackWosByVehicle = directVehicleIds.length
+          ? await supabase
+              .from("work_orders")
+              .select("*")
+              .in("vehicle_id", directVehicleIds)
+              .order("created_at", { ascending: false })
+          : { data: [], error: null };
+
+        if (fallbackWosByVehicle.error) throw fallbackWosByVehicle.error;
+
+        const allWorkOrders = [...(directWos ?? []), ...(fallbackWosByVehicle.data ?? [])] as WorkOrder[];
+        const workOrdersById = new Map<string, WorkOrder>();
+        for (const wo of allWorkOrders) {
+          if (!wo?.id) continue;
+          workOrdersById.set(wo.id, wo);
+        }
+        const mergedWorkOrders = Array.from(workOrdersById.values()).sort(
+          (a, b) => new Date(String(b.created_at ?? "")).getTime() - new Date(String(a.created_at ?? "")).getTime(),
+        );
+
+        const fallbackVehicleIds = Array.from(
+          new Set(
+            mergedWorkOrders
+              .map((wo) => wo.vehicle_id)
+              .filter((id): id is string => typeof id === "string" && id.length > 0),
+          ),
+        ).filter((id) => !directVehicleIds.includes(id));
+
+        const fallbackVehiclesRes = fallbackVehicleIds.length
+          ? await supabase.from("vehicles").select("*").in("id", fallbackVehicleIds)
+          : { data: [], error: null };
+
+        if (fallbackVehiclesRes.error) throw fallbackVehiclesRes.error;
+
+        const vrows = [...directVehicles, ...((fallbackVehiclesRes.data ?? []) as Vehicle[])];
         setVehicles(vrows);
 
         setSelectedVehicleId((prev) => {
@@ -384,14 +429,7 @@ export default function CustomerProfilePage(): JSX.Element {
           return vrows[0]?.id ?? null;
         });
 
-        const { data: wos, error: woErr } = await supabase
-          .from("work_orders")
-          .select("*")
-          .eq("customer_id", customerId)
-          .order("created_at", { ascending: false });
-
-        if (woErr) throw woErr;
-        setWorkOrders((wos ?? []) as WorkOrder[]);
+        setWorkOrders(mergedWorkOrders);
       } catch (e: unknown) {
         const msg =
           e instanceof Error ? e.message : "Failed to load customer file.";

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -1683,6 +1683,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const firstName = pick(row, [/^first[_\s-]*name$/, /^first$/]) ?? null;
       const lastName = pick(row, [/^last[_\s-]*name$/, /^last$/]) ?? null;
       const displayName = pick(row, [/^display[_\s-]*name$/, /^preferred[_\s-]*name$/]) ?? null;
+      const usernameHint =
+        pick(row, [/^username$/, /^user[_\s-]*name$/, /^login$/, /^employee[_\s-]*login$/, /^tech[_\s-]*code$/]) ??
+        null;
       const fallbackJoinedName = [firstName ?? "", lastName ?? ""].filter(Boolean).join(" ").trim();
       const fullName =
         pick(row, [
@@ -1692,7 +1695,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           /staff name/,
         ]) ??
         displayName ??
-        (fallbackJoinedName || null);
+        (fallbackJoinedName || null) ??
+        usernameHint;
 
       const emailRaw = pick(row, [/^email$/, /e-mail/, /mail/]);
       const email = emailRaw && emailRaw.includes("@") ? emailRaw.trim() : null;
@@ -1703,12 +1707,12 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const role = normRole(roleRaw);
 
       // Skip totally empty rows
-      if (!fullName && !email) continue;
+      if (!fullName && !email && !usernameHint) continue;
 
       const notes = pick(row, [/reason/, /note/, /notes/, /comment/]) ?? "Imported from staff CSV";
       const externalUserId = pickSourceId(row, [/^external[_\s-]*user[_\s-]*id$/, /^user[_\s-]*id$/, /^employee[_\s-]*id$/]);
       const normalizedIdentity = normalizeText(email ?? fullName ?? "").replace(/\s+/g, ".");
-      const username = externalUserId ?? (normalizedIdentity || null);
+      const username = externalUserId ?? usernameHint ?? (normalizedIdentity || null);
 
       // Deterministic-ish external id to prevent duplicates on reruns
       const external_id = `import:${intakeId}:staff:${sha1(

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -47,6 +47,12 @@ type ShopBoostSuggestionRow = {
   reason: string | null;
   created_at: string;
 };
+type CanonicalImportStats = {
+  staffSuggestions: number;
+  customers: number;
+  vehiclesLinked: number;
+  workOrdersLinked: number;
+};
 
 type Props = {
   shopId: string | null;
@@ -111,6 +117,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
   const [latest, setLatest] = useState<ShopHealthLatestRow | null>(null);
   const [overview, setOverview] = useState<ShopBoostOverviewRow | null>(null);
   const [suggestions, setSuggestions] = useState<ShopBoostSuggestionRow[]>([]);
+  const [canonicalStats, setCanonicalStats] = useState<CanonicalImportStats | null>(null);
 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -147,14 +154,75 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
       if (suggRes.error) throw suggRes.error;
 
       setLatest((latestRes.data as ShopHealthLatestRow | null) ?? null);
-      setOverview((overviewRes.data as ShopBoostOverviewRow | null) ?? null);
-      setSuggestions((suggRes.data as ShopBoostSuggestionRow[]) ?? []);
+      const latestOverview = (overviewRes.data as ShopBoostOverviewRow | null) ?? null;
+      setOverview(latestOverview);
+
+      const intakeId = latestOverview?.intake_id ?? null;
+      const viewSuggestions = (suggRes.data as ShopBoostSuggestionRow[]) ?? [];
+
+      const [staffRes, canonicalCounts] = intakeId
+        ? await Promise.all([
+            supabase
+              .from("staff_invite_suggestions")
+              .select("id,intake_id,shop_id,full_name,role,notes,confidence,created_at")
+              .eq("shop_id", shopId)
+              .eq("intake_id", intakeId)
+              .order("created_at", { ascending: false })
+              .limit(60),
+            Promise.all([
+              supabase.from("customers").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
+              supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId).not("customer_id", "is", null),
+              supabase.from("work_orders").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId).not("customer_id", "is", null),
+            ]),
+          ])
+        : [null, null];
+
+      if (staffRes?.error) throw staffRes.error;
+
+      const staffFromBase: ShopBoostSuggestionRow[] =
+        (staffRes?.data ?? []).map((row) => ({
+          suggestion_type: "staff_invite",
+          id: String(row.id),
+          shop_id: String(row.shop_id),
+          intake_id: row.intake_id,
+          name: row.full_name ?? row.role ?? "Staff invite",
+          category: row.role ?? null,
+          price_suggestion: null,
+          labor_hours_suggestion: null,
+          confidence: typeof row.confidence === "number" ? row.confidence : null,
+          reason: row.notes ?? null,
+          created_at: row.created_at ?? new Date().toISOString(),
+        })) ?? [];
+
+      const existingStaffIds = new Set(
+        viewSuggestions
+          .filter((row) => row.suggestion_type === "staff_invite")
+          .map((row) => row.id),
+      );
+      const mergedSuggestions = [
+        ...viewSuggestions,
+        ...staffFromBase.filter((row) => !existingStaffIds.has(row.id)),
+      ].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
+      setSuggestions(mergedSuggestions);
+
+      if (canonicalCounts) {
+        setCanonicalStats({
+          staffSuggestions: staffFromBase.length,
+          customers: canonicalCounts[0].count ?? 0,
+          vehiclesLinked: canonicalCounts[1].count ?? 0,
+          workOrdersLinked: canonicalCounts[2].count ?? 0,
+        });
+      } else {
+        setCanonicalStats(null);
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to load Shop Health.";
       setErr(msg);
       setLatest(null);
       setOverview(null);
       setSuggestions([]);
+      setCanonicalStats(null);
     } finally {
       setLoading(false);
     }
@@ -431,6 +499,23 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
                 </button>
               ) : null}
             </div>
+            {canonicalStats ? (
+              <div className={`mt-3 ${cardInner} p-3`}>
+                <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-500">Canonical import linkage</div>
+                <div className="mt-2 grid gap-2 text-xs text-neutral-200 md:grid-cols-4">
+                  <div>Customers: <span className="text-neutral-100">{canonicalStats.customers}</span></div>
+                  <div>Vehicles linked: <span className="text-neutral-100">{canonicalStats.vehiclesLinked}</span></div>
+                  <div>Work orders linked: <span className="text-neutral-100">{canonicalStats.workOrdersLinked}</span></div>
+                  <div>Staff invite rows: <span className="text-neutral-100">{canonicalStats.staffSuggestions}</span></div>
+                </div>
+                {(canonicalStats.customers > 0 &&
+                  (canonicalStats.vehiclesLinked === 0 || canonicalStats.workOrdersLinked === 0)) ? (
+                  <div className="mt-2 text-[11px] text-amber-200">
+                    Snapshot/suggestions can be present even when canonical linkages are incomplete for this intake.
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </section>
 
           {/* How to use this */}


### PR DESCRIPTION
### Motivation
- Shop Health and suggestion layers were reporting successful intake analysis while canonical downstream records (customers → vehicles → work orders, staff invites) were not visible, indicating a mismatch between staged/suggestion outputs and canonical materialized rows or query paths.
- The goal was to minimally repair visibility and importer behavior so UI surfaces reflect actual imports without schema changes, migrations, or new routes.

### Description
- Added a username/login fallback to staff CSV parsing so rows that only include a username/login (common in `staff_users.csv`) are not silently skipped during import, and are persisted to `staff_invite_suggestions` with a deterministic external id (`features/integrations/imports/runFullImport.ts`).
- Expanded customer-detail data fetching to merge work orders found via `customer_id` and work orders discovered by the customer’s vehicle IDs, then hydrate any vehicles referenced only by those work orders to ensure vehicles and history are visible (desktop: `features/customers/app/customers/[id]/page.tsx`, mobile: `app/mobile/customers/[id]/page.tsx`).
- Improved Shop Health / Shop Boost panel to surface reconciliation context by merging direct `staff_invite_suggestions` rows for the latest intake into the suggestions feed and by showing canonical linkage counters (customers, vehicles linked, work orders linked, staff rows) plus a warning when snapshots/suggestions are present but canonical linkages lag (`features/owner/reports/ReportsShopHealthPanel.tsx`).
- No schema changes, no DB migrations, no new routes; all fixes reuse existing importer/materializer tables and existing UI query paths.

Files changed:
- `features/integrations/imports/runFullImport.ts` (staff importer: username fallback)
- `features/customers/app/customers/[id]/page.tsx` (desktop customer detail: work order/vehicle fallback + dedupe)
- `app/mobile/customers/[id]/page.tsx` (mobile customer detail: same fallback behavior)
- `features/owner/reports/ReportsShopHealthPanel.tsx` (Shop Health: merge staff suggestions + canonical linkage counters and messaging)

### Testing
- Ran TypeScript compilation: `npx tsc --noEmit`, which completed successfully.
- Changes are focused and intentionally rely on existing DB tables and views; no automated unit tests were added or modified in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea379e72008328a2f52e47728f527a)