### PR TITLE
Add AI operations observability telemetry, API route, and dashboard widget

### DIFF
--- a/app/api/dashboard/ai-observability/route.ts
+++ b/app/api/dashboard/ai-observability/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getAiOperationsObservability } from "@/features/ai/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager"],
+  });
+
+  if (!access.ok) return access.response;
+
+  try {
+    const shopId = access.profile.shop_id;
+    if (!shopId) {
+      return NextResponse.json({ error: "Shop not found" }, { status: 403 });
+    }
+
+    const observability = await getAiOperationsObservability({
+      supabase: access.supabase,
+      actorContext: {
+        shopId,
+        actorId: access.profile.id,
+        role: access.profile.role,
+        source: "manual",
+      },
+    });
+
+    return NextResponse.json({ observability });
+  } catch {
+    return NextResponse.json({ error: "Failed to load AI observability" }, { status: 500 });
+  }
+}

--- a/docs/ops/ai-observability.md
+++ b/docs/ops/ai-observability.md
@@ -1,0 +1,53 @@
+# AI Observability (Operations)
+
+## Purpose
+
+AI observability provides owner/admin/manager visibility into AI review-layer health without exposing raw evidence, mutation payloads, PIN references, or secrets.
+
+## Metrics surfaced
+
+- **Recommendations**
+  - Active, open, acknowledged, dismissed, resolved, expired
+  - Stale backlog and high/critical-risk backlog
+  - Needs-refresh count
+  - Domain split (`work_orders`, `shop_boost`)
+- **Action previews**
+  - Total, ready, approval required, expired
+  - Execution-blocked signal count (event-derived)
+  - Domain and safe action-type breakdowns
+- **Approvals**
+  - Pending, approved, rejected
+  - Owner PIN required count (boolean-derived only)
+- **Expiration/Cron activity**
+  - Last expiration event timestamp
+  - Expiration counts in last 24 hours / 7 days for recommendations, previews, approvals
+- **Events / errors**
+  - Recent event counts by canonical event type
+  - Error-like event counts (`*.blocked`, `*.failed`, owner-pin validation/missing)
+
+## Cron health inference
+
+`cronProbablyRunning` is inferred conservatively:
+
+- `true` when an expiration event is observed in the recent health window
+- `false` when stale/pending backlog exists but no expiration events are observed
+- `unknown` when there is insufficient evidence to conclude either way
+
+## Environment prerequisites
+
+- Internal stale-expiration route enabled
+- `INTERNAL_CRON_SECRET` configured for cron authentication
+- Vercel cron configured to call stale expiration route on schedule
+
+## If stale backlog grows
+
+1. Confirm `/api/internal/ai/expire-stale` invocation frequency and auth headers.
+2. Check observability widget for last expiration timestamp and error-like events.
+3. Review AI event stream for blocked/failed patterns before taking action.
+4. Verify app role/capability access for operators reviewing AI inbox/recommendations.
+
+## Operational guardrails
+
+- Do **not** start with direct DB mutation.
+- Do **not** bypass approval/PIN controls.
+- Keep response actions in canonical review flows (recommendations + approvals).

