### PR TITLE
Add defensive Shop Boost orchestrator telemetry enrichment

### DIFF
--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -3,7 +3,11 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { getRunByShopIntake, summarizeRunJobs } from "@/features/integrations/shopBoost/orchestrator";
+import {
+  getLatestRunAttemptSummary,
+  getRunByShopIntake,
+  summarizeRunJobs,
+} from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
 type RouteContext = { params: Promise<{ id: string }> };
@@ -157,17 +161,33 @@ export async function GET(req: Request, context: RouteContext) {
     return acc;
   }, {});
 
+  const legacyOrchestrator = asRecord(basics.orchestrator);
   let orchestrator: Record<string, unknown> | null = null;
   try {
     const run = await getRunByShopIntake({ shopId: profile.shop_id, intakeId: intake.id });
     if (run?.id) {
+      const jobSummary = await summarizeRunJobs(run.id);
+      const lastAttempt = await getLatestRunAttemptSummary(run.id);
       orchestrator = {
+        runId: run.id,
+        runState: run.state,
+        activationStatus: run.activation_status,
+        blockers: run.activation_blockers ?? [],
+        jobSummary,
+        lastAttempt,
         run_id: run.id,
         state: run.state,
         activation_status: run.activation_status,
         activation_blockers: run.activation_blockers ?? [],
         activation_snapshot: asRecord(run.activation_snapshot),
-        jobs: await summarizeRunJobs(run.id),
+        jobs: jobSummary,
+        last_error:
+          lastAttempt?.status === "failed" || lastAttempt?.errorMessage
+            ? {
+                code: lastAttempt?.errorCode ?? null,
+                message: lastAttempt?.errorMessage ?? null,
+              }
+            : null,
       };
     }
   } catch (orchestratorErr) {
@@ -176,6 +196,24 @@ export async function GET(req: Request, context: RouteContext) {
       shopId: profile.shop_id,
       error: orchestratorErr instanceof Error ? orchestratorErr.message : String(orchestratorErr),
     });
