### PR TITLE
Wire work-order AI evidence snapshots and read-only operational recommendations

### DIFF
--- a/app/api/work-orders/[id]/ai/recommendations/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { listAiEvidenceSnapshotsForSubject, listAiRecommendationsForSubject } from "@/features/ai/server";
+import { generateWorkOrderEvidenceAndRecommendations } from "@/features/ai/server/domains/workOrders";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+
+async function getShopScopedWorkOrder(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<WorkOrderRow | null> {
+  const { data, error } = await input.supabase
+    .from("work_orders")
+    .select("*")
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<WorkOrderRow>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const { id } = await ctx.params;
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const scopedWorkOrder = await getShopScopedWorkOrder({
+    supabase: access.supabase,
+    workOrderId: id,
+    shopId,
+  });
+
+  if (!scopedWorkOrder) {
+    return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+  }
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  const [recommendations, evidenceSnapshots] = await Promise.all([
+    listAiRecommendationsForSubject(access.supabase, actor, {
+      subjectType: "work_order",
+      subjectId: id,
+      domain: "work_orders",
+      limit: 50,
+    }),
+    listAiEvidenceSnapshotsForSubject(access.supabase, actor, {
+      subjectType: "work_order",
+      subjectId: id,
+      domain: "work_orders",
+      limit: 1,
+    }),
+  ]);
+
+  const openRecommendations = recommendations.filter((row) => row.status === "open" || row.status === "acknowledged");
+  const latestEvidence = evidenceSnapshots[0] ?? null;
+
+  return NextResponse.json({
+    evidenceSnapshot: latestEvidence,
+    recommendations: openRecommendations,
+    skippedDuplicates: [],
+    missingData: Array.isArray(latestEvidence?.missing_data) ? latestEvidence.missing_data : [],
+    warnings: [],
+  });
+}
+
+export async function POST(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = await ctx.params;
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const scopedWorkOrder = await getShopScopedWorkOrder({
+    supabase: access.supabase,
+    workOrderId: id,
+    shopId,
+  });
+
+  if (!scopedWorkOrder) {
+    return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+  }
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  const result = await generateWorkOrderEvidenceAndRecommendations({
+    supabase: access.supabase,
+    actor,
+    workOrderId: id,
+  });
+
+  return NextResponse.json(result);
+}

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -20,6 +20,7 @@ import { useTabState } from "@/features/shared/hooks/useTabState";
 import PartsDrawer from "@/features/parts/components/PartsDrawer";
 import AssignTechModal from "@/features/work-orders/components/workorders/extras/AssignTechModal";
 import { JobCard } from "@/features/work-orders/components/JobCard";
+import WorkOrderAiOperationalRecommendations from "@/features/work-orders/components/WorkOrderAiOperationalRecommendations";
 import PageShell from "@/features/shared/components/PageShell";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import DecisionTimeline, {
@@ -1326,6 +1327,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                 Refreshing work order data…
               </div>
             ) : null}
+            <WorkOrderAiOperationalRecommendations workOrderId={wo.id} />
+
             <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
               <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">
                   <div className={cn(cardInner, "p-2")}>

