### PR TITLE
Add work-order AI freshness indicator (server helper, API, badge, mount)

### DIFF
--- a/app/api/work-orders/[id]/ai/freshness/route.ts
+++ b/app/api/work-orders/[id]/ai/freshness/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getWorkOrderAiFreshness } from "@/features/ai/server/domains/workOrders/getWorkOrderAiFreshness";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = await ctx.params;
+  if (!id) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const { data: scopedWorkOrder, error: workOrderError } = await access.supabase
+    .from("work_orders")
+    .select("id")
+    .eq("id", id)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (workOrderError) {
+    return NextResponse.json({ error: "Failed to validate work order scope." }, { status: 500 });
+  }
+
+  if (!scopedWorkOrder) {
+    return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+  }
+
+  try {
+    const freshness = await getWorkOrderAiFreshness({
+      supabase: access.supabase,
+      actorContext: {
+        shopId,
+        actorId: access.profile.id,
+        role: access.profile.role,
+        source: "ops",
+      },
+      workOrderId: id,
+    });
+
+    return NextResponse.json(freshness);
+  } catch {
+    return NextResponse.json({ error: "Failed to load AI freshness" }, { status: 500 });
+  }
+}

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -21,6 +21,7 @@ import PartsDrawer from "@/features/parts/components/PartsDrawer";
 import AssignTechModal from "@/features/work-orders/components/workorders/extras/AssignTechModal";
 import { JobCard } from "@/features/work-orders/components/JobCard";
 import WorkOrderAiOperationalRecommendations from "@/features/work-orders/components/WorkOrderAiOperationalRecommendations";
+import WorkOrderAiFreshnessBadge from "@/features/work-orders/components/WorkOrderAiFreshnessBadge";
 import PageShell from "@/features/shared/components/PageShell";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import DecisionTimeline, {
@@ -1327,6 +1328,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                 Refreshing work order data…
               </div>
             ) : null}
+            <WorkOrderAiFreshnessBadge workOrderId={wo.id} />
             <WorkOrderAiOperationalRecommendations workOrderId={wo.id} />
 
             <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>

