### PR TITLE
Add AI operating-intelligence substrate: DB migration and server APIs for evidence, recommendations, previews, approvals, events, and safe-actions

### DIFF
--- a/db/sql/2026-04-24_ai_operating_intelligence_substrate.sql
+++ b/db/sql/2026-04-24_ai_operating_intelligence_substrate.sql
@@ -1,0 +1,334 @@
+-- Canonical AI operating intelligence substrate.
+-- This migration is additive and intentionally recommendation/preview-first.
+-- It does NOT enable autonomous action execution.
+
+create table if not exists public.ai_evidence_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  subject_type text not null,
+  subject_id uuid,
+  domain text not null,
+  evidence_kind text not null,
+  snapshot jsonb not null default '{}'::jsonb,
+  source_refs jsonb not null default '[]'::jsonb,
+  missing_data jsonb not null default '[]'::jsonb,
+  freshness_at timestamptz,
+  confidence numeric(5,4),
+  created_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  constraint ai_evidence_snapshots_subject_type_nonempty check (length(btrim(subject_type)) > 0),
+  constraint ai_evidence_snapshots_domain_nonempty check (length(btrim(domain)) > 0),
+  constraint ai_evidence_snapshots_kind_nonempty check (length(btrim(evidence_kind)) > 0),
+  constraint ai_evidence_snapshots_confidence_chk check (confidence is null or (confidence >= 0 and confidence <= 1))
+);
+
+comment on table public.ai_evidence_snapshots is
+  'Immutable AI evidence package for recommendation and action-preview grounding. Not autonomous execution.';
+comment on column public.ai_evidence_snapshots.snapshot is
+  'Evidence snapshot payload captured at a point in time. Treat as immutable.';
+comment on column public.ai_evidence_snapshots.source_refs is
+  'Source references used to build the snapshot.';
+comment on column public.ai_evidence_snapshots.missing_data is
+  'Explicit list of missing data that may reduce confidence.';
+
+create table if not exists public.ai_recommendations (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  domain text not null,
+  recommendation_type text not null,
+  subject_type text not null,
+  subject_id uuid,
+  title text not null,
+  summary text,
+  status text not null default 'open',
+  priority text not null default 'normal',
+  confidence numeric(5,4),
+  risk_tier text not null default 'low',
+  evidence_snapshot_id uuid references public.ai_evidence_snapshots(id) on delete set null,
+  evidence_snapshot_ids uuid[] not null default '{}',
+  missing_data jsonb not null default '[]'::jsonb,
+  recommended_action jsonb not null default '{}'::jsonb,
+  side_effects jsonb not null default '[]'::jsonb,
+  requires_approval boolean not null default false,
+  requires_owner_pin boolean not null default false,
+  source text not null default 'system',
+  source_run_id uuid,
+  created_by uuid references public.profiles(id) on delete set null,
+  assigned_to uuid references public.profiles(id) on delete set null,
+  dismissed_by uuid references public.profiles(id) on delete set null,
+  dismissed_at timestamptz,
+  resolved_by uuid references public.profiles(id) on delete set null,
+  resolved_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  constraint ai_recommendations_domain_nonempty check (length(btrim(domain)) > 0),
+  constraint ai_recommendations_type_nonempty check (length(btrim(recommendation_type)) > 0),
+  constraint ai_recommendations_subject_nonempty check (length(btrim(subject_type)) > 0),
+  constraint ai_recommendations_title_nonempty check (length(btrim(title)) > 0),
+  constraint ai_recommendations_status_chk check (status in ('open','acknowledged','dismissed','resolved','expired','superseded')),
+  constraint ai_recommendations_priority_chk check (priority in ('low','normal','high','urgent')),
+  constraint ai_recommendations_risk_tier_chk check (risk_tier in ('low','medium','high','critical')),
+  constraint ai_recommendations_confidence_chk check (confidence is null or (confidence >= 0 and confidence <= 1))
+);
+
+comment on table public.ai_recommendations is
+  'Canonical AI/rule recommendation ledger with explicit confidence, evidence links, and side-effects.';
+comment on column public.ai_recommendations.recommended_action is
+  'Structured proposed action payload. Recommendation only; no autonomous execution implied.';
+comment on column public.ai_recommendations.side_effects is
+  'Declared side effects for operator review before any future action execution.';
+
+create table if not exists public.ai_action_previews (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  recommendation_id uuid references public.ai_recommendations(id) on delete set null,
+  domain text not null,
+  action_type text not null,
+  subject_type text not null,
+  subject_id uuid,
+  status text not null default 'draft',
+  preview_payload jsonb not null default '{}'::jsonb,
+  intended_mutations jsonb not null default '[]'::jsonb,
+  affected_records jsonb not null default '[]'::jsonb,
+  side_effects jsonb not null default '[]'::jsonb,
+  compensation_plan jsonb not null default '{}'::jsonb,
+  idempotency_key text,
+  requires_approval boolean not null default true,
+  requires_owner_pin boolean not null default false,
+  risk_tier text not null default 'medium',
+  evidence_snapshot_id uuid references public.ai_evidence_snapshots(id) on delete set null,
+  created_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  expires_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  constraint ai_action_previews_domain_nonempty check (length(btrim(domain)) > 0),
+  constraint ai_action_previews_action_type_nonempty check (length(btrim(action_type)) > 0),
+  constraint ai_action_previews_subject_nonempty check (length(btrim(subject_type)) > 0),
+  constraint ai_action_previews_status_chk check (status in ('draft','ready','approval_required','approved','rejected','expired','executed','cancelled','failed')),
+  constraint ai_action_previews_risk_tier_chk check (risk_tier in ('low','medium','high','critical'))
+);
+
+comment on table public.ai_action_previews is
+  'Action preview/dry-run contract for potential future actions. This table does not execute actions.';
+comment on column public.ai_action_previews.intended_mutations is
+  'Explicit mutation preview for human review.';
+comment on column public.ai_action_previews.compensation_plan is
+  'Planned compensating actions if future execution fails.';
+
+create table if not exists public.ai_action_approvals (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  action_preview_id uuid not null references public.ai_action_previews(id) on delete cascade,
+  status text not null default 'pending',
+  requested_by uuid references public.profiles(id) on delete set null,
+  requested_at timestamptz not null default now(),
+  decided_by uuid references public.profiles(id) on delete set null,
+  decided_at timestamptz,
+  decision_note text,
+  owner_pin_required boolean not null default false,
+  owner_pin_verified boolean not null default false,
+  owner_pin_verification_ref text,
+  expires_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  constraint ai_action_approvals_status_chk check (status in ('pending','approved','rejected','expired','cancelled'))
+);
+
+comment on table public.ai_action_approvals is
+  'Human approval gate records for AI action previews.';
+comment on column public.ai_action_approvals.owner_pin_verification_ref is
+  'Reference token/id proving owner PIN verification from existing owner PIN subsystem.';
+
+create table if not exists public.ai_action_events (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  recommendation_id uuid references public.ai_recommendations(id) on delete set null,
+  action_preview_id uuid references public.ai_action_previews(id) on delete set null,
+  approval_id uuid references public.ai_action_approvals(id) on delete set null,
+  event_type text not null,
+  actor_id uuid references public.profiles(id) on delete set null,
+  actor_role text,
+  source text not null default 'system',
+  idempotency_key text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  constraint ai_action_events_event_type_nonempty check (length(btrim(event_type)) > 0)
+);
+
+comment on table public.ai_action_events is
+  'Append-only event trail for recommendation, preview, and approval lifecycle.';
+
+create index if not exists idx_ai_evidence_snapshots_shop on public.ai_evidence_snapshots(shop_id);
+create index if not exists idx_ai_evidence_snapshots_subject on public.ai_evidence_snapshots(shop_id, subject_type, subject_id);
+create index if not exists idx_ai_evidence_snapshots_domain on public.ai_evidence_snapshots(shop_id, domain, evidence_kind);
+create index if not exists idx_ai_evidence_snapshots_created on public.ai_evidence_snapshots(shop_id, created_at desc);
+
+create index if not exists idx_ai_recommendations_shop_status on public.ai_recommendations(shop_id, status, created_at desc);
+create index if not exists idx_ai_recommendations_shop_domain on public.ai_recommendations(shop_id, domain, created_at desc);
+create index if not exists idx_ai_recommendations_subject on public.ai_recommendations(shop_id, subject_type, subject_id);
+create index if not exists idx_ai_recommendations_evidence on public.ai_recommendations(evidence_snapshot_id);
+create index if not exists idx_ai_recommendations_expires on public.ai_recommendations(shop_id, expires_at) where expires_at is not null;
+
+create index if not exists idx_ai_action_previews_shop_status on public.ai_action_previews(shop_id, status, created_at desc);
+create index if not exists idx_ai_action_previews_shop_domain on public.ai_action_previews(shop_id, domain, created_at desc);
+create index if not exists idx_ai_action_previews_subject on public.ai_action_previews(shop_id, subject_type, subject_id);
+create index if not exists idx_ai_action_previews_recommendation on public.ai_action_previews(recommendation_id);
+create unique index if not exists idx_ai_action_previews_idempotency on public.ai_action_previews(shop_id, idempotency_key)
+  where idempotency_key is not null;
+create index if not exists idx_ai_action_previews_expires on public.ai_action_previews(shop_id, expires_at)
+  where expires_at is not null;
+
+create index if not exists idx_ai_action_approvals_shop_status on public.ai_action_approvals(shop_id, status, requested_at desc);
+create index if not exists idx_ai_action_approvals_preview on public.ai_action_approvals(action_preview_id);
+create index if not exists idx_ai_action_approvals_expires on public.ai_action_approvals(shop_id, expires_at)
+  where expires_at is not null;
+
+create index if not exists idx_ai_action_events_shop_created on public.ai_action_events(shop_id, created_at desc);
+create index if not exists idx_ai_action_events_recommendation on public.ai_action_events(recommendation_id);
+create index if not exists idx_ai_action_events_preview on public.ai_action_events(action_preview_id);
+create index if not exists idx_ai_action_events_approval on public.ai_action_events(approval_id);
+create index if not exists idx_ai_action_events_idempotency on public.ai_action_events(shop_id, idempotency_key)
+  where idempotency_key is not null;
+
+alter table public.ai_evidence_snapshots enable row level security;
+alter table public.ai_recommendations enable row level security;
+alter table public.ai_action_previews enable row level security;
+alter table public.ai_action_approvals enable row level security;
+alter table public.ai_action_events enable row level security;
+
+-- Service-role policies for backend jobs/orchestration.
+drop policy if exists "service-role-manage-ai-evidence-snapshots" on public.ai_evidence_snapshots;
+create policy "service-role-manage-ai-evidence-snapshots"
+  on public.ai_evidence_snapshots
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "service-role-manage-ai-recommendations" on public.ai_recommendations;
+create policy "service-role-manage-ai-recommendations"
+  on public.ai_recommendations
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "service-role-manage-ai-action-previews" on public.ai_action_previews;
+create policy "service-role-manage-ai-action-previews"
+  on public.ai_action_previews
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "service-role-manage-ai-action-approvals" on public.ai_action_approvals;
+create policy "service-role-manage-ai-action-approvals"
+  on public.ai_action_approvals
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "service-role-manage-ai-action-events" on public.ai_action_events;
+create policy "service-role-manage-ai-action-events"
+  on public.ai_action_events
+  to service_role
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+-- Authenticated tenant-safe policies.
+do $$ begin
+  create policy ai_evidence_snapshots_shop_select on public.ai_evidence_snapshots
+    for select to authenticated
+    using (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_evidence_snapshots_shop_insert on public.ai_evidence_snapshots
+    for insert to authenticated
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+-- Keep evidence snapshots append-only for authenticated users.
+
+do $$ begin
+  create policy ai_recommendations_shop_select on public.ai_recommendations
+    for select to authenticated
+    using (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_recommendations_shop_insert on public.ai_recommendations
+    for insert to authenticated
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_recommendations_shop_update on public.ai_recommendations
+    for update to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_previews_shop_select on public.ai_action_previews
+    for select to authenticated
+    using (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_previews_shop_insert on public.ai_action_previews
+    for insert to authenticated
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_previews_shop_update on public.ai_action_previews
+    for update to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_approvals_shop_select on public.ai_action_approvals
+    for select to authenticated
+    using (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_approvals_shop_insert on public.ai_action_approvals
+    for insert to authenticated
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_approvals_shop_update on public.ai_action_approvals
+    for update to authenticated
+    using (shop_id = public.current_shop_id())
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_events_shop_select on public.ai_action_events
+    for select to authenticated
+    using (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy ai_action_events_shop_insert on public.ai_action_events
+    for insert to authenticated
+    with check (shop_id = public.current_shop_id());
+exception when duplicate_object then null; end $$;
+
+-- Mutable-table updated_at triggers.
+drop trigger if exists trg_ai_recommendations_updated_at on public.ai_recommendations;
+create trigger trg_ai_recommendations_updated_at
+before update on public.ai_recommendations
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists trg_ai_action_previews_updated_at on public.ai_action_previews;
+create trigger trg_ai_action_previews_updated_at
+before update on public.ai_action_previews
+for each row
+execute function public.set_updated_at();

--- a/features/ai/server/actionApprovals.ts
+++ b/features/ai/server/actionApprovals.ts
@@ -1,0 +1,196 @@
+import type { Json } from "@shared/types/types/supabase";
+import {
+  type AiActionApprovalRecord,
+  type AiActionApprovalStatus,
+  type AiActionPreviewRecord,
+  type AiActorContext,
+  ensureActorContext,
+  fromTable,
+  normalizeObjectJson,
+  type AiServerClient,
+} from "./types";
+import { getAiActionPreview } from "./actionPreviews";
+import { logAiActionEvent } from "./actionEvents";
+
+function validateApprovalTransition(from: AiActionApprovalStatus, to: AiActionApprovalStatus) {
+  const map: Record<AiActionApprovalStatus, ReadonlyArray<AiActionApprovalStatus>> = {
+    pending: ["approved", "rejected", "expired", "cancelled"],
+    approved: [],
+    rejected: [],
+    expired: [],
+    cancelled: [],
+  };
+
+  if (!map[from].includes(to)) {
+    throw new Error(`invalid approval status transition ${from} -> ${to}`);
+  }
+}
+
+async function setPreviewStatus(
+  supabase: AiServerClient,
+  preview: AiActionPreviewRecord,
+  status: string,
+): Promise<void> {
+  const { error } = await fromTable(supabase, "ai_action_previews")
+    .update({ status })
+    .eq("shop_id", preview.shop_id)
+    .eq("id", preview.id);
+
+  if (error) throw new Error(error.message);
+}
+
+export async function requestAiActionApproval(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    actionPreviewId: string;
+    ownerPinRequired?: boolean;
+    expiresAt?: string | null;
+    metadata?: Json;
+  },
+): Promise<AiActionApprovalRecord> {
+  const ctx = ensureActorContext(actor);
+  const preview = await getAiActionPreview(supabase, ctx, input.actionPreviewId);
+  if (!preview) throw new Error("action preview not found");
+
+  const insertPayload = {
+    shop_id: ctx.shopId,
+    action_preview_id: preview.id,
+    status: "pending",
+    requested_by: ctx.actorId,
+    owner_pin_required: input.ownerPinRequired ?? preview.requires_owner_pin,
+    owner_pin_verified: false,
+    owner_pin_verification_ref: null,
+    expires_at: input.expiresAt ?? null,
+    metadata: normalizeObjectJson(input.metadata),
+  };
+
+  const { data, error } = await fromTable(supabase, "ai_action_approvals")
+    .insert(insertPayload)
+    .select("*")
+    .single<AiActionApprovalRecord>();
+
+  if (error) throw new Error(error.message);
+
+  if (preview.status !== "approval_required") {
+    await setPreviewStatus(supabase, preview, "approval_required");
+  }
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId: preview.recommendation_id,
+    actionPreviewId: preview.id,
+    approvalId: data.id,
+    eventType: "approval.requested",
+    payload: {
+      action_preview_id: preview.id,
+      approval_id: data.id,
+      owner_pin_required: data.owner_pin_required,
+    },
+  });
+
+  return data;
+}
+
+async function decideAiActionApproval(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    approvalId: string;
+    status: "approved" | "rejected";
+    decisionNote?: string | null;
+    ownerPinVerified?: boolean;
+    ownerPinVerificationRef?: string | null;
+  },
+): Promise<AiActionApprovalRecord> {
+  const ctx = ensureActorContext(actor);
+
+  const { data: existing, error: lookupError } = await fromTable(supabase, "ai_action_approvals")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("id", input.approvalId)
+    .maybeSingle<AiActionApprovalRecord>();
+
+  if (lookupError) throw new Error(lookupError.message);
+  if (!existing) throw new Error("approval not found");
+
+  validateApprovalTransition(existing.status, input.status);
+
+  if (existing.owner_pin_required && input.status === "approved") {
+    if (!input.ownerPinVerified || !input.ownerPinVerificationRef) {
+      throw new Error("owner PIN verification is required to approve this action preview");
+    }
+  }
+
+  const now = new Date().toISOString();
+
+  const { data, error } = await fromTable(supabase, "ai_action_approvals")
+    .update({
+      status: input.status,
+      decided_by: ctx.actorId,
+      decided_at: now,
+      decision_note: input.decisionNote ?? null,
+      owner_pin_verified: input.ownerPinVerified ?? false,
+      owner_pin_verification_ref: input.ownerPinVerificationRef ?? null,
+    })
+    .eq("shop_id", ctx.shopId)
+    .eq("id", input.approvalId)
+    .select("*")
+    .single<AiActionApprovalRecord>();
+
+  if (error) throw new Error(error.message);
+
+  const preview = await getAiActionPreview(supabase, ctx, data.action_preview_id);
+  if (!preview) throw new Error("linked action preview not found");
+
+  await setPreviewStatus(supabase, preview, input.status === "approved" ? "approved" : "rejected");
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId: preview.recommendation_id,
+    actionPreviewId: preview.id,
+    approvalId: data.id,
+    eventType: input.status === "approved" ? "approval.approved" : "approval.rejected",
+    payload: {
+      action_preview_id: preview.id,
+      approval_id: data.id,
+      decision_note: input.decisionNote ?? null,
+      owner_pin_verified: data.owner_pin_verified,
+      owner_pin_verification_ref: data.owner_pin_verification_ref,
+    },
+  });
+
+  return data;
+}
+
+export async function approveAiActionPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    approvalId: string;
+    decisionNote?: string | null;
+    ownerPinVerified?: boolean;
+    ownerPinVerificationRef?: string | null;
+  },
+): Promise<AiActionApprovalRecord> {
+  return decideAiActionApproval(supabase, actor, {
+    approvalId: input.approvalId,
+    status: "approved",
+    decisionNote: input.decisionNote,
+    ownerPinVerified: input.ownerPinVerified,
+    ownerPinVerificationRef: input.ownerPinVerificationRef,
+  });
+}
+
+export async function rejectAiActionPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    approvalId: string;
+    decisionNote?: string | null;
+  },
+): Promise<AiActionApprovalRecord> {
+  return decideAiActionApproval(supabase, actor, {
+    approvalId: input.approvalId,
+    status: "rejected",
+    decisionNote: input.decisionNote,
+  });
+}

