### PR TITLE
Add preview-only AI closeout gate panel and API to invoice/closeout flow

### DIFF
--- a/app/api/work-orders/[id]/ai/closeout-gate-preview/route.ts
+++ b/app/api/work-orders/[id]/ai/closeout-gate-preview/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { getWorkOrderCloseoutGatePreview } from "@/features/ai/server/domains/workOrders";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = await ctx.params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+  }
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) {
+    return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+  }
+
+  try {
+    const actor = {
+      shopId,
+      actorId: access.profile.id,
+      role: access.profile.role,
+      source: "manual" as const,
+    };
+
+    const preview = await getWorkOrderCloseoutGatePreview({
+      supabase: access.supabase,
+      actor,
+      workOrderId: id,
+    });
+
+    if (!preview) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(preview);
+  } catch {
+    return NextResponse.json({ error: "Failed to load closeout gate preview" }, { status: 500 });
+  }
+}

--- a/features/ai/server/domains/workOrders/getWorkOrderCloseoutGatePreview.ts
+++ b/features/ai/server/domains/workOrders/getWorkOrderCloseoutGatePreview.ts
@@ -1,0 +1,197 @@
+import type { Database, Json } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { listAiEvidenceSnapshotsForSubject, listAiRecommendationsForSubject, type AiActorContext } from "@/features/ai/server";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type RiskTier = "low" | "medium" | "high" | "critical";
+
+type CloseoutGatePreviewItem = {
+  recommendationId: string;
+  title: string;
+  severity: RiskTier;
+  reason: string;
+  recommendedNextStep: string;
+  missingData: string[];
+  source: string;
+  status: string;
+  wouldBlockIfEnabled: boolean;
+};
+
+export type WorkOrderCloseoutGatePreviewDto = {
+  workOrderId: string;
+  mode: "preview_only";
+  enabled: false;
+  wouldBlockIfEnabled: boolean;
+  blockingCandidateCount: number;
+  advisoryCount: number;
+  missingDataCount: number;
+  highestSeverity: RiskTier | null;
+  generatedAt: string | null;
+  freshnessAt: string | null;
+  stale: boolean;
+  items: CloseoutGatePreviewItem[];
+  executionBlocked: true;
+  closeoutCurrentlyBlocked: false;
+  emptyStateHint?: string;
+};
+
+function asObject(value: Json): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function asStringArray(value: Json): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function isCloseoutGateRecommendationType(type: string): boolean {
+  return type.startsWith("closeout_risk_") || type === "ready_for_closeout_review";
+}
+
+function riskRank(value: RiskTier): number {
+  if (value === "critical") return 4;
+  if (value === "high") return 3;
+  if (value === "medium") return 2;
+  return 1;
+}
+
+function computeHighestSeverity(items: CloseoutGatePreviewItem[]): RiskTier | null {
+  if (items.length === 0) return null;
+  return [...items]
+    .sort((a, b) => riskRank(b.severity) - riskRank(a.severity))[0]?.severity ?? null;
+}
+
+function parseIso(value: string | null): number | null {
+  if (!value) return null;
+  const epoch = Date.parse(value);
+  return Number.isFinite(epoch) ? epoch : null;
+}
+
+function isStale(input: { expiresAt: string | null; freshnessAt: string | null; nowMs: number }): boolean {
+  const expiresAtMs = parseIso(input.expiresAt);
+  if (expiresAtMs != null && expiresAtMs <= input.nowMs) return true;
+
+  const freshnessMs = parseIso(input.freshnessAt);
+  if (freshnessMs == null) return false;
+
+  const ageMs = input.nowMs - freshnessMs;
+  return ageMs > 24 * 60 * 60 * 1000;
+}
+
+async function getShopScopedWorkOrder(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<WorkOrderRow | null> {
+  const { data, error } = await input.supabase
+    .from("work_orders")
+    .select("id, shop_id")
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<Pick<WorkOrderRow, "id" | "shop_id">>();
+
+  if (error) throw new Error(error.message);
+  return data as WorkOrderRow | null;
+}
+
+export async function getWorkOrderCloseoutGatePreview(input: {
+  supabase: SupabaseClient<DB>;
+  actor: AiActorContext;
+  workOrderId: string;
+}): Promise<WorkOrderCloseoutGatePreviewDto | null> {
+  const scopedWorkOrder = await getShopScopedWorkOrder({
+    supabase: input.supabase,
+    workOrderId: input.workOrderId,
+    shopId: input.actor.shopId,
+  });
+
+  if (!scopedWorkOrder) return null;
+
+  const [recommendations, evidenceSnapshots] = await Promise.all([
+    listAiRecommendationsForSubject(input.supabase, input.actor, {
+      subjectType: "work_order",
+      subjectId: input.workOrderId,
+      domain: "work_orders",
+      limit: 150,
+    }),
+    listAiEvidenceSnapshotsForSubject(input.supabase, input.actor, {
+      subjectType: "work_order",
+      subjectId: input.workOrderId,
+      domain: "work_orders",
+      limit: 1,
+    }),
+  ]);
+
+  const nowMs = Date.now();
+  const latestEvidence = evidenceSnapshots[0] ?? null;
+
+  const previewItems: CloseoutGatePreviewItem[] = recommendations
+    .filter((row) => (row.status === "open" || row.status === "acknowledged") && isCloseoutGateRecommendationType(row.recommendation_type))
+    .map((row) => {
+      const metadata = asObject(row.metadata);
+      const recommendedAction = asObject(row.recommended_action);
+      const wouldBlockIfEnabled = metadata.would_block_closeout_future === true || metadata.blocks_closeout === true;
+      const recommendedNextStep =
+        typeof recommendedAction.details === "string"
+          ? recommendedAction.details
+          : typeof recommendedAction.label === "string"
+            ? recommendedAction.label
+            : "Review closeout readiness in existing advisor workflow.";
+
+      return {
+        recommendationId: row.id,
+        title: row.title,
+        severity: row.risk_tier,
+        reason: row.summary ?? "Closeout review signal detected.",
+        recommendedNextStep,
+        missingData: asStringArray(row.missing_data),
+        source: typeof row.source === "string" && row.source.trim().length > 0 ? row.source : "work_order_rules",
+        status: row.status,
+        wouldBlockIfEnabled,
+      };
+    });
+
+  const blockingCandidateCount = previewItems.filter((item) => item.wouldBlockIfEnabled).length;
+  const advisoryCount = previewItems.filter((item) => !item.wouldBlockIfEnabled).length;
+  const missingDataCount = previewItems.reduce((sum, item) => sum + item.missingData.length, 0);
+  const generatedAt = latestEvidence?.created_at ?? recommendations[0]?.created_at ?? null;
+  const freshnessAt = latestEvidence?.freshness_at ?? null;
+
+  const latestRecommendationExpiresAt = recommendations
+    .filter((row) => (row.status === "open" || row.status === "acknowledged") && isCloseoutGateRecommendationType(row.recommendation_type))
+    .map((row) => row.expires_at)
+    .find((value) => Boolean(value)) ?? null;
+
+  const stale = isStale({
+    expiresAt: latestRecommendationExpiresAt,
+    freshnessAt,
+    nowMs,
+  });
+
+  return {
+    workOrderId: input.workOrderId,
+    mode: "preview_only",
+    enabled: false,
+    wouldBlockIfEnabled: blockingCandidateCount > 0,
+    blockingCandidateCount,
+    advisoryCount,
+    missingDataCount,
+    highestSeverity: computeHighestSeverity(previewItems),
+    generatedAt,
+    freshnessAt,
+    stale,
+    items: previewItems,
+    executionBlocked: true,
+    closeoutCurrentlyBlocked: false,
+    ...(previewItems.length === 0
+      ? {
+          emptyStateHint:
+            "No closeout preview recommendations yet. Use the work-order AI operational recommendations panel to generate a fresh review.",
+        }
+      : {}),
+  };
+}

--- a/features/ai/server/domains/workOrders/index.ts
+++ b/features/ai/server/domains/workOrders/index.ts
@@ -137,3 +137,5 @@ export * from "./advisorExplanationDrafts";
 
 export { buildWorkOrderTechnicianDispatchEvidence, createWorkOrderTechnicianDispatchEvidenceSnapshot } from "./technicianDispatchEvidence";
 export { evaluateWorkOrderTechnicianDispatchRisk, buildTechnicianDispatchRecommendations } from "./technicianDispatchRules";
+
+export { getWorkOrderCloseoutGatePreview } from "./getWorkOrderCloseoutGatePreview";

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -12,6 +12,7 @@ import type { RepairLine } from "@ai/lib/parseRepairOutput";
 import CustomerPaymentButton from "@/features/stripe/components/CustomerPaymentButton";
 import { WorkOrderInvoiceDownloadButton } from "@work-orders/components/WorkOrderInvoiceDownloadButton";
 import SyncInvoiceToQuickBooksButton from "@/features/integrations/quickbooks/components/SyncInvoiceToQuickBooksButton";
+import WorkOrderCloseoutGatePreview from "@/features/work-orders/components/WorkOrderCloseoutGatePreview";
 
 type DB = Database;
 
@@ -894,6 +895,8 @@ export default function InvoicePreviewPageClient({
             ) : null}
           </div>
         </div>
+
+        <WorkOrderCloseoutGatePreview workOrderId={workOrderId} />
 
         {/* Review issues panel */}
         {!reviewOk ? (

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -343,7 +343,7 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
   }, [evidence?.freshness_at]);
 
   return (
-    <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+    <section id="ai-operational-recommendations" className={cn(PANEL_VARIANTS.secondary, "p-2")}>
       <div className="flex items-center justify-between gap-2">
         <div>
           <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">AI operational recommendations</h2>

--- a/features/work-orders/components/WorkOrderCloseoutGatePreview.tsx
+++ b/features/work-orders/components/WorkOrderCloseoutGatePreview.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { cn } from "@shared/lib/utils";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+
+type CloseoutGatePreviewItem = {
+  recommendationId: string;
+  title: string;
+  severity: "low" | "medium" | "high" | "critical";
+  reason: string;
+  recommendedNextStep: string;
+  missingData: string[];
+  source: string;
+  status: string;
+  wouldBlockIfEnabled: boolean;
+};
+
+type CloseoutGatePreviewDto = {
+  workOrderId: string;
+  mode: "preview_only";
+  enabled: false;
+  wouldBlockIfEnabled: boolean;
+  blockingCandidateCount: number;
+  advisoryCount: number;
+  missingDataCount: number;
+  highestSeverity: "low" | "medium" | "high" | "critical" | null;
+  generatedAt: string | null;
+  freshnessAt: string | null;
+  stale: boolean;
+  items: CloseoutGatePreviewItem[];
+  executionBlocked: true;
+  closeoutCurrentlyBlocked: false;
+  emptyStateHint?: string;
+};
+
+function severityBadgeClass(severity: CloseoutGatePreviewItem["severity"]): string {
+  if (severity === "critical") return "border-red-400/60 text-red-200";
+  if (severity === "high") return "border-orange-400/60 text-orange-200";
+  if (severity === "medium") return "border-amber-400/60 text-amber-200";
+  return "border-white/20 text-neutral-300";
+}
+
+export default function WorkOrderCloseoutGatePreview({ workOrderId }: { workOrderId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<CloseoutGatePreviewDto | null>(null);
+
+  const load = useCallback(async (isRefresh: boolean) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    setError(null);
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/ai/closeout-gate-preview`, { cache: "no-store" });
+      const json = (await res.json().catch(() => null)) as CloseoutGatePreviewDto | { error?: string } | null;
+
+      if (!res.ok) {
+        const message = json && typeof json === "object" && "error" in json ? json.error : null;
+        throw new Error(message || "Failed to load closeout gate preview.");
+      }
+
+      setPreview((json ?? null) as CloseoutGatePreviewDto | null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Failed to load closeout gate preview.");
+    } finally {
+      if (isRefresh) setRefreshing(false);
+      else setLoading(false);
+    }
+  }, [workOrderId]);
+
+  useEffect(() => {
+    void load(false);
+  }, [load]);
+
+  const topItems = useMemo(() => {
+    if (!preview?.items?.length) return [];
+    return preview.items.slice(0, 5);
+  }, [preview?.items]);
+
+  return (
+    <section className={cn(PANEL_VARIANTS.secondary, "p-3")}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">AI closeout gate preview</h2>
+            <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+              Preview only
+            </span>
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">Preview only — ProFixIQ is not blocking closeout yet.</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">These are evidence-backed checks that would become closeout gates if enabled later.</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">No customer message, invoice, or work-order change is made from this panel.</p>
+        </div>
+        <button
+          type="button"
+          className="rounded-md border border-[rgba(184,115,51,0.5)] px-2 py-1 text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:bg-[rgba(184,115,51,0.12)] disabled:opacity-50"
+          onClick={() => void load(true)}
+          disabled={refreshing}
+        >
+          {refreshing ? "Refreshing…" : "Refresh preview"}
+        </button>
+      </div>
+
+      {loading ? <p className="mt-2 text-[11px] text-muted-foreground">Loading AI closeout gate preview…</p> : null}
+      {error ? <p className="mt-2 text-[11px] text-red-300">{error}</p> : null}
+
+      {!loading && !error && preview ? (
+        <>
+          <div className="mt-2 grid gap-2 text-[11px] text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
+            <div className={cn(PANEL_VARIANTS.passive, "p-2")}>
+              <p className="uppercase tracking-[0.14em]">Closeout status</p>
+              <p className="mt-1 text-neutral-200">Not currently blocking closeout</p>
+            </div>
+            <div className={cn(PANEL_VARIANTS.passive, "p-2")}>
+              <p className="uppercase tracking-[0.14em]">Would block if enabled</p>
+              <p className="mt-1 text-neutral-200">{preview.blockingCandidateCount}</p>
+            </div>
+            <div className={cn(PANEL_VARIANTS.passive, "p-2")}>
+              <p className="uppercase tracking-[0.14em]">Advisory items</p>
+              <p className="mt-1 text-neutral-200">{preview.advisoryCount}</p>
+            </div>
+            <div className={cn(PANEL_VARIANTS.passive, "p-2")}>
+              <p className="uppercase tracking-[0.14em]">Missing-data items</p>
+              <p className="mt-1 text-neutral-200">{preview.missingDataCount}</p>
+            </div>
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+            <span>Highest severity: {preview.highestSeverity ?? "none"}</span>
+            <span>•</span>
+            <span>{preview.stale ? "Stale or needs refresh" : "Fresh"}</span>
+            {preview.freshnessAt ? (
+              <>
+                <span>•</span>
+                <span>Evidence freshness: {new Date(preview.freshnessAt).toLocaleString()}</span>
+              </>
+            ) : null}
+          </div>
+
+          {topItems.length > 0 ? (
+            <ul className="mt-2 space-y-2">
+              {topItems.map((item) => (
+                <li key={item.recommendationId} className={cn(PANEL_VARIANTS.passive, "p-2")}>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium text-foreground">{item.title}</p>
+                    <span className={cn("rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide", severityBadgeClass(item.severity))}>
+                      {item.severity}
+                    </span>
+                    {item.wouldBlockIfEnabled ? (
+                      <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
+                        Would block if enabled
+                      </span>
+                    ) : (
+                      <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-neutral-300">
+                        Advisory today
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-[11px] text-muted-foreground">{item.reason}</p>
+                  <p className="mt-1 text-[11px] text-[rgba(184,115,51,0.95)]">Review the items before finalizing.</p>
+                  <p className="mt-1 text-[11px] text-muted-foreground">Next step: {item.recommendedNextStep}</p>
+                  {item.missingData.length > 0 ? (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      Missing data means ProFixIQ cannot prove the closeout is clean yet: {item.missingData.join(", ")}.
+                    </p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className={cn(PANEL_VARIANTS.passive, "mt-2 p-2 text-[11px] text-muted-foreground")}>
+              {preview.emptyStateHint ?? "No closeout preview items yet."}
+            </div>
+          )}
+
+          <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+            <Link href={`/work-orders/${workOrderId}#ai-operational-recommendations`} className="text-[rgba(184,115,51,0.95)] hover:underline">
+              Open work-order AI operational recommendations
+            </Link>
+            <span className="text-muted-foreground">•</span>
+            <Link href="/dashboard/ai-recommendations" className="text-[rgba(184,115,51,0.95)] hover:underline">
+              Open AI recommendations review center
+            </Link>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/tests/work-order-closeout-gate-preview.test.ts
+++ b/tests/work-order-closeout-gate-preview.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  listAiRecommendationsForSubjectMock,
+  listAiEvidenceSnapshotsForSubjectMock,
+} = vi.hoisted(() => ({
+  listAiRecommendationsForSubjectMock: vi.fn(),
+  listAiEvidenceSnapshotsForSubjectMock: vi.fn(),
+}));
+
+vi.mock("@/features/ai/server", () => ({
+  listAiRecommendationsForSubject: listAiRecommendationsForSubjectMock,
+  listAiEvidenceSnapshotsForSubject: listAiEvidenceSnapshotsForSubjectMock,
+}));
+
+import { getWorkOrderCloseoutGatePreview } from "@/features/ai/server/domains/workOrders/getWorkOrderCloseoutGatePreview";
+
+function createSupabaseMock(workOrderExists: boolean) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({
+              data: workOrderExists ? { id: "wo-1", shop_id: "shop-1" } : null,
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+const actor = {
+  shopId: "shop-1",
+  actorId: "actor-1",
+  role: "advisor",
+  source: "manual" as const,
+};
+
+describe("getWorkOrderCloseoutGatePreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listAiRecommendationsForSubjectMock.mockResolvedValue([]);
+    listAiEvidenceSnapshotsForSubjectMock.mockResolvedValue([]);
+  });
+
+  it("returns safe preview-only empty DTO when no recommendations are present", async () => {
+    const supabase = createSupabaseMock(true);
+
+    const preview = await getWorkOrderCloseoutGatePreview({
+      supabase: supabase as never,
+      actor,
+      workOrderId: "wo-1",
+    });
+
+    expect(preview).toMatchObject({
+      workOrderId: "wo-1",
+      mode: "preview_only",
+      enabled: false,
+      wouldBlockIfEnabled: false,
+      closeoutCurrentlyBlocked: false,
+      executionBlocked: true,
+      blockingCandidateCount: 0,
+      advisoryCount: 0,
+      missingDataCount: 0,
+      items: [],
+    });
+    expect(preview?.emptyStateHint).toContain("No closeout preview recommendations yet");
+  });
+
+  it("maps closeout risk recommendation into wouldBlockIfEnabled while keeping closeoutCurrentlyBlocked false", async () => {
+    const supabase = createSupabaseMock(true);
+    listAiRecommendationsForSubjectMock.mockResolvedValue([
+      {
+        id: "rec-1",
+        recommendation_type: "closeout_risk_inspection_incomplete",
+        title: "Do not close yet — inspection is incomplete",
+        summary: "Inspection incomplete",
+        status: "open",
+        risk_tier: "high",
+        source: "work_order_closeout_rules",
+        created_at: "2026-04-24T00:00:00.000Z",
+        expires_at: "2099-01-01T00:00:00.000Z",
+        missing_data: ["inspection_answers_pending"],
+        recommended_action: { details: "Finalize inspection" },
+        metadata: {
+          would_block_closeout_future: true,
+          blocks_closeout: false,
+        },
+      },
+    ]);
+
+    const preview = await getWorkOrderCloseoutGatePreview({
+      supabase: supabase as never,
+      actor,
+      workOrderId: "wo-1",
+    });
+
+    expect(preview?.wouldBlockIfEnabled).toBe(true);
+    expect(preview?.blockingCandidateCount).toBe(1);
+    expect(preview?.closeoutCurrentlyBlocked).toBe(false);
+    expect(preview?.items[0]).toMatchObject({
+      recommendationId: "rec-1",
+      wouldBlockIfEnabled: true,
+      missingData: ["inspection_answers_pending"],
+    });
+  });
+
+  it("surfaces missing data and stale records safely", async () => {
+    const supabase = createSupabaseMock(true);
+    listAiRecommendationsForSubjectMock.mockResolvedValue([
+      {
+        id: "rec-2",
+        recommendation_type: "closeout_risk_missing_verification",
+        title: "Verification missing",
+        summary: "Notes missing",
+        status: "acknowledged",
+        risk_tier: "medium",
+        source: "work_order_closeout_rules",
+        created_at: "2026-04-24T00:00:00.000Z",
+        expires_at: "2020-01-01T00:00:00.000Z",
+        missing_data: ["cause_missing", "correction_missing"],
+        recommended_action: { label: "Review closeout" },
+        metadata: {
+          would_block_closeout_future: false,
+        },
+      },
+    ]);
+    listAiEvidenceSnapshotsForSubjectMock.mockResolvedValue([
+      {
+        id: "ev-1",
+        created_at: "2026-04-20T00:00:00.000Z",
+        freshness_at: "2026-04-20T00:00:00.000Z",
+      },
+    ]);
+
+    const preview = await getWorkOrderCloseoutGatePreview({
+      supabase: supabase as never,
+      actor,
+      workOrderId: "wo-1",
+    });
+
+    expect(preview?.missingDataCount).toBe(2);
+    expect(preview?.stale).toBe(true);
+  });
+
+  it("returns null for cross-shop or missing work order", async () => {
+    const supabase = createSupabaseMock(false);
+
+    const preview = await getWorkOrderCloseoutGatePreview({
+      supabase: supabase as never,
+      actor,
+      workOrderId: "wo-missing",
+    });
+
+    expect(preview).toBeNull();
+    expect(listAiRecommendationsForSubjectMock).not.toHaveBeenCalled();
+  });
+
+  it("never exposes raw evidence snapshot payloads or owner PIN proof metadata", async () => {
+    const supabase = createSupabaseMock(true);
+    listAiRecommendationsForSubjectMock.mockResolvedValue([
+      {
+        id: "rec-3",
+        recommendation_type: "closeout_risk_job_lines_incomplete",
+        title: "Job lines incomplete",
+        summary: "Line still active",
+        status: "open",
+        risk_tier: "high",
+        source: "work_order_closeout_rules",
+        created_at: "2026-04-24T00:00:00.000Z",
+        expires_at: null,
+        missing_data: [],
+        recommended_action: { details: "Finish lines" },
+        metadata: {
+          ownerPinProofRef: { proofType: "owner_pin_attestation", verificationRef: "secret" },
+          rawEvidence: { privateField: "should_not_leak" },
+        },
+      },
+    ]);
+
+    const preview = await getWorkOrderCloseoutGatePreview({
+      supabase: supabase as never,
+      actor,
+      workOrderId: "wo-1",
+    });
+
+    const serialized = JSON.stringify(preview);
+    expect(serialized).not.toContain("ownerPinProofRef");
+    expect(serialized).not.toContain("verificationRef");
+    expect(serialized).not.toContain("rawEvidence");
+    expect(serialized).not.toContain("privateField");
+  });
+});


### PR DESCRIPTION
### Motivation

- Surface closeout-readiness signals to advisors as a non-blocking, evidence-backed PREVIEW layer so teams can review potential future closeout gates without affecting current finalize/invoice flows. 
- Use the existing canonical AI substrate and recommendation/evidence helpers to avoid introducing new recommendation systems or exposing raw evidence/owner PIN metadata. 
- Preserve all existing business behavior and safety rules: no mutations, no automatic messaging, and explicit preview-only semantics.

### Description

- Added a server helper `getWorkOrderCloseoutGatePreview` at `features/ai/server/domains/workOrders/getWorkOrderCloseoutGatePreview.ts` that queries shop-scoped AI recommendations/evidence and returns a safe preview DTO (`mode: "preview_only"`, `enabled: false`, `executionBlocked: true`, `closeoutCurrentlyBlocked: false`).
- Added a read-only, shop-scoped API route `GET /api/work-orders/[id]/ai/closeout-gate-preview` at `app/api/work-orders/[id]/ai/closeout-gate-preview/route.ts` that enforces `requireShopScopedApiAccess` and allowed roles (`owner`, `admin`, `manager`, `advisor`).
- Added a compact UI component `WorkOrderCloseoutGatePreview` at `features/work-orders/components/WorkOrderCloseoutGatePreview.tsx` and mounted it in the invoice/closeout surface (`InvoicePreviewPageClient`) with clear copy, counts, top items, stale indicator, refresh, and links to the operational recommendations and review center; the existing `WorkOrderAiOperationalRecommendations` panel was given an anchor id for linking (`#ai-operational-recommendations`).
- Exported the helper from the work-order AI domain index and added unit tests at `tests/work-order-closeout-gate-preview.test.ts` covering empty state, mapping of future-block candidates, missing-data counts, stale handling, cross-shop rejection, and DTO safety against raw evidence/owner PIN leakage.

### Testing

- Ran type check with `npx tsc --noEmit` which completed successfully. 
- Ran unit tests with `npm test` and the full suite passed (`22 files`, `87 tests` in this run) including the new `tests/work-order-closeout-gate-preview.test.ts` which passed. 
- Verified `getWorkOrderCloseoutGatePreview` returns `null` for cross-shop/missing work orders and that the API route returns safe DTOs and appropriate 4xx/5xx responses where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbc07508c8328a33ba093c9598413)