### PR TITLE
Add read-only AI action preview approval request flow

### DIFF
--- a/app/api/ai/action-previews/[previewId]/approval-request/route.ts
+++ b/app/api/ai/action-previews/[previewId]/approval-request/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { requestAiActionPreviewApproval } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type ApprovalRequestBody = {
+  reason?: string;
+  ownerPinProofRef?: unknown;
+  expiresAt?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseBody(value: unknown): ApprovalRequestBody {
+  if (value == null) return {};
+  if (!isObject(value)) {
+    throw new Error("invalid request body");
+  }
+
+  const reason = typeof value.reason === "string" ? value.reason.trim() : undefined;
+  const ownerPinProofRef = value.ownerPinProofRef;
+  const expiresAt = typeof value.expiresAt === "string" ? value.expiresAt : undefined;
+
+  return {
+    reason: reason && reason.length > 0 ? reason : undefined,
+    ownerPinProofRef,
+    expiresAt,
+  };
+}
+
+function mapStatusFromError(message: string): number {
+  if (message === "action preview not found") return 404;
+  if (
+    message.includes("cannot request approval") ||
+    message.includes("terminal state") ||
+    message.includes("does not require approval")
+  ) {
+    return 409;
+  }
+  if (message.includes("owner PIN proof") || message.includes("invalid request body") || message.includes("invalid expiresAt")) {
+    return 400;
+  }
+  return 500;
+}
+
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ previewId: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { previewId } = await context.params;
+  if (!previewId) {
+    return NextResponse.json({ error: "Missing preview id" }, { status: 400 });
+  }
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) {
+    return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+  }
+
+  let parsedBody: ApprovalRequestBody;
+  try {
+    parsedBody = parseBody(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  try {
+    const result = await requestAiActionPreviewApproval(access.supabase, actor, {
+      previewId,
+      reason: parsedBody.reason,
+      ownerPinProofRef: parsedBody.ownerPinProofRef as never,
+      expiresAt: parsedBody.expiresAt,
+    });
+
+    return NextResponse.json(result, { status: result.created ? 201 : 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to request approval";
+    return NextResponse.json({ error: message }, { status: mapStatusFromError(message) });
+  }
+}

--- a/features/ai/server/actionApprovals.requestPreview.test.ts
+++ b/features/ai/server/actionApprovals.requestPreview.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AI_ACTION_EVENT_TYPES } from "./eventTypes";
+import * as types from "./types";
+
+const getAiActionPreviewMock = vi.fn();
+const logAiActionEventMock = vi.fn();
+const assertAiOwnerPinProofReferenceMock = vi.fn((value: unknown, _args?: unknown) => value);
+
+vi.mock("./actionPreviews", () => ({
+  getAiActionPreview: (...args: unknown[]) => getAiActionPreviewMock.apply(null, args),
+}));
+
+vi.mock("./actionEvents", () => ({
+  logAiActionEvent: (...args: unknown[]) => logAiActionEventMock.apply(null, args),
+}));
+
+vi.mock("./ownerPinProof", () => ({
+  assertAiOwnerPinProofReference: (value: unknown, args?: unknown) =>
+    assertAiOwnerPinProofReferenceMock(value, args),
+}));
+
+import { requestAiActionPreviewApproval } from "./actionApprovals";
+import { assertAiActionCanExecute } from "./safeActions";
+
+const BASE_ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
+
+function buildPreview(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "pv_1",
+    shop_id: "shop_1",
+    recommendation_id: "rec_1",
+    domain: "work_orders",
+    action_type: "demo",
+    subject_type: "work_order",
+    subject_id: "wo_1",
+    status: "approval_required",
+    preview_payload: {},
+    intended_mutations: [],
+    affected_records: [],
+    side_effects: [],
+    compensation_plan: {},
+    idempotency_key: null,
+    requires_approval: true,
+    requires_owner_pin: false,
+    risk_tier: "medium",
+    evidence_snapshot_id: null,
+    created_by: "actor_1",
+    created_at: "2026-04-24T00:00:00.000Z",
+    updated_at: "2026-04-24T00:00:00.000Z",
+    expires_at: null,
+    metadata: {},
+    ...overrides,
+  } as never;
+}
+
+function mockFromTable(args: {
+  pending?: Record<string, unknown> | null;
+  inserted?: Record<string, unknown>;
+}) {
+  return vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+    if (table !== "ai_action_approvals") {
+      throw new Error(`unexpected table ${table}`);
+    }
+
+    return {
+      select() {
+        return this;
+      },
+      eq() {
+        return this;
+      },
+      order() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      maybeSingle: async () => ({ data: (args.pending ?? null) as never, error: null }),
+      insert(payload: unknown) {
+        return {
+          select() {
+            return this;
+          },
+          single: async () => ({
+            data: {
+              id: "appr_1",
+              shop_id: "shop_1",
+              action_preview_id: "pv_1",
+              status: "pending",
+              requested_by: "actor_1",
+              requested_at: "2026-04-24T00:00:00.000Z",
+              decided_by: null,
+              decided_at: null,
+              decision_note: null,
+              owner_pin_required: false,
+              owner_pin_verified: false,
+              owner_pin_verification_ref: null,
+              expires_at: null,
+              metadata: payload as never,
+              ...args.inserted,
+            } as never,
+            error: null,
+          }),
+        };
+      },
+    } as never;
+  });
+}
+
+describe("requestAiActionPreviewApproval", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getAiActionPreviewMock.mockReset();
+    logAiActionEventMock.mockReset();
+    assertAiOwnerPinProofReferenceMock.mockReset();
+    assertAiOwnerPinProofReferenceMock.mockImplementation((value: unknown) => value);
+  });
+
+  it("creates a pending approval for an approval-required preview", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview());
+    mockFromTable({});
+
+    const result = await requestAiActionPreviewApproval({} as never, BASE_ACTOR, { previewId: "pv_1" });
+
+    expect(result.created).toBe(true);
+    expect(result.executionBlocked).toBe(true);
+    expect(result.approval.status).toBe("pending");
+    expect(logAiActionEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ eventType: AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_REQUESTED }),
+    );
+  });
+
+  it("returns existing pending approval and avoids duplicates", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview());
+    mockFromTable({
+      pending: {
+        id: "appr_existing",
+        action_preview_id: "pv_1",
+        status: "pending",
+      },
+    });
+
+    const result = await requestAiActionPreviewApproval({} as never, BASE_ACTOR, { previewId: "pv_1" });
+
+    expect(result.created).toBe(false);
+    expect(result.approval.id).toBe("appr_existing");
+    expect(logAiActionEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects low-risk preview when approval is not required", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview({ requires_approval: false, risk_tier: "low", preview_payload: {}, metadata: {} }));
+    mockFromTable({});
+
+    await expect(requestAiActionPreviewApproval({} as never, BASE_ACTOR, { previewId: "pv_1" })).rejects.toThrow(
+      "does not require approval",
+    );
+  });
+
+  it("rejects terminal preview states", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview({ status: "executed" }));
+    mockFromTable({});
+
+    await expect(requestAiActionPreviewApproval({} as never, BASE_ACTOR, { previewId: "pv_1" })).rejects.toThrow(
+      "terminal state",
+    );
+  });
+
+  it("rejects cross-shop lookup via scoped preview fetch", async () => {
+    getAiActionPreviewMock.mockResolvedValue(null);
+    mockFromTable({});
+
+    await expect(requestAiActionPreviewApproval({} as never, BASE_ACTOR, { previewId: "pv_other" })).rejects.toThrow(
+      "not found",
+    );
+  });
+
+  it("rejects missing owner PIN proof when required", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview({ requires_owner_pin: true }));
+    mockFromTable({});
+
+    await expect(requestAiActionPreviewApproval({} as never, BASE_ACTOR, { previewId: "pv_1" })).rejects.toThrow(
+      "owner PIN proof is required",
+    );
+  });
+
+  it("rejects owner PIN proof shop/actor mismatch", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview({ requires_owner_pin: true }));
+    mockFromTable({});
+    assertAiOwnerPinProofReferenceMock.mockImplementationOnce(() => {
+      throw new Error("owner PIN proof reference actor mismatch");
+    });
+
+    await expect(
+      requestAiActionPreviewApproval({} as never, BASE_ACTOR, {
+        previewId: "pv_1",
+        ownerPinProofRef: { proofType: "owner_pin_attestation" } as never,
+      }),
+    ).rejects.toThrow("invalid owner PIN proof reference");
+  });
+
+  it("stores owner PIN proof as metadata reference only", async () => {
+    getAiActionPreviewMock.mockResolvedValue(buildPreview({ requires_owner_pin: true }));
+    const fromTableSpy = mockFromTable({});
+
+    const proofRef = {
+      proofType: "owner_pin_attestation",
+      shopId: "shop_1",
+      actorId: "actor_1",
+      purpose: "ai_action_approval_high_risk",
+      verifiedAt: "2026-04-24T10:00:00.000Z",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      verificationRef: "verify_1",
+    };
+
+    await requestAiActionPreviewApproval({} as never, BASE_ACTOR, {
+      previewId: "pv_1",
+      ownerPinProofRef: proofRef as never,
+    });
+
+    const approvalsTableCalls = fromTableSpy.mock.calls.filter((entry) => entry[1] === "ai_action_approvals");
+    expect(approvalsTableCalls.length).toBeGreaterThan(0);
+    expect(logAiActionEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ eventType: AI_ACTION_EVENT_TYPES.OWNER_PIN_PROOF_ATTACHED }),
+    );
+  });
+
+  it("keeps execution blocked even after approval request exists", async () => {
+    const result = await assertAiActionCanExecute(
+      {} as never,
+      BASE_ACTOR,
+      { actionPreviewId: "pv_1" },
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it("includes action approval requested in event taxonomy", () => {
+    expect(AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_REQUESTED).toBe("action_approval.requested");
+  });
+});

--- a/features/ai/server/actionApprovals.ts
+++ b/features/ai/server/actionApprovals.ts
@@ -1,6 +1,7 @@
 import type { Json } from "@shared/types/types/supabase";
 import {
   type AiActionApprovalRecord,
+  type AiActionPreviewStatus,
   type AiActionApprovalStatus,
   type AiActionPreviewRecord,
   type AiActorContext,
@@ -69,6 +70,205 @@ function withOwnerPinProofRefInMetadata(input: {
   return {
     ...metadata,
     ownerPinProofRef: proofRef as unknown as Json,
+  };
+}
+
+const APPROVAL_REQUEST_ELIGIBLE_PREVIEW_STATUSES: ReadonlySet<AiActionPreviewStatus> = new Set([
+  "ready",
+  "approval_required",
+]);
+
+const APPROVAL_REQUEST_TERMINAL_PREVIEW_STATUSES: ReadonlySet<AiActionPreviewStatus> = new Set([
+  "approved",
+  "rejected",
+  "expired",
+  "executed",
+  "cancelled",
+  "failed",
+]);
+
+function parseApprovalHintFromPreview(preview: AiActionPreviewRecord): { requiresApproval: boolean } {
+  if (preview.requires_approval) {
+    return { requiresApproval: true };
+  }
+
+  if (preview.risk_tier === "high" || preview.risk_tier === "critical") {
+    return { requiresApproval: true };
+  }
+
+  const previewPayload = normalizeObjectJson(preview.preview_payload) as Record<string, Json>;
+  if (previewPayload.requires_approval === true) {
+    return { requiresApproval: true };
+  }
+
+  const metadata = normalizeObjectJson(preview.metadata) as Record<string, Json>;
+  if (metadata.approval_required === true || metadata.requires_approval === true) {
+    return { requiresApproval: true };
+  }
+
+  return { requiresApproval: false };
+}
+
+export type RequestAiActionPreviewApprovalResult = {
+  approval: AiActionApprovalRecord;
+  preview: AiActionPreviewRecord;
+  created: boolean;
+  executionBlocked: true;
+  warnings: string[];
+};
+
+export async function requestAiActionPreviewApproval(
+  supabase: AiServerClient,
+  actor: AiActorContext,
+  input: {
+    previewId: string;
+    ownerPinProofRef?: AiOwnerPinProofReference;
+    reason?: string | null;
+    expiresAt?: string | null;
+  },
+): Promise<RequestAiActionPreviewApprovalResult> {
+  const ctx = ensureActorContext(actor);
+  const preview = await getAiActionPreview(supabase, ctx, input.previewId);
+  if (!preview) throw new Error("action preview not found");
+
+  if (APPROVAL_REQUEST_TERMINAL_PREVIEW_STATUSES.has(preview.status)) {
+    throw new Error("action preview is in a terminal state");
+  }
+  if (!APPROVAL_REQUEST_ELIGIBLE_PREVIEW_STATUSES.has(preview.status)) {
+    throw new Error(`action preview status ${preview.status} cannot request approval`);
+  }
+
+  const approvalHint = parseApprovalHintFromPreview(preview);
+  if (!approvalHint.requiresApproval) {
+    throw new Error("action preview does not require approval");
+  }
+
+  let ownerPinProofRef: AiOwnerPinProofReference | null = null;
+  if (input.ownerPinProofRef) {
+    try {
+      ownerPinProofRef = assertAiOwnerPinProofReference(input.ownerPinProofRef, {
+        expectedShopId: ctx.shopId,
+        expectedActorId: ctx.actorId,
+      });
+    } catch {
+      await logAiActionEvent(supabase, ctx, {
+        recommendationId: preview.recommendation_id,
+        actionPreviewId: preview.id,
+        eventType: AI_ACTION_EVENT_TYPES.OWNER_PIN_PROOF_INVALID,
+        payload: {
+          action_preview_id: preview.id,
+          approval_request_only: true,
+        },
+      });
+      throw new Error("invalid owner PIN proof reference");
+    }
+  }
+
+  if (preview.requires_owner_pin && !ownerPinProofRef) {
+    await logAiActionEvent(supabase, ctx, {
+      recommendationId: preview.recommendation_id,
+      actionPreviewId: preview.id,
+      eventType: AI_ACTION_EVENT_TYPES.OWNER_PIN_PROOF_MISSING,
+      payload: {
+        action_preview_id: preview.id,
+        approval_request_only: true,
+      },
+    });
+    throw new Error("owner PIN proof is required before requesting approval");
+  }
+
+  const { data: existingPending, error: existingPendingError } = await fromTable(supabase, "ai_action_approvals")
+    .select("*")
+    .eq("shop_id", ctx.shopId)
+    .eq("action_preview_id", preview.id)
+    .eq("status", "pending")
+    .order("requested_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<AiActionApprovalRecord>();
+
+  if (existingPendingError) throw new Error(existingPendingError.message);
+  if (existingPending) {
+    return {
+      approval: existingPending,
+      preview,
+      created: false,
+      executionBlocked: true,
+      warnings: [],
+    };
+  }
+
+  const now = new Date().toISOString();
+  const expiresAt = input.expiresAt ?? null;
+  if (expiresAt && Number.isNaN(Date.parse(expiresAt))) {
+    throw new Error("invalid expiresAt");
+  }
+
+  const metadata = withOwnerPinProofRefInMetadata({
+    metadata: {
+      requestedByActorId: ctx.actorId,
+      requestedAt: now,
+      reason: input.reason ?? null,
+      approvalRequestOnly: true,
+      executionBlocked: true,
+    },
+    ownerPinProofRef: ownerPinProofRef ?? undefined,
+    shopId: ctx.shopId,
+    actorId: ctx.actorId,
+    ownerPinRequired: preview.requires_owner_pin,
+  });
+
+  const { data: approval, error: insertError } = await fromTable(supabase, "ai_action_approvals")
+    .insert({
+      shop_id: ctx.shopId,
+      action_preview_id: preview.id,
+      status: "pending",
+      requested_by: ctx.actorId,
+      owner_pin_required: preview.requires_owner_pin,
+      owner_pin_verified: false,
+      owner_pin_verification_ref: ownerPinProofRef?.verificationRef ?? null,
+      expires_at: expiresAt,
+      metadata,
+    })
+    .select("*")
+    .single<AiActionApprovalRecord>();
+
+  if (insertError) throw new Error(insertError.message);
+
+  if (ownerPinProofRef) {
+    await logAiActionEvent(supabase, ctx, {
+      recommendationId: preview.recommendation_id,
+      actionPreviewId: preview.id,
+      approvalId: approval.id,
+      eventType: AI_ACTION_EVENT_TYPES.OWNER_PIN_PROOF_ATTACHED,
+      payload: {
+        action_preview_id: preview.id,
+        approval_id: approval.id,
+        proof_purpose: ownerPinProofRef.purpose,
+      },
+    });
+  }
+
+  await logAiActionEvent(supabase, ctx, {
+    recommendationId: preview.recommendation_id,
+    actionPreviewId: preview.id,
+    approvalId: approval.id,
+    eventType: AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_REQUESTED,
+    payload: {
+      action_preview_id: preview.id,
+      approval_id: approval.id,
+      approval_request_only: true,
+      execution_blocked: true,
+      owner_pin_required: preview.requires_owner_pin,
+      reason: input.reason ?? null,
+    },
+  });
+
+  return {
+    approval,
+    preview,
+    created: true,
+    executionBlocked: true,
+    warnings: [],
   };
 }
 

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -53,6 +53,7 @@ type PreviewPayloadRecord = {
 type PreviewRow = {
   id: string;
   recommendation_id: string | null;
+  status: string;
   preview_payload: PreviewPayloadRecord;
   intended_mutations: unknown[];
   affected_records: Array<{ type?: string; id?: string }>;
@@ -62,6 +63,13 @@ type PreviewRow = {
   risk_tier: string;
   evidence_snapshot_id: string | null;
   created_at: string;
+};
+
+type ApprovalRow = {
+  id: string;
+  action_preview_id: string;
+  status: string;
+  requested_at: string;
 };
 
 type AdvisorDraftSection = {
@@ -99,6 +107,7 @@ function parsePreview(raw: unknown): PreviewRow | null {
   return {
     id: value.id,
     recommendation_id: typeof value.recommendation_id === "string" ? value.recommendation_id : null,
+    status: typeof value.status === "string" ? value.status : "draft",
     preview_payload: previewPayload,
     intended_mutations: Array.isArray(value.intended_mutations) ? value.intended_mutations : [],
     affected_records: Array.isArray(value.affected_records) ? (value.affected_records as Array<{ type?: string; id?: string }>) : [],
@@ -120,6 +129,8 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [previewLoadingId, setPreviewLoadingId] = useState<string | null>(null);
   const [previewByRecommendationId, setPreviewByRecommendationId] = useState<Record<string, PreviewRow>>({});
+  const [approvalByPreviewId, setApprovalByPreviewId] = useState<Record<string, ApprovalRow>>({});
+  const [approvalRequestLoadingByPreviewId, setApprovalRequestLoadingByPreviewId] = useState<Record<string, boolean>>({});
   const [advisorDraft, setAdvisorDraft] = useState<AdvisorDraft | null>(null);
   const [advisorDraftLoading, setAdvisorDraftLoading] = useState(false);
   const [advisorDraftRefreshing, setAdvisorDraftRefreshing] = useState(false);
@@ -277,6 +288,55 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
     [workOrderId],
   );
 
+  const onRequestApproval = useCallback(
+    async (preview: PreviewRow) => {
+      if (preview.requires_owner_pin) {
+        toast.info("Owner PIN proof required before approval request.");
+        return;
+      }
+
+      setApprovalRequestLoadingByPreviewId((prev) => ({ ...prev, [preview.id]: true }));
+      setError(null);
+
+      try {
+        const res = await fetch(`/api/ai/action-previews/${preview.id}/approval-request`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            reason: "Requested from work order AI operational recommendations UI",
+          }),
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json?.error ?? "Failed to request approval.");
+
+        const approval = json?.approval as ApprovalRow | undefined;
+        if (!approval?.id) {
+          throw new Error("Approval request response was invalid.");
+        }
+
+        setApprovalByPreviewId((prev) => ({
+          ...prev,
+          [preview.id]: approval,
+        }));
+
+        if (json?.created === false) {
+          toast.success("Pending approval already exists.");
+        } else {
+          toast.success("Approval request submitted.");
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to request approval.";
+        setError(message);
+        toast.error(message);
+      } finally {
+        setApprovalRequestLoadingByPreviewId((prev) => ({ ...prev, [preview.id]: false }));
+      }
+    },
+    [],
+  );
+
   const freshnessLabel = useMemo(() => {
     if (!evidence?.freshness_at) return "No evidence snapshot yet";
     return `Evidence freshness: ${new Date(evidence.freshness_at).toLocaleString()}`;
@@ -414,9 +474,46 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                     <p className="mt-1">Side effects: {preview.side_effects.length > 0 ? preview.side_effects.join(" • ") : "No external side effects"}</p>
                     <p className="mt-1">Approval required: {preview.requires_approval ? "Yes" : "No"}</p>
                     <p className="mt-1">Owner PIN required: {preview.requires_owner_pin ? "Yes" : "No"}</p>
+                    <p className="mt-1">Execution blocked: Yes</p>
                     <p className="mt-1">Risk tier: {preview.risk_tier}</p>
                     <p className="mt-1">Execution status: Execution blocked — preview only</p>
                     <p className="mt-1">Evidence snapshot: {preview.evidence_snapshot_id ?? preview.preview_payload.evidence_snapshot_id ?? "Not linked"}</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-1">
+                      {(preview.requires_approval || preview.risk_tier === "high" || preview.risk_tier === "critical") ? (
+                        <>
+                          <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[9px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+                            approval required
+                          </span>
+                          {preview.requires_owner_pin ? (
+                            <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[9px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+                              owner PIN required
+                            </span>
+                          ) : null}
+                          <span className="rounded-full border border-white/20 px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted-foreground">
+                            execution blocked
+                          </span>
+                        </>
+                      ) : null}
+                    </div>
+                    {(preview.status === "ready" || preview.status === "approval_required") &&
+                    (preview.requires_approval || preview.risk_tier === "high" || preview.risk_tier === "critical") ? (
+                      <div className="mt-2">
+                        <button
+                          type="button"
+                          className="rounded-md border border-[rgba(184,115,51,0.5)] px-2 py-1 text-[11px] text-[rgba(184,115,51,0.95)] transition hover:bg-[rgba(184,115,51,0.12)] disabled:opacity-50"
+                          disabled={Boolean(approvalRequestLoadingByPreviewId[preview.id]) || preview.requires_owner_pin}
+                          onClick={() => void onRequestApproval(preview)}
+                        >
+                          {approvalRequestLoadingByPreviewId[preview.id] ? "Requesting approval…" : "Request approval"}
+                        </button>
+                        {preview.requires_owner_pin ? (
+                          <p className="mt-1 text-[10px] text-muted-foreground">Owner PIN proof required before approval request.</p>
+                        ) : null}
+                        {approvalByPreviewId[preview.id]?.status === "pending" ? (
+                          <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Pending approval request exists.</p>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
               </article>


### PR DESCRIPTION
### Motivation
- Allow requesting a canonical approval record for an existing AI action preview when the preview is approval-required or high-risk while keeping execution blocked and avoiding any business-record mutations or automatic execution.

### Description
- Added `requestAiActionPreviewApproval` helper in `features/ai/server/actionApprovals.ts` that loads the preview, enforces same-shop scope, verifies preview lifecycle eligibility (`ready`/`approval_required` only), detects approval-required via preview flags/risk/metadata, validates optional owner PIN proof references, prevents duplicate open `pending` approvals, inserts a canonical `ai_action_approvals` row with safe metadata, and logs canonical AI action events.
- Added a shop-scoped POST API route at `app/api/ai/action-previews/[previewId]/approval-request/route.ts` that enforces auth/role/capability gating, parses input (`reason`, `ownerPinProofRef`, `expiresAt`), calls the canonical helper, and returns safe HTTP statuses (400/401/403/404/409/500) without executing previews.
- Updated the work-order UI at `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx` to surface approval-required / owner-PIN / execution-blocked badges and a single-safe “Request approval” button that calls the new route and shows pending state, while explicitly avoiding any execute/apply actions.
- Added unit tests `features/ai/server/actionApprovals.requestPreview.test.ts` covering creation of pending approvals, duplicate prevention, non-approval rejection, terminal-state rejection, cross-shop rejection, owner PIN proof requirements and metadata handling, and validation that execution remains blocked.

### Testing
- Ran `npx tsc --noEmit` and TypeScript validation passed (non-fatal npm env warning only). 
- Ran `npm test` (Vitest) and the test suite passed: 19 test files, 75 tests succeeded (including the new approval-request tests).
- Executed the new unit tests for approval request behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb47d76c08328b7f9cb71d99b3dba)