--- a/features/ai/server/actionEvents.ts
+++ b/features/ai/server/actionEvents.ts
@@ -1,0 +1,86 @@
+import type { Json } from "@shared/types/types/supabase";
+import {
+  type AiActorContext,
+  type AiActionEventRecord,
+  type AiActionEventType,
+  ensureActorContext,
+  fromTable,
+  normalizeObjectJson,
+  type AiServerClient,
+} from "./types";
+
+type LogAiActionEventInput = {
+  recommendationId?: string | null;
+  actionPreviewId?: string | null;
+  approvalId?: string | null;
+  eventType: AiActionEventType;
+  actorRole?: string | null;
+  source?: string;
+  idempotencyKey?: string | null;
+  payload?: Json;
+  metadata?: Json;
+};
+
+export async function logAiActionEvent(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: LogAiActionEventInput,
+): Promise<AiActionEventRecord> {
+  const ctx = ensureActorContext(actor);
+
+  const insertPayload = {
+    shop_id: ctx.shopId,
+    recommendation_id: input.recommendationId ?? null,
+    action_preview_id: input.actionPreviewId ?? null,
+    approval_id: input.approvalId ?? null,
+    event_type: input.eventType,
+    actor_id: ctx.actorId,
+    actor_role: input.actorRole ?? actor.role ?? null,
+    source: input.source ?? ctx.source,
+    idempotency_key: input.idempotencyKey ?? null,
+    payload: normalizeObjectJson(input.payload),
+    metadata: normalizeObjectJson(input.metadata),
+  };
+
+  const { data, error } = await fromTable(supabase, "ai_action_events")
+    .insert(insertPayload)
+    .select("*")
+    .single<AiActionEventRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function listAiActionEventsForRecommendation(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  recommendationId: string,
+): Promise<AiActionEventRecord[]> {
+  const ctx = ensureActorContext(actor);
+
+  const { data, error } = await fromTable(supabase, "ai_action_events")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("recommendation_id", recommendationId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AiActionEventRecord[];
+}
+
+export async function listAiActionEventsForPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  actionPreviewId: string,
+): Promise<AiActionEventRecord[]> {
+  const ctx = ensureActorContext(actor);
+
+  const { data, error } = await fromTable(supabase, "ai_action_events")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("action_preview_id", actionPreviewId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AiActionEventRecord[];
+}

--- a/features/ai/server/actionPreviews.ts
+++ b/features/ai/server/actionPreviews.ts
@@ -1,0 +1,191 @@
+import type { Json } from "@shared/types/types/supabase";
+import {
+  type AiActionPreviewRecord,
+  type AiActionPreviewStatus,
+  type AiActorContext,
+  type AiRiskTier,
+  assertNonEmpty,
+  ensureActorContext,
+  fromTable,
+  normalizeArrayJson,
+  normalizeObjectJson,
+  type AiServerClient,
+  validateRiskTier,
+} from "./types";
+import { logAiActionEvent } from "./actionEvents";
+
+type CreateAiActionPreviewInput = {
+  recommendationId?: string | null;
+  domain: string;
+  actionType: string;
+  subjectType: string;
+  subjectId?: string | null;
+  previewPayload?: Json;
+  intendedMutations?: Json;
+  affectedRecords?: Json;
+  sideEffects?: Json;
+  compensationPlan?: Json;
+  idempotencyKey?: string | null;
+  requiresApproval?: boolean;
+  requiresOwnerPin?: boolean;
+  riskTier: AiRiskTier;
+  evidenceSnapshotId?: string | null;
+  expiresAt?: string | null;
+  metadata?: Json;
+};
+
+function validatePreviewTransition(from: AiActionPreviewStatus, to: AiActionPreviewStatus) {
+  const map: Record<AiActionPreviewStatus, ReadonlyArray<AiActionPreviewStatus>> = {
+    draft: ["ready", "approval_required", "cancelled", "expired"],
+    ready: ["approval_required", "approved", "rejected", "cancelled", "expired"],
+    approval_required: ["approved", "rejected", "cancelled", "expired"],
+    approved: ["cancelled", "expired", "executed", "failed"],
+    rejected: [],
+    expired: [],
+    executed: [],
+    cancelled: [],
+    failed: [],
+  };
+
+  if (!map[from].includes(to)) {
+    throw new Error(`invalid preview status transition ${from} -> ${to}`);
+  }
+}
+
+export async function createAiActionPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: CreateAiActionPreviewInput,
+): Promise<AiActionPreviewRecord> {
+  const ctx = ensureActorContext(actor);
+
+  const requiresApproval = input.requiresApproval ?? true;
+  const normalizedIntendedMutations = normalizeArrayJson(input.intendedMutations);
+  const normalizedSideEffects = normalizeArrayJson(input.sideEffects);
+
+  if (!Array.isArray(normalizedIntendedMutations)) {
+    throw new Error("intendedMutations must be an array");
+  }
+  if (!Array.isArray(normalizedSideEffects)) {
+    throw new Error("sideEffects must be an array");
+  }
+
+  const insertPayload = {
+    shop_id: ctx.shopId,
+    recommendation_id: input.recommendationId ?? null,
+    domain: assertNonEmpty(input.domain, "domain"),
+    action_type: assertNonEmpty(input.actionType, "actionType"),
+    subject_type: assertNonEmpty(input.subjectType, "subjectType"),
+    subject_id: input.subjectId ?? null,
+    status: requiresApproval ? "approval_required" : "draft",
+    preview_payload: normalizeObjectJson(input.previewPayload),
+    intended_mutations: normalizedIntendedMutations,
+    affected_records: normalizeArrayJson(input.affectedRecords),
+    side_effects: normalizedSideEffects,
+    compensation_plan: normalizeObjectJson(input.compensationPlan),
+    idempotency_key: input.idempotencyKey ?? null,
+    requires_approval: requiresApproval,
+    requires_owner_pin: input.requiresOwnerPin ?? false,
+    risk_tier: validateRiskTier(input.riskTier),
+    evidence_snapshot_id: input.evidenceSnapshotId ?? null,
+    created_by: ctx.actorId,
+    expires_at: input.expiresAt ?? null,
+    metadata: normalizeObjectJson(input.metadata),
+  };
+
+  const { data, error } = await fromTable(supabase, "ai_action_previews")
+    .insert(insertPayload)
+    .select("*")
+    .single<AiActionPreviewRecord>();
+
+  if (error) throw new Error(error.message);
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId: data.recommendation_id,
+    actionPreviewId: data.id,
+    eventType: "preview.created",
+    idempotencyKey: data.idempotency_key,
+    payload: {
+      action_preview_id: data.id,
+      status: data.status,
+      risk_tier: data.risk_tier,
+      requires_approval: data.requires_approval,
+    },
+  });
+
+  return data;
+}
+
+export async function getAiActionPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  previewId: string,
+): Promise<AiActionPreviewRecord | null> {
+  const ctx = ensureActorContext(actor);
+
+  const { data, error } = await fromTable(supabase, "ai_action_previews")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("id", previewId)
+    .maybeSingle<AiActionPreviewRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function updatePreviewStatus(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  previewId: string,
+  nextStatus: AiActionPreviewStatus,
+  eventType: "preview.ready" | "preview.cancelled",
+  metadata?: Json,
+): Promise<AiActionPreviewRecord> {
+  const ctx = ensureActorContext(actor);
+  const existing = await getAiActionPreview(supabase, ctx, previewId);
+
+  if (!existing) throw new Error("action preview not found");
+  validatePreviewTransition(existing.status, nextStatus);
+
+  const { data, error } = await fromTable(supabase, "ai_action_previews")
+    .update({ status: nextStatus, metadata: normalizeObjectJson(metadata ?? existing.metadata) })
+    .eq("shop_id", ctx.shopId)
+    .eq("id", previewId)
+    .select("*")
+    .single<AiActionPreviewRecord>();
+
+  if (error) throw new Error(error.message);
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId: data.recommendation_id,
+    actionPreviewId: data.id,
+    eventType,
+    idempotencyKey: data.idempotency_key,
+    payload: {
+      action_preview_id: data.id,
+      from_status: existing.status,
+      to_status: data.status,
+    },
+  });
+
+  return data;
+}
+
+export async function markAiActionPreviewReady(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  previewId: string,
+): Promise<AiActionPreviewRecord> {
+  return updatePreviewStatus(supabase, actor, previewId, "ready", "preview.ready");
+}
+
+export async function cancelAiActionPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  previewId: string,
+  input?: { reason?: string | null },
+): Promise<AiActionPreviewRecord> {
+  return updatePreviewStatus(supabase, actor, previewId, "cancelled", "preview.cancelled", {
+    cancellation_reason: input?.reason ?? null,
+  });
+}

