### PR TITLE
Harden AI review-layer DTO contracts and tenant guardrails

### DIFF
--- a/app/api/ai/action-previews/[previewId]/approval-request/route.ts
+++ b/app/api/ai/action-previews/[previewId]/approval-request/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requestAiActionPreviewApproval } from "@/features/ai/server";
+import { requestAiActionPreviewApproval, serializeAiApprovalRequestForUi } from "@/features/ai/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type ApprovalRequestBody = {
@@ -86,7 +86,16 @@ export async function POST(
       expiresAt: parsedBody.expiresAt,
     });
 
-    return NextResponse.json(result, { status: result.created ? 201 : 200 });
+    return NextResponse.json(
+      {
+        approval: serializeAiApprovalRequestForUi({
+          approval: result.approval,
+          preview: result.preview,
+        }),
+        created: result.created,
+      },
+      { status: result.created ? 201 : 200 },
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to request approval";
     return NextResponse.json({ error: message }, { status: mapStatusFromError(message) });

--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -300,6 +300,7 @@ export async function POST(req: Request) {
     const review = await reviewWorkOrder({
       supabase: supabaseAdmin,
       workOrderId,
+      shopId: wo.shop_id,
       kind: "invoice_review",
     });
 

--- a/app/api/shop-boost/ai/recommendations/route.ts
+++ b/app/api/shop-boost/ai/recommendations/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import { listAiRecommendationsForSubject } from "@/features/ai/server";
+import {
+  listAiRecommendationsForSubject,
+  serializeAiEvidenceSnapshotForUi,
+  serializeAiRecommendationForUi,
+} from "@/features/ai/server";
 import { generateShopBoostPostActivationEvidenceAndRecommendations } from "@/features/ai/server/domains/shopBoost";
 
 function isUuid(value: string | null | undefined): value is string {
@@ -34,7 +38,9 @@ export async function GET(req: Request) {
     limit: 100,
   });
 
-  const recommendations = rows.filter((row) => row.status === "open" || row.status === "acknowledged");
+  const recommendations = rows
+    .filter((row) => row.status === "open" || row.status === "acknowledged")
+    .map(serializeAiRecommendationForUi);
   return NextResponse.json({ recommendations });
 }
 
@@ -64,5 +70,11 @@ export async function POST(req: Request) {
     sourceRunId: body.sourceRunId?.trim() || null,
   });
 
-  return NextResponse.json(result);
+  return NextResponse.json({
+    evidenceSnapshot: serializeAiEvidenceSnapshotForUi(result.evidenceSnapshot),
+    recommendations: result.recommendations.map(serializeAiRecommendationForUi),
+    skippedDuplicates: result.skippedDuplicates,
+    missingData: result.missingData,
+    warnings: result.warnings,
+  });
 }

