### PR TITLE
Add lifecycle actions for work-order AI recommendations (ack/dismiss/resolve)

### DIFF
--- a/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  acknowledgeAiRecommendation,
+  dismissAiRecommendation,
+  getAiRecommendation,
+  resolveAiRecommendation,
+} from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type LifecycleAction = "acknowledge" | "dismiss" | "resolve";
+
+type PatchBody = {
+  action?: unknown;
+  note?: unknown;
+};
+
+const VALID_ACTIONS: ReadonlySet<LifecycleAction> = new Set(["acknowledge", "dismiss", "resolve"]);
+const MAX_NOTE_LENGTH = 500;
+
+async function getShopScopedWorkOrder(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<WorkOrderRow | null> {
+  const { data, error } = await input.supabase
+    .from("work_orders")
+    .select("*")
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<WorkOrderRow>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+function parsePatchBody(raw: PatchBody): { action: LifecycleAction; note: string | null } {
+  const action = typeof raw.action === "string" ? raw.action.trim() : "";
+  if (!VALID_ACTIONS.has(action as LifecycleAction)) {
+    throw new Error("Invalid action. Expected one of: acknowledge, dismiss, resolve.");
+  }
+
+  if (raw.note != null && typeof raw.note !== "string") {
+    throw new Error("Invalid note. Expected a string.");
+  }
+
+  const note = typeof raw.note === "string" ? raw.note.trim() : "";
+  if (note.length > MAX_NOTE_LENGTH) {
+    throw new Error(`Note must be ${MAX_NOTE_LENGTH} characters or fewer.`);
+  }
+
+  return {
+    action: action as LifecycleAction,
+    note: note.length > 0 ? note : null,
+  };
+}
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string; recommendationId: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id, recommendationId } = await ctx.params;
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+  }
+
+  if (!recommendationId) {
+    return NextResponse.json({ error: "Missing recommendation id" }, { status: 400 });
+  }
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  let body: { action: LifecycleAction; note: string | null };
+  try {
+    const raw = (await req.json().catch(() => null)) as PatchBody | null;
+    if (!raw || typeof raw !== "object") {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    body = parsePatchBody(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid request";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  try {
+    const scopedWorkOrder = await getShopScopedWorkOrder({
+      supabase: access.supabase,
+      workOrderId: id,
+      shopId,
+    });
+
+    if (!scopedWorkOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    const actor = {
+      shopId,
+      actorId: access.profile.id,
+      role: access.profile.role,
+      source: "manual" as const,
+    };
+
+    const recommendation = await getAiRecommendation(access.supabase, actor, recommendationId);
+
+    if (!recommendation) {
+      return NextResponse.json({ error: "Recommendation not found" }, { status: 404 });
+    }
+
+    if (
+      recommendation.shop_id !== shopId ||
+      recommendation.domain !== "work_orders" ||
+      recommendation.subject_type !== "work_order" ||
+      recommendation.subject_id !== id
+    ) {
+      return NextResponse.json({ error: "Recommendation not found" }, { status: 404 });
+    }
+
+    let updated;
+    if (body.action === "acknowledge") {
+      updated = await acknowledgeAiRecommendation(access.supabase, actor, recommendationId, { note: body.note });
+    } else if (body.action === "dismiss") {
+      updated = await dismissAiRecommendation(access.supabase, actor, recommendationId, { note: body.note });
+    } else {
+      updated = await resolveAiRecommendation(access.supabase, actor, recommendationId, { note: body.note });
+    }
+
+    return NextResponse.json({ recommendation: updated });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update recommendation";
+
+    if (message.includes("recommendation not found")) {
+      return NextResponse.json({ error: "Recommendation not found" }, { status: 404 });
+    }
+
+    if (message.includes("invalid recommendation status transition")) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Failed to update recommendation" }, { status: 500 });
+  }
+}

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { cn } from "@shared/lib/utils";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+
+type RecommendationLifecycleAction = "acknowledge" | "dismiss" | "resolve";
 
 type RecommendationRow = {
   id: string;
@@ -33,6 +36,7 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
   const [error, setError] = useState<string | null>(null);
   const [recommendations, setRecommendations] = useState<RecommendationRow[]>([]);
   const [evidence, setEvidence] = useState<EvidenceRow | null>(null);
+  const [activeAction, setActiveAction] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -63,12 +67,61 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
       if (!res.ok) throw new Error(json?.error ?? "Failed to generate operational recommendations.");
       setRecommendations(Array.isArray(json.recommendations) ? json.recommendations : []);
       setEvidence(json.evidenceSnapshot ?? null);
+      toast.success("Operational recommendations refreshed.");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to generate operational recommendations.");
+      const message = err instanceof Error ? err.message : "Failed to generate operational recommendations.";
+      setError(message);
+      toast.error(message);
     } finally {
       setRefreshing(false);
     }
   }, [workOrderId]);
