### PR TITLE
Add AI Mission Control widget (owner/admin dashboard)

### DIFF
--- a/app/api/dashboard/ai-mission-control/route.ts
+++ b/app/api/dashboard/ai-mission-control/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getAiMissionControlSummary } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+
+  if (!access.ok) return access.response;
+
+  try {
+    const shopId = access.profile.shop_id;
+    if (!shopId) {
+      return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+    }
+
+    const actor = {
+      shopId,
+      actorId: access.profile.id,
+      role: access.profile.role,
+      source: "manual" as const,
+    };
+
+    const summary = await getAiMissionControlSummary({
+      supabase: access.supabase,
+      actorContext: actor,
+      limit: 5,
+      domain: "work_orders",
+    });
+
+    return NextResponse.json({ summary });
+  } catch {
+    return NextResponse.json({ error: "Failed to load AI mission control summary" }, { status: 500 });
+  }
+}

--- a/features/ai/server/dashboard/getAiMissionControlSummary.ts
+++ b/features/ai/server/dashboard/getAiMissionControlSummary.ts
@@ -1,0 +1,195 @@
+import type { Json } from "@shared/types/types/supabase";
+import { ensureActorContext, fromTable } from "@/features/ai/server/types";
+import type {
+  AiMissionControlRecommendation,
+  AiMissionControlSummary,
+  GetAiMissionControlSummaryInput,
+} from "@/features/ai/server/dashboard/types";
+
+type RecommendationRow = {
+  id: string;
+  domain: string;
+  recommendation_type: string;
+  subject_type: string;
+  subject_id: string | null;
+  title: string;
+  summary: string | null;
+  status: "open" | "acknowledged" | "dismissed" | "resolved" | "expired" | "superseded";
+  priority: "low" | "normal" | "high" | "urgent";
+  risk_tier: "low" | "medium" | "high" | "critical";
+  confidence: number | null;
+  missing_data: Json;
+  requires_approval: boolean;
+  requires_owner_pin: boolean;
+  created_at: string;
+  expires_at: string | null;
+  recommended_action: Json;
+};
+
+type PreviewCountRow = {
+  recommendation_id: string | null;
+};
+
+function priorityRank(priority: RecommendationRow["priority"]): number {
+  if (priority === "urgent") return 0;
+  if (priority === "high") return 1;
+  if (priority === "normal") return 2;
+  return 3;
+}
+
+function riskRank(riskTier: RecommendationRow["risk_tier"]): number {
+  if (riskTier === "critical") return 0;
+  if (riskTier === "high") return 1;
+  if (riskTier === "medium") return 2;
+  return 3;
+}
+
+function missingDataCount(value: Json): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function toRecommendedActionSummary(value: Json): {
+  recommendedActionType: string | null;
+  recommendedActionLabel: string | null;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { recommendedActionType: null, recommendedActionLabel: null };
+  }
+
+  const obj = value as Record<string, unknown>;
+  const type = typeof obj.type === "string" ? obj.type : null;
+  const label = typeof obj.label === "string"
+    ? obj.label
+    : typeof obj.title === "string"
+      ? obj.title
+      : null;
+
+  return {
+    recommendedActionType: type,
+    recommendedActionLabel: label,
+  };
+}
+
+function isStale(expiresAt: string | null, nowEpochMs: number): boolean {
+  if (!expiresAt) return false;
+  const epoch = Date.parse(expiresAt);
+  if (!Number.isFinite(epoch)) return false;
+  return epoch <= nowEpochMs;
+}
+
+function toMissionControlRecommendation(
+  row: RecommendationRow,
+  previewCount: number,
+): AiMissionControlRecommendation {
+  const action = toRecommendedActionSummary(row.recommended_action);
+  const href = row.subject_type === "work_order" && row.subject_id ? `/work-orders/${row.subject_id}` : null;
+
+  return {
+    id: row.id,
+    domain: row.domain,
+    recommendationType: row.recommendation_type,
+    subjectType: row.subject_type,
+    subjectId: row.subject_id,
+    title: row.title,
+    summary: row.summary,
+    status: row.status,
+    priority: row.priority,
+    riskTier: row.risk_tier,
+    confidence: row.confidence,
+    missingDataCount: missingDataCount(row.missing_data),
+    requiresApproval: row.requires_approval,
+    requiresOwnerPin: row.requires_owner_pin,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    recommendedActionType: action.recommendedActionType,
+    recommendedActionLabel: action.recommendedActionLabel,
+    previewCount,
+    href,
+  };
+}
+
+export async function getAiMissionControlSummary(
+  input: GetAiMissionControlSummaryInput,
+): Promise<AiMissionControlSummary> {
+  const actor = ensureActorContext(input.actorContext);
+  const domain = input.domain ?? "work_orders";
+  const limit = Math.max(3, Math.min(input.limit ?? 5, 20));
+
+  const { data, error } = await fromTable(input.supabase, "ai_recommendations")
+    .select("id, domain, recommendation_type, subject_type, subject_id, title, summary, status, priority, risk_tier, confidence, missing_data, requires_approval, requires_owner_pin, created_at, expires_at, recommended_action")
+    .eq("shop_id", actor.shopId)
+    .eq("domain", domain)
+    .in("status", ["open", "acknowledged"])
+    .limit(200);
+
+  if (error) throw new Error(error.message);
+
+  const rows = ((data ?? []) as RecommendationRow[]).sort((a, b) => {
+    const priorityDelta = priorityRank(a.priority) - priorityRank(b.priority);
+    if (priorityDelta !== 0) return priorityDelta;
+
+    const riskDelta = riskRank(a.risk_tier) - riskRank(b.risk_tier);
+    if (riskDelta !== 0) return riskDelta;
+
+    return Date.parse(a.created_at) - Date.parse(b.created_at);
+  });
+
+  const recommendationIds = rows.map((row) => row.id);
+  const previewCountByRecommendation = new Map<string, number>();
+
+  if (recommendationIds.length > 0) {
+    const { data: previewCounts, error: previewError } = await fromTable(input.supabase, "ai_action_previews")
+      .select("recommendation_id")
+      .eq("shop_id", actor.shopId)
+      .eq("status", "ready")
+      .in("recommendation_id", recommendationIds);
+
+    if (!previewError) {
+      for (const row of (previewCounts ?? []) as PreviewCountRow[]) {
+        if (!row.recommendation_id) continue;
+        const previous = previewCountByRecommendation.get(row.recommendation_id) ?? 0;
+        previewCountByRecommendation.set(row.recommendation_id, previous + 1);
+      }
+    }
+  }
+
+  const nowEpochMs = Date.now();
+
+  const totalOpen = rows.filter((row) => row.status === "open").length;
+  const totalAcknowledged = rows.filter((row) => row.status === "acknowledged").length;
+  const urgentCount = rows.filter((row) => row.priority === "urgent").length;
+  const highCount = rows.filter((row) => row.priority === "high").length;
+  const mediumRiskCount = rows.filter((row) => row.risk_tier === "medium").length;
+  const highRiskCount = rows.filter((row) => row.risk_tier === "high" || row.risk_tier === "critical").length;
+  const staleCount = rows.filter((row) => isStale(row.expires_at, nowEpochMs)).length;
+  const missingDataRecommendations = rows.filter((row) => missingDataCount(row.missing_data) > 0);
+  const workOrdersNeedingAttention = new Set(
+    rows
+      .filter((row) => row.subject_type === "work_order" && row.subject_id)
+      .map((row) => row.subject_id as string),
+  ).size;
+
+  const recommendations = rows.slice(0, limit).map((row) =>
+    toMissionControlRecommendation(row, previewCountByRecommendation.get(row.id) ?? 0),
+  );
+
+  const totalPreviewCount = recommendationIds.reduce(
+    (sum, id) => sum + (previewCountByRecommendation.get(id) ?? 0),
+    0,
+  );
+
+  return {
+    totalOpen,
+    totalAcknowledged,
+    urgentCount,
+    highCount,
+    mediumRiskCount,
+    highRiskCount,
+    staleCount,
+    missingDataCount: missingDataRecommendations.length,
+    workOrdersNeedingAttention,
+    totalPreviewCount,
+    recommendations,
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/features/ai/server/dashboard/index.ts
+++ b/features/ai/server/dashboard/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./getAiMissionControlSummary";

--- a/features/ai/server/dashboard/types.ts
+++ b/features/ai/server/dashboard/types.ts
@@ -1,0 +1,46 @@
+import type { AiActorContext, AiRecommendationPriority, AiRecommendationStatus, AiRiskTier, AiServerClient } from "@/features/ai/server/types";
+
+export type AiMissionControlRecommendation = {
+  id: string;
+  domain: string;
+  recommendationType: string;
+  subjectType: string;
+  subjectId: string | null;
+  title: string;
+  summary: string | null;
+  status: AiRecommendationStatus;
+  priority: AiRecommendationPriority;
+  riskTier: AiRiskTier;
+  confidence: number | null;
+  missingDataCount: number;
+  requiresApproval: boolean;
+  requiresOwnerPin: boolean;
+  createdAt: string;
+  expiresAt: string | null;
+  recommendedActionType: string | null;
+  recommendedActionLabel: string | null;
+  previewCount: number;
+  href: string | null;
+};
+
+export type AiMissionControlSummary = {
+  totalOpen: number;
+  totalAcknowledged: number;
+  urgentCount: number;
+  highCount: number;
+  mediumRiskCount: number;
+  highRiskCount: number;
+  staleCount: number;
+  missingDataCount: number;
+  workOrdersNeedingAttention: number;
+  totalPreviewCount: number;
+  recommendations: AiMissionControlRecommendation[];
+  generatedAt: string;
+};
+
+export type GetAiMissionControlSummaryInput = {
+  supabase: AiServerClient;
+  actorContext: AiActorContext;
+  domain?: "work_orders";
+  limit?: number;
+};

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -7,3 +7,4 @@ export * from "./actionApprovals";
 export * from "./actionEvents";
 export * from "./safeActions";
 export * from "./domains/workOrders";
+export * from "./dashboard";

--- a/features/dashboard/components/DashboardWidgetBoard.tsx
+++ b/features/dashboard/components/DashboardWidgetBoard.tsx
@@ -214,7 +214,7 @@ export default function DashboardWidgetBoard({
 
   const operationTopIds: DashboardWidgetId[] = ["daily_summary", "shop_pulse", "suggested_actions"];
   const operationPrimaryIds: DashboardWidgetId[] = ["work_order_board"];
-  const operationSecondaryIds: DashboardWidgetId[] = ["approval_risk", "waiting_parts"];
+  const operationSecondaryIds: DashboardWidgetId[] = ["approval_risk", "waiting_parts", "ai_mission_control"];
   const operationBusinessIds: DashboardWidgetId[] = ["advisor_queue", "tech_load", "live_shop_load"];
 
   const performanceTopIds: DashboardWidgetId[] = ["stats_overview", "revenue_watch", "reports_performance"];

--- a/features/dashboard/lib/dashboard-responsive-layout.ts
+++ b/features/dashboard/lib/dashboard-responsive-layout.ts
@@ -26,6 +26,7 @@ export const DASHBOARD_WIDGET_RESPONSIVE_META: Record<DashboardWidgetId, Dashboa
   tech_load: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
   approval_risk: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12, compactMinHeightRem: 9.5 },
   waiting_parts: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12, compactMinHeightRem: 9.5 },
+  ai_mission_control: { mode: "feature", span: { desktop: 1, laptop: 1, tablet: 2, mobile: 1 }, preferredMinHeightRem: 14, compactMinHeightRem: 10.5 },
   live_shop_load: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
   stats_overview: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },
   revenue_watch: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },

--- a/features/dashboard/lib/dashboard-views.ts
+++ b/features/dashboard/lib/dashboard-views.ts
@@ -19,6 +19,7 @@ export const DASHBOARD_VIEW_WIDGETS: Record<DashboardView, DashboardWidgetId[]> 
     "tech_load",
     "approval_risk",
     "waiting_parts",
+    "ai_mission_control",
     "live_shop_load",
   ],
   performance: [

--- a/features/dashboard/lib/defaultLayout.ts
+++ b/features/dashboard/lib/defaultLayout.ts
@@ -23,6 +23,7 @@ const STRUCTURED_LAYOUT_SLOTS: StructuredSlot[] = [
   { id: "work_order_board", x: 0, y: 3, w: 8, h: 6 },
   { id: "approval_risk", x: 8, y: 3, w: 4, h: 3 },
   { id: "waiting_parts", x: 8, y: 6, w: 4, h: 3 },
+  { id: "ai_mission_control", x: 0, y: 18, w: 4, h: 3 },
   { id: "comeback_risk", x: 8, y: 9, w: 4, h: 3, hidden: true },
 
   { id: "advisor_queue", x: 0, y: 9, w: 4, h: 3 },
@@ -35,7 +36,7 @@ const STRUCTURED_LAYOUT_SLOTS: StructuredSlot[] = [
 
   { id: "live_shop_load", x: 4, y: 15, w: 4, h: 3, hidden: true },
   { id: "tech_performance", x: 8, y: 15, w: 4, h: 3, hidden: true },
-  { id: "optimization_opportunities", x: 0, y: 18, w: 6, h: 3, hidden: true },
+  { id: "optimization_opportunities", x: 4, y: 18, w: 6, h: 3, hidden: true },
 ];
 
 export function buildDefaultDashboardLayout(

--- a/features/dashboard/lib/widget-registry.tsx
+++ b/features/dashboard/lib/widget-registry.tsx
@@ -17,6 +17,7 @@ import {
   technicianPerformanceWidgetModule,
   waitingPartsWidgetModule,
   workOrderBoardWidgetModule,
+  aiMissionControlWidgetModule,
 } from "@/features/dashboard/widgets/modules";
 import type { DashboardWidgetId } from "@/features/dashboard/types/layout";
 import type { DashboardWidgetModule } from "@/features/dashboard/types/widget";
@@ -33,6 +34,7 @@ export const DASHBOARD_WIDGET_REGISTRY: DashboardWidgetModule[] = [
   techLoadWidgetModule,
   technicianPerformanceWidgetModule,
   waitingPartsWidgetModule,
+  aiMissionControlWidgetModule,
   approvalRiskWidgetModule,
   revenueWatchWidgetModule,
   comebackRiskWidgetModule,

--- a/features/dashboard/types/layout.ts
+++ b/features/dashboard/types/layout.ts
@@ -14,7 +14,8 @@ export type DashboardWidgetId =
   | "work_order_board"
   | "bookings"
   | "advisor_queue"
-  | "optimization_opportunities";
+  | "optimization_opportunities"
+  | "ai_mission_control";
 
 export type DashboardCountState = {
   appointments: number;

--- a/features/dashboard/widgets/AiMissionControlWidget.tsx
+++ b/features/dashboard/widgets/AiMissionControlWidget.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
+
+type RecommendationItem = {
+  id: string;
+  title: string;
+  summary: string | null;
+  status: "open" | "acknowledged";
+  priority: "low" | "normal" | "high" | "urgent";
+  riskTier: "low" | "medium" | "high" | "critical";
+  confidence: number | null;
+  recommendedActionLabel: string | null;
+  href: string | null;
+  previewCount: number;
+};
+
+type MissionControlSummary = {
+  totalOpen: number;
+  totalAcknowledged: number;
+  urgentCount: number;
+  highCount: number;
+  mediumRiskCount: number;
+  highRiskCount: number;
+  staleCount: number;
+  missingDataCount: number;
+  workOrdersNeedingAttention: number;
+  totalPreviewCount: number;
+  recommendations: RecommendationItem[];
+  generatedAt: string;
+};
+
+function priorityClass(priority: RecommendationItem["priority"]): string {
+  if (priority === "urgent") return "border-red-400/40 bg-red-500/20 text-red-100";
+  if (priority === "high") return "border-orange-400/40 bg-orange-500/20 text-orange-100";
+  if (priority === "normal") return "border-yellow-400/35 bg-yellow-500/15 text-yellow-100";
+  return "border-white/15 bg-black/35 text-neutral-300";
+}
+
+function riskClass(riskTier: RecommendationItem["riskTier"]): string {
+  if (riskTier === "critical") return "border-red-400/45 text-red-200";
+  if (riskTier === "high") return "border-orange-400/45 text-orange-200";
+  if (riskTier === "medium") return "border-yellow-400/40 text-yellow-200";
+  return "border-white/20 text-neutral-300";
+}
+
+function statusLabel(status: RecommendationItem["status"]): string {
+  return status === "acknowledged" ? "Acknowledged" : "Open";
+}
+
+function confidenceLabel(confidence: number | null): string {
+  if (typeof confidence !== "number" || !Number.isFinite(confidence)) return "Confidence —";
+  return `Confidence ${Math.round(confidence * 100)}%`;
+}
+
+export default function AiMissionControlWidget() {
+  const [summary, setSummary] = useState<MissionControlSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/dashboard/ai-mission-control", { cache: "no-store" });
+      const json = (await res.json().catch(() => ({}))) as { summary?: MissionControlSummary; error?: string };
+      if (!res.ok) throw new Error(json.error ?? "Failed to load AI mission control summary.");
+      setSummary(json.summary ?? null);
+    } catch (e) {
+      setError(toDashboardFallbackMessage(e, "AI mission control is unavailable right now."));
+      setSummary(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const topRecommendations = useMemo(() => summary?.recommendations?.slice(0, 5) ?? [], [summary]);
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="Operational intelligence"
+      title="AI Mission Control"
+      subtitle="Evidence-backed recommendations from active shop work."
+      compact
+      rightSlot={
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200 transition hover:bg-black/40"
+        >
+          Refresh
+        </button>
+      }
+    >
+      {loading ? (
+        <div className="space-y-2">
+          <div className="h-10 animate-pulse rounded-xl border border-white/10 bg-black/25" />
+          <div className="h-10 animate-pulse rounded-xl border border-white/10 bg-black/25" />
+          <div className="h-10 animate-pulse rounded-xl border border-white/10 bg-black/25" />
+        </div>
+      ) : error ? (
+        <div className="space-y-2 rounded-xl border border-[color:color-mix(in_srgb,var(--brand-accent)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent)_14%,transparent)] px-3 py-3 text-sm text-[color:var(--brand-accent)]">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="rounded-full border border-white/20 bg-black/30 px-2.5 py-1 text-xs text-neutral-100"
+          >
+            Retry
+          </button>
+        </div>
+      ) : !summary || topRecommendations.length === 0 ? (
+        <p className="rounded-xl border border-white/10 bg-black/25 px-3 py-3 text-sm text-neutral-300">
+          No active operational recommendations yet. Generate recommendations from a work order to populate this view.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-3">
+            <Metric label="Active" value={String(summary.totalOpen)} />
+            <Metric label="Urgent + high" value={String(summary.urgentCount + summary.highCount)} />
+            <Metric label="Acknowledged" value={String(summary.totalAcknowledged)} />
+            <Metric label="Missing data" value={String(summary.missingDataCount)} />
+            <Metric label="Stale" value={String(summary.staleCount)} />
+            <Metric label="Preview-ready" value={String(summary.totalPreviewCount)} />
+          </div>
+
+          <div className="space-y-2">
+            {topRecommendations.map((item) => (
+              <div key={item.id} className="rounded-xl border border-white/10 bg-black/25 px-3 py-2.5">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase ${priorityClass(item.priority)}`}>
+                    {item.priority}
+                  </span>
+                  <span className={`rounded-full border px-2 py-0.5 text-[10px] uppercase ${riskClass(item.riskTier)}`}>
+                    {item.riskTier} risk
+                  </span>
+                  <span className="rounded-full border border-white/15 px-2 py-0.5 text-[10px] uppercase text-neutral-300">
+                    {statusLabel(item.status)}
+                  </span>
+                </div>
+                <p className="mt-1.5 text-sm font-semibold text-neutral-100">{item.title}</p>
+                <p className="mt-1 text-[11px] text-neutral-400">{item.recommendedActionLabel ?? "Review recommendation details"}</p>
+                <div className="mt-1.5 flex items-center justify-between text-[11px] text-neutral-400">
+                  <span>{confidenceLabel(item.confidence)}</span>
+                  {item.href ? (
+                    <Link href={item.href} className="text-[var(--brand-primary)] transition hover:opacity-80">
+                      View work order →
+                    </Link>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </DashboardWidgetShell>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/30 px-2.5 py-2">
+      <p className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">{label}</p>
+      <p className="mt-1 text-base font-semibold text-neutral-100">{value}</p>
+    </div>
+  );
+}

--- a/features/dashboard/widgets/modules/AiMissionControlWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/AiMissionControlWidgetModule.tsx
@@ -1,0 +1,15 @@
+import type { DashboardWidgetModule } from "@/features/dashboard/types/widget";
+import AiMissionControlWidget from "@/features/dashboard/widgets/AiMissionControlWidget";
+
+export const aiMissionControlWidgetModule: DashboardWidgetModule = {
+  id: "ai_mission_control",
+  title: "AI Mission Control",
+  description: "Top priority operational recommendations across active work orders",
+  roles: ["owner", "admin", "manager", "advisor"],
+  defaultW: 4,
+  defaultH: 3,
+  minW: 3,
+  minH: 3,
+  selfContained: true,
+  render: () => <AiMissionControlWidget />,
+};

--- a/features/dashboard/widgets/modules/index.ts
+++ b/features/dashboard/widgets/modules/index.ts
@@ -16,3 +16,4 @@ export { technicianPerformanceWidgetModule } from "./TechnicianPerformanceWidget
 
 export { liveShopLoadWidgetModule } from "./LiveShopLoadWidgetModule";
 export { optimizationOpportunitiesWidgetModule } from "./OptimizationOpportunitiesWidgetModule";
+export { aiMissionControlWidgetModule } from "./AiMissionControlWidgetModule";


### PR DESCRIPTION
### Motivation
- Surface shop-level operational intelligence from canonical `ai_recommendations` so owners/admins can review high-priority items quickly. 
- Provide a compact, role-scoped dashboard summary that is read/review-first and does not perform any execution or workflow mutations. 
- Reuse the existing AI substrate and dashboard widget system to keep the change incremental and non-breaking.

### Description
- Added a server-side dashboard helper `getAiMissionControlSummary` under `features/ai/server/dashboard/` that requires an explicit actor/shop context, queries `ai_recommendations` (domain `work_orders`) for `open`/`acknowledged` recommendations, aggregates counters, and returns compact, safe recommendation rows (no raw snapshot payloads). Files: `types.ts`, `getAiMissionControlSummary.ts`, `index.ts` and exported from `features/ai/server/index.ts` via `./dashboard`.
- Added a shop-scoped, authenticated, GET-only API route `GET /api/dashboard/ai-mission-control` that uses `requireShopScopedApiAccess` and is gated to `owner|admin|manager|advisor` with the `canManageWorkOrders` capability and returns the mission-control summary.
- Implemented a compact client widget `AiMissionControlWidget` and module `AiMissionControlWidgetModule` that show counts, top recommendations, confidence, preview-ready counts, and work-order deep links with loading/error/empty states and a Refresh action; the widget is read-only and contains no execute buttons.
- Registered the widget in the dashboard registry and view/layout metadata so it appears for appropriate roles; updated default layout and responsive metadata to include the new `ai_mission_control` widget; no database migrations required (`None`).

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which completed successfully with no type errors. 
- Ran unit tests with `npm test`, and the test suite passed (all tests ran successfully; existing test run showed 29 tests passing). 
- No DB migration applied or generated as part of this change (`None`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8eb5357c8328a16fab9f0a6c5f34)