### PR TITLE
Add onboarding orchestrator and integrate with shop-boost intake flows

### DIFF
--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { getRunByShopIntake, summarizeRunJobs } from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
 type RouteContext = { params: Promise<{ id: string }> };
@@ -156,6 +157,27 @@ export async function GET(req: Request, context: RouteContext) {
     return acc;
   }, {});
 
+  let orchestrator: Record<string, unknown> | null = null;
+  try {
+    const run = await getRunByShopIntake({ shopId: profile.shop_id, intakeId: intake.id });
+    if (run?.id) {
+      orchestrator = {
+        run_id: run.id,
+        state: run.state,
+        activation_status: run.activation_status,
+        activation_blockers: run.activation_blockers ?? [],
+        activation_snapshot: asRecord(run.activation_snapshot),
+        jobs: await summarizeRunJobs(run.id),
+      };
+    }
+  } catch (orchestratorErr) {
+    console.error("[shop-boost/orchestrator] report enrichment failed", {
+      intakeId: intake.id,
+      shopId: profile.shop_id,
+      error: orchestratorErr instanceof Error ? orchestratorErr.message : String(orchestratorErr),
+    });
+  }
+
   const report = {
     intake_id: intake.id,
     status: intake.status,
@@ -180,6 +202,7 @@ export async function GET(req: Request, context: RouteContext) {
         "Based on your uploaded data and conservative shop patterns. Actual value depends on activation, data cleanup, and team adoption.",
     },
     review_outcomes: reviewOutcomes,
+    orchestrator,
   };
 
   const url = new URL(req.url);

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -4,6 +4,7 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { toIntakeProgress } from "@/features/integrations/shopBoost/status";
+import { getRunByShopIntake, summarizeRunJobs } from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
 
@@ -46,6 +47,37 @@ export async function GET() {
   }
   if (!intake) return NextResponse.json({ ok: true, intake: null });
 
+  let orchestrator: {
+    runId: string;
+    state: string;
+    activationStatus: string;
+    activationBlockers: unknown;
+    jobs: Record<string, number> | null;
+  } | null = null;
+
+  try {
+    const run = await getRunByShopIntake({
+      shopId: profile.shop_id,
+      intakeId: intake.id,
+    });
+
+    if (run?.id) {
+      orchestrator = {
+        runId: run.id,
+        state: run.state,
+        activationStatus: run.activation_status,
+        activationBlockers: run.activation_blockers ?? [],
+        jobs: await summarizeRunJobs(run.id),
+      };
+    }
+  } catch (orchestratorErr) {
+    console.error("[shop-boost/orchestrator] latest status enrichment failed", {
+      shopId: profile.shop_id,
+      intakeId: intake.id,
+      error: orchestratorErr instanceof Error ? orchestratorErr.message : String(orchestratorErr),
+    });
+  }
+
   return NextResponse.json({
     ok: true,
     intake: {
@@ -54,6 +86,7 @@ export async function GET() {
       createdAt: intake.created_at,
       processedAt: intake.processed_at,
       progress: toIntakeProgress(intake as never),
+      orchestrator,
     },
   });
 }

--- a/app/api/shop-boost/intakes/process/route.ts
+++ b/app/api/shop-boost/intakes/process/route.ts
@@ -6,8 +6,30 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 import { runShopBoostImport } from "@/features/integrations/imports/runFullImport";
 import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
+import {
+  completeAttempt,
+  createAttempt,
+  ensureRun,
+  evaluateActivationRules,
+  markRunRetryable,
+  markRunRunning,
+  markRunSucceeded,
+  seedRunJobs,
+  setJobResult,
+  setJobRunning,
+} from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
+
+type JobType = "profile" | "materialize" | "verify" | "activate";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function asBoolArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => String(item)) : [];
+}
 
 export async function POST(req: NextRequest) {
   const supabaseUser = createRouteHandlerClient<DB>({ cookies });
@@ -53,6 +75,36 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true, intakeId: intake.id, alreadyRunning: true });
   }
 
