### PR TITLE
Harden Shop Boost completion truth against canonical materialization gaps

### DIFF
--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -195,6 +195,7 @@ export async function POST(req: NextRequest) {
         partsImported: importSummary.partsImported,
         workOrdersImported: importSummary.workOrdersImported,
         invoicesImported: importSummary.invoicesImported,
+        canonicalMaterialization: importSummary.canonicalMaterialization,
         completionState: importSummary.completionState,
       },
     },

--- a/app/api/shop-boost/intakes/process/route.ts
+++ b/app/api/shop-boost/intakes/process/route.ts
@@ -94,6 +94,7 @@ export async function POST(req: NextRequest) {
           partsImported: importSummary.partsImported,
           workOrdersImported: importSummary.workOrdersImported,
           invoicesImported: importSummary.invoicesImported,
+          canonicalMaterialization: importSummary.canonicalMaterialization,
           linkageSummary: importSummary.linkageSummary,
           shopBuildSummary: importSummary.shopBuildSummary,
           partsPipeline: importSummary.partsPipeline ?? null,

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -73,6 +73,30 @@ export type ShopBoostImportSummary = {
     inspectionSuggestions: number;
   };
   partsPipeline?: PartsPipelineSummary;
+  canonicalMaterialization: {
+    expected: {
+      customers: number;
+      vehicles: number;
+      workOrders: number;
+      invoices: number;
+      staff: number;
+    };
+    actual: {
+      customers: number;
+      vehicles: number;
+      workOrders: number;
+      invoices: number;
+      staffSuggestions: number;
+      staffCandidates: number;
+    };
+    gaps: {
+      missingVehicles: boolean;
+      missingWorkOrders: boolean;
+      missingInvoices: boolean;
+      missingStaff: boolean;
+    };
+    status: "ok" | "partial";
+  };
   rowResults: {
     totalRows: number;
     processedRows: number;
@@ -968,6 +992,17 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         },
       },
       shopBuildSummary: emptyShopBuildSummary,
+      canonicalMaterialization: {
+        expected: { customers: 0, vehicles: 0, workOrders: 0, invoices: 0, staff: 0 },
+        actual: { customers: 0, vehicles: 0, workOrders: 0, invoices: 0, staffSuggestions: 0, staffCandidates: 0 },
+        gaps: {
+          missingVehicles: false,
+          missingWorkOrders: false,
+          missingInvoices: false,
+          missingStaff: false,
+        },
+        status: "partial",
+      },
       rowResults: {
         totalRows: 0,
         processedRows: 0,
@@ -1672,9 +1707,17 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   // 4) Import staff -> staff_invite_suggestions (NO auth creation here)
+  let staffRowsExpected = 0;
   if (staffCsv) {
     const { rows } = parseCsv(staffCsv);
+    staffRowsExpected = rows.length;
     await supabase.from("staff_invite_suggestions").delete().eq("shop_id", shopId).eq("intake_id", intakeId);
+    await supabase
+      .from("staff_invite_candidates")
+      .delete()
+      .eq("shop_id", shopId)
+      .eq("intake_id", intakeId)
+      .eq("source", "shop_boost_import");
 
     for (let i = 0; i < rows.length; i += 1) {
       const row = rows[i];
@@ -1737,6 +1780,25 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       if (staffInsErr) {
         console.warn("[staff invite suggestions] upsert failed", staffInsErr);
       }
+
+      const { error: candidateInsErr } = await supabase.from("staff_invite_candidates").insert(
+        {
+          shop_id: shopId,
+          intake_id: intakeId,
+          full_name: fullName,
+          email,
+          phone: phone || null,
+          username,
+          role,
+          confidence: 0.75,
+          notes,
+          source: "shop_boost_import",
+          status: "pending",
+        } as DB["public"]["Tables"]["staff_invite_candidates"]["Insert"],
+      );
+      if (candidateInsErr) {
+        console.warn("[staff invite candidates] insert failed", candidateInsErr);
+      }
     }
   }
 
@@ -1798,7 +1860,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         null;
       const vehicle_id = sourceMatchedVehicleId || fallbackVehicleId || null;
 
-      if (!customer_id || !vehicle_id) {
+      if (!customer_id) {
         rowOutcome.processedRows += 1;
         rowOutcome.reviewCount += 1;
         rowOutcome.byDomain.history.review += 1;
@@ -1808,9 +1870,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           intakeId,
           domain: "work_order",
           issueType: "missing_dependency",
-          summary: !customer_id
-            ? "History row skipped because customer could not be matched."
-            : "History row skipped because vehicle could not be matched.",
+          summary: "History row skipped because customer could not be matched.",
           rawPayload: row,
           suggestedMatches: [{ customerEmail, customerPhone, vin, plate }],
         });
@@ -1838,7 +1898,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           targetDomain: "work_order",
           matchStatus: "unmatched",
           matchConfidence: "low",
-          errorReason: !customer_id ? "missing_customer_match" : "missing_vehicle_match",
+          errorReason: "missing_customer_match",
           reviewRequired: true,
         });
         continue;
