### PR TITLE
Fix Shop Boost runtime blockers: cron parsing, readiness polling, intake-scoped suggestions, UX & tenant scoping

### DIFF
--- a/app/dashboard/setup/review/page.tsx
+++ b/app/dashboard/setup/review/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 
 type Recommendation = {
   recommendedAction: "link_existing" | "create_new" | "merge_candidate" | "ignore";
@@ -71,6 +72,7 @@ function toResolutionAction(action: Recommendation["recommendedAction"]): "linke
 }
 
 export default function ShopBoostReviewPage() {
+  const router = useRouter();
   const [domain, setDomain] = useState("");
   const [items, setItems] = useState<ReviewItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -99,6 +101,47 @@ export default function ShopBoostReviewPage() {
   useEffect(() => {
     void load();
   }, [load]);
+
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | null = null;
+    let delayMs = 5000;
+
+    const pollReadiness = async () => {
+      try {
+        const res = await fetch("/api/shop-boost/intakes/latest", { cache: "no-store" });
+        const json = (await res.json().catch(() => null)) as
+          | {
+              ok?: boolean;
+              intake?: { readiness?: { ui_should_route_forward?: boolean } | null } | null;
+            }
+          | null;
+
+        if (!cancelled && json?.ok && json.intake?.readiness?.ui_should_route_forward === true) {
+          router.replace("/dashboard?setup=shop-boost");
+          return;
+        }
+      } catch {
+        delayMs = Math.min(delayMs + 2000, 15000);
+      }
+
+      if (!cancelled) {
+        timer = window.setTimeout(() => {
+          void pollReadiness();
+        }, delayMs);
+      }
+    };
+
+    timer = window.setTimeout(() => {
+      void pollReadiness();
+    }, delayMs);
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [router]);
 
   const grouped = useMemo(
     () =>
@@ -224,6 +267,7 @@ export default function ShopBoostReviewPage() {
       <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
         <h1 className="text-xl font-semibold text-white">Shop Boost Guided Review</h1>
         <p className="mt-1 text-sm text-neutral-300">Resolve migration issues in guided steps with transparent reasoning and confidence-backed actions.</p>
+        <p className="mt-1 text-xs text-amber-200">This page keeps checking readiness in the background and will auto-continue once activation truth flips ready.</p>
         <div className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-300">
           {Object.entries(grouped).map(([key, count]) => (
             <span key={key} className="rounded-full border border-white/15 px-2 py-1">{key}: {count}</span>

--- a/app/mobile/customers/[id]/page.tsx
+++ b/app/mobile/customers/[id]/page.tsx
@@ -110,10 +110,12 @@ export default function MobileCustomerProfilePage() {
         let fallbackWosByName: WorkOrder[] = [];
         if ((woRes.data?.length ?? 0) === 0 && (fallbackWosRes.data?.length ?? 0) === 0) {
           for (const candidate of fallbackWosByNameCandidates) {
-            const byNameRes = await supabase
+            let byNameQuery = supabase
               .from("work_orders")
               .select("*")
-              .ilike("customer_name", candidate)
+              .ilike("customer_name", candidate);
+            if (customerRecord?.shop_id) byNameQuery = byNameQuery.eq("shop_id", customerRecord.shop_id);
+            const byNameRes = await byNameQuery
               .order("created_at", { ascending: false })
               .limit(25);
             if (byNameRes.error) throw byNameRes.error;

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -347,7 +347,7 @@ export default function CustomerProfilePage(): JSX.Element {
         const { data: cust, error: custErr } = await supabase
           .from("customers")
           .select(
-            "id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, address, city, province, postal_code",
+            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, address, city, province, postal_code",
           )
           .eq("id", customerId)
           .maybeSingle();
@@ -406,10 +406,12 @@ export default function CustomerProfilePage(): JSX.Element {
         let fallbackWosByName: WorkOrder[] = [];
         if ((directWos?.length ?? 0) === 0 && (fallbackWosByVehicle.data?.length ?? 0) === 0) {
           for (const candidate of fallbackWosByNameCandidates) {
-            const byNameRes = await supabase
+            let byNameQuery = supabase
               .from("work_orders")
               .select("*")
-              .ilike("customer_name", candidate)
+              .ilike("customer_name", candidate);
+            if (cust.shop_id) byNameQuery = byNameQuery.eq("shop_id", cust.shop_id);
+            const byNameRes = await byNameQuery
               .order("created_at", { ascending: false })
               .limit(25);
             if (byNameRes.error) throw byNameRes.error;

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -68,6 +68,7 @@ type LatestReadiness = {
   verify_status?: string | null;
   blockers?: unknown[];
   ui_should_route_forward?: boolean;
+  canonical_summary?: Record<string, unknown> | null;
 };
 
 const cardBase =
@@ -111,6 +112,15 @@ function hasOk(v: unknown): v is { ok: true } {
   return isRecord(v) && v.ok === true;
 }
 
+function readSummaryCount(summary: Record<string, unknown> | null | undefined, keys: string[]): number {
+  if (!summary) return 0;
+  for (const key of keys) {
+    const value = summary[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return 0;
+}
+
 function isShopBoostRunResp(v: unknown): v is ShopBoostRunResp {
   if (!isRecord(v)) return false;
   if (typeof v.ok !== "boolean") return false;
@@ -145,7 +155,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
     setErr(null);
 
     try {
-      const [latestRes, overviewRes, suggRes] = await Promise.all([
+      const [latestRes, overviewRes] = await Promise.all([
         supabase.from("v_shop_health_latest").select("*").eq("shop_id", shopId).maybeSingle(),
         supabase
           .from("v_shop_boost_overview")
@@ -154,26 +164,54 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
           .order("intake_created_at", { ascending: false })
           .limit(1)
           .maybeSingle(),
-        supabase
-          .from("v_shop_boost_suggestions")
-          .select("*")
-          .eq("shop_id", shopId)
-          .order("created_at", { ascending: false })
-          .limit(60),
       ]);
 
       if (latestRes.error) throw latestRes.error;
       if (overviewRes.error) throw overviewRes.error;
-      if (suggRes.error) throw suggRes.error;
 
       setLatest((latestRes.data as ShopHealthLatestRow | null) ?? null);
       const latestOverview = (overviewRes.data as ShopBoostOverviewRow | null) ?? null;
       setOverview(latestOverview);
 
       const intakeId = latestOverview?.intake_id ?? null;
-      const viewSuggestions = (suggRes.data as ShopBoostSuggestionRow[]) ?? [];
+      const activeSuggestionQuery = supabase
+        .from("v_shop_boost_suggestions")
+        .select("*")
+        .eq("shop_id", shopId)
+        .order("created_at", { ascending: false })
+        .limit(60);
 
-      const staffRes = intakeId
+      const suggestionRes = intakeId
+        ? await activeSuggestionQuery.eq("intake_id", intakeId)
+        : await activeSuggestionQuery;
+
+      if (suggestionRes.error) throw suggestionRes.error;
+
+      const fallbackSuggestionRes = intakeId && ((suggestionRes.data?.length ?? 0) === 0)
+        ? await supabase
+            .from("v_shop_boost_suggestions")
+            .select("*")
+            .eq("shop_id", shopId)
+            .order("created_at", { ascending: false })
+            .limit(60)
+        : null;
+
+      if (fallbackSuggestionRes?.error) throw fallbackSuggestionRes.error;
+
+      const viewSuggestions =
+        ((suggestionRes.data?.length ?? 0) > 0
+          ? suggestionRes.data
+          : fallbackSuggestionRes?.data) as ShopBoostSuggestionRow[] | null ?? [];
+
+      const staffBaseQuery = supabase
+        .from("staff_invite_suggestions")
+        .select("id,intake_id,shop_id,full_name,role,notes,confidence,created_at")
+        .eq("shop_id", shopId)
+        .order("created_at", { ascending: false })
+        .limit(160);
+
+      const staffRes = intakeId ? await staffBaseQuery.eq("intake_id", intakeId) : await staffBaseQuery;
+      const fallbackStaffRes = intakeId && ((staffRes.data?.length ?? 0) === 0)
         ? await supabase
             .from("staff_invite_suggestions")
             .select("id,intake_id,shop_id,full_name,role,notes,confidence,created_at")
@@ -182,7 +220,10 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
             .limit(160)
         : null;
 
-      const staffRows = staffRes?.error ? [] : staffRes?.data ?? [];
+      if (staffRes?.error) throw staffRes.error;
+      if (fallbackStaffRes?.error) throw fallbackStaffRes.error;
+
+      const staffRows = ((staffRes.data?.length ?? 0) > 0 ? staffRes.data : fallbackStaffRes?.data) ?? [];
       const prioritizedStaffRows = staffRows
         .slice()
         .sort((a, b) => {
@@ -541,7 +582,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
                 </div>
                 <div className="mt-2 text-[11px] text-neutral-300">
                   Snapshot status: <span className="text-neutral-100">{intakeStatus ?? "unknown"}</span> • Canonical materialization:{" "}
-                  <span className={canonicalStats.canonicalStatus === "partial" ? "text-amber-200" : "text-emerald-200"}>
+                  <span className={canonicalStats.canonicalStatus === "ok" ? "text-emerald-200" : "text-amber-200"}>
                     {canonicalStats.canonicalStatus}
                   </span>
                 </div>
@@ -551,6 +592,17 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
                     Staged snapshot data can look healthy while canonical graph materialization is still incomplete.
                   </div>
                 ) : null}
+                {latestReadiness ? (() => {
+                  const canonicalSummary = isRecord(latestReadiness.canonical_summary) ? latestReadiness.canonical_summary : null;
+                  const unresolvedLinks = readSummaryCount(canonicalSummary, ["unresolved_link_count", "unlinked_history_rows", "history_without_vehicle_count"]);
+                  const reviewRequired = readSummaryCount(canonicalSummary, ["review_required_count", "pending_review_count", "blocked_review_count"]);
+                  if (unresolvedLinks <= 0 && reviewRequired <= 0) return null;
+                  return (
+                    <div className="mt-2 rounded-md border border-amber-400/40 bg-amber-950/20 p-2 text-[11px] text-amber-100">
+                      Partial linkage detected: {unresolvedLinks} unresolved history/vehicle link(s), {reviewRequired} review-required item(s).
+                    </div>
+                  );
+                })() : null}
                 {latestReadiness ? (
                   <div className="mt-3 rounded-md border border-white/10 bg-black/30 p-2 text-[11px] text-neutral-200">
                     <div className="font-medium text-neutral-100">Activation truth states</div>

--- a/supabase/functions/shop-boost-cron/index.ts
+++ b/supabase/functions/shop-boost-cron/index.ts
@@ -9,8 +9,8 @@ type ShopBoostIntakeRow = {
 };
 
 type RunResponse =
-  | { ok: true; snapshot: unknown }
-  | { ok: false; snapshot: null; error?: string }
+  | { ok: true; snapshot?: unknown; runsTouched?: number; jobsClaimed?: number; jobsCompleted?: number; jobsFailed?: number; jobsRetried?: number }
+  | { ok: false; error?: string; snapshot?: null }
   | { error: string };
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -77,8 +77,8 @@ async function queueAllPendingIntakes(): Promise<{
 
       const json = (await response.json().catch(() => null)) as RunResponse | null;
 
-      // Count only real successes (ok + snapshot present)
-      if (response.ok && json && "ok" in json && json.ok === true && "snapshot" in json && json.snapshot) {
+      // Count success using the internal worker contract (response.ok + ok=true).
+      if (response.ok && json && "ok" in json && json.ok === true) {
         processed += 1;
         continue;
       }


### PR DESCRIPTION
### Motivation
- Resolve six targeted Shop Boost runtime blockers from the acceptance audit with surgical, non‑breaking fixes. 
- Preserve existing orchestrator, importer, and route contracts while aligning runtime behavior with the real worker payloads and readiness truth model.

### Description
- Align cron success classification to the internal worker contract by treating a run as successful when `response.ok` and JSON `ok === true`, and remove the strict `snapshot` requirement (file: `supabase/functions/shop-boost-cron/index.ts`).
- Continue lightweight polling after the review fallback so the review page auto‑routes to `/dashboard?setup=shop-boost` when `ui_should_route_forward === true`, using safe interval/backoff (file: `app/dashboard/setup/review/page.tsx`).
- Make Shop Health suggestion reads intake‑scoped by default (query active `intake_id` first) and use a shop‑wide recent fallback only when intake results are empty; apply the same intake-first behavior to staff invite suggestions (file: `features/owner/reports/ReportsShopHealthPanel.tsx`).
- Change canonical status visual tone so only `ok` renders green and `partial`/`unknown` render as warning/neutral, and add an explicit partial‑linkage notice surfaced from the readiness canonical summary with unresolved/review counts (file: `features/owner/reports/ReportsShopHealthPanel.tsx`).
- Constrain fallback customer history by `shop_id` on both desktop and mobile customer pages to prevent cross‑tenant leakage while preserving existing fallback behavior (files: `features/customers/app/customers/[id]/page.tsx`, `app/mobile/customers/[id]/page.tsx`).

### Testing
- Ran `npx tsc --noEmit` and TypeScript checks completed successfully. 
- Ran targeted grep/scan checks verifying presence of: cron `ok === true` check, review polling consumption of `/api/shop-boost/intakes/latest`, intake-first suggestion queries and shop fallback, canonical `ok` mapping to green, `shop_id` constraint in fallback work_orders queries, and partial linkage warning text; all verifications matched the edits. 
- Note: the auto‑forward behavior is runtime/timing dependent and cannot be fully proven by static checks alone; the polling logic is present and wired but end‑to‑end confirmation requires exercising a readiness transition in a live/test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8729a5a08328b2a479c09e732b00)