### PR TITLE
Add low-risk work-order AI action preview generation (preview-only)

### DIFF
--- a/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route.ts
@@ -1,0 +1,268 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAiActionPreview, getAiRecommendation, logAiActionEvent, type AiActionPreviewRecord } from "@/features/ai/server";
+import {
+  buildWorkOrderActionPreviewPayload,
+  buildWorkOrderPreviewIdempotencyKey,
+  normalizePreviewWarnings,
+} from "@/features/ai/server/domains/workOrders";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+
+const BLOCKED_REASON = "Autonomous AI action execution is not enabled. This preview is informational only.";
+
+async function getShopScopedWorkOrder(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<WorkOrderRow | null> {
+  const { data, error } = await input.supabase
+    .from("work_orders")
+    .select("*")
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<WorkOrderRow>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function getPreviewByIdempotencyKey(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  idempotencyKey: string;
+}): Promise<AiActionPreviewRecord | null> {
+  const { data, error } = await input.supabase
+    .from("ai_action_previews")
+    .select("*")
+    .eq("shop_id", input.shopId)
+    .eq("idempotency_key", input.idempotencyKey)
+    .maybeSingle<AiActionPreviewRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function listPreviewsForRecommendation(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  recommendationId: string;
+  workOrderId: string;
+}): Promise<AiActionPreviewRecord[]> {
+  const { data, error } = await input.supabase
+    .from("ai_action_previews")
+    .select("*")
+    .eq("shop_id", input.shopId)
+    .eq("recommendation_id", input.recommendationId)
+    .eq("domain", "work_orders")
+    .eq("subject_type", "work_order")
+    .eq("subject_id", input.workOrderId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AiActionPreviewRecord[];
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string; recommendationId: string }> },
+) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const { id, recommendationId } = await ctx.params;
+
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+  if (!recommendationId) return NextResponse.json({ error: "Missing recommendation id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  try {
+    const scopedWorkOrder = await getShopScopedWorkOrder({
+      supabase: access.supabase,
+      workOrderId: id,
+      shopId,
+    });
+
+    if (!scopedWorkOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    const recommendation = await getAiRecommendation(access.supabase, actor, recommendationId);
+
+    if (
+      !recommendation ||
+      recommendation.shop_id !== shopId ||
+      recommendation.domain !== "work_orders" ||
+      recommendation.subject_type !== "work_order" ||
+      recommendation.subject_id !== id
+    ) {
+      return NextResponse.json({ error: "Recommendation not found" }, { status: 404 });
+    }
+
+    const previews = await listPreviewsForRecommendation({
+      supabase: access.supabase,
+      shopId,
+      recommendationId,
+      workOrderId: id,
+    });
+
+    return NextResponse.json({
+      preview: previews[0] ?? null,
+      previews,
+      executionBlocked: true,
+      blockedReason: BLOCKED_REASON,
+      warnings: [BLOCKED_REASON],
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to load action previews" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ id: string; recommendationId: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id, recommendationId } = await ctx.params;
+
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+  if (!recommendationId) return NextResponse.json({ error: "Missing recommendation id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  try {
+    const scopedWorkOrder = await getShopScopedWorkOrder({
+      supabase: access.supabase,
+      workOrderId: id,
+      shopId,
+    });
+
+    if (!scopedWorkOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    const recommendation = await getAiRecommendation(access.supabase, actor, recommendationId);
+
+    if (
+      !recommendation ||
+      recommendation.shop_id !== shopId ||
+      recommendation.domain !== "work_orders" ||
+      recommendation.subject_type !== "work_order" ||
+      recommendation.subject_id !== id
+    ) {
+      return NextResponse.json({ error: "Recommendation not found" }, { status: 404 });
+    }
+
+    const payload = buildWorkOrderActionPreviewPayload({
+      recommendation,
+      workOrderId: id,
+    });
+
+    if ("previewable" in payload && payload.previewable === false) {
+      return NextResponse.json(
+        {
+          error: payload.reason,
+          executionBlocked: true,
+          blockedReason: BLOCKED_REASON,
+          warnings: [payload.reason, BLOCKED_REASON],
+        },
+        { status: 400 },
+      );
+    }
+
+    if (payload.risk_tier === "critical") {
+      return NextResponse.json(
+        {
+          error: "Critical-risk previews are not enabled in this phase.",
+          executionBlocked: true,
+          blockedReason: BLOCKED_REASON,
+          warnings: [BLOCKED_REASON],
+        },
+        { status: 400 },
+      );
+    }
+
+    const idempotencyKey = buildWorkOrderPreviewIdempotencyKey({
+      shopId,
+      workOrderId: id,
+      recommendationId,
+      actionType: payload.action_type,
+    });
+
+    const existing = await getPreviewByIdempotencyKey({
+      supabase: access.supabase,
+      shopId,
+      idempotencyKey,
+    });
+
+    const preview =
+      existing ??
+      (await createAiActionPreview(access.supabase, actor, {
+        recommendationId,
+        domain: "work_orders",
+        actionType: payload.action_type,
+        subjectType: "work_order",
+        subjectId: id,
+        previewPayload: payload,
+        intendedMutations: payload.intended_mutations,
+        affectedRecords: payload.affected_records,
+        sideEffects: payload.side_effects,
+        compensationPlan: payload.compensation_plan,
+        idempotencyKey,
+        riskTier: payload.risk_tier,
+        evidenceSnapshotId: payload.evidence_snapshot_id,
+        requiresApproval: payload.requires_approval,
+        requiresOwnerPin: false,
+        metadata: {
+          blocked_execution_reason: payload.blocked_execution_reason,
+          recommendation_type: recommendation.recommendation_type,
+        },
+      }));
+
+    await logAiActionEvent(access.supabase, actor, {
+      recommendationId,
+      actionPreviewId: preview.id,
+      eventType: "action_preview.blocked_execution",
+      idempotencyKey,
+      payload: {
+        reason: BLOCKED_REASON,
+        execution_blocked: true,
+      },
+    });
+
+    return NextResponse.json({
+      preview,
+      executionBlocked: true,
+      blockedReason: BLOCKED_REASON,
+      warnings: normalizePreviewWarnings(payload),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to generate action preview";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/features/ai/server/actionPreviews.ts
+++ b/features/ai/server/actionPreviews.ts
@@ -103,7 +103,7 @@ export async function createAiActionPreview(
   await logAiActionEvent(supabase, ctx, {
     recommendationId: data.recommendation_id,
     actionPreviewId: data.id,
-    eventType: "preview.created",
+    eventType: "action_preview.created",
     idempotencyKey: data.idempotency_key,
     payload: {
       action_preview_id: data.id,

--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -98,3 +98,5 @@ export type { WorkOrderEvidenceSnapshot, WorkOrderRecommendationDraft } from "./
 export { WORK_ORDER_RULES_VERSION } from "./types";
 export { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot";
 export { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";
+
+export * from "./workOrderActionPreviews";

--- a/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
+++ b/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
@@ -1,0 +1,181 @@
+import type { Json } from "@shared/types/types/supabase";
+import type { AiRecommendationRecord, AiRiskTier } from "@/features/ai/server/types";
+
+export type WorkOrderPreviewActionType =
+  | "review_work_order"
+  | "check_parts_status"
+  | "complete_inspection_review"
+  | "review_closeout_readiness"
+  | "advisor_review_needed"
+  | "priority_escalation_review";
+
+export type WorkOrderRecommendationPreviewability =
+  | { previewable: true; actionType: WorkOrderPreviewActionType }
+  | { previewable: false; reason: string };
+
+export type WorkOrderActionPreviewPayload = {
+  previewable: true;
+  action_type: WorkOrderPreviewActionType;
+  label: string;
+  description: string;
+  recommendation_id: string;
+  work_order_id: string;
+  evidence_snapshot_id: string | null;
+  intended_mutations: [];
+  affected_records: Array<{
+    type: "work_order" | "recommendation" | "evidence_snapshot";
+    id: string;
+  }>;
+  side_effects: string[];
+  compensation_plan: {
+    mode: "preview_only";
+    details: string;
+  };
+  requires_approval: boolean;
+  requires_owner_pin: false;
+  risk_tier: AiRiskTier;
+  blocked_execution_reason: string;
+  evidence_used: {
+    evidence_snapshot_id: string | null;
+    recommendation_id: string;
+    recommendation_type: string;
+  };
+};
+
+type ActionSpec = {
+  actionType: WorkOrderPreviewActionType;
+  label: string;
+  description: string;
+};
+
+const PREVIEW_BLOCKED_REASON = "Autonomous AI action execution is not enabled. This preview is informational only.";
+
+const RECOMMENDATION_PREVIEW_MAP: Record<string, ActionSpec> = {
+  work_order_aging_without_next_action: {
+    actionType: "review_work_order",
+    label: "Review work order",
+    description: "Review assignment, hold reasons, and next operational step for this work order.",
+  },
+  waiting_on_approval: {
+    actionType: "advisor_review_needed",
+    label: "Advisor review needed",
+    description: "Review pending approval state using the existing advisor workflow.",
+  },
+  waiting_on_parts: {
+    actionType: "check_parts_status",
+    label: "Check parts status",
+    description: "Review open parts requests, receiving status, and part-related holds.",
+  },
+  inspection_incomplete: {
+    actionType: "complete_inspection_review",
+    label: "Complete inspection review",
+    description: "Review inspection completeness and finalize through the existing inspection flow.",
+  },
+  ready_for_closeout_review: {
+    actionType: "review_closeout_readiness",
+    label: "Review closeout readiness",
+    description: "Review closeout/invoice readiness with no automatic closeout mutation.",
+  },
+  technician_blocked_or_stale_active_work: {
+    actionType: "review_work_order",
+    label: "Review work order",
+    description: "Review active technician dispatch and stale activity signals.",
+  },
+  priority_escalation_candidate: {
+    actionType: "priority_escalation_review",
+    label: "Priority escalation review",
+    description: "Escalate this work order for internal manager/advisor review only.",
+  },
+};
+
+function isAllowedRiskTier(riskTier: AiRiskTier): boolean {
+  return riskTier === "low" || riskTier === "medium" || riskTier === "high";
+}
+
+export function isWorkOrderRecommendationPreviewable(
+  recommendation: Pick<AiRecommendationRecord, "recommendation_type" | "risk_tier">,
+): WorkOrderRecommendationPreviewability {
+  const mapped = RECOMMENDATION_PREVIEW_MAP[recommendation.recommendation_type];
+
+  if (!mapped) {
+    return { previewable: false, reason: "Recommendation action is not in the low-risk internal preview allowlist." };
+  }
+
+  if (!isAllowedRiskTier(recommendation.risk_tier)) {
+    return { previewable: false, reason: "Critical-risk recommendations are not previewable in this phase." };
+  }
+
+  return { previewable: true, actionType: mapped.actionType };
+}
+
+export function buildWorkOrderActionPreviewPayload(input: {
+  recommendation: Pick<
+    AiRecommendationRecord,
+    "id" | "recommendation_type" | "risk_tier" | "evidence_snapshot_id" | "summary" | "subject_id" | "title"
+  >;
+  workOrderId: string;
+}): WorkOrderActionPreviewPayload | { previewable: false; reason: string } {
+  const previewability = isWorkOrderRecommendationPreviewable(input.recommendation);
+  if (!previewability.previewable) {
+    return previewability;
+  }
+
+  const spec = RECOMMENDATION_PREVIEW_MAP[input.recommendation.recommendation_type];
+  const requiresApproval = input.recommendation.risk_tier === "medium" || input.recommendation.risk_tier === "high";
+
+  const affectedRecords: WorkOrderActionPreviewPayload["affected_records"] = [
+    { type: "work_order", id: input.workOrderId },
+    { type: "recommendation", id: input.recommendation.id },
+  ];
+
+  if (input.recommendation.evidence_snapshot_id) {
+    affectedRecords.push({ type: "evidence_snapshot", id: input.recommendation.evidence_snapshot_id });
+  }
+
+  return {
+    previewable: true,
+    action_type: spec.actionType,
+    label: spec.label,
+    description: input.recommendation.summary?.trim() || spec.description,
+    recommendation_id: input.recommendation.id,
+    work_order_id: input.workOrderId,
+    evidence_snapshot_id: input.recommendation.evidence_snapshot_id,
+    intended_mutations: [],
+    affected_records: affectedRecords,
+    side_effects: ["Internal operational preview only.", "No external/customer-facing side effects."],
+    compensation_plan: {
+      mode: "preview_only",
+      details: "No execution is supported yet; no compensation plan is needed for preview-only generation.",
+    },
+    requires_approval: requiresApproval,
+    requires_owner_pin: false,
+    risk_tier: input.recommendation.risk_tier,
+    blocked_execution_reason: PREVIEW_BLOCKED_REASON,
+    evidence_used: {
+      evidence_snapshot_id: input.recommendation.evidence_snapshot_id,
+      recommendation_id: input.recommendation.id,
+      recommendation_type: input.recommendation.recommendation_type,
+    },
+  };
+}
+
+export function buildWorkOrderPreviewIdempotencyKey(input: {
+  shopId: string;
+  workOrderId: string;
+  recommendationId: string;
+  actionType: WorkOrderPreviewActionType;
+}): string {
+  return [input.shopId, input.workOrderId, input.recommendationId, input.actionType].join(":");
+}
+
+export function normalizePreviewWarnings(preview: WorkOrderActionPreviewPayload): string[] {
+  const warnings: string[] = [preview.blocked_execution_reason];
+  if (preview.requires_approval) {
+    warnings.push("Approval would be required before any future execution phase.");
+  }
+  return warnings;
+}
+
+export function asJsonRecord(value: Record<string, unknown>): Json {
+  return value as Json;
+}

--- a/features/ai/server/types.ts
+++ b/features/ai/server/types.ts
@@ -42,6 +42,8 @@ export type AiActionEventType =
   | "preview.created"
   | "preview.ready"
   | "preview.cancelled"
+  | "action_preview.created"
+  | "action_preview.blocked_execution"
   | "approval.requested"
   | "approval.approved"
   | "approval.rejected";

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -30,6 +30,61 @@ type EvidenceRow = {
   created_at: string;
 };
 
+type PreviewPayloadRecord = {
+  label?: string;
+  description?: string;
+  affected_records?: Array<{ type?: string; id?: string }>;
+  intended_mutations?: unknown[];
+  side_effects?: string[];
+  requires_approval?: boolean;
+  requires_owner_pin?: boolean;
+  risk_tier?: string;
+  blocked_execution_reason?: string;
+  evidence_snapshot_id?: string | null;
+};
+
+type PreviewRow = {
+  id: string;
+  recommendation_id: string | null;
+  preview_payload: PreviewPayloadRecord;
+  intended_mutations: unknown[];
+  affected_records: Array<{ type?: string; id?: string }>;
+  side_effects: string[];
+  requires_approval: boolean;
+  requires_owner_pin: boolean;
+  risk_tier: string;
+  evidence_snapshot_id: string | null;
+  created_at: string;
+};
+
+function isPreviewableRecommendation(item: RecommendationRow): boolean {
+  return item.risk_tier !== "critical";
+}
+
+function parsePreview(raw: unknown): PreviewRow | null {
+  if (!raw || typeof raw !== "object") return null;
+  const value = raw as Record<string, unknown>;
+  if (typeof value.id !== "string") return null;
+
+  const previewPayload = value.preview_payload && typeof value.preview_payload === "object"
+    ? (value.preview_payload as PreviewPayloadRecord)
+    : {};
+
+  return {
+    id: value.id,
+    recommendation_id: typeof value.recommendation_id === "string" ? value.recommendation_id : null,
+    preview_payload: previewPayload,
+    intended_mutations: Array.isArray(value.intended_mutations) ? value.intended_mutations : [],
+    affected_records: Array.isArray(value.affected_records) ? (value.affected_records as Array<{ type?: string; id?: string }>) : [],
+    side_effects: Array.isArray(value.side_effects) ? (value.side_effects as string[]) : [],
+    requires_approval: Boolean(value.requires_approval),
+    requires_owner_pin: Boolean(value.requires_owner_pin),
+    risk_tier: typeof value.risk_tier === "string" ? value.risk_tier : "low",
+    evidence_snapshot_id: typeof value.evidence_snapshot_id === "string" ? value.evidence_snapshot_id : null,
+    created_at: typeof value.created_at === "string" ? value.created_at : "",
+  };
+}
+
 export default function WorkOrderAiOperationalRecommendations({ workOrderId }: { workOrderId: string }) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -37,6 +92,8 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
   const [recommendations, setRecommendations] = useState<RecommendationRow[]>([]);
   const [evidence, setEvidence] = useState<EvidenceRow | null>(null);
   const [activeAction, setActiveAction] = useState<string | null>(null);
+  const [previewLoadingId, setPreviewLoadingId] = useState<string | null>(null);
+  const [previewByRecommendationId, setPreviewByRecommendationId] = useState<Record<string, PreviewRow>>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -98,12 +155,16 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
         const updated = json?.recommendation as RecommendationRow | undefined;
         if (!updated?.id) throw new Error("Updated recommendation response was invalid.");
 
-        setRecommendations((prev) => {
-          if (updated.status === "dismissed" || updated.status === "resolved") {
-            return prev.filter((item) => item.id !== updated.id);
-          }
-          return prev.map((item) => (item.id === updated.id ? updated : item));
-        });
+        if (updated.status === "dismissed" || updated.status === "resolved") {
+          setRecommendations((prev) => prev.filter((item) => item.id !== updated.id));
+          setPreviewByRecommendationId((current) => {
+            const copy = { ...current };
+            delete copy[updated.id];
+            return copy;
+          });
+        } else {
+          setRecommendations((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+        }
 
         if (action === "acknowledge") {
           toast.success("Recommendation acknowledged.");
@@ -118,6 +179,38 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
         toast.error(message);
       } finally {
         setActiveAction(null);
+      }
+    },
+    [workOrderId],
+  );
+
+  const onPreviewAction = useCallback(
+    async (recommendationId: string) => {
+      setPreviewLoadingId(recommendationId);
+      setError(null);
+
+      try {
+        const res = await fetch(`/api/work-orders/${workOrderId}/ai/recommendations/${recommendationId}/preview`, {
+          method: "POST",
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json?.error ?? "Failed to generate action preview.");
+
+        const parsed = parsePreview(json?.preview);
+        if (!parsed) throw new Error("Preview response was invalid.");
+
+        setPreviewByRecommendationId((prev) => ({
+          ...prev,
+          [recommendationId]: parsed,
+        }));
+
+        toast.success("Action preview generated.");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to generate action preview.";
+        setError(message);
+        toast.error(message);
+      } finally {
+        setPreviewLoadingId(null);
       }
     },
     [workOrderId],
@@ -158,6 +251,10 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
         <div className="mt-2 space-y-2">
           {recommendations.map((item) => {
             const isRowBusy = activeAction?.startsWith(`${item.id}:`) ?? false;
+            const preview = previewByRecommendationId[item.id];
+            const previewable = isPreviewableRecommendation(item);
+            const previewBusy = previewLoadingId === item.id;
+
             return (
               <article key={item.id} className={cn(PANEL_VARIANTS.passive, "p-2")}>
                 <div className="flex flex-wrap items-center gap-2">
@@ -173,6 +270,18 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                   Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.label ?? "Review work order"}
                 </div>
                 <div className="mt-2 flex flex-wrap items-center gap-1">
+                  {previewable ? (
+                    <button
+                      type="button"
+                      className="rounded-md border border-[rgba(184,115,51,0.5)] px-2 py-1 text-[11px] text-[rgba(184,115,51,0.95)] transition hover:bg-[rgba(184,115,51,0.12)] disabled:opacity-50"
+                      disabled={previewBusy}
+                      onClick={() => void onPreviewAction(item.id)}
+                    >
+                      {previewBusy ? "Generating preview…" : "Preview action"}
+                    </button>
+                  ) : (
+                    <span className="rounded-md border border-white/10 px-2 py-1 text-[10px] text-muted-foreground">Preview unavailable for critical-risk recommendation</span>
+                  )}
                   <button
                     type="button"
                     className="rounded-md border border-white/20 px-2 py-1 text-[11px] text-muted-foreground transition hover:bg-white/10 disabled:opacity-50"
@@ -198,6 +307,28 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                     {activeAction === `${item.id}:resolve` ? "Resolving…" : "Mark resolved"}
                   </button>
                 </div>
+
+                {preview ? (
+                  <div className="mt-2 rounded-md border border-white/10 bg-white/[0.02] p-2 text-[10px] text-muted-foreground">
+                    <div className="text-[11px] font-medium text-foreground">{preview.preview_payload.label ?? "Action preview"}</div>
+                    <p className="mt-1">{preview.preview_payload.description ?? "Preview generated for operational review."}</p>
+                    <p className="mt-1">Affected records: {preview.affected_records.length}</p>
+                    {preview.affected_records.length > 0 ? (
+                      <ul className="mt-1 list-disc pl-4">
+                        {preview.affected_records.map((record, idx) => (
+                          <li key={`${preview.id}:record:${idx}`}>{record.type ?? "record"}: {record.id ?? "—"}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                    <p className="mt-1">Intended mutations: {preview.intended_mutations.length > 0 ? String(preview.intended_mutations.length) : "None — preview only"}</p>
+                    <p className="mt-1">Side effects: {preview.side_effects.length > 0 ? preview.side_effects.join(" • ") : "No external side effects"}</p>
+                    <p className="mt-1">Approval required: {preview.requires_approval ? "Yes" : "No"}</p>
+                    <p className="mt-1">Owner PIN required: {preview.requires_owner_pin ? "Yes" : "No"}</p>
+                    <p className="mt-1">Risk tier: {preview.risk_tier}</p>
+                    <p className="mt-1">Execution status: Execution blocked — preview only</p>
+                    <p className="mt-1">Evidence snapshot: {preview.evidence_snapshot_id ?? preview.preview_payload.evidence_snapshot_id ?? "Not linked"}</p>
+                  </div>
+                ) : null}
               </article>
             );
           })}


### PR DESCRIPTION
### Motivation
- Provide a safe, preview-only bridge between work-order recommendations and future automated actions so authorized staff can see what would be changed, what side effects would occur, and why execution is blocked, without executing or mutating any workflows.

### Description
- Added a work-order domain mapper and payload builder that maps low-risk recommendation types to previewable internal actions and rejects unknown/critical recommendations (`features/ai/server/domains/workOrders/workOrderActionPreviews.ts`).
- Added a new shop-scoped API route `GET`/`POST /api/work-orders/[id]/ai/recommendations/[recommendationId]/preview` that validates shop/work-order/recommendation ownership, enforces previewability, deduplicates via an idempotency key, creates previews through the canonical substrate (`createAiActionPreview`), and logs a blocked-execution event; responses always include `executionBlocked: true` and an explicit blocked reason (`app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route.ts`).
- Updated the work-order recommendations UI card to show a per-recommendation “Preview action” button with per-row loading state and inline preview rendering (label, description, affected records, intended mutations, side effects, approval/PIN indicators, risk tier, execution-blocked note, evidence reference) and explicitly no execute/apply/send controls (`features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx`).
- Hardened event typing and logging by adding `action_preview.created` and `action_preview.blocked_execution` event types and switching the preview creation log to `action_preview.created` (`features/ai/server/types.ts`, `features/ai/server/actionPreviews.ts`).
- Exported the new work-order preview helpers from the workOrders domain index (`features/ai/server/domains/workOrders/index.ts`).
- Safety constraints enforced: preview-only payloads (`intended_mutations: []`), internal-only side-effects, critical-risk previews rejected, strict shop scoping, recommendation/work-order ownership verification, idempotency/duplicate prevention, and no workflow mutation or execution routes added.

### Testing
- Ran TypeScript checks: `npx tsc --noEmit` completed successfully. 
- Ran unit/integration test suite: `npm test` (Vitest) completed successfully with all tests passing (`26` tests passed across test files in this run).
- Verified repository state with `git status --short` and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7cb87e888328a017e94c432c9f62)