@@ -1989,6 +2049,21 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       if (!workOrderId) continue;
       if (sourceWorkOrderKey) workOrdersBySourceId.set(sourceWorkOrderKey, workOrderId);
 
+      if (!vehicle_id) {
+        rowOutcome.reviewCount += 1;
+        rowOutcome.byDomain.history.review += 1;
+        await createReviewItem({
+          supabase,
+          shopId,
+          intakeId,
+          domain: "work_order",
+          issueType: "missing_dependency",
+          summary: "History row materialized without a matched vehicle. Customer linkage succeeded.",
+          rawPayload: row,
+          suggestedMatches: [{ customerEmail, customerPhone, vin, plate }],
+        });
+      }
+
       await upsertHistoryLine({
         supabase,
         shopId,
@@ -2036,10 +2111,11 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           parts,
         },
         targetDomain: "work_order",
-        matchStatus: woByExternal?.id ? "matched_existing" : "created_new",
-        matchConfidence: "high",
+        matchStatus: !vehicle_id ? "partial_match" : woByExternal?.id ? "matched_existing" : "created_new",
+        matchConfidence: !vehicle_id ? "medium" : "high",
         matchDetails: { workOrderId, customerId: customer_id, vehicleId: vehicle_id },
-        reviewRequired: false,
+        errorReason: !vehicle_id ? "missing_vehicle_match" : undefined,
+        reviewRequired: !vehicle_id,
       });
     }
   }
@@ -2508,6 +2584,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     unresolvedWorkOrdersMissingCustomer,
     unresolvedWorkOrdersMissingVehicle,
     unresolvedInvoicesMissingCustomer,
+    staffSuggestionsCount,
+    staffCandidatesCount,
   ] = await Promise.all([
       supabase
         .from("customers")
@@ -2563,7 +2641,63 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         .eq("shop_id", shopId)
         .contains("metadata", { source_intake_id: intakeId })
         .is("customer_id", null),
+      supabase
+        .from("staff_invite_suggestions")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", shopId)
+        .eq("intake_id", intakeId),
+      supabase
+        .from("staff_invite_candidates")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", shopId)
+        .eq("intake_id", intakeId)
+        .eq("source", "shop_boost_import"),
     ]);
+
+  const expectedVehicles = parsedVehicles.length;
+  const expectedWorkOrders = parsedHistory.length;
+  const expectedInvoices = parsedInvoices.length;
+  const expectedStaff = staffRowsExpected;
+  const canonicalMaterialization: ShopBoostImportSummary["canonicalMaterialization"] = {
+    expected: {
+      customers: parsedCustomers.length,
+      vehicles: expectedVehicles,
+      workOrders: expectedWorkOrders,
+      invoices: expectedInvoices,
+      staff: expectedStaff,
+    },
+    actual: {
+      customers: customersCount.count ?? 0,
+      vehicles: vehiclesCount.count ?? 0,
+      workOrders: workOrdersCount.count ?? 0,
+      invoices: invoicesCount.count ?? 0,
+      staffSuggestions: staffSuggestionsCount.count ?? 0,
+      staffCandidates: staffCandidatesCount.count ?? 0,
+    },
+    gaps: {
+      missingVehicles: expectedVehicles > 0 && (vehiclesCount.count ?? 0) === 0,
+      missingWorkOrders: expectedWorkOrders > 0 && (workOrdersCount.count ?? 0) === 0,
+      missingInvoices: expectedInvoices > 0 && (invoicesCount.count ?? 0) === 0,
+      missingStaff: expectedStaff > 0 && (staffSuggestionsCount.count ?? 0) === 0,
+    },
+    status: "ok",
+  };
+  canonicalMaterialization.status =
+    canonicalMaterialization.gaps.missingVehicles ||
+    canonicalMaterialization.gaps.missingWorkOrders ||
+    canonicalMaterialization.gaps.missingInvoices ||
+    canonicalMaterialization.gaps.missingStaff
+      ? "partial"
+      : "ok";
+
+  const effectiveCompletionState: ShopBoostImportSummary["completionState"] =
+    canonicalMaterialization.status === "partial" &&
+    (completionState === "COMPLETED_CLEAN" ||
+      completionState === "COMPLETED_WITH_REVIEW" ||
+      completionState === "COMPLETED_WITH_WARNINGS" ||
+      completionState === "READY_FOR_GO_LIVE")
+      ? "NOT_READY"
+      : completionState;
 
   const migrationStory = buildMigrationStory({
     totalRows: rowOutcome.totalRows,
@@ -2619,7 +2753,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             partsPipeline: partsPipelineSummary ?? null,
             shopBuildSummary,
             rowResults: rowOutcome,
-            completionState,
+            completionState: effectiveCompletionState,
+            canonicalMaterialization,
             integrity: { ...integrity, integrity_errors: integrityErrors },
             ignoredCount,
             confidence_score: trustScore,
@@ -2636,7 +2771,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             failed_count: rowOutcome.failedCount,
             ignored_count: ignoredCount,
             domains: rowOutcome.byDomain,
-            completionState,
+            completionState: effectiveCompletionState,
             integrity: { ...integrity, integrity_errors: integrityErrors },
             integrity_errors: integrityErrors,
             row_outcome_buckets: outcomeBuckets,
@@ -2648,7 +2783,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
               pendingReviewCount === 0 &&
               failedReviewCount === 0 &&
               rowOutcome.failedCount === 0 &&
-              outcomeBuckets.mismatch === 0,
+              outcomeBuckets.mismatch === 0 &&
+              canonicalMaterialization.status === "ok",
           },
         },
       } satisfies DB["public"]["Tables"]["shop_boost_intakes"]["Update"],