+  }
+
+  if (!orchestrator && Object.keys(legacyOrchestrator).length > 0) {
+    orchestrator = {
+      runId: legacyOrchestrator.run_id ?? null,
+      runState: legacyOrchestrator.state ?? null,
+      activationStatus: legacyOrchestrator.activation_status ?? null,
+      blockers: legacyOrchestrator.activation_blockers ?? [],
+      jobSummary: legacyOrchestrator.job_summary ?? null,
+      lastAttempt: legacyOrchestrator.last_attempt ?? null,
+      run_id: legacyOrchestrator.run_id ?? null,
+      state: legacyOrchestrator.state ?? null,
+      activation_status: legacyOrchestrator.activation_status ?? null,
+      activation_blockers: legacyOrchestrator.activation_blockers ?? [],
+      activation_snapshot: asRecord(legacyOrchestrator.activation_snapshot),
+      jobs: legacyOrchestrator.job_summary ?? null,
+      last_error: legacyOrchestrator.last_error ?? null,
+    };
   }
 
   const report = {

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -4,9 +4,16 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { toIntakeProgress } from "@/features/integrations/shopBoost/status";
-import { getRunByShopIntake, summarizeRunJobs } from "@/features/integrations/shopBoost/orchestrator";
+import {
+  getLatestRunAttemptSummary,
+  getRunByShopIntake,
+  summarizeRunJobs,
+} from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
 
 export async function GET() {
   const supabaseUser = createRouteHandlerClient<DB>({ cookies });
@@ -47,13 +54,10 @@ export async function GET() {
   }
   if (!intake) return NextResponse.json({ ok: true, intake: null });
 
-  let orchestrator: {
-    runId: string;
-    state: string;
-    activationStatus: string;
-    activationBlockers: unknown;
-    jobs: Record<string, number> | null;
-  } | null = null;
+  const basics = asRecord(intake.intake_basics);
+  const basicsOrchestrator = asRecord(basics.orchestrator);
+
+  let orchestrator: Record<string, unknown> | null = null;
 
   try {
     const run = await getRunByShopIntake({
@@ -62,12 +66,25 @@ export async function GET() {
     });
 
     if (run?.id) {
+      const jobSummary = await summarizeRunJobs(run.id);
+      const lastAttempt = await getLatestRunAttemptSummary(run.id);
       orchestrator = {
         runId: run.id,
-        state: run.state,
+        runState: run.state,
         activationStatus: run.activation_status,
+        blockers: run.activation_blockers ?? [],
+        jobSummary,
+        lastAttempt,
+        state: run.state,
         activationBlockers: run.activation_blockers ?? [],
-        jobs: await summarizeRunJobs(run.id),
+        jobs: jobSummary,
+        lastError:
+          lastAttempt?.status === "failed" || lastAttempt?.errorMessage
+            ? {
+                code: lastAttempt?.errorCode ?? null,
+                message: lastAttempt?.errorMessage ?? null,
+              }
+            : null,
       };
     }
   } catch (orchestratorErr) {
@@ -76,6 +93,21 @@ export async function GET() {
       intakeId: intake.id,
       error: orchestratorErr instanceof Error ? orchestratorErr.message : String(orchestratorErr),
     });
+  }
+
+  if (!orchestrator && Object.keys(basicsOrchestrator).length > 0) {
+    orchestrator = {
+      runId: basicsOrchestrator.run_id ?? null,
+      runState: basicsOrchestrator.state ?? null,
+      activationStatus: basicsOrchestrator.activation_status ?? null,
+      blockers: basicsOrchestrator.activation_blockers ?? [],
+      jobSummary: basicsOrchestrator.job_summary ?? null,
+      lastAttempt: basicsOrchestrator.last_attempt ?? null,
+      state: basicsOrchestrator.state ?? null,
+      activationBlockers: basicsOrchestrator.activation_blockers ?? [],
+      jobs: basicsOrchestrator.job_summary ?? null,
+      lastError: basicsOrchestrator.last_error ?? null,
+    };
   }
 
   return NextResponse.json({

--- a/app/api/shop-boost/intakes/process/route.ts
+++ b/app/api/shop-boost/intakes/process/route.ts
@@ -11,10 +11,12 @@ import {
   createAttempt,
   ensureRun,
   evaluateActivationRules,
+  getLatestRunAttemptSummary,
   markRunRetryable,
   markRunRunning,
   markRunSucceeded,
   seedRunJobs,
+  summarizeRunJobs,
   setJobResult,
   setJobRunning,
 } from "@/features/integrations/shopBoost/orchestrator";
@@ -22,6 +24,12 @@ import {
 type DB = Database;
 
 type JobType = "profile" | "materialize" | "verify" | "activate";
+const RUN_STATE_BY_JOB: Record<JobType, "profiling" | "materialize" | "verify" | "activate"> = {
+  profile: "profiling",
+  materialize: "materialize",
+  verify: "verify",
+  activate: "activate",
+};
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
@@ -76,6 +84,7 @@ export async function POST(req: NextRequest) {
   }
 
   let runId: string | null = null;
+  let activeJobType: JobType | null = null;
   const jobIdByType: Partial<Record<JobType, string>> = {};
 
   try {
@@ -95,7 +104,7 @@ export async function POST(req: NextRequest) {
           jobIdByType[key] = job.id;
         }
       }
-      await markRunRunning(runId);
+      await markRunRunning(runId, "profiling");
     }
   } catch (error) {
     console.error("[shop-boost/orchestrator] process bootstrap failed", {
@@ -119,6 +128,8 @@ export async function POST(req: NextRequest) {
     if (!runId || !jobIdByType[jobType]) return fn();
 
     const workerId = `api-shop-boost-process:${jobType}`;
+    activeJobType = jobType;
+    await markRunRunning(runId, RUN_STATE_BY_JOB[jobType]);
     await setJobRunning({ runId, jobType });
     const attemptId = await createAttempt({
       jobId: jobIdByType[jobType] as string,
@@ -135,8 +146,16 @@ export async function POST(req: NextRequest) {
           metrics: { completed_at: new Date().toISOString() },
         });
       }
+      activeJobType = null;
       return result;
     } catch (error) {
+      await setJobResult({
+        runId,
+        jobType,
+        status: "retryable_failed",
+        errorCode: "PROCESS_STEP_FAILED",
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       if (attemptId) {
         await completeAttempt({
           attemptId,
@@ -152,6 +171,7 @@ export async function POST(req: NextRequest) {
           ],
         });
       }
+      activeJobType = null;
       throw error;
     }
   };
@@ -257,12 +277,31 @@ export async function POST(req: NextRequest) {
       .maybeSingle<{ intake_basics: unknown }>();
 
     const intakeBasics = asRecord(intakeRow.data?.intake_basics);
+    const jobSummary = runId ? await summarizeRunJobs(runId) : null;
+    const lastAttempt = runId ? await getLatestRunAttemptSummary(runId) : null;
+    const lastError =
+      lastAttempt?.status === "failed" || lastAttempt?.errorMessage
+        ? {
+            code: lastAttempt?.errorCode ?? null,
+            message: lastAttempt?.errorMessage ?? null,
+          }
+        : null;
+
     const orchestratorPatch = {
       run_id: runId,
       state: completedStatus,
       activation_status: activationEval.activationStatus,
       activation_blockers: activationEval.blockers,
       activation_snapshot: activationEval.snapshot,
+      job_summary: jobSummary,
+      last_attempt: lastAttempt,
+      last_error: lastError,
+      runState: completedStatus,
+      activationStatus: activationEval.activationStatus,
+      blockers: activationEval.blockers,
+      jobSummary,
+      lastAttempt,
+      lastError,
       updated_at: new Date().toISOString(),
     };
 
@@ -351,6 +390,15 @@ export async function POST(req: NextRequest) {
     });
 
     if (runId) {
+      if (activeJobType) {
+        await setJobResult({
+          runId,
+          jobType: activeJobType,
+          status: "retryable_failed",
+          errorCode: "PROCESS_FAILED",
+          errorMessage: msg,
+        });
+      }
       const retryAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
       await markRunRetryable(runId, "PROCESS_FAILED", msg, retryAt);
     }

--- a/features/integrations/shopBoost/orchestrator/index.ts
+++ b/features/integrations/shopBoost/orchestrator/index.ts
@@ -43,6 +43,16 @@ type OnboardingJobRow = {
   idempotency_key: string;
 };
 
+type OnboardingAttemptRow = {
+  id: string;
+  job_id: string;
+  status: string;
+  error_code: string | null;
+  error_message: string | null;
+  created_at: string;
+  completed_at: string | null;
+};
+
 type ActivationRuleRow = {
   min_customer_rows: number | null;
   min_vehicle_rows: number | null;
@@ -87,6 +97,25 @@ export type ActivationEvaluationResult = {
   blockers: string[];
   snapshot: JsonObj;
 };
+
+export type RunAttemptSummary = {
+  attemptId: string;
+  jobId: string;
+  jobType: string | null;
+  domain: string | null;
+  status: string;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  completedAt: string | null;
+};
+
+const SEED_JOBS = [
+  { job_type: "profile", domain: "global", priority: 20 },
+  { job_type: "materialize", domain: "global", priority: 40 },
+  { job_type: "verify", domain: "global", priority: 60 },
+  { job_type: "activate", domain: "global", priority: 80 },
+] as const;
 
 const DEFAULT_RULES: ResolvedActivationRules = {
   min_customer_rows: 1,
@@ -177,22 +206,7 @@ export async function seedRunJobs(args: {
 }): Promise<OnboardingJobRow[]> {
   const supabase = adminAny();
 
-  const { data: existing } = await supabase
-    .from("shop_onboarding_jobs")
-    .select("id,run_id,job_type,domain,status,idempotency_key")
-    .eq("run_id", args.runId)
-    .limit(20);
-
-  if ((existing?.length ?? 0) > 0) {
-    return (existing as OnboardingJobRow[]) ?? [];
-  }
-
-  const seed = [
-    { job_type: "profile", domain: "global", priority: 20 },
-    { job_type: "materialize", domain: "global", priority: 40 },
-    { job_type: "verify", domain: "global", priority: 60 },
-    { job_type: "activate", domain: "global", priority: 80 },
-  ].map((job) => ({
+  const seed = SEED_JOBS.map((job) => ({
     run_id: args.runId,
     shop_id: args.shopId,
     intake_id: args.intakeId,
@@ -223,12 +237,15 @@ export async function seedRunJobs(args: {
   return (data as OnboardingJobRow[]) ?? [];
 }
 
-export async function markRunRunning(runId: string): Promise<void> {
+export async function markRunRunning(
+  runId: string,
+  state: Extract<OrchestratorRunState, "profiling" | "materialize" | "verify" | "activate"> = "materialize",
+): Promise<void> {
   const supabase = adminAny();
   const { error } = await supabase
     .from("shop_onboarding_runs")
     .update({
-      state: "materialize" satisfies OrchestratorRunState,
+      state: state satisfies OrchestratorRunState,
       started_at: new Date().toISOString(),
       failed_at: null,
       error_code: null,
@@ -447,6 +464,46 @@ export async function summarizeRunJobs(runId: string): Promise<Record<string, nu
   }
 
   return summary;
+}
+
+export async function getLatestRunAttemptSummary(runId: string): Promise<RunAttemptSummary | null> {
+  const supabase = adminAny();
+  const { data, error } = await supabase
+    .from("shop_onboarding_attempts")
+    .select("id,job_id,status,error_code,error_message,created_at,completed_at")
+    .eq("run_id", runId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[shop-boost/orchestrator] getLatestRunAttemptSummary failed", {
+      runId,
+      error: error.message,
+    });
+    return null;
+  }
+
+  const attempt = (data as OnboardingAttemptRow | null) ?? null;
+  if (!attempt?.id) return null;
+
+  const { data: job } = await supabase
+    .from("shop_onboarding_jobs")
+    .select("job_type,domain")
+    .eq("id", attempt.job_id)
+    .maybeSingle<{ job_type: string | null; domain: string | null }>();
+
+  return {
+    attemptId: attempt.id,
+    jobId: attempt.job_id,
+    jobType: job?.job_type ?? null,
+    domain: job?.domain ?? null,
+    status: attempt.status,
+    errorCode: attempt.error_code,
+    errorMessage: attempt.error_message,
+    createdAt: attempt.created_at,
+    completedAt: attempt.completed_at,
+  };
 }
 
 export async function evaluateActivationRules(

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -404,6 +404,10 @@ export async function runShopBoostIntake(
               state: run.state,
               activation_status: run.activation_status,
               activation_blockers: run.activation_blockers ?? [],
+              runId: run.id,
+              runState: run.state,
+              activationStatus: run.activation_status,
+              blockers: run.activation_blockers ?? [],
             },
           } as unknown) as DB["public"]["Tables"]["shop_boost_intakes"]["Update"]["intake_basics"],
         })


### PR DESCRIPTION
### Motivation
- Make the new Shop Onboarding Orchestrator tables usefully populated and observable without breaking the existing Shop Boost intake/process/report flows.
- Dual-write orchestrator metadata so new telemetry is available for reporting while preserving legacy intake/migrationProgress consumers as a safe fallback.
- Keep the current executor/processing behavior unchanged and avoid any hard dependency on orchestrator reads/writes.

### Description
- Seed and idempotently upsert the required global run jobs (`profile`, `materialize`, `verify`, `activate`) so a run row has the expected job rows exactly once; added `SEED_JOBS` and switched to `upsert` by `idempotency_key` in `features/integrations/shopBoost/orchestrator/index.ts`.
- Add attempt summary helper (`getLatestRunAttemptSummary`), expand job/run lifecycle signals (`markRunRunning` supports per-phase states), and surface job/attempt transitions and retryable failure marks from `app/api/shop-boost/intakes/process/route.ts` into orchestrator tables without changing the import executor.
- Dual-write and enrich `shop_boost_intakes.intake_basics.orchestrator` with additive fields (`job_summary`, `last_attempt`, `last_error`) plus camelCase mirrors (`runState`, `activationStatus`, `blockers`, `jobSummary`, `lastAttempt`, `lastError`) and preserve legacy keys (`run_id`, `state`, etc.) in `features/integrations/shopBoost/runIntakeHandler.ts` and `app/api/shop-boost/intakes/process/route.ts`.
- Expose orchestrator metadata (additive only) in latest/report APIs: `runId`, `runState`, `activationStatus`, `blockers`, `jobSummary`, and `lastAttempt/lastError`, and fall back to legacy `intake_basics.orchestrator` if orchestrator rows are missing or enrichment fails in `app/api/shop-boost/intakes/latest/route.ts` and `app/api/shop-boost/intakes/[id]/report/route.ts`.
- Files changed: `features/integrations/shopBoost/orchestrator/index.ts`, `features/integrations/shopBoost/runIntakeHandler.ts`, `app/api/shop-boost/intakes/process/route.ts`, `app/api/shop-boost/intakes/latest/route.ts`, `app/api/shop-boost/intakes/[id]/report/route.ts`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully (no type errors introduced).
- Commit created: changes committed with message `Add defensive Shop Boost orchestrator telemetry enrichment` (local commit step completed).
- No additional automated test suites were modified or executed in this pass; changes are defensive and additive to avoid regressions in existing runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6d5d54008328bd2a9e6f1ca81c1a)