+  let runId: string | null = null;
+  const jobIdByType: Partial<Record<JobType, string>> = {};
+
+  try {
+    const run = await ensureRun({
+      shopId,
+      intakeId: intake.id,
+      triggerSource: "api",
+      createdBy: user.id,
+    });
+    runId = run?.id ?? null;
+
+    if (runId) {
+      const jobs = await seedRunJobs({ runId, shopId, intakeId: intake.id });
+      for (const job of jobs) {
+        const key = job.job_type as JobType;
+        if (key === "profile" || key === "materialize" || key === "verify" || key === "activate") {
+          jobIdByType[key] = job.id;
+        }
+      }
+      await markRunRunning(runId);
+    }
+  } catch (error) {
+    console.error("[shop-boost/orchestrator] process bootstrap failed", {
+      shopId,
+      intakeId: intake.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   await updateIntakeProgress({
     intakeId: intake.id,
     status: "processing",
@@ -63,13 +115,132 @@ export async function POST(req: NextRequest) {
 
   const errors: string[] = [];
 
+  const withAttempt = async <T,>(jobType: JobType, fn: () => Promise<T>): Promise<T> => {
+    if (!runId || !jobIdByType[jobType]) return fn();
+
+    const workerId = `api-shop-boost-process:${jobType}`;
+    await setJobRunning({ runId, jobType });
+    const attemptId = await createAttempt({
+      jobId: jobIdByType[jobType] as string,
+      runId,
+      workerId,
+    });
+
+    try {
+      const result = await fn();
+      if (attemptId) {
+        await completeAttempt({
+          attemptId,
+          status: "succeeded",
+          metrics: { completed_at: new Date().toISOString() },
+        });
+      }
+      return result;
+    } catch (error) {
+      if (attemptId) {
+        await completeAttempt({
+          attemptId,
+          status: "failed",
+          errorCode: "PROCESS_STEP_FAILED",
+          errorMessage: error instanceof Error ? error.message : String(error),
+          logs: [
+            {
+              at: new Date().toISOString(),
+              step: jobType,
+              message: error instanceof Error ? error.message : String(error),
+            },
+          ],
+        });
+      }
+      throw error;
+    }
+  };
+
   try {
     await updateIntakeProgress({ intakeId: intake.id, currentStep: "generating_suggestions", progressPercent: 35 });
-    const snapshot = await buildShopBoostProfile({ shopId, intakeId: intake.id });
+
+    const snapshot = await withAttempt("profile", async () => {
+      const out = await buildShopBoostProfile({ shopId, intakeId: intake.id });
+      if (runId) {
+        await setJobResult({
+          runId,
+          jobType: "profile",
+          status: "succeeded",
+          result: {
+            has_snapshot: Boolean(out),
+          },
+        });
+      }
+      return out;
+    });
+
     if (!snapshot) errors.push("AI snapshot generation failed; import continued.");
 
     await updateIntakeProgress({ intakeId: intake.id, currentStep: "materializing_operating_layer", progressPercent: 60 });
-    const importSummary = await runShopBoostImport({ shopId, intakeId: intake.id, options: { createStaffUsers: false } });
+
+    const importSummary = await withAttempt("materialize", async () => {
+      const out = await runShopBoostImport({ shopId, intakeId: intake.id, options: { createStaffUsers: false } });
+      if (runId) {
+        await setJobResult({
+          runId,
+          jobType: "materialize",
+          status: "succeeded",
+          result: {
+            completionState: out.completionState,
+            rowResults: out.rowResults,
+            canonicalMaterialization: out.canonicalMaterialization,
+          },
+        });
+      }
+      return out;
+    });
+
+    const integrityErrors = asBoolArray(importSummary.rowResults.integrityErrors);
+    const totalRows = Number(importSummary.rowResults.totalRows ?? 0);
+    const pendingReviewCount = Number(importSummary.rowResults.reviewCount ?? 0);
+    const failedCount = Number(importSummary.rowResults.failedCount ?? 0);
+
+    const activationEval = await withAttempt("verify", async () => {
+      const out = await evaluateActivationRules(shopId, {
+        completionState: importSummary.completionState,
+        integrityErrorCount: integrityErrors.length,
+        pendingReviewCount,
+        failedCount,
+        totalRows,
+        canonicalStatus: importSummary.canonicalMaterialization.status,
+        canonicalGaps: importSummary.canonicalMaterialization.gaps,
+        customersImported: importSummary.customersImported,
+        vehiclesImported: importSummary.vehiclesImported,
+      });
+
+      if (runId) {
+        await setJobResult({
+          runId,
+          jobType: "verify",
+          status: "succeeded",
+          result: {
+            blockers: out.blockers,
+            activationStatus: out.activationStatus,
+            snapshot: out.snapshot,
+          },
+        });
+      }
+      return out;
+    });
+
+    await withAttempt("activate", async () => {
+      if (runId) {
+        await setJobResult({
+          runId,
+          jobType: "activate",
+          status: "succeeded",
+          result: {
+            activationStatus: activationEval.activationStatus,
+            blockers: activationEval.blockers,
+          },
+        });
+      }
+    });
 
     const completedStatus =
       importSummary.completionState === "PARTIAL_FAILURE" ||
@@ -78,6 +249,35 @@ export async function POST(req: NextRequest) {
       errors.length > 0
         ? "completed_with_errors"
         : "completed";
+
+    const intakeRow = await admin
+      .from("shop_boost_intakes")
+      .select("intake_basics")
+      .eq("id", intake.id)
+      .maybeSingle<{ intake_basics: unknown }>();
+
+    const intakeBasics = asRecord(intakeRow.data?.intake_basics);
+    const orchestratorPatch = {
+      run_id: runId,
+      state: completedStatus,
+      activation_status: activationEval.activationStatus,
+      activation_blockers: activationEval.blockers,
+      activation_snapshot: activationEval.snapshot,
+      updated_at: new Date().toISOString(),
+    };
+
+    await admin
+      .from("shop_boost_intakes")
+      .update({
+        intake_basics: {
+          ...intakeBasics,
+          orchestrator: {
+            ...asRecord(intakeBasics.orchestrator),
+            ...orchestratorPatch,
+          },
+        } as DB["public"]["Tables"]["shop_boost_intakes"]["Update"]["intake_basics"],
+      })
+      .eq("id", intake.id);
 
     await updateIntakeProgress({
       intakeId: intake.id,
@@ -88,6 +288,7 @@ export async function POST(req: NextRequest) {
         completedAt: new Date().toISOString(),
         failedAt: null,
         lastError: errors.join(" ") || null,
+        orchestrator: orchestratorPatch,
         resultSummary: {
           customersImported: importSummary.customersImported,
           vehiclesImported: importSummary.vehiclesImported,
@@ -100,13 +301,45 @@ export async function POST(req: NextRequest) {
           partsPipeline: importSummary.partsPipeline ?? null,
           rowResults: importSummary.rowResults,
           completionState: importSummary.completionState,
+          activation: {
+            status: activationEval.activationStatus,
+            blockers: activationEval.blockers,
+            snapshot: activationEval.snapshot,
+          },
         },
       },
     });
 
-    return NextResponse.json({ ok: true, intakeId: intake.id, status: completedStatus });
+    if (runId) {
+      await markRunSucceeded({
+        runId,
+        metrics: {
+          completionState: importSummary.completionState,
+          completedStatus,
+          rowResults: importSummary.rowResults,
+          canonicalMaterialization: importSummary.canonicalMaterialization,
+        },
+        activationSnapshot: activationEval.snapshot,
+        activationStatus: activationEval.activationStatus,
+        blockers: activationEval.blockers,
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      intakeId: intake.id,
+      status: completedStatus,
+      orchestrator: runId
+        ? {
+            runId,
+            activationStatus: activationEval.activationStatus,
+            activationBlockers: activationEval.blockers,
+          }
+        : null,
+    });
   } catch (error) {
     const msg = error instanceof Error ? error.message : "Failed to process intake";
+
     await updateIntakeProgress({
       intakeId: intake.id,
       status: "failed",
@@ -116,6 +349,12 @@ export async function POST(req: NextRequest) {
         lastError: msg,
       },
     });
+
+    if (runId) {
+      const retryAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+      await markRunRetryable(runId, "PROCESS_FAILED", msg, retryAt);
+    }
+
     return NextResponse.json({ ok: false, error: msg }, { status: 500 });
   }
 }

--- a/features/integrations/shopBoost/orchestrator/index.ts
+++ b/features/integrations/shopBoost/orchestrator/index.ts
@@ -1,0 +1,563 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type OrchestratorActivationStatus = "not_eligible" | "eligible" | "activated" | "blocked";
+type OrchestratorRunState =
+  | "uploaded"
+  | "profiling"
+  | "materialize"
+  | "verify"
+  | "activate"
+  | "completed"
+  | "retryable_failed"
+  | "failed";
+
+type OrchestratorAttemptStatus = "running" | "succeeded" | "failed" | "canceled";
+type OrchestratorJobStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "retryable_failed"
+  | "blocked_manual"
+  | "terminal_failed"
+  | "canceled";
+
+type JsonObj = Record<string, unknown>;
+
+export type OnboardingRunRow = {
+  id: string;
+  shop_id: string;
+  intake_id: string;
+  state: string;
+  activation_status: string;
+  activation_blockers: unknown;
+  activation_snapshot: unknown;
+};
+
+type OnboardingJobRow = {
+  id: string;
+  run_id: string;
+  job_type: string;
+  domain: string | null;
+  status: string;
+  idempotency_key: string;
+};
+
+type ActivationRuleRow = {
+  min_customer_rows: number | null;
+  min_vehicle_rows: number | null;
+  max_pending_review_ratio: number | null;
+  max_failed_ratio: number | null;
+  require_zero_integrity_errors: boolean | null;
+  require_canonical_status_ok: boolean | null;
+  auto_activate: boolean | null;
+  enabled: boolean | null;
+};
+
+type ResolvedActivationRules = {
+  min_customer_rows: number;
+  min_vehicle_rows: number;
+  max_pending_review_ratio: number;
+  max_failed_ratio: number;
+  require_zero_integrity_errors: boolean;
+  require_canonical_status_ok: boolean;
+  auto_activate: boolean;
+  enabled: boolean;
+};
+
+export type ActivationEvaluationInput = {
+  completionState?: string | null;
+  integrityErrorCount?: number;
+  pendingReviewCount?: number;
+  failedCount?: number;
+  totalRows?: number;
+  canonicalStatus?: "ok" | "partial" | null;
+  canonicalGaps?: {
+    missingVehicles?: boolean;
+    missingWorkOrders?: boolean;
+    missingInvoices?: boolean;
+    missingStaff?: boolean;
+  } | null;
+  customersImported?: number;
+  vehiclesImported?: number;
+};
+
+export type ActivationEvaluationResult = {
+  activationStatus: OrchestratorActivationStatus;
+  blockers: string[];
+  snapshot: JsonObj;
+};
+
+const DEFAULT_RULES: ResolvedActivationRules = {
+  min_customer_rows: 1,
+  min_vehicle_rows: 1,
+  max_pending_review_ratio: 0.08,
+  max_failed_ratio: 0.02,
+  require_zero_integrity_errors: true,
+  require_canonical_status_ok: true,
+  auto_activate: true,
+  enabled: true,
+};
+
+function adminAny(): SupabaseClient<any> {
+  return createAdminSupabase() as unknown as SupabaseClient<any>;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+async function setJobStatus(args: {
+  supabase: SupabaseClient<any>;
+  runId: string;
+  jobType: string;
+  domain: string;
+  status: OrchestratorJobStatus;
+  result?: JsonObj;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+}): Promise<void> {
+  const payload: JsonObj = {
+    status: args.status,
+    updated_at: new Date().toISOString(),
+  };
+  if (args.status === "running") payload.started_at = new Date().toISOString();
+  if (args.status === "succeeded" || args.status === "terminal_failed" || args.status === "canceled") {
+    payload.completed_at = new Date().toISOString();
+  }
+  if (args.result) payload.result = args.result;
+  if (typeof args.errorCode !== "undefined") payload.error_code = args.errorCode;
+  if (typeof args.errorMessage !== "undefined") payload.error_message = args.errorMessage;
+
+  await args.supabase
+    .from("shop_onboarding_jobs")
+    .update(payload)
+    .eq("run_id", args.runId)
+    .eq("job_type", args.jobType)
+    .eq("domain", args.domain);
+}
+
+export async function ensureRun(args: {
+  shopId: string;
+  intakeId: string;
+  triggerSource: "manual" | "cron" | "api" | "demo";
+  createdBy?: string | null;
+}): Promise<OnboardingRunRow | null> {
+  const supabase = adminAny();
+  const payload: JsonObj = {
+    shop_id: args.shopId,
+    intake_id: args.intakeId,
+    trigger_source: args.triggerSource,
+    created_by: args.createdBy ?? null,
+    started_at: new Date().toISOString(),
+  };
+
+  const { data, error } = await supabase
+    .from("shop_onboarding_runs")
+    .upsert(payload, { onConflict: "shop_id,intake_id" })
+    .select("id,shop_id,intake_id,state,activation_status,activation_blockers,activation_snapshot")
+    .maybeSingle();
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] ensureRun failed", {
+      shopId: args.shopId,
+      intakeId: args.intakeId,
+      error: error.message,
+    });
+    return null;
+  }
+
+  return (data as OnboardingRunRow | null) ?? null;
+}
+
+export async function seedRunJobs(args: {
+  runId: string;
+  shopId: string;
+  intakeId: string;
+}): Promise<OnboardingJobRow[]> {
+  const supabase = adminAny();
+
+  const { data: existing } = await supabase
+    .from("shop_onboarding_jobs")
+    .select("id,run_id,job_type,domain,status,idempotency_key")
+    .eq("run_id", args.runId)
+    .limit(20);
+
+  if ((existing?.length ?? 0) > 0) {
+    return (existing as OnboardingJobRow[]) ?? [];
+  }
+
+  const seed = [
+    { job_type: "profile", domain: "global", priority: 20 },
+    { job_type: "materialize", domain: "global", priority: 40 },
+    { job_type: "verify", domain: "global", priority: 60 },
+    { job_type: "activate", domain: "global", priority: 80 },
+  ].map((job) => ({
+    run_id: args.runId,
+    shop_id: args.shopId,
+    intake_id: args.intakeId,
+    job_type: job.job_type,
+    domain: job.domain,
+    status: "queued",
+    priority: job.priority,
+    idempotency_key: `run:${args.runId}:${job.job_type}:${job.domain}`,
+    payload: { intake_id: args.intakeId },
+  }));
+
+  const { error } = await supabase.from("shop_onboarding_jobs").upsert(seed, { onConflict: "idempotency_key" });
+  if (error) {
+    console.error("[shop-boost/orchestrator] seedRunJobs failed", {
+      runId: args.runId,
+      shopId: args.shopId,
+      intakeId: args.intakeId,
+      error: error.message,
+    });
+  }
+
+  const { data } = await supabase
+    .from("shop_onboarding_jobs")
+    .select("id,run_id,job_type,domain,status,idempotency_key")
+    .eq("run_id", args.runId)
+    .order("priority", { ascending: true });
+
+  return (data as OnboardingJobRow[]) ?? [];
+}
+
+export async function markRunRunning(runId: string): Promise<void> {
+  const supabase = adminAny();
+  const { error } = await supabase
+    .from("shop_onboarding_runs")
+    .update({
+      state: "materialize" satisfies OrchestratorRunState,
+      started_at: new Date().toISOString(),
+      failed_at: null,
+      error_code: null,
+      error_message: null,
+    })
+    .eq("id", runId);
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] markRunRunning failed", { runId, error: error.message });
+  }
+}
+
+export async function markRunSucceeded(args: {
+  runId: string;
+  metrics: JsonObj;
+  activationSnapshot: JsonObj;
+  activationStatus: OrchestratorActivationStatus;
+  blockers: string[];
+}): Promise<void> {
+  const supabase = adminAny();
+  const { error } = await supabase
+    .from("shop_onboarding_runs")
+    .update({
+      state: "completed" satisfies OrchestratorRunState,
+      completed_at: new Date().toISOString(),
+      failed_at: null,
+      error_code: null,
+      error_message: null,
+      metrics: args.metrics,
+      activation_snapshot: args.activationSnapshot,
+      activation_status: args.activationStatus,
+      activation_blockers: args.blockers,
+    })
+    .eq("id", args.runId);
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] markRunSucceeded failed", {
+      runId: args.runId,
+      error: error.message,
+    });
+  }
+}
+
+export async function markRunFailed(runId: string, errorCode: string, errorMessage: string): Promise<void> {
+  const supabase = adminAny();
+  const { error } = await supabase
+    .from("shop_onboarding_runs")
+    .update({
+      state: "failed" satisfies OrchestratorRunState,
+      failed_at: new Date().toISOString(),
+      error_code: errorCode,
+      error_message: errorMessage,
+    })
+    .eq("id", runId);
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] markRunFailed failed", { runId, error: error.message });
+  }
+}
+
+export async function markRunRetryable(
+  runId: string,
+  errorCode: string,
+  errorMessage: string,
+  retryAfter: string,
+): Promise<void> {
+  const supabase = adminAny();
+  const { error } = await supabase
+    .from("shop_onboarding_runs")
+    .update({
+      state: "retryable_failed" satisfies OrchestratorRunState,
+      failed_at: new Date().toISOString(),
+      error_code: errorCode,
+      error_message: errorMessage,
+      retry_after: retryAfter,
+    })
+    .eq("id", runId);
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] markRunRetryable failed", { runId, error: error.message });
+  }
+}
+
+export async function createAttempt(args: {
+  jobId: string;
+  runId: string;
+  workerId: string;
+}): Promise<string | null> {
+  const supabase = adminAny();
+  const { data, error } = await supabase
+    .from("shop_onboarding_attempts")
+    .insert({
+      job_id: args.jobId,
+      run_id: args.runId,
+      worker_id: args.workerId,
+      status: "running" satisfies OrchestratorAttemptStatus,
+    })
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] createAttempt failed", {
+      runId: args.runId,
+      jobId: args.jobId,
+      error: error.message,
+    });
+    return null;
+  }
+
+  return String(data?.id ?? "") || null;
+}
+
+export async function completeAttempt(args: {
+  attemptId: string;
+  status: OrchestratorAttemptStatus;
+  errorCode?: string;
+  errorMessage?: string;
+  logs?: unknown[];
+  metrics?: JsonObj;
+}): Promise<void> {
+  const supabase = adminAny();
+  const { error } = await supabase
+    .from("shop_onboarding_attempts")
+    .update({
+      status: args.status,
+      completed_at: new Date().toISOString(),
+      error_code: args.errorCode ?? null,
+      error_message: args.errorMessage ?? null,
+      logs: args.logs ?? [],
+      metrics: args.metrics ?? {},
+    })
+    .eq("id", args.attemptId);
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] completeAttempt failed", {
+      attemptId: args.attemptId,
+      error: error.message,
+    });
+  }
+}
+
+export async function setJobRunning(args: {
+  runId: string;
+  jobType: "profile" | "materialize" | "verify" | "activate";
+}): Promise<void> {
+  const supabase = adminAny();
+  await setJobStatus({
+    supabase,
+    runId: args.runId,
+    jobType: args.jobType,
+    domain: "global",
+    status: "running",
+  });
+}
+
+export async function setJobResult(args: {
+  runId: string;
+  jobType: "profile" | "materialize" | "verify" | "activate";
+  status: OrchestratorJobStatus;
+  result?: JsonObj;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+}): Promise<void> {
+  const supabase = adminAny();
+  await setJobStatus({
+    supabase,
+    runId: args.runId,
+    jobType: args.jobType,
+    domain: "global",
+    status: args.status,
+    result: args.result,
+    errorCode: args.errorCode,
+    errorMessage: args.errorMessage,
+  });
+}
+
+export async function getRunByShopIntake(args: {
+  shopId: string;
+  intakeId: string;
+}): Promise<OnboardingRunRow | null> {
+  const supabase = adminAny();
+  const { data, error } = await supabase
+    .from("shop_onboarding_runs")
+    .select("id,shop_id,intake_id,state,activation_status,activation_blockers,activation_snapshot")
+    .eq("shop_id", args.shopId)
+    .eq("intake_id", args.intakeId)
+    .maybeSingle();
+  if (error) {
+    console.error("[shop-boost/orchestrator] getRunByShopIntake failed", {
+      shopId: args.shopId,
+      intakeId: args.intakeId,
+      error: error.message,
+    });
+    return null;
+  }
+  return (data as OnboardingRunRow | null) ?? null;
+}
+
+export async function summarizeRunJobs(runId: string): Promise<Record<string, number> | null> {
+  const supabase = adminAny();
+  const { data, error } = await supabase
+    .from("shop_onboarding_jobs")
+    .select("status")
+    .eq("run_id", runId)
+    .limit(100);
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] summarizeRunJobs failed", { runId, error: error.message });
+    return null;
+  }
+
+  const summary: Record<string, number> = {};
+  for (const row of data ?? []) {
+    const key = String((row as { status?: string }).status ?? "unknown");
+    summary[key] = (summary[key] ?? 0) + 1;
+  }
+
+  return summary;
+}
+
+export async function evaluateActivationRules(
+  shopId: string,
+  computedSummary: ActivationEvaluationInput,
+): Promise<ActivationEvaluationResult> {
+  const supabase = adminAny();
+
+  const { data, error } = await supabase
+    .from("shop_onboarding_activation_rules")
+    .select(
+      "enabled,min_customer_rows,min_vehicle_rows,max_pending_review_ratio,max_failed_ratio,require_zero_integrity_errors,require_canonical_status_ok,auto_activate",
+    )
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[shop-boost/activation] load activation rules failed; using defaults", {
+      shopId,
+      error: error.message,
+    });
+  }
+
+  const fromDb = (data as ActivationRuleRow | null) ?? null;
+  const rules: ResolvedActivationRules = {
+    min_customer_rows: fromDb?.min_customer_rows ?? DEFAULT_RULES.min_customer_rows,
+    min_vehicle_rows: fromDb?.min_vehicle_rows ?? DEFAULT_RULES.min_vehicle_rows,
+    max_pending_review_ratio: fromDb?.max_pending_review_ratio ?? DEFAULT_RULES.max_pending_review_ratio,
+    max_failed_ratio: fromDb?.max_failed_ratio ?? DEFAULT_RULES.max_failed_ratio,
+    require_zero_integrity_errors: fromDb?.require_zero_integrity_errors ?? DEFAULT_RULES.require_zero_integrity_errors,
+    require_canonical_status_ok: fromDb?.require_canonical_status_ok ?? DEFAULT_RULES.require_canonical_status_ok,
+    auto_activate: fromDb?.auto_activate ?? DEFAULT_RULES.auto_activate,
+    enabled: fromDb?.enabled ?? DEFAULT_RULES.enabled,
+  };
+
+  const totalRows = Math.max(0, asNumber(computedSummary.totalRows, 0));
+  const pendingReviewCount = Math.max(0, asNumber(computedSummary.pendingReviewCount, 0));
+  const failedCount = Math.max(0, asNumber(computedSummary.failedCount, 0));
+  const integrityErrorCount = Math.max(0, asNumber(computedSummary.integrityErrorCount, 0));
+  const customersImported = Math.max(0, asNumber(computedSummary.customersImported, 0));
+  const vehiclesImported = Math.max(0, asNumber(computedSummary.vehiclesImported, 0));
+
+  const pendingRatio = totalRows > 0 ? pendingReviewCount / totalRows : 0;
+  const failedRatio = totalRows > 0 ? failedCount / totalRows : 0;
+
+  const blockers: string[] = [];
+
+  if (!rules.enabled) {
+    blockers.push("Activation rules disabled for this shop.");
+  }
+
+  const completion = String(computedSummary.completionState ?? "");
+  if (!completion || ["PARTIAL_FAILURE", "FAILED", "NOT_READY"].includes(completion)) {
+    blockers.push(`Completion state ${completion || "unknown"} is not go-live eligible.`);
+  }
+
+  if (rules.require_zero_integrity_errors && integrityErrorCount > 0) {
+    blockers.push(`Integrity errors detected: ${integrityErrorCount}.`);
+  }
+
+  if (pendingRatio > rules.max_pending_review_ratio) {
+    blockers.push(
+      `Pending review ratio ${(pendingRatio * 100).toFixed(2)}% exceeds ${(rules.max_pending_review_ratio * 100).toFixed(2)}%.`,
+    );
+  }
+
+  if (failedRatio > rules.max_failed_ratio) {
+    blockers.push(`Failed ratio ${(failedRatio * 100).toFixed(2)}% exceeds ${(rules.max_failed_ratio * 100).toFixed(2)}%.`);
+  }
+
+  if (rules.require_canonical_status_ok && computedSummary.canonicalStatus && computedSummary.canonicalStatus !== "ok") {
+    blockers.push(`Canonical materialization status is ${computedSummary.canonicalStatus}.`);
+  }
+
+  const gaps = computedSummary.canonicalGaps;
+  if (gaps?.missingVehicles) blockers.push("Canonical gap: vehicles missing.");
+  if (gaps?.missingWorkOrders) blockers.push("Canonical gap: work orders missing.");
+  if (gaps?.missingInvoices) blockers.push("Canonical gap: invoices missing.");
+
+  if (customersImported < rules.min_customer_rows) {
+    blockers.push(`Customers imported (${customersImported}) below minimum (${rules.min_customer_rows}).`);
+  }
+  if (vehiclesImported < rules.min_vehicle_rows) {
+    blockers.push(`Vehicles imported (${vehiclesImported}) below minimum (${rules.min_vehicle_rows}).`);
+  }
+
+  const eligible = blockers.length === 0;
+  const activationStatus: OrchestratorActivationStatus = eligible
+    ? rules.auto_activate
+      ? "activated"
+      : "eligible"
+    : "blocked";
+
+  return {
+    activationStatus,
+    blockers,
+    snapshot: {
+      evaluated_at: new Date().toISOString(),
+      completionState: completion || null,
+      integrityErrorCount,
+      pendingReviewCount,
+      failedCount,
+      totalRows,
+      pendingRatio,
+      failedRatio,
+      canonicalStatus: computedSummary.canonicalStatus ?? null,
+      canonicalGaps: computedSummary.canonicalGaps ?? null,
+      customersImported,
+      vehiclesImported,
+      rules,
+      eligible,
+    },
+  };
+}

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -20,6 +20,7 @@ import {
 } from "@/features/integrations/shopBoost/uploadDatasets";
 
 import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