@@ -2678,8 +2814,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     },
     partsPipeline: partsPipelineSummary,
     shopBuildSummary,
+    canonicalMaterialization,
     rowResults: rowOutcome,
-    completionState,
+    completionState: effectiveCompletionState,
   };
 }
 

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -396,6 +396,12 @@ export async function runShopBoostIntake(
           menuSuggestions: 0,
           inspectionSuggestions: 0,
         },
+        canonicalMaterialization: {
+          expected: { customers: 0, vehicles: 0, workOrders: 0, invoices: 0, staff: 0 },
+          actual: { customers: 0, vehicles: 0, workOrders: 0, invoices: 0, staffSuggestions: 0, staffCandidates: 0 },
+          gaps: { missingVehicles: false, missingWorkOrders: false, missingInvoices: false, missingStaff: false },
+          status: "ok",
+        },
         rowResults: {
           totalRows: 0,
           processedRows: 0,
@@ -447,6 +453,12 @@ export async function runShopBoostIntake(
       linkedMenuToInspection: 0,
       menuSuggestions: 0,
       inspectionSuggestions: 0,
+    },
+    canonicalMaterialization: {
+      expected: { customers: 0, vehicles: 0, workOrders: 0, invoices: 0, staff: 0 },
+      actual: { customers: 0, vehicles: 0, workOrders: 0, invoices: 0, staffSuggestions: 0, staffCandidates: 0 },
+      gaps: { missingVehicles: false, missingWorkOrders: false, missingInvoices: false, missingStaff: false },
+      status: "ok",
     },
     rowResults: {
       totalRows: 0,

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -49,9 +49,11 @@ type ShopBoostSuggestionRow = {
 };
 type CanonicalImportStats = {
   staffSuggestions: number;
+  staffCandidates: number;
   customers: number;
-  vehiclesLinked: number;
-  workOrdersLinked: number;
+  vehicles: number;
+  workOrders: number;
+  canonicalStatus: "ok" | "partial" | "unknown";
 };
 
 type Props = {
@@ -171,8 +173,14 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
               .limit(60),
             Promise.all([
               supabase.from("customers").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
-              supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId).not("customer_id", "is", null),
-              supabase.from("work_orders").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId).not("customer_id", "is", null),
+              supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
+              supabase.from("work_orders").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
+              supabase.from("staff_invite_candidates").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("source", "shop_boost_import"),
+              supabase
+                .from("shop_boost_intakes")
+                .select("intake_basics")
+                .eq("id", intakeId)
+                .maybeSingle(),
             ]),
           ])
         : [null, null];