--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -12,18 +12,21 @@ export type ReviewKind = "ai_review" | "invoice_review";
 type Args = {
   supabase: SupabaseClient<DB>;
   workOrderId: string;
+  shopId: string;
   kind: ReviewKind;
 };
 
 export async function reviewWorkOrder({
   supabase,
   workOrderId,
+  shopId,
   kind,
 }: Args): Promise<{ ok: boolean; issues: ReviewIssue[] }> {
   const { data: wo, error: woErr } = await supabase
     .from("work_orders")
     .select("*")
     .eq("id", workOrderId)
+    .eq("shop_id", shopId)
     .maybeSingle();
 
   if (woErr) throw woErr;
@@ -38,7 +41,8 @@ export async function reviewWorkOrder({
   const { data: lines, error: lnErr } = await supabase
     .from("work_order_lines")
     .select("*")
-    .eq("work_order_id", wo.id);
+    .eq("work_order_id", wo.id)
+    .eq("shop_id", shopId);
 
   if (lnErr) throw lnErr;
 
@@ -101,6 +105,7 @@ export async function reviewWorkOrder({
       .from("customers")
       .select("email")
       .eq("id", wo.customer_id)
+      .eq("shop_id", shopId)
       .maybeSingle();
 
     if (cErr) throw cErr;
@@ -120,6 +125,7 @@ export async function reviewWorkOrder({
           .from("vehicles")
           .select("id, year, make, model")
           .eq("id", wo.vehicle_id)
+          .eq("shop_id", shopId)
           .maybeSingle();
         vehicle = vehicleRow ?? null;
       }

--- a/app/api/work-orders/[id]/ai-review/route.ts
+++ b/app/api/work-orders/[id]/ai-review/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
 import type { Database } from "@shared/types/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { reviewWorkOrder } from "../_lib/reviewWorkOrder";
 
 type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 
 function getIdFromUrl(url: string): string | null {
   const parts = new URL(url).pathname.split("/"); // ["", "api", "work-orders", "<id>", "ai-review"]
@@ -15,8 +16,37 @@ function isError(x: unknown): x is Error {
   return typeof x === "object" && x !== null && "message" in x;
 }
 
+async function getShopScopedWorkOrder(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<WorkOrderRow | null> {
+  const { data, error } = await input.supabase
+    .from("work_orders")
+    .select("*")
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<WorkOrderRow>();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) {
+    return NextResponse.json(
+      { ok: false, issues: [{ kind: "forbidden", message: "Shop not found" }] },
+      { status: 403 },
+    );
+  }
+
   const woId = getIdFromUrl(req.url);
 
   if (!woId) {
@@ -27,9 +57,23 @@ export async function POST(req: Request) {
   }
 
   try {
-    const result = await reviewWorkOrder({
-      supabase,
+    const scopedWorkOrder = await getShopScopedWorkOrder({
+      supabase: access.supabase,
       workOrderId: woId,
+      shopId,
+    });
+
+    if (!scopedWorkOrder) {
+      return NextResponse.json(
+        { ok: false, issues: [{ kind: "missing_wo", message: "WO not found" }] },
+        { status: 404 },
+      );
+    }
+
+    const result = await reviewWorkOrder({
+      supabase: access.supabase,
+      workOrderId: woId,
+      shopId,
       kind: "ai_review",
     });
 

--- a/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { createAiActionPreview, getAiRecommendation, logAiActionEvent, type AiActionPreviewRecord } from "@/features/ai/server";
+import {
+  createAiActionPreview,
+  getAiRecommendation,
+  logAiActionEvent,
+  serializeAiActionPreviewForUi,
+  type AiActionPreviewRecord,
+} from "@/features/ai/server";
 import { AI_ACTION_EVENT_TYPES } from "@/features/ai/server/eventTypes";
 import {
   buildWorkOrderActionPreviewPayload,
@@ -120,8 +126,8 @@ export async function GET(
     });
 
     return NextResponse.json({
-      preview: previews[0] ?? null,
-      previews,
+      preview: previews[0] ? serializeAiActionPreviewForUi(previews[0]) : null,
+      previews: previews.map(serializeAiActionPreviewForUi),
       executionBlocked: true,
       blockedReason: BLOCKED_REASON,
       warnings: [BLOCKED_REASON],
@@ -257,7 +263,7 @@ export async function POST(
     });
 
     return NextResponse.json({
-      preview,
+      preview: serializeAiActionPreviewForUi(preview),
       executionBlocked: true,
       blockedReason: BLOCKED_REASON,
       warnings: normalizePreviewWarnings(payload),

--- a/app/api/work-orders/[id]/ai/recommendations/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import { listAiEvidenceSnapshotsForSubject, listAiRecommendationsForSubject } from "@/features/ai/server";
+import {
+  listAiEvidenceSnapshotsForSubject,
+  listAiRecommendationsForSubject,
+  serializeAiEvidenceSnapshotForUi,
+  serializeAiRecommendationForUi,
+} from "@/features/ai/server";
 import { generateWorkOrderEvidenceAndRecommendations } from "@/features/ai/server/domains/workOrders";
 
 type DB = Database;
@@ -70,10 +75,10 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const latestEvidence = evidenceSnapshots[0] ?? null;
 
   return NextResponse.json({
-    evidenceSnapshot: latestEvidence,
-    recommendations: openRecommendations,
+    evidenceSnapshot: serializeAiEvidenceSnapshotForUi(latestEvidence),
+    recommendations: openRecommendations.map(serializeAiRecommendationForUi),
     skippedDuplicates: [],
-    missingData: Array.isArray(latestEvidence?.missing_data) ? latestEvidence.missing_data : [],
+    missingData: serializeAiEvidenceSnapshotForUi(latestEvidence)?.missingData ?? [],
     warnings: [],
   });
 }
@@ -114,5 +119,11 @@ export async function POST(_req: Request, ctx: { params: Promise<{ id: string }>
     workOrderId: id,
   });
 
-  return NextResponse.json(result);
+  return NextResponse.json({
+    evidenceSnapshot: serializeAiEvidenceSnapshotForUi(result.evidenceSnapshot),
+    recommendations: result.recommendations.map(serializeAiRecommendationForUi),
+    skippedDuplicates: result.skippedDuplicates,
+    missingData: result.missingData,
+    warnings: result.warnings,
+  });
 }

--- a/app/api/work-orders/[id]/invoice/route.ts
+++ b/app/api/work-orders/[id]/invoice/route.ts
@@ -35,9 +35,24 @@ export async function POST(
   }
 
   try {
+    const { data: scopedWorkOrder, error: scopedWorkOrderError } = await supabase
+      .from("work_orders")
+      .select("shop_id")
+      .eq("id", woId)
+      .maybeSingle<{ shop_id: string | null }>();
+
+    if (scopedWorkOrderError) throw scopedWorkOrderError;
+    if (!scopedWorkOrder?.shop_id) {
+      return NextResponse.json(
+        { ok: false, issues: [{ kind: "missing_wo", message: "WO not found" }] },
+        { status: 404 },
+      );
+    }
+
     const result = await reviewWorkOrder({
       supabase,
       workOrderId: woId,
+      shopId: scopedWorkOrder.shop_id,
       kind: "invoice_review",
     });
 

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -7,6 +7,7 @@ export * from "./actionApprovals";
 export * from "./actionEvents";
 export * from "./safeActions";
 export * from "./ownerPinProof";
+export * from "./serializers";
 export * from "./domains/workOrders";
 export * from "./dashboard";
 export * from "./maintenance";

--- a/features/ai/server/serializers.ts
+++ b/features/ai/server/serializers.ts
@@ -1,0 +1,185 @@
+import { normalizeArrayJson, normalizeObjectJson, type AiActionApprovalRecord, type AiActionPreviewRecord, type AiEvidenceSnapshotRecord, type AiRecommendationRecord } from "./types";
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function normalizeSideEffectLabels(value: unknown): string[] {
+  const labels = normalizeStringArray(value);
+  const unique = new Set<string>();
+
+  for (const label of labels) {
+    unique.add(label.toLowerCase());
+  }
+
+  return [...unique];
+}
+
+function getArrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+export type AiEvidenceSnapshotUiDto = {
+  evidenceSnapshotId: string;
+  evidenceKind: string;
+  domain: string;
+  subjectType: string;
+  subjectId: string | null;
+  generatedAt: string;
+  freshnessAt: string | null;
+  confidence: number | null;
+  missingData: string[];
+  missingDataCount: number;
+};
+
+export function serializeAiEvidenceSnapshotForUi(snapshot: AiEvidenceSnapshotRecord | null): AiEvidenceSnapshotUiDto | null {
+  if (!snapshot) return null;
+  const missingData = normalizeStringArray(snapshot.missing_data);
+
+  return {
+    evidenceSnapshotId: snapshot.id,
+    evidenceKind: snapshot.evidence_kind,
+    domain: snapshot.domain,
+    subjectType: snapshot.subject_type,
+    subjectId: snapshot.subject_id ?? null,
+    generatedAt: snapshot.created_at,
+    freshnessAt: snapshot.freshness_at ?? null,
+    confidence: typeof snapshot.confidence === "number" ? snapshot.confidence : null,
+    missingData,
+    missingDataCount: missingData.length,
+  };
+}
+
+export type AiRecommendationUiDto = {
+  id: string;
+  title: string;
+  summary: string | null;
+  priority: AiRecommendationRecord["priority"];
+  confidence: number | null;
+  risk_tier: AiRecommendationRecord["risk_tier"];
+  status: AiRecommendationRecord["status"];
+  recommendation_type: string;
+  recommended_action: {
+    label?: string;
+    details?: string;
+  } | null;
+  missing_data: string[];
+  created_at: string;
+  evidence_snapshot_id: string | null;
+  requires_approval: boolean;
+  requires_owner_pin: boolean;
+};
+
+export function serializeAiRecommendationForUi(recommendation: AiRecommendationRecord): AiRecommendationUiDto {
+  const recommendedAction = normalizeObjectJson(recommendation.recommended_action) as Record<string, unknown>;
+
+  return {
+    id: recommendation.id,
+    title: recommendation.title,
+    summary: recommendation.summary ?? null,
+    priority: recommendation.priority,
+    confidence: typeof recommendation.confidence === "number" ? recommendation.confidence : null,
+    risk_tier: recommendation.risk_tier,
+    status: recommendation.status,
+    recommendation_type: recommendation.recommendation_type,
+    recommended_action: {
+      label: typeof recommendedAction.label === "string" ? recommendedAction.label : undefined,
+      details: typeof recommendedAction.details === "string" ? recommendedAction.details : undefined,
+    },
+    missing_data: normalizeStringArray(recommendation.missing_data),
+    created_at: recommendation.created_at,
+    evidence_snapshot_id: recommendation.evidence_snapshot_id ?? null,
+    requires_approval: recommendation.requires_approval,
+    requires_owner_pin: recommendation.requires_owner_pin,
+  };
+}
+
+export type AiActionPreviewUiDto = {
+  previewId: string;
+  recommendationId: string | null;
+  actionType: string;
+  status: string;
+  title: string;
+  description: string | null;
+  approvalRequired: boolean;
+  requiresOwnerPin: boolean;
+  executionBlocked: true;
+  riskTier: string;
+  severitySummary: string;
+  affectedRecordCount: number;
+  intendedMutationCount: number;
+  sideEffectLabels: string[];
+  createdAt: string;
+  expiresAt: string | null;
+  evidenceSnapshotId: string | null;
+  subjectType: string;
+  subjectId: string | null;
+};
+
+export function serializeAiActionPreviewForUi(preview: AiActionPreviewRecord): AiActionPreviewUiDto {
+  const previewPayload = normalizeObjectJson(preview.preview_payload) as Record<string, unknown>;
+  const payloadLabels = normalizeSideEffectLabels(previewPayload.side_effects);
+  const persistedLabels = normalizeSideEffectLabels(preview.side_effects);
+  const sideEffectLabels = persistedLabels.length > 0 ? persistedLabels : payloadLabels;
+
+  const title =
+    (typeof previewPayload.label === "string" && previewPayload.label.trim().length > 0 ? previewPayload.label.trim() : null)
+    ?? `Preview: ${preview.action_type}`;
+
+  const description = typeof previewPayload.description === "string" && previewPayload.description.trim().length > 0
+    ? previewPayload.description.trim()
+    : null;
+
+  return {
+    previewId: preview.id,
+    recommendationId: preview.recommendation_id ?? null,
+    actionType: preview.action_type,
+    status: preview.status,
+    title,
+    description,
+    approvalRequired: preview.requires_approval,
+    requiresOwnerPin: preview.requires_owner_pin,
+    executionBlocked: true,
+    riskTier: preview.risk_tier,
+    severitySummary: `severity:${preview.risk_tier}`,
+    affectedRecordCount: getArrayLength(normalizeArrayJson(preview.affected_records)),
+    intendedMutationCount: getArrayLength(normalizeArrayJson(preview.intended_mutations)),
+    sideEffectLabels,
+    createdAt: preview.created_at,
+    expiresAt: preview.expires_at ?? null,
+    evidenceSnapshotId: preview.evidence_snapshot_id ?? null,
+    subjectType: preview.subject_type,
+    subjectId: preview.subject_id ?? null,
+  };
+}
+
+export type AiApprovalRequestUiDto = {
+  approvalId: string;
+  previewId: string;
+  status: string;
+  requestedAt: string;
+  approvalRequired: boolean;
+  requiresOwnerPin: boolean;
+  executionBlocked: true;
+  message: string;
+};
+
+export function serializeAiApprovalRequestForUi(input: {
+  approval: AiActionApprovalRecord;
+  preview: AiActionPreviewRecord;
+}): AiApprovalRequestUiDto {
+  return {
+    approvalId: input.approval.id,
+    previewId: input.preview.id,
+    status: input.approval.status,
+    requestedAt: input.approval.requested_at,
+    approvalRequired: true,
+    requiresOwnerPin: Boolean(input.preview.requires_owner_pin),
+    executionBlocked: true,
+    message: "Approval request recorded for review only. Action execution remains blocked.",
+  };
+}

--- a/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
+++ b/features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx
@@ -30,46 +30,42 @@ type RecommendationRow = {
 };
 
 type EvidenceRow = {
-  id: string;
-  freshness_at: string | null;
+  evidenceSnapshotId: string;
+  freshnessAt: string | null;
   confidence: number | null;
-  missing_data: string[] | null;
-  created_at: string;
-};
-
-type PreviewPayloadRecord = {
-  label?: string;
-  description?: string;
-  affected_records?: Array<{ type?: string; id?: string }>;
-  intended_mutations?: unknown[];
-  side_effects?: string[];
-  requires_approval?: boolean;
-  requires_owner_pin?: boolean;
-  risk_tier?: string;
-  blocked_execution_reason?: string;
-  evidence_snapshot_id?: string | null;
+  missingData: string[];
+  generatedAt: string;
 };
 
 type PreviewRow = {
-  id: string;
-  recommendation_id: string | null;
+  previewId: string;
+  recommendationId: string | null;
+  actionType: string;
   status: string;
-  preview_payload: PreviewPayloadRecord;
-  intended_mutations: unknown[];
-  affected_records: Array<{ type?: string; id?: string }>;
-  side_effects: string[];
-  requires_approval: boolean;
-  requires_owner_pin: boolean;
-  risk_tier: string;
-  evidence_snapshot_id: string | null;
-  created_at: string;
+  title: string;
+  description: string | null;
+  approvalRequired: boolean;
+  requiresOwnerPin: boolean;
+  executionBlocked: true;
+  riskTier: string;
+  severitySummary: string;
+  affectedRecordCount: number;
+  intendedMutationCount: number;
+  sideEffectLabels: string[];
+  createdAt: string;
+  expiresAt: string | null;
+  evidenceSnapshotId: string | null;
 };
 
 type ApprovalRow = {
-  id: string;
-  action_preview_id: string;
+  approvalId: string;
+  previewId: string;
   status: string;
-  requested_at: string;
+  requestedAt: string;
+  approvalRequired: boolean;
+  requiresOwnerPin: boolean;
+  executionBlocked: true;
+  message: string;
 };
 
 type AdvisorDraftSection = {
@@ -98,25 +94,26 @@ function isPreviewableRecommendation(item: RecommendationRow): boolean {
 function parsePreview(raw: unknown): PreviewRow | null {
   if (!raw || typeof raw !== "object") return null;
   const value = raw as Record<string, unknown>;
-  if (typeof value.id !== "string") return null;
-
-  const previewPayload = value.preview_payload && typeof value.preview_payload === "object"
-    ? (value.preview_payload as PreviewPayloadRecord)
-    : {};
+  if (typeof value.previewId !== "string") return null;
 
   return {
-    id: value.id,
-    recommendation_id: typeof value.recommendation_id === "string" ? value.recommendation_id : null,
+    previewId: value.previewId,
+    recommendationId: typeof value.recommendationId === "string" ? value.recommendationId : null,
+    actionType: typeof value.actionType === "string" ? value.actionType : "unknown",
     status: typeof value.status === "string" ? value.status : "draft",
-    preview_payload: previewPayload,
-    intended_mutations: Array.isArray(value.intended_mutations) ? value.intended_mutations : [],
-    affected_records: Array.isArray(value.affected_records) ? (value.affected_records as Array<{ type?: string; id?: string }>) : [],
-    side_effects: Array.isArray(value.side_effects) ? (value.side_effects as string[]) : [],
-    requires_approval: Boolean(value.requires_approval),
-    requires_owner_pin: Boolean(value.requires_owner_pin),
-    risk_tier: typeof value.risk_tier === "string" ? value.risk_tier : "low",
-    evidence_snapshot_id: typeof value.evidence_snapshot_id === "string" ? value.evidence_snapshot_id : null,
-    created_at: typeof value.created_at === "string" ? value.created_at : "",
+    title: typeof value.title === "string" ? value.title : "Action preview",
+    description: typeof value.description === "string" ? value.description : null,
+    approvalRequired: Boolean(value.approvalRequired),
+    requiresOwnerPin: Boolean(value.requiresOwnerPin),
+    executionBlocked: true,
+    riskTier: typeof value.riskTier === "string" ? value.riskTier : "low",
+    severitySummary: typeof value.severitySummary === "string" ? value.severitySummary : "severity:low",
+    affectedRecordCount: typeof value.affectedRecordCount === "number" ? value.affectedRecordCount : 0,
+    intendedMutationCount: typeof value.intendedMutationCount === "number" ? value.intendedMutationCount : 0,
+    sideEffectLabels: Array.isArray(value.sideEffectLabels) ? (value.sideEffectLabels.filter((item): item is string => typeof item === "string")) : [],
+    createdAt: typeof value.createdAt === "string" ? value.createdAt : "",
+    expiresAt: typeof value.expiresAt === "string" ? value.expiresAt : null,
+    evidenceSnapshotId: typeof value.evidenceSnapshotId === "string" ? value.evidenceSnapshotId : null,
   };
 }
 
@@ -290,16 +287,16 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
 
   const onRequestApproval = useCallback(
     async (preview: PreviewRow) => {
-      if (preview.requires_owner_pin) {
+      if (preview.requiresOwnerPin) {
         toast.info("Owner PIN proof required before approval request.");
         return;
       }
 
-      setApprovalRequestLoadingByPreviewId((prev) => ({ ...prev, [preview.id]: true }));
+      setApprovalRequestLoadingByPreviewId((prev) => ({ ...prev, [preview.previewId]: true }));
       setError(null);
 
       try {
-        const res = await fetch(`/api/ai/action-previews/${preview.id}/approval-request`, {
+        const res = await fetch(`/api/ai/action-previews/${preview.previewId}/approval-request`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -312,13 +309,13 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
         if (!res.ok) throw new Error(json?.error ?? "Failed to request approval.");
 
         const approval = json?.approval as ApprovalRow | undefined;
-        if (!approval?.id) {
+        if (!approval?.approvalId) {
           throw new Error("Approval request response was invalid.");
         }
 
         setApprovalByPreviewId((prev) => ({
           ...prev,
-          [preview.id]: approval,
+          [preview.previewId]: approval,
         }));
 
         if (json?.created === false) {
@@ -331,16 +328,16 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
         setError(message);
         toast.error(message);
       } finally {
-        setApprovalRequestLoadingByPreviewId((prev) => ({ ...prev, [preview.id]: false }));
+        setApprovalRequestLoadingByPreviewId((prev) => ({ ...prev, [preview.previewId]: false }));
       }
     },
     [],
   );
 
   const freshnessLabel = useMemo(() => {
-    if (!evidence?.freshness_at) return "No evidence snapshot yet";
-    return `Evidence freshness: ${new Date(evidence.freshness_at).toLocaleString()}`;
-  }, [evidence?.freshness_at]);
+    if (!evidence?.freshnessAt) return "No evidence snapshot yet";
+    return `Evidence freshness: ${new Date(evidence.freshnessAt).toLocaleString()}`;
+  }, [evidence?.freshnessAt]);
 
   return (
     <section id="ai-operational-recommendations" className={cn(PANEL_VARIANTS.secondary, "p-2")}>
@@ -460,31 +457,25 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
 
                 {preview ? (
                   <div className="mt-2 rounded-md border border-white/10 bg-white/[0.02] p-2 text-[10px] text-muted-foreground">
-                    <div className="text-[11px] font-medium text-foreground">{preview.preview_payload.label ?? "Action preview"}</div>
-                    <p className="mt-1">{preview.preview_payload.description ?? "Preview generated for operational review."}</p>
-                    <p className="mt-1">Affected records: {preview.affected_records.length}</p>
-                    {preview.affected_records.length > 0 ? (
-                      <ul className="mt-1 list-disc pl-4">
-                        {preview.affected_records.map((record, idx) => (
-                          <li key={`${preview.id}:record:${idx}`}>{record.type ?? "record"}: {record.id ?? "—"}</li>
-                        ))}
-                      </ul>
-                    ) : null}
-                    <p className="mt-1">Intended mutations: {preview.intended_mutations.length > 0 ? String(preview.intended_mutations.length) : "None — preview only"}</p>
-                    <p className="mt-1">Side effects: {preview.side_effects.length > 0 ? preview.side_effects.join(" • ") : "No external side effects"}</p>
-                    <p className="mt-1">Approval required: {preview.requires_approval ? "Yes" : "No"}</p>
-                    <p className="mt-1">Owner PIN required: {preview.requires_owner_pin ? "Yes" : "No"}</p>
+                    <div className="text-[11px] font-medium text-foreground">{preview.title}</div>
+                    <p className="mt-1">{preview.description ?? "Preview generated for operational review."}</p>
+                    <p className="mt-1">Action type: {preview.actionType}</p>
+                    <p className="mt-1">Affected records: {preview.affectedRecordCount}</p>
+                    <p className="mt-1">Intended mutations: {preview.intendedMutationCount > 0 ? String(preview.intendedMutationCount) : "None — preview only"}</p>
+                    <p className="mt-1">Side effects: {preview.sideEffectLabels.length > 0 ? preview.sideEffectLabels.join(" • ") : "No external side effects"}</p>
+                    <p className="mt-1">Approval required: {preview.approvalRequired ? "Yes" : "No"}</p>
+                    <p className="mt-1">Owner PIN required: {preview.requiresOwnerPin ? "Yes" : "No"}</p>
                     <p className="mt-1">Execution blocked: Yes</p>
-                    <p className="mt-1">Risk tier: {preview.risk_tier}</p>
+                    <p className="mt-1">Risk tier: {preview.riskTier}</p>
                     <p className="mt-1">Execution status: Execution blocked — preview only</p>
-                    <p className="mt-1">Evidence snapshot: {preview.evidence_snapshot_id ?? preview.preview_payload.evidence_snapshot_id ?? "Not linked"}</p>
+                    <p className="mt-1">Evidence snapshot: {preview.evidenceSnapshotId ?? "Not linked"}</p>
                     <div className="mt-2 flex flex-wrap items-center gap-1">
-                      {(preview.requires_approval || preview.risk_tier === "high" || preview.risk_tier === "critical") ? (
+                      {(preview.approvalRequired || preview.riskTier === "high" || preview.riskTier === "critical") ? (
                         <>
                           <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[9px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
                             approval required
                           </span>
-                          {preview.requires_owner_pin ? (
+                          {preview.requiresOwnerPin ? (
                             <span className="rounded-full border border-[rgba(184,115,51,0.5)] px-2 py-0.5 text-[9px] uppercase tracking-wide text-[rgba(184,115,51,0.95)]">
                               owner PIN required
                             </span>
@@ -496,20 +487,20 @@ export default function WorkOrderAiOperationalRecommendations({ workOrderId }: {
                       ) : null}
                     </div>
                     {(preview.status === "ready" || preview.status === "approval_required") &&
-                    (preview.requires_approval || preview.risk_tier === "high" || preview.risk_tier === "critical") ? (
+                    (preview.approvalRequired || preview.riskTier === "high" || preview.riskTier === "critical") ? (
                       <div className="mt-2">
                         <button
                           type="button"
                           className="rounded-md border border-[rgba(184,115,51,0.5)] px-2 py-1 text-[11px] text-[rgba(184,115,51,0.95)] transition hover:bg-[rgba(184,115,51,0.12)] disabled:opacity-50"
-                          disabled={Boolean(approvalRequestLoadingByPreviewId[preview.id]) || preview.requires_owner_pin}
+                          disabled={Boolean(approvalRequestLoadingByPreviewId[preview.previewId]) || preview.requiresOwnerPin}
                           onClick={() => void onRequestApproval(preview)}
                         >
-                          {approvalRequestLoadingByPreviewId[preview.id] ? "Requesting approval…" : "Request approval"}
+                          {approvalRequestLoadingByPreviewId[preview.previewId] ? "Requesting approval…" : "Request approval"}
                         </button>
-                        {preview.requires_owner_pin ? (
+                        {preview.requiresOwnerPin ? (
                           <p className="mt-1 text-[10px] text-muted-foreground">Owner PIN proof required before approval request.</p>
                         ) : null}
-                        {approvalByPreviewId[preview.id]?.status === "pending" ? (
+                        {approvalByPreviewId[preview.previewId]?.status === "pending" ? (
                           <p className="mt-1 text-[10px] text-[rgba(184,115,51,0.95)]">Pending approval request exists.</p>
                         ) : null}
                       </div>

--- a/tests/ai-review-layer-safety-routes.test.ts
+++ b/tests/ai-review-layer-safety-routes.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const requireShopScopedApiAccessMock = vi.fn();
+const listAiEvidenceSnapshotsForSubjectMock = vi.fn();
+const listAiRecommendationsForSubjectMock = vi.fn();
+const getAiRecommendationMock = vi.fn();
+const createAiActionPreviewMock = vi.fn();
+const logAiActionEventMock = vi.fn();
+const requestAiActionPreviewApprovalMock = vi.fn();
+const generateShopBoostEvidenceAndRecommendationsMock = vi.fn();
+const generateWorkOrderEvidenceAndRecommendationsMock = vi.fn();
+const reviewWorkOrderMock = vi.fn();
+const approveAiActionPreviewMock = vi.fn();
+const rejectAiActionPreviewMock = vi.fn();
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: requireShopScopedApiAccessMock,
+}));
+
+vi.mock("@/features/ai/server", async () => {
+  const actual = await vi.importActual<typeof import("@/features/ai/server")>("@/features/ai/server");
+  return {
+    ...actual,
+    listAiEvidenceSnapshotsForSubject: listAiEvidenceSnapshotsForSubjectMock,
+    listAiRecommendationsForSubject: listAiRecommendationsForSubjectMock,
+    getAiRecommendation: getAiRecommendationMock,
+    createAiActionPreview: createAiActionPreviewMock,
+    logAiActionEvent: logAiActionEventMock,
+    requestAiActionPreviewApproval: requestAiActionPreviewApprovalMock,
+    approveAiActionPreview: approveAiActionPreviewMock,
+    rejectAiActionPreview: rejectAiActionPreviewMock,
+  };
+});
+
+vi.mock("@/features/ai/server/domains/workOrders", async () => {
+  const actual = await vi.importActual<typeof import("@/features/ai/server/domains/workOrders")>("@/features/ai/server/domains/workOrders");
+  return {
+    ...actual,
+    generateWorkOrderEvidenceAndRecommendations: generateWorkOrderEvidenceAndRecommendationsMock,
+    buildWorkOrderActionPreviewPayload: vi.fn(() => ({
+      action_type: "advisor_review_needed",
+      intended_mutations: [{ op: "update", internal: true }],
+      affected_records: [{ id: "wo_1" }],
+      side_effects: ["queue_update"],
+      compensation_plan: {},
+      risk_tier: "high",
+      evidence_snapshot_id: "ev_1",
+      requires_approval: true,
+      blocked_execution_reason: "blocked",
+    })),
+    buildWorkOrderPreviewIdempotencyKey: vi.fn(() => "idem_1"),
+    normalizePreviewWarnings: vi.fn(() => ["preview_only"]),
+  };
+});
+
+vi.mock("@/features/ai/server/domains/shopBoost", async () => {
+  const actual = await vi.importActual<typeof import("@/features/ai/server/domains/shopBoost")>("@/features/ai/server/domains/shopBoost");
+  return {
+    ...actual,
+    generateShopBoostPostActivationEvidenceAndRecommendations: generateShopBoostEvidenceAndRecommendationsMock,
+  };
+});
+
+vi.mock("../app/api/work-orders/[id]/_lib/reviewWorkOrder", () => ({
+  reviewWorkOrder: reviewWorkOrderMock,
+}));
+
+function createScopedSupabase(workOrderExists = true) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: workOrderExists ? { id: "wo_1", shop_id: "shop_1" } : null, error: null })),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  requireShopScopedApiAccessMock.mockResolvedValue({
+    ok: true,
+    profile: { id: "actor_1", role: "manager", shop_id: "shop_1" },
+    supabase: createScopedSupabase(true),
+  });
+});
+
+describe("review-layer route safe contracts", () => {
+  it("work-order recommendations GET omits raw evidence snapshot payload", async () => {
+    listAiRecommendationsForSubjectMock.mockResolvedValue([
+      {
+        id: "rec_1",
+        title: "Dispatch review",
+        summary: "Internal only",
+        priority: "high",
+        confidence: 0.8,
+        risk_tier: "high",
+        status: "open",
+        recommendation_type: "dispatch_review",
+        recommended_action: { label: "Review queue" },
+        missing_data: ["assignment_missing"],
+        created_at: "2026-04-24T00:00:00.000Z",
+        evidence_snapshot_id: "ev_1",
+        requires_approval: true,
+        requires_owner_pin: false,
+      },
+    ]);
+    listAiEvidenceSnapshotsForSubjectMock.mockResolvedValue([
+      {
+        id: "ev_1",
+        evidence_kind: "work_order_operational",
+        domain: "work_orders",
+        subject_type: "work_order",
+        subject_id: "wo_1",
+        created_at: "2026-04-24T00:00:00.000Z",
+        freshness_at: "2026-04-24T00:00:00.000Z",
+        confidence: 0.9,
+        missing_data: ["assignment_missing"],
+        snapshot: { private: true },
+        metadata: { internal: true },
+      },
+    ]);
+
+    const { GET } = await import("../app/api/work-orders/[id]/ai/recommendations/route");
+    const response = await GET(new Request("http://localhost"), { params: Promise.resolve({ id: "wo_1" }) });
+    const json = await response.json() as Record<string, unknown>;
+    const serialized = JSON.stringify(json);
+
+    expect(response.status).toBe(200);
+    expect(serialized).not.toContain("\"snapshot\":");
+    expect(serialized).not.toContain("metadata");
+    expect(serialized).toContain("evidenceSnapshotId");
+  });
+
+  it("preview route GET/POST omit raw preview payload internals", async () => {
+    getAiRecommendationMock.mockResolvedValue({
+      id: "rec_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+    });
+    createAiActionPreviewMock.mockResolvedValue({
+      id: "preview_1",
+      recommendation_id: "rec_1",
+      action_type: "advisor_review_needed",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+      status: "approval_required",
+      preview_payload: { label: "Preview", ownerPinProofRef: "secret" },
+      intended_mutations: [{ op: "update" }],
+      affected_records: [{ id: "wo_1" }],
+      side_effects: ["queue_update"],
+      requires_approval: true,
+      requires_owner_pin: false,
+      risk_tier: "high",
+      evidence_snapshot_id: "ev_1",
+      created_at: "2026-04-24T00:00:00.000Z",
+      expires_at: null,
+    });
+
+    const { GET, POST } = await import("../app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route");
+    const getResponse = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "wo_1", recommendationId: "rec_1" }),
+    });
+    const getJson = await getResponse.json() as Record<string, unknown>;
+    expect(JSON.stringify(getJson)).not.toContain("preview_payload");
+
+    const postResponse = await POST(new Request("http://localhost", { method: "POST" }), {
+      params: Promise.resolve({ id: "wo_1", recommendationId: "rec_1" }),
+    });
+    const postJson = await postResponse.json() as Record<string, unknown>;
+    const serialized = JSON.stringify(postJson);
+    expect(serialized).not.toContain("intended_mutations");
+    expect(serialized).not.toContain("ownerPinProofRef");
+    expect(serialized).not.toContain("side_effects\":[{");
+    expect(postJson.executionBlocked).toBe(true);
+  });
+
+  it("approval-request route returns minimal DTO and hides owner pin proof refs", async () => {
+    requestAiActionPreviewApprovalMock.mockResolvedValue({
+      approval: {
+        id: "approval_1",
+        status: "pending",
+        requested_at: "2026-04-24T00:00:00.000Z",
+        owner_pin_verification_ref: "proof",
+        metadata: { ownerPinProofRef: "secret" },
+      },
+      preview: {
+        id: "preview_1",
+        requires_owner_pin: true,
+      },
+      created: true,
+    });
+
+    const { POST } = await import("../app/api/ai/action-previews/[previewId]/approval-request/route");
+    const response = await POST(
+      new Request("http://localhost", { method: "POST", body: JSON.stringify({ reason: "please approve" }) }),
+      { params: Promise.resolve({ previewId: "preview_1" }) },
+    );
+
+    const json = await response.json() as Record<string, unknown>;
+    const serialized = JSON.stringify(json);
+    expect(response.status).toBe(201);
+    expect(serialized).not.toContain("owner_pin_verification_ref");
+    expect(serialized).not.toContain("ownerPinProofRef");
+    expect(serialized).not.toContain("metadata");
+    expect(serialized).toContain("approvalId");
+  });
+
+  it("shop boost recommendations POST omits raw evidence snapshot payload", async () => {
+    generateShopBoostEvidenceAndRecommendationsMock.mockResolvedValue({
+      evidenceSnapshot: {
+        id: "ev_sb_1",
+        evidence_kind: "shop_boost",
+        domain: "shop_boost",
+        subject_type: "shop_boost_intake",
+        subject_id: "intake_1",
+        created_at: "2026-04-24T00:00:00.000Z",
+        freshness_at: "2026-04-24T00:00:00.000Z",
+        confidence: 0.9,
+        missing_data: [],
+        snapshot: { importPayload: "raw" },
+        source_refs: [],
+        metadata: { materializationPayload: "raw" },
+      },
+      recommendations: [],
+      skippedDuplicates: [],
+      missingData: [],
+      warnings: [],
+    });
+
+    const { POST } = await import("../app/api/shop-boost/ai/recommendations/route");
+    const response = await POST(new Request("http://localhost", { method: "POST", body: "{}" }));
+    const json = await response.json() as Record<string, unknown>;
+    const serialized = JSON.stringify(json);
+
+    expect(response.status).toBe(200);
+    expect(serialized).not.toContain("importPayload");
+    expect(serialized).not.toContain("materializationPayload");
+    expect(serialized).toContain("evidenceSnapshotId");
+  });
+
+  it("legacy ai-review rejects unauthenticated and cross-shop access", async () => {
+    requireShopScopedApiAccessMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+    const { POST } = await import("../app/api/work-orders/[id]/ai-review/route");
+    const unauth = await POST(new Request("http://localhost/api/work-orders/wo_1/ai-review", { method: "POST" }));
+    expect(unauth.status).toBe(401);
+
+    requireShopScopedApiAccessMock.mockResolvedValueOnce({
+      ok: true,
+      profile: { id: "actor_1", role: "manager", shop_id: "shop_1" },
+      supabase: createScopedSupabase(false),
+    });
+    const notFound = await POST(new Request("http://localhost/api/work-orders/wo_cross/ai-review", { method: "POST" }));
+    expect(notFound.status).toBe(404);
+    expect(reviewWorkOrderMock).not.toHaveBeenCalled();
+  });
+
+  it("approval decision route cannot accept execute/apply semantics", async () => {
+    const { PATCH } = await import("../app/api/ai/action-approvals/[approvalId]/route");
+    const response = await PATCH(
+      new Request("http://localhost", {
+        method: "PATCH",
+        body: JSON.stringify({ decision: "execute" }),
+      }),
+      { params: Promise.resolve({ approvalId: "approval_1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(approveAiActionPreviewMock).not.toHaveBeenCalled();
+    expect(rejectAiActionPreviewMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ai-safe-serializers.test.ts
+++ b/tests/ai-safe-serializers.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+  serializeAiActionPreviewForUi,
+  serializeAiApprovalRequestForUi,
+  serializeAiEvidenceSnapshotForUi,
+  serializeAiRecommendationForUi,
+} from "@/features/ai/server";
+
+describe("AI safe serializers", () => {
+  it("strips raw evidence payloads and metadata", () => {
+    const dto = serializeAiEvidenceSnapshotForUi({
+      id: "ev_1",
+      shop_id: "shop_1",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+      domain: "work_orders",
+      evidence_kind: "work_order_operational",
+      snapshot: { private: "raw" },
+      source_refs: [{ secret: "ref" }],
+      missing_data: ["missing_parts", "missing_approval"],
+      freshness_at: "2026-04-24T00:00:00.000Z",
+      confidence: 0.82,
+      created_by: "actor_1",
+      created_at: "2026-04-24T00:00:00.000Z",
+      metadata: { internalRef: "do-not-leak" },
+    });
+
+    expect(dto).toMatchObject({
+      evidenceSnapshotId: "ev_1",
+      evidenceKind: "work_order_operational",
+      missingDataCount: 2,
+    });
+    const serialized = JSON.stringify(dto);
+    expect(serialized).not.toContain("snapshot");
+    expect(serialized).not.toContain("source_refs");
+    expect(serialized).not.toContain("metadata");
+    expect(serialized).not.toContain("internalRef");
+  });
+
+  it("strips preview payload internals and keeps execution blocked", () => {
+    const dto = serializeAiActionPreviewForUi({
+      id: "preview_1",
+      shop_id: "shop_1",
+      recommendation_id: "rec_1",
+      domain: "work_orders",
+      action_type: "advisor_review_needed",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+      status: "approval_required",
+      preview_payload: {
+        label: "Review technician dispatch",
+        description: "Internal review only.",
+        side_effects: ["queue_update"],
+        ownerPinProofRef: "/proof/path",
+      },
+      intended_mutations: [{ op: "update" }],
+      affected_records: [{ id: "wo_1" }],
+      side_effects: ["queue_update", "QUEUE_UPDATE"],
+      compensation_plan: { rollback: true },
+      idempotency_key: "idem_1",
+      requires_approval: true,
+      requires_owner_pin: true,
+      risk_tier: "high",
+      evidence_snapshot_id: "ev_1",
+      created_by: "actor_1",
+      created_at: "2026-04-24T00:00:00.000Z",
+      updated_at: "2026-04-24T00:00:00.000Z",
+      expires_at: null,
+      metadata: {
+        token: "sensitive",
+        secret: "sensitive",
+        hash: "sensitive",
+        pin: "sensitive",
+      },
+    });
+
+    expect(dto.executionBlocked).toBe(true);
+    expect(dto.intendedMutationCount).toBe(1);
+    expect(dto.sideEffectLabels).toEqual(["queue_update"]);
+    const serialized = JSON.stringify(dto);
+    expect(serialized).not.toContain("intended_mutations");
+    expect(serialized).not.toContain("ownerPinProofRef");
+    expect(serialized).not.toContain("token");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("hash");
+    expect(serialized).not.toContain("pin");
+  });
+
+  it("returns minimal approval request DTO without proof references", () => {
+    const dto = serializeAiApprovalRequestForUi({
+      approval: {
+        id: "approval_1",
+        shop_id: "shop_1",
+        action_preview_id: "preview_1",
+        status: "pending",
+        requested_by: "actor_1",
+        requested_at: "2026-04-24T00:00:00.000Z",
+        decided_by: null,
+        decided_at: null,
+        decision_note: null,
+        owner_pin_required: true,
+        owner_pin_verified: false,
+        owner_pin_verification_ref: "proof_ref",
+        expires_at: null,
+        metadata: {
+          ownerPinProofRef: "/internal/path",
+          token: "nope",
+        },
+      },
+      preview: {
+        id: "preview_1",
+        shop_id: "shop_1",
+        recommendation_id: "rec_1",
+        domain: "work_orders",
+        action_type: "advisor_review_needed",
+        subject_type: "work_order",
+        subject_id: "wo_1",
+        status: "approval_required",
+        preview_payload: {},
+        intended_mutations: [],
+        affected_records: [],
+        side_effects: [],
+        compensation_plan: {},
+        idempotency_key: null,
+        requires_approval: true,
+        requires_owner_pin: true,
+        risk_tier: "high",
+        evidence_snapshot_id: null,
+        created_by: null,
+        created_at: "2026-04-24T00:00:00.000Z",
+        updated_at: "2026-04-24T00:00:00.000Z",
+        expires_at: null,
+        metadata: {},
+      },
+    });
+
+    expect(dto).toMatchObject({
+      approvalId: "approval_1",
+      previewId: "preview_1",
+      executionBlocked: true,
+      requiresOwnerPin: true,
+    });
+    expect(JSON.stringify(dto)).not.toContain("owner_pin_verification_ref");
+    expect(JSON.stringify(dto)).not.toContain("ownerPinProofRef");
+    expect(JSON.stringify(dto)).not.toContain("token");
+  });
+
+  it("serializes recommendation with allowlisted fields only", () => {
+    const dto = serializeAiRecommendationForUi({
+      id: "rec_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      recommendation_type: "dispatch_review",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+      title: "Dispatch review",
+      summary: "Review dispatch",
+      status: "open",
+      priority: "high",
+      confidence: 0.9,
+      risk_tier: "high",
+      evidence_snapshot_id: "ev_1",
+      evidence_snapshot_ids: ["ev_1"],
+      missing_data: ["tech_assignment"],
+      recommended_action: { label: "Review", details: "Review queue", token: "internal" },
+      side_effects: ["internal_effect"],
+      requires_approval: true,
+      requires_owner_pin: false,
+      source: "manual",
+      source_run_id: null,
+      created_by: "actor_1",
+      assigned_to: null,
+      dismissed_by: null,
+      dismissed_at: null,
+      resolved_by: null,
+      resolved_at: null,
+      expires_at: null,
+      created_at: "2026-04-24T00:00:00.000Z",
+      updated_at: "2026-04-24T00:00:00.000Z",
+      metadata: { secret: "nope" },
+    });
+
+    const serialized = JSON.stringify(dto);
+    expect(serialized).not.toContain("metadata");
+    expect(serialized).not.toContain("side_effects");
+    expect(serialized).not.toContain("token");
+    expect(dto.requires_approval).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent leakage of raw evidence/preview/approval payloads and internal proof refs from AI review-layer APIs by introducing allowlisted UI DTOs.
- Ensure legacy review endpoints explicitly enforce shop-scoped access and do not rely on implicit or weaker scoping patterns.
- Preserve review-only, execution-blocked posture across preview/approval surfaces while making response contracts safe for UI consumption.

### Description
- Added canonical safe serializers in `features/ai/server/serializers.ts` (`serializeAiEvidenceSnapshotForUi`, `serializeAiActionPreviewForUi`, `serializeAiApprovalRequestForUi`, `serializeAiRecommendationForUi`) that build allowlisted DTOs field-by-field and never spread raw DB rows.
- Replaced raw-record responses with safe DTOs in API routes: `app/api/work-orders/[id]/ai/recommendations/route.ts`, `app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route.ts`, `app/api/ai/action-previews/[previewId]/approval-request/route.ts`, and `app/api/shop-boost/ai/recommendations/route.ts`.
- Hardened legacy review flow by applying `requireShopScopedApiAccess` and explicit `shop_id` checks in `app/api/work-orders/[id]/ai-review/route.ts` and tightened `reviewWorkOrder` queries in `app/api/work-orders/[id]/_lib/reviewWorkOrder.ts` to filter by `shop_id` on work orders, lines, customers, and vehicles.
- Updated the operational recommendations UI to consume the safe preview DTO shape and render curated `sideEffectLabels`/counts only in `features/work-orders/components/WorkOrderAiOperationalRecommendations.tsx`.
- Exported serializers via `features/ai/server/index.ts` and added tests under `tests/ai-safe-serializers.test.ts` and `tests/ai-review-layer-safety-routes.test.ts` to assert unsafe fields are stripped and legacy route scoping/behavior is enforced.
- No DB migrations were added and no new execution/apply/approve-and-run paths were introduced.

### Testing
- Ran typecheck with `npx tsc --noEmit`, which passed (note: npm emitted the known non-blocking warning `Unknown env config "http-proxy"`).
- Ran unit tests with `npm test` (Vitest) and all tests passed: 31 test files, 127 tests (including the new serializer and route contract tests).
- New tests specifically validate that `snapshot`, `metadata`, `intended_mutations`, owner PIN proof refs, and token/secret/hash/pin-like fields are not present in API/serializer outputs and that previews/approvals remain `executionBlocked`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebed7e04988328ba9801d9b2362cdb)