### PR TITLE
Add scoped bulk lifecycle controls for AI recommendations

### DIFF
--- a/app/api/ai/recommendations/bulk-lifecycle/route.ts
+++ b/app/api/ai/recommendations/bulk-lifecycle/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { BULK_RECOMMENDATION_MAX_LIMIT, bulkUpdateAiRecommendationsForReview } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type BulkAction = "dismiss" | "resolve";
+type BulkDomain = "work_orders" | "shop_boost";
+type BulkStatusFilter = "open" | "acknowledged";
+type BulkRiskFilter = "low" | "medium" | "high" | "critical";
+
+type RequestBody = {
+  action?: unknown;
+  domain?: unknown;
+  confirm?: unknown;
+  limit?: unknown;
+  filters?: {
+    status?: unknown;
+    risk?: unknown;
+    recommendationType?: unknown;
+    subjectType?: unknown;
+    subjectId?: unknown;
+    olderThan?: unknown;
+    staleOnly?: unknown;
+  };
+};
+
+function parseString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value.trim();
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "string") throw new Error("Invalid string filter value");
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseBody(raw: RequestBody) {
+  const action = parseString(raw.action, "action");
+  if (action !== "dismiss" && action !== "resolve") {
+    throw new Error("action must be dismiss or resolve");
+  }
+
+  const domain = parseString(raw.domain, "domain");
+  if (domain !== "work_orders" && domain !== "shop_boost") {
+    throw new Error("domain must be work_orders or shop_boost");
+  }
+
+  const confirm = parseString(raw.confirm, "confirm");
+
+  const parsedLimit = raw.limit == null ? 50 : Number(raw.limit);
+  if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > BULK_RECOMMENDATION_MAX_LIMIT) {
+    throw new Error(`limit must be an integer between 1 and ${BULK_RECOMMENDATION_MAX_LIMIT}`);
+  }
+
+  const filtersRaw = raw.filters ?? {};
+  const status = filtersRaw.status == null ? undefined : parseString(filtersRaw.status, "filters.status");
+  if (status && status !== "open" && status !== "acknowledged") {
+    throw new Error("filters.status must be open or acknowledged");
+  }
+
+  const risk = filtersRaw.risk == null ? undefined : parseString(filtersRaw.risk, "filters.risk");
+  if (risk && risk !== "low" && risk !== "medium" && risk !== "high" && risk !== "critical") {
+    throw new Error("filters.risk must be low, medium, high, or critical");
+  }
+
+  if (filtersRaw.staleOnly != null && typeof filtersRaw.staleOnly !== "boolean") {
+    throw new Error("filters.staleOnly must be boolean");
+  }
+
+  return {
+    action: action as BulkAction,
+    domain: domain as BulkDomain,
+    confirm,
+    limit: parsedLimit,
+    filters: {
+      status: status as BulkStatusFilter | undefined,
+      risk: risk as BulkRiskFilter | undefined,
+      recommendationType: parseOptionalString(filtersRaw.recommendationType),
+      subjectType: parseOptionalString(filtersRaw.subjectType),
+      subjectId: parseOptionalString(filtersRaw.subjectId),
+      olderThan: parseOptionalString(filtersRaw.olderThan),
+      staleOnly: filtersRaw.staleOnly === true,
+    },
+  };
+}
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+
+  try {
+    const raw = (await request.json().catch(() => null)) as RequestBody | null;
+    if (!raw || typeof raw !== "object") {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const body = parseBody(raw);
+
+    const result = await bulkUpdateAiRecommendationsForReview({
+      supabase: access.supabase,
+      actorContext: {
+        shopId,
+        actorId: access.profile.id,
+        role: access.profile.role,
+        source: "manual",
+      },
+      action: body.action,
+      domain: body.domain,
+      confirm: body.confirm,
+      limit: body.limit,
+      filters: body.filters,
+    });
+
+    return NextResponse.json({
+      ...result,
+      executionBlocked: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid request";
+    const status = message.includes("required") || message.includes("must be") || message.includes("Invalid") ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/features/ai/components/AiRecommendationsReviewClient.tsx
+++ b/features/ai/components/AiRecommendationsReviewClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 type RecommendationRow = {
   id: string;
@@ -46,6 +47,9 @@ type ApiResponse = {
   nextCursor: string | null;
 };
 
+type BulkAction = "dismiss" | "resolve";
+type BulkDomain = "work_orders" | "shop_boost";
+
 const DEFAULT_SUMMARY: Summary = {
   total: 0,
   open: 0,
@@ -55,6 +59,17 @@ const DEFAULT_SUMMARY: Summary = {
   missingData: 0,
   pendingApprovals: 0,
   previewsReady: 0,
+};
+
+const BULK_CONFIRMATION_TOKENS: Record<BulkAction, Record<BulkDomain, string>> = {
+  dismiss: {
+    work_orders: "DISMISS_WORK_ORDERS_RECOMMENDATIONS",
+    shop_boost: "DISMISS_SHOP_BOOST_RECOMMENDATIONS",
+  },
+  resolve: {
+    work_orders: "RESOLVE_WORK_ORDERS_RECOMMENDATIONS",
+    shop_boost: "RESOLVE_SHOP_BOOST_RECOMMENDATIONS",
+  },
 };
 
 export default function AiRecommendationsReviewClient() {
@@ -71,6 +86,12 @@ export default function AiRecommendationsReviewClient() {
   const [hasPreview, setHasPreview] = useState("all");
   const [requiresApproval, setRequiresApproval] = useState("all");
   const [search, setSearch] = useState("");
+  const [recommendationType, setRecommendationType] = useState("");
+  const [subjectType, setSubjectType] = useState("");
+  const [subjectId, setSubjectId] = useState("");
+  const [bulkAction, setBulkAction] = useState<BulkAction>("dismiss");
+  const [confirm, setConfirm] = useState("");
+  const [bulkWorking, setBulkWorking] = useState(false);
 
   const queryString = useMemo(() => {
     const params = new URLSearchParams({
@@ -116,6 +137,81 @@ export default function AiRecommendationsReviewClient() {
     void load(null);
   }, [load]);
 
+  const bulkDomain = domain === "work_orders" || domain === "shop_boost" ? (domain as BulkDomain) : null;
+  const safeScopedFilters = useMemo(() => {
+    return (
+      status !== "all"
+      || risk !== "all"
+      || recommendationType.trim().length > 0
+      || subjectType.trim().length > 0
+      || subjectId.trim().length > 0
+      || search.trim().length > 0
+      || missingData !== "all"
+      || hasPreview !== "all"
+      || requiresApproval !== "all"
+    );
+  }, [status, risk, recommendationType, subjectType, subjectId, search, missingData, hasPreview, requiresApproval]);
+
+  const bulkEnabled = bulkDomain !== null && safeScopedFilters;
+  const requiredConfirm = bulkDomain ? BULK_CONFIRMATION_TOKENS[bulkAction][bulkDomain] : "";
+
+  const handleBulkAction = useCallback(async () => {
+    if (!bulkDomain) return;
+    if (!bulkEnabled) {
+      toast.error("Add filters to scope bulk review before running this action.");
+      return;
+    }
+    if (confirm.trim() !== requiredConfirm) {
+      toast.error("Confirmation text does not match required token.");
+      return;
+    }
+
+    setBulkWorking(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/ai/recommendations/bulk-lifecycle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: bulkAction,
+          domain: bulkDomain,
+          confirm: confirm.trim(),
+          limit: 100,
+          filters: {
+            status: status === "all" ? undefined : status,
+            risk: risk === "all" ? undefined : risk,
+            recommendationType: recommendationType.trim() || undefined,
+            subjectType: subjectType.trim() || undefined,
+            subjectId: subjectId.trim() || undefined,
+          },
+        }),
+      });
+
+      const json = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        matchedCount?: number;
+        updatedCount?: number;
+        skippedCount?: number;
+        executionBlocked?: boolean;
+      };
+      if (!response.ok) throw new Error(json.error ?? "Bulk lifecycle update failed.");
+
+      toast.success(`Bulk ${bulkAction} complete: ${json.updatedCount ?? 0} updated, ${json.skippedCount ?? 0} skipped.`);
+      if (json.executionBlocked !== true) {
+        toast.warning("Execution is expected to remain blocked. Please verify policy settings.");
+      }
+      setConfirm("");
+      await load(null);
+    } catch (bulkError) {
+      const message = bulkError instanceof Error ? bulkError.message : "Bulk lifecycle update failed.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setBulkWorking(false);
+    }
+  }, [bulkDomain, bulkEnabled, confirm, requiredConfirm, bulkAction, status, risk, recommendationType, subjectType, subjectId, load]);
+
   return (
     <section className="space-y-4">
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
@@ -133,6 +229,33 @@ export default function AiRecommendationsReviewClient() {
           <SelectFilter label="Missing data" value={missingData} onChange={setMissingData} options={["all", "true", "false"]} />
           <SelectFilter label="Has preview" value={hasPreview} onChange={setHasPreview} options={["all", "true", "false"]} />
           <SelectFilter label="Requires approval" value={requiresApproval} onChange={setRequiresApproval} options={["all", "true", "false"]} />
+          <label className="flex flex-col gap-1 text-xs text-neutral-300">
+            Recommendation type
+            <input
+              value={recommendationType}
+              onChange={(event) => setRecommendationType(event.target.value)}
+              placeholder="e.g. closeout_risk"
+              className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white outline-none ring-0 placeholder:text-neutral-500"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-neutral-300">
+            Subject type
+            <input
+              value={subjectType}
+              onChange={(event) => setSubjectType(event.target.value)}
+              placeholder="e.g. work_order"
+              className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white outline-none ring-0 placeholder:text-neutral-500"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-neutral-300">
+            Subject id
+            <input
+              value={subjectId}
+              onChange={(event) => setSubjectId(event.target.value)}
+              placeholder="WO-123"
+              className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white outline-none ring-0 placeholder:text-neutral-500"
+            />
+          </label>
           <label className="flex flex-col gap-1 text-xs text-neutral-300 md:col-span-2">
             Search
             <input
@@ -154,6 +277,42 @@ export default function AiRecommendationsReviewClient() {
           </button>
         </div>
       </div>
+
+      {bulkDomain ? (
+        <div className="rounded-2xl border border-amber-400/25 bg-amber-500/5 p-4">
+          <h3 className="text-sm font-semibold text-amber-100">Bulk review actions</h3>
+          <p className="mt-1 text-xs text-amber-200/90">
+            This will {bulkAction} up to 100 open/acknowledged {bulkDomain === "work_orders" ? "work-order" : "Shop Boost"} AI recommendations matching the current filters.
+          </p>
+          <p className="mt-1 text-xs text-neutral-300">No execution / no business records changed. This updates recommendation lifecycle state only.</p>
+          <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-3">
+            <SelectFilter label="Bulk action" value={bulkAction} onChange={(value) => setBulkAction(value as BulkAction)} options={["dismiss", "resolve"]} />
+            <label className="flex flex-col gap-1 text-xs text-neutral-300 md:col-span-2">
+              Type confirmation token to enable
+              <input
+                value={confirm}
+                onChange={(event) => setConfirm(event.target.value)}
+                placeholder={requiredConfirm}
+                className="rounded-lg border border-white/15 bg-black/35 px-2.5 py-2 text-sm text-white outline-none ring-0 placeholder:text-neutral-500"
+              />
+            </label>
+          </div>
+          {!safeScopedFilters ? (
+            <p className="mt-2 text-xs text-amber-200">Add one or more filters (status/risk/type/subject/search/flags) to safely scope this bulk action.</p>
+          ) : null}
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              disabled={!bulkEnabled || confirm.trim() !== requiredConfirm || bulkWorking}
+              onClick={() => void handleBulkAction()}
+              className="rounded-full border border-amber-300/45 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-100 hover:bg-amber-500/20 disabled:opacity-50"
+            >
+              {bulkWorking ? "Applying…" : `Confirm ${bulkAction}`}
+            </button>
+            <span className="text-xs text-neutral-400">Required token: {requiredConfirm}</span>
+          </div>
+        </div>
+      ) : null}
 
       {loading ? <p className="text-sm text-neutral-400">Loading AI recommendations…</p> : null}
       {error ? <p className="rounded-xl border border-red-400/30 bg-red-950/20 p-3 text-sm text-red-200">{error}</p> : null}

--- a/features/ai/server/dashboard/bulkUpdateAiRecommendationsForReview.test.ts
+++ b/features/ai/server/dashboard/bulkUpdateAiRecommendationsForReview.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as types from "@/features/ai/server/types";
+import * as actionEvents from "@/features/ai/server/actionEvents";
+import { BULK_RECOMMENDATION_CONFIRMATION_TOKENS, bulkUpdateAiRecommendationsForReview } from "./bulkUpdateAiRecommendationsForReview";
+
+const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
+
+type Row = {
+  id: string;
+  shop_id: string;
+  domain: "work_orders" | "shop_boost";
+  status: "open" | "acknowledged" | "dismissed" | "resolved" | "expired" | "superseded";
+  recommendation_type: string;
+  subject_type: string;
+  subject_id: string | null;
+  risk_tier: "low" | "medium" | "high" | "critical";
+  expires_at: string | null;
+  created_at: string;
+  dismissed_by?: string | null;
+  resolved_by?: string | null;
+};
+
+const db = {
+  rows: [] as Row[],
+};
+
+function seedRows() {
+  db.rows = [
+    {
+      id: "rec_open_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      status: "open",
+      recommendation_type: "closeout_risk",
+      subject_type: "work_order",
+      subject_id: "WO-1",
+      risk_tier: "high",
+      expires_at: null,
+      created_at: "2026-04-20T00:00:00.000Z",
+    },
+    {
+      id: "rec_ack_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      status: "acknowledged",
+      recommendation_type: "parts_delay",
+      subject_type: "work_order",
+      subject_id: "WO-2",
+      risk_tier: "critical",
+      expires_at: "2026-04-21T00:00:00.000Z",
+      created_at: "2026-04-19T00:00:00.000Z",
+    },
+    {
+      id: "rec_resolved",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      status: "resolved",
+      recommendation_type: "closeout_risk",
+      subject_type: "work_order",
+      subject_id: "WO-3",
+      risk_tier: "high",
+      expires_at: null,
+      created_at: "2026-04-18T00:00:00.000Z",
+    },
+    {
+      id: "rec_other_shop",
+      shop_id: "shop_2",
+      domain: "work_orders",
+      status: "open",
+      recommendation_type: "closeout_risk",
+      subject_type: "work_order",
+      subject_id: "WO-9",
+      risk_tier: "critical",
+      expires_at: null,
+      created_at: "2026-04-22T00:00:00.000Z",
+    },
+  ];
+}
+
+function mockFromTable() {
+  vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+    if (table !== "ai_recommendations") throw new Error(`Unexpected table ${table}`);
+
+    return {
+      select() {
+        const filters: Record<string, unknown> = {};
+        let limitValue = 100;
+        let staleOnly = false;
+        let staleBefore = "";
+
+        const query = {
+          eq(field: string, value: unknown) {
+            filters[field] = value;
+            return query;
+          },
+          order() {
+            return query;
+          },
+          limit(value: number) {
+            limitValue = value;
+            return query;
+          },
+          lte(field: string, value: string) {
+            filters[`lte:${field}`] = value;
+            return query;
+          },
+          not(field: string, op: string, value: unknown) {
+            if (field === "expires_at" && op === "is" && value === null) staleOnly = true;
+            return query;
+          },
+          then(resolve: (value: { data: unknown[]; error: null }) => void) {
+            const rows = db.rows
+              .filter((row) => (filters.shop_id ? row.shop_id === filters.shop_id : true))
+              .filter((row) => (filters.domain ? row.domain === filters.domain : true))
+              .filter((row) => (filters.status ? row.status === filters.status : true))
+              .filter((row) => (filters.risk_tier ? row.risk_tier === filters.risk_tier : true))
+              .filter((row) => (filters.recommendation_type ? row.recommendation_type === filters.recommendation_type : true))
+              .filter((row) => (filters.subject_type ? row.subject_type === filters.subject_type : true))
+              .filter((row) => (filters.subject_id ? row.subject_id === filters.subject_id : true))
+              .filter((row) => {
+                const createdCutoff = filters["lte:created_at"] as string | undefined;
+                return createdCutoff ? row.created_at <= createdCutoff : true;
+              })
+              .filter((row) => {
+                staleBefore = (filters["lte:expires_at"] as string | undefined) ?? "";
+                if (!staleOnly) return true;
+                return row.expires_at != null && row.expires_at <= staleBefore;
+              })
+              .slice(0, limitValue);
+
+            resolve({ data: rows, error: null });
+          },
+        };
+
+        return query;
+      },
+      update(payload: Record<string, unknown>) {
+        const eqFilters: Record<string, unknown> = {};
+        let statuses: string[] = [];
+
+        const query = {
+          eq(field: string, value: unknown) {
+            eqFilters[field] = value;
+            return query;
+          },
+          in(field: string, value: string[]) {
+            if (field === "status") statuses = value;
+            return query;
+          },
+          select() {
+            return query;
+          },
+          maybeSingle: async () => {
+            const row = db.rows.find((candidate) => (
+              candidate.id === eqFilters.id
+              && candidate.shop_id === eqFilters.shop_id
+              && statuses.includes(candidate.status)
+            ));
+
+            if (!row) return { data: null, error: null };
+
+            row.status = String(payload.status) as Row["status"];
+            return { data: { id: row.id }, error: null };
+          },
+        };
+
+        return query;
+      },
+    } as never;
+  });
+}
+
+describe("bulkUpdateAiRecommendationsForReview", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    seedRows();
+    mockFromTable();
+    vi.spyOn(actionEvents, "logAiActionEvent").mockResolvedValue({} as never);
+  });
+
+  it("rejects missing or incorrect confirmation", async () => {
+    await expect(() => bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "dismiss",
+      domain: "work_orders",
+      confirm: "DISMISS_WRONG",
+    })).rejects.toThrow("Invalid confirmation token");
+  });
+
+  it("rejects unsupported action", async () => {
+    await expect(() => bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "archive" as never,
+      domain: "work_orders",
+      confirm: BULK_RECOMMENDATION_CONFIRMATION_TOKENS.dismiss.work_orders,
+    })).rejects.toThrow();
+  });
+
+  it("enforces shop scope and updates only eligible rows", async () => {
+    const result = await bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "dismiss",
+      domain: "work_orders",
+      confirm: BULK_RECOMMENDATION_CONFIRMATION_TOKENS.dismiss.work_orders,
+      limit: 100,
+    });
+
+    expect(result.executionBlocked).toBe(true);
+    expect(result.updatedCount).toBe(2);
+    expect(result.skippedCount).toBe(1);
+    expect(db.rows.find((row) => row.id === "rec_open_1")?.status).toBe("dismissed");
+    expect(db.rows.find((row) => row.id === "rec_ack_1")?.status).toBe("dismissed");
+    expect(db.rows.find((row) => row.id === "rec_resolved")?.status).toBe("resolved");
+    expect(db.rows.find((row) => row.id === "rec_other_shop")?.status).toBe("open");
+  });
+
+  it("respects bounded limit and stale-only filtering", async () => {
+    const result = await bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "resolve",
+      domain: "work_orders",
+      confirm: BULK_RECOMMENDATION_CONFIRMATION_TOKENS.resolve.work_orders,
+      limit: 1,
+      filters: { staleOnly: true },
+    });
+
+    expect(result.matchedCount).toBe(1);
+    expect(result.updatedCount).toBe(1);
+    expect(db.rows.find((row) => row.id === "rec_ack_1")?.status).toBe("resolved");
+  });
+
+  it("does not expose unsafe payload fields in summary", async () => {
+    const result = await bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "dismiss",
+      domain: "work_orders",
+      confirm: BULK_RECOMMENDATION_CONFIRMATION_TOKENS.dismiss.work_orders,
+      filters: { status: "open" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(result.sampleUpdatedIds).toBeTypeOf("object");
+    expect(result.snapshot).toBeUndefined();
+    expect(result.metadata).toBeUndefined();
+    expect(result.recommended_action).toBeUndefined();
+    expect(result.owner_pin_verification_ref).toBeUndefined();
+  });
+
+  it("logs canonical lifecycle events for each changed recommendation", async () => {
+    await bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "dismiss",
+      domain: "work_orders",
+      confirm: BULK_RECOMMENDATION_CONFIRMATION_TOKENS.dismiss.work_orders,
+      filters: { status: "open" },
+    });
+
+    expect(actionEvents.logAiActionEvent).toHaveBeenCalledTimes(1);
+    expect(actionEvents.logAiActionEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ shopId: "shop_1" }),
+      expect.objectContaining({
+        recommendationId: "rec_open_1",
+        eventType: "recommendation.dismissed",
+      }),
+    );
+  });
+
+  it("enforces bounded limit validation", async () => {
+    await expect(() => bulkUpdateAiRecommendationsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      action: "dismiss",
+      domain: "work_orders",
+      confirm: BULK_RECOMMENDATION_CONFIRMATION_TOKENS.dismiss.work_orders,
+      limit: 101,
+    })).rejects.toThrow("limit must be an integer between 1 and 100");
+  });
+});