--- a/features/ai/server/domains/workOrders/getWorkOrderAiFreshness.test.ts
+++ b/features/ai/server/domains/workOrders/getWorkOrderAiFreshness.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { evaluateWorkOrderAiFreshness } from "@/features/ai/server/domains/workOrders/getWorkOrderAiFreshness";
+
+const NOW = "2026-04-24T12:00:00.000Z";
+
+describe("getWorkOrderAiFreshness", () => {
+  it("returns missing when no evidence or recommendations exist", () => {
+    const result = evaluateWorkOrderAiFreshness({
+      workOrderId: "wo-1",
+      generatedAt: NOW,
+      evidenceRows: [],
+      recommendationRows: [],
+      previewRows: [],
+    });
+
+    expect(result.status).toBe("missing");
+    expect(result.label).toBe("Missing");
+  });
+
+  it("returns fresh for recent evidence/recommendations", () => {
+    const result = evaluateWorkOrderAiFreshness({
+      workOrderId: "wo-1",
+      generatedAt: NOW,
+      evidenceRows: [
+        {
+          created_at: "2026-04-24T10:30:00.000Z",
+          freshness_at: "2026-04-24T10:30:00.000Z",
+          missing_data: [],
+        },
+      ],
+      recommendationRows: [
+        {
+          id: "rec-1",
+          created_at: "2026-04-24T10:45:00.000Z",
+          status: "open",
+          expires_at: "2026-04-25T10:45:00.000Z",
+          missing_data: [],
+        },
+      ],
+      previewRows: [{ recommendation_id: "rec-1" }],
+    });
+
+    expect(result.status).toBe("fresh");
+    expect(result.hasPreviewReady).toBe(true);
+    expect(result.openRecommendationCount).toBe(1);
+  });
+
+  it("returns aging for signals older than 24h and within 72h", () => {
+    const result = evaluateWorkOrderAiFreshness({
+      workOrderId: "wo-1",
+      generatedAt: NOW,
+      evidenceRows: [
+        {
+          created_at: "2026-04-23T00:00:00.000Z",
+          freshness_at: "2026-04-23T00:00:00.000Z",
+          missing_data: [],
+        },
+      ],
+      recommendationRows: [
+        {
+          id: "rec-1",
+          created_at: "2026-04-23T00:00:00.000Z",
+          status: "acknowledged",
+          expires_at: "2026-04-26T00:00:00.000Z",
+          missing_data: [],
+        },
+      ],
+      previewRows: [],
+    });
+
+    expect(result.status).toBe("aging");
+  });
+
+  it("returns stale for recommendation stale/expired window breaches", () => {
+    const result = evaluateWorkOrderAiFreshness({
+      workOrderId: "wo-1",
+      generatedAt: NOW,
+      evidenceRows: [
+        {
+          created_at: "2026-04-20T00:00:00.000Z",
+          freshness_at: "2026-04-20T00:00:00.000Z",
+          missing_data: [],
+        },
+      ],
+      recommendationRows: [
+        {
+          id: "rec-1",
+          created_at: "2026-04-20T00:00:00.000Z",
+          status: "open",
+          expires_at: "2026-04-21T00:00:00.000Z",
+          missing_data: [],
+        },
+      ],
+      previewRows: [],
+    });
+
+    expect(result.status).toBe("stale");
+    expect(result.staleRecommendationCount).toBe(1);
+  });
+
+  it("returns needs_refresh when missing data or expired recommendations are present", () => {
+    const result = evaluateWorkOrderAiFreshness({
+      workOrderId: "wo-1",
+      generatedAt: NOW,
+      evidenceRows: [
+        {
+          created_at: "2026-04-24T10:30:00.000Z",
+          freshness_at: "2026-04-24T10:30:00.000Z",
+          missing_data: ["approval_status"],
+        },
+      ],
+      recommendationRows: [
+        {
+          id: "rec-1",
+          created_at: "2026-04-24T10:45:00.000Z",
+          status: "expired",
+          expires_at: "2026-04-24T11:00:00.000Z",
+          missing_data: ["parts_eta"],
+        },
+      ],
+      previewRows: [],
+    });
+
+    expect(result.status).toBe("needs_refresh");
+    expect(result.expiredRecommendationCount).toBe(1);
+    expect(result.missingDataCount).toBeGreaterThan(0);
+  });
+
+  it("returns safe DTO-only fields", () => {
+    const result = evaluateWorkOrderAiFreshness({
+      workOrderId: "wo-1",
+      generatedAt: NOW,
+      evidenceRows: [],
+      recommendationRows: [],
+      previewRows: [],
+    });
+
+    expect(Object.keys(result)).not.toContain("snapshot");
+    expect(Object.keys(result)).not.toContain("owner_pin_verification_ref");
+    expect(Object.keys(result)).not.toContain("intended_mutations");
+    expect(Object.keys(result)).not.toContain("preview_payload");
+  });
+});

