### PR TITLE
Enforce canonical verify gate for Shop Boost activation and routing

### DIFF
--- a/app/api/internal/shop-boost/run/route.ts
+++ b/app/api/internal/shop-boost/run/route.ts
@@ -160,6 +160,7 @@ export async function POST(req: NextRequest) {
     const jobs = await getRunJobs(target.runId);
     const materializeJob = jobs.find((job) => job.job_type === "materialize" && String(job.domain ?? "global") === "customers");
     const verifyJob = jobs.find((job) => job.job_type === "verify" && String(job.domain ?? "global") === "global");
+    const verifyResult = asRecord(verifyJob?.result);
     const latestImportSummary = execution.latestImportSummary ?? asImportSummary(materializeJob?.result);
     const latestActivationEval =
       execution.latestActivationEval ??
@@ -181,6 +182,17 @@ export async function POST(req: NextRequest) {
       Number(jobSummary?.terminal_failed ?? 0) > 0 ||
       Number(jobSummary?.retryable_failed ?? 0) > 0;
 
+    const verifyPassed = verifyResult.verifyPassed === true;
+    const uiShouldRouteForward =
+      verifyPassed && (latestActivationEval.activationStatus === "activated" || latestActivationEval.activationStatus === "eligible");
+    const truthStates = {
+      snapshot_complete: Boolean(verifyJob),
+      import_complete: verifyResult.stateModel && typeof verifyResult.stateModel === "object" ? Boolean(asRecord(verifyResult.stateModel).import_complete) : false,
+      canonical_ready: verifyResult.stateModel && typeof verifyResult.stateModel === "object" ? Boolean(asRecord(verifyResult.stateModel).canonical_ready) : false,
+      activation_eligible: verifyResult.stateModel && typeof verifyResult.stateModel === "object" ? Boolean(asRecord(verifyResult.stateModel).activation_eligible) : false,
+      activated: latestActivationEval.activationStatus === "activated",
+    };
+
     const status = hasPending ? "processing" : hasErrors ? "completed_with_errors" : "completed";
     const progressPercent = hasPending ? 65 : 100;
     await updateIntakeProgress({
@@ -198,12 +210,22 @@ export async function POST(req: NextRequest) {
           activation_status: latestActivationEval.activationStatus,
           activation_blockers: latestActivationEval.blockers,
           activation_snapshot: latestActivationEval.snapshot,
+          verify_result: verifyResult,
+          verify_status: String(verifyResult.verifyStatus ?? "partial"),
+          verify_passed: verifyPassed,
+          truth_states: truthStates,
+          ui_should_route_forward: uiShouldRouteForward,
           job_summary: jobSummary,
           job_summary_detailed: jobSummaryDetailed,
           last_attempt: lastAttempt,
           runState: status,
           activationStatus: latestActivationEval.activationStatus,
           blockers: latestActivationEval.blockers,
+          verifyResult,
+          verifyStatus: String(verifyResult.verifyStatus ?? "partial"),
+          verifyPassed,
+          truthStates,
+          uiShouldRouteForward,
           jobSummary,
           jobSummaryDetailed,
           lastAttempt,

--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -6,6 +6,7 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import {
   getLatestRunAttemptSummary,
   getRunByShopIntake,
+  getRunJobs,
   summarizeRunJobs,
   summarizeRunJobsDetailed,
 } from "@/features/integrations/shopBoost/orchestrator";
@@ -167,14 +168,40 @@ export async function GET(req: Request, context: RouteContext) {
   try {
     const run = await getRunByShopIntake({ shopId: profile.shop_id, intakeId: intake.id });
     if (run?.id) {
+      const jobs = await getRunJobs(run.id);
+      const verifyJob = jobs.find((job) => job.job_type === "verify" && String(job.domain ?? "global") === "global");
+      const activateJob = jobs.find((job) => job.job_type === "activate" && String(job.domain ?? "global") === "global");
+      const verifyResult = asRecord(verifyJob?.result);
+      const domains = asRecord(verifyResult.domains);
+      const canonicalSummary = asRecord(verifyResult.canonicalSummary);
+      const stateModel = asRecord(verifyResult.stateModel);
+      const verifyStatus = String(verifyResult.verifyStatus ?? "partial");
+      const verifyPassed = verifyResult.verifyPassed === true;
+      const activationEligible = run.activation_status === "eligible" || run.activation_status === "activated";
+      const activated = run.activation_status === "activated";
+      const uiShouldRouteForward = verifyPassed && activationEligible;
       const jobSummary = await summarizeRunJobs(run.id);
       const jobSummaryDetailed = await summarizeRunJobsDetailed(run.id);
       const lastAttempt = await getLatestRunAttemptSummary(run.id);
       orchestrator = {
         runId: run.id,
         runState: run.state,
+        verifyStatus,
+        verifyPassed,
         activationStatus: run.activation_status,
         blockers: run.activation_blockers ?? [],
+        canonicalSummary,
+        domainPassCount: Number(domains.passCount ?? 0),
+        domainFailCount: Number(domains.failCount ?? 0),
+        domainPendingCount: Number(domains.pendingCount ?? 0),
+        truthStates: {
+          snapshot_complete: Boolean(verifyJob),
+          import_complete: Boolean(stateModel.import_complete),
+          canonical_ready: Boolean(stateModel.canonical_ready),
+          activation_eligible: activationEligible,
+          activated,
+        },
+        uiShouldRouteForward,
         jobSummary,
         jobSummaryDetailed,
         lastAttempt,
@@ -183,6 +210,22 @@ export async function GET(req: Request, context: RouteContext) {
         activation_status: run.activation_status,
         activation_blockers: run.activation_blockers ?? [],
         activation_snapshot: asRecord(run.activation_snapshot),
+        verify_result: verifyResult,
+        verify_status: verifyStatus,
+        verify_passed: verifyPassed,
+        canonical_summary: canonicalSummary,
+        domain_pass_count: Number(domains.passCount ?? 0),
+        domain_fail_count: Number(domains.failCount ?? 0),
+        domain_pending_count: Number(domains.pendingCount ?? 0),
+        truth_states: {
+          snapshot_complete: Boolean(verifyJob),
+          import_complete: Boolean(stateModel.import_complete),
+          canonical_ready: Boolean(stateModel.canonical_ready),
+          activation_eligible: activationEligible,
+          activated,
+        },
+        ui_should_route_forward: uiShouldRouteForward,
+        activate_job_status: activateJob?.status ?? null,
         jobs: jobSummary,
         jobsDetailed: jobSummaryDetailed,
         last_error:
@@ -245,6 +288,14 @@ export async function GET(req: Request, context: RouteContext) {
     },
     review_outcomes: reviewOutcomes,
     orchestrator,
+    readiness: {
+      snapshot_complete: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).snapshot_complete : false),
+      import_complete: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).import_complete : false),
+      canonical_ready: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).canonical_ready : false),
+      activation_eligible: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).activation_eligible : false),
+      activated: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).activated : false),
+      ui_should_route_forward: Boolean(asRecord(orchestrator ?? {}).uiShouldRouteForward ?? asRecord(orchestrator ?? {}).ui_should_route_forward ?? false),
+    },
   };
 
   const url = new URL(req.url);

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -7,6 +7,7 @@ import { toIntakeProgress } from "@/features/integrations/shopBoost/status";
 import {
   getLatestRunAttemptSummary,
   getRunByShopIntake,
+  getRunJobs,
   summarizeRunJobs,
   summarizeRunJobsDetailed,
 } from "@/features/integrations/shopBoost/orchestrator";