--- a/features/ai/server/evidenceSnapshots.ts
+++ b/features/ai/server/evidenceSnapshots.ts
@@ -1,0 +1,119 @@
+import type { Json } from "@shared/types/types/supabase";
+import {
+  type AiActorContext,
+  type AiEvidenceSnapshotRecord,
+  assertNonEmpty,
+  ensureActorContext,
+  fromTable,
+  normalizeArrayJson,
+  normalizeObjectJson,
+  type AiServerClient,
+  validateConfidence,
+} from "./types";
+import { logAiActionEvent } from "./actionEvents";
+
+type CreateAiEvidenceSnapshotInput = {
+  subjectType: string;
+  subjectId?: string | null;
+  domain: string;
+  evidenceKind: string;
+  snapshot?: Json;
+  sourceRefs?: Json;
+  missingData?: Json;
+  freshnessAt?: string | null;
+  confidence?: number | null;
+  metadata?: Json;
+};
+
+export async function createAiEvidenceSnapshot(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: CreateAiEvidenceSnapshotInput,
+): Promise<AiEvidenceSnapshotRecord> {
+  const ctx = ensureActorContext(actor);
+
+  const insertPayload = {
+    shop_id: ctx.shopId,
+    subject_type: assertNonEmpty(input.subjectType, "subjectType"),
+    subject_id: input.subjectId ?? null,
+    domain: assertNonEmpty(input.domain, "domain"),
+    evidence_kind: assertNonEmpty(input.evidenceKind, "evidenceKind"),
+    snapshot: normalizeObjectJson(input.snapshot),
+    source_refs: normalizeArrayJson(input.sourceRefs),
+    missing_data: normalizeArrayJson(input.missingData),
+    freshness_at: input.freshnessAt ?? null,
+    confidence: validateConfidence(input.confidence),
+    created_by: ctx.actorId,
+    metadata: normalizeObjectJson(input.metadata),
+  };
+
+  const { data, error } = await fromTable(supabase, "ai_evidence_snapshots")
+    .insert(insertPayload)
+    .select("*")
+    .single<AiEvidenceSnapshotRecord>();
+
+  if (error) throw new Error(error.message);
+
+  await logAiActionEvent(supabase, ctx, {
+    eventType: "evidence.created",
+    payload: {
+      evidence_snapshot_id: data.id,
+      domain: data.domain,
+      evidence_kind: data.evidence_kind,
+      subject_type: data.subject_type,
+      subject_id: data.subject_id,
+    },
+  });
+
+  return data;
+}
+
+export async function getAiEvidenceSnapshot(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  snapshotId: string,
+): Promise<AiEvidenceSnapshotRecord | null> {
+  const ctx = ensureActorContext(actor);
+
+  const { data, error } = await fromTable(supabase, "ai_evidence_snapshots")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("id", snapshotId)
+    .maybeSingle<AiEvidenceSnapshotRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function listAiEvidenceSnapshotsForSubject(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    subjectType: string;
+    subjectId?: string | null;
+    domain?: string;
+    limit?: number;
+  },
+): Promise<AiEvidenceSnapshotRecord[]> {
+  const ctx = ensureActorContext(actor);
+
+  let query = fromTable(supabase, "ai_evidence_snapshots")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("subject_type", assertNonEmpty(input.subjectType, "subjectType"))
+    .order("created_at", { ascending: false })
+    .limit(Math.min(Math.max(input.limit ?? 50, 1), 200));
+
+  if (input.subjectId) {
+    query = query.eq("subject_id", input.subjectId);
+  }
+
+  if (input.domain) {
+    query = query.eq("domain", input.domain);
+  }
+
+  const { data, error } = await query;
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AiEvidenceSnapshotRecord[];
+}

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -1,0 +1,7 @@
+export * from "./types";
+export * from "./evidenceSnapshots";
+export * from "./recommendations";
+export * from "./actionPreviews";
+export * from "./actionApprovals";
+export * from "./actionEvents";
+export * from "./safeActions";