@@ -207,11 +215,21 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
       setSuggestions(mergedSuggestions);
 
       if (canonicalCounts) {
+        const intakeBasics = canonicalCounts[4].data?.intake_basics as Record<string, unknown> | null;
+        const importSummary = (intakeBasics?.importSummary ?? null) as Record<string, unknown> | null;
+        const canonicalMaterialization = (importSummary?.canonicalMaterialization ?? null) as Record<string, unknown> | null;
+        const canonicalStatus =
+          canonicalMaterialization?.status === "ok" || canonicalMaterialization?.status === "partial"
+            ? canonicalMaterialization.status
+            : "unknown";
+
         setCanonicalStats({
           staffSuggestions: staffFromBase.length,
+          staffCandidates: canonicalCounts[3].count ?? 0,
           customers: canonicalCounts[0].count ?? 0,
-          vehiclesLinked: canonicalCounts[1].count ?? 0,
-          workOrdersLinked: canonicalCounts[2].count ?? 0,
+          vehicles: canonicalCounts[1].count ?? 0,
+          workOrders: canonicalCounts[2].count ?? 0,
+          canonicalStatus,
         });
       } else {
         setCanonicalStats(null);
@@ -501,17 +519,23 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
             </div>
             {canonicalStats ? (
               <div className={`mt-3 ${cardInner} p-3`}>
-                <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-500">Canonical import linkage</div>
+                <div className="text-[10px] uppercase tracking-[0.18em] text-neutral-500">Import truth (snapshot vs canonical)</div>
                 <div className="mt-2 grid gap-2 text-xs text-neutral-200 md:grid-cols-4">
                   <div>Customers: <span className="text-neutral-100">{canonicalStats.customers}</span></div>
-                  <div>Vehicles linked: <span className="text-neutral-100">{canonicalStats.vehiclesLinked}</span></div>
-                  <div>Work orders linked: <span className="text-neutral-100">{canonicalStats.workOrdersLinked}</span></div>
-                  <div>Staff invite rows: <span className="text-neutral-100">{canonicalStats.staffSuggestions}</span></div>
+                  <div>Vehicles materialized: <span className="text-neutral-100">{canonicalStats.vehicles}</span></div>
+                  <div>Work orders materialized: <span className="text-neutral-100">{canonicalStats.workOrders}</span></div>
+                  <div>Staff suggestions/candidates: <span className="text-neutral-100">{canonicalStats.staffSuggestions}/{canonicalStats.staffCandidates}</span></div>
+                </div>
+                <div className="mt-2 text-[11px] text-neutral-300">
+                  Snapshot status: <span className="text-neutral-100">{intakeStatus ?? "unknown"}</span> • Canonical materialization:{" "}
+                  <span className={canonicalStats.canonicalStatus === "partial" ? "text-amber-200" : "text-emerald-200"}>
+                    {canonicalStats.canonicalStatus}
+                  </span>
                 </div>
                 {(canonicalStats.customers > 0 &&
-                  (canonicalStats.vehiclesLinked === 0 || canonicalStats.workOrdersLinked === 0)) ? (
+                  (canonicalStats.vehicles === 0 || canonicalStats.workOrders === 0)) ? (
                   <div className="mt-2 text-[11px] text-amber-200">
-                    Snapshot/suggestions can be present even when canonical linkages are incomplete for this intake.
+                    Staged snapshot data can look healthy while canonical graph materialization is still incomplete.
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
### Motivation
- Shop Boost was reporting completed/success from staged/snapshot artifacts even when canonical materialization (customers, vehicles, work_orders, invoices, staff) remained missing according to the read-only DB audit.
- Staff visibility was inconsistent because importer wrote suggestions to one table while UI/admin surfaces read another view, producing split counts.
- Minimal, non-breaking fix required to ensure intake completion reflects true canonical outcomes and UI surfaces show reconciled truth.

### Description
- Add canonical materialization accounting to the import summary by adding a `canonicalMaterialization` structure (expected vs actual counters, gap flags, status) to `runShopBoostImport` and propagated result payloads. (changes in `features/integrations/imports/runFullImport.ts`, `features/integrations/shopBoost/runIntakeHandler.ts`).
- Derive an `effectiveCompletionState` that downgrades optimistic completion states to `NOT_READY` when canonical gaps exist and persist that into intake `importSummary` and `migrationProgress`, ensuring `updateIntakeProgress` reflects canonical outcomes (changed `app/api/shop-boost/intakes/process/route.ts` and `app/api/demo/shop-boost/activate/route.ts`).
- Reconcile staff outputs by writing importer rows to both `staff_invite_suggestions` and `staff_invite_candidates` (tags `source = "shop_boost_import"`) so UI and admin candidate lists observe the same imported staff rows (changed `features/integrations/imports/runFullImport.ts`).
- Relax history materialization to still create canonical work orders when a customer match exists even if vehicle linkage is missing, while marking those rows as `partial_match`/review-required and creating review items, reducing lost history while surfacing linkage gaps (changed `features/integrations/imports/runFullImport.ts`).
- Make Shop Health / Reports UI explicitly show snapshot/staged status versus canonical materialization counts and status (changed `features/owner/reports/ReportsShopHealthPanel.tsx`).
- Files changed: `features/integrations/imports/runFullImport.ts`, `features/integrations/shopBoost/runIntakeHandler.ts`, `app/api/shop-boost/intakes/process/route.ts`, `app/api/demo/shop-boost/activate/route.ts`, `features/owner/reports/ReportsShopHealthPanel.tsx`.

### Testing
- Type-check: ran `npx tsc --noEmit` to validate TypeScript types; the check completed successfully.
- Local validation: committed changes and confirmed modified files compile against the repo type definitions; no schema, migration, or route changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4a576bd483288f5350d47a35b7f0)