### PR TITLE
Add advisory closeout risk evaluator for work-order AI recommendations

### DIFF
--- a/features/ai/server/domains/workOrders/buildWorkOrderEvidenceSnapshot.ts
+++ b/features/ai/server/domains/workOrders/buildWorkOrderEvidenceSnapshot.ts
@@ -145,6 +145,9 @@ export async function buildWorkOrderEvidenceSnapshot(input: BuildInput): Promise
   let blockedCount = 0;
   let activeCount = 0;
   let completedCount = 0;
+  let missingCauseCount = 0;
+  let missingCorrectionCount = 0;
+  let missingNotesCount = 0;
 
   for (const line of lines) {
     const status = normalize(line.status);
@@ -160,6 +163,12 @@ export async function buildWorkOrderEvidenceSnapshot(input: BuildInput): Promise
     if (status === "on_hold" || status === "awaiting_parts" || normalize(line.hold_reason).includes("part")) blockedCount += 1;
     if (status === "active") activeCount += 1;
     if (status === "completed" || status === "ready_to_invoice" || status === "invoiced") completedCount += 1;
+
+    if (normalize(line.line_type) !== "info" && (status === "completed" || status === "ready_to_invoice" || status === "invoiced")) {
+      if (!String(line.cause ?? "").trim()) missingCauseCount += 1;
+      if (!String(line.correction ?? "").trim()) missingCorrectionCount += 1;
+      if (!String(line.notes ?? "").trim()) missingNotesCount += 1;
+    }
   }
 
   const newestInspection = inspections
@@ -329,6 +338,10 @@ export async function buildWorkOrderEvidenceSnapshot(input: BuildInput): Promise
       inspection_finalized: inspectionFinalized,
       lines_complete: linesComplete,
       approval_resolved: approvalResolved,