--- a/features/ai/server/domains/workOrders/buildWorkOrderEvidenceSnapshot.ts
+++ b/features/ai/server/domains/workOrders/buildWorkOrderEvidenceSnapshot.ts
@@ -1,0 +1,368 @@
+import type { Database, Json } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAiEvidenceSnapshot, type AiActorContext, type AiEvidenceSnapshotRecord } from "@/features/ai/server";
+import { WORK_ORDER_RULES_VERSION, type WorkOrderEvidenceSnapshot } from "./types";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type InspectionSessionRow = DB["public"]["Tables"]["inspection_sessions"]["Row"];
+type WorkOrderApprovalRow = DB["public"]["Tables"]["work_order_approvals"]["Row"];
+type PartsRequestRow = DB["public"]["Tables"]["parts_requests"]["Row"];
+type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+type LaborSegmentRow = DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
+
+type BuildInput = {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  workOrderId: string;
+};
+
+function normalize(value: string | null | undefined): string {
+  return String(value ?? "unknown").trim().toLowerCase().replaceAll(" ", "_");
+}
+
+function hoursBetween(nowIso: string, fromIso: string | null): number | null {
+  if (!fromIso) return null;
+  const from = Date.parse(fromIso);
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(from) || !Number.isFinite(now)) return null;
+  return Math.max(0, (now - from) / 3_600_000);
+}
+
+function increment(map: Record<string, number>, key: string) {
+  map[key] = (map[key] ?? 0) + 1;
+}
+
+function getInspectionMetrics(state: Json | null): { missingAnswerCount: number | null; photoCount: number | null } {
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    return { missingAnswerCount: null, photoCount: null };
+  }
+
+  const raw = state as Record<string, Json | undefined>;
+  const missingAnswerCount =
+    typeof raw.missing_answer_count === "number"
+      ? raw.missing_answer_count
+      : typeof raw.unanswered_count === "number"
+        ? raw.unanswered_count
+        : null;
+
+  const photoCount =
+    typeof raw.photo_count === "number"
+      ? raw.photo_count
+      : Array.isArray(raw.photos)
+        ? raw.photos.length
+        : null;
+
+  return { missingAnswerCount, photoCount };
+}
+
+function computeConfidence(missingData: string[]): number {
+  const penalties: Record<string, number> = {
+    missing_customer_id: 0.06,
+    missing_vehicle_id: 0.06,
+    missing_work_order_status: 0.08,
+    no_work_order_lines: 0.2,
+    missing_inspection_data: 0.1,
+    missing_approval_data: 0.1,
+    missing_parts_data: 0.1,
+    missing_labor_data: 0.1,
+    missing_financial_totals: 0.08,
+  };
+
+  let score = 1;
+  for (const item of missingData) {
+    score -= penalties[item] ?? 0.03;
+  }
+
+  return Math.max(0, Math.min(1, Number(score.toFixed(2))));
+}
+
+export async function buildWorkOrderEvidenceSnapshot(input: BuildInput): Promise<{
+  evidence: AiEvidenceSnapshotRecord;
+  snapshot: WorkOrderEvidenceSnapshot;
+}> {
+  const { supabase, actor, workOrderId } = input;
+  const nowIso = new Date().toISOString();
+  const missingData = new Set<string>();
+
+  const { data: workOrder, error: woErr } = await supabase
+    .from("work_orders")
+    .select("*")
+    .eq("id", workOrderId)
+    .eq("shop_id", actor.shopId)
+    .maybeSingle<WorkOrderRow>();
+
+  if (woErr) throw new Error(woErr.message);
+  if (!workOrder) throw new Error("work order not found");
+
+  const [linesRes, inspectionRes, approvalsRes, partsReqRes, allocationRes, laborSegRes] = await Promise.all([
+    supabase
+      .from("work_order_lines")
+      .select("*")
+      .eq("work_order_id", workOrderId)
+      .eq("shop_id", actor.shopId),
+    supabase.from("inspection_sessions").select("*").eq("work_order_id", workOrderId),
+    supabase.from("work_order_approvals").select("*").eq("work_order_id", workOrderId),
+    supabase.from("parts_requests").select("*").eq("work_order_id", workOrderId),
+    supabase.from("work_order_part_allocations").select("*").eq("work_order_id", workOrderId),
+    supabase.from("work_order_line_labor_segments").select("*").eq("work_order_id", workOrderId).eq("shop_id", actor.shopId),
+  ]);
+
+  if (linesRes.error) throw new Error(linesRes.error.message);
+  if (inspectionRes.error) throw new Error(inspectionRes.error.message);
+  if (approvalsRes.error) throw new Error(approvalsRes.error.message);
+  if (partsReqRes.error) throw new Error(partsReqRes.error.message);
+  if (allocationRes.error) throw new Error(allocationRes.error.message);
+  if (laborSegRes.error) throw new Error(laborSegRes.error.message);
+
+  const lines = (linesRes.data ?? []) as WorkOrderLineRow[];
+  const inspections = (inspectionRes.data ?? []) as InspectionSessionRow[];
+  const approvals = (approvalsRes.data ?? []) as WorkOrderApprovalRow[];
+  const partRequests = (partsReqRes.data ?? []) as PartsRequestRow[];
+  const allocations = (allocationRes.data ?? []) as AllocationRow[];
+  const laborSegments = (laborSegRes.data ?? []) as LaborSegmentRow[];
+
+  if (!workOrder.customer_id) missingData.add("missing_customer_id");
+  if (!workOrder.vehicle_id) missingData.add("missing_vehicle_id");
+  if (!workOrder.status) missingData.add("missing_work_order_status");
+  if (lines.length === 0) missingData.add("no_work_order_lines");
+  if (inspections.length === 0) missingData.add("missing_inspection_data");
+  if (!workOrder.approval_state && approvals.length === 0) missingData.add("missing_approval_data");
+  if (partRequests.length === 0 && allocations.length === 0) missingData.add("missing_parts_data");
+  if (laborSegments.length === 0 && !lines.some((line) => line.punched_in_at)) missingData.add("missing_labor_data");
+  if (workOrder.invoice_total == null && workOrder.parts_total == null && workOrder.labor_total == null) {
+    missingData.add("missing_financial_totals");
+  }
+
+  const lineStatusCounts: Record<string, number> = {};
+  const lineApprovalCounts: Record<string, number> = {};
+  const jobPriorityCounts: Record<string, number> = {};
+  const assignedTechIds = new Set<string>();
+
+  let actionableLines = 0;
+  let informationalLines = 0;
+  let blockedCount = 0;
+  let activeCount = 0;
+  let completedCount = 0;
+
+  for (const line of lines) {
+    const status = normalize(line.status);
+    increment(lineStatusCounts, status);
+    increment(lineApprovalCounts, normalize(line.approval_state));
+    increment(jobPriorityCounts, normalize(line.job_priority));
+
+    if (line.assigned_tech_id) assignedTechIds.add(line.assigned_tech_id);
+
+    if (normalize(line.line_type) === "info") informationalLines += 1;
+    else actionableLines += 1;
+
+    if (status === "on_hold" || status === "awaiting_parts" || normalize(line.hold_reason).includes("part")) blockedCount += 1;
+    if (status === "active") activeCount += 1;
+    if (status === "completed" || status === "ready_to_invoice" || status === "invoiced") completedCount += 1;
+  }
+
+  const newestInspection = inspections
+    .slice()
+    .sort((a, b) => Date.parse(b.updated_at ?? b.completed_at ?? "") - Date.parse(a.updated_at ?? a.completed_at ?? ""))[0];
+
+  const inspectionMetrics = getInspectionMetrics(newestInspection?.state ?? null);
+  const inspectionWarnings: string[] = [];
+
+  if (newestInspection && normalize(newestInspection.status) !== "completed") {
+    inspectionWarnings.push("inspection_not_completed");
+  }
+  if ((inspectionMetrics.missingAnswerCount ?? 0) > 0) {
+    inspectionWarnings.push("inspection_missing_answers");
+  }
+
+  const approvalState = normalize(workOrder.approval_state);
+  const approvalPending = approvalState.includes("awaiting") || approvalState.includes("pending");
+  const approvalDeclined = approvalState.includes("declin");
+  const approvalApproved = approvalState.includes("approved") || approvals.some((row) => !!row.approved_at);
+  const approvalRequired =
+    lines.some((line) => normalize(line.approval_state) === "awaiting_approval") ||
+    approvalPending ||
+    approvalApproved ||
+    approvalDeclined;
+
+  const firstApprovalSentAt = workOrder.customer_approval_at ?? workOrder.customer_agreed_at;
+  const waitingMinutes = approvalPending && firstApprovalSentAt
+    ? Math.round(((Date.parse(nowIso) - Date.parse(firstApprovalSentAt)) / 60_000) * 10) / 10
+    : null;
+
+  const waitingParts =
+    partRequests.some((row) => !row.fulfilled_at) ||
+    lines.some((line) => normalize(line.status) === "on_hold" && normalize(line.hold_reason).includes("part"));
+
+  const activePunchCount = lines.filter((line) => !!line.punched_in_at && !line.punched_out_at).length;
+  const staleActivePunch = lines.some((line) => {
+    const age = hoursBetween(nowIso, line.punched_in_at);
+    return !!line.punched_in_at && !line.punched_out_at && (age ?? 0) >= 8;
+  });
+
+  const createdAt = workOrder.created_at;
+  const updatedAt = workOrder.updated_at;
+  const status = normalize(workOrder.status);
+
+  const ageHours = hoursBetween(nowIso, createdAt);
+  const staleHours = hoursBetween(nowIso, updatedAt);
+
+  const stalenessTier =
+    (staleHours ?? 0) >= 48 ? "critical" : (staleHours ?? 0) >= 24 ? "stale" : (staleHours ?? 0) >= 8 ? "monitor" : "fresh";
+
+  const invoiceStatus =
+    status === "invoiced" || !!workOrder.invoice_sent_at
+      ? "invoiced"
+      : status === "ready_to_invoice" || !!workOrder.invoice_url
+        ? "ready"
+        : "not_ready";
+
+  const inspectionFinalized =
+    !!workOrder.inspection_pdf_url ||
+    normalize(newestInspection?.status) === "completed" ||
+    !!newestInspection?.completed_at;
+
+  const linesComplete = lines.length > 0 && completedCount === lines.length;
+  const approvalResolved = !approvalRequired || approvalApproved || approvalDeclined;
+
+  const blockers: string[] = [];
+  if (!inspectionFinalized) blockers.push("inspection_not_finalized");
+  if (!linesComplete) blockers.push("lines_not_complete");
+  if (!approvalResolved) blockers.push("approval_unresolved");
+  if (invoiceStatus === "not_ready") blockers.push("invoice_not_ready");
+
+  const snapshot: WorkOrderEvidenceSnapshot = {
+    shop_id: actor.shopId,
+    work_order_id: workOrder.id,
+    work_order_number: workOrder.custom_id,
+    customer_id: workOrder.customer_id,
+    vehicle_id: workOrder.vehicle_id,
+    fleet_context: {
+      source_fleet_program_id: workOrder.source_fleet_program_id,
+      source_fleet_service_request_id: workOrder.source_fleet_service_request_id,
+    },
+    timestamps: {
+      created_at: workOrder.created_at,
+      opened_at: workOrder.created_at,
+      updated_at: workOrder.updated_at,
+      completed_at: status === "completed" || status === "invoiced" ? workOrder.updated_at : null,
+    },
+    work_order_state: {
+      status: workOrder.status,
+      approval_state: workOrder.approval_state,
+      estimate_status: workOrder.quote_url ? "available" : "not_generated",
+      invoice_status: invoiceStatus,
+      priority: workOrder.priority,
+      is_waiter: workOrder.is_waiter,
+      age_hours: ageHours,
+      stale_hours: staleHours,
+      staleness_tier: stalenessTier,
+    },
+    lines: {
+      total: lines.length,
+      actionable: actionableLines,
+      informational: informationalLines,
+      status_counts: lineStatusCounts,
+      approval_state_counts: lineApprovalCounts,
+      job_priority_counts: jobPriorityCounts,
+      assigned_technician_ids: Array.from(assignedTechIds),
+      blocked_count: blockedCount,
+      active_count: activeCount,
+      completed_count: completedCount,
+    },
+    inspections: {
+      exists: inspections.length > 0,
+      completed: inspections.some((item) => normalize(item.status) === "completed"),
+      finalize_state: inspectionFinalized ? "finalized" : "pending",
+      missing_answer_count: inspectionMetrics.missingAnswerCount,
+      photo_count: inspectionMetrics.photoCount,
+      warnings: inspectionWarnings,
+    },
+    approvals: {
+      required: approvalRequired,
+      sent_for_approval: approvalPending || Boolean(firstApprovalSentAt),
+      resolved: approvalResolved,
+      status: approvalRequired
+        ? approvalDeclined
+          ? "declined"
+          : approvalApproved
+            ? "approved"
+            : approvalPending
+              ? "pending"
+              : "unknown"
+        : "not_required",
+      waiting_minutes: waitingMinutes,
+      metadata: {
+        approval_rows: approvals.length as unknown as Json,
+      },
+    },
+    parts: {
+      requested_count: partRequests.length,
+      allocated_count: allocations.length,
+      waiting_parts: waitingParts,
+      fulfilled_request_count: partRequests.filter((row) => !!row.fulfilled_at).length,
+      missing_or_blocked: waitingParts || blockedCount > 0,
+    },
+    labor: {
+      active_punch_count: activePunchCount,
+      labor_segment_count: laborSegments.length,
+      active_technician_ids: Array.from(new Set(laborSegments.filter((s) => !s.ended_at).map((s) => s.technician_id))),
+      stale_active_punch: staleActivePunch,
+    },
+    financials: {
+      estimate_total: typeof workOrder.quote === "object" && workOrder.quote && "total" in workOrder.quote
+        ? Number((workOrder.quote as { total?: unknown }).total ?? 0)
+        : null,
+      invoice_total: workOrder.invoice_total,
+      labor_total: workOrder.labor_total,
+      parts_total: workOrder.parts_total,
+      margin_signal:
+        workOrder.invoice_total != null && workOrder.parts_total != null && workOrder.labor_total != null
+          ? workOrder.invoice_total - (workOrder.parts_total + workOrder.labor_total) >= 0
+            ? "non_negative"
+            : "negative"
+          : null,
+    },
+    closeout: {
+      invoice_ready: invoiceStatus !== "not_ready",
+      inspection_finalized: inspectionFinalized,
+      lines_complete: linesComplete,
+      approval_resolved: approvalResolved,
+      blockers,
+    },
+    evidence_metadata: {
+      source_refs: [
+        { table: "work_orders", id: workOrder.id },
+        { table: "work_order_lines", id: workOrder.id },
+        { table: "inspection_sessions", id: workOrder.id },
+        { table: "work_order_approvals", id: workOrder.id },
+        { table: "parts_requests", id: workOrder.id },
+        { table: "work_order_part_allocations", id: workOrder.id },
+        { table: "work_order_line_labor_segments", id: workOrder.id },
+      ],
+      missing_data: Array.from(missingData),
+      freshness_at: nowIso,
+      confidence: computeConfidence(Array.from(missingData)),
+      generated_at: nowIso,
+      rules_version: WORK_ORDER_RULES_VERSION,
+    },
+  };
+
+  const evidence = await createAiEvidenceSnapshot(supabase, actor, {
+    domain: "work_orders",
+    subjectType: "work_order",
+    subjectId: workOrder.id,
+    evidenceKind: "work_order_operational_state",
+    snapshot: snapshot as unknown as Json,
+    sourceRefs: snapshot.evidence_metadata.source_refs as unknown as Json,
+    missingData: snapshot.evidence_metadata.missing_data as unknown as Json,
+    freshnessAt: nowIso,
+    confidence: snapshot.evidence_metadata.confidence,
+    metadata: {
+      rules_version: WORK_ORDER_RULES_VERSION,
+    },
+  });
+
+  return { evidence, snapshot };
+}