+import { ensureRun, seedRunJobs } from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
 
@@ -370,6 +371,51 @@ export async function runShopBoostIntake(
     progressPercent: 5,
     patch: { startedAt: new Date().toISOString(), lastError: null },
   });
+
+  try {
+    const run = await ensureRun({
+      shopId,
+      intakeId,
+      triggerSource: "api",
+      createdBy: user.id,
+    });
+
+    if (run?.id) {
+      await seedRunJobs({
+        runId: run.id,
+        shopId,
+        intakeId,
+      });
+
+      const { data: row } = await supabaseAdmin
+        .from("shop_boost_intakes")
+        .select("intake_basics")
+        .eq("id", intakeId)
+        .maybeSingle<{ intake_basics: unknown }>();
+
+      const existingBasics = isRecord(row?.intake_basics) ? row.intake_basics : {};
+      await supabaseAdmin
+        .from("shop_boost_intakes")
+        .update({
+          intake_basics: ({
+            ...existingBasics,
+            orchestrator: {
+              run_id: run.id,
+              state: run.state,
+              activation_status: run.activation_status,
+              activation_blockers: run.activation_blockers ?? [],
+            },
+          } as unknown) as DB["public"]["Tables"]["shop_boost_intakes"]["Update"]["intake_basics"],
+        })
+        .eq("id", intakeId);
+    }
+  } catch (error) {
+    console.error("[shop-boost/orchestrator] ensure+seed on intake run failed", {
+      shopId,
+      intakeId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   if (mode.deferProcessing) {
     return {


### PR DESCRIPTION
### Motivation
- Introduce an orchestrator for tracking onboarding runs, jobs, and activation evaluation to provide visibility and retryability for shop-boost ingests.
- Enrich existing intake-related APIs and intake rows with orchestrator metadata so status and job summaries are available via the UI and reports.

### Description
- Add a new module `features/integrations/shopBoost/orchestrator` with functions including `ensureRun`, `seedRunJobs`, `getRunByShopIntake`, `summarizeRunJobs`, `evaluateActivationRules`, `createAttempt`, `completeAttempt`, `setJobRunning`, `setJobResult`, `markRunRunning`, `markRunSucceeded`, `markRunFailed`, and `markRunRetryable` to manage runs, jobs, attempts, and activation rule evaluation. 
- Integrate orchestrator into intake processing in `app/api/shop-boost/intakes/process/route.ts` by calling `ensureRun`/`seedRunJobs`, wrapping major steps in attempt lifecycle logic, recording per-job results with `setJobResult`, updating `shop_boost_intakes.intake_basics.orchestrator`, and calling `markRunSucceeded` or `markRunRetryable` on completion or failure. 
- Enrich intake endpoints `app/api/shop-boost/intakes/latest/route.ts` and `app/api/shop-boost/intakes/[id]/report/route.ts` to include orchestrator summaries and job status summaries by using `getRunByShopIntake` and `summarizeRunJobs`. 
- Update `features/integrations/shopBoost/runIntakeHandler.ts` to create/seed an orchestrator run when new intakes are created and persist run metadata into the intake row.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea60557ea88328929767f92db264f2)