@@ -67,19 +68,61 @@ export async function GET() {
     });
 
     if (run?.id) {
+      const jobs = await getRunJobs(run.id);
+      const verifyJob = jobs.find((job) => job.job_type === "verify" && String(job.domain ?? "global") === "global");
+      const activateJob = jobs.find((job) => job.job_type === "activate" && String(job.domain ?? "global") === "global");
+      const verifyResult = asRecord(verifyJob?.result);
+      const domains = asRecord(verifyResult.domains);
+      const canonicalSummary = asRecord(verifyResult.canonicalSummary);
+      const stateModel = asRecord(verifyResult.stateModel);
+      const verifyStatus = String(verifyResult.verifyStatus ?? "partial");
+      const verifyPassed = verifyResult.verifyPassed === true;
+      const activationEligible = run.activation_status === "eligible" || run.activation_status === "activated";
+      const activated = run.activation_status === "activated";
+      const uiShouldRouteForward = verifyPassed && activationEligible;
       const jobSummary = await summarizeRunJobs(run.id);
       const jobSummaryDetailed = await summarizeRunJobsDetailed(run.id);
       const lastAttempt = await getLatestRunAttemptSummary(run.id);
       orchestrator = {
         runId: run.id,
         runState: run.state,
+        verifyStatus,
+        verifyPassed,
         activationStatus: run.activation_status,
         blockers: run.activation_blockers ?? [],
+        canonicalSummary,
+        domainPassCount: Number(domains.passCount ?? 0),
+        domainFailCount: Number(domains.failCount ?? 0),
+        domainPendingCount: Number(domains.pendingCount ?? 0),
+        truthStates: {
+          snapshot_complete: Boolean(verifyJob),
+          import_complete: Boolean(stateModel.import_complete),
+          canonical_ready: Boolean(stateModel.canonical_ready),
+          activation_eligible: activationEligible,
+          activated,
+        },
+        uiShouldRouteForward,
         jobSummary,
         jobSummaryDetailed,
         lastAttempt,
         state: run.state,
         activationBlockers: run.activation_blockers ?? [],
+        verify_result: verifyResult,
+        verify_status: verifyStatus,
+        verify_passed: verifyPassed,
+        canonical_summary: canonicalSummary,
+        domain_pass_count: Number(domains.passCount ?? 0),
+        domain_fail_count: Number(domains.failCount ?? 0),
+        domain_pending_count: Number(domains.pendingCount ?? 0),
+        truth_states: {
+          snapshot_complete: Boolean(verifyJob),
+          import_complete: Boolean(stateModel.import_complete),
+          canonical_ready: Boolean(stateModel.canonical_ready),
+          activation_eligible: activationEligible,
+          activated,
+        },
+        ui_should_route_forward: uiShouldRouteForward,
+        activate_job_status: activateJob?.status ?? null,
         jobs: jobSummary,
         jobsDetailed: jobSummaryDetailed,
         lastError:
@@ -104,7 +147,15 @@ export async function GET() {
       runId: basicsOrchestrator.run_id ?? null,
       runState: basicsOrchestrator.state ?? null,
       activationStatus: basicsOrchestrator.activation_status ?? null,
+      verifyStatus: basicsOrchestrator.verify_status ?? null,
+      verifyPassed: basicsOrchestrator.verify_passed ?? null,
       blockers: basicsOrchestrator.activation_blockers ?? [],
+      canonicalSummary: basicsOrchestrator.canonical_summary ?? null,
+      domainPassCount: basicsOrchestrator.domain_pass_count ?? null,
+      domainFailCount: basicsOrchestrator.domain_fail_count ?? null,
+      domainPendingCount: basicsOrchestrator.domain_pending_count ?? null,
+      truthStates: basicsOrchestrator.truth_states ?? null,
+      uiShouldRouteForward: basicsOrchestrator.ui_should_route_forward ?? null,
       jobSummary: basicsOrchestrator.job_summary ?? null,
       lastAttempt: basicsOrchestrator.last_attempt ?? null,
       state: basicsOrchestrator.state ?? null,
@@ -113,6 +164,9 @@ export async function GET() {
       lastError: basicsOrchestrator.last_error ?? null,
     };
   }
+
+  const orchestratorRecord = asRecord(orchestrator);
+  const truthStates = asRecord(orchestratorRecord.truthStates ?? orchestratorRecord.truth_states);
 
   return NextResponse.json({
     ok: true,
@@ -123,6 +177,23 @@ export async function GET() {
       processedAt: intake.processed_at,
       progress: toIntakeProgress(intake as never),
       orchestrator,
+      readiness: orchestrator
+        ? {
+            snapshot_complete: Boolean(truthStates.snapshot_complete),
+            import_complete: Boolean(truthStates.import_complete),
+            canonical_ready: Boolean(truthStates.canonical_ready),
+            activation_eligible: Boolean(truthStates.activation_eligible),
+            activated: Boolean(truthStates.activated),
+            verify_status: orchestratorRecord.verifyStatus ?? orchestratorRecord.verify_status ?? null,
+            verify_passed: orchestratorRecord.verifyPassed ?? orchestratorRecord.verify_passed ?? null,
+            blockers: orchestratorRecord.blockers ?? orchestratorRecord.activation_blockers ?? [],
+            domain_pass_count: orchestratorRecord.domainPassCount ?? orchestratorRecord.domain_pass_count ?? 0,
+            domain_fail_count: orchestratorRecord.domainFailCount ?? orchestratorRecord.domain_fail_count ?? 0,
+            domain_pending_count: orchestratorRecord.domainPendingCount ?? orchestratorRecord.domain_pending_count ?? 0,
+            canonical_summary: orchestratorRecord.canonicalSummary ?? orchestratorRecord.canonical_summary ?? null,
+            ui_should_route_forward: orchestratorRecord.uiShouldRouteForward ?? orchestratorRecord.ui_should_route_forward ?? false,
+          }
+        : null,
     },
   });
 }

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -245,6 +245,7 @@ export default function ShopBoostOnboardingPage() {
         setError(json.error || "Failed to queue Shop Boost migration.");
         return;
       }
+      const resolvedIntakeId = json.intakeId;
 
       try {
         await fetch("/api/shop-boost/intakes/process", {
@@ -256,11 +257,40 @@ export default function ShopBoostOnboardingPage() {
         // best-effort kickoff; cron/owner retry will continue
       }
 
+      const resolveNextRoute = async (): Promise<string> => {
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+          try {
+            const latestRes = await fetch("/api/shop-boost/intakes/latest", { cache: "no-store" });
+            const latestJson = (await latestRes.json().catch(() => null)) as
+              | {
+                  ok?: boolean;
+                  intake?: {
+                    id?: string;
+                    status?: string;
+                    readiness?: { ui_should_route_forward?: boolean; blockers?: unknown[]; verify_status?: string | null } | null;
+                  } | null;
+                }
+              | null;
+            const readiness = latestJson?.intake?.readiness;
+            const matchesIntake = latestJson?.intake?.id === resolvedIntakeId;
+            if (matchesIntake && readiness?.ui_should_route_forward) {
+              return "/dashboard?setup=shop-boost";
+            }
+            const settled = matchesIntake && latestJson?.intake?.status !== "processing";
+            if (settled) break;
+          } catch {
+            // keep polling
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1200));
+        }
+        return `/dashboard/setup/review?source=shop-boost&intakeId=${encodeURIComponent(resolvedIntakeId)}`;
+      };
+
       if (typeof window !== "undefined") {
         window.localStorage.removeItem(UPLOAD_SESSION_STORAGE_KEY);
       }
 
-      router.replace("/dashboard?setup=shop-boost");
+      router.replace(await resolveNextRoute());
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unexpected error during upload.";
       setError(message);

--- a/features/dashboard/components/ShopBoostActivationPanel.tsx
+++ b/features/dashboard/components/ShopBoostActivationPanel.tsx
@@ -48,6 +48,16 @@ type IntakeState = {
     integrity?: Record<string, unknown>;
     migration_story?: MigrationStory;
   } | null;
+  readiness?: {
+    snapshot_complete?: boolean;
+    import_complete?: boolean;
+    canonical_ready?: boolean;
+    activation_eligible?: boolean;
+    activated?: boolean;
+    verify_status?: string | null;
+    blockers?: unknown[];
+    ui_should_route_forward?: boolean;
+  } | null;
 };
 
 const ACTIVE_STATUSES = new Set(["queued", "pending", "processing"]);
@@ -81,6 +91,7 @@ function getPanelMode(intake: IntakeState | null): "hidden" | "full" | "summary"
   const trustStatus = intake.progress?.migration_story?.trust_status;
   if (trustStatus && trustStatus !== "READY" && isRecentlyProcessed(intake)) return "full";
   const isCompletedLike =
+    intake.readiness?.ui_should_route_forward === true ||
     completionState === "READY_FOR_GO_LIVE" ||
     completionState === "COMPLETED_CLEAN" ||
     completionState === "COMPLETED_WITH_REVIEW" ||
@@ -222,7 +233,9 @@ export default function ShopBoostActivationPanel({ eligible = false }: { eligibl
         </div>
       ) : null}
 
-      {(intake.progress?.completionState === "READY_FOR_GO_LIVE" || story?.trust_status === "READY") ? (
+      {(intake.readiness?.ui_should_route_forward === true ||
+        intake.progress?.completionState === "READY_FOR_GO_LIVE" ||
+        story?.trust_status === "READY") ? (
         <div className="mt-3 rounded-md border border-emerald-300/30 bg-emerald-950/20 p-2 text-xs text-emerald-100">
           <div className="font-semibold">Go live complete</div>
           <div className="mt-1">Confidence score: {fallbackConfidence}% • What you reviewed: {story?.review_resolved_count ?? 0} • What was ignored: {story?.ignored_count ?? 0}</div>

--- a/features/integrations/shopBoost/orchestrator/executeRun.ts
+++ b/features/integrations/shopBoost/orchestrator/executeRun.ts
@@ -31,6 +31,20 @@ function toRetryableStatus(summary: ShopBoostImportSummary): "succeeded" | "retr
   return "succeeded";
 }
 
+type VerifyOutcomeStatus = "passed" | "failed" | "partial";
+
+function toVerifyOutcomeStatus(params: {
+  domainJobsTotal: number;
+  domainFailed: number;
+  domainPending: number;
+  activationStatus: ActivationEvaluationResult["activationStatus"];
+}): VerifyOutcomeStatus {
+  if (params.domainJobsTotal === 0 || params.domainPending > 0) return "partial";
+  if (params.domainFailed > 0) return "failed";
+  if (params.activationStatus === "blocked" || params.activationStatus === "not_eligible") return "failed";
+  return "passed";
+}
+
 export async function executeShopBoostRun(args: {
   runId: string;
   shopId: string;
@@ -114,6 +128,9 @@ export async function executeShopBoostRun(args: {
           const failedDomains = domainJobs
             .filter((job) => ["retryable_failed", "terminal_failed"].includes(String(job.status)))
             .map((job) => String(job.domain ?? "global"));
+          const pendingDomains = domainJobs
+            .filter((job) => ["queued", "running", "retryable_failed"].includes(String(job.status)))
+            .map((job) => String(job.domain ?? "global"));
           const domainOutcomes = domainJobs.reduce(
             (acc: Record<string, { status: string; importedCount: number; rowResults: { success: number; review: number; failed: number } | null }>, job) => {
               const jobDomain = String(job.domain ?? "global");
@@ -153,19 +170,76 @@ export async function executeShopBoostRun(args: {
             vehiclesImported: latestImportSummary.vehiclesImported,
           });
 
+          const verifyStatus = toVerifyOutcomeStatus({
+            domainJobsTotal: domainJobs.length,
+            domainFailed: blockedDomains.length + failedDomains.length,
+            domainPending: pendingDomains.length,
+            activationStatus: latestActivationEval.activationStatus,
+          });
+          const activationEligible =
+            latestActivationEval.activationStatus === "eligible" || latestActivationEval.activationStatus === "activated";
+          const activated = latestActivationEval.activationStatus === "activated";
+          const verifyBlockers = [
+            ...latestActivationEval.blockers,
+            ...blockedDomains.map((domain) => `Materialize domain ${domain} is blocked.`),
+            ...failedDomains.map((domain) => `Materialize domain ${domain} failed.`),
+            ...pendingDomains.map((domain) => `Materialize domain ${domain} still pending.`),
+          ];
+          const recommendedNextAction =
+            verifyStatus === "passed"
+              ? activated
+                ? "dashboard"
+                : "activate/global"
+              : verifyStatus === "partial"
+                ? "wait_for_materialize"
+                : "review_queue";
+
           await markClaimedJobResult({
             jobId: claimed.id,
             status: "succeeded",
             result: {
+              verifyStatus,
+              verifyPassed: verifyStatus === "passed",
+              nextAction: recommendedNextAction,
               blockers: latestActivationEval.blockers,
               activationStatus: latestActivationEval.activationStatus,
               snapshot: latestActivationEval.snapshot,
+              stateModel: {
+                snapshot_complete: true,
+                import_complete: pendingDomains.length === 0 && blockedDomains.length === 0 && failedDomains.length === 0,
+                canonical_ready: latestImportSummary.canonicalMaterialization.status === "ok",
+                activation_eligible: activationEligible,
+                activated,
+              },
               domains: {
                 required: MATERIALIZE_DOMAINS,
                 blocked: blockedDomains,
                 failed: failedDomains,
+                pending: pendingDomains,
                 statusCounts: domainStatusCounts,
                 outcomes: domainOutcomes,
+                passCount: domainJobs.filter((job) => String(job.status) === "succeeded").length,
+                failCount: blockedDomains.length + failedDomains.length,
+                pendingCount: pendingDomains.length,
+              },
+              canonicalSummary: latestImportSummary.canonicalMaterialization,
+              review: {
+                totalRows: Number(latestImportSummary.rowResults.totalRows ?? 0),
+                pendingReviewCount: Number(latestImportSummary.rowResults.reviewCount ?? 0),
+                pendingReviewRatio:
+                  Number(latestImportSummary.rowResults.totalRows ?? 0) > 0
+                    ? Number(latestImportSummary.rowResults.reviewCount ?? 0) /
+                      Number(latestImportSummary.rowResults.totalRows ?? 0)
+                    : 0,
+              },
+              integrity: {
+                integrityErrorCount: integrityErrors.length,
+                integrityErrors,
+              },
+              activationPolicy: {
+                eligible: activationEligible,
+                blockers: verifyBlockers,
+                activationStatus: latestActivationEval.activationStatus,
               },
               canonicalGaps: latestImportSummary.canonicalMaterialization.gaps,
               completionState: latestImportSummary.completionState,
@@ -176,11 +250,12 @@ export async function executeShopBoostRun(args: {
 
       if (claimed.jobType === "activate") {
         await markRunRunning(args.runId, "activate");
+        const jobs = await getRunJobs(args.runId);
+        const verify = jobs.find((job) => job.job_type === "verify" && String(job.domain ?? "global") === "global");
+        const verifyResult = asRecord(verify?.result);
+        const verifyPassed = verifyResult.verifyPassed === true;
 
         if (!latestActivationEval) {
-          const jobs = await getRunJobs(args.runId);
-          const verify = jobs.find((job) => job.job_type === "verify" && String(job.domain ?? "global") === "global");
-          const verifyResult = asRecord(verify?.result);
           const verifyStatus = String(verifyResult.activationStatus ?? verifyResult.activation_status ?? "blocked");
           latestActivationEval = {
             activationStatus: (verifyStatus as ActivationEvaluationResult["activationStatus"]) ?? "blocked",
@@ -192,14 +267,17 @@ export async function executeShopBoostRun(args: {
         await markClaimedJobResult({
           jobId: claimed.id,
           status:
-            latestActivationEval.activationStatus === "blocked" || latestActivationEval.activationStatus === "not_eligible"
+            latestActivationEval.activationStatus === "blocked" ||
+            latestActivationEval.activationStatus === "not_eligible" ||
+            !verifyPassed
               ? "blocked_manual"
               : "succeeded",
           result: {
             activationStatus: latestActivationEval.activationStatus,
-            blockers: latestActivationEval.blockers,
+            blockers: verifyPassed ? latestActivationEval.blockers : ["verify/global did not pass.", ...latestActivationEval.blockers],
             snapshot: latestActivationEval.snapshot,
             source: "verify/global",
+            verifyPassed,
           },
         });
       }

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -59,6 +59,16 @@ type CanonicalImportStats = {
 type Props = {
   shopId: string | null;
 };
+type LatestReadiness = {
+  snapshot_complete: boolean;
+  import_complete: boolean;
+  canonical_ready: boolean;
+  activation_eligible: boolean;
+  activated: boolean;
+  verify_status?: string | null;
+  blockers?: unknown[];
+  ui_should_route_forward?: boolean;
+};
 
 const cardBase =
   "rounded-2xl border border-white/10 bg-black/35 shadow-[0_18px_45px_rgba(0,0,0,0.85)] backdrop-blur";
@@ -120,6 +130,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
   const [overview, setOverview] = useState<ShopBoostOverviewRow | null>(null);
   const [suggestions, setSuggestions] = useState<ShopBoostSuggestionRow[]>([]);
   const [canonicalStats, setCanonicalStats] = useState<CanonicalImportStats | null>(null);
+  const [latestReadiness, setLatestReadiness] = useState<LatestReadiness | null>(null);
 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -210,6 +221,13 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
       setSuggestions(mergedSuggestions);
 
       if (intakeId) {
+        try {
+          const latestRes = await fetch("/api/shop-boost/intakes/latest", { cache: "no-store" });
+          const latestJson = (await latestRes.json().catch(() => null)) as { intake?: { readiness?: LatestReadiness | null } } | null;
+          setLatestReadiness(latestJson?.intake?.readiness ?? null);
+        } catch {
+          setLatestReadiness(null);
+        }
         const canonicalCounts = await Promise.all([
           supabase.from("customers").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
           supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
@@ -226,6 +244,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
         });
       } else {
         setCanonicalStats(null);
+        setLatestReadiness(null);
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to load Shop Health.";
@@ -234,6 +253,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
       setOverview(null);
       setSuggestions([]);
       setCanonicalStats(null);
+      setLatestReadiness(null);
     } finally {
       setLoading(false);
     }
@@ -529,6 +549,23 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
                   (canonicalStats.vehicles === 0 || canonicalStats.workOrders === 0)) ? (
                   <div className="mt-2 text-[11px] text-amber-200">
                     Staged snapshot data can look healthy while canonical graph materialization is still incomplete.
+                  </div>
+                ) : null}
+                {latestReadiness ? (
+                  <div className="mt-3 rounded-md border border-white/10 bg-black/30 p-2 text-[11px] text-neutral-200">
+                    <div className="font-medium text-neutral-100">Activation truth states</div>
+                    <div className="mt-1 grid gap-1 md:grid-cols-5">
+                      <div>Snapshot: <span className={latestReadiness.snapshot_complete ? "text-emerald-200" : "text-amber-200"}>{latestReadiness.snapshot_complete ? "complete" : "pending"}</span></div>
+                      <div>Import: <span className={latestReadiness.import_complete ? "text-emerald-200" : "text-amber-200"}>{latestReadiness.import_complete ? "complete" : "pending"}</span></div>
+                      <div>Canonical: <span className={latestReadiness.canonical_ready ? "text-emerald-200" : "text-amber-200"}>{latestReadiness.canonical_ready ? "ready" : "not ready"}</span></div>
+                      <div>Eligible: <span className={latestReadiness.activation_eligible ? "text-emerald-200" : "text-amber-200"}>{latestReadiness.activation_eligible ? "yes" : "no"}</span></div>
+                      <div>Activated: <span className={latestReadiness.activated ? "text-emerald-200" : "text-amber-200"}>{latestReadiness.activated ? "yes" : "no"}</span></div>
+                    </div>
+                    {!latestReadiness.ui_should_route_forward ? (
+                      <div className="mt-1 text-amber-200">
+                        Routing remains in review flow until verify/global passes activation policy.
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
### Motivation
- Make `verify/global` the authoritative gate for Shop Boost activation so UI and routing only advance when canonical materialization and activation policy truly pass.
- Prevent optimistic/false-positive "completed/activated" states that previously allowed onboarding to route to dashboard before canonical readiness.
- Surface a clear, additive truth model (snapshot/import/canonical/activation) to downstream APIs and UI without breaking legacy payloads.
- Keep changes incremental, non-breaking, and preserve worker execution and telemetry.

### Description
- Hardened verify evaluation and emitted payloads in the orchestrator so `verify` now returns a structured result including `verifyStatus`, `verifyPassed`, `stateModel` (snapshot_complete/import_complete/canonical_ready/activation_eligible/activated), per-domain pass/fail/pending counts, `canonicalSummary`, integrity/review metrics, blockers, and a recommended next action; implemented in `features/integrations/shopBoost/orchestrator/executeRun.ts`.
- Block `activate/global` from succeeding unless `verifyPassed === true`, and propagate explicit blockers when activation is prevented; implemented in `features/integrations/shopBoost/orchestrator/executeRun.ts`.
- Persist additive orchestrator truth fields (`verify_result`, `verify_status`, `verify_passed`, `truth_states`, `ui_should_route_forward`, etc.) into intake progress in the internal worker route so `/intakes/latest` reflects canonical outcomes; implemented in `app/api/internal/shop-boost/run/route.ts`.
- Enrich `/api/shop-boost/intakes/latest` to return the new readiness object and enriched orchestrator view (verify/activation/canonical/domain counts/ui routing signal) while preserving legacy fields; implemented in `app/api/shop-boost/intakes/latest/route.ts`.
- Enrich `/api/shop-boost/intakes/[id]/report` with the same additive readiness/truth model and expose `readiness` in JSON reports; implemented in `app/api/shop-boost/intakes/[id]/report/route.ts`.
- Change onboarding completion routing so Shop Boost waits (polls `/intakes/latest`) and only redirects to the dashboard when `ui_should_route_forward` is true; otherwise it routes to the setup review/status flow; implemented in `app/onboarding/shop-boost/page.tsx`.
- Update Shop Health UI and Shop Boost activation panel to clearly show and consume the five truth states and the routing signal so the UI distinguishes snapshot vs import vs canonical vs activation eligibility vs activated; implemented in `features/owner/reports/ReportsShopHealthPanel.tsx` and `features/dashboard/components/ShopBoostActivationPanel.tsx`.
- Files changed (additive fields only): `features/integrations/shopBoost/orchestrator/executeRun.ts`, `app/api/internal/shop-boost/run/route.ts`, `app/api/shop-boost/intakes/latest/route.ts`, `app/api/shop-boost/intakes/[id]/report/route.ts`, `app/onboarding/shop-boost/page.tsx`, `features/owner/reports/ReportsShopHealthPanel.tsx`, and `features/dashboard/components/ShopBoostActivationPanel.tsx`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully with no new type errors.
- Sanity/audit greps executed to verify integration points and new fields: ran targeted `git grep`/`rg` checks for `verify/global`, `activate/global`, `verifyStatus`, `verify_passed`, `ui_should_route_forward`, and related job_type patterns and they returned the updated call sites and payload locations as expected.
- Verified runtime wiring by checking updated orchestrator and internal-run JSON assembly points so `verify` outputs are persisted into intake progress and surfaced to `intakes/latest` and `intakes/[id]/report` (no DB schema changes were made, all additions are additive to existing intake/orchestrator payloads).
- Notes: changes are additive and preserve legacy compatibility fields; no automated integration tests were added in this pass, and UI behavior relies on the new `readiness` fields being available from the runtime orchestrator in the environment where workers run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7f7299f483289c449027fb909112)