### PR TITLE
Fix Shop Boost import linkage and surface staff suggestions in owner UI

### DIFF
--- a/app/mobile/customers/[id]/page.tsx
+++ b/app/mobile/customers/[id]/page.tsx
@@ -97,7 +97,34 @@ export default function MobileCustomerProfilePage() {
 
         if (fallbackWosRes.error) throw fallbackWosRes.error;
 
-        const allWorkOrders = [...(woRes.data ?? []), ...(fallbackWosRes.data ?? [])];
+        const customerRecord = cRes.data;
+        const fallbackWosByNameCandidates = [
+          customerRecord?.business_name,
+          customerRecord?.name,
+          [customerRecord?.first_name ?? "", customerRecord?.last_name ?? ""]
+            .filter(Boolean)
+            .join(" ")
+            .trim(),
+        ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+        let fallbackWosByName: WorkOrder[] = [];
+        if ((woRes.data?.length ?? 0) === 0 && (fallbackWosRes.data?.length ?? 0) === 0) {
+          for (const candidate of fallbackWosByNameCandidates) {
+            const byNameRes = await supabase
+              .from("work_orders")
+              .select("*")
+              .ilike("customer_name", candidate)
+              .order("created_at", { ascending: false })
+              .limit(25);
+            if (byNameRes.error) throw byNameRes.error;
+            if ((byNameRes.data?.length ?? 0) > 0) {
+              fallbackWosByName = byNameRes.data as WorkOrder[];
+              break;
+            }
+          }
+        }
+
+        const allWorkOrders = [...(woRes.data ?? []), ...(fallbackWosRes.data ?? []), ...fallbackWosByName];
         const workOrdersById = new Map<string, WorkOrder>();
         for (const wo of allWorkOrders) {
           if (!wo?.id) continue;

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -397,7 +397,34 @@ export default function CustomerProfilePage(): JSX.Element {
 
         if (fallbackWosByVehicle.error) throw fallbackWosByVehicle.error;
 
-        const allWorkOrders = [...(directWos ?? []), ...(fallbackWosByVehicle.data ?? [])] as WorkOrder[];
+        const fallbackWosByNameCandidates = [
+          cust.business_name,
+          cust.name,
+          [cust.first_name ?? "", cust.last_name ?? ""].filter(Boolean).join(" ").trim(),
+        ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+        let fallbackWosByName: WorkOrder[] = [];
+        if ((directWos?.length ?? 0) === 0 && (fallbackWosByVehicle.data?.length ?? 0) === 0) {
+          for (const candidate of fallbackWosByNameCandidates) {
+            const byNameRes = await supabase
+              .from("work_orders")
+              .select("*")
+              .ilike("customer_name", candidate)
+              .order("created_at", { ascending: false })
+              .limit(25);
+            if (byNameRes.error) throw byNameRes.error;
+            if ((byNameRes.data?.length ?? 0) > 0) {
+              fallbackWosByName = byNameRes.data as WorkOrder[];
+              break;
+            }
+          }
+        }
+
+        const allWorkOrders = [
+          ...(directWos ?? []),
+          ...(fallbackWosByVehicle.data ?? []),
+          ...fallbackWosByName,
+        ] as WorkOrder[];
         const workOrdersById = new Map<string, WorkOrder>();
         for (const wo of allWorkOrders) {
           if (!wo?.id) continue;

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -1254,11 +1254,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
       const existingId =
         (sourceCustomerKey && customersBySourceId.get(sourceCustomerKey)) ||
-        (!sourceCustomerId
-          ? (email && !conflictingCustomerEmails.has(email) && uniqueCustomersByEmail.get(email)) ||
-            (phone && !conflictingCustomerPhones.has(phone) && uniqueCustomersByPhone.get(phone)) ||
-            (normalizedName && !conflictingCustomerNames.has(normalizedName) && uniqueCustomersByName.get(normalizedName))
-          : null);
+        (email && !conflictingCustomerEmails.has(email) && uniqueCustomersByEmail.get(email)) ||
+        (phone && !conflictingCustomerPhones.has(phone) && uniqueCustomersByPhone.get(phone)) ||
+        (normalizedName && !conflictingCustomerNames.has(normalizedName) && uniqueCustomersByName.get(normalizedName));
       const bestNameMatch = name
         ? customerNames
             .map((candidate) => ({ id: candidate.id, similarity: nameSimilarity(name, candidate.name) }))
@@ -1526,18 +1524,16 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
       const existingId =
         (sourceVehicleKey && vehiclesBySourceId.get(sourceVehicleKey)) ||
-        (!sourceVehicleId
-          ? (customer_id &&
-              unit &&
-              !conflictingVehiclesByCustomerUnit.has(compositeKey(customer_id, lower(unit))) &&
-              uniqueVehiclesByCustomerUnit.get(compositeKey(customer_id, lower(unit)))) ||
-            (vin && vehiclesByVin.get(vin)) ||
-            (customer_id &&
-              plate &&
-              !conflictingVehiclesByCustomerPlate.has(compositeKey(customer_id, plate)) &&
-              uniqueVehiclesByCustomerPlate.get(compositeKey(customer_id, plate))) ||
-            (plate && vehiclesByPlate.get(plate))
-          : null);
+        ((customer_id &&
+          unit &&
+          !conflictingVehiclesByCustomerUnit.has(compositeKey(customer_id, lower(unit))) &&
+          uniqueVehiclesByCustomerUnit.get(compositeKey(customer_id, lower(unit)))) ||
+          (vin && vehiclesByVin.get(vin)) ||
+          (customer_id &&
+            plate &&
+            !conflictingVehiclesByCustomerPlate.has(compositeKey(customer_id, plate)) &&
+            uniqueVehiclesByCustomerPlate.get(compositeKey(customer_id, plate))) ||
+          (plate && vehiclesByPlate.get(plate)));
 
       if (existingId) {
         await supabase
@@ -1929,7 +1925,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
               .maybeSingle<{ id: string }>()
           ).data;
 
-      if (!woByExternal?.id && vehicle_id && customer_id) {
+      if (vehicle_id && customer_id) {
         await supabase
           .from("vehicles")
           .update({ customer_id } as DB["public"]["Tables"]["vehicles"]["Update"])
@@ -1965,9 +1961,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       let woErr: { message?: string } | null = null;
 
       if (woByExternal?.id) {
+        const woUpdatePayload: DB["public"]["Tables"]["work_orders"]["Update"] = {
+          ...woPayload,
+          vehicle_id: vehicle_id ?? undefined,
+        };
         await supabase
           .from("work_orders")
-          .update(woPayload as DB["public"]["Tables"]["work_orders"]["Update"])
+          .update(woUpdatePayload)
           .eq("id", woByExternal.id);
         woInserted = [{ id: woByExternal.id }];
       } else {
@@ -2144,11 +2144,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const customerName = normalizeNameKey(pick(row, [/customer name/, /^name$/, /account name/]));
       const resolvedCustomerId =
         (sourceCustomerKey && customersBySourceId.get(sourceCustomerKey)) ||
-        (!sourceCustomerId
-          ? (customerEmail && !conflictingCustomerEmails.has(customerEmail) && uniqueCustomersByEmail.get(customerEmail)) ||
-            (customerPhone && !conflictingCustomerPhones.has(customerPhone) && uniqueCustomersByPhone.get(customerPhone)) ||
-            (customerName && !conflictingCustomerNames.has(customerName) && uniqueCustomersByName.get(customerName))
-          : null) ||
+        (customerEmail && !conflictingCustomerEmails.has(customerEmail) && uniqueCustomersByEmail.get(customerEmail)) ||
+        (customerPhone && !conflictingCustomerPhones.has(customerPhone) && uniqueCustomersByPhone.get(customerPhone)) ||
+        (customerName && !conflictingCustomerNames.has(customerName) && uniqueCustomersByName.get(customerName)) ||
         null;
 
       let workOrderId: string | null =
@@ -2287,11 +2285,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       );
       const matchedCustomerId =
         (sourceCustomerKey && customersBySourceId.get(sourceCustomerKey)) ||
-        (!sourceCustomerId
-          ? (email && !conflictingCustomerEmails.has(email) && uniqueCustomersByEmail.get(email)) ||
-            (phone && !conflictingCustomerPhones.has(phone) && uniqueCustomersByPhone.get(phone)) ||
-            (customerName && !conflictingCustomerNames.has(customerName) && uniqueCustomersByName.get(customerName))
-          : null) ||
+        (email && !conflictingCustomerEmails.has(email) && uniqueCustomersByEmail.get(email)) ||
+        (phone && !conflictingCustomerPhones.has(phone) && uniqueCustomersByPhone.get(phone)) ||
+        (customerName && !conflictingCustomerNames.has(customerName) && uniqueCustomersByName.get(customerName)) ||
         null;
 
       if (!matchedCustomerId) continue;
@@ -2359,17 +2355,15 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const customerName = normalizeNameKey(pick(row, [/customer name/, /^name$/, /account name/]));
       const matchedCustomerId =
         (sourceCustomerKey && customersBySourceId.get(sourceCustomerKey)) ||
-        (!sourceCustomerId
-          ? (customerEmail &&
-              !conflictingCustomerEmails.has(customerEmail) &&
-              uniqueCustomersByEmail.get(customerEmail)) ||
-            (customerPhone &&
-              !conflictingCustomerPhones.has(customerPhone) &&
-              uniqueCustomersByPhone.get(customerPhone)) ||
-            (customerName &&
-              !conflictingCustomerNames.has(customerName) &&
-              uniqueCustomersByName.get(customerName))
-          : null) ||
+        (customerEmail &&
+          !conflictingCustomerEmails.has(customerEmail) &&
+          uniqueCustomersByEmail.get(customerEmail)) ||
+        (customerPhone &&
+          !conflictingCustomerPhones.has(customerPhone) &&
+          uniqueCustomersByPhone.get(customerPhone)) ||
+        (customerName &&
+          !conflictingCustomerNames.has(customerName) &&
+          uniqueCustomersByName.get(customerName)) ||
         null;
 
       if (!matchedCustomerId) continue;

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -168,9 +168,8 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
               .from("staff_invite_suggestions")
               .select("id,intake_id,shop_id,full_name,role,notes,confidence,created_at")
               .eq("shop_id", shopId)
-              .eq("intake_id", intakeId)
               .order("created_at", { ascending: false })
-              .limit(60),
+              .limit(160),
             Promise.all([
               supabase.from("customers").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
               supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
@@ -187,8 +186,18 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
 
       if (staffRes?.error) throw staffRes.error;
 
+      const prioritizedStaffRows = (staffRes?.data ?? [])
+        .slice()
+        .sort((a, b) => {
+          const aMatchesIntake = intakeId && a.intake_id === intakeId ? 1 : 0;
+          const bMatchesIntake = intakeId && b.intake_id === intakeId ? 1 : 0;
+          if (aMatchesIntake !== bMatchesIntake) return bMatchesIntake - aMatchesIntake;
+          return new Date(b.created_at ?? "").getTime() - new Date(a.created_at ?? "").getTime();
+        })
+        .slice(0, 60);
+
       const staffFromBase: ShopBoostSuggestionRow[] =
-        (staffRes?.data ?? []).map((row) => ({
+        prioritizedStaffRows.map((row) => ({
           suggestion_type: "staff_invite",
           id: String(row.id),
           shop_id: String(row.shop_id),


### PR DESCRIPTION
### Motivation
- Repair canonical import materialization so a real Shop Boost intake produces customer records with linked vehicles and work-order history and surfaces staff suggestions in the owner UI. 
- The failing cases were deterministic matching being skipped when source IDs were present but unresolved, work orders being updated with null vehicle links, and the owner panel not reliably showing staged staff suggestions. 
- Make narrow, non-breaking fixes to importer write paths and the actual customer/shop-health read paths used by the UI (no schema or route additions). 

### Description
- Always run deterministic fallback matching (email/phone/name for customers and VIN/plate/unit for vehicles) after source-ID lookups in `runFullImport` so canonical customer/vehicle IDs are set when possible. 
- Prevent history upserts from clobbering an existing `work_orders.vehicle_id` by using a guarded update payload when updating existing work orders, and ensure vehicle ownership reconciliation still runs when history rows provide both customer and vehicle IDs. 
- Add fallback read queries on the customer detail pages (desktop and mobile) to load work orders by `work_orders.customer_name` when direct `customer_id` + vehicle joins return empty, then dedupe/merge results so vehicles discovered via history hydrate into the customer view. 
- Improve Shop Health owner-panel staff suggestion visibility by loading recent `staff_invite_suggestions` for the shop (increasing fetch limit), prioritizing rows from the active intake, and merging them into the displayed suggestions list. 
- Files changed: `features/integrations/imports/runFullImport.ts`, `features/customers/app/customers/[id]/page.tsx`, `app/mobile/customers/[id]/page.tsx`, `features/owner/reports/ReportsShopHealthPanel.tsx`. 

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully. 
- All changes are incremental and conservative to avoid breaking multi-tenant or RLS protections; no DB migrations or route changes were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea516d68988328953ab8557f4c2e6b)