--- a/features/ai/server/dashboard/getAiOperationsObservability.test.ts
+++ b/features/ai/server/dashboard/getAiOperationsObservability.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as types from "@/features/ai/server/types";
+import { getAiOperationsObservability } from "./getAiOperationsObservability";
+
+const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
+const NOW = new Date("2026-04-24T12:00:00.000Z");
+
+type RecommendationRow = {
+  id: string;
+  shop_id: string;
+  domain: "work_orders" | "shop_boost";
+  status: "open" | "acknowledged" | "dismissed" | "resolved" | "expired" | "superseded";
+  risk_tier: "low" | "medium" | "high" | "critical";
+  missing_data: unknown[];
+  created_at: string;
+  expires_at: string | null;
+  preview_payload?: unknown;
+};
+
+type PreviewRow = {
+  id: string;
+  shop_id: string;
+  domain: "work_orders" | "shop_boost";
+  action_type: string;
+  status: "draft" | "ready" | "approval_required" | "approved" | "rejected" | "expired" | "executed" | "cancelled" | "failed";
+  created_at: string;
+  expires_at: string | null;
+  intended_mutations?: Record<string, unknown>;
+};
+
+type ApprovalRow = {
+  id: string;
+  shop_id: string;
+  status: "pending" | "approved" | "rejected" | "expired" | "cancelled";
+  owner_pin_required: boolean;
+  requested_at: string;
+  expires_at: string | null;
+  owner_pin_verification_ref?: string;
+};
+
+type EventRow = {
+  id: string;
+  shop_id: string;
+  event_type: string;
+  created_at: string;
+  payload?: Record<string, unknown>;
+};
+
+const db = {
+  recommendations: [] as RecommendationRow[],
+  previews: [] as PreviewRow[],
+  approvals: [] as ApprovalRow[],
+  events: [] as EventRow[],
+};
+
+function seed() {
+  db.recommendations = [
+    { id: "rec_1", shop_id: "shop_1", domain: "work_orders", status: "open", risk_tier: "high", missing_data: ["labor_state"], created_at: "2026-04-24T10:00:00.000Z", expires_at: "2026-04-24T11:00:00.000Z", preview_payload: { unsafe: true } },
+    { id: "rec_2", shop_id: "shop_1", domain: "shop_boost", status: "acknowledged", risk_tier: "critical", missing_data: [], created_at: "2026-04-24T02:00:00.000Z", expires_at: "2026-04-25T00:00:00.000Z" },
+    { id: "rec_3", shop_id: "shop_1", domain: "work_orders", status: "resolved", risk_tier: "medium", missing_data: [], created_at: "2026-04-20T02:00:00.000Z", expires_at: null },
+    { id: "rec_other", shop_id: "shop_2", domain: "work_orders", status: "open", risk_tier: "critical", missing_data: [], created_at: "2026-04-24T10:00:00.000Z", expires_at: null },
+  ];
+
+  db.previews = [
+    { id: "pre_1", shop_id: "shop_1", domain: "work_orders", action_type: "dispatch_review", status: "ready", created_at: "2026-04-24T10:00:00.000Z", expires_at: null, intended_mutations: { hidden: true } },
+    { id: "pre_2", shop_id: "shop_1", domain: "shop_boost", action_type: "review_shop_boost_readiness", status: "approval_required", created_at: "2026-04-24T01:00:00.000Z", expires_at: null },
+    { id: "pre_3", shop_id: "shop_1", domain: "work_orders", action_type: "dispatch_review", status: "expired", created_at: "2026-04-23T12:00:00.000Z", expires_at: "2026-04-23T20:00:00.000Z" },
+  ];
+
+  db.approvals = [
+    { id: "ap_1", shop_id: "shop_1", status: "pending", owner_pin_required: true, requested_at: "2026-04-24T11:30:00.000Z", expires_at: null, owner_pin_verification_ref: "secret_ref" },
+    { id: "ap_2", shop_id: "shop_1", status: "approved", owner_pin_required: false, requested_at: "2026-04-22T01:00:00.000Z", expires_at: null },
+    { id: "ap_3", shop_id: "shop_1", status: "rejected", owner_pin_required: false, requested_at: "2026-04-22T03:00:00.000Z", expires_at: null },
+  ];
+
+  db.events = [
+    { id: "ev_1", shop_id: "shop_1", event_type: "recommendation.expired", created_at: "2026-04-24T11:45:00.000Z" },
+    { id: "ev_2", shop_id: "shop_1", event_type: "action_preview.expired", created_at: "2026-04-24T11:40:00.000Z" },
+    { id: "ev_3", shop_id: "shop_1", event_type: "action_approval.expired", created_at: "2026-04-24T11:35:00.000Z" },
+    { id: "ev_4", shop_id: "shop_1", event_type: "action_execution.failed", created_at: "2026-04-24T11:20:00.000Z", payload: { token: "secret" } },
+    { id: "ev_5", shop_id: "shop_1", event_type: "action_preview.blocked_execution", created_at: "2026-04-24T11:10:00.000Z" },
+    { id: "ev_6", shop_id: "shop_2", event_type: "recommendation.expired", created_at: "2026-04-24T11:00:00.000Z" },
+    { id: "ev_old", shop_id: "shop_1", event_type: "recommendation.expired", created_at: "2026-04-15T01:00:00.000Z" },
+  ];
+}
+
+function mockFromTable() {
+  vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+    const data = table === "ai_recommendations"
+      ? db.recommendations
+      : table === "ai_action_previews"
+        ? db.previews
+        : table === "ai_action_approvals"
+          ? db.approvals
+          : table === "ai_action_events"
+            ? db.events
+            : [];
+
+    return {
+      select() {
+        const filters: Record<string, unknown> = {};
+        let limitValue = Number.MAX_SAFE_INTEGER;
+        let orderDesc = false;
+
+        const query = {
+          eq(field: string, value: unknown) {
+            filters[field] = value;
+            return query;
+          },
+          gte(field: string, value: string) {
+            filters[`gte:${field}`] = value;
+            return query;
+          },
+          order(_field: string, options?: { ascending?: boolean }) {
+            orderDesc = options?.ascending === false;
+            return query;
+          },
+          limit(value: number) {
+            limitValue = value;
+            return query;
+          },
+          then(resolve: (value: { data: unknown[]; error: null }) => void) {
+            let rows = [...data]
+              .filter((row: any) => (filters.shop_id ? row.shop_id === filters.shop_id : true))
+              .filter((row: any) => {
+                const gte = filters["gte:created_at"] as string | undefined;
+                return gte ? row.created_at >= gte : true;
+              });
+
+            if (orderDesc) rows = rows.sort((a: any, b: any) => b.created_at.localeCompare(a.created_at));
+            rows = rows.slice(0, limitValue);
+
+            resolve({ data: rows, error: null });
+          },
+        };
+
+        return query;
+      },
+    } as never;
+  });
+}
+
+describe("getAiOperationsObservability", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    seed();
+    mockFromTable();
+  });
+
+  it("enforces shop scoping", async () => {
+    const result = await getAiOperationsObservability({ supabase: {} as never, actorContext: ACTOR, now: NOW });
+    expect(result.recommendations.byDomain.work_orders).toBe(2);
+    expect(result.recommendations.totalActive).toBe(2);
+    expect(result.expiration.recommendationsExpiredLast7d).toBe(1);
+  });
+
+  it("returns safe DTO shape without raw payload fields", async () => {
+    const result = await getAiOperationsObservability({ supabase: {} as never, actorContext: ACTOR, now: NOW }) as Record<string, unknown>;
+    expect(result).toHaveProperty("recommendations");
+    expect(result).not.toHaveProperty("preview_payload");
+    expect(result).not.toHaveProperty("intended_mutations");
+    expect(result).not.toHaveProperty("owner_pin_verification_ref");
+    expect(result).not.toHaveProperty("payload");
+  });
+
+  it("computes stale and pending approval backlog flags", async () => {
+    const result = await getAiOperationsObservability({ supabase: {} as never, actorContext: ACTOR, now: NOW });
+    expect(result.health.hasStaleBacklog).toBe(true);
+    expect(result.health.hasPendingApprovalBacklog).toBe(true);
+    expect(result.health.hasHighRiskBacklog).toBe(true);
+  });
+
+  it("infers cron health from expiration events", async () => {
+    const running = await getAiOperationsObservability({ supabase: {} as never, actorContext: ACTOR, now: NOW });
+    expect(running.health.cronProbablyRunning).toBe(true);
+
+    db.events = db.events.filter((row) => !row.event_type.endsWith(".expired"));
+    const stalled = await getAiOperationsObservability({ supabase: {} as never, actorContext: ACTOR, now: NOW });
+    expect(stalled.health.cronProbablyRunning).toBe(false);
+  });
+
+  it("reports expiration windows and domain breakdown", async () => {
+    const result = await getAiOperationsObservability({ supabase: {} as never, actorContext: ACTOR, now: NOW });
+    expect(result.expiration.recommendationsExpiredLast24h).toBe(1);
+    expect(result.expiration.previewsExpiredLast24h).toBe(1);
+    expect(result.expiration.approvalsExpiredLast24h).toBe(1);
+    expect(result.actionPreviews.byDomain.work_orders).toBe(2);
+    expect(result.actionPreviews.byDomain.shop_boost).toBe(1);
+  });
+});