--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -1,0 +1,100 @@
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  createAiRecommendation,
+  listAiRecommendationsForSubject,
+  type AiActorContext,
+  type AiRecommendationRecord,
+} from "@/features/ai/server";
+import { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot";
+import { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";
+import { WORK_ORDER_RULES_VERSION } from "./types";
+
+type DB = Database;
+
+export async function generateWorkOrderEvidenceAndRecommendations(input: {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  workOrderId: string;
+}): Promise<{
+  evidenceSnapshot: Awaited<ReturnType<typeof buildWorkOrderEvidenceSnapshot>>["evidence"];
+  recommendations: AiRecommendationRecord[];
+  skippedDuplicates: string[];
+  missingData: string[];
+  warnings: string[];
+}> {
+  const { supabase, actor, workOrderId } = input;
+
+  const { evidence, snapshot } = await buildWorkOrderEvidenceSnapshot({
+    supabase,
+    actor,
+    workOrderId,
+  });
+
+  const drafts = buildWorkOrderRecommendationsFromSnapshot(snapshot);
+  const existing = await listAiRecommendationsForSubject(supabase, actor, {
+    subjectType: "work_order",
+    subjectId: workOrderId,
+    domain: "work_orders",
+    limit: 200,
+  });
+
+  const openOrAcknowledged = new Set(
+    existing
+      .filter((row) => row.status === "open" || row.status === "acknowledged")
+      .map((row) => row.recommendation_type),
+  );
+
+  const created: AiRecommendationRecord[] = [];
+  const skippedDuplicates: string[] = [];
+
+  for (const draft of drafts) {
+    if (openOrAcknowledged.has(draft.recommendation_type)) {
+      skippedDuplicates.push(draft.recommendation_type);
+      continue;
+    }
+
+    const recommendation = await createAiRecommendation(supabase, actor, {
+      domain: "work_orders",
+      recommendationType: draft.recommendation_type,
+      subjectType: "work_order",
+      subjectId: workOrderId,
+      title: draft.title,
+      summary: draft.summary,
+      priority: draft.priority,
+      confidence: draft.confidence,
+      riskTier: draft.risk_tier,
+      evidenceSnapshotId: evidence.id,
+      missingData: draft.missing_data,
+      recommendedAction: draft.recommended_action,
+      sideEffects: draft.side_effects,
+      requiresApproval: draft.requires_approval,
+      requiresOwnerPin: false,
+      source: "work_order_rules",
+      metadata: {
+        rules_version: WORK_ORDER_RULES_VERSION,
+        ...draft.metadata,
+      },
+    });
+
+    created.push(recommendation);
+  }
+
+  const warnings: string[] = [];
+  if (drafts.length === 0) {
+    warnings.push("no_rule_triggers");
+  }
+
+  return {
+    evidenceSnapshot: evidence,
+    recommendations: created,
+    skippedDuplicates,
+    missingData: snapshot.evidence_metadata.missing_data,
+    warnings,
+  };
+}
+
+export type { WorkOrderEvidenceSnapshot, WorkOrderRecommendationDraft } from "./types";
+export { WORK_ORDER_RULES_VERSION } from "./types";
+export { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot";
+export { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";

--- a/features/ai/server/domains/workOrders/types.ts
+++ b/features/ai/server/domains/workOrders/types.ts
@@ -1,0 +1,114 @@
+import type { Json } from "@shared/types/types/supabase";
+import type { AiRecommendationPriority, AiRiskTier } from "@/features/ai/server/types";
+
+export const WORK_ORDER_RULES_VERSION = "wo_rules_v1";
+
+export type WorkOrderEvidenceSnapshot = {
+  shop_id: string;
+  work_order_id: string;
+  work_order_number: string | null;
+  customer_id: string | null;
+  vehicle_id: string | null;
+  fleet_context: {
+    source_fleet_program_id: string | null;
+    source_fleet_service_request_id: string | null;
+  };
+  timestamps: {
+    created_at: string | null;
+    opened_at: string | null;
+    updated_at: string | null;
+    completed_at: string | null;
+  };
+  work_order_state: {
+    status: string | null;
+    approval_state: string | null;
+    estimate_status: string | null;
+    invoice_status: string | null;
+    priority: number | null;
+    is_waiter: boolean;
+    age_hours: number | null;
+    stale_hours: number | null;
+    staleness_tier: "fresh" | "monitor" | "stale" | "critical";
+  };
+  lines: {
+    total: number;
+    actionable: number;
+    informational: number;
+    status_counts: Record<string, number>;
+    approval_state_counts: Record<string, number>;
+    job_priority_counts: Record<string, number>;
+    assigned_technician_ids: string[];
+    blocked_count: number;
+    active_count: number;
+    completed_count: number;
+  };
+  inspections: {
+    exists: boolean;
+    completed: boolean;
+    finalize_state: string;
+    missing_answer_count: number | null;
+    photo_count: number | null;
+    warnings: string[];
+  };
+  approvals: {
+    required: boolean;
+    sent_for_approval: boolean;
+    resolved: boolean;
+    status: "not_required" | "pending" | "approved" | "declined" | "unknown";
+    waiting_minutes: number | null;
+    metadata: Record<string, Json>;
+  };
+  parts: {
+    requested_count: number;
+    allocated_count: number;
+    waiting_parts: boolean;
+    fulfilled_request_count: number;
+    missing_or_blocked: boolean;
+  };
+  labor: {
+    active_punch_count: number;
+    labor_segment_count: number;
+    active_technician_ids: string[];
+    stale_active_punch: boolean;
+  };
+  financials: {
+    estimate_total: number | null;
+    invoice_total: number | null;
+    labor_total: number | null;
+    parts_total: number | null;
+    margin_signal: string | null;
+  };
+  closeout: {
+    invoice_ready: boolean;
+    inspection_finalized: boolean;
+    lines_complete: boolean;
+    approval_resolved: boolean;
+    blockers: string[];
+  };
+  evidence_metadata: {
+    source_refs: Array<Record<string, string | null>>;
+    missing_data: string[];
+    freshness_at: string;
+    confidence: number;
+    generated_at: string;
+    rules_version: string;
+  };
+};
+
+export type WorkOrderRecommendationDraft = {
+  recommendation_type: string;
+  title: string;
+  summary: string;
+  priority: AiRecommendationPriority;
+  confidence: number;
+  risk_tier: AiRiskTier;
+  missing_data: string[];
+  recommended_action: {
+    action_type: string;
+    label: string;
+    details: string;
+  };
+  side_effects: string[];
+  requires_approval: boolean;
+  metadata?: Record<string, Json>;
+};

--- a/features/ai/server/domains/workOrders/workOrderRecommendationRules.ts
+++ b/features/ai/server/domains/workOrders/workOrderRecommendationRules.ts
@@ -1,0 +1,152 @@
+import { WORK_ORDER_RULES_VERSION, type WorkOrderEvidenceSnapshot, type WorkOrderRecommendationDraft } from "./types";
+
+export function buildWorkOrderRecommendationsFromSnapshot(snapshot: WorkOrderEvidenceSnapshot): WorkOrderRecommendationDraft[] {
+  const recommendations: WorkOrderRecommendationDraft[] = [];
+
+  const ageHours = snapshot.work_order_state.age_hours ?? 0;
+  const staleHours = snapshot.work_order_state.stale_hours ?? 0;
+  const isStale = staleHours >= 24 || ageHours >= 72;
+  const hasNextAction = snapshot.lines.active_count > 0 || snapshot.parts.waiting_parts || snapshot.approvals.status === "pending";
+
+  if (isStale && !hasNextAction) {
+    recommendations.push({
+      recommendation_type: "work_order_aging_without_next_action",
+      title: "Aging work order needs next operational step",
+      summary: "No active line, parts wait, or approval wait was detected while the work order is stale.",
+      priority: ageHours >= 120 ? "urgent" : "high",
+      confidence: 0.86,
+      risk_tier: "medium",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "review_work_order",
+        label: "Review work order",
+        details: "Confirm owner, assignment, and current bottleneck before additional delay.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  if (snapshot.approvals.status === "pending") {
+    recommendations.push({
+      recommendation_type: "waiting_on_approval",
+      title: "Waiting on customer/fleet approval",
+      summary: `Approval has not been resolved${snapshot.approvals.waiting_minutes ? ` for ~${Math.round(snapshot.approvals.waiting_minutes)} min` : ""}.`,
+      priority: snapshot.approvals.waiting_minutes && snapshot.approvals.waiting_minutes > 240 ? "high" : "normal",
+      confidence: 0.9,
+      risk_tier: "low",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "send_estimate_review_needed",
+        label: "Review approval queue",
+        details: "Advisor should verify quote/approval status and follow existing approval workflow.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  if (snapshot.parts.waiting_parts) {
+    recommendations.push({
+      recommendation_type: "waiting_on_parts",
+      title: "Work order appears blocked by parts",
+      summary: "Open parts requests or part-related hold state detected.",
+      priority: "high",
+      confidence: 0.84,
+      risk_tier: "medium",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "check_parts_status",
+        label: "Check parts status",
+        details: "Review open requests, receiving state, and line hold reasons.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  if (snapshot.inspections.exists && (!snapshot.inspections.completed || (snapshot.inspections.missing_answer_count ?? 0) > 0)) {
+    recommendations.push({
+      recommendation_type: "inspection_incomplete",
+      title: "Inspection data is incomplete",
+      summary: "Inspection exists but completion/finalization signals are incomplete.",
+      priority: "high",
+      confidence: 0.88,
+      risk_tier: "medium",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "complete_inspection",
+        label: "Complete inspection",
+        details: "Finish outstanding inspection answers and finalize existing inspection flow.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  if (snapshot.closeout.lines_complete && snapshot.closeout.approval_resolved && !snapshot.closeout.invoice_ready) {
+    recommendations.push({
+      recommendation_type: "ready_for_closeout_review",
+      title: "Ready for closeout review",
+      summary: "Lines and approvals look complete, but invoice/closeout state is still pending.",
+      priority: "normal",
+      confidence: 0.85,
+      risk_tier: "low",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "review_closeout_readiness",
+        label: "Review closeout readiness",
+        details: "Advisor should confirm invoice readiness and completion workflow.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  if (snapshot.labor.stale_active_punch || (snapshot.lines.active_count > 0 && staleHours > 8 && snapshot.lines.blocked_count > 0)) {
+    recommendations.push({
+      recommendation_type: "technician_blocked_or_stale_active_work",
+      title: "Technician work appears blocked or stale",
+      summary: "An active labor session or active line appears stale and may need dispatch intervention.",
+      priority: "high",
+      confidence: 0.81,
+      risk_tier: "medium",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "review_work_order",
+        label: "Review technician dispatch state",
+        details: "Confirm line ownership, punch state, and hold reason.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  if ((snapshot.lines.job_priority_counts.urgent ?? 0) > 0 && (isStale || snapshot.parts.waiting_parts || snapshot.approvals.status === "pending")) {
+    recommendations.push({
+      recommendation_type: "priority_escalation_candidate",
+      title: "Priority escalation candidate",
+      summary: "Urgent priority exists with delay or blocker signals.",
+      priority: "urgent",
+      confidence: 0.83,
+      risk_tier: "high",
+      missing_data: snapshot.evidence_metadata.missing_data,
+      recommended_action: {
+        action_type: "review_work_order",
+        label: "Escalate operational review",
+        details: "Escalate to manager/advisor queue based on existing priority process.",
+      },
+      side_effects: ["no_mutation"],
+      requires_approval: false,
+      metadata: { rules_version: WORK_ORDER_RULES_VERSION },
+    });
+  }
+
+  return recommendations;
+}

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -5,3 +5,4 @@ export * from "./actionPreviews";
 export * from "./actionApprovals";
 export * from "./actionEvents";
 export * from "./safeActions";
+export * from "./domains/workOrders";

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { cn } from "@shared/lib/utils";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+
+type RecommendationRow = {
+  id: string;
+  title: string;
+  summary: string | null;
+  priority: "low" | "normal" | "high" | "urgent";
+  confidence: number | null;
+  risk_tier: "low" | "medium" | "high" | "critical";
+  status: string;
+  recommended_action: {
+    label?: string;
+  } | null;
+  missing_data: string[] | null;
+  created_at: string;
+};
+
+type EvidenceRow = {
+  id: string;
+  freshness_at: string | null;
+  confidence: number | null;
+  missing_data: string[] | null;
+  created_at: string;
+};
+
+export default function WorkOrderAiOperationalRecommendations({ workOrderId }: { workOrderId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [recommendations, setRecommendations] = useState<RecommendationRow[]>([]);
+  const [evidence, setEvidence] = useState<EvidenceRow | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/ai/recommendations`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load operational recommendations.");
+      setRecommendations(Array.isArray(json.recommendations) ? json.recommendations : []);
+      setEvidence(json.evidenceSnapshot ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load operational recommendations.");
+    } finally {
+      setLoading(false);
+    }
+  }, [workOrderId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onGenerate = useCallback(async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/ai/recommendations`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to generate operational recommendations.");
+      setRecommendations(Array.isArray(json.recommendations) ? json.recommendations : []);
+      setEvidence(json.evidenceSnapshot ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate operational recommendations.");
+    } finally {
+      setRefreshing(false);
+    }
+  }, [workOrderId]);
+
+  const freshnessLabel = useMemo(() => {
+    if (!evidence?.freshness_at) return "No evidence snapshot yet";
+    return `Evidence freshness: ${new Date(evidence.freshness_at).toLocaleString()}`;
+  }, [evidence?.freshness_at]);
+
+  return (
+    <section className={cn(PANEL_VARIANTS.secondary, "p-2")}> 
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">AI operational recommendations</h2>
+          <p className="mt-1 text-[11px] text-muted-foreground">Rules-based readiness signals. Read-only, no autonomous execution.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-md border border-[rgba(184,115,51,0.5)] px-2 py-1 text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:bg-[rgba(184,115,51,0.12)] disabled:opacity-50"
+          onClick={() => void onGenerate()}
+          disabled={refreshing}
+        >
+          {refreshing ? "Generating…" : "Generate / Refresh"}
+        </button>
+      </div>
+
+      {loading ? <p className="mt-2 text-[11px] text-muted-foreground">Loading operational recommendations…</p> : null}
+      {error ? <p className="mt-2 text-[11px] text-red-300">{error}</p> : null}
+
+      {!loading && !error && recommendations.length === 0 ? (
+        <div className={cn(PANEL_VARIANTS.passive, "mt-2 p-2 text-[11px] text-muted-foreground")}>
+          No active operational recommendations. Generate a fresh evidence snapshot.
+        </div>
+      ) : null}
+
+      {!loading && !error && recommendations.length > 0 ? (
+        <div className="mt-2 space-y-2">
+          {recommendations.map((item) => (
+            <article key={item.id} className={cn(PANEL_VARIANTS.passive, "p-2")}> 
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-medium text-foreground">{item.title}</p>
+                <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{item.priority}</span>
+                <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">risk {item.risk_tier}</span>
+              </div>
+              <p className="mt-1 text-[11px] text-muted-foreground">{item.summary ?? "Operational review suggested."}</p>
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.label ?? "Review work order"}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      <p className="mt-2 text-[10px] text-muted-foreground">{freshnessLabel} • Generated by work order rules.</p>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Integrate the canonical AI substrate into the work-order domain to produce deterministic, shop-scoped, evidence-backed operational recommendations without mutating workflows. 
- Provide advisor/dispatch surfaces with non-autonomous, read-only signals that surface blockers (parts, approvals, inspections, stale labor) and reduce manual triage time.

### Description
- Added a new work-order AI domain module with types, a deterministic evidence snapshot builder, and rule-based recommendation generator at `features/ai/server/domains/workOrders/` (files: `types.ts`, `buildWorkOrderEvidenceSnapshot.ts`, `workOrderRecommendationRules.ts`, `index.ts`).
- Persisted evidence with `createAiEvidenceSnapshot` and persisted recommendations with `createAiRecommendation`, including deterministic completeness scoring, source refs, freshness, and rules version metadata.
- Implemented duplicate-prevention (skip creating a recommendation when an open/acknowledged recommendation of the same type already exists) and kept all writes limited to `ai_evidence_snapshots` and `ai_recommendations`.
- Added a shop-scoped, authenticated API route `GET/POST /api/work-orders/[id]/ai/recommendations` which returns open recommendations and latest evidence (GET) and generates fresh evidence + recommendations with role/capability gating (POST).
- Added a read-only UI card `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx` and wired it into the work-order detail page for safe load/generate/refresh behavior, with loading/empty/error states and no execution buttons.
- Exported the new domain from `features/ai/server/index.ts` and made no schema migrations (the AI substrate was pre-run as requested).

### Testing
- Ran type checking with `npx tsc --noEmit`, which completed successfully. 
- Ran the test suite with `npm test`, which completed successfully (tests passed). 
- Attempted `npm test -- --runInBand` but it failed because Vitest in this environment does not support the `--runInBand` flag, which is a tooling mismatch and not a functional regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74a1a96c8328bb00de48b3d6505f)