### PR TITLE
Bridge Shop Boost post-activation insights into canonical AI recommendations

### DIFF
--- a/app/api/dashboard/ai-mission-control/route.ts
+++ b/app/api/dashboard/ai-mission-control/route.ts
@@ -27,7 +27,7 @@ export async function GET() {
       supabase: access.supabase,
       actorContext: actor,
       limit: 5,
-      domain: "work_orders",
+      domains: ["work_orders", "shop_boost"],
     });
 
     return NextResponse.json({ summary });

--- a/app/api/shop-boost/ai/recommendations/route.ts
+++ b/app/api/shop-boost/ai/recommendations/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { listAiRecommendationsForSubject } from "@/features/ai/server";
+import { generateShopBoostPostActivationEvidenceAndRecommendations } from "@/features/ai/server/domains/shopBoost";
+
+function isUuid(value: string | null | undefined): value is string {
+  return !!value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+export async function GET(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  const url = new URL(req.url);
+  const intakeId = url.searchParams.get("intakeId")?.trim() || null;
+
+  const rows = await listAiRecommendationsForSubject(access.supabase, actor, {
+    subjectType: "shop_boost_intake",
+    subjectId: intakeId && isUuid(intakeId) ? intakeId : undefined,
+    domain: "shop_boost",
+    limit: 100,
+  });
+
+  const recommendations = rows.filter((row) => row.status === "open" || row.status === "acknowledged");
+  return NextResponse.json({ recommendations });
+}
+
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager"],
+  });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const body = (await req.json().catch(() => ({}))) as { intakeId?: string; sourceRunId?: string };
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  const result = await generateShopBoostPostActivationEvidenceAndRecommendations({
+    supabase: access.supabase,
+    actor,
+    intakeId: body.intakeId?.trim() || null,
+    sourceRunId: body.sourceRunId?.trim() || null,
+  });
+
+  return NextResponse.json(result);
+}

