### PR TITLE
Add AI Recommendations review center and read-only API

### DIFF
--- a/app/api/dashboard/ai-recommendations/route.ts
+++ b/app/api/dashboard/ai-recommendations/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { listAiRecommendationsForReview } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+function parseBooleanFilter(value: string | null): "all" | boolean {
+  if (!value || value === "all") return "all";
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return "all";
+}
+
+export async function GET(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+
+  if (!access.ok) return access.response;
+
+  try {
+    const url = new URL(request.url);
+    const params = url.searchParams;
+
+    const domain = params.get("domain") ?? "all";
+    const status = params.get("status") ?? "all";
+    const risk = params.get("risk") ?? "all";
+    const missingData = parseBooleanFilter(params.get("missingData"));
+    const hasPreview = parseBooleanFilter(params.get("hasPreview"));
+    const requiresApproval = parseBooleanFilter(params.get("requiresApproval"));
+    const search = params.get("search") ?? undefined;
+    const createdFrom = params.get("createdFrom") ?? undefined;
+    const createdTo = params.get("createdTo") ?? undefined;
+    const cursor = params.get("cursor");
+    const limit = Number.parseInt(params.get("limit") ?? "25", 10);
+
+    const shopId = access.profile.shop_id;
+    if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+    const result = await listAiRecommendationsForReview({
+      supabase: access.supabase,
+      actorContext: {
+        shopId,
+        actorId: access.profile.id,
+        role: access.profile.role,
+        source: "manual",
+      },
+      filters: {
+        domain: domain as "all" | "work_orders" | "shop_boost",
+        status: status as "all" | "open" | "acknowledged" | "resolved" | "dismissed" | "expired" | "superseded",
+        risk: risk as "all" | "urgent" | "high" | "medium" | "low",
+        missingData,
+        hasPreview,
+        requiresApproval,
+        search,
+        createdFrom,
+        createdTo,
+      },
+      pagination: {
+        cursor,
+        limit: Number.isFinite(limit) ? limit : 25,
+      },
+    });
+
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json({ error: "Failed to load AI recommendations" }, { status: 500 });
+  }
+}

--- a/app/dashboard/ai-recommendations/page.tsx
+++ b/app/dashboard/ai-recommendations/page.tsx
@@ -1,0 +1,17 @@
+import AiRecommendationsReviewClient from "@/features/ai/components/AiRecommendationsReviewClient";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function AiRecommendationsPage() {
+  await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
+
+  return (
+    <main className="space-y-5">
+      <section className="rounded-2xl border border-white/10 bg-black/25 px-5 py-4 backdrop-blur-xl">
+        <p className="text-[10px] uppercase tracking-[0.2em] text-neutral-500">AI Review Center</p>
+        <h1 className="mt-1 text-3xl font-semibold text-white">AI Recommendations</h1>
+        <p className="mt-1 text-sm text-neutral-300">Evidence-backed operating signals awaiting review</p>
+      </section>
+      <AiRecommendationsReviewClient />
+    </main>
+  );
+}

