### PR TITLE
Add AI Approval Inbox (review-only) and safe approval APIs

### DIFF
--- a/app/api/ai/action-approvals/[approvalId]/route.ts
+++ b/app/api/ai/action-approvals/[approvalId]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { approveAiActionPreview, rejectAiActionPreview } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DecisionBody = {
+  decision: "approved" | "rejected";
+  decisionNote?: string;
+};
+
+function parseBody(value: unknown): DecisionBody {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid request body");
+  }
+
+  const raw = value as Record<string, unknown>;
+  const decision = raw.decision;
+  if (decision !== "approved" && decision !== "rejected") {
+    throw new Error("invalid decision");
+  }
+
+  const decisionNote = typeof raw.decisionNote === "string" ? raw.decisionNote.trim() : undefined;
+
+  return {
+    decision,
+    decisionNote: decisionNote && decisionNote.length > 0 ? decisionNote : undefined,
+  };
+}
+
+function mapStatusFromError(message: string): number {
+  if (message === "approval not found") return 404;
+  if (message.includes("invalid approval status transition")) return 409;
+  if (message.includes("owner PIN")) return 409;
+  if (message.includes("invalid decision") || message.includes("invalid request body")) return 400;
+  return 500;
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ approvalId: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  const { approvalId } = await context.params;
+  if (!approvalId) return NextResponse.json({ error: "Missing approval id" }, { status: 400 });
+
+  let body: DecisionBody;
+  try {
+    body = parseBody(await request.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const actor = {
+    shopId,
+    actorId: access.profile.id,
+    role: access.profile.role,
+    source: "manual" as const,
+  };
+
+  try {
+    const approval = body.decision === "approved"
+      ? await approveAiActionPreview(access.supabase, actor, { approvalId, decisionNote: body.decisionNote })
+      : await rejectAiActionPreview(access.supabase, actor, { approvalId, decisionNote: body.decisionNote });
+
+    return NextResponse.json({
+      approval: {
+        id: approval.id,
+        status: approval.status,
+        decidedAt: approval.decided_at,
+        decidedBy: approval.decided_by,
+      },
+      executionBlocked: true,
+      message: "Approving records review approval only. It does not execute the action.",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update approval";
+    return NextResponse.json({ error: message }, { status: mapStatusFromError(message) });
+  }
+}

--- a/app/api/ai/action-approvals/route.ts
+++ b/app/api/ai/action-approvals/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { listAiActionApprovalsForReview, type AiApprovalInboxDomainFilter, type AiApprovalInboxRiskFilter, type AiApprovalInboxStatusFilter } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+function parseStatus(value: string | null): AiApprovalInboxStatusFilter {
+  if (value === "pending" || value === "approved" || value === "rejected" || value === "expired" || value === "all") {
+    return value;
+  }
+  return "pending";
+}
+
+function parseDomain(value: string | null): AiApprovalInboxDomainFilter {
+  if (value === "work_orders" || value === "shop_boost" || value === "all") return value;
+  return "all";
+}
+
+function parseRisk(value: string | null): AiApprovalInboxRiskFilter {
+  if (value === "low" || value === "medium" || value === "high" || value === "critical" || value === "all") return value;
+  return "all";
+}
+
+export async function GET(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+
+  if (!access.ok) return access.response;
+
+  try {
+    const shopId = access.profile.shop_id;
+    if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+    const params = new URL(request.url).searchParams;
+    const status = parseStatus(params.get("status"));
+    const domain = parseDomain(params.get("domain"));
+    const risk = parseRisk(params.get("risk"));
+    const search = params.get("search") ?? undefined;
+    const cursor = params.get("cursor");
+    const parsedLimit = Number.parseInt(params.get("limit") ?? "25", 10);
+
+    const result = await listAiActionApprovalsForReview({
+      supabase: access.supabase,
+      actorContext: {
+        shopId,
+        actorId: access.profile.id,
+        role: access.profile.role,
+        source: "manual",
+      },
+      filters: { status, domain, risk, search },
+      pagination: {
+        cursor,
+        limit: Number.isFinite(parsedLimit) ? parsedLimit : 25,
+      },
+    });
+
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json({ error: "Failed to load AI approval inbox" }, { status: 500 });
+  }
+}

--- a/app/dashboard/ai-approvals/page.tsx
+++ b/app/dashboard/ai-approvals/page.tsx
@@ -1,0 +1,17 @@
+import AiActionApprovalsInboxClient from "@/features/ai/components/AiActionApprovalsInboxClient";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function AiApprovalsPage() {
+  await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
+
+  return (
+    <main className="space-y-5">
+      <section className="rounded-2xl border border-white/10 bg-black/25 px-5 py-4 backdrop-blur-xl">
+        <p className="text-[10px] uppercase tracking-[0.2em] text-neutral-500">AI Review Center</p>
+        <h1 className="mt-1 text-3xl font-semibold text-white">AI Approval Inbox</h1>
+        <p className="mt-1 text-sm text-neutral-300">Review requested AI action previews. Execution remains blocked.</p>
+      </section>
+      <AiActionApprovalsInboxClient />
+    </main>
+  );
+}

--- a/app/dashboard/ai-recommendations/page.tsx
+++ b/app/dashboard/ai-recommendations/page.tsx
@@ -1,5 +1,6 @@
 import AiRecommendationsReviewClient from "@/features/ai/components/AiRecommendationsReviewClient";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import Link from "next/link";
 
 export default async function AiRecommendationsPage() {
   await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
@@ -10,6 +11,11 @@ export default async function AiRecommendationsPage() {
         <p className="text-[10px] uppercase tracking-[0.2em] text-neutral-500">AI Review Center</p>
         <h1 className="mt-1 text-3xl font-semibold text-white">AI Recommendations</h1>
         <p className="mt-1 text-sm text-neutral-300">Evidence-backed operating signals awaiting review</p>
+        <div className="mt-3">
+          <Link href="/dashboard/ai-approvals" className="rounded-full border border-cyan-400/35 bg-cyan-500/10 px-3 py-1.5 text-xs font-semibold text-cyan-100 transition hover:bg-cyan-500/20">
+            Approval inbox
+          </Link>
+        </div>
       </section>
       <AiRecommendationsReviewClient />
     </main>

--- a/features/ai/components/AiActionApprovalsInboxClient.tsx
+++ b/features/ai/components/AiActionApprovalsInboxClient.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+type AiApprovalInboxStatus = "pending" | "approved" | "rejected" | "expired";
+
+type AiApprovalInboxRow = {
+  id: string;
+  status: AiApprovalInboxStatus;
+  domain: string;
+  subjectType: string | null;
+  subjectId: string | null;
+  subjectHref: string | null;
+  title: string;
+  description: string;
+  riskLevel: string | null;
+  approvalRequired: boolean;
+  ownerPinRequired: boolean;
+  ownerPinProofAttached: boolean;
+  requestedAt: string | null;
+  requestedByLabel: string | null;
+  decidedAt: string | null;
+  decidedByLabel: string | null;
+  previewId: string | null;
+  recommendationId: string | null;
+  previewStatus: string | null;
+  recommendationStatus: string | null;
+  executionBlocked: true;
+};
+
+type Summary = {
+  pending: number;
+  approved: number;
+  rejected: number;
+  expired: number;
+  ownerPinRequired: number;
+  highRisk: number;
+};
+
+type ApiResult = {
+  rows: AiApprovalInboxRow[];
+  summary: Summary;
+  nextCursor: string | null;
+};
+
+const EMPTY_SUMMARY: Summary = {
+  pending: 0,
+  approved: 0,
+  rejected: 0,
+  expired: 0,
+  ownerPinRequired: 0,
+  highRisk: 0,
+};
+
+export default function AiActionApprovalsInboxClient() {
+  const [rows, setRows] = useState<AiApprovalInboxRow[]>([]);
+  const [summary, setSummary] = useState<Summary>(EMPTY_SUMMARY);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actingId, setActingId] = useState<string | null>(null);
+
+  const [status, setStatus] = useState<"pending" | "approved" | "rejected" | "expired" | "all">("pending");
+  const [domain, setDomain] = useState<"all" | "work_orders" | "shop_boost">("all");
+  const [risk, setRisk] = useState<"all" | "low" | "medium" | "high" | "critical">("all");
+  const [search, setSearch] = useState("");
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams({
+      status,
+      domain,
+      risk,
+      limit: "25",
+    });
+
+    const trimmed = search.trim();
+    if (trimmed) params.set("search", trimmed);
+
+    return params.toString();
+  }, [status, domain, risk, search]);
+
+  const load = useCallback(async (cursor?: string | null) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const suffix = cursor ? `&cursor=${encodeURIComponent(cursor)}` : "";
+      const response = await fetch(`/api/ai/action-approvals?${queryString}${suffix}`, { cache: "no-store" });
+      const json = (await response.json().catch(() => ({}))) as Partial<ApiResult> & { error?: string };
+      if (!response.ok) throw new Error(json.error ?? "Failed to load AI approvals.");
+
+      setRows(Array.isArray(json.rows) ? json.rows : []);
+      setSummary(json.summary ?? EMPTY_SUMMARY);
+      setNextCursor(json.nextCursor ?? null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Failed to load AI approvals.");
+      setRows([]);
+      setSummary(EMPTY_SUMMARY);
+      setNextCursor(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [queryString]);
+
+  useEffect(() => {
+    void load(null);
+  }, [load]);
+
+  const decide = useCallback(async (approvalId: string, decision: "approved" | "rejected") => {
+    setActingId(approvalId);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/ai/action-approvals/${approvalId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision }),
+      });
+
+      const json = (await response.json().catch(() => ({}))) as { error?: string; executionBlocked?: boolean; message?: string };
+      if (!response.ok) throw new Error(json.error ?? `Failed to ${decision} approval.`);
+
+      toast.success(json.message ?? "Approval decision recorded.");
+      if (json.executionBlocked !== true) {
+        toast.warning("Execution remains blocked by policy.");
+      }
+      await load(null);
+    } catch (decisionError) {
+      const message = decisionError instanceof Error ? decisionError.message : `Failed to ${decision} approval.`;
+      setError(message);
+      toast.error(message);
+    } finally {
+      setActingId(null);
+    }
+  }, [load]);
+
+  return (
+    <section className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <SummaryCard label="Pending" value={summary.pending} />
+        <SummaryCard label="High risk" value={summary.highRisk} />
+        <SummaryCard label="Owner PIN required" value={summary.ownerPinRequired} />
+        <SummaryCard label="Recently decided" value={summary.approved + summary.rejected + summary.expired} />
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
+          <SelectFilter label="Status" value={status} onChange={(value) => setStatus(value as never)} options={["pending", "approved", "rejected", "expired", "all"]} />
+          <SelectFilter label="Domain" value={domain} onChange={(value) => setDomain(value as never)} options={["all", "work_orders", "shop_boost"]} />
+          <SelectFilter label="Risk" value={risk} onChange={(value) => setRisk(value as never)} options={["all", "critical", "high", "medium", "low"]} />
+          <label className="flex flex-col gap-1 text-xs text-neutral-300 md:col-span-2">
+            Search
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search approval title or subject"
+              className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white outline-none ring-0 placeholder:text-neutral-500"
+            />
+          </label>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-neutral-400">
+          <button
+            type="button"
+            onClick={() => void load(null)}
+            className="rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white hover:bg-white/20"
+          >
+            Refresh
+          </button>
+          <span>Approving records review approval only. It does not execute the action.</span>
+        </div>
+      </div>
+
+      {loading ? <p className="text-sm text-neutral-400">Loading approval inbox…</p> : null}
+      {error ? <p className="rounded-xl border border-red-400/30 bg-red-950/20 p-3 text-sm text-red-200">{error}</p> : null}
+
+      {!loading && !error && rows.length === 0 ? (
+        <p className="rounded-2xl border border-white/10 bg-black/25 p-4 text-sm text-neutral-300">
+          No approval requests matched your filters.
+        </p>
+      ) : null}
+
+      <div className="space-y-3">
+        {rows.map((row) => (
+          <article key={row.id} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] uppercase">
+              <span className="rounded-full border border-white/20 px-2 py-0.5 text-neutral-200">{row.status}</span>
+              <span className="rounded-full border border-white/20 px-2 py-0.5 text-neutral-200">{row.riskLevel ?? "unknown"} risk</span>
+              <span className="rounded-full border border-cyan-400/35 px-2 py-0.5 text-cyan-200">{row.domain === "shop_boost" ? "Shop Boost" : "Work order"}</span>
+              {row.ownerPinRequired ? (
+                <span className="rounded-full border border-amber-400/40 px-2 py-0.5 text-amber-200">
+                  Owner PIN {row.ownerPinProofAttached ? "proof attached" : "required"}
+                </span>
+              ) : null}
+            </div>
+
+            <h2 className="mt-2 text-base font-semibold text-white">{row.title}</h2>
+            <p className="mt-1 text-sm text-neutral-300">{row.description}</p>
+
+            <div className="mt-2 grid grid-cols-1 gap-2 text-xs text-neutral-400 md:grid-cols-2 xl:grid-cols-4">
+              <span>Requested: {row.requestedAt ? new Date(row.requestedAt).toLocaleString() : "—"}</span>
+              <span>Requested by: {row.requestedByLabel ?? "—"}</span>
+              <span>Decided: {row.decidedAt ? new Date(row.decidedAt).toLocaleString() : "—"}</span>
+              <span>Decided by: {row.decidedByLabel ?? "—"}</span>
+              <span>Preview status: {row.previewStatus ?? "—"}</span>
+              <span>Recommendation status: {row.recommendationStatus ?? "—"}</span>
+              <span>Execution blocked: {row.executionBlocked ? "yes" : "no"}</span>
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+              {row.subjectHref ? (
+                <Link href={row.subjectHref} className="text-[var(--brand-primary)] hover:opacity-80">
+                  {row.domain === "shop_boost" ? "View source" : "Open work order"} →
+                </Link>
+              ) : null}
+              {row.recommendationId ? (
+                <Link href="/dashboard/ai-recommendations" className="text-[var(--brand-primary)] hover:opacity-80">
+                  View recommendation queue →
+                </Link>
+              ) : null}
+            </div>
+
+            {row.status === "pending" ? (
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  disabled={actingId === row.id}
+                  onClick={() => void decide(row.id, "approved")}
+                  className="rounded-full border border-emerald-400/35 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-100 hover:bg-emerald-500/20 disabled:opacity-50"
+                >
+                  Approve request
+                </button>
+                <button
+                  type="button"
+                  disabled={actingId === row.id}
+                  onClick={() => void decide(row.id, "rejected")}
+                  className="rounded-full border border-red-400/35 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-100 hover:bg-red-500/20 disabled:opacity-50"
+                >
+                  Reject request
+                </button>
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+
+      {!loading && nextCursor ? (
+        <button
+          type="button"
+          onClick={() => void load(nextCursor)}
+          className="rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white hover:bg-white/20"
+        >
+          Next page
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/30 p-3">
+      <p className="text-[10px] uppercase tracking-[0.15em] text-neutral-500">{label}</p>
+      <p className="mt-1 text-xl font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
+function SelectFilter({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-neutral-300">
+      {label}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white"
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/features/ai/server/actionApprovals.decide.test.ts
+++ b/features/ai/server/actionApprovals.decide.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as types from "./types";
+import { AI_ACTION_EVENT_TYPES } from "./eventTypes";
+
+const getAiActionPreviewMock = vi.fn();
+const logAiActionEventMock = vi.fn();
+
+vi.mock("./actionPreviews", () => ({
+  getAiActionPreview: (...args: unknown[]) => getAiActionPreviewMock.apply(null, args),
+}));
+
+vi.mock("./actionEvents", () => ({
+  logAiActionEvent: (...args: unknown[]) => logAiActionEventMock.apply(null, args),
+}));
+
+import { approveAiActionPreview, rejectAiActionPreview } from "./actionApprovals";
+
+const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
+
+function mockFromTable(initialStatus: "pending" | "approved") {
+  const calledTables: string[] = [];
+
+  vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+    calledTables.push(table);
+
+    if (table === "ai_action_approvals") {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: {
+                  id: "approval_1",
+                  shop_id: "shop_1",
+                  action_preview_id: "preview_1",
+                  status: initialStatus,
+                  owner_pin_required: false,
+                  owner_pin_verified: false,
+                  owner_pin_verification_ref: null,
+                  metadata: {},
+                },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+        update: (payload: Record<string, unknown>) => ({
+          eq: () => ({
+            eq: () => ({
+              select: () => ({
+                single: async () => ({
+                  data: {
+                    id: "approval_1",
+                    shop_id: "shop_1",
+                    action_preview_id: "preview_1",
+                    status: payload.status,
+                    owner_pin_required: false,
+                    owner_pin_verified: false,
+                    owner_pin_verification_ref: null,
+                    metadata: {},
+                    decided_at: "2026-04-24T12:30:00.000Z",
+                    decided_by: "actor_1",
+                  },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }),
+      } as never;
+    }
+
+    if (table === "ai_action_previews") {
+      return {
+        update: (payload: Record<string, unknown>) => ({
+          eq: () => ({
+            eq: async () => ({ data: { status: payload.status }, error: null }),
+          }),
+        }),
+      } as never;
+    }
+
+    throw new Error(`Unexpected table ${table}`);
+  });
+
+  return calledTables;
+}
+
+describe("approve/reject ai action approvals", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getAiActionPreviewMock.mockReset();
+    logAiActionEventMock.mockReset();
+    getAiActionPreviewMock.mockResolvedValue({
+      id: "preview_1",
+      shop_id: "shop_1",
+      recommendation_id: "rec_1",
+      status: "approval_required",
+    });
+  });
+
+  it("allows pending -> approved and logs canonical event", async () => {
+    const calledTables = mockFromTable("pending");
+
+    const result = await approveAiActionPreview({} as never, ACTOR, { approvalId: "approval_1" });
+
+    expect(result.status).toBe("approved");
+    expect(logAiActionEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ eventType: AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_APPROVED }),
+    );
+    expect(calledTables).toContain("ai_action_approvals");
+    expect(calledTables).toContain("ai_action_previews");
+  });
+
+  it("allows pending -> rejected and logs canonical event", async () => {
+    mockFromTable("pending");
+
+    const result = await rejectAiActionPreview({} as never, ACTOR, { approvalId: "approval_1" });
+
+    expect(result.status).toBe("rejected");
+    expect(logAiActionEventMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ eventType: AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_REJECTED }),
+    );
+  });
+
+  it("rejects terminal status transitions", async () => {
+    mockFromTable("approved");
+
+    await expect(approveAiActionPreview({} as never, ACTOR, { approvalId: "approval_1" })).rejects.toThrow(
+      "invalid approval status transition",
+    );
+  });
+});

--- a/features/ai/server/dashboard/getAiMissionControlSummary.ts
+++ b/features/ai/server/dashboard/getAiMissionControlSummary.ts
@@ -27,6 +27,7 @@ type RecommendationRow = {
 };
 
 type PreviewCountRow = {
+  id: string;
   recommendation_id: string | null;
 };
 
@@ -146,10 +147,11 @@ export async function getAiMissionControlSummary(
 
   const recommendationIds = rows.map((row) => row.id);
   const previewCountByRecommendation = new Map<string, number>();
+  const previewIds: string[] = [];
 
   if (recommendationIds.length > 0) {
     const { data: previewCounts, error: previewError } = await fromTable(input.supabase, "ai_action_previews")
-      .select("recommendation_id")
+      .select("id, recommendation_id")
       .eq("shop_id", actor.shopId)
       .eq("status", "ready")
       .in("recommendation_id", recommendationIds);
@@ -157,9 +159,23 @@ export async function getAiMissionControlSummary(
     if (!previewError) {
       for (const row of (previewCounts ?? []) as PreviewCountRow[]) {
         if (!row.recommendation_id) continue;
+        previewIds.push(row.id);
         const previous = previewCountByRecommendation.get(row.recommendation_id) ?? 0;
         previewCountByRecommendation.set(row.recommendation_id, previous + 1);
       }
+    }
+  }
+
+  let pendingApprovalCount = 0;
+  if (previewIds.length > 0) {
+    const { data: pendingApprovals, error: approvalsError } = await fromTable(input.supabase, "ai_action_approvals")
+      .select("id")
+      .eq("shop_id", actor.shopId)
+      .eq("status", "pending")
+      .in("action_preview_id", previewIds);
+
+    if (!approvalsError) {
+      pendingApprovalCount = (pendingApprovals ?? []).length;
     }
   }
 
@@ -199,6 +215,7 @@ export async function getAiMissionControlSummary(
     missingDataCount: missingDataRecommendations.length,
     workOrdersNeedingAttention,
     totalPreviewCount,
+    pendingApprovalCount,
     recommendations,
     generatedAt: new Date().toISOString(),
   };

--- a/features/ai/server/dashboard/index.ts
+++ b/features/ai/server/dashboard/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./getAiMissionControlSummary";
 export * from "./listAiRecommendationsForReview";
+export * from "./listAiActionApprovalsForReview";

--- a/features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts
+++ b/features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as types from "@/features/ai/server/types";
+import { listAiActionApprovalsForReview } from "./listAiActionApprovalsForReview";
+
+const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
+
+function mockFromTable() {
+  return vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+    if (table === "ai_action_approvals") {
+      const rows = [
+        {
+          id: "approval_pending",
+          action_preview_id: "preview_work_order",
+          status: "pending",
+          owner_pin_required: true,
+          owner_pin_verification_ref: null,
+          requested_at: "2026-04-24T12:00:00.000Z",
+          requested_by: "actor_2",
+          decided_at: null,
+          decided_by: null,
+          metadata: {
+            ownerPinProofRef: {
+              proofType: "owner_pin_attestation",
+              shopId: "shop_1",
+              actorId: "actor_2",
+            },
+          },
+        },
+        {
+          id: "approval_approved",
+          action_preview_id: "preview_shop_boost",
+          status: "approved",
+          owner_pin_required: false,
+          owner_pin_verification_ref: null,
+          requested_at: "2026-04-24T10:00:00.000Z",
+          requested_by: "actor_3",
+          decided_at: "2026-04-24T11:00:00.000Z",
+          decided_by: "actor_4",
+          metadata: {},
+        },
+        {
+          id: "approval_other_shop",
+          action_preview_id: "preview_other_shop",
+          status: "pending",
+          owner_pin_required: false,
+          owner_pin_verification_ref: null,
+          requested_at: "2026-04-24T09:00:00.000Z",
+          requested_by: "actor_5",
+          decided_at: null,
+          decided_by: null,
+          metadata: {},
+        },
+      ];
+
+      const query = {
+        eq(field: string, _value: unknown) {
+          if (field === "shop_id") {
+            return {
+              limit() {
+                return {
+                  eq(_statusField: string, statusValue: unknown) {
+                    const filtered = rows.filter((row) => row.status === statusValue && row.id !== "approval_other_shop");
+                    return Promise.resolve({ data: filtered, error: null });
+                  },
+                  then(resolve: (value: { data: unknown[]; error: null }) => void) {
+                    resolve({ data: rows.filter((row) => row.id !== "approval_other_shop"), error: null });
+                  },
+                };
+              },
+            };
+          }
+          return query;
+        },
+      };
+
+      return {
+        select: () => query,
+      } as never;
+    }
+
+    if (table === "ai_action_previews") {
+      return {
+        select: () => ({
+          eq: () => ({
+            in: async () => ({
+              data: [
+                {
+                  id: "preview_work_order",
+                  recommendation_id: "rec_work_order",
+                  domain: "work_orders",
+                  subject_type: "work_order",
+                  subject_id: "WO-42",
+                  status: "approval_required",
+                  requires_approval: true,
+                  risk_tier: "critical",
+                  preview_payload: {
+                    label: "Unsafe payload title",
+                    description: "Unsafe payload description",
+                    intended_mutations: [{ should: "not leak" }],
+                  },
+                },
+                {
+                  id: "preview_shop_boost",
+                  recommendation_id: "rec_shop_boost",
+                  domain: "shop_boost",
+                  subject_type: "shop_boost_activation",
+                  subject_id: null,
+                  status: "approved",
+                  requires_approval: true,
+                  risk_tier: "low",
+                  preview_payload: {
+                    label: "Shop boost follow-up",
+                    description: "Review only",
+                    side_effects: ["do not leak"],
+                  },
+                },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      } as never;
+    }
+
+    if (table === "ai_recommendations") {
+      return {
+        select: () => ({
+          eq: () => ({
+            in: async () => ({
+              data: [
+                {
+                  id: "rec_work_order",
+                  title: "Work order line review",
+                  summary: "Advisor should review line pricing",
+                  status: "open",
+                },
+                {
+                  id: "rec_shop_boost",
+                  title: "Shop Boost review",
+                  summary: "Confirm setup details",
+                  status: "acknowledged",
+                },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      } as never;
+    }
+
+    if (table === "profiles") {
+      return {
+        select: () => ({
+          eq: () => ({
+            in: async () => ({
+              data: [
+                { id: "actor_2", full_name: "Ada Advisor", email: "ada@example.com" },
+                { id: "actor_3", full_name: "Mark Manager", email: "mark@example.com" },
+                { id: "actor_4", full_name: "Olive Owner", email: "olive@example.com" },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      } as never;
+    }
+
+    throw new Error(`Unexpected table ${table}`);
+  });
+}
+
+describe("listAiActionApprovalsForReview", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists pending approvals for current shop only", async () => {
+    mockFromTable();
+
+    const result = await listAiActionApprovalsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "pending" },
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.id).toBe("approval_pending");
+    expect(result.rows[0]?.domain).toBe("work_orders");
+  });
+
+  it("returns safe display DTO shape and proof booleans only", async () => {
+    mockFromTable();
+
+    const result = await listAiActionApprovalsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "all" },
+    });
+
+    const first = result.rows[0] as unknown as Record<string, unknown>;
+
+    expect(first.ownerPinProofAttached).toBeTypeOf("boolean");
+    expect(first.preview_payload).toBeUndefined();
+    expect(first.intended_mutations).toBeUndefined();
+    expect(first.owner_pin_verification_ref).toBeUndefined();
+    expect(first.snapshot).toBeUndefined();
+    expect(first.executionBlocked).toBe(true);
+  });
+
+  it("returns summary counts and supports domain + risk filters", async () => {
+    mockFromTable();
+
+    const filtered = await listAiActionApprovalsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "all", domain: "work_orders", risk: "critical" },
+    });
+
+    expect(filtered.rows).toHaveLength(1);
+    expect(filtered.summary.pending).toBe(1);
+    expect(filtered.summary.approved).toBe(0);
+    expect(filtered.summary.highRisk).toBe(1);
+    expect(filtered.summary.ownerPinRequired).toBe(1);
+  });
+
+  it("supports search and excludes cross-shop approvals", async () => {
+    mockFromTable();
+
+    const result = await listAiActionApprovalsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "all", search: "shop boost" },
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.id).toBe("approval_approved");
+  });
+});

--- a/features/ai/server/dashboard/listAiActionApprovalsForReview.ts
+++ b/features/ai/server/dashboard/listAiActionApprovalsForReview.ts
@@ -1,0 +1,325 @@
+import type { Json } from "@shared/types/types/supabase";
+import { ensureActorContext, fromTable, type AiActorContext, type AiServerClient } from "@/features/ai/server/types";
+
+export type AiApprovalInboxStatus = "pending" | "approved" | "rejected" | "expired";
+export type AiApprovalInboxDomainFilter = "all" | "work_orders" | "shop_boost";
+export type AiApprovalInboxStatusFilter = AiApprovalInboxStatus | "all";
+export type AiApprovalInboxRiskFilter = "all" | "low" | "medium" | "high" | "critical";
+
+export type AiApprovalInboxRow = {
+  id: string;
+  status: AiApprovalInboxStatus;
+  domain: string;
+  subjectType: string | null;
+  subjectId: string | null;
+  subjectHref: string | null;
+  title: string;
+  description: string;
+  riskLevel: string | null;
+  approvalRequired: boolean;
+  ownerPinRequired: boolean;
+  ownerPinProofAttached: boolean;
+  requestedAt: string | null;
+  requestedByLabel: string | null;
+  decidedAt: string | null;
+  decidedByLabel: string | null;
+  previewId: string | null;
+  recommendationId: string | null;
+  previewStatus: string | null;
+  recommendationStatus: string | null;
+  executionBlocked: true;
+};
+
+export type AiApprovalInboxSummary = {
+  pending: number;
+  approved: number;
+  rejected: number;
+  expired: number;
+  ownerPinRequired: number;
+  highRisk: number;
+};
+
+export type AiApprovalInboxResult = {
+  rows: AiApprovalInboxRow[];
+  summary: AiApprovalInboxSummary;
+  nextCursor: string | null;
+};
+
+export type ListAiActionApprovalsForReviewInput = {
+  supabase: AiServerClient;
+  actorContext: AiActorContext;
+  filters?: {
+    status?: AiApprovalInboxStatusFilter;
+    domain?: AiApprovalInboxDomainFilter;
+    risk?: AiApprovalInboxRiskFilter;
+    search?: string;
+  };
+  pagination?: {
+    limit?: number;
+    cursor?: string | null;
+  };
+};
+
+type ApprovalRow = {
+  id: string;
+  action_preview_id: string;
+  status: string;
+  owner_pin_required: boolean;
+  owner_pin_verification_ref: string | null;
+  requested_at: string | null;
+  requested_by: string | null;
+  decided_at: string | null;
+  decided_by: string | null;
+  metadata: Json;
+};
+
+type PreviewRow = {
+  id: string;
+  recommendation_id: string | null;
+  domain: string;
+  subject_type: string;
+  subject_id: string | null;
+  status: string;
+  requires_approval: boolean;
+  risk_tier: "low" | "medium" | "high" | "critical";
+  preview_payload: Json;
+};
+
+type RecommendationRow = {
+  id: string;
+  title: string;
+  summary: string | null;
+  status: string;
+};
+
+type ProfileRow = {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+};
+
+function safeSearchTerm(value: string | undefined): string | null {
+  if (!value) return null;
+  const cleaned = value.trim().replace(/[,%]/g, "");
+  return cleaned.length > 0 ? cleaned.toLowerCase() : null;
+}
+
+function parseCursor(cursor: string | null | undefined): number {
+  if (!cursor) return 0;
+  const parsed = Number.parseInt(cursor, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
+}
+
+function toSubjectHref(subjectType: string | null, subjectId: string | null, domain: string): string | null {
+  if (subjectType === "work_order" && subjectId) return `/work-orders/${subjectId}`;
+  if (domain === "shop_boost") return "/dashboard/setup/review?source=shop-boost";
+  return null;
+}
+
+function toApprovalStatus(status: string): AiApprovalInboxStatus | null {
+  if (status === "pending" || status === "approved" || status === "rejected" || status === "expired") {
+    return status;
+  }
+  return null;
+}
+
+function parsePreviewPayload(value: Json): { label: string | null; description: string | null; ownerPinProofAttached: boolean } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { label: null, description: null, ownerPinProofAttached: false };
+  }
+
+  const payload = value as Record<string, unknown>;
+  return {
+    label: typeof payload.label === "string" ? payload.label : null,
+    description: typeof payload.description === "string" ? payload.description : null,
+    ownerPinProofAttached: false,
+  };
+}
+
+function hasOwnerPinProofRef(value: Json): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const metadata = value as Record<string, unknown>;
+  const ref = metadata.ownerPinProofRef;
+  return Boolean(ref && typeof ref === "object" && !Array.isArray(ref));
+}
+
+function containsSearch(row: AiApprovalInboxRow, term: string | null): boolean {
+  if (!term) return true;
+
+  const haystack = [
+    row.title,
+    row.description,
+    row.domain,
+    row.subjectType ?? "",
+    row.subjectId ?? "",
+    row.requestedByLabel ?? "",
+    row.decidedByLabel ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(term);
+}
+
+function actorLabel(profile: ProfileRow | undefined, actorId: string | null): string | null {
+  if (!actorId) return null;
+  if (profile?.full_name) return profile.full_name;
+  if (profile?.email) return profile.email;
+  return `User ${actorId.slice(0, 8)}`;
+}
+
+export async function listAiActionApprovalsForReview(
+  input: ListAiActionApprovalsForReviewInput,
+): Promise<AiApprovalInboxResult> {
+  const actor = ensureActorContext(input.actorContext);
+  const statusFilter = input.filters?.status ?? "pending";
+  const domainFilter = input.filters?.domain ?? "all";
+  const riskFilter = input.filters?.risk ?? "all";
+  const searchTerm = safeSearchTerm(input.filters?.search);
+  const limit = Math.max(1, Math.min(input.pagination?.limit ?? 25, 100));
+  const cursorOffset = parseCursor(input.pagination?.cursor);
+
+  let approvalQuery = fromTable(input.supabase, "ai_action_approvals")
+    .select("id, action_preview_id, status, owner_pin_required, owner_pin_verification_ref, requested_at, requested_by, decided_at, decided_by, metadata")
+    .eq("shop_id", actor.shopId)
+    .limit(600);
+
+  if (statusFilter !== "all") {
+    approvalQuery = approvalQuery.eq("status", statusFilter);
+  }
+
+  const { data: approvalData, error: approvalError } = await approvalQuery;
+  if (approvalError) throw new Error(approvalError.message);
+
+  const approvals = ((approvalData ?? []) as ApprovalRow[])
+    .map((row) => ({ row, status: toApprovalStatus(row.status) }))
+    .filter((row): row is { row: ApprovalRow; status: AiApprovalInboxStatus } => Boolean(row.status));
+
+  const previewIds = approvals.map((item) => item.row.action_preview_id);
+
+  const previewsById = new Map<string, PreviewRow>();
+  if (previewIds.length > 0) {
+    const { data: previewData, error: previewError } = await fromTable(input.supabase, "ai_action_previews")
+      .select("id, recommendation_id, domain, subject_type, subject_id, status, requires_approval, risk_tier, preview_payload")
+      .eq("shop_id", actor.shopId)
+      .in("id", previewIds);
+
+    if (previewError) throw new Error(previewError.message);
+    for (const preview of (previewData ?? []) as PreviewRow[]) {
+      previewsById.set(preview.id, preview);
+    }
+  }
+
+  const recommendationIds = Array.from(new Set(Array.from(previewsById.values()).flatMap((preview) => (
+    preview.recommendation_id ? [preview.recommendation_id] : []
+  ))));
+
+  const recommendationsById = new Map<string, RecommendationRow>();
+  if (recommendationIds.length > 0) {
+    const { data: recommendationData, error: recommendationError } = await fromTable(input.supabase, "ai_recommendations")
+      .select("id, title, summary, status")
+      .eq("shop_id", actor.shopId)
+      .in("id", recommendationIds);
+
+    if (recommendationError) throw new Error(recommendationError.message);
+    for (const recommendation of (recommendationData ?? []) as RecommendationRow[]) {
+      recommendationsById.set(recommendation.id, recommendation);
+    }
+  }
+
+  const actorIds = Array.from(
+    new Set(
+      approvals.flatMap((item) => [item.row.requested_by, item.row.decided_by].filter((id): id is string => Boolean(id))),
+    ),
+  );
+
+  const profilesById = new Map<string, ProfileRow>();
+  if (actorIds.length > 0) {
+    const { data: profileData, error: profileError } = await fromTable(input.supabase, "profiles")
+      .select("id, full_name, email")
+      .eq("shop_id", actor.shopId)
+      .in("id", actorIds);
+
+    if (!profileError) {
+      for (const profile of (profileData ?? []) as ProfileRow[]) {
+        profilesById.set(profile.id, profile);
+      }
+    }
+  }
+
+  const rows = approvals
+    .map(({ row, status }) => {
+      const preview = previewsById.get(row.action_preview_id);
+      if (!preview) return null;
+
+      if (domainFilter !== "all" && preview.domain !== domainFilter) return null;
+      if (riskFilter !== "all" && preview.risk_tier !== riskFilter) return null;
+
+      const recommendation = preview.recommendation_id ? recommendationsById.get(preview.recommendation_id) : undefined;
+      const previewPayload = parsePreviewPayload(preview.preview_payload);
+
+      const title = recommendation?.title ?? previewPayload.label ?? `${preview.domain} ${preview.subject_type} preview`;
+      const description = recommendation?.summary ?? previewPayload.description ?? "Review-only action preview request.";
+
+      const inboxRow: AiApprovalInboxRow = {
+        id: row.id,
+        status,
+        domain: preview.domain,
+        subjectType: preview.subject_type,
+        subjectId: preview.subject_id,
+        subjectHref: toSubjectHref(preview.subject_type, preview.subject_id, preview.domain),
+        title,
+        description,
+        riskLevel: preview.risk_tier,
+        approvalRequired: preview.requires_approval,
+        ownerPinRequired: row.owner_pin_required,
+        ownerPinProofAttached: Boolean(row.owner_pin_verification_ref) || hasOwnerPinProofRef(row.metadata) || previewPayload.ownerPinProofAttached,
+        requestedAt: row.requested_at,
+        requestedByLabel: actorLabel(profilesById.get(row.requested_by ?? ""), row.requested_by),
+        decidedAt: row.decided_at,
+        decidedByLabel: actorLabel(profilesById.get(row.decided_by ?? ""), row.decided_by),
+        previewId: preview.id,
+        recommendationId: preview.recommendation_id,
+        previewStatus: preview.status,
+        recommendationStatus: recommendation?.status ?? null,
+        executionBlocked: true,
+      };
+
+      if (!containsSearch(inboxRow, searchTerm)) return null;
+      return inboxRow;
+    })
+    .filter((row): row is AiApprovalInboxRow => Boolean(row));
+
+  const sorted = rows.sort((a, b) => {
+    const statusRank = (value: AiApprovalInboxStatus) => {
+      if (value === "pending") return 0;
+      if (value === "approved") return 1;
+      if (value === "rejected") return 2;
+      return 3;
+    };
+
+    const statusDelta = statusRank(a.status) - statusRank(b.status);
+    if (statusDelta !== 0) return statusDelta;
+
+    return Date.parse(b.requestedAt ?? "") - Date.parse(a.requestedAt ?? "");
+  });
+
+  const summary: AiApprovalInboxSummary = {
+    pending: sorted.filter((row) => row.status === "pending").length,
+    approved: sorted.filter((row) => row.status === "approved").length,
+    rejected: sorted.filter((row) => row.status === "rejected").length,
+    expired: sorted.filter((row) => row.status === "expired").length,
+    ownerPinRequired: sorted.filter((row) => row.ownerPinRequired).length,
+    highRisk: sorted.filter((row) => row.riskLevel === "high" || row.riskLevel === "critical").length,
+  };
+
+  const pageRows = sorted.slice(cursorOffset, cursorOffset + limit + 1);
+  const hasMore = pageRows.length > limit;
+
+  return {
+    rows: pageRows.slice(0, limit),
+    summary,
+    nextCursor: hasMore ? String(cursorOffset + limit) : null,
+  };
+}

--- a/features/ai/server/dashboard/types.ts
+++ b/features/ai/server/dashboard/types.ts
@@ -35,6 +35,7 @@ export type AiMissionControlSummary = {
   missingDataCount: number;
   workOrdersNeedingAttention: number;
   totalPreviewCount: number;
+  pendingApprovalCount: number;
   recommendations: AiMissionControlRecommendation[];
   generatedAt: string;
 };

--- a/features/dashboard/widgets/AiMissionControlWidget.tsx
+++ b/features/dashboard/widgets/AiMissionControlWidget.tsx
@@ -31,6 +31,7 @@ type MissionControlSummary = {
   missingDataCount: number;
   workOrdersNeedingAttention: number;
   totalPreviewCount: number;
+  pendingApprovalCount: number;
   recommendations: RecommendationItem[];
   generatedAt: string;
 };
@@ -97,6 +98,11 @@ export default function AiMissionControlWidget() {
           <Link href="/dashboard/ai-recommendations" className="rounded-full border border-cyan-400/35 bg-cyan-500/10 px-3 py-1 text-[11px] font-semibold text-cyan-100 transition hover:bg-cyan-500/20">
             View all
           </Link>
+          {summary && summary.pendingApprovalCount > 0 ? (
+            <Link href="/dashboard/ai-approvals" className="rounded-full border border-amber-400/35 bg-amber-500/10 px-3 py-1 text-[11px] font-semibold text-amber-100 transition hover:bg-amber-500/20">
+              Approval inbox
+            </Link>
+          ) : null}
           <button
             type="button"
             onClick={() => void load()}
@@ -137,6 +143,7 @@ export default function AiMissionControlWidget() {
             <Metric label="Missing data" value={String(summary.missingDataCount)} />
             <Metric label="Stale" value={String(summary.staleCount)} />
             <Metric label="Preview-ready" value={String(summary.totalPreviewCount)} />
+            <Metric label="Pending approvals" value={String(summary.pendingApprovalCount)} />
           </div>
 
           <div className="space-y-2">


### PR DESCRIPTION
### Motivation

- Provide a centralized UI surface for owner/admin/manager/advisor users to review pending AI approval requests generated from action previews. 
- Preserve the existing AI substrate, shop scoping, actor context, gating and event logging patterns. 
- Keep this rollout review-only: approvals are recorded but never executed or used to mutate business records.

### Description

- Added a canonical server helper `listAiActionApprovalsForReview` that is shop-scoped, supports bounded pagination and filters (`status`, `domain`, `risk`, `search`), and returns a display-safe DTO (no raw payload, secrets, owner PIN tokens, evidence blobs, or intended mutation payloads). (new file: `features/ai/server/dashboard/listAiActionApprovalsForReview.ts`)
- Added API routes: `GET /api/ai/action-approvals` to list inbox items (role/capability gated via `requireShopScopedApiAccess`), and `PATCH /api/ai/action-approvals/[approvalId]` to record review-only decisions (allowed transition: `pending -> approved | rejected`) that call the existing `approveAiActionPreview`/`rejectAiActionPreview` helpers and return `executionBlocked: true`. (new files: `app/api/ai/action-approvals/route.ts`, `app/api/ai/action-approvals/[approvalId]/route.ts`)
- Added dashboard UI: page `/dashboard/ai-approvals` and client component `AiActionApprovalsInboxClient` with summary cards, filters, search, safe row cards, subject/recommendation links, and explicit review-only Approve/Reject controls; no execution or business mutation is performed by UI actions. (new files: `app/dashboard/ai-approvals/page.tsx`, `features/ai/components/AiActionApprovalsInboxClient.tsx`)
- Linked navigation from existing review surfaces: the AI Recommendations page includes an Approval inbox link and the AI Mission Control widget now surfaces an Approval inbox link and a `pendingApprovalCount` metric. Extended mission-control summary computation and types to provide `pendingApprovalCount`. (modified files: `app/dashboard/ai-recommendations/page.tsx`, `features/dashboard/widgets/AiMissionControlWidget.tsx`, `features/ai/server/dashboard/getAiMissionControlSummary.ts`, `features/ai/server/dashboard/types.ts`, `features/ai/server/dashboard/index.ts`)
- Tests: added focused unit tests covering the inbox listing safety, shop scoping, filters/search and the safe DTO shape, and tests covering approval decision transitions and event logging. (new tests: `features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts`, `features/ai/server/actionApprovals.decide.test.ts`)
- Safety: explicit guardrails were followed—no execution wiring, no approve-and-run behavior, no downstream business record mutations, and owner PIN references are represented only as boolean/opaque references in DTOs.

### Testing

- Type check: ran `npx tsc --noEmit` and it passed (environment emitted a known non-blocking npm warning about `http-proxy`).
- Unit tests: ran `npm test` (Vitest); all test suites passed after the change (100 tests passing in the local run), with the same non-blocking `npm warn Unknown env config "http-proxy"` message noted.
- Added tests that assert: listing is shop-scoped and returns safe DTOs, summary counters are correct, owner PIN proof is represented as boolean-only in DTOs, filters and search behave as expected, and approval lifecycle transitions are enforced (pending→approved/pending→rejected allowed; terminal transitions rejected) while keeping executionBlocked semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc33323c083288c0538a4499d98c1)