--- a/features/ai/server/recommendations.ts
+++ b/features/ai/server/recommendations.ts
@@ -1,0 +1,297 @@
+import type { Json } from "@shared/types/types/supabase";
+import {
+  type AiActorContext,
+  type AiRecommendationPriority,
+  type AiRecommendationRecord,
+  type AiRecommendationStatus,
+  type AiRiskTier,
+  assertNonEmpty,
+  ensureActorContext,
+  fromTable,
+  normalizeArrayJson,
+  normalizeObjectJson,
+  type AiServerClient,
+  validateConfidence,
+  validateRiskTier,
+} from "./types";
+import { logAiActionEvent } from "./actionEvents";
+
+const STATUS_TRANSITIONS: Record<AiRecommendationStatus, ReadonlyArray<AiRecommendationStatus>> = {
+  open: ["acknowledged", "dismissed", "resolved", "expired", "superseded"],
+  acknowledged: ["dismissed", "resolved", "expired", "superseded"],
+  dismissed: [],
+  resolved: [],
+  expired: [],
+  superseded: [],
+};
+
+function validatePriority(value: string): AiRecommendationPriority {
+  if (value === "low" || value === "normal" || value === "high" || value === "urgent") {
+    return value;
+  }
+  throw new Error(`invalid priority: ${value}`);
+}
+
+function ensureTransition(from: AiRecommendationStatus, to: AiRecommendationStatus) {
+  if (!STATUS_TRANSITIONS[from].includes(to)) {
+    throw new Error(`invalid recommendation status transition ${from} -> ${to}`);
+  }
+}
+
+type CreateAiRecommendationInput = {
+  domain: string;
+  recommendationType: string;
+  subjectType: string;
+  subjectId?: string | null;
+  title: string;
+  summary?: string | null;
+  priority?: AiRecommendationPriority;
+  confidence?: number | null;
+  riskTier?: AiRiskTier;
+  evidenceSnapshotId?: string | null;
+  evidenceSnapshotIds?: string[];
+  missingData?: Json;
+  recommendedAction?: Json;
+  sideEffects?: Json;
+  requiresApproval?: boolean;
+  requiresOwnerPin?: boolean;
+  source?: string;
+  sourceRunId?: string | null;
+  assignedTo?: string | null;
+  expiresAt?: string | null;
+  metadata?: Json;
+};
+
+export async function createAiRecommendation(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: CreateAiRecommendationInput,
+): Promise<AiRecommendationRecord> {
+  const ctx = ensureActorContext(actor);
+
+  const priority = validatePriority(input.priority ?? "normal");
+  const riskTier = validateRiskTier(input.riskTier ?? "low");
+
+  const insertPayload = {
+    shop_id: ctx.shopId,
+    domain: assertNonEmpty(input.domain, "domain"),
+    recommendation_type: assertNonEmpty(input.recommendationType, "recommendationType"),
+    subject_type: assertNonEmpty(input.subjectType, "subjectType"),
+    subject_id: input.subjectId ?? null,
+    title: assertNonEmpty(input.title, "title"),
+    summary: input.summary ?? null,
+    status: "open",
+    priority,
+    confidence: validateConfidence(input.confidence),
+    risk_tier: riskTier,
+    evidence_snapshot_id: input.evidenceSnapshotId ?? null,
+    evidence_snapshot_ids: input.evidenceSnapshotIds ?? [],
+    missing_data: normalizeArrayJson(input.missingData),
+    recommended_action: normalizeObjectJson(input.recommendedAction),
+    side_effects: normalizeArrayJson(input.sideEffects),
+    requires_approval: input.requiresApproval ?? false,
+    requires_owner_pin: input.requiresOwnerPin ?? false,
+    source: input.source ?? ctx.source,
+    source_run_id: input.sourceRunId ?? null,
+    created_by: ctx.actorId,
+    assigned_to: input.assignedTo ?? null,
+    expires_at: input.expiresAt ?? null,
+    metadata: normalizeObjectJson(input.metadata),
+  };
+
+  const { data, error } = await fromTable(supabase, "ai_recommendations")
+    .insert(insertPayload)
+    .select("*")
+    .single<AiRecommendationRecord>();
+
+  if (error) throw new Error(error.message);
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId: data.id,
+    eventType: "recommendation.created",
+    payload: {
+      recommendation_id: data.id,
+      title: data.title,
+      risk_tier: data.risk_tier,
+      requires_approval: data.requires_approval,
+    },
+  });
+
+  return data;
+}
+
+export async function getAiRecommendation(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  recommendationId: string,
+): Promise<AiRecommendationRecord | null> {
+  const ctx = ensureActorContext(actor);
+
+  const { data, error } = await fromTable(supabase, "ai_recommendations")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("id", recommendationId)
+    .maybeSingle<AiRecommendationRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function listOpenAiRecommendations(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input?: { domain?: string; limit?: number },
+): Promise<AiRecommendationRecord[]> {
+  const ctx = ensureActorContext(actor);
+
+  let query = fromTable(supabase, "ai_recommendations")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .in("status", ["open", "acknowledged"])
+    .order("created_at", { ascending: false })
+    .limit(Math.min(Math.max(input?.limit ?? 100, 1), 200));
+
+  if (input?.domain) {
+    query = query.eq("domain", input.domain);
+  }
+
+  const { data, error } = await query;
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AiRecommendationRecord[];
+}
+
+export async function listAiRecommendationsForSubject(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: { subjectType: string; subjectId?: string | null; domain?: string; limit?: number },
+): Promise<AiRecommendationRecord[]> {
+  const ctx = ensureActorContext(actor);
+
+  let query = fromTable(supabase, "ai_recommendations")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("subject_type", assertNonEmpty(input.subjectType, "subjectType"))
+    .order("created_at", { ascending: false })
+    .limit(Math.min(Math.max(input.limit ?? 100, 1), 200));
+
+  if (input.subjectId) {
+    query = query.eq("subject_id", input.subjectId);
+  }
+
+  if (input.domain) {
+    query = query.eq("domain", input.domain);
+  }
+
+  const { data, error } = await query;
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AiRecommendationRecord[];
+}
+
+async function updateRecommendationStatus(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  recommendationId: string,
+  nextStatus: AiRecommendationStatus,
+  eventType: "recommendation.acknowledged" | "recommendation.dismissed" | "recommendation.resolved",
+  input?: { note?: string | null },
+): Promise<AiRecommendationRecord> {
+  const ctx = ensureActorContext(actor);
+  const existing = await getAiRecommendation(supabase, ctx, recommendationId);
+
+  if (!existing) throw new Error("recommendation not found");
+  ensureTransition(existing.status, nextStatus);
+
+  const now = new Date().toISOString();
+  const updatePayload: Record<string, string | null> = {
+    status: nextStatus,
+  };
+
+  if (nextStatus === "dismissed") {
+    updatePayload.dismissed_by = ctx.actorId;
+    updatePayload.dismissed_at = now;
+  }
+
+  if (nextStatus === "resolved") {
+    updatePayload.resolved_by = ctx.actorId;
+    updatePayload.resolved_at = now;
+  }
+
+  const { data, error } = await fromTable(supabase, "ai_recommendations")
+    .update(updatePayload)
+    .eq("shop_id", ctx.shopId)
+    .eq("id", recommendationId)
+    .select("*")
+    .single<AiRecommendationRecord>();
+
+  if (error) throw new Error(error.message);
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId,
+    eventType,
+    payload: {
+      recommendation_id: recommendationId,
+      from_status: existing.status,
+      to_status: nextStatus,
+      note: input?.note ?? null,
+    },
+  });
+
+  return data;
+}
+
+export function canTransitionAiRecommendationStatus(
+  from: AiRecommendationStatus,
+  to: AiRecommendationStatus,
+): boolean {
+  return STATUS_TRANSITIONS[from].includes(to);
+}
+
+export async function acknowledgeAiRecommendation(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  recommendationId: string,
+  input?: { note?: string | null },
+): Promise<AiRecommendationRecord> {
+  return updateRecommendationStatus(
+    supabase,
+    actor,
+    recommendationId,
+    "acknowledged",
+    "recommendation.acknowledged",
+    input,
+  );
+}
+
+export async function dismissAiRecommendation(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  recommendationId: string,
+  input?: { note?: string | null },
+): Promise<AiRecommendationRecord> {
+  return updateRecommendationStatus(
+    supabase,
+    actor,
+    recommendationId,
+    "dismissed",
+    "recommendation.dismissed",
+    input,
+  );
+}
+
+export async function resolveAiRecommendation(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  recommendationId: string,
+  input?: { note?: string | null },
+): Promise<AiRecommendationRecord> {
+  return updateRecommendationStatus(
+    supabase,
+    actor,
+    recommendationId,
+    "resolved",
+    "recommendation.resolved",
+    input,
+  );
+}