--- a/features/ai/server/domains/workOrders/getWorkOrderAiFreshness.ts
+++ b/features/ai/server/domains/workOrders/getWorkOrderAiFreshness.ts
@@ -1,0 +1,246 @@
+import type { Json } from "@shared/types/types/supabase";
+import { ensureActorContext, fromTable, type AiActorContext, type AiServerClient } from "@/features/ai/server/types";
+
+const FRESH_MAX_HOURS = 24;
+const AGING_MAX_HOURS = 72;
+
+export type WorkOrderAiFreshnessStatus =
+  | "fresh"
+  | "aging"
+  | "stale"
+  | "missing"
+  | "needs_refresh";
+
+export type WorkOrderAiFreshnessDto = {
+  workOrderId: string;
+  status: WorkOrderAiFreshnessStatus;
+  label: string;
+  description: string;
+  generatedAt: string | null;
+  latestEvidenceAt: string | null;
+  latestRecommendationAt: string | null;
+  openRecommendationCount: number;
+  acknowledgedRecommendationCount: number;
+  staleRecommendationCount: number;
+  expiredRecommendationCount: number;
+  missingDataCount: number;
+  hasPreviewReady: boolean;
+  canRefresh: boolean;
+};
+
+type EvidenceRow = {
+  created_at: string;
+  freshness_at: string | null;
+  missing_data: Json;
+};
+
+type RecommendationRow = {
+  id: string;
+  created_at: string;
+  status: "open" | "acknowledged" | "dismissed" | "resolved" | "expired" | "superseded";
+  expires_at: string | null;
+  missing_data: Json;
+};
+
+type PreviewRow = {
+  recommendation_id: string | null;
+};
+
+type EvaluateInput = {
+  workOrderId: string;
+  generatedAt: string;
+  evidenceRows: EvidenceRow[];
+  recommendationRows: RecommendationRow[];
+  previewRows: PreviewRow[];
+};
+
+function parseTime(value: string | null): number | null {
+  if (!value) return null;
+  const epoch = Date.parse(value);
+  return Number.isFinite(epoch) ? epoch : null;
+}
+
+function countMissing(value: Json): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function hoursSince(nowMs: number, iso: string | null): number | null {
+  const parsed = parseTime(iso);
+  if (parsed == null) return null;
+  return Math.max(0, (nowMs - parsed) / (1000 * 60 * 60));
+}
+
+function toRelative(ageHours: number | null): string | null {
+  if (ageHours == null) return null;
+  if (ageHours < 1) return "just now";
+  if (ageHours < 24) return `${Math.round(ageHours)}h ago`;
+  const days = Math.round(ageHours / 24);
+  return `${days}d ago`;
+}
+
+export function evaluateWorkOrderAiFreshness(input: EvaluateInput): WorkOrderAiFreshnessDto {
+  const nowMs = parseTime(input.generatedAt) ?? Date.now();
+
+  const latestEvidenceAt =
+    input.evidenceRows
+      .map((row) => row.freshness_at ?? row.created_at)
+      .sort((a, b) => Date.parse(b) - Date.parse(a))[0] ?? null;
+
+  const latestRecommendationAt =
+    input.recommendationRows
+      .map((row) => row.created_at)
+      .sort((a, b) => Date.parse(b) - Date.parse(a))[0] ?? null;
+
+  const openRecommendations = input.recommendationRows.filter((row) => row.status === "open");
+  const acknowledgedRecommendations = input.recommendationRows.filter((row) => row.status === "acknowledged");
+  const activeRecommendations = input.recommendationRows.filter(
+    (row) => row.status === "open" || row.status === "acknowledged",
+  );
+
+  const staleRecommendationCount = activeRecommendations.filter((row) => {
+    const expiresAt = parseTime(row.expires_at);
+    return expiresAt != null && expiresAt <= nowMs;
+  }).length;
+
+  const expiredRecommendationCount = input.recommendationRows.filter((row) => row.status === "expired").length;
+
+  const missingDataCount =
+    activeRecommendations.reduce((sum, row) => sum + countMissing(row.missing_data), 0) +
+    input.evidenceRows.reduce((sum, row) => sum + countMissing(row.missing_data), 0);
+
+  const activeRecommendationIds = new Set(activeRecommendations.map((row) => row.id));
+  const hasPreviewReady = input.previewRows.some((row) => {
+    if (!row.recommendation_id) return false;
+    return activeRecommendationIds.has(row.recommendation_id);
+  });
+
+  const noEvidence = input.evidenceRows.length === 0;
+  const noRecommendations = input.recommendationRows.length === 0;
+  const evidenceAgeHours = hoursSince(nowMs, latestEvidenceAt);
+  const latestSignalAt = [latestEvidenceAt, latestRecommendationAt]
+    .filter((value): value is string => Boolean(value))
+    .sort((a, b) => Date.parse(b) - Date.parse(a))[0] ?? null;
+  const latestSignalAgeHours = hoursSince(nowMs, latestSignalAt);
+
+  const hasPartialSignals = (noEvidence && !noRecommendations) || (!noEvidence && noRecommendations);
+  const hasExpiredOrMissingData = expiredRecommendationCount > 0 || missingDataCount > 0;
+
+  let status: WorkOrderAiFreshnessStatus = "fresh";
+
+  if (noEvidence && noRecommendations) {
+    status = "missing";
+  } else if (hasPartialSignals || hasExpiredOrMissingData) {
+    status = "needs_refresh";
+  } else if ((evidenceAgeHours ?? 0) > AGING_MAX_HOURS || staleRecommendationCount > 0 || (latestSignalAgeHours ?? 0) > AGING_MAX_HOURS) {
+    status = "stale";
+  } else if ((latestSignalAgeHours ?? 0) > FRESH_MAX_HOURS) {
+    status = "aging";
+  }
+
+  const labelByStatus: Record<WorkOrderAiFreshnessStatus, string> = {
+    fresh: "Fresh",
+    aging: "Aging",
+    stale: "Stale",
+    missing: "Missing",
+    needs_refresh: "Needs refresh",
+  };
+
+  const relative = toRelative(latestSignalAgeHours);
+
+  const description =
+    status === "missing"
+      ? "No AI evidence or recommendations yet."
+      : status === "needs_refresh"
+        ? "AI context has gaps or expired signals; review and refresh is recommended."
+        : status === "stale"
+          ? `AI signals are stale${relative ? ` (updated ${relative})` : ""}.`
+          : status === "aging"
+            ? `AI signals are aging${relative ? ` (updated ${relative})` : ""}.`
+            : `AI signals updated ${relative ?? "recently"}.`;
+
+  return {
+    workOrderId: input.workOrderId,
+    status,
+    label: labelByStatus[status],
+    description,
+    generatedAt: input.generatedAt,
+    latestEvidenceAt,
+    latestRecommendationAt,
+    openRecommendationCount: openRecommendations.length,
+    acknowledgedRecommendationCount: acknowledgedRecommendations.length,
+    staleRecommendationCount,
+    expiredRecommendationCount,
+    missingDataCount,
+    hasPreviewReady,
+    canRefresh: status !== "fresh",
+  };
+}
+
+export async function getWorkOrderAiFreshness(input: {
+  supabase: AiServerClient;
+  actorContext: AiActorContext;
+  workOrderId: string;
+}): Promise<WorkOrderAiFreshnessDto> {
+  const actor = ensureActorContext(input.actorContext);
+  const workOrderId = input.workOrderId.trim();
+  const generatedAt = new Date().toISOString();
+
+  if (!workOrderId) {
+    throw new Error("workOrderId is required");
+  }
+
+  const [evidenceResult, recommendationResult] = await Promise.all([
+    fromTable(input.supabase, "ai_evidence_snapshots")
+      .select("created_at, freshness_at, missing_data")
+      .eq("shop_id", actor.shopId)
+      .eq("domain", "work_orders")
+      .eq("subject_type", "work_order")
+      .eq("subject_id", workOrderId)
+      .order("created_at", { ascending: false })
+      .limit(25),
+    fromTable(input.supabase, "ai_recommendations")
+      .select("id, created_at, status, expires_at, missing_data")
+      .eq("shop_id", actor.shopId)
+      .eq("domain", "work_orders")
+      .eq("subject_type", "work_order")
+      .eq("subject_id", workOrderId)
+      .order("created_at", { ascending: false })
+      .limit(100),
+  ]);
+
+  if (evidenceResult.error) {
+    throw new Error(`Failed to load work-order evidence freshness: ${evidenceResult.error.message}`);
+  }
+
+  if (recommendationResult.error) {
+    throw new Error(`Failed to load work-order recommendation freshness: ${recommendationResult.error.message}`);
+  }
+
+  const recommendations = (recommendationResult.data ?? []) as RecommendationRow[];
+  const recommendationIds = recommendations.map((row) => row.id);
+
+  let previewRows: PreviewRow[] = [];
+
+  if (recommendationIds.length > 0) {
+    const { data: previews, error: previewError } = await fromTable(input.supabase, "ai_action_previews")
+      .select("recommendation_id")
+      .eq("shop_id", actor.shopId)
+      .eq("status", "ready")
+      .in("recommendation_id", recommendationIds)
+      .limit(100);
+
+    if (previewError) {
+      throw new Error(`Failed to load work-order preview readiness: ${previewError.message}`);
+    }
+
+    previewRows = (previews ?? []) as PreviewRow[];
+  }
+
+  return evaluateWorkOrderAiFreshness({
+    workOrderId,
+    generatedAt,
+    evidenceRows: (evidenceResult.data ?? []) as EvidenceRow[],
+    recommendationRows: recommendations,
+    previewRows,
+  });
+}