--- a/features/ai/server/dashboard/getAiMissionControlSummary.ts
+++ b/features/ai/server/dashboard/getAiMissionControlSummary.ts
@@ -8,7 +8,7 @@ import type {
 
 type RecommendationRow = {
   id: string;
-  domain: string;
+  domain: "work_orders" | "shop_boost";
   recommendation_type: string;
   subject_type: string;
   subject_id: string | null;
@@ -77,16 +77,26 @@ function isStale(expiresAt: string | null, nowEpochMs: number): boolean {
   return epoch <= nowEpochMs;
 }
 
+function toDomainLabel(domain: RecommendationRow["domain"]): "Work order" | "Shop Boost" {
+  return domain === "shop_boost" ? "Shop Boost" : "Work order";
+}
+
+function toHref(row: RecommendationRow): string | null {
+  if (row.subject_type === "work_order" && row.subject_id) return `/work-orders/${row.subject_id}`;
+  if (row.domain === "shop_boost") return "/dashboard/setup/review?source=shop-boost";
+  return null;
+}
+
 function toMissionControlRecommendation(
   row: RecommendationRow,
   previewCount: number,
 ): AiMissionControlRecommendation {
   const action = toRecommendedActionSummary(row.recommended_action);
-  const href = row.subject_type === "work_order" && row.subject_id ? `/work-orders/${row.subject_id}` : null;
 
   return {
     id: row.id,
     domain: row.domain,
+    domainLabel: toDomainLabel(row.domain),
     recommendationType: row.recommendation_type,
     subjectType: row.subject_type,
     subjectId: row.subject_id,
@@ -104,7 +114,7 @@ function toMissionControlRecommendation(
     recommendedActionType: action.recommendedActionType,
     recommendedActionLabel: action.recommendedActionLabel,
     previewCount,
-    href,
+    href: toHref(row),
   };
 }
 
@@ -112,13 +122,13 @@ export async function getAiMissionControlSummary(
   input: GetAiMissionControlSummaryInput,
 ): Promise<AiMissionControlSummary> {
   const actor = ensureActorContext(input.actorContext);
-  const domain = input.domain ?? "work_orders";
+  const domains = input.domains?.length ? input.domains : ["work_orders", "shop_boost"];
   const limit = Math.max(3, Math.min(input.limit ?? 5, 20));
 
   const { data, error } = await fromTable(input.supabase, "ai_recommendations")
     .select("id, domain, recommendation_type, subject_type, subject_id, title, summary, status, priority, risk_tier, confidence, missing_data, requires_approval, requires_owner_pin, created_at, expires_at, recommended_action")
     .eq("shop_id", actor.shopId)
-    .eq("domain", domain)
+    .in("domain", domains)
     .in("status", ["open", "acknowledged"])
     .limit(200);
 

--- a/features/ai/server/dashboard/types.ts
+++ b/features/ai/server/dashboard/types.ts
@@ -2,7 +2,8 @@ import type { AiActorContext, AiRecommendationPriority, AiRecommendationStatus, 
 
 export type AiMissionControlRecommendation = {
   id: string;
-  domain: string;
+  domain: "work_orders" | "shop_boost";
+  domainLabel: "Work order" | "Shop Boost";
   recommendationType: string;
   subjectType: string;
   subjectId: string | null;
@@ -41,6 +42,6 @@ export type AiMissionControlSummary = {
 export type GetAiMissionControlSummaryInput = {
   supabase: AiServerClient;
   actorContext: AiActorContext;
-  domain?: "work_orders";
+  domains?: Array<"work_orders" | "shop_boost">;
   limit?: number;
 };

--- a/features/ai/server/domains/shopBoost/buildShopBoostEvidenceSnapshot.test.ts
+++ b/features/ai/server/domains/shopBoost/buildShopBoostEvidenceSnapshot.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildShopBoostAiEvidence } from "./buildShopBoostEvidenceSnapshot";
+
+describe("buildShopBoostAiEvidence", () => {
+  it("handles missing linkage fields safely and reports missingData", () => {
+    const evidence = buildShopBoostAiEvidence({
+      shopId: "shop-1",
+      intake: {
+        id: "intake-1",
+        shop_id: "shop-1",
+        status: "completed",
+        created_at: "2026-04-24T00:00:00.000Z",
+        processed_at: null,
+        intake_basics: {},
+      },
+      suggestionCounts: { menuCount: 0, inspectionCount: 0, staffCount: 0, menuHigh: 0, inspectionHigh: 0 },
+    });
+
+    expect(evidence.linkageSummary.unresolvedVehicles).toBeNull();
+    expect(evidence.missingData).toContain("linkage_unresolved_counts_missing");
+    expect(evidence.confidence).toBeGreaterThanOrEqual(0);
+    expect(evidence.confidence).toBeLessThanOrEqual(1);
+  });
+});

--- a/features/ai/server/domains/shopBoost/buildShopBoostEvidenceSnapshot.ts
+++ b/features/ai/server/domains/shopBoost/buildShopBoostEvidenceSnapshot.ts
@@ -1,0 +1,236 @@
+import type { Database, Json } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAiEvidenceSnapshot, type AiActorContext, type AiEvidenceSnapshotRecord } from "@/features/ai/server";
+import type { ShopBoostAiEvidence } from "./types";
+
+type DB = Database;
+
+type IntakeRow = Pick<
+  DB["public"]["Tables"]["shop_boost_intakes"]["Row"],
+  "id" | "shop_id" | "status" | "created_at" | "processed_at" | "intake_basics"
+>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function clampConfidence(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0.5;
+  return Math.max(0, Math.min(1, Number(value.toFixed(4))));
+}
+
+function isUuid(value: string | null | undefined): value is string {
+  return !!value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function pullLinkage(basics: Record<string, unknown>) {
+  const importSummary = asRecord(basics.importSummary);
+  const linkageSummary = asRecord(importSummary.linkageSummary);
+  const linked = asRecord(linkageSummary.linked);
+  const unresolved = asRecord(linkageSummary.unresolved);
+
+  return {
+    customersLinked: asNumber(linked.customers) ?? asNumber(linked.customersLinked),
+    vehiclesLinked: asNumber(linked.vehicles) ?? asNumber(linked.vehiclesCustomerId),
+    workOrdersLinked: asNumber(linked.workOrders) ?? asNumber(linked.workOrdersCustomerId),
+    invoicesLinked: asNumber(linked.invoices) ?? asNumber(linked.invoicesCustomerId),
+    unresolvedCustomers: asNumber(unresolved.customers) ?? asNumber(unresolved.customersMissingLink),
+    unresolvedVehicles: asNumber(unresolved.vehicles) ?? asNumber(unresolved.vehiclesCustomerId),
+    unresolvedWorkOrders: asNumber(unresolved.workOrders) ?? asNumber(unresolved.workOrdersCustomerId) ?? asNumber(unresolved.workOrdersVehicleId),
+    unresolvedInvoices: asNumber(unresolved.invoices) ?? asNumber(unresolved.invoicesCustomerId),
+  };
+}
+
+async function countSuggestions(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  intakeId: string;
+}) {
+  const [menu, inspection, staff] = await Promise.all([
+    input.supabase
+      .from("menu_item_suggestions")
+      .select("confidence", { count: "exact" })
+      .eq("shop_id", input.shopId)
+      .eq("intake_id", input.intakeId),
+    input.supabase
+      .from("inspection_template_suggestions")
+      .select("confidence", { count: "exact" })
+      .eq("shop_id", input.shopId)
+      .eq("intake_id", input.intakeId),
+    input.supabase
+      .from("staff_invite_suggestions")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", input.shopId)
+      .eq("intake_id", input.intakeId),
+  ]);
+
+  if (menu.error) throw new Error(menu.error.message);
+  if (inspection.error) throw new Error(inspection.error.message);
+  if (staff.error) throw new Error(staff.error.message);
+
+  const menuRows = menu.data ?? [];
+  const inspectionRows = inspection.data ?? [];
+
+  const menuHigh = menuRows.filter((row) => Number(row.confidence ?? 0) >= 0.85).length;
+  const inspectionHigh = inspectionRows.filter((row) => Number(row.confidence ?? 0) >= 0.85).length;
+
+  return {
+    menuCount: menu.count ?? 0,
+    inspectionCount: inspection.count ?? 0,
+    staffCount: staff.count ?? 0,
+    menuHigh,
+    inspectionHigh,
+  };
+}
+
+export function buildShopBoostAiEvidence(input: {
+  shopId: string;
+  intake: IntakeRow;
+  sourceRunId?: string | null;
+  suggestionCounts: {
+    menuCount: number;
+    inspectionCount: number;
+    staffCount: number;
+    menuHigh: number;
+    inspectionHigh: number;
+  };
+}): ShopBoostAiEvidence {
+  const basics = asRecord(input.intake.intake_basics);
+  const orchestrator = asRecord(basics.orchestrator);
+  const migrationProgress = asRecord(basics.migrationProgress);
+  const roi = asRecord(migrationProgress.roi ?? basics.roi_summary);
+  const trust = asRecord(migrationProgress.trustStatement ?? basics.trust_statement);
+  const linkageSummary = pullLinkage(basics);
+
+  const missingData: string[] = [];
+  const unresolvedDataCategories: string[] = [];
+
+  if (linkageSummary.unresolvedVehicles == null && linkageSummary.unresolvedWorkOrders == null) {
+    missingData.push("linkage_unresolved_counts_missing");
+  }
+
+  const reviewQueueCount = asNumber(asRecord(basics.importSummary).reviewQueueCount ?? migrationProgress.reviewQueueCount);
+  const blockerCount = asNumber(asRecord(basics.importSummary).blockerCount ?? migrationProgress.blockerCount);
+  if (reviewQueueCount == null) missingData.push("review_queue_count_missing");
+  if (blockerCount == null) missingData.push("blocker_count_missing");
+
+  if ((linkageSummary.unresolvedCustomers ?? 0) > 0) unresolvedDataCategories.push("customers");
+  if ((linkageSummary.unresolvedVehicles ?? 0) > 0) unresolvedDataCategories.push("vehicles");
+  if ((linkageSummary.unresolvedWorkOrders ?? 0) > 0) unresolvedDataCategories.push("work_orders");
+  if ((linkageSummary.unresolvedInvoices ?? 0) > 0) unresolvedDataCategories.push("invoices");
+
+  const staleWarnings: string[] = [];
+  if ((reviewQueueCount ?? 0) > 0) staleWarnings.push("pending_review_queue_items_detected");
+  if ((blockerCount ?? 0) > 0) staleWarnings.push("import_blockers_detected");
+
+  const confidence = clampConfidence(
+    asNumber(trust.confidence_score) ?? asNumber(trust.confidence) ?? asNumber(migrationProgress.confidenceScore),
+  );
+
+  return {
+    shopId: input.shopId,
+    intakeId: input.intake.id,
+    sourceRunId: input.sourceRunId ?? (typeof orchestrator.run_id === "string" ? orchestrator.run_id : null),
+    activationStatus: typeof orchestrator.activation_status === "string" ? orchestrator.activation_status : null,
+    readinessStatus: typeof migrationProgress.readiness === "string" ? migrationProgress.readiness : null,
+    generatedAt: new Date().toISOString(),
+    confidence,
+    confidenceSummary: {
+      trustScore: asNumber(trust.confidence_score) ?? asNumber(trust.confidence),
+      trustMessage: typeof trust.message === "string" ? trust.message : null,
+      confidenceScore: asNumber(migrationProgress.confidenceScore),
+    },
+    linkageSummary,
+    suggestionsSummary: {
+      inspectionTemplateSuggestions: input.suggestionCounts.inspectionCount,
+      inspectionTemplateHighConfidenceCount: input.suggestionCounts.inspectionHigh,
+      menuItemSuggestions: input.suggestionCounts.menuCount,
+      menuItemHighConfidenceCount: input.suggestionCounts.menuHigh,
+      staffSuggestions: input.suggestionCounts.staffCount,
+      customerSuggestions: null,
+      historySuggestions: null,
+      highConfidenceCount: input.suggestionCounts.menuHigh + input.suggestionCounts.inspectionHigh,
+      reviewNeededCount: reviewQueueCount ?? 0,
+    },
+    roiImpactSummary: {
+      estimatedMonthlyImpact: asNumber(roi.estimated_monthly_impact),
+      approvalSpeedGain: asNumber(roi.approval_speed_gain),
+      laborRecoveryHours: asNumber(roi.labor_recovery_hours),
+      partsLeakageReduction: asNumber(roi.parts_leakage_reduction),
+      confidence: asNumber(roi.confidence),
+    },
+    unresolvedDataCategories,
+    staleOrUnscopedSuggestionWarnings: staleWarnings,
+    sourceRefs: [
+      { table: "shop_boost_intakes", id: input.intake.id },
+      { table: "shop_boost_intakes", field: "intake_basics.importSummary" },
+      { table: "menu_item_suggestions", id: input.intake.id, field: "intake_id" },
+      { table: "inspection_template_suggestions", id: input.intake.id, field: "intake_id" },
+      { table: "staff_invite_suggestions", id: input.intake.id, field: "intake_id" },
+    ],
+    missingData,
+  };
+}
+
+export async function createShopBoostPostActivationEvidenceSnapshot(input: {
+  supabase: SupabaseClient<DB>;
+  actorContext: AiActorContext;
+  intakeId?: string | null;
+  sourceRunId?: string | null;
+}): Promise<{
+  intake: IntakeRow;
+  evidence: AiEvidenceSnapshotRecord;
+  snapshot: ShopBoostAiEvidence;
+  missingData: string[];
+}> {
+  const { supabase, actorContext } = input;
+  const shopId = actorContext.shopId;
+  if (!shopId) throw new Error("shopId is required in actor context");
+
+  let intakeQuery = supabase
+    .from("shop_boost_intakes")
+    .select("id,shop_id,status,created_at,processed_at,intake_basics")
+    .eq("shop_id", shopId)
+    .order("processed_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  if (input.intakeId) {
+    intakeQuery = intakeQuery.eq("id", input.intakeId);
+  }
+
+  const { data: intake, error: intakeError } = await intakeQuery.maybeSingle<IntakeRow>();
+  if (intakeError) throw new Error(intakeError.message);
+  if (!intake) throw new Error("No Shop Boost intake found for this shop.");
+
+  const suggestions = await countSuggestions({ supabase, shopId, intakeId: intake.id });
+  const snapshot = buildShopBoostAiEvidence({
+    shopId,
+    intake,
+    sourceRunId: input.sourceRunId,
+    suggestionCounts: suggestions,
+  });
+
+  const evidence = await createAiEvidenceSnapshot(supabase, actorContext, {
+    domain: "shop_boost",
+    subjectType: "shop_boost_intake",
+    subjectId: isUuid(intake.id) ? intake.id : null,
+    evidenceKind: "shop_boost_post_activation_state",
+    snapshot: snapshot as unknown as Json,
+    sourceRefs: snapshot.sourceRefs as unknown as Json,
+    missingData: snapshot.missingData,
+    confidence: snapshot.confidence,
+    freshnessAt: intake.processed_at ?? intake.created_at,
+    metadata: {
+      intakeId: intake.id,
+      sourceRunId: snapshot.sourceRunId,
+      advisory_only: true,
+    },
+  });
+
+  return { intake, evidence, snapshot, missingData: snapshot.missingData };
+}

--- a/features/ai/server/domains/shopBoost/index.ts
+++ b/features/ai/server/domains/shopBoost/index.ts
@@ -1,0 +1,126 @@
+import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAiRecommendation, fromTable, type AiActorContext, type AiRecommendationRecord } from "@/features/ai/server";
+import { createShopBoostPostActivationEvidenceSnapshot } from "./buildShopBoostEvidenceSnapshot";
+import { buildShopBoostPostActivationRecommendations } from "./shopBoostRecommendationRules";
+import { SHOP_BOOST_RULES_VERSION } from "./types";
+
+type DB = Database;
+
+async function hasOpenDuplicate(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  recommendationType: string;
+  subjectId: string | null;
+  intakeId: string;
+  sourceRunId: string | null;
+}): Promise<boolean> {
+  let query = fromTable(input.supabase, "ai_recommendations")
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", input.shopId)
+    .eq("domain", "shop_boost")
+    .eq("subject_type", "shop_boost_intake")
+    .eq("recommendation_type", input.recommendationType)
+    .in("status", ["open", "acknowledged"])
+    .limit(1);
+
+  if (input.subjectId) {
+    query = query.eq("subject_id", input.subjectId);
+  } else {
+    query = query.is("subject_id", null).contains("metadata", { intakeId: input.intakeId });
+    if (input.sourceRunId) {
+      query = query.eq("source_run_id", input.sourceRunId);
+    }
+  }
+
+  const { count, error } = await query;
+  if (error) throw new Error(error.message);
+  return (count ?? 0) > 0;
+}
+
+export async function generateShopBoostPostActivationEvidenceAndRecommendations(input: {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  intakeId?: string | null;
+  sourceRunId?: string | null;
+}): Promise<{
+  evidenceSnapshot: Awaited<ReturnType<typeof createShopBoostPostActivationEvidenceSnapshot>>["evidence"];
+  recommendations: AiRecommendationRecord[];
+  skippedDuplicates: string[];
+  missingData: string[];
+  warnings: string[];
+}> {
+  const { supabase, actor } = input;
+
+  const built = await createShopBoostPostActivationEvidenceSnapshot({
+    supabase,
+    actorContext: actor,
+    intakeId: input.intakeId,
+    sourceRunId: input.sourceRunId,
+  });
+
+  const drafts = buildShopBoostPostActivationRecommendations({
+    evidence: built.snapshot,
+    evidenceSnapshotId: built.evidence.id,
+  });
+
+  const created: AiRecommendationRecord[] = [];
+  const skippedDuplicates: string[] = [];
+
+  for (const draft of drafts) {
+    const duplicate = await hasOpenDuplicate({
+      supabase,
+      shopId: actor.shopId,
+      recommendationType: draft.recommendation_type,
+      subjectId: built.evidence.subject_id,
+      intakeId: built.snapshot.intakeId,
+      sourceRunId: built.snapshot.sourceRunId,
+    });
+
+    if (duplicate) {
+      skippedDuplicates.push(draft.recommendation_type);
+      continue;
+    }
+
+    const recommendation = await createAiRecommendation(supabase, actor, {
+      domain: "shop_boost",
+      recommendationType: draft.recommendation_type,
+      subjectType: "shop_boost_intake",
+      subjectId: built.evidence.subject_id,
+      title: draft.title,
+      summary: draft.summary,
+      priority: draft.priority,
+      confidence: draft.confidence,
+      riskTier: draft.risk_tier,
+      evidenceSnapshotId: draft.evidence_snapshot_id,
+      missingData: draft.missing_data,
+      recommendedAction: draft.recommended_action,
+      sideEffects: draft.side_effects,
+      requiresApproval: draft.requires_approval,
+      requiresOwnerPin: false,
+      source: draft.source,
+      sourceRunId: built.snapshot.sourceRunId,
+      expiresAt: draft.expires_at,
+      metadata: {
+        ...draft.metadata,
+        rules_version: SHOP_BOOST_RULES_VERSION,
+      },
+    });
+
+    created.push(recommendation);
+  }
+
+  return {
+    evidenceSnapshot: built.evidence,
+    recommendations: created,
+    skippedDuplicates,
+    missingData: built.missingData,
+    warnings: drafts.length === 0 ? ["no_rule_triggers"] : [],
+  };
+}
+
+export * from "./types";
+export * from "./buildShopBoostEvidenceSnapshot";
+export * from "./shopBoostRecommendationRules";
+
+export * from "./shopBoostActionPreviews";

--- a/features/ai/server/domains/shopBoost/shopBoostActionPreviews.ts
+++ b/features/ai/server/domains/shopBoost/shopBoostActionPreviews.ts
@@ -1,0 +1,36 @@
+import type { AiRiskTier } from "@/features/ai/server";
+import type { ShopBoostRecommendationKind } from "./types";
+
+type ShopBoostPreviewActionType =
+  | "review_import_linkage"
+  | "review_inspection_template_suggestions"
+  | "review_menu_item_suggestions"
+  | "review_shop_boost_readiness"
+  | "review_roi_opportunities";
+
+const MAP: Record<ShopBoostRecommendationKind, ShopBoostPreviewActionType> = {
+  shop_boost_review_unresolved_import_links: "review_import_linkage",
+  shop_boost_review_high_confidence_inspection_templates: "review_inspection_template_suggestions",
+  shop_boost_review_high_confidence_menu_items: "review_menu_item_suggestions",
+  shop_boost_review_low_confidence_suggestions: "review_shop_boost_readiness",
+  shop_boost_review_day_one_readiness_gaps: "review_shop_boost_readiness",
+  shop_boost_review_roi_opportunities: "review_roi_opportunities",
+  shop_boost_review_stale_or_unscoped_suggestions: "review_shop_boost_readiness",
+};
+
+export function buildShopBoostPreviewOnlyPayload(input: {
+  recommendationId: string;
+  intakeId: string;
+  recommendationType: ShopBoostRecommendationKind;
+  riskTier: AiRiskTier;
+}) {
+  return {
+    action_type: MAP[input.recommendationType],
+    recommendation_id: input.recommendationId,
+    intake_id: input.intakeId,
+    intended_mutations: [] as const,
+    side_effects: ["No external side effects. Internal Shop Boost review only."],
+    executionBlocked: true as const,
+    risk_tier: input.riskTier,
+  };
+}

--- a/features/ai/server/domains/shopBoost/shopBoostRecommendationRules.test.ts
+++ b/features/ai/server/domains/shopBoost/shopBoostRecommendationRules.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildShopBoostPostActivationRecommendations } from "./shopBoostRecommendationRules";
+import type { ShopBoostAiEvidence } from "./types";
+
+function baseEvidence(overrides: Partial<ShopBoostAiEvidence> = {}): ShopBoostAiEvidence {
+  return {
+    shopId: "shop-1",
+    intakeId: "intake-1",
+    sourceRunId: "run-1",
+    activationStatus: "activated",
+    readinessStatus: "READY",
+    generatedAt: "2026-04-24T00:00:00.000Z",
+    confidence: 0.82,
+    confidenceSummary: { trustScore: 0.82, trustMessage: "ok", confidenceScore: 0.82 },
+    linkageSummary: {
+      customersLinked: 10,
+      vehiclesLinked: 10,
+      workOrdersLinked: 8,
+      invoicesLinked: 6,
+      unresolvedCustomers: 0,
+      unresolvedVehicles: 0,
+      unresolvedWorkOrders: 0,
+      unresolvedInvoices: 0,
+    },
+    suggestionsSummary: {
+      inspectionTemplateSuggestions: 2,
+      inspectionTemplateHighConfidenceCount: 1,
+      menuItemSuggestions: 2,
+      menuItemHighConfidenceCount: 1,
+      staffSuggestions: 1,
+      customerSuggestions: null,
+      historySuggestions: null,
+      highConfidenceCount: 2,
+      reviewNeededCount: 0,
+    },
+    roiImpactSummary: {
+      estimatedMonthlyImpact: 1200,
+      approvalSpeedGain: 10,
+      laborRecoveryHours: 4,
+      partsLeakageReduction: 5,
+      confidence: 0.75,
+    },
+    unresolvedDataCategories: [],
+    staleOrUnscopedSuggestionWarnings: [],
+    sourceRefs: [{ table: "shop_boost_intakes", id: "intake-1" }],
+    missingData: [],
+    ...overrides,
+  };
+}
+
+describe("buildShopBoostPostActivationRecommendations", () => {
+  it("creates high-confidence review recommendations only (no materialization action)", () => {
+    const recs = buildShopBoostPostActivationRecommendations({
+      evidence: baseEvidence(),
+      evidenceSnapshotId: "evidence-1",
+    });
+
+    expect(recs.some((r) => r.recommendation_type === "shop_boost_review_high_confidence_inspection_templates")).toBe(true);
+    expect(recs.some((r) => r.recommendation_type === "shop_boost_review_high_confidence_menu_items")).toBe(true);
+    expect(recs.every((r) => !String(r.summary).toLowerCase().includes("auto-create"))).toBe(true);
+    expect(recs.every((r) => !String(r.summary).toLowerCase().includes("materialize now"))).toBe(true);
+    expect(recs.every((r) => r.metadata.advisory_only)).toBe(true);
+    expect(recs.every((r) => r.confidence >= 0 && r.confidence <= 1)).toBe(true);
+  });
+
+  it("creates unresolved linkage recommendation when unresolved linkage exists", () => {
+    const recs = buildShopBoostPostActivationRecommendations({
+      evidence: baseEvidence({
+        linkageSummary: {
+          ...baseEvidence().linkageSummary,
+          unresolvedWorkOrders: 3,
+        },
+      }),
+      evidenceSnapshotId: "evidence-1",
+    });
+
+    expect(recs.some((r) => r.recommendation_type === "shop_boost_review_unresolved_import_links")).toBe(true);
+  });
+});

--- a/features/ai/server/domains/shopBoost/shopBoostRecommendationRules.ts
+++ b/features/ai/server/domains/shopBoost/shopBoostRecommendationRules.ts
@@ -1,0 +1,217 @@
+import type { ShopBoostAiEvidence, ShopBoostPostActivationRecommendation } from "./types";
+import { SHOP_BOOST_RULES_VERSION } from "./types";
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.max(0, Math.min(1, Number(value.toFixed(4))));
+}
+
+function defaultExpiresAt(days = 5): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function recommendationBase(input: {
+  evidence: ShopBoostAiEvidence;
+  evidenceSnapshotId: string;
+  recommendation: Omit<ShopBoostPostActivationRecommendation, "evidence_snapshot_id" | "missing_data" | "metadata" | "source" | "expires_at">;
+}): ShopBoostPostActivationRecommendation {
+  return {
+    ...input.recommendation,
+    confidence: clampConfidence(input.recommendation.confidence),
+    evidence_snapshot_id: input.evidenceSnapshotId,
+    missing_data: input.evidence.missingData,
+    source: "shop_boost_post_activation_rules",
+    metadata: {
+      intakeId: input.evidence.intakeId,
+      sourceRunId: input.evidence.sourceRunId,
+      recommendationKind: input.recommendation.recommendation_type,
+      advisory_only: true,
+      rule_version: SHOP_BOOST_RULES_VERSION,
+    },
+    expires_at: defaultExpiresAt(5),
+  };
+}
+
+export function buildShopBoostPostActivationRecommendations(input: {
+  evidence: ShopBoostAiEvidence;
+  evidenceSnapshotId: string;
+}): ShopBoostPostActivationRecommendation[] {
+  const { evidence, evidenceSnapshotId } = input;
+  const recs: ShopBoostPostActivationRecommendation[] = [];
+
+  const unresolvedTotal =
+    (evidence.linkageSummary.unresolvedCustomers ?? 0) +
+    (evidence.linkageSummary.unresolvedVehicles ?? 0) +
+    (evidence.linkageSummary.unresolvedWorkOrders ?? 0) +
+    (evidence.linkageSummary.unresolvedInvoices ?? 0);
+
+  if (unresolvedTotal > 0) {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_unresolved_import_links",
+          title: "Review unresolved Shop Boost import linkage",
+          summary: `${unresolvedTotal} unresolved linkage signal(s) were detected across imported records and should be reviewed before relying on migrated history.`,
+          priority: unresolvedTotal >= 10 ? "high" : "normal",
+          risk_tier: "medium",
+          confidence: evidence.confidence,
+          recommended_action: {
+            type: "review_import_linkage",
+            label: "Review import linkage",
+            details: "Review unresolved linkage in Shop Boost review queue. No data is auto-imported or materialized.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  if ((evidence.suggestionsSummary.inspectionTemplateHighConfidenceCount ?? 0) > 0) {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_high_confidence_inspection_templates",
+          title: "Review high-confidence inspection template suggestions",
+          summary: `${evidence.suggestionsSummary.inspectionTemplateHighConfidenceCount} high-confidence inspection template suggestion(s) are ready for owner/admin review.`,
+          priority: "normal",
+          risk_tier: "low",
+          confidence: Math.max(0.8, evidence.confidence),
+          recommended_action: {
+            type: "review_inspection_template_suggestions",
+            label: "Review inspection template suggestions",
+            details: "Review suggestions in Shop Boost. This is advisory only and does not auto-create templates.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  if ((evidence.suggestionsSummary.menuItemHighConfidenceCount ?? 0) > 0) {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_high_confidence_menu_items",
+          title: "Review high-confidence menu item suggestions",
+          summary: `${evidence.suggestionsSummary.menuItemHighConfidenceCount} high-confidence menu item suggestion(s) are ready for owner/admin review.`,
+          priority: "normal",
+          risk_tier: "low",
+          confidence: Math.max(0.8, evidence.confidence),
+          recommended_action: {
+            type: "review_menu_item_suggestions",
+            label: "Review menu item suggestions",
+            details: "Review suggestions in Shop Boost. This is advisory only and does not auto-create menu items.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  if ((evidence.suggestionsSummary.reviewNeededCount ?? 0) > 0) {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_low_confidence_suggestions",
+          title: "Review low-confidence Shop Boost suggestions",
+          summary: `${evidence.suggestionsSummary.reviewNeededCount} suggestion(s) still need manual review before any manual materialization decisions.`,
+          priority: "high",
+          risk_tier: "medium",
+          confidence: 0.78,
+          recommended_action: {
+            type: "review_shop_boost_readiness",
+            label: "Review Shop Boost readiness",
+            details: "Review low-confidence records and blockers in the existing Shop Boost review UI.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  if (evidence.readinessStatus === "BLOCKED" || evidence.activationStatus === "blocked" || evidence.activationStatus === "not_eligible") {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_day_one_readiness_gaps",
+          title: "Review Shop Boost day-one readiness gaps",
+          summary: "Activation/readiness signals indicate unresolved setup blockers that should be reviewed by an owner/admin.",
+          priority: "high",
+          risk_tier: "high",
+          confidence: 0.85,
+          recommended_action: {
+            type: "review_shop_boost_readiness",
+            label: "Review readiness blockers",
+            details: "Use the Shop Boost readiness/report views to resolve blockers. No automatic activation changes are performed.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  if ((evidence.roiImpactSummary.estimatedMonthlyImpact ?? 0) > 0) {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_roi_opportunities",
+          title: "Review Shop Boost ROI opportunities",
+          summary: `Shop Boost estimated potential monthly impact of $${Math.round(evidence.roiImpactSummary.estimatedMonthlyImpact ?? 0).toLocaleString()} from operational improvements.`,
+          priority: "normal",
+          risk_tier: "low",
+          confidence: clampConfidence(evidence.roiImpactSummary.confidence ?? evidence.confidence),
+          recommended_action: {
+            type: "review_roi_opportunities",
+            label: "Review ROI opportunities",
+            details: "Review impact assumptions and prioritize internal onboarding follow-through tasks.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  if (evidence.staleOrUnscopedSuggestionWarnings.length > 0) {
+    recs.push(
+      recommendationBase({
+        evidence,
+        evidenceSnapshotId,
+        recommendation: {
+          recommendation_type: "shop_boost_review_stale_or_unscoped_suggestions",
+          title: "Review stale or unscoped Shop Boost suggestions",
+          summary: "Suggestion freshness/scoping warnings were detected and should be confirmed before acting on recommendations.",
+          priority: "normal",
+          risk_tier: "medium",
+          confidence: 0.74,
+          recommended_action: {
+            type: "review_shop_boost_readiness",
+            label: "Review suggestion freshness",
+            details: "Confirm suggestion freshness and scope in Shop Boost review surfaces before any manual follow-up.",
+          },
+          side_effects: [],
+          requires_approval: false,
+        },
+      }),
+    );
+  }
+
+  return recs;
+}

--- a/features/ai/server/domains/shopBoost/types.ts
+++ b/features/ai/server/domains/shopBoost/types.ts
@@ -1,0 +1,93 @@
+import type { AiRecommendationPriority, AiRiskTier } from "@/features/ai/server/types";
+
+export const SHOP_BOOST_RULES_VERSION = "shop_boost_rules_v1";
+
+export type ShopBoostRecommendationKind =
+  | "shop_boost_review_unresolved_import_links"
+  | "shop_boost_review_high_confidence_inspection_templates"
+  | "shop_boost_review_high_confidence_menu_items"
+  | "shop_boost_review_low_confidence_suggestions"
+  | "shop_boost_review_day_one_readiness_gaps"
+  | "shop_boost_review_roi_opportunities"
+  | "shop_boost_review_stale_or_unscoped_suggestions";
+
+export type ShopBoostRecommendationRisk = AiRiskTier;
+
+export type ShopBoostAiEvidence = {
+  shopId: string;
+  intakeId: string;
+  sourceRunId: string | null;
+  activationStatus: string | null;
+  readinessStatus: string | null;
+  generatedAt: string;
+  confidence: number;
+  confidenceSummary: {
+    trustScore: number | null;
+    trustMessage: string | null;
+    confidenceScore: number | null;
+  };
+  linkageSummary: {
+    customersLinked: number | null;
+    vehiclesLinked: number | null;
+    workOrdersLinked: number | null;
+    invoicesLinked: number | null;
+    unresolvedCustomers: number | null;
+    unresolvedVehicles: number | null;
+    unresolvedWorkOrders: number | null;
+    unresolvedInvoices: number | null;
+  };
+  suggestionsSummary: {
+    inspectionTemplateSuggestions: number | null;
+    inspectionTemplateHighConfidenceCount: number | null;
+    menuItemSuggestions: number | null;
+    menuItemHighConfidenceCount: number | null;
+    staffSuggestions: number | null;
+    customerSuggestions: number | null;
+    historySuggestions: number | null;
+    highConfidenceCount: number;
+    reviewNeededCount: number;
+  };
+  roiImpactSummary: {
+    estimatedMonthlyImpact: number | null;
+    approvalSpeedGain: number | null;
+    laborRecoveryHours: number | null;
+    partsLeakageReduction: number | null;
+    confidence: number | null;
+  };
+  unresolvedDataCategories: string[];
+  staleOrUnscopedSuggestionWarnings: string[];
+  sourceRefs: Array<{ table: string; id?: string; path?: string; field?: string }>;
+  missingData: string[];
+};
+
+export type ShopBoostPostActivationRecommendation = {
+  recommendation_type: ShopBoostRecommendationKind;
+  title: string;
+  summary: string;
+  priority: AiRecommendationPriority;
+  confidence: number;
+  risk_tier: ShopBoostRecommendationRisk;
+  evidence_snapshot_id: string;
+  missing_data: string[];
+  recommended_action: {
+    type:
+      | "review_import_linkage"
+      | "review_inspection_template_suggestions"
+      | "review_menu_item_suggestions"
+      | "review_shop_boost_readiness"
+      | "review_roi_opportunities";
+    label: string;
+    details: string;
+  };
+  side_effects: [];
+  requires_approval: false;
+  metadata: {
+    intakeId: string;
+    sourceRunId: string | null;
+    recommendationKind: ShopBoostRecommendationKind;
+    advisory_only: true;
+    rule_version: string;
+  };
+  source: "shop_boost_post_activation_rules";
+  expires_at: string;
+};

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -9,3 +9,5 @@ export * from "./safeActions";
 export * from "./domains/workOrders";
 export * from "./dashboard";
 export * from "./maintenance";
+
+export * from "./domains/shopBoost";

--- a/features/dashboard/widgets/AiMissionControlWidget.tsx
+++ b/features/dashboard/widgets/AiMissionControlWidget.tsx
@@ -7,6 +7,8 @@ import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fall
 
 type RecommendationItem = {
   id: string;
+  domain: "work_orders" | "shop_boost";
+  domainLabel: "Work order" | "Shop Boost";
   title: string;
   summary: string | null;
   status: "open" | "acknowledged";
@@ -142,6 +144,9 @@ export default function AiMissionControlWidget() {
                   <span className={`rounded-full border px-2 py-0.5 text-[10px] uppercase ${riskClass(item.riskTier)}`}>
                     {item.riskTier} risk
                   </span>
+                  <span className="rounded-full border border-cyan-400/30 px-2 py-0.5 text-[10px] uppercase text-cyan-100">
+                    {item.domainLabel}
+                  </span>
                   <span className="rounded-full border border-white/15 px-2 py-0.5 text-[10px] uppercase text-neutral-300">
                     {statusLabel(item.status)}
                   </span>
@@ -152,7 +157,7 @@ export default function AiMissionControlWidget() {
                   <span>{confidenceLabel(item.confidence)}</span>
                   {item.href ? (
                     <Link href={item.href} className="text-[var(--brand-primary)] transition hover:opacity-80">
-                      View work order →
+                      {item.domain === "shop_boost" ? "Open Shop Boost review →" : "View work order →"}
                     </Link>
                   ) : null}
                 </div>


### PR DESCRIPTION
### Motivation

- Surface high-value post-activation Shop Boost guidance into the canonical AI substrate so Owner/Admin Mission Control can show the same lifecycle, evidence, expiration, and audit context used by other AI recommendations.
- Keep Shop Boost UI/behavior unchanged and preserve recommendation-first, advisory-only safety constraints (no auto-materialization or other side effects).

### Description

- Added a new Shop Boost AI domain bridge under `features/ai/server/domains/shopBoost/` with typed evidence shapes, deterministic evidence snapshot builder (`createShopBoostPostActivationEvidenceSnapshot`), recommendation rules (`buildShopBoostPostActivationRecommendations`), duplicate-prevention, and preview-only payload mapper.
- Added a safe, shop-scoped API at `app/api/shop-boost/ai/recommendations/route.ts` exposing `GET` (list canonical shop_boost recs) and `POST` (generate evidence + recommendations) with role/capability gating and no Shop Boost materialization.
- Wired Mission Control to include both `work_orders` and `shop_boost` domains, added domain labels and safe href behavior, and updated the dashboard widget to show domain chips and a Shop Boost review link when applicable.
- Exported the new domain from the AI server barrel (`features/ai/server/index.ts`) and added focused unit tests for evidence building and recommendation rules under `features/ai/server/domains/shopBoost/`.
- Migration: None (no DB migrations created or applied).

### Testing

- Ran TypeScript validation with `npx tsc --noEmit`, which succeeded.
- Ran the test suite with `npm test` (Vitest); unit tests executed and passed (all tests in the run succeeded).
- Verified that new Shop Boost domain files and Mission Control changes compile and that recommendation rules/unit tests exercise advisory-only behaviour (no materialization or mutation paths invoked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba51d6e848328a4964e33c2db04fd)