### PR TITLE
Add stale AI expiration maintenance and internal trigger

### DIFF
--- a/app/api/internal/ai/expire-stale/route.ts
+++ b/app/api/internal/ai/expire-stale/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { expireStaleAiRecords } from "@/features/ai/server";
+import { requireInternalApiSecret } from "@/features/shared/lib/server/api-route-guard";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type ExpireStaleBody = {
+  dryRun?: unknown;
+  shopId?: unknown;
+  limit?: unknown;
+};
+
+const MAX_LIMIT = 100;
+
+function parseBody(raw: ExpireStaleBody | null): { dryRun: boolean; shopId?: string; limit: number } {
+  const dryRun = typeof raw?.dryRun === "boolean" ? raw.dryRun : true;
+
+  const shopId = typeof raw?.shopId === "string" && raw.shopId.trim().length > 0
+    ? raw.shopId.trim()
+    : undefined;
+
+  let limit = 50;
+  if (typeof raw?.limit === "number" && Number.isFinite(raw.limit)) {
+    limit = Math.max(1, Math.min(Math.floor(raw.limit), MAX_LIMIT));
+  }
+
+  return { dryRun, shopId, limit };
+}
+
+export async function POST(req: Request) {
+  const internalGate = requireInternalApiSecret({
+    request: req,
+    envSecretName: "INTERNAL_CRON_SECRET",
+    headerName: "x-internal-cron-secret",
+    routeLabel: "internal/ai/expire-stale",
+  });
+
+  if (!internalGate.ok) {
+    return internalGate.response;
+  }
+
+  let input: { dryRun: boolean; shopId?: string; limit: number };
+  try {
+    const body = (await req.json().catch(() => null)) as ExpireStaleBody | null;
+    input = parseBody(body);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const result = await expireStaleAiRecords({
+      supabase: createAdminSupabase(),
+      dryRun: input.dryRun,
+      shopId: input.shopId,
+      limit: input.limit,
+      actorContext: input.shopId
+        ? {
+          shopId: input.shopId,
+          actorId: "internal-ai-expirer",
+          role: "system",
+          source: "system",
+        }
+        : undefined,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      summary: {
+        dryRun: result.dryRun,
+        now: result.now,
+        recommendations: {
+          candidates: result.recommendations.candidates,
+          expired: result.recommendations.expired,
+        },
+        previews: {
+          candidates: result.previews.candidates,
+          expired: result.previews.expired,
+        },
+        approvals: {
+          candidates: result.approvals.candidates,
+          expired: result.approvals.expired,
+        },
+        warnings: result.warnings,
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to expire stale AI records" }, { status: 500 });
+  }
+}

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -8,3 +8,4 @@ export * from "./actionEvents";
 export * from "./safeActions";
 export * from "./domains/workOrders";
 export * from "./dashboard";
+export * from "./maintenance";

--- a/features/ai/server/maintenance/expireStaleAiRecords.ts
+++ b/features/ai/server/maintenance/expireStaleAiRecords.ts
@@ -1,0 +1,303 @@
+import { logAiActionEvent } from "../actionEvents";
+import { AI_ACTION_EVENT_TYPES } from "../eventTypes";
+import {
+  ensureActorContext,
+  fromTable,
+  type AiActorContext,
+  type AiActionApprovalStatus,
+  type AiActionPreviewStatus,
+  type AiRecommendationStatus,
+} from "../types";
+import type { ExpirationCounts, ExpireStaleAiRecordsInput, ExpireStaleAiRecordsResult } from "./types";
+
+type RecommendationCandidateRow = {
+  id: string;
+  shop_id: string;
+  status: AiRecommendationStatus;
+  expires_at: string | null;
+};
+
+type ActionPreviewCandidateRow = {
+  id: string;
+  shop_id: string;
+  recommendation_id: string | null;
+  idempotency_key: string | null;
+  status: AiActionPreviewStatus;
+  expires_at: string | null;
+};
+
+type ActionApprovalCandidateRow = {
+  id: string;
+  shop_id: string;
+  action_preview_id: string;
+  status: AiActionApprovalStatus;
+  expires_at: string | null;
+};
+
+type PreviewReferenceRow = {
+  id: string;
+  recommendation_id: string | null;
+  idempotency_key: string | null;
+};
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const SYSTEM_ACTOR_ID = "ai-maintenance-expirer";
+const EXPIRY_REASON = "expires_at_elapsed";
+
+function toIsoString(now?: Date): string {
+  if (!now) return new Date().toISOString();
+  if (Number.isNaN(now.getTime())) {
+    throw new Error("Invalid now value supplied to expireStaleAiRecords");
+  }
+  return now.toISOString();
+}
+
+function sanitizeLimit(limit?: number): number {
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(Math.floor(limit as number), MAX_LIMIT));
+}
+
+function buildDefaultActor(shopId: string): AiActorContext {
+  return {
+    shopId,
+    actorId: SYSTEM_ACTOR_ID,
+    role: "system",
+    source: "system",
+  };
+}
+
+function buildScopedActor(input: {
+  shopId: string;
+  actorContext?: AiActorContext;
+}): AiActorContext {
+  const actor = input.actorContext
+    ? { ...input.actorContext, shopId: input.shopId }
+    : buildDefaultActor(input.shopId);
+
+  return ensureActorContext(actor);
+}
+
+export async function expireStaleAiRecords(input: ExpireStaleAiRecordsInput): Promise<ExpireStaleAiRecordsResult> {
+  const dryRun = input.dryRun ?? false;
+  const nowIso = toIsoString(input.now);
+  const limit = sanitizeLimit(input.limit);
+  const warnings: string[] = [];
+
+  let recommendationQuery = fromTable(input.supabase, "ai_recommendations")
+    .select("id, shop_id, status, expires_at")
+    .not("expires_at", "is", null)
+    .lte("expires_at", nowIso)
+    .in("status", ["open", "acknowledged"])
+    .order("expires_at", { ascending: true })
+    .limit(limit);
+
+  if (input.shopId) {
+    recommendationQuery = recommendationQuery.eq("shop_id", input.shopId);
+  }
+
+  const { data: recommendationCandidatesData, error: recommendationCandidatesError } =
+    await recommendationQuery;
+
+  if (recommendationCandidatesError) {
+    throw new Error(`Failed to load stale recommendations: ${recommendationCandidatesError.message}`);
+  }
+
+  const recommendationCandidates = (recommendationCandidatesData ?? []) as RecommendationCandidateRow[];
+
+  let previewQuery = fromTable(input.supabase, "ai_action_previews")
+    .select("id, shop_id, recommendation_id, idempotency_key, status, expires_at")
+    .not("expires_at", "is", null)
+    .lte("expires_at", nowIso)
+    .in("status", ["draft", "ready", "approval_required"])
+    .order("expires_at", { ascending: true })
+    .limit(limit);
+
+  if (input.shopId) {
+    previewQuery = previewQuery.eq("shop_id", input.shopId);
+  }
+
+  const { data: previewCandidatesData, error: previewCandidatesError } = await previewQuery;
+
+  if (previewCandidatesError) {
+    throw new Error(`Failed to load stale action previews: ${previewCandidatesError.message}`);
+  }
+
+  const previewCandidates = (previewCandidatesData ?? []) as ActionPreviewCandidateRow[];
+
+  let approvalQuery = fromTable(input.supabase, "ai_action_approvals")
+    .select("id, shop_id, action_preview_id, status, expires_at")
+    .not("expires_at", "is", null)
+    .lte("expires_at", nowIso)
+    .eq("status", "pending")
+    .order("expires_at", { ascending: true })
+    .limit(limit);
+
+  if (input.shopId) {
+    approvalQuery = approvalQuery.eq("shop_id", input.shopId);
+  }
+
+  const { data: approvalCandidatesData, error: approvalCandidatesError } = await approvalQuery;
+
+  if (approvalCandidatesError) {
+    throw new Error(`Failed to load stale action approvals: ${approvalCandidatesError.message}`);
+  }
+
+  const approvalCandidates = (approvalCandidatesData ?? []) as ActionApprovalCandidateRow[];
+
+  const recommendations = {
+    candidates: recommendationCandidates.length,
+    expired: 0,
+    candidateIds: recommendationCandidates.map((row) => row.id),
+  } satisfies ExpirationCounts;
+
+  const previews = {
+    candidates: previewCandidates.length,
+    expired: 0,
+    candidateIds: previewCandidates.map((row) => row.id),
+  } satisfies ExpirationCounts;
+
+  const approvals = {
+    candidates: approvalCandidates.length,
+    expired: 0,
+    candidateIds: approvalCandidates.map((row) => row.id),
+  } satisfies ExpirationCounts;
+
+  if (!dryRun) {
+    const approvalPreviewIds = Array.from(new Set(approvalCandidates.map((row) => row.action_preview_id)));
+    const previewReferenceById = new Map<string, PreviewReferenceRow>();
+
+    if (approvalPreviewIds.length > 0) {
+      let previewReferenceQuery = fromTable(input.supabase, "ai_action_previews")
+        .select("id, recommendation_id, idempotency_key")
+        .in("id", approvalPreviewIds)
+        .limit(Math.min(approvalPreviewIds.length, MAX_LIMIT));
+
+      if (input.shopId) {
+        previewReferenceQuery = previewReferenceQuery.eq("shop_id", input.shopId);
+      }
+
+      const { data: previewReferenceData, error: previewReferenceError } = await previewReferenceQuery;
+
+      if (previewReferenceError) {
+        warnings.push(`Failed to load preview references for approvals: ${previewReferenceError.message}`);
+      } else {
+        for (const row of (previewReferenceData ?? []) as PreviewReferenceRow[]) {
+          previewReferenceById.set(row.id, row);
+        }
+      }
+    }
+
+    for (const row of recommendationCandidates) {
+      const { data: updated, error } = await fromTable(input.supabase, "ai_recommendations")
+        .update({ status: "expired" })
+        .eq("shop_id", row.shop_id)
+        .eq("id", row.id)
+        .eq("status", row.status)
+        .select("id")
+        .maybeSingle<{ id: string }>();
+
+      if (error) {
+        warnings.push(`Failed to expire recommendation ${row.id}: ${error.message}`);
+        continue;
+      }
+
+      if (!updated) continue;
+
+      const actor = buildScopedActor({ shopId: row.shop_id, actorContext: input.actorContext });
+      await logAiActionEvent(input.supabase, actor, {
+        recommendationId: row.id,
+        eventType: AI_ACTION_EVENT_TYPES.RECOMMENDATION_EXPIRED,
+        payload: {
+          recommendation_id: row.id,
+          previous_status: row.status,
+          expires_at: row.expires_at,
+          expired_at: nowIso,
+          reason: EXPIRY_REASON,
+        },
+      });
+
+      recommendations.expired += 1;
+    }
+
+    for (const row of previewCandidates) {
+      const { data: updated, error } = await fromTable(input.supabase, "ai_action_previews")
+        .update({ status: "expired" })
+        .eq("shop_id", row.shop_id)
+        .eq("id", row.id)
+        .eq("status", row.status)
+        .select("id")
+        .maybeSingle<{ id: string }>();
+
+      if (error) {
+        warnings.push(`Failed to expire action preview ${row.id}: ${error.message}`);
+        continue;
+      }
+
+      if (!updated) continue;
+
+      const actor = buildScopedActor({ shopId: row.shop_id, actorContext: input.actorContext });
+      await logAiActionEvent(input.supabase, actor, {
+        recommendationId: row.recommendation_id,
+        actionPreviewId: row.id,
+        eventType: AI_ACTION_EVENT_TYPES.ACTION_PREVIEW_EXPIRED,
+        idempotencyKey: row.idempotency_key,
+        payload: {
+          action_preview_id: row.id,
+          previous_status: row.status,
+          expires_at: row.expires_at,
+          expired_at: nowIso,
+          reason: EXPIRY_REASON,
+        },
+      });
+
+      previews.expired += 1;
+    }
+
+    for (const row of approvalCandidates) {
+      const { data: updated, error } = await fromTable(input.supabase, "ai_action_approvals")
+        .update({ status: "expired" })
+        .eq("shop_id", row.shop_id)
+        .eq("id", row.id)
+        .eq("status", row.status)
+        .select("id")
+        .maybeSingle<{ id: string }>();
+
+      if (error) {
+        warnings.push(`Failed to expire action approval ${row.id}: ${error.message}`);
+        continue;
+      }
+
+      if (!updated) continue;
+
+      const previewReference = previewReferenceById.get(row.action_preview_id);
+      const actor = buildScopedActor({ shopId: row.shop_id, actorContext: input.actorContext });
+      await logAiActionEvent(input.supabase, actor, {
+        recommendationId: previewReference?.recommendation_id ?? null,
+        actionPreviewId: row.action_preview_id,
+        approvalId: row.id,
+        eventType: AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_EXPIRED,
+        idempotencyKey: previewReference?.idempotency_key ?? null,
+        payload: {
+          approval_id: row.id,
+          action_preview_id: row.action_preview_id,
+          previous_status: row.status,
+          expires_at: row.expires_at,
+          expired_at: nowIso,
+          reason: EXPIRY_REASON,
+        },
+      });
+
+      approvals.expired += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    now: nowIso,
+    recommendations,
+    previews,
+    approvals,
+    warnings,
+  };
+}

--- a/features/ai/server/maintenance/index.ts
+++ b/features/ai/server/maintenance/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./expireStaleAiRecords";

--- a/features/ai/server/maintenance/types.ts
+++ b/features/ai/server/maintenance/types.ts
@@ -1,0 +1,25 @@
+import type { AiActorContext, AiServerClient } from "../types";
+
+export type ExpirationCounts = {
+  candidates: number;
+  expired: number;
+  candidateIds: string[];
+};
+
+export type ExpireStaleAiRecordsResult = {
+  dryRun: boolean;
+  now: string;
+  recommendations: ExpirationCounts;
+  previews: ExpirationCounts;
+  approvals: ExpirationCounts;
+  warnings: string[];
+};
+
+export type ExpireStaleAiRecordsInput = {
+  supabase: AiServerClient;
+  now?: Date;
+  shopId?: string;
+  dryRun?: boolean;
+  limit?: number;
+  actorContext?: AiActorContext;
+};


### PR DESCRIPTION
### Motivation
- Prevent stale AI recommendations, action previews, and approvals from lingering in dashboards and work-order cards by adding a maintenance cleanup helper.  
- Provide a safe, shop-scoped, and auditable way to expire records when their `expires_at` timestamps have elapsed without changing business workflows.  

### Description
- Add a canonical maintenance helper `expireStaleAiRecords(...)` under `features/ai/server/maintenance` that supports `supabase`, `now`, optional `shopId`, `dryRun`, `limit`, and `actorContext`, finds candidates by `expires_at <= now`, and returns candidates/expired counts and warnings.  
- Implement status-only expirations for eligible states and event logging: `ai_recommendations` (`open|acknowledged -> expired`), `ai_action_previews` (`draft|ready|approval_required -> expired`), and `ai_action_approvals` (`pending -> expired`), emitting canonical events `recommendation.expired`, `action_preview.expired`, and `action_approval.expired`.  
- Add a shop-safe internal POST route `app/api/internal/ai/expire-stale` protected by the existing `requireInternalApiSecret` pattern (uses `INTERNAL_CRON_SECRET` via `x-internal-cron-secret`), defaults to `dryRun: true`, and caps `limit` to a safe max.  
- Export the maintenance module from the main AI server index and keep all changes non-invasive (no DB migrations, no workflow execution, no preview execution).  

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` and it passed.  
- Ran unit tests with `npm test` (Vitest) and all tests passed: 10 files / 29 tests succeeded.  
- Verified `git status` and committed the new files: `features/ai/server/maintenance/*`, `app/api/internal/ai/expire-stale/route.ts`, and the `features/ai/server/index.ts` export update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb93b91fb08328a8fa5a824abafb54)