### PR TITLE
Add technician dispatch evidence snapshots and advisory work-order recommendations

### DIFF
--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -10,6 +10,8 @@ import { buildWorkOrderEvidenceSnapshot } from "./buildWorkOrderEvidenceSnapshot
 import { buildWorkOrderRecommendationsFromSnapshot } from "./workOrderRecommendationRules";
 import { createWorkOrderPartsDelayEvidenceSnapshot } from "./partsDelayEvidence";
 import { buildPartsDelayRecommendations } from "./partsDelayRules";
+import { createWorkOrderTechnicianDispatchEvidenceSnapshot } from "./technicianDispatchEvidence";
+import { buildTechnicianDispatchRecommendations } from "./technicianDispatchRules";
 import { WORK_ORDER_RULES_VERSION } from "./types";
 
 type DB = Database;
@@ -46,7 +48,18 @@ export async function generateWorkOrderEvidenceAndRecommendations(input: {
     evidenceSnapshotId: partsDelayEvidenceRecord.id,
   });
 
-  const drafts = [...operationalDrafts, ...partsDelayDrafts];
+  const { evidence: technicianDispatchEvidenceRecord, snapshot: technicianDispatchSnapshot } = await createWorkOrderTechnicianDispatchEvidenceSnapshot({
+    supabase,
+    actor,
+    workOrderId,
+  });
+
+  const technicianDispatchDrafts = buildTechnicianDispatchRecommendations({
+    evidence: technicianDispatchSnapshot,
+    evidenceSnapshotId: technicianDispatchEvidenceRecord.id,
+  });
+
+  const drafts = [...operationalDrafts, ...partsDelayDrafts, ...technicianDispatchDrafts];
   const existing = await listAiRecommendationsForSubject(supabase, actor, {
     subjectType: "work_order",
     subjectId: workOrderId,
@@ -121,3 +134,6 @@ export { evaluateWorkOrderCloseoutRisk, buildCloseoutRiskRecommendations } from 
 export * from "./workOrderActionPreviews";
 
 export * from "./advisorExplanationDrafts";
+
+export { buildWorkOrderTechnicianDispatchEvidence, createWorkOrderTechnicianDispatchEvidenceSnapshot } from "./technicianDispatchEvidence";
+export { evaluateWorkOrderTechnicianDispatchRisk, buildTechnicianDispatchRecommendations } from "./technicianDispatchRules";

--- a/features/ai/server/domains/workOrders/technicianDispatchEvidence.ts
+++ b/features/ai/server/domains/workOrders/technicianDispatchEvidence.ts
@@ -1,0 +1,239 @@
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAiEvidenceSnapshot, type AiActorContext, type AiEvidenceSnapshotRecord } from "@/features/ai/server";
+import type { WorkOrderTechnicianDispatchEvidence } from "./types";
+
+type DB = Database;
+type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type LaborSegmentRow = DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
+type TechShiftRow = DB["public"]["Tables"]["tech_shifts"]["Row"];
+type StaffTimeOffRow = DB["public"]["Tables"]["staff_time_off_requests"]["Row"];
+type StaffCertificationRow = DB["public"]["Tables"]["staff_certifications"]["Row"];
+
+function normalize(value: string | null | undefined): string {
+  return String(value ?? "unknown").trim().toLowerCase().replaceAll(" ", "_");
+}
+
+function isActionableLine(line: WorkOrderLineRow): boolean {
+  const lineType = normalize(line.line_type);
+  const status = normalize(line.status);
+  if (lineType === "info") return false;
+  if (status === "completed" || status === "ready_to_invoice" || status === "invoiced" || status === "cancelled") return false;
+  return true;
+}
+
+function overlapsNow(startIso: string | null, endIso: string | null, nowMs: number): boolean {
+  if (!startIso) return false;
+  const start = Date.parse(startIso);
+  const end = endIso ? Date.parse(endIso) : Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(start)) return false;
+  return start <= nowMs && nowMs <= end;
+}
+
+function staleHours(startIso: string | null, nowMs: number): number | null {
+  if (!startIso) return null;
+  const start = Date.parse(startIso);
+  if (!Number.isFinite(start)) return null;
+  return Math.max(0, (nowMs - start) / 3_600_000);
+}
+
+function boundedConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function buildConfidence(missingData: string[]): number {
+  const penalties: Record<string, number> = {
+    missing_line_assignment_data: 0.2,
+    missing_schedule_data: 0.15,
+    missing_time_off_data: 0.15,
+    missing_certification_data: 0.15,
+    missing_load_or_labor_history_data: 0.2,
+  };
+
+  let score = 1;
+  for (const key of missingData) score -= penalties[key] ?? 0.04;
+  return boundedConfidence(score);
+}
+
+export async function buildWorkOrderTechnicianDispatchEvidence(input: {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  workOrderId: string;
+}): Promise<WorkOrderTechnicianDispatchEvidence> {
+  const { supabase, actor, workOrderId } = input;
+  const generatedAt = new Date().toISOString();
+  const nowMs = Date.parse(generatedAt);
+
+  const missingData = new Set<string>();
+
+  const { data: linesData, error: linesError } = await supabase
+    .from("work_order_lines")
+    .select("*")
+    .eq("shop_id", actor.shopId)
+    .eq("work_order_id", workOrderId);
+  if (linesError) throw new Error(linesError.message);
+  const lines = (linesData ?? []) as WorkOrderLineRow[];
+
+  const assignedTechIds = Array.from(new Set(lines.map((line) => line.assigned_tech_id).filter((id): id is string => Boolean(id))));
+
+  const [laborRes, shiftsRes, timeOffRes, certRes] = await Promise.all([
+    supabase.from("work_order_line_labor_segments").select("*").eq("shop_id", actor.shopId).eq("work_order_id", workOrderId),
+    assignedTechIds.length > 0
+      ? supabase.from("tech_shifts").select("*").eq("shop_id", actor.shopId).in("user_id", assignedTechIds)
+      : Promise.resolve({ data: [], error: null }),
+    assignedTechIds.length > 0
+      ? supabase.from("staff_time_off_requests").select("*").eq("shop_id", actor.shopId).in("user_id", assignedTechIds)
+      : Promise.resolve({ data: [], error: null }),
+    assignedTechIds.length > 0
+      ? supabase.from("staff_certifications").select("*").eq("shop_id", actor.shopId).in("user_id", assignedTechIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (laborRes.error) throw new Error(laborRes.error.message);
+  if (shiftsRes.error) missingData.add("missing_schedule_data");
+  if (timeOffRes.error) missingData.add("missing_time_off_data");
+  if (certRes.error) missingData.add("missing_certification_data");
+
+  const laborSegments = (laborRes.data ?? []) as LaborSegmentRow[];
+  const shifts = ((shiftsRes as { data?: TechShiftRow[] }).data ?? []) as TechShiftRow[];
+  const timeOffRequests = ((timeOffRes as { data?: StaffTimeOffRow[] }).data ?? []) as StaffTimeOffRow[];
+  const certifications = ((certRes as { data?: StaffCertificationRow[] }).data ?? []) as StaffCertificationRow[];
+
+  if (lines.length === 0) missingData.add("missing_line_assignment_data");
+  if (laborSegments.length === 0 && !lines.some((line) => line.punched_in_at || line.punched_out_at)) {
+    missingData.add("missing_load_or_labor_history_data");
+  }
+
+  const actionableLines = lines.filter(isActionableLine);
+  const unassignedActionableLines = actionableLines.filter((line) => !line.assigned_tech_id);
+  const highPriorityActionableLines = actionableLines.filter((line) => normalize(line.job_priority) === "high");
+  const urgentPriorityActionableLines = actionableLines.filter((line) => normalize(line.job_priority) === "urgent");
+  const blockedLines = actionableLines.filter((line) => {
+    const status = normalize(line.status);
+    return status === "on_hold" || status === "awaiting_parts" || normalize(line.hold_reason).includes("block");
+  });
+  const waitingLines = actionableLines.filter((line) => {
+    const status = normalize(line.status);
+    return status === "awaiting" || status === "queued" || status === "waiting";
+  });
+
+  const activeLaborSegments = laborSegments.filter((seg) => !seg.ended_at);
+  const activeTechIds = Array.from(new Set(activeLaborSegments.map((seg) => seg.technician_id)));
+
+  const staleActiveLaborCount =
+    activeLaborSegments.filter((seg) => {
+      const age = staleHours(seg.started_at, nowMs);
+      return (age ?? 0) >= 8;
+    }).length +
+    lines.filter((line) => !!line.punched_in_at && !line.punched_out_at && (staleHours(line.punched_in_at, nowMs) ?? 0) >= 8).length;
+
+  const openShiftByUserId = new Set(
+    shifts
+      .filter((shift) => shift.user_id)
+      .filter((shift) => normalize(shift.status) === "open" && normalize(shift.type) === "shift" && overlapsNow(shift.start_time, shift.end_time, nowMs))
+      .map((shift) => shift.user_id as string),
+  );
+
+  const activeApprovedTimeOffByUserId = new Set(
+    timeOffRequests
+      .filter((request) => request.user_id)
+      .filter((request) => normalize(request.status) === "approved" && overlapsNow(request.starts_at, request.ends_at, nowMs))
+      .map((request) => request.user_id),
+  );
+
+  const unavailableAssignedTechCount = assignedTechIds.filter(
+    (techId) => !openShiftByUserId.has(techId) || activeApprovedTimeOffByUserId.has(techId),
+  ).length;
+
+  const lineCountByTech: Record<string, number> = {};
+  for (const line of actionableLines) {
+    if (!line.assigned_tech_id) continue;
+    lineCountByTech[line.assigned_tech_id] = (lineCountByTech[line.assigned_tech_id] ?? 0) + 1;
+  }
+
+  const activeLaborByTech: Record<string, number> = {};
+  for (const seg of activeLaborSegments) {
+    activeLaborByTech[seg.technician_id] = (activeLaborByTech[seg.technician_id] ?? 0) + 1;
+  }
+
+  const overloadedTechCount = assignedTechIds.filter((techId) => {
+    const assignedLoad = lineCountByTech[techId] ?? 0;
+    const activeLoad = activeLaborByTech[techId] ?? 0;
+    return assignedLoad + activeLoad >= 4;
+  }).length;
+
+  const activeCertsByUser: Record<string, number> = {};
+  for (const cert of certifications) {
+    if (normalize(cert.status) !== "active") continue;
+    activeCertsByUser[cert.user_id] = (activeCertsByUser[cert.user_id] ?? 0) + 1;
+  }
+
+  const certRelevantLineCount = actionableLines.filter((line) => Boolean(String(line.service_code ?? line.job_type ?? "").trim())).length;
+  const assignedWithoutActiveCertCount = actionableLines.filter(
+    (line) => line.assigned_tech_id && (activeCertsByUser[line.assigned_tech_id] ?? 0) === 0,
+  ).length;
+
+  const sourceRefs: Array<Record<string, string | null>> = [
+    { table: "work_order_lines", id: workOrderId },
+    { table: "work_order_line_labor_segments", id: workOrderId },
+  ];
+  if (!shiftsRes.error) sourceRefs.push({ table: "tech_shifts", id: actor.shopId });
+  if (!timeOffRes.error) sourceRefs.push({ table: "staff_time_off_requests", id: actor.shopId });
+  if (!certRes.error) sourceRefs.push({ table: "staff_certifications", id: actor.shopId });
+
+  const evidence: WorkOrderTechnicianDispatchEvidence = {
+    workOrderId,
+    shopId: actor.shopId,
+    generatedAt,
+    lineCount: lines.length,
+    actionableLineCount: actionableLines.length,
+    unassignedActionableLineCount: unassignedActionableLines.length,
+    assignedTechnicianIds: assignedTechIds,
+    activeTechnicianIds: activeTechIds,
+    activeLaborSegmentCount: activeLaborSegments.length,
+    staleActiveLaborCount,
+    highPriorityLineCount: highPriorityActionableLines.length,
+    urgentPriorityLineCount: urgentPriorityActionableLines.length,
+    blockedLineCount: blockedLines.length,
+    waitingLineCount: waitingLines.length,
+    scheduleDataAvailable: !shiftsRes.error,
+    timeOffDataAvailable: !timeOffRes.error,
+    certificationDataAvailable: !certRes.error,
+    laborHistoryAvailable: !missingData.has("missing_load_or_labor_history_data"),
+    technicianLoadAvailable: actionableLines.length > 0,
+    unavailableAssignedTechCount: !shiftsRes.error || !timeOffRes.error ? unavailableAssignedTechCount : null,
+    overloadedTechCount: actionableLines.length > 0 ? overloadedTechCount : null,
+    certRelevantLineCount,
+    assignedWithoutActiveCertCount: !certRes.error ? assignedWithoutActiveCertCount : null,
+    missingData: Array.from(missingData),
+    sourceRefs,
+    confidence: buildConfidence(Array.from(missingData)),
+  };
+
+  return evidence;
+}
+
+export async function createWorkOrderTechnicianDispatchEvidenceSnapshot(input: {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  workOrderId: string;
+}): Promise<{ evidence: AiEvidenceSnapshotRecord; snapshot: WorkOrderTechnicianDispatchEvidence }> {
+  const snapshot = await buildWorkOrderTechnicianDispatchEvidence(input);
+  const evidence = await createAiEvidenceSnapshot(input.supabase, input.actor, {
+    domain: "work_orders",
+    subjectType: "work_order",
+    subjectId: input.workOrderId,
+    evidenceKind: "work_order_technician_dispatch_state",
+    snapshot,
+    sourceRefs: snapshot.sourceRefs,
+    missingData: snapshot.missingData,
+    confidence: snapshot.confidence,
+    freshnessAt: snapshot.generatedAt,
+    metadata: {
+      advisory_only: true,
+      evidence_scope: "technician_dispatch",
+    },
+  });
+
+  return { evidence, snapshot };
+}

--- a/features/ai/server/domains/workOrders/technicianDispatchRules.test.ts
+++ b/features/ai/server/domains/workOrders/technicianDispatchRules.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { WorkOrderTechnicianDispatchEvidence } from "./types";
+import { buildTechnicianDispatchRecommendations, evaluateWorkOrderTechnicianDispatchRisk } from "./technicianDispatchRules";
+
+function baseEvidence(overrides: Partial<WorkOrderTechnicianDispatchEvidence> = {}): WorkOrderTechnicianDispatchEvidence {
+  return {
+    workOrderId: "wo-1",
+    shopId: "shop-1",
+    generatedAt: "2026-04-24T00:00:00.000Z",
+    lineCount: 3,
+    actionableLineCount: 2,
+    unassignedActionableLineCount: 0,
+    assignedTechnicianIds: ["tech-1"],
+    activeTechnicianIds: ["tech-1"],
+    activeLaborSegmentCount: 1,
+    staleActiveLaborCount: 0,
+    highPriorityLineCount: 0,
+    urgentPriorityLineCount: 0,
+    blockedLineCount: 0,
+    waitingLineCount: 0,
+    scheduleDataAvailable: true,
+    timeOffDataAvailable: true,
+    certificationDataAvailable: true,
+    laborHistoryAvailable: true,
+    technicianLoadAvailable: true,
+    unavailableAssignedTechCount: 0,
+    overloadedTechCount: 0,
+    certRelevantLineCount: 0,
+    assignedWithoutActiveCertCount: 0,
+    missingData: [],
+    sourceRefs: [{ table: "work_order_lines", id: "wo-1" }],
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+describe("technicianDispatchRules", () => {
+  it("creates advisory risk for unassigned actionable lines", () => {
+    const risks = evaluateWorkOrderTechnicianDispatchRisk(baseEvidence({ unassignedActionableLineCount: 1 }));
+    expect(risks.some((risk) => risk.risk_code === "unassigned_actionable_lines")).toBe(true);
+    expect(risks.every((risk) => risk.advisory_only)).toBe(true);
+  });
+
+  it("raises severity when urgent/high-priority unassigned lines exist", () => {
+    const risks = evaluateWorkOrderTechnicianDispatchRisk(
+      baseEvidence({ unassignedActionableLineCount: 1, urgentPriorityLineCount: 1 }),
+    );
+    const risk = risks.find((item) => item.risk_code === "high_priority_unassigned");
+    expect(risk?.severity).toBe("high");
+  });
+
+  it("only triggers stale active labor when stale timestamps are present", () => {
+    const clean = evaluateWorkOrderTechnicianDispatchRisk(baseEvidence({ staleActiveLaborCount: 0 }));
+    const stale = evaluateWorkOrderTechnicianDispatchRisk(baseEvidence({ staleActiveLaborCount: 1 }));
+    expect(clean.some((risk) => risk.risk_code === "active_labor_stale")).toBe(false);
+    expect(stale.some((risk) => risk.risk_code === "active_labor_stale")).toBe(true);
+  });
+
+  it("only triggers unavailable assignee risk when schedule/time-off support exists", () => {
+    const unsupported = evaluateWorkOrderTechnicianDispatchRisk(
+      baseEvidence({ scheduleDataAvailable: false, timeOffDataAvailable: false, unavailableAssignedTechCount: 2 }),
+    );
+    const supported = evaluateWorkOrderTechnicianDispatchRisk(
+      baseEvidence({ scheduleDataAvailable: true, unavailableAssignedTechCount: 1 }),
+    );
+
+    expect(unsupported.some((risk) => risk.risk_code === "assigned_tech_unavailable")).toBe(false);
+    expect(supported.some((risk) => risk.risk_code === "assigned_tech_unavailable")).toBe(true);
+  });
+
+  it("uses missing_data when certification signals are unavailable", () => {
+    const risks = evaluateWorkOrderTechnicianDispatchRisk(
+      baseEvidence({
+        certificationDataAvailable: false,
+        certRelevantLineCount: 2,
+        assignedWithoutActiveCertCount: 2,
+        missingData: ["missing_certification_data"],
+      }),
+    );
+
+    expect(risks.some((risk) => risk.risk_code === "certification_review_needed")).toBe(false);
+
+    const recs = buildTechnicianDispatchRecommendations({
+      evidence: baseEvidence({
+        unassignedActionableLineCount: 1,
+        missingData: ["missing_certification_data"],
+      }),
+      evidenceSnapshotId: "evidence-1",
+    });
+    expect(recs[0]?.missing_data).toContain("missing_certification_data");
+  });
+
+  it("returns no risk when actionable lines are assigned and dispatch state is clean", () => {
+    const risks = evaluateWorkOrderTechnicianDispatchRisk(baseEvidence());
+    expect(risks).toHaveLength(0);
+  });
+
+  it("builds advisory-only recommendations with no auto-assignment action and bounded confidence", () => {
+    const recs = buildTechnicianDispatchRecommendations({
+      evidence: baseEvidence({
+        confidence: 1.8,
+        unassignedActionableLineCount: 2,
+      }),
+      evidenceSnapshotId: "evidence-1",
+    });
+
+    expect(recs.length).toBeGreaterThan(0);
+    expect(recs.every((rec) => rec.metadata?.advisory_only === true)).toBe(true);
+    expect(recs.every((rec) => rec.recommended_action.action_type === "review_technician_dispatch")).toBe(true);
+    expect(recs.every((rec) => rec.confidence >= 0 && rec.confidence <= 1)).toBe(true);
+  });
+});

--- a/features/ai/server/domains/workOrders/technicianDispatchRules.ts
+++ b/features/ai/server/domains/workOrders/technicianDispatchRules.ts
@@ -1,0 +1,193 @@
+import type {
+  WorkOrderRecommendationDraft,
+  WorkOrderTechnicianDispatchEvidence,
+  WorkOrderTechnicianDispatchRisk,
+} from "./types";
+
+export const WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION = "wo_technician_dispatch_v1";
+
+function boundedConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function minConfidence(evidenceConfidence: number, cap: number): number {
+  return boundedConfidence(Math.min(cap, evidenceConfidence));
+}
+
+function riskPriority(severity: WorkOrderTechnicianDispatchRisk["severity"]): WorkOrderRecommendationDraft["priority"] {
+  if (severity === "critical") return "urgent";
+  if (severity === "high") return "high";
+  return "normal";
+}
+
+export function evaluateWorkOrderTechnicianDispatchRisk(
+  evidence: WorkOrderTechnicianDispatchEvidence,
+): WorkOrderTechnicianDispatchRisk[] {
+  const risks: WorkOrderTechnicianDispatchRisk[] = [];
+
+  if (evidence.actionableLineCount > 0 && evidence.unassignedActionableLineCount > 0) {
+    risks.push({
+      risk_code: "unassigned_actionable_lines",
+      title: "Dispatch review — actionable lines are unassigned",
+      summary: `${evidence.unassignedActionableLineCount} actionable line(s) appear unassigned and may need dispatch review.`,
+      severity: evidence.unassignedActionableLineCount >= 3 ? "high" : "medium",
+      confidence: minConfidence(evidence.confidence, 0.9),
+      evidence_refs: ["work_order_lines"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Assign actionable job line",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if ((evidence.highPriorityLineCount > 0 || evidence.urgentPriorityLineCount > 0) && evidence.unassignedActionableLineCount > 0) {
+    risks.push({
+      risk_code: "high_priority_unassigned",
+      title: "Dispatch review — high-priority line is unassigned",
+      summary: "High/urgent priority actionable work appears unassigned and may need immediate dispatch attention.",
+      severity: evidence.urgentPriorityLineCount > 0 ? "high" : "medium",
+      confidence: minConfidence(evidence.confidence, 0.88),
+      evidence_refs: ["work_order_lines", "job_priority"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review technician assignment",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if ((evidence.scheduleDataAvailable || evidence.timeOffDataAvailable) && (evidence.unavailableAssignedTechCount ?? 0) > 0) {
+    risks.push({
+      risk_code: "assigned_tech_unavailable",
+      title: "Dispatch review — assigned technician may be unavailable",
+      summary: `${evidence.unavailableAssignedTechCount} assigned technician(s) may be unavailable based on current shift/time-off signals.`,
+      severity: "medium",
+      confidence: minConfidence(evidence.confidence, 0.78),
+      evidence_refs: ["tech_shifts", "staff_time_off_requests"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Confirm technician availability",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if (evidence.staleActiveLaborCount > 0) {
+    risks.push({
+      risk_code: "active_labor_stale",
+      title: "Dispatch review — active labor state appears stale",
+      summary: "One or more active labor/punch states appear stale and should be reviewed before further dispatch decisions.",
+      severity: evidence.staleActiveLaborCount >= 2 ? "high" : "medium",
+      confidence: minConfidence(evidence.confidence, 0.84),
+      evidence_refs: ["work_order_line_labor_segments", "work_order_lines"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review active labor/punch state",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if (evidence.technicianLoadAvailable && (evidence.overloadedTechCount ?? 0) > 0) {
+    risks.push({
+      risk_code: "overloaded_technician_review",
+      title: "Dispatch review — technician load appears high",
+      summary: `${evidence.overloadedTechCount} technician(s) may be overloaded relative to current assignment/labor signals.`,
+      severity: "medium",
+      confidence: minConfidence(evidence.confidence, 0.76),
+      evidence_refs: ["work_order_lines", "work_order_line_labor_segments"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review technician assignment",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if (evidence.certificationDataAvailable && evidence.certRelevantLineCount > 0 && (evidence.assignedWithoutActiveCertCount ?? 0) > 0) {
+    risks.push({
+      risk_code: "certification_review_needed",
+      title: "Dispatch review — certification/skill fit should be confirmed",
+      summary: "Assigned technician certification coverage is unclear for one or more cert-relevant lines.",
+      severity: "medium",
+      confidence: minConfidence(evidence.confidence, 0.68),
+      evidence_refs: ["staff_certifications", "work_order_lines"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Check certification/skill fit",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if (evidence.blockedLineCount > 0 || evidence.waitingLineCount > 0) {
+    risks.push({
+      risk_code: "blocked_line_dispatch_review",
+      title: "Dispatch review — blocked/waiting lines need attention",
+      summary: "Blocked or waiting actionable lines were detected and may need advisor/dispatch coordination.",
+      severity: evidence.highPriorityLineCount > 0 || evidence.urgentPriorityLineCount > 0 ? "high" : "medium",
+      confidence: minConfidence(evidence.confidence, 0.82),
+      evidence_refs: ["work_order_lines"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review blocked line with advisor/dispatch",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  if (evidence.confidence < 0.65 || evidence.missingData.length >= 3) {
+    risks.push({
+      risk_code: "dispatch_state_unknown",
+      title: "Dispatch review — state confidence is limited",
+      summary: "Dispatch signals are incomplete and require manual review before acting.",
+      severity: "low",
+      confidence: minConfidence(evidence.confidence, 0.7),
+      evidence_refs: ["work_order_lines"],
+      missing_data: evidence.missingData,
+      recommended_next_step: "Review technician assignment",
+      advisory_only: true,
+      rule_version: WORK_ORDER_TECHNICIAN_DISPATCH_RULES_VERSION,
+    });
+  }
+
+  return risks;
+}
+
+const RISK_TO_RECOMMENDATION: Record<WorkOrderTechnicianDispatchRisk["risk_code"], string> = {
+  unassigned_actionable_lines: "technician_dispatch_unassigned_lines",
+  high_priority_unassigned: "technician_dispatch_high_priority_unassigned",
+  assigned_tech_unavailable: "technician_dispatch_unavailable_assignee",
+  active_labor_stale: "technician_dispatch_stale_active_labor",
+  overloaded_technician_review: "technician_dispatch_overload_review",
+  certification_review_needed: "technician_dispatch_certification_review",
+  blocked_line_dispatch_review: "technician_dispatch_blocked_line_review",
+  dispatch_state_unknown: "technician_dispatch_state_unknown",
+};
+
+export function buildTechnicianDispatchRecommendations(input: {
+  evidence: WorkOrderTechnicianDispatchEvidence;
+  evidenceSnapshotId: string;
+}): WorkOrderRecommendationDraft[] {
+  const expiresAt = new Date(Date.now() + 48 * 3_600_000).toISOString();
+
+  return evaluateWorkOrderTechnicianDispatchRisk(input.evidence).map((risk) => ({
+    recommendation_type: RISK_TO_RECOMMENDATION[risk.risk_code],
+    title: "Dispatch review",
+    summary: `${risk.title}. ${risk.summary}`,
+    priority: riskPriority(risk.severity),
+    confidence: boundedConfidence(Math.min(risk.confidence, input.evidence.confidence)),
+    risk_tier: risk.severity,
+    missing_data: risk.missing_data,
+    recommended_action: {
+      action_type: "review_technician_dispatch",
+      label: "Dispatch review",
+      details: risk.recommended_next_step,
+    },
+    side_effects: [],
+    requires_approval: false,
+    source: "work_order_technician_dispatch_rules",
+    expires_at: expiresAt,
+    metadata: {
+      risk_code: risk.risk_code,
+      advisory_only: true,
+      rule_version: risk.rule_version,
+      evidence_refs: risk.evidence_refs,
+    },
+    evidence_snapshot_id: input.evidenceSnapshotId,
+  }));
+}

--- a/features/ai/server/domains/workOrders/types.ts
+++ b/features/ai/server/domains/workOrders/types.ts
@@ -163,6 +163,74 @@ export type WorkOrderPartsDelayRisk = {
   rule_version: string;
 };
 
+
+export type WorkOrderTechnicianDispatchEvidence = {
+  workOrderId: string;
+  shopId: string;
+  generatedAt: string;
+  lineCount: number;
+  actionableLineCount: number;
+  unassignedActionableLineCount: number;
+  assignedTechnicianIds: string[];
+  activeTechnicianIds: string[];
+  activeLaborSegmentCount: number;
+  staleActiveLaborCount: number;
+  highPriorityLineCount: number;
+  urgentPriorityLineCount: number;
+  blockedLineCount: number;
+  waitingLineCount: number;
+  scheduleDataAvailable: boolean;
+  timeOffDataAvailable: boolean;
+  certificationDataAvailable: boolean;
+  laborHistoryAvailable: boolean;
+  technicianLoadAvailable: boolean;
+  unavailableAssignedTechCount: number | null;
+  overloadedTechCount: number | null;
+  certRelevantLineCount: number;
+  assignedWithoutActiveCertCount: number | null;
+  missingData: string[];
+  sourceRefs: Array<Record<string, string | null>>;
+  confidence: number;
+};
+
+export type TechnicianDispatchCandidateSummary = {
+  technicianId: string;
+  assignedActionableCount: number;
+  activeLaborCount: number;
+  hasOpenShift: boolean | null;
+  hasApprovedTimeOffNow: boolean | null;
+  activeCertificationCount: number | null;
+};
+
+export type WorkOrderTechnicianDispatchSignal = {
+  code: string;
+  severity: AiRiskTier;
+  count: number;
+  confidence: number;
+  evidence_refs: string[];
+  missing_data: string[];
+};
+
+export type WorkOrderTechnicianDispatchRisk = {
+  risk_code:
+    | "unassigned_actionable_lines"
+    | "high_priority_unassigned"
+    | "assigned_tech_unavailable"
+    | "active_labor_stale"
+    | "overloaded_technician_review"
+    | "certification_review_needed"
+    | "blocked_line_dispatch_review"
+    | "dispatch_state_unknown";
+  title: string;
+  summary: string;
+  severity: AiRiskTier;
+  confidence: number;
+  evidence_refs: string[];
+  missing_data: string[];
+  recommended_next_step: string;
+  advisory_only: true;
+  rule_version: string;
+};
 export type WorkOrderCloseoutRisk = {
   risk_code:
     | "inspection_incomplete"

--- a/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
+++ b/features/ai/server/domains/workOrders/workOrderActionPreviews.ts
@@ -9,7 +9,11 @@ export type WorkOrderPreviewActionType =
   | "advisor_review_needed"
   | "priority_escalation_review"
   | "review_parts_delay"
-  | "confirm_po_receiving_status";
+  | "confirm_po_receiving_status"
+  | "review_technician_dispatch"
+  | "review_assignment"
+  | "confirm_technician_availability"
+  | "review_active_labor_state";
 
 export type WorkOrderRecommendationPreviewability =
   | { previewable: true; actionType: WorkOrderPreviewActionType }
@@ -152,6 +156,47 @@ const RECOMMENDATION_PREVIEW_MAP: Record<string, ActionSpec> = {
     actionType: "review_parts_delay",
     label: "Parts delay review",
     description: "Review missing parts linkage and clarify internal parts status.",
+  },
+
+  technician_dispatch_unassigned_lines: {
+    actionType: "review_technician_dispatch",
+    label: "Dispatch review",
+    description: "Review unassigned actionable lines with dispatch/advisor workflow only.",
+  },
+  technician_dispatch_high_priority_unassigned: {
+    actionType: "review_assignment",
+    label: "Dispatch review",
+    description: "Review high-priority unassigned work with no assignment mutation.",
+  },
+  technician_dispatch_unavailable_assignee: {
+    actionType: "confirm_technician_availability",
+    label: "Dispatch review",
+    description: "Confirm assigned technician availability using existing scheduling workflow.",
+  },
+  technician_dispatch_stale_active_labor: {
+    actionType: "review_active_labor_state",
+    label: "Dispatch review",
+    description: "Review stale active labor/punch state with no labor mutation.",
+  },
+  technician_dispatch_overload_review: {
+    actionType: "review_technician_dispatch",
+    label: "Dispatch review",
+    description: "Review potential technician overload using current assignment view.",
+  },
+  technician_dispatch_certification_review: {
+    actionType: "review_technician_dispatch",
+    label: "Dispatch review",
+    description: "Review certification/skill fit internally; do not auto-assign.",
+  },
+  technician_dispatch_blocked_line_review: {
+    actionType: "review_technician_dispatch",
+    label: "Dispatch review",
+    description: "Review blocked or waiting lines with advisor/dispatch coordination.",
+  },
+  technician_dispatch_state_unknown: {
+    actionType: "review_technician_dispatch",
+    label: "Dispatch review",
+    description: "Review incomplete dispatch signals before taking any manual action.",
   },
   priority_escalation_candidate: {
     actionType: "priority_escalation_review",

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -317,6 +317,7 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
             const previewBusy = previewLoadingId === item.id;
             const isCloseoutRisk = item.recommendation_type.startsWith("closeout_risk_");
             const isPartsDelay = item.recommendation_type.startsWith("parts_delay_");
+            const isDispatchReview = item.recommendation_type.startsWith("technician_dispatch_");
             const severityLabel = `severity ${item.risk_tier}`;
             const recommendedNextStep = item.recommended_action?.details ?? item.recommended_action?.label ?? "Review work order";
 
@@ -334,6 +335,11 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                       Parts delay review
                     </span>
                   ) : null}
+                  {isDispatchReview ? (
+                    <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+                      Dispatch review
+                    </span>
+                  ) : null}
                   <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{item.priority}</span>
                   <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">{severityLabel}</span>
                   {item.status === "acknowledged" ? (
@@ -346,6 +352,9 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                 ) : null}
                 {isPartsDelay ? (
                   <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Advisory only — internal parts-delay review, no execution.</p>
+                ) : null}
+                {isDispatchReview ? (
+                  <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Advisory only — internal dispatch review, no assignment/schedule/labor mutation.</p>
                 ) : null}
                 <div className="mt-1 text-[10px] text-muted-foreground">
                   Confidence: {typeof item.confidence === "number" ? item.confidence.toFixed(2) : "—"} • Missing data: {item.missing_data?.length ?? 0} • Next: {recommendedNextStep}


### PR DESCRIPTION
### Motivation
- Provide deterministic, evidence-backed dispatch intelligence for work orders so advisors/managers can spot unassigned, unavailable, overloaded, certification-risk, stale-labor, high-priority, and blocked lines without any autonomous action. 
- Keep the system recommendation-first and advisory-only, preserving existing shop scoping and RLS patterns. 
- Surface dispatch signals into the existing AI recommendations pipeline and UI so Mission Control and work-order cards can show dispatch review items alongside other operational signals.

### Description
- Add typed dispatch structures to `features/ai/server/domains/workOrders/types.ts` including `WorkOrderTechnicianDispatchEvidence`, `WorkOrderTechnicianDispatchRisk`, `WorkOrderTechnicianDispatchSignal`, and `TechnicianDispatchCandidateSummary`. 
- Implement a shop-scoped evidence builder `buildWorkOrderTechnicianDispatchEvidence` and snapshot creator `createWorkOrderTechnicianDispatchEvidenceSnapshot` in `features/ai/server/domains/workOrders/technicianDispatchEvidence.ts` that reads `work_order_lines`, `work_order_line_labor_segments`, `tech_shifts`, `staff_time_off_requests`, and `staff_certifications` where available, marks missing data, and computes a bounded confidence score. 
- Add deterministic rule evaluator and recommendation builder in `features/ai/server/domains/workOrders/technicianDispatchRules.ts` covering unassigned/high-priority_unassigned/assigned_unavailable/active_labor_stale/overload/certification/blocked/dispatch_state_unknown, producing advisory-only `work_orders` recommendations (no mutations, no auto-assignment). 
- Wire dispatch evidence + recommendations into the work-order generator (`generateWorkOrderEvidenceAndRecommendations` in `features/ai/server/domains/workOrders/index.ts`) with the same duplicate suppression behavior and no DB migrations. 
- Extend the preview allowlist with dispatch review action types (`review_technician_dispatch`, `review_assignment`, `confirm_technician_availability`, `review_active_labor_state`) in `workOrderActionPreviews.ts` and update UI copy in `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx` to label dispatch signals as “Dispatch review” and emphasize advisory-only semantics. 
- Add deterministic unit tests `features/ai/server/domains/workOrders/technicianDispatchRules.test.ts` validating rule triggers, missing-data behavior, advisory-only guarantees, and bounded confidence.

### Testing
- Ran `npx tsc --noEmit` which completed successfully with no type errors. 
- Attempted `npm test -- --runInBand` which failed due to an unsupported Vitest flag, but then ran `npm test` which completed successfully. 
- `npm test` (Vitest) reported the test suite passed including the new file `features/ai/server/domains/workOrders/technicianDispatchRules.test.ts`, overall results: all test files and tests succeeded (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9ff19f448328a153a1e05a5fd9d6)