+
+  const onLifecycleAction = useCallback(
+    async (recommendationId: string, action: RecommendationLifecycleAction) => {
+      const actionKey = `${recommendationId}:${action}`;
+      setActiveAction(actionKey);
+      setError(null);
+
+      try {
+        const res = await fetch(`/api/work-orders/${workOrderId}/ai/recommendations/${recommendationId}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ action }),
+        });
+
+        const json = await res.json();
+        if (!res.ok) throw new Error(json?.error ?? "Failed to update recommendation.");
+
+        const updated = json?.recommendation as RecommendationRow | undefined;
+        if (!updated?.id) throw new Error("Updated recommendation response was invalid.");
+
+        setRecommendations((prev) => {
+          if (updated.status === "dismissed" || updated.status === "resolved") {
+            return prev.filter((item) => item.id !== updated.id);
+          }
+          return prev.map((item) => (item.id === updated.id ? updated : item));
+        });
+
+        if (action === "acknowledge") {
+          toast.success("Recommendation acknowledged.");
+        } else if (action === "dismiss") {
+          toast.success("Recommendation dismissed.");
+        } else {
+          toast.success("Recommendation marked resolved.");
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to update recommendation.";
+        setError(message);
+        toast.error(message);
+      } finally {
+        setActiveAction(null);
+      }
+    },
+    [workOrderId],
+  );
 
   const freshnessLabel = useMemo(() => {
     if (!evidence?.freshness_at) return "No evidence snapshot yet";
@@ -76,7 +129,7 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
   }, [evidence?.freshness_at]);
 
   return (
-    <section className={cn(PANEL_VARIANTS.secondary, "p-2")}> 
+    <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
       <div className="flex items-center justify-between gap-2">
         <div>
           <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">AI operational recommendations</h2>
@@ -103,19 +156,51 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
 
       {!loading && !error && recommendations.length > 0 ? (
         <div className="mt-2 space-y-2">
-          {recommendations.map((item) => (
-            <article key={item.id} className={cn(PANEL_VARIANTS.passive, "p-2")}> 
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-medium text-foreground">{item.title}</p>
-                <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{item.priority}</span>
-                <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">risk {item.risk_tier}</span>
-              </div>
-              <p className="mt-1 text-[11px] text-muted-foreground">{item.summary ?? "Operational review suggested."}</p>
-              <div className="mt-1 text-[10px] text-muted-foreground">
-                Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.label ?? "Review work order"}
-              </div>
-            </article>
-          ))}
+          {recommendations.map((item) => {
+            const isRowBusy = activeAction?.startsWith(`${item.id}:`) ?? false;
+            return (
+              <article key={item.id} className={cn(PANEL_VARIANTS.passive, "p-2")}>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">{item.title}</p>
+                  <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{item.priority}</span>
+                  <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">risk {item.risk_tier}</span>
+                  {item.status === "acknowledged" ? (
+                    <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">acknowledged</span>
+                  ) : null}
+                </div>
+                <p className="mt-1 text-[11px] text-muted-foreground">{item.summary ?? "Operational review suggested."}</p>
+                <div className="mt-1 text-[10px] text-muted-foreground">
+                  Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.label ?? "Review work order"}
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-1">
+                  <button
+                    type="button"
+                    className="rounded-md border border-white/20 px-2 py-1 text-[11px] text-muted-foreground transition hover:bg-white/10 disabled:opacity-50"
+                    disabled={isRowBusy || item.status === "acknowledged"}
+                    onClick={() => void onLifecycleAction(item.id, "acknowledge")}
+                  >
+                    {activeAction === `${item.id}:acknowledge` ? "Acknowledging…" : "Acknowledge"}
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md border border-white/20 px-2 py-1 text-[11px] text-muted-foreground transition hover:bg-white/10 disabled:opacity-50"
+                    disabled={isRowBusy}
+                    onClick={() => void onLifecycleAction(item.id, "dismiss")}
+                  >
+                    {activeAction === `${item.id}:dismiss` ? "Dismissing…" : "Dismiss"}
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md border border-white/20 px-2 py-1 text-[11px] text-muted-foreground transition hover:bg-white/10 disabled:opacity-50"
+                    disabled={isRowBusy}
+                    onClick={() => void onLifecycleAction(item.id, "resolve")}
+                  >
+                    {activeAction === `${item.id}:resolve` ? "Resolving…" : "Mark resolved"}
+                  </button>
+                </div>
+              </article>
+            );
+          })}
         </div>
       ) : null}
 


### PR DESCRIPTION
### Motivation
- Provide authorized shop staff a simple, safe way to acknowledge, dismiss, or resolve AI operational recommendations tied to a work order. 
- Keep everything recommendation-first and canonical by reusing the existing ai_recommendations helpers and event logging without adding execution or side-effect flows.

### Description
- Added a shop-scoped `PATCH` API route at `app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts` that accepts `{ action: "acknowledge" | "dismiss" | "resolve", note?: string }`, validates input, enforces `canManageWorkOrders` + allowed roles, verifies work-order and recommendation ownership, and delegates to `acknowledgeAiRecommendation`, `dismissAiRecommendation`, or `resolveAiRecommendation`.
- Updated the work-order recommendations card `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx` to show per-recommendation actions (`Acknowledge`, `Dismiss`, `Mark resolved`) with per-row loading state, toast feedback, and local state updates where acknowledged items show a badge and dismissed/resolved items are removed from the open list.
- Strict validation and safety: note length limit, explicit action whitelist, shop scoping, subject/domain checks, and mapped error responses for 400/403/404/500 cases.
- Files changed: `app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts`, `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx`.

### Testing
- Ran type check with `npx tsc --noEmit` which completed successfully (no emit errors).
- Ran unit tests with `npm test` (Vitest) and the test suite passed (all tests green).
- Verified working tree and commit: `git status --short` shows the two files staged and committed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb797e5dcc8328bcaad35e3b2e0cc6)