--- a/features/ai/server/dashboard/getAiOperationsObservability.ts
+++ b/features/ai/server/dashboard/getAiOperationsObservability.ts
@@ -1,0 +1,317 @@
+import type { Json } from "@shared/types/types/supabase";
+import { AI_ACTION_EVENT_TYPES } from "@/features/ai/server/eventTypes";
+import { ensureActorContext, fromTable, type AiActionApprovalStatus, type AiActionPreviewStatus, type AiRecommendationStatus, type AiRiskTier, type AiServerClient } from "@/features/ai/server/types";
+
+const DEFAULT_EVENT_WINDOW_DAYS = 7;
+const DEFAULT_MAX_ROWS = 5000;
+
+export type GetAiOperationsObservabilityInput = {
+  supabase: AiServerClient;
+  actorContext: {
+    shopId: string;
+    actorId: string;
+    role?: string | null;
+    source: "system" | "planner" | "ops" | "manual";
+    capabilities?: ReadonlyArray<string>;
+  };
+  now?: Date;
+};
+
+type RecommendationRow = {
+  id: string;
+  domain: "work_orders" | "shop_boost";
+  status: AiRecommendationStatus;
+  risk_tier: AiRiskTier;
+  missing_data: Json;
+  created_at: string;
+  expires_at: string | null;
+};
+
+type ActionPreviewRow = {
+  id: string;
+  domain: "work_orders" | "shop_boost";
+  action_type: string;
+  status: AiActionPreviewStatus;
+  created_at: string;
+  expires_at: string | null;
+};
+
+type ActionApprovalRow = {
+  id: string;
+  status: AiActionApprovalStatus;
+  owner_pin_required: boolean;
+  requested_at: string;
+  expires_at: string | null;
+};
+
+type ActionEventRow = {
+  id: string;
+  event_type: string;
+  created_at: string;
+};
+
+export type AiOperationsObservability = {
+  generatedAt: string;
+  recommendations: {
+    totalActive: number;
+    open: number;
+    acknowledged: number;
+    dismissed: number;
+    resolved: number;
+    expired: number;
+    stale: number;
+    highOrCriticalRisk: number;
+    needsRefresh: number;
+    byDomain: Record<"work_orders" | "shop_boost", number>;
+  };
+  actionPreviews: {
+    total: number;
+    ready: number;
+    approvalRequired: number;
+    expired: number;
+    executionBlocked: number;
+    byDomain: Record<"work_orders" | "shop_boost", number>;
+    byActionType: Array<{ actionType: string; count: number }>;
+  };
+  approvals: {
+    pending: number;
+    approved: number;
+    rejected: number;
+    ownerPinRequiredCount: number;
+  };
+  expiration: {
+    lastExpirationEventAt: string | null;
+    recommendationsExpiredLast24h: number;
+    recommendationsExpiredLast7d: number;
+    previewsExpiredLast24h: number;
+    previewsExpiredLast7d: number;
+    approvalsExpiredLast24h: number;
+    approvalsExpiredLast7d: number;
+  };
+  events: {
+    lastEventAt: string | null;
+    recentByType: Array<{ eventType: string; count: number }>;
+    recentErrorLikeByType: Array<{ eventType: string; count: number }>;
+  };
+  health: {
+    cronProbablyRunning: boolean | "unknown";
+    hasStaleBacklog: boolean;
+    hasHighRiskBacklog: boolean;
+    hasPendingApprovalBacklog: boolean;
+    hasRecentAiActivity: boolean;
+  };
+};
+
+function isExpiredOrStale(expiresAt: string | null, nowMs: number): boolean {
+  if (!expiresAt) return false;
+  const ts = Date.parse(expiresAt);
+  if (!Number.isFinite(ts)) return false;
+  return ts <= nowMs;
+}
+
+function hasMissingData(value: Json): boolean {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function withinWindow(createdAt: string, thresholdMs: number): boolean {
+  const createdMs = Date.parse(createdAt);
+  return Number.isFinite(createdMs) && createdMs >= thresholdMs;
+}
+
+function countByEventType(rows: ActionEventRow[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    counts.set(row.event_type, (counts.get(row.event_type) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function sortCounts(counts: Map<string, number>): Array<{ eventType: string; count: number }> {
+  return Array.from(counts.entries())
+    .map(([eventType, count]) => ({ eventType, count }))
+    .sort((a, b) => b.count - a.count || a.eventType.localeCompare(b.eventType));
+}
+
+export async function getAiOperationsObservability(input: GetAiOperationsObservabilityInput): Promise<AiOperationsObservability> {
+  const actor = ensureActorContext(input.actorContext);
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const nowMs = now.getTime();
+  const since24hMs = nowMs - 24 * 60 * 60 * 1000;
+  const since7dMs = nowMs - DEFAULT_EVENT_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  const since7dIso = new Date(since7dMs).toISOString();
+
+  const [{ data: recommendationsData, error: recommendationsError }, { data: previewsData, error: previewsError }, { data: approvalsData, error: approvalsError }, { data: recentEventsData, error: recentEventsError }, { data: allEventsData, error: allEventsError }] = await Promise.all([
+    fromTable(input.supabase, "ai_recommendations")
+      .select("id, domain, status, risk_tier, missing_data, created_at, expires_at")
+      .eq("shop_id", actor.shopId)
+      .limit(DEFAULT_MAX_ROWS),
+    fromTable(input.supabase, "ai_action_previews")
+      .select("id, domain, action_type, status, created_at, expires_at")
+      .eq("shop_id", actor.shopId)
+      .limit(DEFAULT_MAX_ROWS),
+    fromTable(input.supabase, "ai_action_approvals")
+      .select("id, status, owner_pin_required, requested_at, expires_at")
+      .eq("shop_id", actor.shopId)
+      .limit(DEFAULT_MAX_ROWS),
+    fromTable(input.supabase, "ai_action_events")
+      .select("id, event_type, created_at")
+      .eq("shop_id", actor.shopId)
+      .gte("created_at", since7dIso)
+      .order("created_at", { ascending: false })
+      .limit(DEFAULT_MAX_ROWS),
+    fromTable(input.supabase, "ai_action_events")
+      .select("id, event_type, created_at")
+      .eq("shop_id", actor.shopId)
+      .order("created_at", { ascending: false })
+      .limit(DEFAULT_MAX_ROWS),
+  ]);
+
+  if (recommendationsError) throw new Error(recommendationsError.message);
+  if (previewsError) throw new Error(previewsError.message);
+  if (approvalsError) throw new Error(approvalsError.message);
+  if (recentEventsError) throw new Error(recentEventsError.message);
+  if (allEventsError) throw new Error(allEventsError.message);
+
+  const recommendations = (recommendationsData ?? []) as RecommendationRow[];
+  const previews = (previewsData ?? []) as ActionPreviewRow[];
+  const approvals = (approvalsData ?? []) as ActionApprovalRow[];
+  const recentEvents = (recentEventsData ?? []) as ActionEventRow[];
+  const allEvents = (allEventsData ?? []) as ActionEventRow[];
+
+  const recommendationsByDomain: Record<"work_orders" | "shop_boost", number> = {
+    work_orders: 0,
+    shop_boost: 0,
+  };
+  for (const row of recommendations) {
+    recommendationsByDomain[row.domain] += 1;
+  }
+
+  const openRecommendations = recommendations.filter((row) => row.status === "open");
+  const acknowledgedRecommendations = recommendations.filter((row) => row.status === "acknowledged");
+  const activeRecommendations = recommendations.filter((row) => row.status === "open" || row.status === "acknowledged");
+  const staleRecommendations = activeRecommendations.filter((row) => isExpiredOrStale(row.expires_at, nowMs));
+  const highRiskBacklog = activeRecommendations.filter((row) => row.risk_tier === "high" || row.risk_tier === "critical");
+  const needsRefreshRecommendations = activeRecommendations.filter((row) => hasMissingData(row.missing_data) || isExpiredOrStale(row.expires_at, nowMs));
+
+  const previewsByDomain: Record<"work_orders" | "shop_boost", number> = {
+    work_orders: 0,
+    shop_boost: 0,
+  };
+  const actionTypeCounts = new Map<string, number>();
+  for (const row of previews) {
+    previewsByDomain[row.domain] += 1;
+    actionTypeCounts.set(row.action_type, (actionTypeCounts.get(row.action_type) ?? 0) + 1);
+  }
+
+  const recentEventCounts = countByEventType(recentEvents);
+  const blockedExecutionCount = (recentEventCounts.get(AI_ACTION_EVENT_TYPES.ACTION_PREVIEW_BLOCKED_EXECUTION) ?? 0)
+    + (recentEventCounts.get(AI_ACTION_EVENT_TYPES.ACTION_EXECUTION_BLOCKED) ?? 0);
+
+  const expirationEventTypes = new Set<string>([
+    AI_ACTION_EVENT_TYPES.RECOMMENDATION_EXPIRED,
+    AI_ACTION_EVENT_TYPES.ACTION_PREVIEW_EXPIRED,
+    AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_EXPIRED,
+  ]);
+
+  const expirationEvents = allEvents.filter((row) => expirationEventTypes.has(row.event_type));
+  const lastExpirationEventAt = expirationEvents.length > 0 ? expirationEvents[0]?.created_at ?? null : null;
+
+  const recommendationsExpiredLast24h = recentEvents.filter(
+    (row) => row.event_type === AI_ACTION_EVENT_TYPES.RECOMMENDATION_EXPIRED && withinWindow(row.created_at, since24hMs),
+  ).length;
+  const recommendationsExpiredLast7d = recentEvents.filter((row) => row.event_type === AI_ACTION_EVENT_TYPES.RECOMMENDATION_EXPIRED).length;
+
+  const previewsExpiredLast24h = recentEvents.filter(
+    (row) => row.event_type === AI_ACTION_EVENT_TYPES.ACTION_PREVIEW_EXPIRED && withinWindow(row.created_at, since24hMs),
+  ).length;
+  const previewsExpiredLast7d = recentEvents.filter((row) => row.event_type === AI_ACTION_EVENT_TYPES.ACTION_PREVIEW_EXPIRED).length;
+
+  const approvalsExpiredLast24h = recentEvents.filter(
+    (row) => row.event_type === AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_EXPIRED && withinWindow(row.created_at, since24hMs),
+  ).length;
+  const approvalsExpiredLast7d = recentEvents.filter((row) => row.event_type === AI_ACTION_EVENT_TYPES.ACTION_APPROVAL_EXPIRED).length;
+
+  const errorLikeEventTypes = new Set<string>([
+    AI_ACTION_EVENT_TYPES.ACTION_EXECUTION_FAILED,
+    AI_ACTION_EVENT_TYPES.ACTION_EXECUTION_BLOCKED,
+    AI_ACTION_EVENT_TYPES.ACTION_PREVIEW_BLOCKED_EXECUTION,
+    AI_ACTION_EVENT_TYPES.OWNER_PIN_PROOF_INVALID,
+    AI_ACTION_EVENT_TYPES.OWNER_PIN_PROOF_MISSING,
+  ]);
+
+  const recentErrorLikeCounts = countByEventType(recentEvents.filter((row) => errorLikeEventTypes.has(row.event_type)));
+
+  const lastEventAt = allEvents[0]?.created_at ?? null;
+
+  const hasStaleBacklog = staleRecommendations.length > 0;
+  const hasHighRiskBacklog = highRiskBacklog.length > 0;
+  const hasPendingApprovalBacklog = approvals.some((row) => row.status === "pending");
+  const hasRecentAiActivity =
+    recommendations.some((row) => withinWindow(row.created_at, since24hMs))
+    || previews.some((row) => withinWindow(row.created_at, since24hMs))
+    || approvals.some((row) => withinWindow(row.requested_at, since24hMs))
+    || recentEvents.some((row) => withinWindow(row.created_at, since24hMs));
+
+  let cronProbablyRunning: boolean | "unknown" = "unknown";
+  if (lastExpirationEventAt) {
+    cronProbablyRunning = Date.parse(lastExpirationEventAt) >= nowMs - 36 * 60 * 60 * 1000;
+  } else if (hasStaleBacklog || hasPendingApprovalBacklog) {
+    cronProbablyRunning = false;
+  }
+
+  return {
+    generatedAt: nowIso,
+    recommendations: {
+      totalActive: activeRecommendations.length,
+      open: openRecommendations.length,
+      acknowledged: acknowledgedRecommendations.length,
+      dismissed: recommendations.filter((row) => row.status === "dismissed").length,
+      resolved: recommendations.filter((row) => row.status === "resolved").length,
+      expired: recommendations.filter((row) => row.status === "expired").length,
+      stale: staleRecommendations.length,
+      highOrCriticalRisk: highRiskBacklog.length,
+      needsRefresh: needsRefreshRecommendations.length,
+      byDomain: recommendationsByDomain,
+    },
+    actionPreviews: {
+      total: previews.length,
+      ready: previews.filter((row) => row.status === "ready").length,
+      approvalRequired: previews.filter((row) => row.status === "approval_required").length,
+      expired: previews.filter((row) => row.status === "expired").length,
+      executionBlocked: blockedExecutionCount,
+      byDomain: previewsByDomain,
+      byActionType: Array.from(actionTypeCounts.entries())
+        .map(([actionType, count]) => ({ actionType, count }))
+        .sort((a, b) => b.count - a.count || a.actionType.localeCompare(b.actionType))
+        .slice(0, 6),
+    },
+    approvals: {
+      pending: approvals.filter((row) => row.status === "pending").length,
+      approved: approvals.filter((row) => row.status === "approved").length,
+      rejected: approvals.filter((row) => row.status === "rejected").length,
+      ownerPinRequiredCount: approvals.filter((row) => row.owner_pin_required).length,
+    },
+    expiration: {
+      lastExpirationEventAt,
+      recommendationsExpiredLast24h,
+      recommendationsExpiredLast7d,
+      previewsExpiredLast24h,
+      previewsExpiredLast7d,
+      approvalsExpiredLast24h,
+      approvalsExpiredLast7d,
+    },
+    events: {
+      lastEventAt,
+      recentByType: sortCounts(recentEventCounts).slice(0, 10),
+      recentErrorLikeByType: sortCounts(recentErrorLikeCounts),
+    },
+    health: {
+      cronProbablyRunning,
+      hasStaleBacklog,
+      hasHighRiskBacklog,
+      hasPendingApprovalBacklog,
+      hasRecentAiActivity,
+    },
+  };
+}

--- a/features/ai/server/dashboard/index.ts
+++ b/features/ai/server/dashboard/index.ts
@@ -3,3 +3,4 @@ export * from "./getAiMissionControlSummary";
 export * from "./listAiRecommendationsForReview";
 export * from "./listAiActionApprovalsForReview";
 export * from "./bulkUpdateAiRecommendationsForReview";
+export * from "./getAiOperationsObservability";

--- a/features/dashboard/lib/dashboard-responsive-layout.ts
+++ b/features/dashboard/lib/dashboard-responsive-layout.ts
@@ -27,6 +27,7 @@ export const DASHBOARD_WIDGET_RESPONSIVE_META: Record<DashboardWidgetId, Dashboa
   approval_risk: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12, compactMinHeightRem: 9.5 },
   waiting_parts: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12, compactMinHeightRem: 9.5 },
   ai_mission_control: { mode: "feature", span: { desktop: 1, laptop: 1, tablet: 2, mobile: 1 }, preferredMinHeightRem: 14, compactMinHeightRem: 10.5 },
+  ai_operations_observability: { mode: "feature", span: { desktop: 1, laptop: 1, tablet: 2, mobile: 1 }, preferredMinHeightRem: 14, compactMinHeightRem: 10.5 },
   live_shop_load: { mode: "standard", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 12.5, compactMinHeightRem: 10 },
   stats_overview: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },
   revenue_watch: { mode: "signal", span: { desktop: 1, laptop: 1, tablet: 1, mobile: 1 }, preferredMinHeightRem: 11.5, compactMinHeightRem: 9.5 },

--- a/features/dashboard/lib/dashboard-views.ts
+++ b/features/dashboard/lib/dashboard-views.ts
@@ -20,6 +20,7 @@ export const DASHBOARD_VIEW_WIDGETS: Record<DashboardView, DashboardWidgetId[]> 
     "approval_risk",
     "waiting_parts",
     "ai_mission_control",
+    "ai_operations_observability",
     "live_shop_load",
   ],
   performance: [

--- a/features/dashboard/lib/defaultLayout.ts
+++ b/features/dashboard/lib/defaultLayout.ts
@@ -24,6 +24,7 @@ const STRUCTURED_LAYOUT_SLOTS: StructuredSlot[] = [
   { id: "approval_risk", x: 8, y: 3, w: 4, h: 3 },
   { id: "waiting_parts", x: 8, y: 6, w: 4, h: 3 },
   { id: "ai_mission_control", x: 0, y: 18, w: 4, h: 3 },
+  { id: "ai_operations_observability", x: 8, y: 18, w: 4, h: 3, hidden: true },
   { id: "comeback_risk", x: 8, y: 9, w: 4, h: 3, hidden: true },
 
   { id: "advisor_queue", x: 0, y: 9, w: 4, h: 3 },

--- a/features/dashboard/lib/widget-registry.tsx
+++ b/features/dashboard/lib/widget-registry.tsx
@@ -18,6 +18,7 @@ import {
   waitingPartsWidgetModule,
   workOrderBoardWidgetModule,
   aiMissionControlWidgetModule,
+  aiOperationsObservabilityWidgetModule,
 } from "@/features/dashboard/widgets/modules";
 import type { DashboardWidgetId } from "@/features/dashboard/types/layout";
 import type { DashboardWidgetModule } from "@/features/dashboard/types/widget";
@@ -35,6 +36,7 @@ export const DASHBOARD_WIDGET_REGISTRY: DashboardWidgetModule[] = [
   technicianPerformanceWidgetModule,
   waitingPartsWidgetModule,
   aiMissionControlWidgetModule,
+  aiOperationsObservabilityWidgetModule,
   approvalRiskWidgetModule,
   revenueWatchWidgetModule,
   comebackRiskWidgetModule,

--- a/features/dashboard/types/layout.ts
+++ b/features/dashboard/types/layout.ts
@@ -15,7 +15,8 @@ export type DashboardWidgetId =
   | "bookings"
   | "advisor_queue"
   | "optimization_opportunities"
-  | "ai_mission_control";
+  | "ai_mission_control"
+  | "ai_operations_observability";
 
 export type DashboardCountState = {
   appointments: number;

--- a/features/dashboard/widgets/AiOperationsObservabilityWidget.tsx
+++ b/features/dashboard/widgets/AiOperationsObservabilityWidget.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
+import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
+
+type Observability = {
+  generatedAt: string;
+  recommendations: {
+    totalActive: number;
+    stale: number;
+    byDomain: Record<"work_orders" | "shop_boost", number>;
+  };
+  approvals: {
+    pending: number;
+  };
+  expiration: {
+    lastExpirationEventAt: string | null;
+    recommendationsExpiredLast24h: number;
+    recommendationsExpiredLast7d: number;
+  };
+  events: {
+    lastEventAt: string | null;
+  };
+  health: {
+    cronProbablyRunning: boolean | "unknown";
+    hasStaleBacklog: boolean;
+    hasHighRiskBacklog: boolean;
+    hasPendingApprovalBacklog: boolean;
+  };
+};
+
+function rel(iso: string | null): string {
+  if (!iso) return "—";
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return "—";
+  const delta = Date.now() - ms;
+  const mins = Math.floor(delta / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function healthLabel(value: boolean | "unknown"): string {
+  if (value === "unknown") return "Unknown";
+  return value ? "Running" : "Needs review";
+}
+
+export default function AiOperationsObservabilityWidget() {
+  const [data, setData] = useState<Observability | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/dashboard/ai-observability", { cache: "no-store" });
+      const json = (await res.json().catch(() => ({}))) as { observability?: Observability; error?: string };
+      if (!res.ok) throw new Error(json.error ?? "Failed to load AI observability.");
+      setData(json.observability ?? null);
+    } catch (e) {
+      setError(toDashboardFallbackMessage(e, "AI observability is unavailable right now."));
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const flags = useMemo(() => {
+    if (!data) return [];
+    const items: Array<{ label: string; active: boolean }> = [
+      { label: "Stale backlog", active: data.health.hasStaleBacklog },
+      { label: "High-risk backlog", active: data.health.hasHighRiskBacklog },
+      { label: "Pending approvals", active: data.health.hasPendingApprovalBacklog },
+    ];
+    return items;
+  }, [data]);
+
+  return (
+    <DashboardWidgetShell
+      eyebrow="AI operations"
+      title="AI Observability"
+      subtitle="Operational health and expiration telemetry."
+      compact
+      rightSlot={
+        <div className="flex items-center gap-2">
+          <Link href="/dashboard/ai-recommendations" className="rounded-full border border-cyan-400/35 bg-cyan-500/10 px-3 py-1 text-[11px] font-semibold text-cyan-100 transition hover:bg-cyan-500/20">
+            Recommendations
+          </Link>
+          <Link href="/dashboard/ai-approvals" className="rounded-full border border-amber-400/35 bg-amber-500/10 px-3 py-1 text-[11px] font-semibold text-amber-100 transition hover:bg-amber-500/20">
+            Approvals
+          </Link>
+        </div>
+      }
+    >
+      {loading ? (
+        <div className="h-16 animate-pulse rounded-xl border border-white/10 bg-black/25" />
+      ) : error ? (
+        <div className="rounded-xl border border-[color:color-mix(in_srgb,var(--brand-accent)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-accent)_14%,transparent)] px-3 py-3 text-sm text-[color:var(--brand-accent)]">{error}</div>
+      ) : !data ? (
+        <p className="rounded-xl border border-white/10 bg-black/25 px-3 py-3 text-sm text-neutral-300">No AI observability data yet.</p>
+      ) : (
+        <div className="space-y-3 text-xs">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <Metric label="Active recs" value={String(data.recommendations.totalActive)} />
+            <Metric label="Stale backlog" value={String(data.recommendations.stale)} />
+            <Metric label="Pending approvals" value={String(data.approvals.pending)} />
+            <Metric label="Cron health" value={healthLabel(data.health.cronProbablyRunning)} />
+          </div>
+
+          <div className="flex flex-wrap gap-1.5">
+            <Chip label={`Work Orders ${data.recommendations.byDomain.work_orders}`} />
+            <Chip label={`Shop Boost ${data.recommendations.byDomain.shop_boost}`} />
+            <Chip label={`Expired 24h ${data.expiration.recommendationsExpiredLast24h}`} />
+            <Chip label={`Expired 7d ${data.expiration.recommendationsExpiredLast7d}`} />
+          </div>
+
+          <div className="flex flex-wrap gap-1.5">
+            {flags.map((flag) => (
+              <Chip key={flag.label} label={flag.label} tone={flag.active ? "warn" : "ok"} />
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 gap-2 text-[11px] text-neutral-400 sm:grid-cols-2">
+            <p>Last AI activity: <span className="text-neutral-200">{rel(data.events.lastEventAt)}</span></p>
+            <p>Last stale expiration: <span className="text-neutral-200">{rel(data.expiration.lastExpirationEventAt)}</span></p>
+          </div>
+        </div>
+      )}
+    </DashboardWidgetShell>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/30 px-2.5 py-2">
+      <p className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-neutral-100">{value}</p>
+    </div>
+  );
+}
+
+function Chip({ label, tone = "default" }: { label: string; tone?: "default" | "warn" | "ok" }) {
+  const toneClass = tone === "warn"
+    ? "border-amber-400/35 bg-amber-500/15 text-amber-100"
+    : tone === "ok"
+      ? "border-emerald-400/35 bg-emerald-500/15 text-emerald-100"
+      : "border-white/15 bg-black/30 text-neutral-300";
+
+  return <span className={`rounded-full border px-2 py-0.5 text-[10px] ${toneClass}`}>{label}</span>;
+}

--- a/features/dashboard/widgets/modules/AiOperationsObservabilityWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/AiOperationsObservabilityWidgetModule.tsx
@@ -1,0 +1,15 @@
+import type { DashboardWidgetModule } from "@/features/dashboard/types/widget";
+import AiOperationsObservabilityWidget from "@/features/dashboard/widgets/AiOperationsObservabilityWidget";
+
+export const aiOperationsObservabilityWidgetModule: DashboardWidgetModule = {
+  id: "ai_operations_observability",
+  title: "AI Observability",
+  description: "Operational telemetry for recommendation freshness, approvals, and stale expiration health",
+  roles: ["owner", "admin", "manager"],
+  defaultW: 4,
+  defaultH: 3,
+  minW: 3,
+  minH: 3,
+  selfContained: true,
+  render: () => <AiOperationsObservabilityWidget />,
+};

--- a/features/dashboard/widgets/modules/index.ts
+++ b/features/dashboard/widgets/modules/index.ts
@@ -17,3 +17,4 @@ export { technicianPerformanceWidgetModule } from "./TechnicianPerformanceWidget
 export { liveShopLoadWidgetModule } from "./LiveShopLoadWidgetModule";
 export { optimizationOpportunitiesWidgetModule } from "./OptimizationOpportunitiesWidgetModule";
 export { aiMissionControlWidgetModule } from "./AiMissionControlWidgetModule";
+export { aiOperationsObservabilityWidgetModule } from "./AiOperationsObservabilityWidgetModule";

--- a/tests/dashboard-ai-observability-route.test.ts
+++ b/tests/dashboard-ai-observability-route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const requireShopScopedApiAccessMock = vi.fn();
+const getAiOperationsObservabilityMock = vi.fn();
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: requireShopScopedApiAccessMock,
+}));
+
+vi.mock("@/features/ai/server", () => ({
+  getAiOperationsObservability: getAiOperationsObservabilityMock,
+}));
+
+describe("GET /api/dashboard/ai-observability", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    requireShopScopedApiAccessMock.mockResolvedValue({
+      ok: true,
+      profile: { id: "actor_1", role: "owner", shop_id: "shop_1" },
+      supabase: {},
+    });
+
+    getAiOperationsObservabilityMock.mockResolvedValue({
+      generatedAt: "2026-04-24T12:00:00.000Z",
+      recommendations: { totalActive: 2 },
+      health: { cronProbablyRunning: true },
+    });
+  });
+
+  it("rejects unauthenticated users", async () => {
+    requireShopScopedApiAccessMock.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+
+    const { GET } = await import("../app/api/dashboard/ai-observability/route");
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(getAiOperationsObservabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("returns success with safe response shape", async () => {
+    const { GET } = await import("../app/api/dashboard/ai-observability/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Record<string, unknown>;
+    expect(body.observability).toBeTruthy();
+    expect(body.preview_payload).toBeUndefined();
+    expect(body.owner_pin_verification_ref).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide owners/admins a concise, production-safe view of AI review-layer health (recommendation and preview volume, stale/expired counts, approval queue, cron expiration activity, recent AI events/errors, and domain breakdowns) without exposing raw evidence or execution capabilities. 
- Use a conservative, read-only approach that preserves `shop_id` scoping and existing RLS/auth patterns and avoids any autonomous or mutation-capable behavior.
- Surface simple health flags (e.g. `cronProbablyRunning`, backlog indicators) so operational teams can triage before making any operational changes.

### Description
- Add a canonical, shop-scoped server helper `getAiOperationsObservability` in `features/ai/server/dashboard/getAiOperationsObservability.ts` that reads only canonical AI substrate tables and returns an aggregate, safe DTO with recommendation, preview, approval, expiration, event/error, and health metrics. 
- Add a read-only API route `GET /api/dashboard/ai-observability` at `app/api/dashboard/ai-observability/route.ts` gated via `requireShopScopedApiAccess` for owner/admin/manager and returning only the helper DTO (no writes, no execution). 
- Add a compact dashboard widget `AiOperationsObservabilityWidget` and module `aiOperationsObservabilityWidgetModule` and register it with the dashboard registry/layout/responsive metadata so owner/admin/manager roles can add it to the Operations view. 
- Add focused unit tests for the helper and route (`features/ai/server/dashboard/getAiOperationsObservability.test.ts` and `tests/dashboard-ai-observability-route.test.ts`) and an ops doc `docs/ops/ai-observability.md` describing metric semantics, cron inference, prerequisites, and guardrails. 

### Testing
- Type-check: ran `npx tsc --noEmit` which completed successfully (note: npm emitted the known non-blocking warning `Unknown env config "http-proxy"`).
- Unit tests: ran `npm test` (Vitest); all tests passed — total: 29 test files, 117 tests (including the newly added helper and route tests) and no failures.
- Route/security tests: new route rejects unauthenticated access and returns the safe DTO shape in authorized responses as verified by `tests/dashboard-ai-observability-route.test.ts`.
- Helper tests: `features/ai/server/dashboard/getAiOperationsObservability.test.ts` verifies shop scoping, DTO safety (no raw payloads/secrets exposed), stale/pending backlog flags, cron health inference, expiration windows, and domain breakdowns and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcf839ed883289c4ad05bcc802f39)