### PR TITLE
Add internal-only advisor explanation draft generator for work orders

### DIFF
--- a/app/api/work-orders/[id]/ai/advisor-draft/route.ts
+++ b/app/api/work-orders/[id]/ai/advisor-draft/route.ts
@@ -1,0 +1,294 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  buildAdvisorExplanationDraftFromRecommendation,
+  buildAdvisorExplanationDraftFromSnapshot,
+  createAiActionPreview,
+  listAiEvidenceSnapshotsForSubject,
+  listAiRecommendationsForSubject,
+  type AiActionPreviewRecord,
+} from "@/features/ai/server";
+import { generateWorkOrderEvidenceAndRecommendations, type WorkOrderEvidenceSnapshot } from "@/features/ai/server/domains/workOrders";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+
+const ACTION_TYPE = "advisor_explanation_draft";
+const EXECUTION_BLOCKED_REASON = "No external side effects. Internal advisor draft only.";
+
+function parseSnapshot(value: unknown): WorkOrderEvidenceSnapshot | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const candidate = value as Partial<WorkOrderEvidenceSnapshot>;
+  if (typeof candidate.work_order_id !== "string") return null;
+  if (!candidate.evidence_metadata || typeof candidate.evidence_metadata !== "object") return null;
+
+  return candidate as WorkOrderEvidenceSnapshot;
+}
+
+async function getShopScopedWorkOrder(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<WorkOrderRow | null> {
+  const { data, error } = await input.supabase
+    .from("work_orders")
+    .select("*")
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<WorkOrderRow>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function getLatestAdvisorDraftPreview(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+}): Promise<AiActionPreviewRecord | null> {
+  const { data, error } = await input.supabase
+    .from("ai_action_previews")
+    .select("*")
+    .eq("shop_id", input.shopId)
+    .eq("domain", "work_orders")
+    .eq("subject_type", "work_order")
+    .eq("subject_id", input.workOrderId)
+    .eq("action_type", ACTION_TYPE)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<AiActionPreviewRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function getAdvisorDraftPreviewByIdempotency(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  idempotencyKey: string;
+}): Promise<AiActionPreviewRecord | null> {
+  const { data, error } = await input.supabase
+    .from("ai_action_previews")
+    .select("*")
+    .eq("shop_id", input.shopId)
+    .eq("idempotency_key", input.idempotencyKey)
+    .maybeSingle<AiActionPreviewRecord>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+function selectPrimaryRecommendation<T extends { status: string; created_at: string }>(recommendations: T[]): T | null {
+  const open = recommendations.filter((row) => row.status === "open" || row.status === "acknowledged");
+  if (open.length === 0) return null;
+  return open.slice().sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0] ?? null;
+}
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = await ctx.params;
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  try {
+    const workOrder = await getShopScopedWorkOrder({
+      supabase: access.supabase,
+      workOrderId: id,
+      shopId,
+    });
+
+    if (!workOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    const actor = {
+      shopId,
+      actorId: access.profile.id,
+      role: access.profile.role,
+      source: "manual" as const,
+    };
+
+    const [snapshots, recommendations, preview] = await Promise.all([
+      listAiEvidenceSnapshotsForSubject(access.supabase, actor, {
+        subjectType: "work_order",
+        subjectId: id,
+        domain: "work_orders",
+        limit: 1,
+      }),
+      listAiRecommendationsForSubject(access.supabase, actor, {
+        subjectType: "work_order",
+        subjectId: id,
+        domain: "work_orders",
+        limit: 50,
+      }),
+      getLatestAdvisorDraftPreview({
+        supabase: access.supabase,
+        shopId,
+        workOrderId: id,
+      }),
+    ]);
+
+    const latestEvidence = snapshots[0] ?? null;
+    if (!latestEvidence) {
+      return NextResponse.json({
+        draft: null,
+        advisoryOnly: true,
+        warnings: ["No evidence snapshot available yet. Use POST to generate one."],
+      });
+    }
+
+    const snapshot = parseSnapshot(latestEvidence.snapshot);
+    if (!snapshot) {
+      return NextResponse.json({ error: "Latest evidence snapshot payload is invalid." }, { status: 500 });
+    }
+
+    const primaryRecommendation = selectPrimaryRecommendation(recommendations);
+    const draft = primaryRecommendation
+      ? buildAdvisorExplanationDraftFromRecommendation({
+          snapshot,
+          evidenceSnapshotId: latestEvidence.id,
+          workOrderId: id,
+          recommendation: primaryRecommendation,
+        })
+      : buildAdvisorExplanationDraftFromSnapshot({
+          snapshot,
+          evidenceSnapshotId: latestEvidence.id,
+          workOrderId: id,
+        });
+
+    return NextResponse.json({
+      draft,
+      advisoryOnly: true,
+      preview,
+      executionBlocked: true,
+      blockedReason: EXECUTION_BLOCKED_REASON,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load advisor explanation draft";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = await ctx.params;
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  try {
+    const workOrder = await getShopScopedWorkOrder({
+      supabase: access.supabase,
+      workOrderId: id,
+      shopId,
+    });
+
+    if (!workOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    const actor = {
+      shopId,
+      actorId: access.profile.id,
+      role: access.profile.role,
+      source: "manual" as const,
+    };
+
+    const result = await generateWorkOrderEvidenceAndRecommendations({
+      supabase: access.supabase,
+      actor,
+      workOrderId: id,
+    });
+
+    const snapshot = parseSnapshot(result.evidenceSnapshot.snapshot);
+    if (!snapshot) {
+      return NextResponse.json({ error: "Generated evidence snapshot payload is invalid." }, { status: 500 });
+    }
+
+    const primaryRecommendation = selectPrimaryRecommendation(result.recommendations);
+    const draft = primaryRecommendation
+      ? buildAdvisorExplanationDraftFromRecommendation({
+          snapshot,
+          evidenceSnapshotId: result.evidenceSnapshot.id,
+          workOrderId: id,
+          recommendation: primaryRecommendation,
+        })
+      : buildAdvisorExplanationDraftFromSnapshot({
+          snapshot,
+          evidenceSnapshotId: result.evidenceSnapshot.id,
+          workOrderId: id,
+        });
+
+    const idempotencyKey = [shopId, id, result.evidenceSnapshot.id, primaryRecommendation?.id ?? "none", ACTION_TYPE].join(":");
+
+    const existingPreview = await getAdvisorDraftPreviewByIdempotency({
+      supabase: access.supabase,
+      shopId,
+      idempotencyKey,
+    });
+
+    const preview =
+      existingPreview ??
+      (await createAiActionPreview(access.supabase, actor, {
+        recommendationId: primaryRecommendation?.id ?? null,
+        domain: "work_orders",
+        actionType: ACTION_TYPE,
+        subjectType: "work_order",
+        subjectId: id,
+        previewPayload: {
+          ...draft,
+          executionBlocked: true,
+        },
+        intendedMutations: [],
+        affectedRecords: [
+          { type: "work_order", id },
+          { type: "evidence_snapshot", id: result.evidenceSnapshot.id },
+          ...(primaryRecommendation?.id ? [{ type: "recommendation", id: primaryRecommendation.id }] : []),
+        ],
+        sideEffects: [EXECUTION_BLOCKED_REASON],
+        compensationPlan: {
+          mode: "preview_only",
+          details: "No execution path is enabled. Internal advisor draft generation only.",
+        },
+        idempotencyKey,
+        riskTier: "low",
+        evidenceSnapshotId: result.evidenceSnapshot.id,
+        requiresApproval: false,
+        requiresOwnerPin: false,
+        metadata: {
+          advisory_only: true,
+          audience: "internal_advisor",
+          execution_blocked: true,
+        },
+      }));
+
+    return NextResponse.json({
+      draft,
+      preview,
+      advisoryOnly: true,
+      executionBlocked: true,
+      blockedReason: EXECUTION_BLOCKED_REASON,
+      warnings: draft.warnings,
+      prohibitedActions: draft.prohibitedActions,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to generate advisor explanation draft";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/features/ai/server/domains/workOrders/advisorExplanationDrafts.ts
+++ b/features/ai/server/domains/workOrders/advisorExplanationDrafts.ts
@@ -1,0 +1,221 @@
+import type { Json } from "@shared/types/types/supabase";
+import type { AiRecommendationRecord } from "@/features/ai/server/types";
+import type { WorkOrderEvidenceSnapshot } from "./types";
+
+const INTERNAL_DISCLAIMER = "Internal advisor draft — verify before customer communication.";
+
+export type AdvisorDraftSection = {
+  heading: string;
+  bullets: string[];
+};
+
+export type AdvisorExplanationDraft = {
+  title: string;
+  audience: "internal_advisor";
+  advisoryOnly: true;
+  evidenceSnapshotId: string;
+  recommendationId: string | null;
+  workOrderId: string;
+  sections: AdvisorDraftSection[];
+  missingData: string[];
+  confidence: number;
+  warnings: string[];
+  prohibitedActions: string[];
+};
+
+type RecommendationLike = Pick<
+  AiRecommendationRecord,
+  "id" | "recommendation_type" | "title" | "summary" | "confidence" | "risk_tier" | "recommended_action" | "missing_data"
+>;
+
+function asRecord(value: Json | null | undefined): Record<string, Json> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, Json>;
+}
+
+function asStringArray(value: Json | null | undefined): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0) : [];
+}
+
+function toPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function normalizeConfidence(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0.5;
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function computeDraftConfidence(snapshot: WorkOrderEvidenceSnapshot, recommendation?: RecommendationLike | null): number {
+  const snapshotConfidence = normalizeConfidence(snapshot.evidence_metadata.confidence);
+  const recommendationConfidence = normalizeConfidence(recommendation?.confidence);
+  const missingPenalty = Math.min(0.35, snapshot.evidence_metadata.missing_data.length * 0.03);
+  const blended = recommendation ? (snapshotConfidence * 0.65) + (recommendationConfidence * 0.35) : snapshotConfidence;
+  return Math.max(0, Math.min(1, Number((blended - missingPenalty).toFixed(2))));
+}
+
+function buildSituationSummary(snapshot: WorkOrderEvidenceSnapshot): AdvisorDraftSection {
+  const bullets = [
+    `Work order ${snapshot.work_order_number ?? snapshot.work_order_id} is currently ${snapshot.work_order_state.status ?? "unknown"}.`,
+    `Approval status is ${snapshot.approvals.status}; pending wait is ${snapshot.approvals.waiting_minutes != null ? `${Math.round(snapshot.approvals.waiting_minutes)} minutes` : "not available"}.`,
+    `Line state: ${snapshot.lines.completed_count}/${snapshot.lines.total} completed, ${snapshot.lines.active_count} active, ${snapshot.lines.blocked_count} blocked.`,
+    `Inspection status: ${snapshot.inspections.exists ? (snapshot.inspections.completed ? "completed" : "incomplete") : "not found"}; missing answers: ${snapshot.inspections.missing_answer_count ?? "unknown"}.`,
+    `Parts status: ${snapshot.parts.waiting_parts ? "waiting on parts signals present" : "no current parts wait signal"}.`,
+  ];
+
+  if (!snapshot.customer_id) {
+    bullets.push("Customer linkage is missing in evidence; confirm customer record before external communication.");
+  }
+  if (!snapshot.vehicle_id) {
+    bullets.push("Vehicle linkage is missing in evidence; confirm vehicle details before external communication.");
+  }
+
+  return {
+    heading: "Situation summary",
+    bullets,
+  };
+}
+
+function buildTalkingPoints(snapshot: WorkOrderEvidenceSnapshot, recommendation?: RecommendationLike | null): AdvisorDraftSection {
+  const bullets = [
+    "Use only verified work-order and inspection facts in conversation prep.",
+    `Current closeout readiness signals: inspection finalized = ${snapshot.closeout.inspection_finalized ? "yes" : "no"}, approval resolved = ${snapshot.closeout.approval_resolved ? "yes" : "no"}, invoice ready = ${snapshot.closeout.invoice_ready ? "yes" : "no"}.`,
+    "Describe operational state and next review step; do not state a final diagnosis unless documented by technician evidence.",
+  ];
+
+  if (recommendation) {
+    bullets.push(`Linked recommendation: ${recommendation.title}${recommendation.summary ? ` — ${recommendation.summary}` : ""}.`);
+    const action = asRecord(recommendation.recommended_action);
+    const label = typeof action.label === "string" ? action.label : null;
+    const details = typeof action.details === "string" ? action.details : null;
+    if (label || details) {
+      bullets.push(`Recommendation talking point: ${label ?? "Review recommendation"}${details ? ` (${details})` : ""}.`);
+    }
+  }
+
+  if (snapshot.approvals.status === "pending") {
+    bullets.push("Approval is still pending; avoid language that implies customer or fleet approval already exists.");
+  }
+
+  return {
+    heading: "Advisor talking points",
+    bullets,
+  };
+}
+
+function buildNeedsReview(snapshot: WorkOrderEvidenceSnapshot): AdvisorDraftSection {
+  const bullets: string[] = [];
+
+  if ((snapshot.inspections.missing_answer_count ?? 0) > 0) bullets.push("Inspection has unanswered items that require review.");
+  if (snapshot.approvals.status === "pending") bullets.push("Approval appears pending and should be rechecked.");
+  if (!snapshot.closeout.lines_complete) bullets.push("One or more work-order lines are incomplete.");
+  if (snapshot.parts.waiting_parts) bullets.push("Parts wait signals exist (open request or part-related hold).");
+  if (snapshot.labor.active_punch_count > 0 || snapshot.labor.stale_active_punch) bullets.push("Active labor sessions detected; verify technician progress/dispatch.");
+
+  const hasCloseoutRisk = snapshot.closeout.blockers.length > 0;
+  if (hasCloseoutRisk) {
+    bullets.push(`Closeout review blockers present: ${snapshot.closeout.blockers.join(", ")}.`);
+  }
+
+  if (snapshot.closeout.missing_notes_count > 0 || snapshot.closeout.missing_cause_count > 0 || snapshot.closeout.missing_correction_count > 0) {
+    bullets.push("Verification notes/cause/correction fields appear incomplete for completed lines.");
+  }
+
+  if (bullets.length === 0) bullets.push("No additional internal review blockers were detected in current evidence snapshot.");
+
+  return {
+    heading: "What needs review",
+    bullets,
+  };
+}
+
+function suggestInternalNextStep(snapshot: WorkOrderEvidenceSnapshot, recommendation?: RecommendationLike | null): string {
+  if (!snapshot.inspections.completed || (snapshot.inspections.missing_answer_count ?? 0) > 0) return "Review inspection results";
+  if (snapshot.approvals.status === "pending") return "Confirm approval status";
+  if (snapshot.parts.waiting_parts) return "Check parts availability";
+  if (!snapshot.closeout.invoice_ready || snapshot.closeout.blockers.length > 0) return "Review closeout readiness";
+
+  const action = asRecord(recommendation?.recommended_action);
+  const actionType = typeof action.action_type === "string" ? action.action_type : "";
+  if (actionType.includes("dispatch") || actionType.includes("review_work_order")) return "Ask technician for verification note";
+
+  return "Review work order evidence with advisor checklist";
+}
+
+function buildMissingDataSection(snapshot: WorkOrderEvidenceSnapshot, recommendation?: RecommendationLike | null): AdvisorDraftSection {
+  const recommendationMissing = asStringArray(recommendation?.missing_data ?? null);
+  const unknowns = Array.from(new Set([...snapshot.evidence_metadata.missing_data, ...recommendationMissing]));
+
+  const bullets = unknowns.length > 0
+    ? unknowns.map((item) => `Unknown/missing evidence: ${item}. Do not present as confirmed fact.`)
+    : ["No explicit missing-data markers in snapshot; still verify all customer-facing details before any communication."];
+
+  return {
+    heading: "Missing data / do not say yet",
+    bullets,
+  };
+}
+
+export function buildAdvisorExplanationDraftFromSnapshot(input: {
+  snapshot: WorkOrderEvidenceSnapshot;
+  evidenceSnapshotId: string;
+  workOrderId: string;
+  recommendation?: RecommendationLike | null;
+}): AdvisorExplanationDraft {
+  const { snapshot, evidenceSnapshotId, workOrderId, recommendation } = input;
+  const recommendationMissing = asStringArray(recommendation?.missing_data ?? null);
+  const missingData = Array.from(new Set([...snapshot.evidence_metadata.missing_data, ...recommendationMissing]));
+  const confidence = computeDraftConfidence(snapshot, recommendation);
+
+  return {
+    title: recommendation
+      ? `Advisor explanation draft: ${recommendation.title}`
+      : `Advisor explanation draft for work order ${snapshot.work_order_number ?? workOrderId}`,
+    audience: "internal_advisor",
+    advisoryOnly: true,
+    evidenceSnapshotId,
+    recommendationId: recommendation?.id ?? null,
+    workOrderId,
+    sections: [
+      buildSituationSummary(snapshot),
+      buildTalkingPoints(snapshot, recommendation),
+      buildNeedsReview(snapshot),
+      {
+        heading: "Suggested next internal step",
+        bullets: [suggestInternalNextStep(snapshot, recommendation)],
+      },
+      buildMissingDataSection(snapshot, recommendation),
+    ],
+    missingData,
+    confidence,
+    warnings: [
+      INTERNAL_DISCLAIMER,
+      `Evidence snapshot reference: ${evidenceSnapshotId}.`,
+      recommendation?.id ? `Recommendation reference: ${recommendation.id}.` : "No recommendation reference was linked.",
+      `Confidence is advisory (${toPercent(confidence)}). Validate against current work-order record before any customer communication.`,
+      "Do not claim diagnosis, safety status, parts availability, pricing, approval, or completion unless explicitly evidenced.",
+    ],
+    prohibitedActions: [
+      "Do not send customer messages from this draft.",
+      "Do not send estimates or invoices.",
+      "Do not approve quotes or order parts.",
+      "Do not mutate work-order state.",
+      "Do not execute action previews.",
+      "Do not present this as final customer-ready copy.",
+    ],
+  };
+}
+
+export function buildAdvisorExplanationDraftFromRecommendation(input: {
+  snapshot: WorkOrderEvidenceSnapshot;
+  evidenceSnapshotId: string;
+  workOrderId: string;
+  recommendation: RecommendationLike;
+}): AdvisorExplanationDraft {
+  return buildAdvisorExplanationDraftFromSnapshot({
+    snapshot: input.snapshot,
+    evidenceSnapshotId: input.evidenceSnapshotId,
+    workOrderId: input.workOrderId,
+    recommendation: input.recommendation,
+  });
+}

--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -102,3 +102,5 @@ export { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommenda
 export { evaluateWorkOrderCloseoutRisk, buildCloseoutRiskRecommendations } from "./closeoutRiskRules";
 
 export * from "./workOrderActionPreviews";
+
+export * from "./advisorExplanationDrafts";

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -64,6 +64,25 @@ type PreviewRow = {
   created_at: string;
 };
 
+type AdvisorDraftSection = {
+  heading: string;
+  bullets: string[];
+};
+
+type AdvisorDraft = {
+  title: string;
+  audience: "internal_advisor";
+  advisoryOnly: true;
+  evidenceSnapshotId: string;
+  recommendationId: string | null;
+  workOrderId: string;
+  sections: AdvisorDraftSection[];
+  missingData: string[];
+  confidence: number;
+  warnings: string[];
+  prohibitedActions: string[];
+};
+
 function isPreviewableRecommendation(item: RecommendationRow): boolean {
   return item.risk_tier !== "critical";
 }
@@ -101,6 +120,9 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [previewLoadingId, setPreviewLoadingId] = useState<string | null>(null);
   const [previewByRecommendationId, setPreviewByRecommendationId] = useState<Record<string, PreviewRow>>({});
+  const [advisorDraft, setAdvisorDraft] = useState<AdvisorDraft | null>(null);
+  const [advisorDraftLoading, setAdvisorDraftLoading] = useState(false);
+  const [advisorDraftRefreshing, setAdvisorDraftRefreshing] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -111,6 +133,19 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
       if (!res.ok) throw new Error(json?.error ?? "Failed to load operational recommendations.");
       setRecommendations(Array.isArray(json.recommendations) ? json.recommendations : []);
       setEvidence(json.evidenceSnapshot ?? null);
+
+      setAdvisorDraftLoading(true);
+      try {
+        const draftRes = await fetch(`/api/work-orders/${workOrderId}/ai/advisor-draft`, { cache: "no-store" });
+        const draftJson = await draftRes.json();
+        if (draftRes.ok && draftJson?.draft) {
+          setAdvisorDraft(draftJson.draft as AdvisorDraft);
+        } else {
+          setAdvisorDraft(null);
+        }
+      } finally {
+        setAdvisorDraftLoading(false);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load operational recommendations.");
     } finally {
@@ -138,6 +173,25 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
       toast.error(message);
     } finally {
       setRefreshing(false);
+    }
+  }, [workOrderId]);
+
+  const onGenerateAdvisorDraft = useCallback(async () => {
+    setAdvisorDraftRefreshing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/ai/advisor-draft`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to generate advisor explanation draft.");
+      if (!json?.draft) throw new Error("Advisor draft response was invalid.");
+      setAdvisorDraft(json.draft as AdvisorDraft);
+      toast.success("Internal advisor draft generated.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate advisor explanation draft.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setAdvisorDraftRefreshing(false);
     }
   }, [workOrderId]);
 
@@ -351,6 +405,74 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
           })}
         </div>
       ) : null}
+
+      <div className={cn(PANEL_VARIANTS.passive, "mt-2 p-2")}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="text-[11px] font-medium text-foreground">Advisor explanation draft</p>
+            <p className="text-[10px] text-muted-foreground">Internal-only, advisory-only explanation prep from evidence snapshots.</p>
+          </div>
+          <button
+            type="button"
+            className="rounded-md border border-[rgba(184,115,51,0.5)] px-2 py-1 text-[11px] text-[rgba(184,115,51,0.95)] transition hover:bg-[rgba(184,115,51,0.12)] disabled:opacity-50"
+            onClick={() => void onGenerateAdvisorDraft()}
+            disabled={advisorDraftRefreshing}
+          >
+            {advisorDraftRefreshing ? "Generating draft…" : "Generate advisor draft"}
+          </button>
+        </div>
+
+        {advisorDraftLoading ? <p className="mt-2 text-[10px] text-muted-foreground">Loading advisor draft…</p> : null}
+
+        {advisorDraft ? (
+          <div className="mt-2 rounded-md border border-white/10 bg-white/[0.02] p-2 text-[10px] text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 uppercase tracking-wide text-[9px] text-[rgba(184,115,51,0.95)]">internal-only</span>
+              <span className="rounded-full border border-white/20 px-2 py-0.5 uppercase tracking-wide text-[9px] text-muted-foreground">advisory-only</span>
+            </div>
+            <p className="mt-1 text-[11px] font-medium text-foreground">{advisorDraft.title}</p>
+            <p className="mt-1">Confidence: {advisorDraft.confidence.toFixed(2)} • Missing data: {advisorDraft.missingData.length}</p>
+            <p className="mt-1">Evidence snapshot: {advisorDraft.evidenceSnapshotId}{advisorDraft.recommendationId ? ` • Recommendation: ${advisorDraft.recommendationId}` : ""}</p>
+
+            <div className="mt-2 space-y-2">
+              {advisorDraft.sections.map((section) => (
+                <div key={section.heading}>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-foreground">{section.heading}</p>
+                  <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                    {section.bullets.map((bullet, idx) => (
+                      <li key={`${section.heading}:${idx}`}>{bullet}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+
+            {advisorDraft.warnings.length > 0 ? (
+              <div className="mt-2">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-foreground">Warnings</p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  {advisorDraft.warnings.map((warning, idx) => (
+                    <li key={`warning:${idx}`}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {advisorDraft.prohibitedActions.length > 0 ? (
+              <div className="mt-2">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-foreground">Do not do</p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  {advisorDraft.prohibitedActions.map((item, idx) => (
+                    <li key={`prohibit:${idx}`}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <p className="mt-2 text-[10px] text-muted-foreground">No advisor draft yet. Generate one for internal review.</p>
+        )}
+      </div>
 
       <p className="mt-2 text-[10px] text-muted-foreground">{freshnessLabel} • Generated by work order rules.</p>
     </section>

--- a/tests/advisor-explanation-drafts.test.ts
+++ b/tests/advisor-explanation-drafts.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAdvisorExplanationDraftFromRecommendation,
+  buildAdvisorExplanationDraftFromSnapshot,
+} from "@/features/ai/server/domains/workOrders/advisorExplanationDrafts";
+import type { WorkOrderEvidenceSnapshot } from "@/features/ai/server/domains/workOrders/types";
+
+type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] };
+
+function buildSnapshot(overrides: DeepPartial<WorkOrderEvidenceSnapshot> = {}): WorkOrderEvidenceSnapshot {
+  const base: WorkOrderEvidenceSnapshot = {
+    shop_id: "shop-1",
+    work_order_id: "wo-1",
+    work_order_number: "RO-42",
+    customer_id: "cust-1",
+    vehicle_id: "veh-1",
+    fleet_context: {
+      source_fleet_program_id: null,
+      source_fleet_service_request_id: null,
+    },
+    timestamps: {
+      created_at: "2026-04-20T00:00:00.000Z",
+      opened_at: "2026-04-20T00:00:00.000Z",
+      updated_at: "2026-04-20T00:00:00.000Z",
+      completed_at: null,
+    },
+    work_order_state: {
+      status: "in_progress",
+      approval_state: "pending",
+      estimate_status: "available",
+      invoice_status: "not_ready",
+      priority: 1,
+      is_waiter: false,
+      age_hours: 6,
+      stale_hours: 2,
+      staleness_tier: "fresh",
+    },
+    lines: {
+      total: 2,
+      actionable: 2,
+      informational: 0,
+      status_counts: {},
+      approval_state_counts: {},
+      job_priority_counts: {},
+      assigned_technician_ids: [],
+      blocked_count: 0,
+      active_count: 1,
+      completed_count: 1,
+    },
+    inspections: {
+      exists: true,
+      completed: false,
+      finalize_state: "in_progress",
+      missing_answer_count: 2,
+      photo_count: 1,
+      warnings: ["inspection_missing_answers"],
+    },
+    approvals: {
+      required: true,
+      sent_for_approval: true,
+      resolved: false,
+      status: "pending",
+      waiting_minutes: 45,
+      metadata: {},
+    },
+    parts: {
+      requested_count: 1,
+      allocated_count: 0,
+      waiting_parts: true,
+      fulfilled_request_count: 0,
+      missing_or_blocked: true,
+    },
+    labor: {
+      active_punch_count: 1,
+      labor_segment_count: 1,
+      active_technician_ids: ["tech-1"],
+      stale_active_punch: false,
+    },
+    financials: {
+      estimate_total: 100,
+      invoice_total: null,
+      labor_total: 50,
+      parts_total: 50,
+      margin_signal: "non_negative",
+    },
+    closeout: {
+      invoice_ready: false,
+      inspection_finalized: false,
+      lines_complete: false,
+      approval_resolved: false,
+      missing_cause_count: 1,
+      missing_correction_count: 1,
+      missing_notes_count: 1,
+      verification_signals_available: true,
+      blockers: ["inspection_not_finalized"],
+    },
+    evidence_metadata: {
+      source_refs: [],
+      missing_data: ["missing_parts_data"],
+      freshness_at: "2026-04-20T00:00:00.000Z",
+      confidence: 0.9,
+      generated_at: "2026-04-20T00:00:00.000Z",
+      rules_version: "wo_rules_v1",
+    },
+  };
+
+  const merged = {
+    ...base,
+    ...overrides,
+    work_order_state: { ...base.work_order_state, ...(overrides.work_order_state ?? {}) },
+    lines: { ...base.lines, ...(overrides.lines ?? {}) },
+    inspections: { ...base.inspections, ...(overrides.inspections ?? {}) },
+    approvals: { ...base.approvals, ...(overrides.approvals ?? {}) },
+    parts: { ...base.parts, ...(overrides.parts ?? {}) },
+    labor: { ...base.labor, ...(overrides.labor ?? {}) },
+    financials: { ...base.financials, ...(overrides.financials ?? {}) },
+    closeout: { ...base.closeout, ...(overrides.closeout ?? {}) },
+    evidence_metadata: { ...base.evidence_metadata, ...(overrides.evidence_metadata ?? {}) },
+  };
+
+  return merged as WorkOrderEvidenceSnapshot;
+}
+
+describe("advisor explanation draft builder", () => {
+  it("builds internal/advisory-only draft from snapshot facts", () => {
+    const draft = buildAdvisorExplanationDraftFromSnapshot({
+      snapshot: buildSnapshot(),
+      evidenceSnapshotId: "ev-1",
+      workOrderId: "wo-1",
+    });
+
+    expect(draft.audience).toBe("internal_advisor");
+    expect(draft.advisoryOnly).toBe(true);
+    expect(draft.sections.length).toBeGreaterThan(0);
+    expect(draft.sections.some((section) => section.heading === "Situation summary")).toBe(true);
+    expect(draft.sections.flatMap((section) => section.bullets).join(" ")).toContain("pending");
+  });
+
+  it("surfaces missing data in do-not-say-yet section", () => {
+    const draft = buildAdvisorExplanationDraftFromSnapshot({
+      snapshot: buildSnapshot({
+        evidence_metadata: {
+          missing_data: ["missing_customer_id", "missing_vehicle_id"],
+        },
+      }),
+      evidenceSnapshotId: "ev-2",
+      workOrderId: "wo-1",
+    });
+
+    const doNotSay = draft.sections.find((section) => section.heading === "Missing data / do not say yet");
+    expect(doNotSay?.bullets.join(" ")).toContain("missing_customer_id");
+    expect(doNotSay?.bullets.join(" ")).toContain("missing_vehicle_id");
+  });
+
+  it("keeps confidence bounded 0..1 and carries no external side effects language", () => {
+    const draft = buildAdvisorExplanationDraftFromSnapshot({
+      snapshot: buildSnapshot({
+        evidence_metadata: {
+          confidence: 1,
+          missing_data: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        },
+      }),
+      evidenceSnapshotId: "ev-3",
+      workOrderId: "wo-1",
+    });
+
+    expect(draft.confidence).toBeGreaterThanOrEqual(0);
+    expect(draft.confidence).toBeLessThanOrEqual(1);
+    expect(draft.prohibitedActions.some((item) => item.includes("Do not send customer messages"))).toBe(true);
+  });
+
+  it("builds recommendation-linked draft without customer-send language", () => {
+    const draft = buildAdvisorExplanationDraftFromRecommendation({
+      snapshot: buildSnapshot(),
+      evidenceSnapshotId: "ev-4",
+      workOrderId: "wo-1",
+      recommendation: {
+        id: "rec-1",
+        recommendation_type: "waiting_on_approval",
+        title: "Waiting on approval",
+        summary: "Approval still pending.",
+        confidence: 0.8,
+        risk_tier: "low",
+        recommended_action: {
+          action_type: "advisor_review_needed",
+          label: "Review approval queue",
+          details: "Confirm pending authorization",
+        },
+        missing_data: ["missing_approval_data"],
+      },
+    });
+
+    const allText = [
+      draft.title,
+      ...draft.sections.flatMap((section) => section.bullets),
+      ...draft.warnings,
+      ...draft.prohibitedActions,
+    ].join(" ").toLowerCase();
+
+    expect(draft.recommendationId).toBe("rec-1");
+    expect(allText.includes("send this to customer")).toBe(false);
+    expect(allText.includes("customer-ready")).toBe(true);
+    expect(draft.warnings.some((warning) => warning.includes("Internal advisor draft"))).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide advisors with an evidence-grounded, internal-only explanation draft derived from existing work-order evidence snapshots and rule recommendations to aid internal conversations without creating customer-facing messages or executing actions.
- Ensure drafts are deterministic, auditable, shop-scoped, and include clear guardrails (missing-data, warnings, prohibited actions) so advisors do not accidentally surface unsupported facts.

### Description
- Added a deterministic draft builder at `features/ai/server/domains/workOrders/advisorExplanationDrafts.ts` exporting `buildAdvisorExplanationDraftFromSnapshot(...)` and `buildAdvisorExplanationDraftFromRecommendation(...)` that produce a structured internal draft containing sections, missingData, confidence, warnings, and prohibitedActions.
- New shop-scoped API route `app/api/work-orders/[id]/ai/advisor-draft/route.ts` with `GET` (returns latest derived draft) and `POST` (regenerates evidence/recommendations, returns draft, and stores a preview-only `ai_action_previews` record with `action_type: advisor_explanation_draft`, empty intended mutations, and execution blocked); route is gated by `requireShopScopedApiAccess` for owner/admin/manager/advisor and verifies work order shop membership.
- Integrated a compact internal-only panel into the existing work-order AI UI at `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx` that shows an internal/advisory badge, confidence, missing-data count, sections, warnings, and a “Generate advisor draft” button.
- Exported the new helpers from the work-order AI domain index and added unit tests for the draft builder at `tests/advisor-explanation-drafts.test.ts` to validate evidence-only grounding, missing-data surfacing, advisory-only labeling, and confidence bounds.
- No DB migrations were added (None), and all side-effects are explicit preview-only records (no mutations, no customer messaging, no execution path).

### Testing
- Ran typecheck and tests: `npx tsc --noEmit` succeeded and `npm test` completed successfully.
- Test results: Vitest ran and passed (12 test files, 41 tests passed), including new advisor draft unit tests.
- Verified repository status: staged/committed changes; no migrations created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb99c553a88328adb296620d254e06)