--- a/features/ai/components/AiRecommendationsReviewClient.tsx
+++ b/features/ai/components/AiRecommendationsReviewClient.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type RecommendationRow = {
+  id: string;
+  domain: "work_orders" | "shop_boost";
+  subjectType: string;
+  subjectId: string | null;
+  title: string;
+  summary: string | null;
+  status: "open" | "acknowledged" | "resolved" | "dismissed" | "expired" | "superseded";
+  priority: "low" | "normal" | "high" | "urgent";
+  riskTier: "low" | "medium" | "high" | "critical";
+  confidence: number | null;
+  missingDataCount: number;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+  source: string;
+  recommendationType: string;
+  recommendedActionType: string | null;
+  targetLabel: string;
+  targetHref: string | null;
+  hasPreview: boolean;
+  previewStatus: string | null;
+  pendingApprovalCount: number;
+  requiresApproval: boolean;
+};
+
+type Summary = {
+  total: number;
+  open: number;
+  acknowledged: number;
+  urgent: number;
+  high: number;
+  missingData: number;
+  pendingApprovals: number;
+  previewsReady: number;
+};
+
+type ApiResponse = {
+  items: RecommendationRow[];
+  summary: Summary;
+  nextCursor: string | null;
+};
+
+const DEFAULT_SUMMARY: Summary = {
+  total: 0,
+  open: 0,
+  acknowledged: 0,
+  urgent: 0,
+  high: 0,
+  missingData: 0,
+  pendingApprovals: 0,
+  previewsReady: 0,
+};
+
+export default function AiRecommendationsReviewClient() {
+  const [items, setItems] = useState<RecommendationRow[]>([]);
+  const [summary, setSummary] = useState<Summary>(DEFAULT_SUMMARY);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [domain, setDomain] = useState("all");
+  const [status, setStatus] = useState("all");
+  const [risk, setRisk] = useState("all");
+  const [missingData, setMissingData] = useState("all");
+  const [hasPreview, setHasPreview] = useState("all");
+  const [requiresApproval, setRequiresApproval] = useState("all");
+  const [search, setSearch] = useState("");
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams({
+      domain,
+      status,
+      risk,
+      missingData,
+      hasPreview,
+      requiresApproval,
+      limit: "25",
+    });
+
+    const trimmed = search.trim();
+    if (trimmed) params.set("search", trimmed);
+
+    return params.toString();
+  }, [domain, status, risk, missingData, hasPreview, requiresApproval, search]);
+
+  const load = useCallback(async (nextCursor?: string | null) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const suffix = nextCursor ? `&cursor=${encodeURIComponent(nextCursor)}` : "";
+      const res = await fetch(`/api/dashboard/ai-recommendations?${queryString}${suffix}`, { cache: "no-store" });
+      const json = (await res.json().catch(() => ({}))) as Partial<ApiResponse> & { error?: string };
+      if (!res.ok) throw new Error(json.error ?? "Failed to load recommendations.");
+
+      setItems(Array.isArray(json.items) ? json.items : []);
+      setSummary(json.summary ?? DEFAULT_SUMMARY);
+      setCursor(json.nextCursor ?? null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Failed to load recommendations.");
+      setItems([]);
+      setSummary(DEFAULT_SUMMARY);
+      setCursor(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [queryString]);
+
+  useEffect(() => {
+    void load(null);
+  }, [load]);
+
+  return (
+    <section className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <SummaryCard label="Open" value={summary.open} />
+        <SummaryCard label="Urgent / High" value={summary.urgent + summary.high} />
+        <SummaryCard label="Missing data" value={summary.missingData} />
+        <SummaryCard label="Pending approvals" value={summary.pendingApprovals} />
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
+          <SelectFilter label="Domain" value={domain} onChange={setDomain} options={["all", "work_orders", "shop_boost"]} />
+          <SelectFilter label="Status" value={status} onChange={setStatus} options={["all", "open", "acknowledged", "resolved", "dismissed", "expired"]} />
+          <SelectFilter label="Risk/Priority" value={risk} onChange={setRisk} options={["all", "urgent", "high", "medium", "low"]} />
+          <SelectFilter label="Missing data" value={missingData} onChange={setMissingData} options={["all", "true", "false"]} />
+          <SelectFilter label="Has preview" value={hasPreview} onChange={setHasPreview} options={["all", "true", "false"]} />
+          <SelectFilter label="Requires approval" value={requiresApproval} onChange={setRequiresApproval} options={["all", "true", "false"]} />
+          <label className="flex flex-col gap-1 text-xs text-neutral-300 md:col-span-2">
+            Search
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search title or summary"
+              className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white outline-none ring-0 placeholder:text-neutral-500"
+            />
+          </label>
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={() => void load(null)}
+            className="rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white hover:bg-white/20"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {loading ? <p className="text-sm text-neutral-400">Loading AI recommendations…</p> : null}
+      {error ? <p className="rounded-xl border border-red-400/30 bg-red-950/20 p-3 text-sm text-red-200">{error}</p> : null}
+
+      {!loading && !error && items.length === 0 ? (
+        <p className="rounded-2xl border border-white/10 bg-black/25 p-4 text-sm text-neutral-300">
+          No recommendations matched your filters.
+        </p>
+      ) : null}
+
+      <div className="space-y-3">
+        {items.map((item) => (
+          <article key={item.id} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] uppercase">
+              <span className="rounded-full border border-cyan-400/35 px-2 py-0.5 text-cyan-200">
+                {item.domain === "shop_boost" ? "Shop Boost" : "Work order"}
+              </span>
+              <span className="rounded-full border border-white/20 px-2 py-0.5 text-neutral-200">{item.status}</span>
+              <span className="rounded-full border border-white/20 px-2 py-0.5 text-neutral-200">{item.priority}</span>
+              <span className="rounded-full border border-white/20 px-2 py-0.5 text-neutral-200">{item.riskTier}</span>
+            </div>
+
+            <h2 className="mt-2 text-base font-semibold text-white">{item.title}</h2>
+            <p className="mt-1 text-sm text-neutral-300">{item.summary ?? "No summary provided."}</p>
+
+            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-neutral-400 md:grid-cols-4">
+              <span>Confidence: {item.confidence == null ? "—" : `${Math.round(item.confidence * 100)}%`}</span>
+              <span>Missing data: {item.missingDataCount}</span>
+              <span>Pending approvals: {item.pendingApprovalCount}</span>
+              <span>Source: {item.source}</span>
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+              <span className="text-neutral-400">Updated: {new Date(item.updatedAt).toLocaleString()}</span>
+              <span className="text-neutral-400">Type: {item.recommendationType}</span>
+              <span className="text-neutral-400">Action: {item.recommendedActionType ?? "review_only"}</span>
+              {item.previewStatus ? <span className="text-neutral-400">Preview: {item.previewStatus}</span> : null}
+              {item.targetHref ? (
+                <Link href={item.targetHref} className="text-[var(--brand-primary)] hover:opacity-80">
+                  View target →
+                </Link>
+              ) : null}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {!loading && cursor ? (
+        <button
+          type="button"
+          onClick={() => void load(cursor)}
+          className="rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white hover:bg-white/20"
+        >
+          Next page
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/30 p-3">
+      <p className="text-[10px] uppercase tracking-[0.15em] text-neutral-500">{label}</p>
+      <p className="mt-1 text-xl font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
+function SelectFilter({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-neutral-300">
+      {label}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white"
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/features/ai/server/dashboard/index.ts
+++ b/features/ai/server/dashboard/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./getAiMissionControlSummary";
+export * from "./listAiRecommendationsForReview";

--- a/features/ai/server/dashboard/listAiRecommendationsForReview.test.ts
+++ b/features/ai/server/dashboard/listAiRecommendationsForReview.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as types from "@/features/ai/server/types";
+import { listAiRecommendationsForReview } from "./listAiRecommendationsForReview";
+
+const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
+
+function mockFromTable() {
+  return vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+    if (table === "ai_recommendations") {
+      const rows = [
+        {
+          id: "rec_urgent",
+          domain: "work_orders",
+          recommendation_type: "closeout_risk",
+          subject_type: "work_order",
+          subject_id: "WO-1",
+          title: "Urgent closeout risk",
+          summary: "Needs advisor review",
+          status: "open",
+          priority: "urgent",
+          risk_tier: "critical",
+          confidence: 0.88,
+          missing_data: [{ field: "owner" }],
+          created_at: "2026-04-24T11:00:00.000Z",
+          updated_at: "2026-04-24T12:00:00.000Z",
+          expires_at: null,
+          source: "manual",
+          recommended_action: { type: "advisor_review_needed", payload: { unsafe: true } },
+          requires_approval: true,
+        },
+        {
+          id: "rec_shop_boost",
+          domain: "shop_boost",
+          recommendation_type: "activation_followup",
+          subject_type: "shop_boost_activation",
+          subject_id: null,
+          title: "Shop Boost intake follow-up",
+          summary: "Review onboarding blockers",
+          status: "acknowledged",
+          priority: "high",
+          risk_tier: "high",
+          confidence: 0.7,
+          missing_data: [],
+          created_at: "2026-04-24T10:00:00.000Z",
+          updated_at: "2026-04-24T10:30:00.000Z",
+          expires_at: null,
+          source: "ops",
+          recommended_action: { type: "review_shop_boost" },
+          requires_approval: false,
+        },
+      ];
+
+      let filtered = [...rows];
+      const query = {
+        eq(field: string, value: unknown) {
+          if (field === "status") filtered = filtered.filter((row) => row.status === value);
+          if (field === "domain") filtered = filtered.filter((row) => row.domain === value);
+          return query;
+        },
+        limit(_value: number) {
+          return query;
+        },
+        or(_value: string) {
+          return query;
+        },
+        gte(_field: string, _value: string) {
+          return query;
+        },
+        lte(_field: string, _value: string) {
+          return query;
+        },
+        then(resolve: (value: { data: unknown[]; error: null }) => void) {
+          resolve({ data: filtered, error: null });
+        },
+      };
+
+      return {
+        select: () => query,
+      } as never;
+    }
+
+    if (table === "ai_action_previews") {
+      return {
+        select: () => ({
+          eq: () => ({
+            in: async () => ({
+              data: [
+                { id: "pv_1", recommendation_id: "rec_urgent", status: "ready", requires_approval: true },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      } as never;
+    }
+
+    if (table === "ai_action_approvals") {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              in: async () => ({
+                data: [{ action_preview_id: "pv_1", status: "pending" }],
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      } as never;
+    }
+
+    throw new Error(`Unexpected table ${table}`);
+  });
+}
+
+describe("listAiRecommendationsForReview", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns safe display rows without raw action payloads", async () => {
+    mockFromTable();
+
+    const result = await listAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      pagination: { limit: 10 },
+    });
+
+    const urgent = result.items[0];
+    expect(urgent.id).toBe("rec_urgent");
+    expect(urgent.recommendedActionType).toBe("advisor_review_needed");
+    expect((urgent as unknown as Record<string, unknown>).recommended_action).toBeUndefined();
+    expect((urgent as unknown as Record<string, unknown>).snapshot).toBeUndefined();
+  });
+
+  it("filters by domain and requires approval", async () => {
+    mockFromTable();
+
+    const result = await listAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { domain: "work_orders", requiresApproval: true },
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.domain).toBe("work_orders");
+  });
+
+  it("orders open urgent recommendations first and maps safe target links", async () => {
+    mockFromTable();
+
+    const result = await listAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+    });
+
+    expect(result.items[0]?.id).toBe("rec_urgent");
+    expect(result.items[0]?.targetHref).toBe("/work-orders/WO-1");
+    expect(result.items[1]?.targetHref).toBe("/dashboard/setup/review?source=shop-boost");
+  });
+
+  it("returns safe summary and pending approvals", async () => {
+    mockFromTable();
+
+    const result = await listAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "resolved" },
+    });
+
+    expect(result.items).toHaveLength(0);
+    expect(result.summary.total).toBe(0);
+    expect(result.summary.pendingApprovals).toBe(0);
+  });
+});

--- a/features/ai/server/dashboard/listAiRecommendationsForReview.ts
+++ b/features/ai/server/dashboard/listAiRecommendationsForReview.ts
@@ -1,0 +1,351 @@
+import type { Json } from "@shared/types/types/supabase";
+import { ensureActorContext, fromTable, type AiActorContext, type AiRecommendationStatus, type AiServerClient } from "@/features/ai/server/types";
+
+export type AiReviewDomainFilter = "all" | "work_orders" | "shop_boost";
+export type AiReviewStatusFilter = AiRecommendationStatus | "all";
+export type AiReviewRiskFilter = "all" | "urgent" | "high" | "medium" | "low";
+export type AiReviewBooleanFilter = "all" | boolean;
+
+export type ListAiRecommendationsForReviewInput = {
+  supabase: AiServerClient;
+  actorContext: AiActorContext;
+  filters?: {
+    domain?: AiReviewDomainFilter;
+    status?: AiReviewStatusFilter;
+    risk?: AiReviewRiskFilter;
+    missingData?: AiReviewBooleanFilter;
+    hasPreview?: AiReviewBooleanFilter;
+    requiresApproval?: AiReviewBooleanFilter;
+    search?: string;
+    createdFrom?: string;
+    createdTo?: string;
+  };
+  pagination?: {
+    limit?: number;
+    cursor?: string | null;
+  };
+};
+
+type RecommendationRow = {
+  id: string;
+  domain: "work_orders" | "shop_boost";
+  recommendation_type: string;
+  subject_type: string;
+  subject_id: string | null;
+  title: string;
+  summary: string | null;
+  status: AiRecommendationStatus;
+  priority: "low" | "normal" | "high" | "urgent";
+  risk_tier: "low" | "medium" | "high" | "critical";
+  confidence: number | null;
+  missing_data: Json;
+  created_at: string;
+  updated_at: string;
+  expires_at: string | null;
+  source: string;
+  recommended_action: Json;
+  requires_approval: boolean;
+};
+
+type PreviewRow = {
+  id: string;
+  recommendation_id: string | null;
+  status: string;
+  requires_approval: boolean;
+};
+
+type ApprovalRow = {
+  action_preview_id: string;
+  status: string;
+};
+
+export type AiRecommendationReviewRow = {
+  id: string;
+  domain: "work_orders" | "shop_boost";
+  subjectType: string;
+  subjectId: string | null;
+  title: string;
+  summary: string | null;
+  status: AiRecommendationStatus;
+  priority: "low" | "normal" | "high" | "urgent";
+  riskTier: "low" | "medium" | "high" | "critical";
+  confidence: number | null;
+  missingDataCount: number;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+  source: string;
+  recommendationType: string;
+  recommendedActionType: string | null;
+  targetLabel: string;
+  targetHref: string | null;
+  hasPreview: boolean;
+  previewStatus: string | null;
+  pendingApprovalCount: number;
+  requiresApproval: boolean;
+};
+
+export type AiRecommendationsReviewSummary = {
+  total: number;
+  open: number;
+  acknowledged: number;
+  urgent: number;
+  high: number;
+  missingData: number;
+  pendingApprovals: number;
+  previewsReady: number;
+};
+
+export type ListAiRecommendationsForReviewResult = {
+  items: AiRecommendationReviewRow[];
+  summary: AiRecommendationsReviewSummary;
+  nextCursor: string | null;
+};
+
+function toMissingDataCount(value: Json): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function toRecommendedActionType(value: Json): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const typeValue = (value as Record<string, unknown>).type;
+  return typeof typeValue === "string" ? typeValue : null;
+}
+
+function parseCursor(cursor: string | null | undefined): number {
+  if (!cursor) return 0;
+  const parsed = Number.parseInt(cursor, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
+}
+
+function safeSearchTerm(value: string | undefined): string | null {
+  if (!value) return null;
+  const cleaned = value.trim().replace(/[,%]/g, "");
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function toTarget(row: RecommendationRow): { targetLabel: string; targetHref: string | null } {
+  if (row.subject_type === "work_order" && row.subject_id) {
+    return {
+      targetLabel: `Work order ${row.subject_id}`,
+      targetHref: `/work-orders/${row.subject_id}`,
+    };
+  }
+
+  if (row.domain === "shop_boost") {
+    return {
+      targetLabel: "Shop Boost review",
+      targetHref: "/dashboard/setup/review?source=shop-boost",
+    };
+  }
+
+  return {
+    targetLabel: row.subject_id ? `${row.subject_type} ${row.subject_id}` : row.subject_type,
+    targetHref: null,
+  };
+}
+
+function priorityRank(priority: RecommendationRow["priority"]): number {
+  if (priority === "urgent") return 0;
+  if (priority === "high") return 1;
+  if (priority === "normal") return 2;
+  return 3;
+}
+
+function statusRank(status: RecommendationRow["status"]): number {
+  if (status === "open") return 0;
+  if (status === "acknowledged") return 1;
+  if (status === "resolved") return 2;
+  if (status === "dismissed") return 3;
+  if (status === "expired") return 4;
+  return 5;
+}
+
+function riskMatchesFilter(row: RecommendationRow, riskFilter: AiReviewRiskFilter): boolean {
+  if (riskFilter === "all") return true;
+  if (riskFilter === "urgent") return row.priority === "urgent" || row.risk_tier === "critical";
+  if (riskFilter === "high") return row.priority === "high" || row.risk_tier === "high";
+  if (riskFilter === "medium") return row.priority === "normal" || row.risk_tier === "medium";
+  return row.priority === "low" || row.risk_tier === "low";
+}
+
+function formatPreviewStatus(statusCounts: Map<string, number>): string | null {
+  if (statusCounts.size === 0) return null;
+  return Array.from(statusCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([status, count]) => `${status}:${count}`)
+    .join(" • ");
+}
+
+export async function listAiRecommendationsForReview(
+  input: ListAiRecommendationsForReviewInput,
+): Promise<ListAiRecommendationsForReviewResult> {
+  const actor = ensureActorContext(input.actorContext);
+  const domainFilter = input.filters?.domain ?? "all";
+  const statusFilter = input.filters?.status ?? "all";
+  const riskFilter = input.filters?.risk ?? "all";
+  const missingDataFilter = input.filters?.missingData ?? "all";
+  const hasPreviewFilter = input.filters?.hasPreview ?? "all";
+  const requiresApprovalFilter = input.filters?.requiresApproval ?? "all";
+  const searchTerm = safeSearchTerm(input.filters?.search);
+
+  const limit = Math.max(1, Math.min(input.pagination?.limit ?? 25, 100));
+  const cursorOffset = parseCursor(input.pagination?.cursor);
+
+  let query = fromTable(input.supabase, "ai_recommendations")
+    .select("id, domain, recommendation_type, subject_type, subject_id, title, summary, status, priority, risk_tier, confidence, missing_data, created_at, updated_at, expires_at, source, recommended_action, requires_approval")
+    .eq("shop_id", actor.shopId)
+    .limit(500);
+
+  if (domainFilter !== "all") query = query.eq("domain", domainFilter);
+  if (statusFilter !== "all") query = query.eq("status", statusFilter);
+  if (searchTerm) {
+    query = query.or(`title.ilike.%${searchTerm}%,summary.ilike.%${searchTerm}%`);
+  }
+  if (input.filters?.createdFrom) query = query.gte("created_at", input.filters.createdFrom);
+  if (input.filters?.createdTo) query = query.lte("created_at", input.filters.createdTo);
+
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+
+  const allRows = (data ?? []) as RecommendationRow[];
+  const recommendationIds = allRows.map((row) => row.id);
+
+  const previewsByRecommendation = new Map<string, PreviewRow[]>();
+  const previewIds: string[] = [];
+
+  if (recommendationIds.length > 0) {
+    const { data: previewData, error: previewError } = await fromTable(input.supabase, "ai_action_previews")
+      .select("id, recommendation_id, status, requires_approval")
+      .eq("shop_id", actor.shopId)
+      .in("recommendation_id", recommendationIds);
+
+    if (!previewError) {
+      for (const preview of (previewData ?? []) as PreviewRow[]) {
+        if (!preview.recommendation_id) continue;
+        previewIds.push(preview.id);
+        const bucket = previewsByRecommendation.get(preview.recommendation_id) ?? [];
+        bucket.push(preview);
+        previewsByRecommendation.set(preview.recommendation_id, bucket);
+      }
+    }
+  }
+
+  const pendingApprovalCountByRecommendation = new Map<string, number>();
+
+  if (previewIds.length > 0) {
+    const { data: approvalData, error: approvalError } = await fromTable(input.supabase, "ai_action_approvals")
+      .select("action_preview_id, status")
+      .eq("shop_id", actor.shopId)
+      .eq("status", "pending")
+      .in("action_preview_id", previewIds);
+
+    if (!approvalError) {
+      const previewToRecommendation = new Map<string, string>();
+      for (const [recommendationId, previews] of previewsByRecommendation.entries()) {
+        for (const preview of previews) previewToRecommendation.set(preview.id, recommendationId);
+      }
+
+      for (const approval of (approvalData ?? []) as ApprovalRow[]) {
+        const recommendationId = previewToRecommendation.get(approval.action_preview_id);
+        if (!recommendationId) continue;
+        const prev = pendingApprovalCountByRecommendation.get(recommendationId) ?? 0;
+        pendingApprovalCountByRecommendation.set(recommendationId, prev + 1);
+      }
+    }
+  }
+
+  const filteredRows = allRows.filter((row) => {
+    if (!riskMatchesFilter(row, riskFilter)) return false;
+
+    const missingDataCount = toMissingDataCount(row.missing_data);
+    if (typeof missingDataFilter === "boolean") {
+      if (missingDataFilter && missingDataCount <= 0) return false;
+      if (!missingDataFilter && missingDataCount > 0) return false;
+    }
+
+    const previews = previewsByRecommendation.get(row.id) ?? [];
+    const hasPreview = previews.length > 0;
+    if (typeof hasPreviewFilter === "boolean" && hasPreview !== hasPreviewFilter) return false;
+
+    if (typeof requiresApprovalFilter === "boolean" && row.requires_approval !== requiresApprovalFilter) return false;
+
+    return true;
+  });
+
+  const sortedRows = filteredRows.sort((a, b) => {
+    const p = priorityRank(a.priority) - priorityRank(b.priority);
+    if (p !== 0) return p;
+
+    const s = statusRank(a.status) - statusRank(b.status);
+    if (s !== 0) return s;
+
+    const updatedDelta = Date.parse(b.updated_at) - Date.parse(a.updated_at);
+    if (updatedDelta !== 0) return updatedDelta;
+
+    return Date.parse(b.created_at) - Date.parse(a.created_at);
+  });
+
+  const pageRows = sortedRows.slice(cursorOffset, cursorOffset + limit + 1);
+  const hasMore = pageRows.length > limit;
+  const items = pageRows.slice(0, limit).map((row) => {
+    const previews = previewsByRecommendation.get(row.id) ?? [];
+    const previewStatusCounts = new Map<string, number>();
+    let readyPreviewCount = 0;
+
+    for (const preview of previews) {
+      previewStatusCounts.set(preview.status, (previewStatusCounts.get(preview.status) ?? 0) + 1);
+      if (preview.status === "ready") readyPreviewCount += 1;
+    }
+
+    const target = toTarget(row);
+
+    return {
+      id: row.id,
+      domain: row.domain,
+      subjectType: row.subject_type,
+      subjectId: row.subject_id,
+      title: row.title,
+      summary: row.summary,
+      status: row.status,
+      priority: row.priority,
+      riskTier: row.risk_tier,
+      confidence: row.confidence,
+      missingDataCount: toMissingDataCount(row.missing_data),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      expiresAt: row.expires_at,
+      source: row.source,
+      recommendationType: row.recommendation_type,
+      recommendedActionType: toRecommendedActionType(row.recommended_action),
+      targetLabel: target.targetLabel,
+      targetHref: target.targetHref,
+      hasPreview: previews.length > 0,
+      previewStatus: formatPreviewStatus(previewStatusCounts),
+      pendingApprovalCount: pendingApprovalCountByRecommendation.get(row.id) ?? 0,
+      requiresApproval: row.requires_approval,
+      previewsReady: readyPreviewCount,
+    };
+  });
+
+  const summary: AiRecommendationsReviewSummary = {
+    total: sortedRows.length,
+    open: sortedRows.filter((row) => row.status === "open").length,
+    acknowledged: sortedRows.filter((row) => row.status === "acknowledged").length,
+    urgent: sortedRows.filter((row) => row.priority === "urgent").length,
+    high: sortedRows.filter((row) => row.priority === "high").length,
+    missingData: sortedRows.filter((row) => toMissingDataCount(row.missing_data) > 0).length,
+    pendingApprovals: sortedRows.reduce((sum, row) => sum + (pendingApprovalCountByRecommendation.get(row.id) ?? 0), 0),
+    previewsReady: sortedRows.filter((row) => {
+      const previews = previewsByRecommendation.get(row.id) ?? [];
+      return previews.some((preview) => preview.status === "ready");
+    }).length,
+  };
+
+  return {
+    items: items.map(({ previewsReady: _unused, ...row }) => row),
+    summary,
+    nextCursor: hasMore ? String(cursorOffset + limit) : null,
+  };
+}

--- a/features/dashboard/widgets/AiMissionControlWidget.tsx
+++ b/features/dashboard/widgets/AiMissionControlWidget.tsx
@@ -93,13 +93,18 @@ export default function AiMissionControlWidget() {
       subtitle="Evidence-backed recommendations from active shop work."
       compact
       rightSlot={
-        <button
-          type="button"
-          onClick={() => void load()}
-          className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200 transition hover:bg-black/40"
-        >
-          Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          <Link href="/dashboard/ai-recommendations" className="rounded-full border border-cyan-400/35 bg-cyan-500/10 px-3 py-1 text-[11px] font-semibold text-cyan-100 transition hover:bg-cyan-500/20">
+            View all
+          </Link>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200 transition hover:bg-black/40"
+          >
+            Refresh
+          </button>
+        </div>
       }
     >
       {loading ? (


### PR DESCRIPTION
### Motivation
- Provide a safe, read/review-first dashboard surface for owners/admins/managers/advisors to browse canonical AI recommendations across domains without executing or mutating any records. 
- Surface evidence-backed signals from the existing canonical AI substrate (ai_recommendations / ai_action_previews / ai_action_approvals) while preventing raw evidence/action payload exposure and preserving tenant/shop scoping and RLS rules. 

### Description
- Add a canonical server helper `listAiRecommendationsForReview` in `features/ai/server/dashboard/` that queries `ai_recommendations` scoped to the actor's `shop_id`, supports domain/status/risk/boolean/search filters, bounded pagination, deterministic ordering, preview and pending-approval summarization, and returns display-safe rows (no snapshot JSON or intended mutation payloads). 
- Add a shop-scoped GET API route `app/api/dashboard/ai-recommendations/route.ts` that wires the helper and enforces capability/role gating via `requireShopScopedApiAccess` (roles: owner, admin, manager, advisor; capability: `canManageWorkOrders`). 
- Add dashboard page `app/dashboard/ai-recommendations/page.tsx` (server-gated by `requireAdminPageAccess`) and a client component `features/ai/components/AiRecommendationsReviewClient.tsx` for interactivity (filters, summary cards, list, safe links, refresh, paging). 
- Update AI Mission Control widget `features/dashboard/widgets/AiMissionControlWidget.tsx` to include a non-executing “View all” link to the new drill-down page. 
- Export the new helper from the dashboard module and add unit tests for `listAiRecommendationsForReview`. 
- Migration files: None.

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` (passed). 
- Ran test suite: `npm test` (Vitest); all tests passed including new unit tests for the list helper. 
- Added targeted unit tests `features/ai/server/dashboard/listAiRecommendationsForReview.test.ts` validating safe row shaping, filters, ordering, target href generation, and summary/pending-approval counts (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb7d6bc7c83288a48bff6d36a7675)