--- a/features/ai/server/safeActions.ts
+++ b/features/ai/server/safeActions.ts
@@ -1,0 +1,99 @@
+import type { Json } from "@shared/types/types/supabase";
+import type { AiActionPreviewRecord, AiActorContext, AiRiskTier } from "./types";
+import { createAiActionPreview, getAiActionPreview } from "./actionPreviews";
+import type { AiServerClient } from "./types";
+
+export type SafeActionExecutionGuard = {
+  allowed: false;
+  reason: string;
+  requirements: {
+    tenantShopIdRequired: true;
+    actorContextRequired: true;
+    previewRequired: true;
+    evidenceRequired: true;
+    idempotencyKeyRequired: true;
+    compensationPlanRequired: true;
+    approvalRequiredForRisk: ReadonlyArray<AiRiskTier>;
+    ownerPinRequiredForHighRisk: true;
+  };
+};
+
+export async function buildAiActionPreview(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    recommendationId?: string | null;
+    domain: string;
+    actionType: string;
+    subjectType: string;
+    subjectId?: string | null;
+    previewPayload?: Json;
+    intendedMutations?: Json;
+    affectedRecords?: Json;
+    sideEffects?: Json;
+    compensationPlan?: Json;
+    idempotencyKey?: string | null;
+    riskTier: AiRiskTier;
+    evidenceSnapshotId?: string | null;
+    requiresOwnerPin?: boolean;
+    metadata?: Json;
+  },
+): Promise<AiActionPreviewRecord> {
+  return createAiActionPreview(supabase, actor, {
+    recommendationId: input.recommendationId,
+    domain: input.domain,
+    actionType: input.actionType,
+    subjectType: input.subjectType,
+    subjectId: input.subjectId,
+    previewPayload: input.previewPayload,
+    intendedMutations: input.intendedMutations,
+    affectedRecords: input.affectedRecords,
+    sideEffects: input.sideEffects,
+    compensationPlan: input.compensationPlan,
+    idempotencyKey: input.idempotencyKey,
+    riskTier: input.riskTier,
+    evidenceSnapshotId: input.evidenceSnapshotId,
+    requiresApproval: true,
+    requiresOwnerPin: input.requiresOwnerPin ?? (input.riskTier === "high" || input.riskTier === "critical"),
+    metadata: input.metadata,
+  });
+}
+
+export function requireAiActionApproval(input: {
+  riskTier: AiRiskTier;
+  requiresApproval: boolean;
+}): { required: boolean; reason: string } {
+  if (!input.requiresApproval) {
+    return { required: false, reason: "approval explicitly disabled for this preview" };
+  }
+
+  if (input.riskTier === "medium" || input.riskTier === "high" || input.riskTier === "critical") {
+    return { required: true, reason: `approval required for ${input.riskTier} risk action preview` };
+  }
+
+  return { required: true, reason: "approval required by safe-action substrate default" };
+}
+
+export async function assertAiActionCanExecute(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: { actionPreviewId: string },
+): Promise<SafeActionExecutionGuard> {
+  await getAiActionPreview(supabase, actor, input.actionPreviewId);
+
+  return {
+    allowed: false,
+    reason:
+      "Autonomous AI action execution is not enabled. This substrate supports preview and approval only.",
+    requirements: {
+      tenantShopIdRequired: true,
+      actorContextRequired: true,
+      previewRequired: true,
+      evidenceRequired: true,
+      idempotencyKeyRequired: true,
+      compensationPlanRequired: true,
+      approvalRequiredForRisk: ["medium", "high", "critical"],
+      ownerPinRequiredForHighRisk: true,
+    },
+  };
+}

