### PR TITLE
Add work-order parts-delay evidence & advisory recommendations

### DIFF
--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -8,6 +8,8 @@ import {
 } from "@/features/ai/server";
 import { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot";
 import { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";
+import { createWorkOrderPartsDelayEvidenceSnapshot } from "./partsDelayEvidence";
+import { buildPartsDelayRecommendations } from "./partsDelayRules";
 import { WORK_ORDER_RULES_VERSION } from "./types";
 
 type DB = Database;
@@ -31,7 +33,20 @@ export async function generateWorkOrderEvidenceAndRecommendations(input: {
     workOrderId,
   });
 
-  const drafts = buildWorkOrderRecommendationsFromSnapshot(snapshot);
+  const operationalDrafts = buildWorkOrderRecommendationsFromSnapshot(snapshot);
+
+  const { evidence: partsDelayEvidenceRecord, snapshot: partsDelaySnapshot } = await createWorkOrderPartsDelayEvidenceSnapshot({
+    supabase,
+    actor,
+    workOrderId,
+  });
+
+  const partsDelayDrafts = buildPartsDelayRecommendations({
+    evidence: partsDelaySnapshot,
+    evidenceSnapshotId: partsDelayEvidenceRecord.id,
+  });
+
+  const drafts = [...operationalDrafts, ...partsDelayDrafts];
   const existing = await listAiRecommendationsForSubject(supabase, actor, {
     subjectType: "work_order",
     subjectId: workOrderId,
@@ -64,7 +79,7 @@ export async function generateWorkOrderEvidenceAndRecommendations(input: {
       priority: draft.priority,
       confidence: draft.confidence,
       riskTier: draft.risk_tier,
-      evidenceSnapshotId: evidence.id,
+      evidenceSnapshotId: draft.evidence_snapshot_id ?? evidence.id,
       missingData: draft.missing_data,
       recommendedAction: draft.recommended_action,
       sideEffects: draft.side_effects,
@@ -99,6 +114,8 @@ export type { WorkOrderEvidenceSnapshot, WorkOrderRecommendationDraft } from "./
 export { WORK_ORDER_RULES_VERSION } from "./types";
 export { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot";
 export { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";
+export { buildWorkOrderPartsDelayEvidence, createWorkOrderPartsDelayEvidenceSnapshot } from "./partsDelayEvidence";
+export { evaluateWorkOrderPartsDelayRisk, buildPartsDelayRecommendations } from "./partsDelayRules";
 export { evaluateWorkOrderCloseoutRisk, buildCloseoutRiskRecommendations } from "./closeoutRiskRules";
 
 export * from "./workOrderActionPreviews";

--- a/features/ai/server/domains/workOrders/partsDelayEvidence.ts
+++ b/features/ai/server/domains/workOrders/partsDelayEvidence.ts
@@ -1,0 +1,301 @@
+import type { Database, Json } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAiEvidenceSnapshot, type AiActorContext, type AiEvidenceSnapshotRecord } from "@/features/ai/server";
+import type { WorkOrderPartsDelayEvidence } from "./types";
+
+const PARTS_DELAY_RULE_VERSION = "wo_parts_delay_v1";
+const PARTS_REQUEST_STALE_HOURS = 48;
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
+type WorkOrderPartAllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+type PartsRequestRow = DB["public"]["Tables"]["parts_requests"]["Row"];
+type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
+type PurchaseOrderRow = DB["public"]["Tables"]["purchase_orders"]["Row"];
+type PartStockSummaryRow = DB["public"]["Views"]["part_stock_summary"]["Row"];
+
+type BuildInput = {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  workOrderId: string;
+};
+
+function toHoursAgo(now: number, iso: string | null): number | null {
+  if (!iso) return null;
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return null;
+  return Math.max(0, (now - ts) / 3_600_000);
+}
+
+function clampConfidence(score: number): number {
+  return Math.max(0, Math.min(1, Number(score.toFixed(2))));
+}
+
+function normalizeStatus(value: string | null | undefined): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function hasLinePartSignal(line: WorkOrderLineRow): boolean {
+  const partsText = String(line.parts ?? "").trim();
+  const partsNeeded = line.parts_needed;
+  const partsRequired = line.parts_required;
+
+  const hasPartsNeeded = Array.isArray(partsNeeded)
+    ? partsNeeded.length > 0
+    : !!(partsNeeded && typeof partsNeeded === "object" && Object.keys(partsNeeded as Record<string, unknown>).length > 0);
+
+  const hasPartsRequired = Array.isArray(partsRequired)
+    ? partsRequired.length > 0
+    : !!(partsRequired && typeof partsRequired === "object" && Object.keys(partsRequired as Record<string, unknown>).length > 0);
+
+  return partsText.length > 0 || hasPartsNeeded || hasPartsRequired || normalizeStatus(line.hold_reason).includes("part");
+}
+
+function computePartsDelayConfidence(missingData: string[]): number {
+  const penalties: Record<string, number> = {
+    missing_parts_linkage_data: 0.14,
+    missing_availability_data: 0.2,
+    unsupported_eta_signal: 0.08,
+    unsupported_backorder_signal: 0.08,
+    unsupported_vendor_reliability_signal: 0.08,
+    unsupported_po_linkage_for_requests: 0.1,
+    no_parts_linkage_with_line_part_signals: 0.1,
+  };
+
+  let score = 1;
+  for (const marker of missingData) {
+    score -= penalties[marker] ?? 0.03;
+  }
+
+  return clampConfidence(score);
+}
+
+export async function buildWorkOrderPartsDelayEvidence(input: BuildInput): Promise<WorkOrderPartsDelayEvidence> {
+  const { supabase, actor, workOrderId } = input;
+  const nowIso = new Date().toISOString();
+  const nowTs = Date.parse(nowIso);
+
+  const { data: workOrder, error: workOrderError } = await supabase
+    .from("work_orders")
+    .select("id, shop_id")
+    .eq("id", workOrderId)
+    .eq("shop_id", actor.shopId)
+    .maybeSingle<Pick<WorkOrderRow, "id" | "shop_id">>();
+
+  if (workOrderError) throw new Error(workOrderError.message);
+  if (!workOrder) throw new Error("work order not found");
+
+  const [
+    workOrderPartsRes,
+    allocationsRes,
+    partsRequestsRes,
+    partRequestItemsRes,
+    workOrderLinesRes,
+  ] = await Promise.all([
+    supabase.from("work_order_parts").select("*").eq("work_order_id", workOrderId),
+    supabase.from("work_order_part_allocations").select("*").eq("work_order_id", workOrderId).eq("shop_id", actor.shopId),
+    supabase.from("parts_requests").select("*").eq("work_order_id", workOrderId),
+    supabase.from("part_request_items").select("*").eq("work_order_id", workOrderId),
+    supabase.from("work_order_lines").select("*").eq("work_order_id", workOrderId).eq("shop_id", actor.shopId),
+  ]);
+
+  if (workOrderPartsRes.error) throw new Error(workOrderPartsRes.error.message);
+  if (allocationsRes.error) throw new Error(allocationsRes.error.message);
+  if (partsRequestsRes.error) throw new Error(partsRequestsRes.error.message);
+  if (partRequestItemsRes.error) throw new Error(partRequestItemsRes.error.message);
+  if (workOrderLinesRes.error) throw new Error(workOrderLinesRes.error.message);
+
+  const workOrderParts = (workOrderPartsRes.data ?? []) as WorkOrderPartRow[];
+  const allocations = (allocationsRes.data ?? []) as WorkOrderPartAllocationRow[];
+  const partsRequests = (partsRequestsRes.data ?? []) as PartsRequestRow[];
+  const partRequestItems = (partRequestItemsRes.data ?? []) as PartRequestItemRow[];
+  const workOrderLines = (workOrderLinesRes.data ?? []) as WorkOrderLineRow[];
+
+  const sourceRefs: Array<Record<string, string | null>> = [
+    { table: "work_orders", id: workOrderId },
+    { table: "work_order_parts", id: workOrderId },
+    { table: "part_request_items", id: workOrderId },
+    { table: "parts_requests", id: workOrderId },
+    { table: "work_order_part_allocations", id: workOrderId },
+  ];
+
+  const missingData = new Set<string>(["unsupported_backorder_signal", "unsupported_vendor_reliability_signal"]);
+
+  const linkedPartIds = Array.from(
+    new Set(
+      [...workOrderParts.map((row) => row.part_id), ...partRequestItems.map((row) => row.part_id), ...allocations.map((row) => row.part_id)]
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  );
+
+  const { data: stockRows, error: stockError } = linkedPartIds.length > 0
+    ? await supabase
+      .from("part_stock_summary")
+      .select("part_id, on_hand, shop_id")
+      .eq("shop_id", actor.shopId)
+      .in("part_id", linkedPartIds)
+    : { data: [], error: null };
+
+  if (stockError) throw new Error(stockError.message);
+  const partStockRows = (stockRows ?? []) as PartStockSummaryRow[];
+
+  const stockByPart = new Map<string, number>();
+  for (const row of partStockRows) {
+    if (!row.part_id) continue;
+    const current = stockByPart.get(row.part_id) ?? 0;
+    stockByPart.set(row.part_id, current + Number(row.on_hand ?? 0));
+  }
+
+  if (linkedPartIds.length > 0 && partStockRows.length === 0) {
+    missingData.add("missing_availability_data");
+  }
+
+  const unresolvedItemStatuses = new Set([
+    "requested",
+    "quoted",
+    "awaiting_customer_approval",
+    "approved",
+    "reserved",
+    "picking",
+    "picked",
+    "ordered",
+    "partially_received",
+  ]);
+
+  const unresolvedRequestItems = partRequestItems.filter((row) => unresolvedItemStatuses.has(normalizeStatus(row.status)));
+  const waitingPartsCount = unresolvedRequestItems.length + partsRequests.filter((row) => !row.fulfilled_at).length;
+  const partSignalsOnLines = workOrderLines.some((line) => hasLinePartSignal(line));
+
+  const unresolvedRequiredRows = workOrderParts.filter((row) => Number(row.quantity ?? 0) > 0);
+
+  const requestedPartsCount =
+    workOrderParts.length > 0
+      ? workOrderParts.length
+      : partRequestItems.length > 0
+        ? partRequestItems.length
+        : partsRequests.length;
+
+  const allocatedPartsCount = allocations.length;
+
+  const receivedFromRequestItems = partRequestItems.filter(
+    (row) => Number(row.qty_received ?? 0) > 0 || ["received", "consumed"].includes(normalizeStatus(row.status)),
+  ).length;
+
+  const receivedPartsCount = Math.max(receivedFromRequestItems, partRequestItems.filter((row) => normalizeStatus(row.status) === "received").length);
+
+  const unavailablePartRowCount = unresolvedRequiredRows.filter((row) => {
+    if (!row.part_id) return false;
+    const onHand = stockByPart.get(row.part_id);
+    return typeof onHand === "number" ? onHand <= 0 : false;
+  }).length;
+
+  const unknownAvailabilityCount = unresolvedRequiredRows.filter((row) => {
+    if (!row.part_id) return true;
+    return !stockByPart.has(row.part_id);
+  }).length;
+
+  if (requestedPartsCount === 0 && allocatedPartsCount === 0 && partRequestItems.length === 0 && partsRequests.length === 0) {
+    missingData.add("missing_parts_linkage_data");
+  }
+
+  if (partSignalsOnLines && requestedPartsCount === 0) {
+    missingData.add("no_parts_linkage_with_line_part_signals");
+  }
+
+  const poIds = Array.from(new Set(partRequestItems.map((row) => row.po_id).filter((id): id is string => typeof id === "string" && id.length > 0)));
+
+  const { data: purchaseOrdersData, error: purchaseOrdersError } = poIds.length > 0
+    ? await supabase.from("purchase_orders").select("*").in("id", poIds).eq("shop_id", actor.shopId)
+    : { data: [], error: null };
+
+  if (purchaseOrdersError) throw new Error(purchaseOrdersError.message);
+
+  const purchaseOrders = (purchaseOrdersData ?? []) as PurchaseOrderRow[];
+
+  if (poIds.length > 0 && purchaseOrders.length === 0) {
+    missingData.add("unsupported_po_linkage_for_requests");
+  }
+
+  const openStatuses = new Set(["draft", "open", "sent", "ordered", "partially_received"]);
+  const openPurchaseOrders = purchaseOrders.filter((po) => {
+    const status = normalizeStatus(po.status);
+    return !po.received_at && (openStatuses.has(status) || status.length === 0);
+  });
+
+  const today = new Date(nowIso);
+  const openPurchaseOrderCount = openPurchaseOrders.length;
+  const overduePurchaseOrderCount = openPurchaseOrders.filter((po) => {
+    if (!po.expected_at) return false;
+    return Date.parse(po.expected_at) < Date.parse(today.toISOString().slice(0, 10));
+  }).length;
+
+  const etaMissingCount = openPurchaseOrders.filter((po) => !po.expected_at).length;
+  if (openPurchaseOrderCount === 0) {
+    missingData.add("unsupported_eta_signal");
+  }
+
+  const staleFromRequests = partsRequests.filter((row) => {
+    if (row.fulfilled_at) return false;
+    const age = toHoursAgo(nowTs, row.created_at);
+    return (age ?? 0) >= PARTS_REQUEST_STALE_HOURS;
+  }).length;
+
+  const staleFromRequestItems = unresolvedRequestItems.filter((row) => {
+    const age = toHoursAgo(nowTs, row.updated_at ?? row.created_at);
+    return (age ?? 0) >= PARTS_REQUEST_STALE_HOURS;
+  }).length;
+
+  const stalePartsRequestCount = staleFromRequests + staleFromRequestItems;
+
+  const evidence: WorkOrderPartsDelayEvidence = {
+    workOrderId,
+    shopId: actor.shopId,
+    generatedAt: nowIso,
+    partsLinked: requestedPartsCount > 0 || allocatedPartsCount > 0 || partRequestItems.length > 0,
+    requestedPartsCount,
+    allocatedPartsCount,
+    receivedPartsCount,
+    unavailablePartsCount: unavailablePartRowCount,
+    waitingPartsCount,
+    backorderedPartsCount: null,
+    unknownAvailabilityCount,
+    openPurchaseOrderCount,
+    overduePurchaseOrderCount,
+    etaMissingCount,
+    stalePartsRequestCount,
+    vendorReliabilityAvailable: false,
+    linePartSignalsDetected: partSignalsOnLines,
+    missingData: Array.from(missingData),
+    sourceRefs,
+    confidence: computePartsDelayConfidence(Array.from(missingData)),
+  };
+
+  return evidence;
+}
+
+export async function createWorkOrderPartsDelayEvidenceSnapshot(input: BuildInput): Promise<{
+  evidence: AiEvidenceSnapshotRecord;
+  snapshot: WorkOrderPartsDelayEvidence;
+}> {
+  const { supabase, actor } = input;
+  const snapshot = await buildWorkOrderPartsDelayEvidence(input);
+
+  const evidence = await createAiEvidenceSnapshot(supabase, actor, {
+    domain: "work_orders",
+    subjectType: "work_order",
+    subjectId: snapshot.workOrderId,
+    evidenceKind: "work_order_parts_delay_state",
+    snapshot: snapshot as unknown as Json,
+    sourceRefs: snapshot.sourceRefs as unknown as Json,
+    missingData: snapshot.missingData as unknown as Json,
+    freshnessAt: snapshot.generatedAt,
+    confidence: snapshot.confidence,
+    metadata: {
+      rules_version: PARTS_DELAY_RULE_VERSION,
+    },
+  });
+
+  return { evidence, snapshot };
+}

--- a/features/ai/server/domains/workOrders/partsDelayRules.test.ts
+++ b/features/ai/server/domains/workOrders/partsDelayRules.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { WorkOrderPartsDelayEvidence } from "./types";
+import { buildPartsDelayRecommendations, evaluateWorkOrderPartsDelayRisk } from "./partsDelayRules";
+
+function baseEvidence(overrides: Partial<WorkOrderPartsDelayEvidence> = {}): WorkOrderPartsDelayEvidence {
+  return {
+    workOrderId: "wo-1",
+    shopId: "shop-1",
+    generatedAt: "2026-04-24T00:00:00.000Z",
+    partsLinked: true,
+    requestedPartsCount: 2,
+    allocatedPartsCount: 2,
+    receivedPartsCount: 2,
+    unavailablePartsCount: 0,
+    waitingPartsCount: 0,
+    backorderedPartsCount: null,
+    unknownAvailabilityCount: 0,
+    openPurchaseOrderCount: 0,
+    overduePurchaseOrderCount: 0,
+    etaMissingCount: 0,
+    stalePartsRequestCount: 0,
+    vendorReliabilityAvailable: false,
+    linePartSignalsDetected: false,
+    missingData: [],
+    sourceRefs: [{ table: "work_orders", id: "wo-1" }],
+    confidence: 0.92,
+    ...overrides,
+  };
+}
+
+describe("partsDelayRules", () => {
+  it("keeps missing ETA/backorder as missing_data markers instead of faking values", () => {
+    const evidence = baseEvidence({
+      missingData: ["unsupported_eta_signal", "unsupported_backorder_signal"],
+    });
+
+    const risks = evaluateWorkOrderPartsDelayRisk(evidence);
+    expect(risks.length).toBe(0);
+
+    const recs = buildPartsDelayRecommendations({
+      evidence: baseEvidence({
+        unavailablePartsCount: 1,
+        missingData: ["unsupported_eta_signal", "unsupported_backorder_signal"],
+      }),
+      evidenceSnapshotId: "evidence-1",
+    });
+
+    expect(recs[0]?.missing_data).toContain("unsupported_eta_signal");
+    expect(recs[0]?.missing_data).toContain("unsupported_backorder_signal");
+  });
+
+  it("creates advisory risk for unavailable or unknown parts state", () => {
+    const risks = evaluateWorkOrderPartsDelayRisk(
+      baseEvidence({
+        unavailablePartsCount: 1,
+        unknownAvailabilityCount: 1,
+        allocatedPartsCount: 0,
+        waitingPartsCount: 2,
+      }),
+    );
+
+    expect(risks.some((risk) => risk.risk_code === "parts_waiting_on_unavailable_items")).toBe(true);
+    expect(risks.every((risk) => risk.advisory_only)).toBe(true);
+  });
+
+  it("returns no risk for complete received allocated state", () => {
+    const risks = evaluateWorkOrderPartsDelayRisk(baseEvidence());
+    expect(risks).toHaveLength(0);
+  });
+
+  it("only triggers stale request rule when stale timestamp evidence is present", () => {
+    const noStale = evaluateWorkOrderPartsDelayRisk(baseEvidence({ stalePartsRequestCount: 0 }));
+    const stale = evaluateWorkOrderPartsDelayRisk(baseEvidence({ stalePartsRequestCount: 2 }));
+
+    expect(noStale.some((risk) => risk.risk_code === "parts_request_stale")).toBe(false);
+    expect(stale.some((risk) => risk.risk_code === "parts_request_stale")).toBe(true);
+  });
+
+  it("builds advisory-only recommendations with no ordering actions and bounded confidence", () => {
+    const recommendations = buildPartsDelayRecommendations({
+      evidence: baseEvidence({
+        confidence: 1.5,
+        unavailablePartsCount: 1,
+        waitingPartsCount: 1,
+      }),
+      evidenceSnapshotId: "evidence-1",
+    });
+
+    expect(recommendations.length).toBeGreaterThan(0);
+    expect(recommendations.every((item) => item.metadata?.advisory_only === true)).toBe(true);
+    expect(recommendations.every((item) => item.recommended_action.action_type !== "order_parts")).toBe(true);
+    expect(recommendations.every((item) => item.confidence >= 0 && item.confidence <= 1)).toBe(true);
+  });
+});

--- a/features/ai/server/domains/workOrders/partsDelayRules.ts
+++ b/features/ai/server/domains/workOrders/partsDelayRules.ts
@@ -1,0 +1,157 @@
+import type { WorkOrderPartsDelayEvidence, WorkOrderPartsDelayRisk, WorkOrderRecommendationDraft } from "./types";
+
+export const WORK_ORDER_PARTS_DELAY_RULES_VERSION = "wo_parts_delay_v1";
+
+function boundedConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function minConfidence(evidenceConfidence: number, cap: number): number {
+  return boundedConfidence(Math.min(cap, evidenceConfidence));
+}
+
+export function evaluateWorkOrderPartsDelayRisk(evidence: WorkOrderPartsDelayEvidence): WorkOrderPartsDelayRisk[] {
+  const risks: WorkOrderPartsDelayRisk[] = [];
+
+  if (
+    evidence.unavailablePartsCount > 0 ||
+    evidence.unknownAvailabilityCount > 0 ||
+    (evidence.waitingPartsCount > 0 && evidence.allocatedPartsCount < Math.max(1, evidence.requestedPartsCount))
+  ) {
+    risks.push({
+      risk_code: "parts_waiting_on_unavailable_items",
+      title: "Parts delay risk — unavailable or unresolved items",
+      summary: "One or more required parts appear unavailable, unresolved, or have unknown availability.",
+      severity: evidence.unavailablePartsCount > 0 ? "high" : "medium",
+      confidence: minConfidence(evidence.confidence, 0.9),
+      evidence_refs: ["work_order_parts", "part_request_items", "part_stock_summary"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review parts availability",
+      advisory_only: true,
+      rule_version: WORK_ORDER_PARTS_DELAY_RULES_VERSION,
+    });
+  }
+
+  if (evidence.etaMissingCount > 0) {
+    risks.push({
+      risk_code: "parts_eta_missing",
+      title: "Parts delay risk — ETA is missing",
+      summary: "Open purchase order coverage exists, but expected receipt date is missing for one or more records.",
+      severity: "medium",
+      confidence: minConfidence(evidence.confidence, 0.84),
+      evidence_refs: ["purchase_orders", "part_request_items"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Add missing ETA",
+      advisory_only: true,
+      rule_version: WORK_ORDER_PARTS_DELAY_RULES_VERSION,
+    });
+  }
+
+  if (evidence.overduePurchaseOrderCount > 0) {
+    risks.push({
+      risk_code: "parts_po_overdue",
+      title: "Parts delay risk — purchase order appears overdue",
+      summary: "Expected purchase-order receipt date has passed while received state remains incomplete.",
+      severity: "high",
+      confidence: minConfidence(evidence.confidence, 0.88),
+      evidence_refs: ["purchase_orders", "part_request_items"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Confirm PO/receiving status",
+      advisory_only: true,
+      rule_version: WORK_ORDER_PARTS_DELAY_RULES_VERSION,
+    });
+  }
+
+  if (
+    evidence.partsLinked &&
+    evidence.requestedPartsCount > 0 &&
+    (evidence.allocatedPartsCount < evidence.requestedPartsCount || evidence.receivedPartsCount < evidence.requestedPartsCount)
+  ) {
+    risks.push({
+      risk_code: "parts_allocation_incomplete",
+      title: "Parts delay risk — allocation/receiving appears incomplete",
+      summary: "Required parts linkage exists, but allocation and/or receipt signals look incomplete.",
+      severity: "medium",
+      confidence: minConfidence(evidence.confidence, 0.82),
+      evidence_refs: ["work_order_part_allocations", "part_request_items", "work_order_parts"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Check allocation before promising completion",
+      advisory_only: true,
+      rule_version: WORK_ORDER_PARTS_DELAY_RULES_VERSION,
+    });
+  }
+
+  if (evidence.stalePartsRequestCount > 0) {
+    risks.push({
+      risk_code: "parts_request_stale",
+      title: "Parts delay risk — request appears stale",
+      summary: "Parts request/workflow has remained unresolved beyond safe stale thresholds.",
+      severity: "medium",
+      confidence: minConfidence(evidence.confidence, 0.8),
+      evidence_refs: ["parts_requests", "part_request_items"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review parts request",
+      advisory_only: true,
+      rule_version: WORK_ORDER_PARTS_DELAY_RULES_VERSION,
+    });
+  }
+
+  if (!evidence.partsLinked && evidence.linePartSignalsDetected) {
+    risks.push({
+      risk_code: "parts_state_unknown",
+      title: "Parts delay risk — parts state is unknown",
+      summary: "Line-level part signals exist but no linked parts workflow records were found.",
+      severity: "low",
+      confidence: minConfidence(evidence.confidence, 0.7),
+      evidence_refs: ["work_order_lines"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review parts linkage for this work order",
+      advisory_only: true,
+      rule_version: WORK_ORDER_PARTS_DELAY_RULES_VERSION,
+    });
+  }
+
+  return risks;
+}
+
+const RISK_TO_RECOMMENDATION: Record<WorkOrderPartsDelayRisk["risk_code"], string> = {
+  parts_waiting_on_unavailable_items: "parts_delay_unavailable_items",
+  parts_eta_missing: "parts_delay_eta_missing",
+  parts_po_overdue: "parts_delay_po_overdue",
+  parts_allocation_incomplete: "parts_delay_allocation_incomplete",
+  parts_request_stale: "parts_delay_request_stale",
+  parts_state_unknown: "parts_delay_state_unknown",
+};
+
+export function buildPartsDelayRecommendations(input: {
+  evidence: WorkOrderPartsDelayEvidence;
+  evidenceSnapshotId: string;
+}): WorkOrderRecommendationDraft[] {
+  const risks = evaluateWorkOrderPartsDelayRisk(input.evidence);
+  const expiresAt = new Date(Date.now() + 48 * 3_600_000).toISOString();
+
+  return risks.map((risk) => ({
+    recommendation_type: RISK_TO_RECOMMENDATION[risk.risk_code],
+    title: "Parts delay review",
+    summary: `${risk.title}. ${risk.summary}`,
+    priority: risk.severity === "high" ? "high" : risk.severity === "critical" ? "urgent" : "normal",
+    confidence: boundedConfidence(Math.min(risk.confidence, input.evidence.confidence)),
+    risk_tier: risk.severity,
+    missing_data: risk.missing_data,
+    recommended_action: {
+      action_type: risk.risk_code === "parts_po_overdue" ? "confirm_po_receiving_status" : "review_parts_delay",
+      label: "Parts delay review",
+      details: risk.recommended_next_step,
+    },
+    side_effects: [],
+    requires_approval: false,
+    source: "work_order_parts_delay_rules",
+    expires_at: expiresAt,
+    metadata: {
+      risk_code: risk.risk_code,
+      advisory_only: true,
+      rule_version: risk.rule_version,
+    },
+    evidence_snapshot_id: input.evidenceSnapshotId,
+  }));
+}

--- a/features/ai/server/domains/workOrders/types.ts
+++ b/features/ai/server/domains/workOrders/types.ts
@@ -118,6 +118,49 @@ export type WorkOrderRecommendationDraft = {
   source?: string;
   expires_at?: string | null;
   metadata?: Record<string, Json>;
+  evidence_snapshot_id?: string;
+};
+
+export type WorkOrderPartsDelayEvidence = {
+  workOrderId: string;
+  shopId: string;
+  generatedAt: string;
+  partsLinked: boolean;
+  requestedPartsCount: number;
+  allocatedPartsCount: number;
+  receivedPartsCount: number;
+  unavailablePartsCount: number;
+  waitingPartsCount: number;
+  backorderedPartsCount: number | null;
+  unknownAvailabilityCount: number;
+  openPurchaseOrderCount: number;
+  overduePurchaseOrderCount: number;
+  etaMissingCount: number;
+  stalePartsRequestCount: number;
+  vendorReliabilityAvailable: boolean;
+  linePartSignalsDetected: boolean;
+  missingData: string[];
+  sourceRefs: Array<Record<string, string | null>>;
+  confidence: number;
+};
+
+export type WorkOrderPartsDelayRisk = {
+  risk_code:
+    | "parts_waiting_on_unavailable_items"
+    | "parts_eta_missing"
+    | "parts_po_overdue"
+    | "parts_allocation_incomplete"
+    | "parts_request_stale"
+    | "parts_state_unknown";
+  title: string;
+  summary: string;
+  severity: AiRiskTier;
+  confidence: number;
+  evidence_refs: string[];
+  missing_data: string[];
+  recommended_next_step: string;
+  advisory_only: true;
+  rule_version: string;
 };
 
 export type WorkOrderCloseoutRisk = {

--- a/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
+++ b/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
@@ -7,7 +7,9 @@ export type WorkOrderPreviewActionType =
   | "complete_inspection_review"
   | "review_closeout_readiness"
   | "advisor_review_needed"
-  | "priority_escalation_review";
+  | "priority_escalation_review"
+  | "review_parts_delay"
+  | "confirm_po_receiving_status";
 
 export type WorkOrderRecommendationPreviewability =
   | { previewable: true; actionType: WorkOrderPreviewActionType }
@@ -120,6 +122,36 @@ const RECOMMENDATION_PREVIEW_MAP: Record<string, ActionSpec> = {
     actionType: "review_work_order",
     label: "Review work order",
     description: "Review active technician dispatch and stale activity signals.",
+  },
+  parts_delay_unavailable_items: {
+    actionType: "review_parts_delay",
+    label: "Parts delay review",
+    description: "Review unavailable or unresolved parts signals with no ordering or inventory mutation.",
+  },
+  parts_delay_eta_missing: {
+    actionType: "review_parts_delay",
+    label: "Parts delay review",
+    description: "Review missing ETA signals and update internal tracking only.",
+  },
+  parts_delay_po_overdue: {
+    actionType: "confirm_po_receiving_status",
+    label: "Confirm PO receiving status",
+    description: "Review overdue PO and receiving status without sending messages or mutating records.",
+  },
+  parts_delay_allocation_incomplete: {
+    actionType: "check_parts_status",
+    label: "Check parts status",
+    description: "Review allocation and receiving completeness before promising completion.",
+  },
+  parts_delay_request_stale: {
+    actionType: "review_parts_delay",
+    label: "Parts delay review",
+    description: "Review stale parts-request state internally; no external actions.",
+  },
+  parts_delay_state_unknown: {
+    actionType: "review_parts_delay",
+    label: "Parts delay review",
+    description: "Review missing parts linkage and clarify internal parts status.",
   },
   priority_escalation_candidate: {
     actionType: "priority_escalation_review",

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -316,7 +316,9 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
             const previewable = isPreviewableRecommendation(item);
             const previewBusy = previewLoadingId === item.id;
             const isCloseoutRisk = item.recommendation_type.startsWith("closeout_risk_");
+            const isPartsDelay = item.recommendation_type.startsWith("parts_delay_");
             const severityLabel = `severity ${item.risk_tier}`;
+            const recommendedNextStep = item.recommended_action?.details ?? item.recommended_action?.label ?? "Review work order";
 
             return (
               <article key={item.id} className={cn(PANEL_VARIANTS.passive, "p-2")}>
@@ -325,6 +327,11 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                   {isCloseoutRisk ? (
                     <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
                       Closeout review
+                    </span>
+                  ) : null}
+                  {isPartsDelay ? (
+                    <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+                      Parts delay review
                     </span>
                   ) : null}
                   <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{item.priority}</span>
@@ -337,8 +344,11 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                 {isCloseoutRisk ? (
                   <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Advisory only — does not block closeout yet.</p>
                 ) : null}
+                {isPartsDelay ? (
+                  <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Advisory only — internal parts-delay review, no execution.</p>
+                ) : null}
                 <div className="mt-1 text-[10px] text-muted-foreground">
-                  Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {item.recommended_action?.details ?? item.recommended_action?.label ?? "Review work order"}
+                  Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {recommendedNextStep}
                 </div>
                 <div className="mt-2 flex flex-wrap items-center gap-1">
                   {previewable ? (


### PR DESCRIPTION
### Motivation
- Detect and surface deterministic, evidence-backed parts delay signals for work orders so advisors can review stalls without introducing any autonomous ordering or inventory mutations.
- Provide a compact, shop-scoped parts-delay snapshot that can feed recommendation rules and be referenced independently from the general operational snapshot.

### Description
- Added typed parts-delay models and extended recommendation draft to carry an `evidence_snapshot_id` for parts-specific snapshots (`features/ai/server/domains/workOrders/types.ts`).
- Implemented a deterministic evidence builder `buildWorkOrderPartsDelayEvidence` and `createWorkOrderPartsDelayEvidenceSnapshot` that reads `work_order_parts`, `work_order_part_allocations`, `parts_requests`, `part_request_items`, `purchase_orders`, and `part_stock_summary` and writes `ai_evidence_snapshots` with `evidence_kind: "work_order_parts_delay_state"` (`features/ai/server/domains/workOrders/partsDelayEvidence.ts`).
- Implemented deterministic parts-delay rule evaluator and recommendation builder (`partsDelayRules.ts`) producing advisory-only recommendations (`parts_delay_*`) and wired these into the existing `generateWorkOrderEvidenceAndRecommendations` flow so parts-delay recommendations are created and de-duplicated via existing recommendation-type checks (`features/ai/server/domains/workOrders/index.ts`).
- Extended the preview allowlist with read-only parts-delay preview actions (`review_parts_delay`, `confirm_po_receiving_status`) and updated the work-order AI recommendations UI to label parts-delay items as “Parts delay review” and show advisory-only next steps (`workOrderActionPreviews.ts`, `WorkOrderAiOperationalRecommendations.tsx`).
- Added unit tests covering rule behavior, missing-data handling, advisory-only semantics, and bounded confidence (`features/ai/server/domains/workOrders/partsDelayRules.test.ts`).
- No DB migrations were added (None). No ordering/PO/receiving/allocation/inventory/communication/approval/execution paths were introduced.

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` completed successfully.
- Ran unit tests: `npm test` completed successfully and all tests passed, including the new `partsDelayRules` tests (test run: 46 tests passed total).
- Verified `git status` and committed the added files; changes include the new evidence builder, rules, tests, types, preview allowlist update, generator wiring, and UI copy updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9c9f2c9883289b6dc9bc34e10a73)