### PR TITLE
Add Vercel cron for AI stale expiration and safe scheduled GET handler

### DIFF
--- a/app/api/internal/ai/expire-stale/route.ts
+++ b/app/api/internal/ai/expire-stale/route.ts
@@ -12,6 +12,8 @@ type ExpireStaleBody = {
   limit?: unknown;
 };
 
+const DEFAULT_LIMIT = 50;
+const SCHEDULED_GET_LIMIT = 100;
 const MAX_LIMIT = 100;
 
 function parseBody(raw: ExpireStaleBody | null): { dryRun: boolean; shopId?: string; limit: number } {
@@ -21,7 +23,7 @@ function parseBody(raw: ExpireStaleBody | null): { dryRun: boolean; shopId?: str
     ? raw.shopId.trim()
     : undefined;
 
-  let limit = 50;
+  let limit = DEFAULT_LIMIT;
   if (typeof raw?.limit === "number" && Number.isFinite(raw.limit)) {
     limit = Math.max(1, Math.min(Math.floor(raw.limit), MAX_LIMIT));
   }
@@ -29,7 +31,31 @@ function parseBody(raw: ExpireStaleBody | null): { dryRun: boolean; shopId?: str
   return { dryRun, shopId, limit };
 }
 
-export async function POST(req: Request) {
+function parseBearerSecret(req: Request): string | null {
+  const authorization = req.headers.get("authorization")?.trim();
+  if (!authorization) {
+    return null;
+  }
+
+  const [scheme, token] = authorization.split(/\s+/, 2);
+  if (!scheme || !token || scheme.toLowerCase() !== "bearer") {
+    return null;
+  }
+
+  return token;
+}
+
+function isVercelCronAuthorized(req: Request): boolean {
+  const configuredSecret = process.env.INTERNAL_CRON_SECRET;
+  if (!configuredSecret) {
+    return false;
+  }
+
+  const bearerSecret = parseBearerSecret(req);
+  return !!bearerSecret && bearerSecret === configuredSecret;
+}
+
+function authorizeInternalRequest(req: Request): { ok: true } | { ok: false; response: NextResponse } {
   const internalGate = requireInternalApiSecret({
     request: req,
     envSecretName: "INTERNAL_CRON_SECRET",
@@ -37,8 +63,68 @@ export async function POST(req: Request) {
     routeLabel: "internal/ai/expire-stale",
   });
 
-  if (!internalGate.ok) {
-    return internalGate.response;
+  if (internalGate.ok || isVercelCronAuthorized(req)) {
+    return { ok: true };
+  }
+
+  return { ok: false, response: internalGate.response };
+}
+
+async function runExpiration(input: { dryRun: boolean; shopId?: string; limit: number }) {
+  const result = await expireStaleAiRecords({
+    supabase: createAdminSupabase(),
+    dryRun: input.dryRun,
+    shopId: input.shopId,
+    limit: input.limit,
+    actorContext: input.shopId
+      ? {
+        shopId: input.shopId,
+        actorId: "internal-ai-expirer",
+        role: "system",
+        source: "system",
+      }
+      : undefined,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    summary: {
+      dryRun: result.dryRun,
+      now: result.now,
+      recommendations: {
+        candidates: result.recommendations.candidates,
+        expired: result.recommendations.expired,
+      },
+      previews: {
+        candidates: result.previews.candidates,
+        expired: result.previews.expired,
+      },
+      approvals: {
+        candidates: result.approvals.candidates,
+        expired: result.approvals.expired,
+      },
+      warnings: result.warnings,
+    },
+  });
+}
+
+export async function GET(req: Request) {
+  const gate = authorizeInternalRequest(req);
+  if (!gate.ok) {
+    return gate.response;
+  }
+
+  try {
+    return await runExpiration({ dryRun: false, limit: SCHEDULED_GET_LIMIT });
+  } catch {
+    return NextResponse.json({ error: "Failed to expire stale AI records" }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const gate = authorizeInternalRequest(req);
+  if (!gate.ok) {
+    return gate.response;
   }
 
   let input: { dryRun: boolean; shopId?: string; limit: number };
@@ -50,41 +136,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    const result = await expireStaleAiRecords({
-      supabase: createAdminSupabase(),
-      dryRun: input.dryRun,
-      shopId: input.shopId,
-      limit: input.limit,
-      actorContext: input.shopId
-        ? {
-          shopId: input.shopId,
-          actorId: "internal-ai-expirer",
-          role: "system",
-          source: "system",
-        }
-        : undefined,
-    });
-
-    return NextResponse.json({
-      ok: true,
-      summary: {
-        dryRun: result.dryRun,
-        now: result.now,
-        recommendations: {
-          candidates: result.recommendations.candidates,
-          expired: result.recommendations.expired,
-        },
-        previews: {
-          candidates: result.previews.candidates,
-          expired: result.previews.expired,
-        },
-        approvals: {
-          candidates: result.approvals.candidates,
-          expired: result.approvals.expired,
-        },
-        warnings: result.warnings,
-      },
-    });
+    return await runExpiration(input);
   } catch {
     return NextResponse.json({ error: "Failed to expire stale AI records" }, { status: 500 });
   }

--- a/docs/ops/ai-stale-expiration.md
+++ b/docs/ops/ai-stale-expiration.md
@@ -1,0 +1,54 @@
+# AI stale expiration cron
+
+## Purpose
+This scheduled job calls the internal stale-expiration route to expire stale canonical AI substrate records (`ai_recommendations`, `ai_action_previews`, `ai_action_approvals`) that are already eligible for expiration.
+
+## Scheduler configuration
+- Provider: Vercel Cron
+- Route: `/api/internal/ai/expire-stale`
+- Schedule: `17 3 * * *` (daily at 03:17 UTC)
+- Method: `GET`
+
+## Authorization model
+- The route remains internal-only.
+- Allowed auth patterns:
+  - `x-internal-cron-secret: <INTERNAL_CRON_SECRET>`
+  - `Authorization: Bearer <INTERNAL_CRON_SECRET>`
+- Required env var names:
+  - `INTERNAL_CRON_SECRET`
+  - `CRON_SECRET` (set to the same value as `INTERNAL_CRON_SECRET` so Vercel Cron's bearer token is accepted)
+
+## Behavior
+- Scheduled `GET` runs expiration with:
+  - `dryRun: false`
+  - `limit: 100` (bounded)
+- Manual `POST` remains available for controlled operations and defaults to `dryRun: true` when omitted.
+
+## Manual invocation examples
+Dry run (POST):
+
+```bash
+curl -X POST "https://<your-domain>/api/internal/ai/expire-stale" \
+  -H "content-type: application/json" \
+  -H "x-internal-cron-secret: <INTERNAL_CRON_SECRET>" \
+  -d '{"dryRun":true,"limit":25}'
+```
+
+Execute expiration (POST):
+
+```bash
+curl -X POST "https://<your-domain>/api/internal/ai/expire-stale" \
+  -H "content-type: application/json" \
+  -H "x-internal-cron-secret: <INTERNAL_CRON_SECRET>" \
+  -d '{"dryRun":false,"limit":100}'
+```
+
+## Safety notes
+- Expires stale canonical AI substrate status only.
+- No autonomous execution.
+- No preview execution.
+- No action approval execution.
+- No customer/staff/vendor messaging.
+- No invoice sending or parts ordering.
+- No work-order, assignment, schedule, or Shop Boost mutation.
+- Response returns safe summary counts only (no raw evidence or payload exposure).

--- a/tests/internal-ai-expire-stale-route.test.ts
+++ b/tests/internal-ai-expire-stale-route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const expireStaleAiRecordsMock = vi.fn();
+const createAdminSupabaseMock = vi.fn(() => ({ mocked: true }));
+
+vi.mock("@/features/ai/server", () => ({
+  expireStaleAiRecords: expireStaleAiRecordsMock,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: createAdminSupabaseMock,
+}));
+
+function buildResult(overrides?: Partial<any>) {
+  return {
+    dryRun: true,
+    now: "2026-04-24T00:00:00.000Z",
+    recommendations: { candidates: 2, expired: 1 },
+    previews: { candidates: 3, expired: 1 },
+    approvals: { candidates: 1, expired: 0 },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("/api/internal/ai/expire-stale route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.INTERNAL_CRON_SECRET = "test-secret";
+    expireStaleAiRecordsMock.mockResolvedValue(buildResult());
+  });
+
+  it("rejects unauthorized GET requests", async () => {
+    const { GET } = await import("../app/api/internal/ai/expire-stale/route");
+    const response = await GET(new Request("http://localhost/api/internal/ai/expire-stale", { method: "GET" }));
+
+    expect(response.status).toBe(401);
+    expect(expireStaleAiRecordsMock).not.toHaveBeenCalled();
+  });
+
+  it("allows scheduled GET using bearer token and executes with bounded limit", async () => {
+    expireStaleAiRecordsMock.mockResolvedValue(buildResult({ dryRun: false }));
+
+    const { GET } = await import("../app/api/internal/ai/expire-stale/route");
+    const response = await GET(new Request("http://localhost/api/internal/ai/expire-stale", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer test-secret",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(expireStaleAiRecordsMock).toHaveBeenCalledTimes(1);
+    expect(expireStaleAiRecordsMock).toHaveBeenCalledWith(expect.objectContaining({
+      dryRun: false,
+      limit: 100,
+      shopId: undefined,
+    }));
+
+    const body = await response.json();
+    expect(body).toEqual(expect.objectContaining({ ok: true }));
+    expect(body.summary).toEqual(expect.objectContaining({
+      dryRun: false,
+      recommendations: expect.objectContaining({ candidates: 2, expired: 1 }),
+      previews: expect.objectContaining({ candidates: 3, expired: 1 }),
+      approvals: expect.objectContaining({ candidates: 1, expired: 0 }),
+    }));
+  });
+
+  it("keeps POST dryRun default true and bounds limit", async () => {
+    const { POST } = await import("../app/api/internal/ai/expire-stale/route");
+    const response = await POST(new Request("http://localhost/api/internal/ai/expire-stale", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-internal-cron-secret": "test-secret",
+      },
+      body: JSON.stringify({ limit: 1000 }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(expireStaleAiRecordsMock).toHaveBeenCalledWith(expect.objectContaining({
+      dryRun: true,
+      limit: 100,
+    }));
+
+    const body = await response.json();
+    expect(body.summary).toEqual(expect.objectContaining({
+      dryRun: true,
+    }));
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/internal/ai/expire-stale",
+      "schedule": "17 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Wire the existing internal stale-AI expiration logic into the deployment scheduler so stale `ai_recommendations` / previews / approvals can be expired automatically in production without changing expiration behavior. 
- Preserve internal-only protection and prevent weakening auth while making Vercel Cron-compatible access possible.

### Description
- Added root `vercel.json` with a cron entry for `/api/internal/ai/expire-stale` scheduled at `17 3 * * *` (daily 03:17 UTC). 
- Extended `app/api/internal/ai/expire-stale/route.ts` to support safe scheduled `GET` calls that run expiration with `dryRun: false` and a bounded `limit: 100`, while preserving the existing `POST` behavior (manual dry-run support, default `dryRun: true`, bounded limit). 
- Kept the existing header-based internal guard (`x-internal-cron-secret`) and added bearer-token acceptance (`Authorization: Bearer <INTERNAL_CRON_SECRET>`) mapped to the same `INTERNAL_CRON_SECRET` so Vercel Cron can authenticate without removing the original guard. 
- Added ops documentation at `docs/ops/ai-stale-expiration.md` explaining schedule, route, env names, and safe `curl` examples. 
- Added unit tests at `tests/internal-ai-expire-stale-route.test.ts` covering unauthorized access, scheduled GET behavior, and POST dry-run/limit bounding.

### Testing
- Ran typecheck with `npx tsc --noEmit`, which passed (only an npm env warning printed). 
- Ran unit tests with `npm test` (`vitest`), which passed: all tests passed including the new `internal-ai-expire-stale-route` tests (total: 82 tests passed). 
- Verified repository changes with `git status --short` and committed the added/modified files (`app/api/internal/ai/expire-stale/route.ts`, `vercel.json`, `docs/ops/ai-stale-expiration.md`, `tests/internal-ai-expire-stale-route.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebba3f4ba8832888c5c3a5983f552c)