--- a/features/ai/server/types.ts
+++ b/features/ai/server/types.ts
@@ -1,0 +1,212 @@
+import type { Json, Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type DB = Database;
+export type AiServerClient = SupabaseClient<Database>;
+
+export type AiRecommendationStatus =
+  | "open"
+  | "acknowledged"
+  | "dismissed"
+  | "resolved"
+  | "expired"
+  | "superseded";
+
+export type AiRecommendationPriority = "low" | "normal" | "high" | "urgent";
+export type AiRiskTier = "low" | "medium" | "high" | "critical";
+
+export type AiActionPreviewStatus =
+  | "draft"
+  | "ready"
+  | "approval_required"
+  | "approved"
+  | "rejected"
+  | "expired"
+  | "executed"
+  | "cancelled"
+  | "failed";
+
+export type AiActionApprovalStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "expired"
+  | "cancelled";
+
+export type AiActionEventType =
+  | "evidence.created"
+  | "recommendation.created"
+  | "recommendation.acknowledged"
+  | "recommendation.dismissed"
+  | "recommendation.resolved"
+  | "preview.created"
+  | "preview.ready"
+  | "preview.cancelled"
+  | "approval.requested"
+  | "approval.approved"
+  | "approval.rejected";
+
+export type AiActorSource = "system" | "planner" | "ops" | "manual";
+
+export type AiActorContext = {
+  shopId: string;
+  actorId: string;
+  role?: string | null;
+  capabilities?: ReadonlyArray<string>;
+  source: AiActorSource;
+};
+
+export type AiEvidenceSnapshotRecord = {
+  id: string;
+  shop_id: string;
+  subject_type: string;
+  subject_id: string | null;
+  domain: string;
+  evidence_kind: string;
+  snapshot: Json;
+  source_refs: Json;
+  missing_data: Json;
+  freshness_at: string | null;
+  confidence: number | null;
+  created_by: string | null;
+  created_at: string;
+  metadata: Json;
+};
+
+export type AiRecommendationRecord = {
+  id: string;
+  shop_id: string;
+  domain: string;
+  recommendation_type: string;
+  subject_type: string;
+  subject_id: string | null;
+  title: string;
+  summary: string | null;
+  status: AiRecommendationStatus;
+  priority: AiRecommendationPriority;
+  confidence: number | null;
+  risk_tier: AiRiskTier;
+  evidence_snapshot_id: string | null;
+  evidence_snapshot_ids: string[];
+  missing_data: Json;
+  recommended_action: Json;
+  side_effects: Json;
+  requires_approval: boolean;
+  requires_owner_pin: boolean;
+  source: string;
+  source_run_id: string | null;
+  created_by: string | null;
+  assigned_to: string | null;
+  dismissed_by: string | null;
+  dismissed_at: string | null;
+  resolved_by: string | null;
+  resolved_at: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  metadata: Json;
+};
+
+export type AiActionPreviewRecord = {
+  id: string;
+  shop_id: string;
+  recommendation_id: string | null;
+  domain: string;
+  action_type: string;
+  subject_type: string;
+  subject_id: string | null;
+  status: AiActionPreviewStatus;
+  preview_payload: Json;
+  intended_mutations: Json;
+  affected_records: Json;
+  side_effects: Json;
+  compensation_plan: Json;
+  idempotency_key: string | null;
+  requires_approval: boolean;
+  requires_owner_pin: boolean;
+  risk_tier: AiRiskTier;
+  evidence_snapshot_id: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  expires_at: string | null;
+  metadata: Json;
+};
+
+export type AiActionApprovalRecord = {
+  id: string;
+  shop_id: string;
+  action_preview_id: string;
+  status: AiActionApprovalStatus;
+  requested_by: string | null;
+  requested_at: string;
+  decided_by: string | null;
+  decided_at: string | null;
+  decision_note: string | null;
+  owner_pin_required: boolean;
+  owner_pin_verified: boolean;
+  owner_pin_verification_ref: string | null;
+  expires_at: string | null;
+  metadata: Json;
+};
+
+export type AiActionEventRecord = {
+  id: string;
+  shop_id: string;
+  recommendation_id: string | null;
+  action_preview_id: string | null;
+  approval_id: string | null;
+  event_type: string;
+  actor_id: string | null;
+  actor_role: string | null;
+  source: string;
+  idempotency_key: string | null;
+  payload: Json;
+  created_at: string;
+  metadata: Json;
+};
+
+export function assertNonEmpty(value: string, label: string): string {
+  const cleaned = value.trim();
+  if (!cleaned) {
+    throw new Error(`${label} is required`);
+  }
+  return cleaned;
+}
+
+export function validateConfidence(confidence: number | null | undefined): number | null {
+  if (confidence == null) return null;
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new Error("confidence must be between 0 and 1");
+  }
+  return confidence;
+}
+
+export function normalizeArrayJson(value: Json | null | undefined): Json {
+  return Array.isArray(value) ? value : [];
+}
+
+export function normalizeObjectJson(value: Json | null | undefined): Json {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  return {};
+}
+
+export function validateRiskTier(value: string): AiRiskTier {
+  if (value === "low" || value === "medium" || value === "high" || value === "critical") {
+    return value;
+  }
+  throw new Error(`invalid risk tier: ${value}`);
+}
+
+export function ensureActorContext(ctx: AiActorContext): AiActorContext {
+  return {
+    ...ctx,
+    shopId: assertNonEmpty(ctx.shopId, "shopId"),
+    actorId: assertNonEmpty(ctx.actorId, "actorId"),
+    source: assertNonEmpty(ctx.source, "source") as AiActorSource,
+  };
+}
+
+export function fromTable(client: AiServerClient, table: string) {
+  return client.from(table as never);
+}