+      missing_cause_count: missingCauseCount,
+      missing_correction_count: missingCorrectionCount,
+      missing_notes_count: missingNotesCount,
+      verification_signals_available: true,
       blockers,
     },
     evidence_metadata: {

--- a/features/ai/server/domains/workOrders/closeoutRiskRules.ts
+++ b/features/ai/server/domains/workOrders/closeoutRiskRules.ts
@@ -1,0 +1,212 @@
+import {
+  WORK_ORDER_CLOSEOUT_RULES_VERSION,
+  type WorkOrderCloseoutRisk,
+  type WorkOrderEvidenceSnapshot,
+  type WorkOrderRecommendationDraft,
+} from "./types";
+
+const CLOSEOUT_RECOMMENDATION_TYPE_BY_RISK: Record<WorkOrderCloseoutRisk["risk_code"], string> = {
+  inspection_incomplete: "closeout_risk_inspection_incomplete",
+  approval_pending: "closeout_risk_approval_pending",
+  job_lines_incomplete: "closeout_risk_job_lines_incomplete",
+  waiting_parts: "closeout_risk_waiting_parts",
+  active_labor_or_punch: "closeout_risk_active_labor",
+  invoice_not_ready_or_missing: "closeout_risk_invoice_not_ready",
+  missing_verification_notes: "closeout_risk_missing_verification",
+  stale_work_order_state: "closeout_risk_stale_state",
+};
+
+function unique(items: string[]): string[] {
+  return Array.from(new Set(items.filter((item) => item.trim().length > 0)));
+}
+
+function riskToPriority(risk: WorkOrderCloseoutRisk["severity"]): WorkOrderRecommendationDraft["priority"] {
+  if (risk === "critical") return "urgent";
+  if (risk === "high") return "high";
+  return "normal";
+}
+
+export function evaluateWorkOrderCloseoutRisk(snapshot: WorkOrderEvidenceSnapshot): WorkOrderCloseoutRisk[] {
+  const risks: WorkOrderCloseoutRisk[] = [];
+  const baseMissing = [...snapshot.evidence_metadata.missing_data];
+
+  if (snapshot.inspections.exists && !snapshot.closeout.inspection_finalized) {
+    risks.push({
+      risk_code: "inspection_incomplete",
+      title: "Do not close yet — inspection is incomplete",
+      summary: "Inspection records exist, but final completion/finalization is still pending.",
+      severity: "high",
+      confidence: 0.93,
+      evidence_refs: ["inspections", "closeout"],
+      missing_data: baseMissing,
+      recommended_next_step: "Complete/finalize the inspection using the existing inspection flow.",
+      blocks_closeout: false,
+      would_block_closeout_future: true,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  if (snapshot.approvals.required && !snapshot.approvals.resolved) {
+    risks.push({
+      risk_code: "approval_pending",
+      title: "Closeout needs review — approval is still pending",
+      summary: "Approval appears required and has not been resolved yet.",
+      severity: "high",
+      confidence: 0.92,
+      evidence_refs: ["approvals", "closeout"],
+      missing_data: baseMissing,
+      recommended_next_step: "Review pending customer/fleet approval and complete the existing approval workflow.",
+      blocks_closeout: false,
+      would_block_closeout_future: true,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  if (snapshot.lines.actionable > 0 && !snapshot.closeout.lines_complete) {
+    risks.push({
+      risk_code: "job_lines_incomplete",
+      title: "Closeout needs review — job lines are not complete",
+      summary: "One or more actionable work-order lines are still not in a completed closeout-ready state.",
+      severity: "high",
+      confidence: 0.94,
+      evidence_refs: ["lines", "closeout"],
+      missing_data: baseMissing,
+      recommended_next_step: "Finish or correctly close remaining actionable lines before closeout review.",
+      blocks_closeout: false,
+      would_block_closeout_future: true,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  if (snapshot.parts.waiting_parts) {
+    risks.push({
+      risk_code: "waiting_parts",
+      title: "Closeout needs review — parts/labor state is unresolved",
+      summary: "Parts-related waiting/blocked signals were detected.",
+      severity: "medium",
+      confidence: 0.88,
+      evidence_refs: ["parts", "lines"],
+      missing_data: baseMissing,
+      recommended_next_step: "Verify open parts requests and part-related hold reasons before closeout.",
+      blocks_closeout: false,
+      would_block_closeout_future: true,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  if (snapshot.labor.active_punch_count > 0 || snapshot.lines.active_count > 0) {
+    risks.push({
+      risk_code: "active_labor_or_punch",
+      title: "Closeout needs review — active labor is still in progress",
+      summary: "Active punch or in-progress technician line activity is still open.",
+      severity: "high",
+      confidence: 0.9,
+      evidence_refs: ["labor", "lines"],
+      missing_data: baseMissing,
+      recommended_next_step: "Pause/finish active labor sessions and confirm final line statuses.",
+      blocks_closeout: false,
+      would_block_closeout_future: true,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  if (
+    snapshot.closeout.lines_complete &&
+    snapshot.closeout.approval_resolved &&
+    snapshot.closeout.inspection_finalized &&
+    !snapshot.closeout.invoice_ready
+  ) {
+    risks.push({
+      risk_code: "invoice_not_ready_or_missing",
+      title: "Closeout needs review — invoice/finalize state is not ready",
+      summary: "Core completion signals are present, but invoice/finalize readiness is still missing.",
+      severity: "medium",
+      confidence: 0.86,
+      evidence_refs: ["closeout", "work_order_state", "financials"],
+      missing_data: baseMissing,
+      recommended_next_step: "Review invoice readiness/finalization steps in the current advisor workflow.",
+      blocks_closeout: false,
+      would_block_closeout_future: true,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  if (snapshot.closeout.verification_signals_available) {
+    const missingVerificationSignals =
+      snapshot.closeout.missing_cause_count + snapshot.closeout.missing_correction_count + snapshot.closeout.missing_notes_count;
+
+    if (snapshot.closeout.lines_complete && missingVerificationSignals > 0) {
+      risks.push({
+        risk_code: "missing_verification_notes",
+        title: "Closeout needs review — verification notes are missing",
+        summary: "Completed lines are missing cause/correction/notes details needed for confident closeout review.",
+        severity: "medium",
+        confidence: 0.81,
+        evidence_refs: ["lines", "closeout"],
+        missing_data: baseMissing,
+        recommended_next_step: "Add missing cause/correction/notes where required by existing shop process.",
+        blocks_closeout: false,
+        would_block_closeout_future: true,
+        rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+      });
+    }
+  } else {
+    baseMissing.push("closeout_verification_fields_unavailable_todo");
+  }
+
+  const nearCloseout =
+    snapshot.closeout.lines_complete || snapshot.closeout.approval_resolved || snapshot.closeout.inspection_finalized;
+  const staleHours = snapshot.work_order_state.stale_hours ?? 0;
+  if (nearCloseout && staleHours >= 24) {
+    risks.push({
+      risk_code: "stale_work_order_state",
+      title: "Closeout needs review — work order state is stale",
+      summary: "Work order appears near closeout but has been inactive long enough to require internal review.",
+      severity: staleHours >= 48 ? "high" : "medium",
+      confidence: 0.8,
+      evidence_refs: ["work_order_state", "closeout"],
+      missing_data: unique(baseMissing),
+      recommended_next_step: "Review current owner, next step, and stale blockers before closeout.",
+      blocks_closeout: false,
+      would_block_closeout_future: false,
+      rule_version: WORK_ORDER_CLOSEOUT_RULES_VERSION,
+    });
+  }
+
+  return risks.map((risk) => ({
+    ...risk,
+    missing_data: unique(risk.missing_data),
+    blocks_closeout: false,
+  }));
+}
+
+export function buildCloseoutRiskRecommendations(snapshot: WorkOrderEvidenceSnapshot): WorkOrderRecommendationDraft[] {
+  const expiresAt = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
+
+  return evaluateWorkOrderCloseoutRisk(snapshot).map((risk) => ({
+    recommendation_type: CLOSEOUT_RECOMMENDATION_TYPE_BY_RISK[risk.risk_code],
+    title: risk.title,
+    summary: risk.summary,
+    priority: riskToPriority(risk.severity),
+    confidence: risk.confidence,
+    risk_tier: risk.severity,
+    missing_data: risk.missing_data,
+    recommended_action: {
+      action_type: "review_closeout_risk",
+      label: "Review closeout risk",
+      details: risk.recommended_next_step,
+    },
+    side_effects: [],
+    requires_approval: false,
+    source: "work_order_closeout_rules",
+    expires_at: expiresAt,
+    metadata: {
+      risk_code: risk.risk_code,
+      rule_version: risk.rule_version,
+      blocks_closeout: false,
+      advisory_only: true,
+      would_block_closeout_future: risk.would_block_closeout_future,
+      evidence_refs: risk.evidence_refs,
+    },
+  }));
+}

--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -70,7 +70,8 @@ export async function generateWorkOrderEvidenceAndRecommendations(input: {
       sideEffects: draft.side_effects,
       requiresApproval: draft.requires_approval,
       requiresOwnerPin: false,
-      source: "work_order_rules",
+      source: draft.source ?? "work_order_rules",
+      expiresAt: draft.expires_at ?? null,
       metadata: {
         rules_version: WORK_ORDER_RULES_VERSION,
         ...draft.metadata,
@@ -98,5 +99,6 @@ export type { WorkOrderEvidenceSnapshot, WorkOrderRecommendationDraft } from "./
 export { WORK_ORDER_RULES_VERSION } from "./types";
 export { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot";
 export { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";
+export { evaluateWorkOrderCloseoutRisk, buildCloseoutRiskRecommendations } from "./closeoutRiskRules";
 
 export * from "./workOrderActionPreviews";

--- a/features/ai/server/domains/workOrders/types.ts
+++ b/features/ai/server/domains/workOrders/types.ts
@@ -2,6 +2,7 @@ import type { Json } from "@shared/types/types/supabase";
 import type { AiRecommendationPriority, AiRiskTier } from "@/features/ai/server/types";
 
 export const WORK_ORDER_RULES_VERSION = "wo_rules_v1";
+export const WORK_ORDER_CLOSEOUT_RULES_VERSION = "wo_closeout_risk_v1";
 
 export type WorkOrderEvidenceSnapshot = {
   shop_id: string;
@@ -83,6 +84,10 @@ export type WorkOrderEvidenceSnapshot = {
     inspection_finalized: boolean;
     lines_complete: boolean;
     approval_resolved: boolean;
+    missing_cause_count: number;
+    missing_correction_count: number;
+    missing_notes_count: number;
+    verification_signals_available: boolean;
     blockers: string[];
   };
   evidence_metadata: {
@@ -110,5 +115,29 @@ export type WorkOrderRecommendationDraft = {
   };
   side_effects: string[];
   requires_approval: boolean;
+  source?: string;
+  expires_at?: string | null;
   metadata?: Record<string, Json>;
+};
+
+export type WorkOrderCloseoutRisk = {
+  risk_code:
+    | "inspection_incomplete"
+    | "approval_pending"
+    | "job_lines_incomplete"
+    | "waiting_parts"
+    | "active_labor_or_punch"
+    | "invoice_not_ready_or_missing"
+    | "missing_verification_notes"
+    | "stale_work_order_state";
+  title: string;
+  summary: string;
+  severity: AiRiskTier;
+  confidence: number;
+  evidence_refs: string[];
+  missing_data: string[];
+  recommended_next_step: string;
+  blocks_closeout: false;
+  would_block_closeout_future: boolean;
+  rule_version: string;
 };

--- a/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
+++ b/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
@@ -76,6 +76,46 @@ const RECOMMENDATION_PREVIEW_MAP: Record<string, ActionSpec> = {
     label: "Review closeout readiness",
     description: "Review closeout/invoice readiness with no automatic closeout mutation.",
   },
+  closeout_risk_inspection_incomplete: {
+    actionType: "review_closeout_readiness",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_approval_pending: {
+    actionType: "review_closeout_readiness",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_job_lines_incomplete: {
+    actionType: "review_closeout_readiness",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_waiting_parts: {
+    actionType: "check_parts_status",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_active_labor: {
+    actionType: "review_work_order",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_invoice_not_ready: {
+    actionType: "review_closeout_readiness",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_missing_verification: {
+    actionType: "review_closeout_readiness",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
+  closeout_risk_stale_state: {
+    actionType: "review_work_order",
+    label: "Review closeout risk",
+    description: "Review closeout risk evidence and finish required internal workflow steps.",
+  },
   technician_blocked_or_stale_active_work: {
     actionType: "review_work_order",
     label: "Review work order",

--- a/features/ai/server/domains/workOrders/workOrderRecommendationRules.ts
+++ b/features/ai/server/domains/workOrders/workOrderRecommendationRules.ts
@@ -1,4 +1,5 @@
 import { WORK_ORDER_RULES_VERSION, type WorkOrderEvidenceSnapshot, type WorkOrderRecommendationDraft } from "./types";
+import { buildCloseoutRiskRecommendations } from "./closeoutRiskRules";
 
 export function buildWorkOrderRecommendationsFromSnapshot(snapshot: WorkOrderEvidenceSnapshot): WorkOrderRecommendationDraft[] {
   const recommendations: WorkOrderRecommendationDraft[] = [];
@@ -147,6 +148,8 @@ export function buildWorkOrderRecommendationsFromSnapshot(snapshot: WorkOrderEvi
       metadata: { rules_version: WORK_ORDER_RULES_VERSION },
     });
   }
+
+  recommendations.push(...buildCloseoutRiskRecommendations(snapshot));
 
   return recommendations;
 }

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -17,6 +17,13 @@ type RecommendationRow = {
   status: string;
   recommended_action: {
     label?: string;
+    details?: string;
+  } | null;
+  recommendation_type: string;
+  metadata?: {
+    risk_code?: string;
+    advisory_only?: boolean;
+    blocks_closeout?: boolean;
   } | null;
   missing_data: string[] | null;
   created_at: string;
@@ -254,20 +261,30 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
             const preview = previewByRecommendationId[item.id];
             const previewable = isPreviewableRecommendation(item);
             const previewBusy = previewLoadingId === item.id;
+            const isCloseoutRisk = item.recommendation_type.startsWith("closeout_risk_");
+            const severityLabel = `severity ${item.risk_tier}`;
 
             return (
               <article key={item.id} className={cn(PANEL_VARIANTS.passive, "p-2")}>
                 <div className="flex flex-wrap items-center gap-2">
                   <p className="text-sm font-medium text-foreground">{item.title}</p>
+                  {isCloseoutRisk ? (
+                    <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+                      Closeout review
+                    </span>
+                  ) : null}
                   <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{item.priority}</span>
-                  <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">risk {item.risk_tier}</span>
+                  <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{severityLabel}</span>
                   {item.status === "acknowledged" ? (
                     <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">acknowledged</span>
                   ) : null}
                 </div>
                 <p className="mt-1 text-[11px] text-muted-foreground">{item.summary ?? "Operational review suggested."}</p>
+                {isCloseoutRisk ? (
+                  <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Advisory only — does not block closeout yet.</p>
+                ) : null}
                 <div className="mt-1 text-[10px] text-muted-foreground">
-                  Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.label ?? "Review work order"}
+                  Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.details ?? item.recommended_action?.label ?? "Review work order"}
                 </div>
                 <div className="mt-2 flex flex-wrap items-center gap-1">
                   {previewable ? (

--- a/tests/work-order-closeout-risk-rules.test.ts
+++ b/tests/work-order-closeout-risk-rules.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import { evaluateWorkOrderCloseoutRisk } from "@/features/ai/server/domains/workOrders/closeoutRiskRules";
+import type { WorkOrderEvidenceSnapshot } from "@/features/ai/server/domains/workOrders/types";
+
+type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] };
+
+function buildSnapshot(overrides: DeepPartial<WorkOrderEvidenceSnapshot> = {}): WorkOrderEvidenceSnapshot {
+  const base: WorkOrderEvidenceSnapshot = {
+    shop_id: "shop-1",
+    work_order_id: "wo-1",
+    work_order_number: "RO-1",
+    customer_id: "cust-1",
+    vehicle_id: "veh-1",
+    fleet_context: {
+      source_fleet_program_id: null,
+      source_fleet_service_request_id: null,
+    },
+    timestamps: {
+      created_at: "2026-04-20T00:00:00.000Z",
+      opened_at: "2026-04-20T00:00:00.000Z",
+      updated_at: "2026-04-20T00:00:00.000Z",
+      completed_at: null,
+    },
+    work_order_state: {
+      status: "in_progress",
+      approval_state: "pending",
+      estimate_status: "available",
+      invoice_status: "not_ready",
+      priority: 1,
+      is_waiter: false,
+      age_hours: 5,
+      stale_hours: 1,
+      staleness_tier: "fresh",
+    },
+    lines: {
+      total: 2,
+      actionable: 2,
+      informational: 0,
+      status_counts: {},
+      approval_state_counts: {},
+      job_priority_counts: {},
+      assigned_technician_ids: [],
+      blocked_count: 0,
+      active_count: 0,
+      completed_count: 2,
+    },
+    inspections: {
+      exists: true,
+      completed: true,
+      finalize_state: "finalized",
+      missing_answer_count: 0,
+      photo_count: 1,
+      warnings: [],
+    },
+    approvals: {
+      required: true,
+      sent_for_approval: true,
+      resolved: true,
+      status: "approved",
+      waiting_minutes: null,
+      metadata: {},
+    },
+    parts: {
+      requested_count: 0,
+      allocated_count: 0,
+      waiting_parts: false,
+      fulfilled_request_count: 0,
+      missing_or_blocked: false,
+    },
+    labor: {
+      active_punch_count: 0,
+      labor_segment_count: 0,
+      active_technician_ids: [],
+      stale_active_punch: false,
+    },
+    financials: {
+      estimate_total: 100,
+      invoice_total: 100,
+      labor_total: 50,
+      parts_total: 50,
+      margin_signal: "non_negative",
+    },
+    closeout: {
+      invoice_ready: true,
+      inspection_finalized: true,
+      lines_complete: true,
+      approval_resolved: true,
+      missing_cause_count: 0,
+      missing_correction_count: 0,
+      missing_notes_count: 0,
+      verification_signals_available: true,
+      blockers: [],
+    },
+    evidence_metadata: {
+      source_refs: [],
+      missing_data: [],
+      freshness_at: "2026-04-20T00:00:00.000Z",
+      confidence: 1,
+      generated_at: "2026-04-20T00:00:00.000Z",
+      rules_version: "wo_rules_v1",
+    },
+  };
+
+  const merged = {
+    ...base,
+    ...overrides,
+    work_order_state: { ...base.work_order_state, ...(overrides.work_order_state ?? {}) },
+    lines: { ...base.lines, ...(overrides.lines ?? {}) },
+    inspections: { ...base.inspections, ...(overrides.inspections ?? {}) },
+    approvals: { ...base.approvals, ...(overrides.approvals ?? {}) },
+    parts: { ...base.parts, ...(overrides.parts ?? {}) },
+    labor: { ...base.labor, ...(overrides.labor ?? {}) },
+    financials: { ...base.financials, ...(overrides.financials ?? {}) },
+    closeout: { ...base.closeout, ...(overrides.closeout ?? {}) },
+    evidence_metadata: { ...base.evidence_metadata, ...(overrides.evidence_metadata ?? {}) },
+  };
+
+  return merged as WorkOrderEvidenceSnapshot;
+}
+
+describe("evaluateWorkOrderCloseoutRisk", () => {
+  it("flags incomplete inspection risk", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(
+      buildSnapshot({
+        closeout: { inspection_finalized: false },
+      }),
+    );
+    expect(risks.some((risk) => risk.risk_code === "inspection_incomplete")).toBe(true);
+  });
+
+  it("flags pending approval risk", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(
+      buildSnapshot({
+        approvals: { required: true, resolved: false, status: "pending" },
+      }),
+    );
+    expect(risks.some((risk) => risk.risk_code === "approval_pending")).toBe(true);
+  });
+
+  it("flags incomplete job line risk", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(
+      buildSnapshot({
+        lines: { actionable: 2, completed_count: 1 },
+        closeout: { lines_complete: false },
+      }),
+    );
+    expect(risks.some((risk) => risk.risk_code === "job_lines_incomplete")).toBe(true);
+  });
+
+  it("flags waiting parts risk", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(buildSnapshot({ parts: { waiting_parts: true } }));
+    expect(risks.some((risk) => risk.risk_code === "waiting_parts")).toBe(true);
+  });
+
+  it("flags active labor risk", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(buildSnapshot({ labor: { active_punch_count: 1 } }));
+    expect(risks.some((risk) => risk.risk_code === "active_labor_or_punch")).toBe(true);
+  });
+
+  it("returns no closeout risk when closeout signals are complete and resolved", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(buildSnapshot());
+    expect(risks).toHaveLength(0);
+  });
+
+  it("adds missing_data TODO when verification fields are unavailable instead of inventing missing verification risk", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(
+      buildSnapshot({
+        closeout: {
+          verification_signals_available: false,
+        },
+        work_order_state: { stale_hours: 25 },
+      }),
+    );
+
+    const missingVerificationRisk = risks.find((risk) => risk.risk_code === "missing_verification_notes");
+    expect(missingVerificationRisk).toBeUndefined();
+
+    const staleRisk = risks.find((risk) => risk.risk_code === "stale_work_order_state");
+    expect(staleRisk?.missing_data).toContain("closeout_verification_fields_unavailable_todo");
+  });
+
+  it("always keeps blocks_closeout false", () => {
+    const risks = evaluateWorkOrderCloseoutRisk(
+      buildSnapshot({
+        approvals: { required: true, resolved: false, status: "pending" },
+        closeout: { inspection_finalized: false, lines_complete: false, invoice_ready: false },
+      }),
+    );
+    expect(risks.length).toBeGreaterThan(0);
+    expect(risks.every((risk) => risk.blocks_closeout === false)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Surface deterministic, evidence-backed closeout risks (inspection, approvals, lines, parts, labor, invoice readiness, verification, stale state) to advisors so they can review before closing a work order without blocking workflows.
- Keep behavior advisory-first: no closeout blocking, no work-order mutations, and no autonomous execution while providing traceable evidence refs and confidence signals.

### Description
- Added a deterministic closeout risk evaluator and recommendation builder in `features/ai/server/domains/workOrders/closeoutRiskRules.ts` with `evaluateWorkOrderCloseoutRisk(snapshot)` and `buildCloseoutRiskRecommendations(snapshot)`. 
- Extended the work-order evidence snapshot to include cause/correction/notes completeness counters and a verification-availability signal in `buildWorkOrderEvidenceSnapshot.ts` and exported the new evaluators via the domain index. 
- Wired closeout risk drafts into the existing recommendation flow (`workOrderRecommendationRules.ts` → generation path) with advisory metadata (`blocks_closeout: false`, `advisory_only: true`), TTL (`expires_at`), and `source` passthrough in `index.ts`. 
- Added preview allowlist entries for the new recommendation types, updated the recommendation card UI to label closeout items as “Closeout review” with severity and advisory copy, and added focused unit tests for the evaluator. 

### Testing
- Ran `npx tsc --noEmit` which completed successfully (typecheck passed). 
- Ran `npm test` (Vitest) and all suites passed, including the new `tests/work-order-closeout-risk-rules.test.ts`. 
- Verified the new recommendations are created via the existing duplicate-prevention path and that `blocks_closeout` remains false in all emitted risks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb96ed44648328afe7210bfe9f58b3)