--- a/features/work-orders/components/WorkOrderAiFreshnessBadge.tsx
+++ b/features/work-orders/components/WorkOrderAiFreshnessBadge.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@shared/lib/utils";
+import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
+import type { WorkOrderAiFreshnessDto, WorkOrderAiFreshnessStatus } from "@/features/ai/server/domains/workOrders/getWorkOrderAiFreshness";
+
+const STATUS_VARIANT: Record<WorkOrderAiFreshnessStatus, "success" | "warning" | "danger" | "neutral"> = {
+  fresh: "success",
+  aging: "warning",
+  stale: "danger",
+  missing: "neutral",
+  needs_refresh: "warning",
+};
+
+function toSupportingCopy(dto: WorkOrderAiFreshnessDto): string {
+  const latest = dto.latestRecommendationAt ?? dto.latestEvidenceAt;
+  if (!latest) return "No AI evidence yet.";
+
+  const date = new Date(latest);
+  if (Number.isNaN(date.getTime())) return dto.description;
+
+  return `AI signals updated ${formatDistanceToNow(date, { addSuffix: true })}.`;
+}
+
+export default function WorkOrderAiFreshnessBadge({ workOrderId }: { workOrderId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dto, setDto] = useState<WorkOrderAiFreshnessDto | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/ai/freshness`, { cache: "no-store" });
+      const json = await res.json();
+
+      if (!res.ok) {
+        if (res.status === 403) {
+          setDto(null);
+          return;
+        }
+        throw new Error(json?.error ?? "Failed to load AI freshness.");
+      }
+
+      setDto(json as WorkOrderAiFreshnessDto);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load AI freshness.");
+    } finally {
+      setLoading(false);
+    }
+  }, [workOrderId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const supportingCopy = useMemo(() => (dto ? toSupportingCopy(dto) : ""), [dto]);
+
+  if (loading) {
+    return (
+      <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+        <p className="text-[11px] text-muted-foreground">Loading AI freshness…</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+        <p className="text-[11px] text-amber-200">AI freshness unavailable: {error}</p>
+      </section>
+    );
+  }
+
+  if (!dto) {
+    return null;
+  }
+
+  return (
+    <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">AI freshness</span>
+        <StatusBadge variant={STATUS_VARIANT[dto.status]} size="sm">
+          {dto.label}
+        </StatusBadge>
+        <span className="text-[11px] text-muted-foreground">{supportingCopy}</span>
+        <Link
+          href="#ai-operational-recommendations"
+          className="text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:underline"
+        >
+          View AI recommendations
+        </Link>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Surface a compact, read-only AI “freshness” signal on the work-order header so advisors/admins/managers/owners can quickly see whether AI evidence/recommendations are fresh, aging, stale, missing, or need refresh without opening the AI panel. 
- Keep the change display-only and conservative: do not mutate work-orders, trigger execution, or expose raw/sensitive AI payloads.

### Description
- Added a canonical AI freshness evaluator and shop-scoped server helper at `features/ai/server/domains/workOrders/getWorkOrderAiFreshness.ts` that returns a display-safe DTO (`fresh | aging | stale | missing | needs_refresh`) and centralizes freshness thresholds (fresh ≤ 24h, aging ≤ 72h, stale > 72h). 
- Implemented a guarded, GET-only API route at `app/api/work-orders/[id]/ai/freshness/route.ts` that requires shop-scoped authentication and role/capability allowlist before returning the DTO. 
- Added a compact client component `features/work-orders/components/WorkOrderAiFreshnessBadge.tsx` that fetches the DTO, shows status + supporting copy (e.g., “AI signals updated 2h ago”), handles loading/error/403, and links to the existing AI recommendations anchor. 
- Mounted the badge in the canonical work-order detail header at `app/work-orders/[id]/Client.tsx` so the signal is visible without opening the recommendations panel. 
- Added focused unit tests for the evaluator at `features/ai/server/domains/workOrders/getWorkOrderAiFreshness.test.ts` covering missing, fresh, aging, stale, needs_refresh, and DTO-safety assertions. 
- No DB migrations or schema changes were added, and the DTO intentionally omits raw evidence JSON, owner PIN/proof details, intended_mutations, and other sensitive payloads.

### Testing
- Ran TypeScript check: `npx tsc --noEmit` — succeeded. 
- Ran unit tests: `npm test` (Vitest) — all tests passed in this environment (examples: `features/ai/server/domains/workOrders/getWorkOrderAiFreshness.test.ts` passed; full run: 93 tests passed). 
- The new evaluator tests validate freshness states and DTO safety and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbf6cdd1083289d924f1f1fdfea3f)