### PR DESCRIPTION
### Motivation
- Introduce a canonical, tenant-scoped AI operating-intelligence substrate to record immutable evidence snapshots and manage recommendation and action-preview lifecycles without enabling autonomous execution.
- Provide a structured workflow for recommendation generation, preview/dry-run creation, human approvals, and an append-only event trail to support auditability and operator review.

### Description
- Add a DB migration `db/sql/2026-04-24_ai_operating_intelligence_substrate.sql` that creates tables `ai_evidence_snapshots`, `ai_recommendations`, `ai_action_previews`, `ai_action_approvals`, and `ai_action_events` with constraints, indexes, RLS, service-role policies, and `updated_at` triggers for mutable tables.
- Implement server-side TypeScript feature modules under `features/ai/server/` including `types.ts`, `index.ts`, `evidenceSnapshots.ts`, `recommendations.ts`, `actionPreviews.ts`, `actionApprovals.ts`, `actionEvents.ts`, and `safeActions.ts` that provide typed APIs for create/get/list/update flows, validation helpers, event logging, and a safe-action guard that explicitly disallows autonomous execution.
- Enforce domain-specific validations and transitions (status/risk/confidence/idempotency) across recommendations, previews, and approvals, and log lifecycle events via `logAiActionEvent` for auditability.

### Testing
- Ran TypeScript type check with `yarn tsc` against the new modules, which completed successfully. 
- Ran linting with `yarn lint` to ensure formatting and style conformance, which completed successfully.
- No new automated unit tests were added in this change; integration was exercised by applying the migration to a development database and exercising the primary create/get flows manually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaecdc06188328b702708dab89f28d)