--- a/features/ai/server/dashboard/bulkUpdateAiRecommendationsForReview.ts
+++ b/features/ai/server/dashboard/bulkUpdateAiRecommendationsForReview.ts
@@ -1,0 +1,219 @@
+import { AI_ACTION_EVENT_TYPES } from "@/features/ai/server/eventTypes";
+import { logAiActionEvent } from "@/features/ai/server/actionEvents";
+import { ensureActorContext, fromTable, type AiActorContext, type AiRecommendationStatus, type AiRiskTier, type AiServerClient } from "@/features/ai/server/types";
+
+const MAX_BULK_RECOMMENDATIONS = 100;
+const ELIGIBLE_STATUSES: ReadonlyArray<AiRecommendationStatus> = ["open", "acknowledged"];
+
+type BulkLifecycleAction = "dismiss" | "resolve";
+type BulkLifecycleDomain = "work_orders" | "shop_boost";
+
+type BulkStatusFilter = "open" | "acknowledged";
+
+type BulkReviewFilters = {
+  status?: BulkStatusFilter;
+  risk?: AiRiskTier;
+  recommendationType?: string;
+  subjectType?: string;
+  subjectId?: string;
+  olderThan?: string;
+  staleOnly?: boolean;
+};
+
+type BulkUpdateInput = {
+  supabase: AiServerClient;
+  actorContext: AiActorContext;
+  action: BulkLifecycleAction;
+  domain: BulkLifecycleDomain;
+  confirm: string;
+  limit?: number;
+  filters?: BulkReviewFilters;
+};
+
+type BulkUpdateResult = {
+  matchedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  action: BulkLifecycleAction;
+  domain: BulkLifecycleDomain;
+  executionBlocked: true;
+  sampleUpdatedIds: string[];
+};
+
+type RecommendationRow = {
+  id: string;
+  shop_id: string;
+  domain: BulkLifecycleDomain;
+  status: AiRecommendationStatus;
+  recommendation_type: string;
+  subject_type: string;
+  subject_id: string | null;
+  risk_tier: AiRiskTier;
+  expires_at: string | null;
+  created_at: string;
+};
+
+
+function assertBulkAction(value: string): BulkLifecycleAction {
+  if (value !== "dismiss" && value !== "resolve") {
+    throw new Error("action must be dismiss or resolve");
+  }
+  return value;
+}
+
+function assertBulkDomain(value: string): BulkLifecycleDomain {
+  if (value !== "work_orders" && value !== "shop_boost") {
+    throw new Error("domain must be work_orders or shop_boost");
+  }
+  return value;
+}
+
+const BULK_CONFIRMATION_TOKENS: Record<BulkLifecycleAction, Record<BulkLifecycleDomain, string>> = {
+  dismiss: {
+    work_orders: "DISMISS_WORK_ORDERS_RECOMMENDATIONS",
+    shop_boost: "DISMISS_SHOP_BOOST_RECOMMENDATIONS",
+  },
+  resolve: {
+    work_orders: "RESOLVE_WORK_ORDERS_RECOMMENDATIONS",
+    shop_boost: "RESOLVE_SHOP_BOOST_RECOMMENDATIONS",
+  },
+};
+
+function sanitizeOptionalFilter(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.trim();
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+function validateBoundedLimit(limit: number | undefined): number {
+  const resolved = limit ?? 50;
+  if (!Number.isInteger(resolved) || resolved < 1 || resolved > MAX_BULK_RECOMMENDATIONS) {
+    throw new Error(`limit must be an integer between 1 and ${MAX_BULK_RECOMMENDATIONS}`);
+  }
+  return resolved;
+}
+
+function validateConfirmation(input: { action: BulkLifecycleAction; domain: BulkLifecycleDomain; confirm: string }) {
+  const expected = BULK_CONFIRMATION_TOKENS[input.action][input.domain];
+  if (input.confirm !== expected) {
+    throw new Error(`Invalid confirmation token. Expected: ${expected}`);
+  }
+}
+
+function validateIsoDate(value: string | undefined, label: string): string | undefined {
+  if (!value) return undefined;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error(`${label} must be a valid ISO-8601 timestamp`);
+  return new Date(timestamp).toISOString();
+}
+
+export async function bulkUpdateAiRecommendationsForReview(input: BulkUpdateInput): Promise<BulkUpdateResult> {
+  const actor = ensureActorContext(input.actorContext);
+  const action = assertBulkAction(input.action);
+  const domain = assertBulkDomain(input.domain);
+  const limit = validateBoundedLimit(input.limit);
+
+  validateConfirmation({
+    action,
+    domain,
+    confirm: input.confirm,
+  });
+
+  const recommendationType = sanitizeOptionalFilter(input.filters?.recommendationType);
+  const subjectType = sanitizeOptionalFilter(input.filters?.subjectType);
+  const subjectId = sanitizeOptionalFilter(input.filters?.subjectId);
+  const olderThan = validateIsoDate(sanitizeOptionalFilter(input.filters?.olderThan), "olderThan");
+
+  let query = fromTable(input.supabase, "ai_recommendations")
+    .select("id, shop_id, domain, status, recommendation_type, subject_type, subject_id, risk_tier, expires_at, created_at")
+    .eq("shop_id", actor.shopId)
+    .eq("domain", domain)
+    .order("created_at", { ascending: true })
+    .limit(limit);
+
+  if (input.filters?.status) query = query.eq("status", input.filters.status);
+  if (input.filters?.risk) query = query.eq("risk_tier", input.filters.risk);
+  if (recommendationType) query = query.eq("recommendation_type", recommendationType);
+  if (subjectType) query = query.eq("subject_type", subjectType);
+  if (subjectId) query = query.eq("subject_id", subjectId);
+  if (olderThan) query = query.lte("created_at", olderThan);
+
+  if (input.filters?.staleOnly) {
+    query = query.not("expires_at", "is", null).lte("expires_at", new Date().toISOString());
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+
+  const rows = (data ?? []) as RecommendationRow[];
+  let updatedCount = 0;
+  let skippedCount = 0;
+  const sampleUpdatedIds: string[] = [];
+
+  for (const row of rows) {
+    if (!ELIGIBLE_STATUSES.includes(row.status)) {
+      skippedCount += 1;
+      continue;
+    }
+
+    const nextStatus: AiRecommendationStatus = action === "dismiss" ? "dismissed" : "resolved";
+    const now = new Date().toISOString();
+    const updatePayload: Record<string, string> = {
+      status: nextStatus,
+    };
+
+    if (action === "dismiss") {
+      updatePayload.dismissed_by = actor.actorId;
+      updatePayload.dismissed_at = now;
+    } else {
+      updatePayload.resolved_by = actor.actorId;
+      updatePayload.resolved_at = now;
+    }
+
+    const { data: updated, error: updateError } = await fromTable(input.supabase, "ai_recommendations")
+      .update(updatePayload)
+      .eq("shop_id", actor.shopId)
+      .eq("id", row.id)
+      .in("status", ELIGIBLE_STATUSES)
+      .select("id")
+      .maybeSingle<{ id: string }>();
+
+    if (updateError) throw new Error(updateError.message);
+    if (!updated) {
+      skippedCount += 1;
+      continue;
+    }
+
+    updatedCount += 1;
+    if (sampleUpdatedIds.length < 10) sampleUpdatedIds.push(updated.id);
+
+    await logAiActionEvent(input.supabase, actor, {
+      recommendationId: row.id,
+      eventType: action === "dismiss" ? AI_ACTION_EVENT_TYPES.RECOMMENDATION_DISMISSED : AI_ACTION_EVENT_TYPES.RECOMMENDATION_RESOLVED,
+      payload: {
+        recommendation_id: row.id,
+        from_status: row.status,
+        to_status: nextStatus,
+        bulk: true,
+        domain,
+      },
+      metadata: {
+        execution_blocked: true,
+        review_only: true,
+      },
+    });
+  }
+
+  return {
+    matchedCount: rows.length,
+    updatedCount,
+    skippedCount,
+    action,
+    domain,
+    executionBlocked: true,
+    sampleUpdatedIds,
+  };
+}
+
+export const BULK_RECOMMENDATION_MAX_LIMIT = MAX_BULK_RECOMMENDATIONS;
+export const BULK_RECOMMENDATION_CONFIRMATION_TOKENS = BULK_CONFIRMATION_TOKENS;

--- a/features/ai/server/dashboard/index.ts
+++ b/features/ai/server/dashboard/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./getAiMissionControlSummary";
 export * from "./listAiRecommendationsForReview";
 export * from "./listAiActionApprovalsForReview";
+export * from "./bulkUpdateAiRecommendationsForReview";

--- a/tests/ai-recommendations-bulk-lifecycle-route.test.ts
+++ b/tests/ai-recommendations-bulk-lifecycle-route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const requireShopScopedApiAccessMock = vi.fn();
+const bulkUpdateAiRecommendationsForReviewMock = vi.fn();
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: requireShopScopedApiAccessMock,
+}));
+
+vi.mock("@/features/ai/server", () => ({
+  BULK_RECOMMENDATION_MAX_LIMIT: 100,
+  bulkUpdateAiRecommendationsForReview: bulkUpdateAiRecommendationsForReviewMock,
+}));
+
+describe("POST /api/ai/recommendations/bulk-lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    requireShopScopedApiAccessMock.mockResolvedValue({
+      ok: true,
+      profile: { id: "actor_1", role: "manager", shop_id: "shop_1" },
+      supabase: {},
+    });
+    bulkUpdateAiRecommendationsForReviewMock.mockResolvedValue({
+      matchedCount: 4,
+      updatedCount: 3,
+      skippedCount: 1,
+      action: "dismiss",
+      domain: "work_orders",
+      executionBlocked: true,
+      sampleUpdatedIds: ["rec_1"],
+    });
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    requireShopScopedApiAccessMock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+
+    const { POST } = await import("../app/api/ai/recommendations/bulk-lifecycle/route");
+    const response = await POST(new Request("http://localhost/api/ai/recommendations/bulk-lifecycle", { method: "POST", body: "{}" }));
+
+    expect(response.status).toBe(401);
+    expect(bulkUpdateAiRecommendationsForReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid input", async () => {
+    const { POST } = await import("../app/api/ai/recommendations/bulk-lifecycle/route");
+    const response = await POST(new Request("http://localhost/api/ai/recommendations/bulk-lifecycle", {
+      method: "POST",
+      body: JSON.stringify({ action: "dismiss", domain: "work_orders", confirm: "DISMISS_WORK_ORDERS_RECOMMENDATIONS", limit: 999 }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(bulkUpdateAiRecommendationsForReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("returns safe success response shape", async () => {
+    const { POST } = await import("../app/api/ai/recommendations/bulk-lifecycle/route");
+    const response = await POST(new Request("http://localhost/api/ai/recommendations/bulk-lifecycle", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "dismiss",
+        domain: "work_orders",
+        confirm: "DISMISS_WORK_ORDERS_RECOMMENDATIONS",
+        limit: 25,
+        filters: { status: "open", risk: "high" },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    const json = await response.json() as Record<string, unknown>;
+    expect(json.updatedCount).toBe(3);
+    expect(json.executionBlocked).toBe(true);
+    expect(json.snapshot).toBeUndefined();
+    expect(json.metadata).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Motivation
- Make AI recommendations review usable at higher volume by providing safe, domain-scoped bulk lifecycle actions (dismiss / resolve) while keeping all business execution blocked.  
- Ensure strict guards (confirmation token, domain, shop scoping, bounded batch size, eligible-status-only) to prevent accidental or broad updates.  
- Keep the change lifecycle-only and avoid any execution/path that mutates work orders, invoices, Shop Boost materialization, messaging, or action preview execution.

### Description
- Added a canonical server helper `bulkUpdateAiRecommendationsForReview` to `features/ai/server/dashboard/bulkUpdateAiRecommendationsForReview.ts` that accepts explicit actor/shop context, validates confirmation tokens, supports `work_orders` and `shop_boost` domains, applies optional filters (`status`, `risk`, `recommendationType`, `subjectType`, `subjectId`, `olderThan`, `staleOnly`), enforces a bounded limit (max 100), only transitions eligible statuses (`open`/`acknowledged` -> `dismissed`/`resolved`), skips terminal rows, logs canonical `ai_action_events`, and returns a safe summary DTO (matched/updated/skipped counts, executionBlocked: true, sampleUpdatedIds).
- Exposed a safe API route at `POST /api/ai/recommendations/bulk-lifecycle` (`app/api/ai/recommendations/bulk-lifecycle/route.ts`) that requires shop-scoped auth and capability (`canManageWorkOrders`) for owner/admin/manager/advisor roles, validates input, calls the helper, and returns the execution-blocked summary DTO.
- Added compact bulk controls to the AI Recommendations drill-down client (`features/ai/components/AiRecommendationsReviewClient.tsx`) that: require domain selection, require additional scoping before enabling, require explicit typed confirmation tokens per action/domain, show clear “No execution / no business records changed” copy, call the new route, toast results, and refresh the list/summary; controls appear only on advisor/manager/admin surfaces and are strictly scoped in the UI.
- Wired new helper into the dashboard server exports (`features/ai/server/dashboard/index.ts`) and added focused unit tests for the helper and lightweight route tests for the API route.
- No DB migrations were created and no business execution or downstream mutations were added.

### Testing
- Ran static type check: `npx tsc --noEmit` — passed, with a known non-blocking npm warning `Unknown env config "http-proxy"` (documented).  
- Ran test suite: `npm test` — all tests passed (existing + new tests).  
- Tests added: `features/ai/server/dashboard/bulkUpdateAiRecommendationsForReview.test.ts` (helper: confirmation/domain/action guards, shop-scope, eligible/terminal skipping, bounded limits, stale-only, safe DTO, event logging) and `tests/ai-recommendations-bulk-lifecycle-route.test.ts` (route: unauthenticated rejection, invalid input rejection, success response shape).  
- Validation summary: typecheck passed and the full test run succeeded; no migrations applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc9f03e9883289b55a6b9acbc8157)