### PR TITLE
Make Shop Boost materialize jobs execute per-domain handlers

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -41,6 +41,7 @@ type RunArgs = {
    */
   options?: {
     createStaffUsers?: boolean;
+    materializeDomain?: "customers" | "vehicles" | "history" | "invoices" | "parts" | "staff";
   };
 };
 
@@ -163,6 +164,26 @@ type CacheVehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "v
 type CacheProfileRow = Pick<DB["public"]["Tables"]["profiles"]["Row"], "id" | "email" | "full_name">;
 type RowBucketRow = Pick<DB["public"]["Tables"]["shop_boost_row_results"]["Row"], "match_status" | "review_required" | "error_reason">;
 type KeyFixRow = Pick<DB["public"]["Tables"]["shop_boost_review_items"]["Row"], "domain" | "issue_type" | "status" | "resolution_action">;
+type MaterializeDomain = NonNullable<RunArgs["options"]>["materializeDomain"];
+
+function domainSourceFile(domain: MaterializeDomain): string | null {
+  if (domain === "customers") return "customers";
+  if (domain === "vehicles") return "vehicles";
+  if (domain === "history") return "history";
+  if (domain === "invoices") return "invoices";
+  if (domain === "parts") return "parts";
+  return null;
+}
+
+function domainReviewItems(domain: MaterializeDomain): string[] {
+  if (domain === "customers") return ["customer"];
+  if (domain === "vehicles") return ["vehicle"];
+  if (domain === "history") return ["work_order", "history"];
+  if (domain === "invoices") return ["invoice"];
+  if (domain === "parts") return ["part"];
+  if (domain === "staff") return [];
+  return [];
+}
 
 function norm(s: string): string {
   return (s ?? "").trim();
@@ -947,6 +968,14 @@ async function createReviewItem(args: {
 export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImportSummary> {
   const { shopId, intakeId } = args;
   const supabase = createAdminSupabase();
+  const materializeDomain = args.options?.materializeDomain ?? null;
+  const runCustomers = !materializeDomain || materializeDomain === "customers";
+  const runVehicles = !materializeDomain || materializeDomain === "vehicles";
+  const runParts = !materializeDomain || materializeDomain === "parts";
+  const runStaff = !materializeDomain || materializeDomain === "staff";
+  const runHistory = !materializeDomain || materializeDomain === "history";
+  const runInvoices = !materializeDomain || materializeDomain === "invoices";
+  const runLinkagePass = !materializeDomain || materializeDomain === "history";
 
   // 🔒 hard safety gate for any future staff autocreate logic (currently NOT used)
   const createStaffUsers =
@@ -1038,7 +1067,11 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const parsedHistory = historyCsv ? parseCsv(historyCsv).rows : [];
   const parsedInvoices = invoicesCsvFromManifest ? parseCsv(invoicesCsvFromManifest).rows : [];
   const totalRows =
-    parsedCustomers.length + parsedVehicles.length + parsedParts.length + parsedHistory.length + parsedInvoices.length;
+    (runCustomers ? parsedCustomers.length : 0) +
+    (runVehicles ? parsedVehicles.length : 0) +
+    (runParts ? parsedParts.length : 0) +
+    (runHistory ? parsedHistory.length : 0) +
+    (runInvoices ? parsedInvoices.length : 0);
 
   const rowOutcome = {
     totalRows,
@@ -1067,20 +1100,51 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     },
   };
 
-  await Promise.all([
-    supabase.from("shop_boost_row_results").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
-    supabase.from("shop_boost_review_items").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
-  ]);
+  if (!materializeDomain) {
+    await Promise.all([
+      supabase.from("shop_boost_row_results").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
+      supabase.from("shop_boost_review_items").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
+    ]);
+  } else {
+    const sourceFile = domainSourceFile(materializeDomain);
+    if (sourceFile) {
+      await supabase
+        .from("shop_boost_row_results")
+        .delete()
+        .eq("shop_id", shopId)
+        .eq("intake_id", intakeId)
+        .eq("source_file", sourceFile);
+    }
+    const reviewDomains = domainReviewItems(materializeDomain);
+    if (reviewDomains.length > 0) {
+      await supabase
+        .from("shop_boost_review_items")
+        .delete()
+        .eq("shop_id", shopId)
+        .eq("intake_id", intakeId)
+        .in("domain", reviewDomains);
+    }
+  }
 
-  await stageSupplementalUploads({ shopId, intakeId, uploadManifest });
-  const serviceCatalogCsv = await downloadCsv(uploadManifest.serviceCatalog?.path ?? null);
-  const shopBuildSummary = await bridgeOperatingLayerFromCsv({
-    supabase,
-    shopId,
-    intakeId,
-    serviceCatalogCsv,
-    historyCsv,
-  });
+  if (!materializeDomain) {
+    await stageSupplementalUploads({ shopId, intakeId, uploadManifest });
+  }
+  const serviceCatalogCsv = !materializeDomain ? await downloadCsv(uploadManifest.serviceCatalog?.path ?? null) : null;
+  const shopBuildSummary = !materializeDomain
+    ? await bridgeOperatingLayerFromCsv({
+        supabase,
+        shopId,
+        intakeId,
+        serviceCatalogCsv,
+        historyCsv,
+      })
+    : {
+        menuItemsCreated: 0,
+        inspectionTemplatesCreated: 0,
+        linkedMenuToInspection: 0,
+        menuSuggestions: 0,
+        inspectionSuggestions: 0,
+      };
 
   // Build caches (keep light: only key columns)
   const customersByEmail = new Map<string, string>();
@@ -1203,7 +1267,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   let partsPipelineSummary: PartsPipelineSummary | undefined;
 
   // 1) Import customers
-  if (parsedCustomers.length > 0) {
+  if (runCustomers && parsedCustomers.length > 0) {
     const customerNames: Array<{ id: string; name: string }> = [];
     {
       const { data } = await supabase
@@ -1459,7 +1523,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   // 2) Import vehicles (link to customer if possible)
-  if (parsedVehicles.length > 0) {
+  if (runVehicles && parsedVehicles.length > 0) {
     for (let i = 0; i < parsedVehicles.length; i += 1) {
       const row = parsedVehicles[i];
       const sourceVehicleId = pickSourceId(row, [/^vehicle[_\s-]*id$/, /external vehicle id/, /^unit id$/]);
@@ -1683,7 +1747,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   // 3) Import parts (staged pipeline with review queue + safe promotion)
-  if (partsCsv) {
+  if (runParts && partsCsv) {
     partsPipelineSummary = await runPartsImportPipeline({
       shopId,
       intakeId,
@@ -1704,7 +1768,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
   // 4) Import staff -> staff_invite_suggestions (NO auth creation here)
   let staffRowsExpected = 0;
-  if (staffCsv) {
+  if (runStaff && staffCsv) {
     const { rows } = parseCsv(staffCsv);
     staffRowsExpected = rows.length;
     await supabase.from("staff_invite_suggestions").delete().eq("shop_id", shopId).eq("intake_id", intakeId);
@@ -1799,7 +1863,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   // 5) Import history → completed work orders + lines (+ invoices if totals exist)
-  if (parsedHistory.length > 0) {
+  if (runHistory && parsedHistory.length > 0) {
     for (let i = 0; i < parsedHistory.length; i += 1) {
       const row = parsedHistory[i];
       const sourceWorkOrderId = pickSourceId(row, [/^work[_\s-]*order[_\s-]*id$/, /^wo[_\s-]*id$/, /^ro[_\s-]*id$/, /^invoice[_\s-]*id$/]);
@@ -2121,7 +2185,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
 
   // 6) Import invoice exports (canonical upsert when deterministic keys resolve)
-  if (parsedInvoices.length > 0) {
+  if (runInvoices && parsedInvoices.length > 0) {
     for (let i = 0; i < parsedInvoices.length; i += 1) {
       const row = parsedInvoices[i];
       const sourceInvoiceId = pickSourceId(row, [/^invoice[_\s-]*id$/, /^invoice[_\s-]*number$/, /external invoice id/]);
@@ -2270,7 +2334,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   };
 
   // 7) Post-import linkage pass (safe, idempotent, shop-scoped)
-  if (vehiclesCsv) {
+  if (runLinkagePass && vehiclesCsv) {
     const { rows } = parseCsv(vehiclesCsv);
 
     for (let i = 0; i < rows.length; i += 1) {
@@ -2312,7 +2376,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     }
   }
 
-  if (historyCsv) {
+  if (runLinkagePass && historyCsv) {
     const uniqueVehiclesByVin = new Map<string, string>();
     const uniqueVehiclesByPlate = new Map<string, string>();
     const uniqueVehiclesByUnit = new Map<string, string>();
@@ -2492,12 +2556,16 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
   const integrityErrors: string[] = integrity.integrityErrors;
 
-  const { data: rowBucketRows } = await supabase
+  let rowBucketQuery = supabase
     .from("shop_boost_row_results")
     .select("match_status,review_required,error_reason")
     .eq("shop_id", shopId)
-    .eq("intake_id", intakeId)
-    .limit(100000);
+    .eq("intake_id", intakeId);
+  if (materializeDomain) {
+    const sourceFile = domainSourceFile(materializeDomain);
+    if (sourceFile) rowBucketQuery = rowBucketQuery.eq("source_file", sourceFile);
+  }
+  const { data: rowBucketRows } = await rowBucketQuery.limit(100000);
 
   const outcomeBuckets = {
     materialized: 0,

--- a/features/integrations/shopBoost/orchestrator/executeRun.ts
+++ b/features/integrations/shopBoost/orchestrator/executeRun.ts
@@ -1,5 +1,6 @@
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
-import { runShopBoostImport, type ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
+import { type ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
+import { runShopBoostDomainMaterialize } from "@/features/integrations/shopBoost/orchestrator/materializeHandlers";
 import {
   MATERIALIZE_DOMAINS,
   claimNextRunnableJob,
@@ -15,13 +16,6 @@ import {
   type MaterializeDomain,
 } from "./index";
 
-type DomainJobResult = {
-  domain: MaterializeDomain;
-  completionState: string;
-  rowResults: { success: number; review: number; failed: number };
-  importedCount: number;
-};
-
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
@@ -29,26 +23,6 @@ function asRecord(value: unknown): Record<string, unknown> {
 function asImportSummary(value: unknown): ShopBoostImportSummary | null {
   const rec = asRecord(value);
   return Object.keys(rec).length ? (rec as unknown as ShopBoostImportSummary) : null;
-}
-
-function readDomainResult(summary: ShopBoostImportSummary, domain: MaterializeDomain): DomainJobResult {
-  const byDomain = summary.rowResults.byDomain ?? {};
-  const rowResults = byDomain[domain] ?? { success: 0, review: 0, failed: 0 };
-  const importedCountMap: Record<MaterializeDomain, number> = {
-    customers: Number(summary.customersImported ?? 0),
-    vehicles: Number(summary.vehiclesImported ?? 0),
-    history: Number(summary.workOrdersImported ?? 0),
-    invoices: Number(summary.invoicesImported ?? 0),
-    parts: Number(summary.partsImported ?? 0),
-    staff: Number(summary.canonicalMaterialization.actual.staffSuggestions ?? 0),
-  };
-
-  return {
-    domain,
-    completionState: summary.completionState,
-    rowResults,
-    importedCount: importedCountMap[domain],
-  };
 }
 
 function toRetryableStatus(summary: ShopBoostImportSummary): "succeeded" | "retryable_failed" | "blocked_manual" {
@@ -96,53 +70,17 @@ export async function executeShopBoostRun(args: {
       if (claimed.jobType === "materialize") {
         await markRunRunning(args.runId, "materialize");
         const domain = claimed.domain as MaterializeDomain;
-
-        if (domain === "customers") {
-          latestImportSummary = await runShopBoostImport({
-            shopId: args.shopId,
-            intakeId: args.intakeId,
-            options: { createStaffUsers: false },
-          });
-
-          const domainResult = readDomainResult(latestImportSummary, domain);
-          await markClaimedJobResult({
-            jobId: claimed.id,
-            status: toRetryableStatus(latestImportSummary),
-            result: {
-              mode: "full_import_anchor",
-              ...domainResult,
-              canonicalMaterialization: latestImportSummary.canonicalMaterialization,
-              rowResultsFull: latestImportSummary.rowResults,
-            },
-          });
-        } else {
-          if (!latestImportSummary) {
-            const jobs = await getRunJobs(args.runId);
-            const anchor = jobs.find(
-              (job) => job.job_type === "materialize" && String(job.domain ?? "global") === "customers",
-            );
-            latestImportSummary = asImportSummary(anchor?.result);
-          }
-
-          if (!latestImportSummary) {
-            await markClaimedJobResult({
-              jobId: claimed.id,
-              status: "blocked_manual",
-              errorCode: "MATERIALIZE_ANCHOR_MISSING",
-              errorMessage: "Customers materialize anchor result is required before domain fanout.",
-            });
-          } else {
-            const domainResult = readDomainResult(latestImportSummary, domain);
-            await markClaimedJobResult({
-              jobId: claimed.id,
-              status: toRetryableStatus(latestImportSummary),
-              result: {
-                mode: "derived_from_anchor",
-                ...domainResult,
-              },
-            });
-          }
-        }
+        const materialize = await runShopBoostDomainMaterialize({
+          shopId: args.shopId,
+          intakeId: args.intakeId,
+          domain,
+        });
+        latestImportSummary = materialize.summary;
+        await markClaimedJobResult({
+          jobId: claimed.id,
+          status: toRetryableStatus(materialize.summary),
+          result: materialize.domainResult,
+        });
       }
 
       if (claimed.jobType === "verify") {
@@ -176,6 +114,28 @@ export async function executeShopBoostRun(args: {
           const failedDomains = domainJobs
             .filter((job) => ["retryable_failed", "terminal_failed"].includes(String(job.status)))
             .map((job) => String(job.domain ?? "global"));
+          const domainOutcomes = domainJobs.reduce(
+            (acc: Record<string, { status: string; importedCount: number; rowResults: { success: number; review: number; failed: number } | null }>, job) => {
+              const jobDomain = String(job.domain ?? "global");
+              const result = asRecord(job.result);
+              const rowResultsRecord = asRecord(result.rowResults);
+              const rowResults =
+                Object.keys(rowResultsRecord).length > 0
+                  ? {
+                      success: Number(rowResultsRecord.success ?? 0),
+                      review: Number(rowResultsRecord.review ?? 0),
+                      failed: Number(rowResultsRecord.failed ?? 0),
+                    }
+                  : null;
+              acc[jobDomain] = {
+                status: String(job.status ?? "unknown"),
+                importedCount: Number(result.importedCount ?? 0),
+                rowResults,
+              };
+              return acc;
+            },
+            {},
+          );
 
           const integrityErrors = Array.isArray(latestImportSummary.rowResults.integrityErrors)
             ? latestImportSummary.rowResults.integrityErrors.map((row) => String(row))
@@ -205,6 +165,7 @@ export async function executeShopBoostRun(args: {
                 blocked: blockedDomains,
                 failed: failedDomains,
                 statusCounts: domainStatusCounts,
+                outcomes: domainOutcomes,
               },
               canonicalGaps: latestImportSummary.canonicalMaterialization.gaps,
               completionState: latestImportSummary.completionState,

--- a/features/integrations/shopBoost/orchestrator/materializeHandlers.ts
+++ b/features/integrations/shopBoost/orchestrator/materializeHandlers.ts
@@ -1,0 +1,50 @@
+import { runShopBoostImport, type ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
+import type { MaterializeDomain } from "./index";
+
+export type DomainMaterializeResult = {
+  domain: MaterializeDomain;
+  mode: "domain_handler";
+  completionState: ShopBoostImportSummary["completionState"];
+  rowResults: { success: number; review: number; failed: number };
+  importedCount: number;
+  canonicalMaterialization: ShopBoostImportSummary["canonicalMaterialization"];
+};
+
+function importedCountForDomain(summary: ShopBoostImportSummary, domain: MaterializeDomain): number {
+  if (domain === "customers") return Number(summary.customersImported ?? 0);
+  if (domain === "vehicles") return Number(summary.vehiclesImported ?? 0);
+  if (domain === "history") return Number(summary.workOrdersImported ?? 0);
+  if (domain === "invoices") return Number(summary.invoicesImported ?? 0);
+  if (domain === "parts") return Number(summary.partsImported ?? 0);
+  return Number(summary.canonicalMaterialization.actual.staffSuggestions ?? 0);
+}
+
+export async function runShopBoostDomainMaterialize(args: {
+  shopId: string;
+  intakeId: string;
+  domain: MaterializeDomain;
+}): Promise<{ summary: ShopBoostImportSummary; domainResult: DomainMaterializeResult }> {
+  const summary = await runShopBoostImport({
+    shopId: args.shopId,
+    intakeId: args.intakeId,
+    options: {
+      createStaffUsers: false,
+      materializeDomain: args.domain,
+    },
+  });
+
+  const byDomain = summary.rowResults.byDomain ?? {};
+  const rowResults = byDomain[args.domain] ?? { success: 0, review: 0, failed: 0 };
+
+  return {
+    summary,
+    domainResult: {
+      domain: args.domain,
+      mode: "domain_handler",
+      completionState: summary.completionState,
+      rowResults,
+      importedCount: importedCountForDomain(summary, args.domain),
+      canonicalMaterialization: summary.canonicalMaterialization,
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Move materialize execution from an anchor/fanout model into true per-domain execution seams so each `materialize/<domain>` job runs domain-specific logic and produces domain-meaningful idempotency/results while remaining incremental and non-breaking.
- Preserve existing intake, latest/report fields, worker path, and activation/verify contracts during the transition so UI and routes remain stable.

### Description
- Added `options.materializeDomain` to `runShopBoostImport` and implemented selective domain execution flags, scoped cleanup (`shop_boost_row_results` / `shop_boost_review_items`), and scoped row-bucket evaluation for domain runs in `features/integrations/imports/runFullImport.ts` so the importer can run only one domain safely.
- Introduced `features/integrations/shopBoost/orchestrator/materializeHandlers.ts` exposing `runShopBoostDomainMaterialize({shopId,intakeId,domain})`, which calls `runShopBoostImport(..., { materializeDomain })` and returns a domain-scoped result (imported count, rowResults, completionState, canonicalMaterialization).
- Refactored `executeShopBoostRun` to dispatch each `materialize/<domain>` job to the new domain handler and to persist the handler result as the job `result`; also extended `verify/global` to aggregate per-domain outcomes (status, importedCount, rowResults) into the verify payload (no change to dependency graph or routes).
- Files changed: `features/integrations/imports/runFullImport.ts` (add domain scoping and scoped cleanup), `features/integrations/shopBoost/orchestrator/executeRun.ts` (dispatch to domain handler and include outcomes), and new `features/integrations/shopBoost/orchestrator/materializeHandlers.ts` (domain seam).

### Testing
- Type-check: ran `npx tsc --noEmit`, which completed successfully.
- Code/audit greps: ran `rg --no-ignore -n "runShopBoostDomainMaterialize\(|materializeDomain:"` and verified the new domain seam is wired, and ran the legacy-anchor search `rg --no-ignore -n "mode: \"derived_from_anchor\"|full_import_anchor|MATERIALIZE_ANCHOR_MISSING"` which returned no legacy anchor logic in `executeRun` (checks passed).
- Verify consumption: inspected `executeRun` and confirmed `verify/global` now gathers per-materialize job `result` values into `domains.outcomes` for activation evaluation (static inspection succeeded).
- No DB migrations were applied and no runtime tests were added; all automated static checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7c0c42988328947c2dee1626bc80)