### PR TITLE
Harden AI lifecycle PATCH response and approval-inbox preview safety

### DIFF
--- a/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts
@@ -6,6 +6,7 @@ import {
   dismissAiRecommendation,
   getAiRecommendation,
   resolveAiRecommendation,
+  serializeAiRecommendationForUi,
 } from "@/features/ai/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
@@ -135,7 +136,10 @@ export async function PATCH(
       updated = await resolveAiRecommendation(access.supabase, actor, recommendationId, { note: body.note });
     }
 
-    return NextResponse.json({ recommendation: updated });
+    return NextResponse.json({
+      recommendation: serializeAiRecommendationForUi(updated),
+      executionBlocked: true,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to update recommendation";
 

--- a/features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts
+++ b/features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts
@@ -87,6 +87,7 @@ function mockFromTable() {
                 {
                   id: "preview_work_order",
                   recommendation_id: "rec_work_order",
+                  action_type: "advisor_review_needed",
                   domain: "work_orders",
                   subject_type: "work_order",
                   subject_id: "WO-42",
@@ -102,6 +103,7 @@ function mockFromTable() {
                 {
                   id: "preview_shop_boost",
                   recommendation_id: "rec_shop_boost",
+                  action_type: "shop_boost_review",
                   domain: "shop_boost",
                   subject_type: "shop_boost_activation",
                   subject_id: null,
@@ -234,5 +236,212 @@ describe("listAiActionApprovalsForReview", () => {
 
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0]?.id).toBe("approval_approved");
+  });
+
+  it("falls back to deterministic safe copy when preview payload fields are unsafe", async () => {
+    vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+      if (table === "ai_action_approvals") {
+        return {
+          select: () => ({
+            eq: () => ({
+              limit: () => ({
+                eq: async () => ({
+                  data: [
+                    {
+                      id: "approval_unsafe_preview",
+                      action_preview_id: "preview_unsafe",
+                      status: "pending",
+                      owner_pin_required: false,
+                      owner_pin_verification_ref: null,
+                      requested_at: "2026-04-24T12:00:00.000Z",
+                      requested_by: "actor_2",
+                      decided_at: null,
+                      decided_by: null,
+                      metadata: {},
+                    },
+                  ],
+                  error: null,
+                }),
+                then(resolve: (value: { data: unknown[]; error: null }) => void) {
+                  resolve({
+                    data: [
+                      {
+                        id: "approval_unsafe_preview",
+                        action_preview_id: "preview_unsafe",
+                        status: "pending",
+                        owner_pin_required: false,
+                        owner_pin_verification_ref: null,
+                        requested_at: "2026-04-24T12:00:00.000Z",
+                        requested_by: "actor_2",
+                        decided_at: null,
+                        decided_by: null,
+                        metadata: {},
+                      },
+                    ],
+                    error: null,
+                  });
+                },
+              }),
+            }),
+          }),
+        } as never;
+      }
+
+      if (table === "ai_action_previews") {
+        return {
+          select: () => ({
+            eq: () => ({
+              in: async () => ({
+                data: [
+                  {
+                    id: "preview_unsafe",
+                    recommendation_id: null,
+                    action_type: "advisor_review_needed",
+                    domain: "work_orders",
+                    subject_type: "work_order",
+                    subject_id: "WO-77",
+                    status: "approval_required",
+                    requires_approval: true,
+                    risk_tier: "high",
+                    preview_payload: {
+                      label: "secret token abc",
+                      description: { nested: "bad" },
+                    },
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        } as never;
+      }
+
+      if (table === "ai_recommendations") {
+        return {
+          select: () => ({
+            eq: () => ({
+              in: async () => ({ data: [], error: null }),
+            }),
+          }),
+        } as never;
+      }
+
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              in: async () => ({ data: [], error: null }),
+            }),
+          }),
+        } as never;
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await listAiActionApprovalsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "all" },
+    });
+
+    expect(result.rows).toHaveLength(1);
+    const row = result.rows[0];
+    expect(row?.title).toBe("Review work_orders advisor_review_needed action");
+    expect(row?.description).toBe("Review-only approval_required request for work_order.");
+    expect(row?.title).not.toContain("secret token abc");
+  });
+
+  it("rejects json/blob-looking preview description strings and falls back", async () => {
+    vi.spyOn(types, "fromTable").mockImplementation((_, table: string) => {
+      if (table === "ai_action_approvals") {
+        return {
+          select: () => ({
+            eq: () => ({
+              limit: () => ({
+                eq: async () => ({
+                  data: [{
+                    id: "approval_blob_preview",
+                    action_preview_id: "preview_blob",
+                    status: "pending",
+                    owner_pin_required: false,
+                    owner_pin_verification_ref: null,
+                    requested_at: "2026-04-24T12:00:00.000Z",
+                    requested_by: "actor_2",
+                    decided_at: null,
+                    decided_by: null,
+                    metadata: {},
+                  }],
+                  error: null,
+                }),
+                then(resolve: (value: { data: unknown[]; error: null }) => void) {
+                  resolve({
+                    data: [{
+                      id: "approval_blob_preview",
+                      action_preview_id: "preview_blob",
+                      status: "pending",
+                      owner_pin_required: false,
+                      owner_pin_verification_ref: null,
+                      requested_at: "2026-04-24T12:00:00.000Z",
+                      requested_by: "actor_2",
+                      decided_at: null,
+                      decided_by: null,
+                      metadata: {},
+                    }],
+                    error: null,
+                  });
+                },
+              }),
+            }),
+          }),
+        } as never;
+      }
+      if (table === "ai_action_previews") {
+        return {
+          select: () => ({
+            eq: () => ({
+              in: async () => ({
+                data: [{
+                  id: "preview_blob",
+                  recommendation_id: null,
+                  action_type: "advisor_review_needed",
+                  domain: "work_orders",
+                  subject_type: "work_order",
+                  subject_id: "WO-77",
+                  status: "approval_required",
+                  requires_approval: true,
+                  risk_tier: "high",
+                  preview_payload: {
+                    label: "Safe heading",
+                    description: "{\"raw\":\"secret\",\"token\":\"abc\"}",
+                  },
+                }],
+                error: null,
+              }),
+            }),
+          }),
+        } as never;
+      }
+      if (table === "ai_recommendations" || table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              in: async () => ({ data: [], error: null }),
+            }),
+          }),
+        } as never;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await listAiActionApprovalsForReview({
+      supabase: {} as never,
+      actorContext: ACTOR,
+      filters: { status: "all" },
+    });
+
+    expect(result.rows[0]?.title).toBe("Safe heading");
+    expect(result.rows[0]?.description).toBe("Review-only approval_required request for work_order.");
+    expect(result.rows[0]?.description).not.toContain("token");
   });
 });

--- a/features/ai/server/dashboard/listAiActionApprovalsForReview.ts
+++ b/features/ai/server/dashboard/listAiActionApprovalsForReview.ts
@@ -76,6 +76,7 @@ type ApprovalRow = {
 type PreviewRow = {
   id: string;
   recommendation_id: string | null;
+  action_type: string;
   domain: string;
   subject_type: string;
   subject_id: string | null;
@@ -124,6 +125,24 @@ function toApprovalStatus(status: string): AiApprovalInboxStatus | null {
   return null;
 }
 
+const SENSITIVE_PREVIEW_TEXT_PATTERN = /\b(token|secret|owner[_\s-]?pin|pin|hash|proof|owner[_\s-]?pin[_\s-]?verification[_\s-]?ref|ownerPinProofRef)\b/i;
+
+function looksLikeBlob(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length > 280) return true;
+  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) return true;
+  return false;
+}
+
+function safePreviewText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (SENSITIVE_PREVIEW_TEXT_PATTERN.test(trimmed)) return null;
+  if (looksLikeBlob(trimmed)) return null;
+  return trimmed;
+}
+
 function parsePreviewPayload(value: Json): { label: string | null; description: string | null; ownerPinProofAttached: boolean } {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return { label: null, description: null, ownerPinProofAttached: false };
@@ -131,10 +150,18 @@ function parsePreviewPayload(value: Json): { label: string | null; description: 
 
   const payload = value as Record<string, unknown>;
   return {
-    label: typeof payload.label === "string" ? payload.label : null,
-    description: typeof payload.description === "string" ? payload.description : null,
+    label: safePreviewText(payload.label),
+    description: safePreviewText(payload.description),
     ownerPinProofAttached: false,
   };
+}
+
+function fallbackInboxTitle(preview: PreviewRow): string {
+  return `Review ${preview.domain} ${preview.action_type} action`;
+}
+
+function fallbackInboxDescription(preview: PreviewRow): string {
+  return `Review-only ${preview.status} request for ${preview.subject_type}.`;
 }
 
 function hasOwnerPinProofRef(value: Json): boolean {
@@ -201,7 +228,7 @@ export async function listAiActionApprovalsForReview(
   const previewsById = new Map<string, PreviewRow>();
   if (previewIds.length > 0) {
     const { data: previewData, error: previewError } = await fromTable(input.supabase, "ai_action_previews")
-      .select("id, recommendation_id, domain, subject_type, subject_id, status, requires_approval, risk_tier, preview_payload")
+      .select("id, recommendation_id, action_type, domain, subject_type, subject_id, status, requires_approval, risk_tier, preview_payload")
       .eq("shop_id", actor.shopId)
       .in("id", previewIds);
 
@@ -259,8 +286,8 @@ export async function listAiActionApprovalsForReview(
       const recommendation = preview.recommendation_id ? recommendationsById.get(preview.recommendation_id) : undefined;
       const previewPayload = parsePreviewPayload(preview.preview_payload);
 
-      const title = recommendation?.title ?? previewPayload.label ?? `${preview.domain} ${preview.subject_type} preview`;
-      const description = recommendation?.summary ?? previewPayload.description ?? "Review-only action preview request.";
+      const title = recommendation?.title ?? previewPayload.label ?? fallbackInboxTitle(preview);
+      const description = recommendation?.summary ?? previewPayload.description ?? fallbackInboxDescription(preview);
 
       const inboxRow: AiApprovalInboxRow = {
         id: row.id,

--- a/tests/ai-review-layer-safety-routes.test.ts
+++ b/tests/ai-review-layer-safety-routes.test.ts
@@ -13,6 +13,9 @@ const generateWorkOrderEvidenceAndRecommendationsMock = vi.fn();
 const reviewWorkOrderMock = vi.fn();
 const approveAiActionPreviewMock = vi.fn();
 const rejectAiActionPreviewMock = vi.fn();
+const acknowledgeAiRecommendationMock = vi.fn();
+const dismissAiRecommendationMock = vi.fn();
+const resolveAiRecommendationMock = vi.fn();
 
 vi.mock("@/features/shared/lib/server/admin-access", () => ({
   requireShopScopedApiAccess: requireShopScopedApiAccessMock,
@@ -30,6 +33,9 @@ vi.mock("@/features/ai/server", async () => {
     requestAiActionPreviewApproval: requestAiActionPreviewApprovalMock,
     approveAiActionPreview: approveAiActionPreviewMock,
     rejectAiActionPreview: rejectAiActionPreviewMock,
+    acknowledgeAiRecommendation: acknowledgeAiRecommendationMock,
+    dismissAiRecommendation: dismissAiRecommendationMock,
+    resolveAiRecommendation: resolveAiRecommendationMock,
   };
 });
 
@@ -212,6 +218,7 @@ describe("review-layer route safe contracts", () => {
     expect(serialized).not.toContain("ownerPinProofRef");
     expect(serialized).not.toContain("metadata");
     expect(serialized).toContain("approvalId");
+    expect((json.approval as { executionBlocked?: boolean }).executionBlocked).toBe(true);
   });
 
   it("shop boost recommendations POST omits raw evidence snapshot payload", async () => {
@@ -279,5 +286,129 @@ describe("review-layer route safe contracts", () => {
     expect(response.status).toBe(400);
     expect(approveAiActionPreviewMock).not.toHaveBeenCalled();
     expect(rejectAiActionPreviewMock).not.toHaveBeenCalled();
+  });
+
+  it("approval decision route returns explicit executionBlocked semantics", async () => {
+    approveAiActionPreviewMock.mockResolvedValue({
+      id: "approval_1",
+      status: "approved",
+      decided_at: "2026-04-24T00:00:00.000Z",
+      decided_by: "actor_1",
+    });
+
+    const { PATCH } = await import("../app/api/ai/action-approvals/[approvalId]/route");
+    const response = await PATCH(
+      new Request("http://localhost", {
+        method: "PATCH",
+        body: JSON.stringify({ decision: "approved" }),
+      }),
+      { params: Promise.resolve({ approvalId: "approval_1" }) },
+    );
+
+    const json = await response.json() as Record<string, unknown>;
+    expect(response.status).toBe(200);
+    expect(json.executionBlocked).toBe(true);
+  });
+
+  it("work-order recommendation lifecycle PATCH returns serialized recommendation only", async () => {
+    getAiRecommendationMock.mockResolvedValue({
+      id: "rec_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+    });
+    acknowledgeAiRecommendationMock.mockResolvedValue({
+      id: "rec_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      recommendation_type: "dispatch_review",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+      title: "Dispatch review",
+      summary: "Review dispatch line",
+      status: "acknowledged",
+      priority: "high",
+      confidence: 0.9,
+      risk_tier: "high",
+      evidence_snapshot_id: "ev_1",
+      evidence_snapshot_ids: ["ev_1"],
+      missing_data: ["tech_assignment"],
+      recommended_action: { label: "Review", details: "Review queue" },
+      side_effects: ["queue_update"],
+      requires_approval: true,
+      requires_owner_pin: false,
+      source: "manual",
+      source_run_id: null,
+      created_by: "actor_1",
+      assigned_to: null,
+      dismissed_by: null,
+      dismissed_at: null,
+      resolved_by: null,
+      resolved_at: null,
+      expires_at: null,
+      created_at: "2026-04-24T00:00:00.000Z",
+      updated_at: "2026-04-24T00:01:00.000Z",
+      metadata: {
+        token: "secret",
+        preview_payload: { hidden: true },
+        side_effects: [{ internal: true }],
+        ownerPinProofRef: "/secret",
+        owner_pin_verification_ref: "proof_ref",
+      },
+      preview_payload: { label: "leak" },
+      intended_mutations: [{ op: "update" }],
+    });
+
+    const { PATCH } = await import("../app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route");
+    const response = await PATCH(
+      new Request("http://localhost", {
+        method: "PATCH",
+        body: JSON.stringify({ action: "acknowledge", note: "safe note" }),
+      }),
+      { params: Promise.resolve({ id: "wo_1", recommendationId: "rec_1" }) },
+    );
+
+    const json = await response.json() as Record<string, unknown>;
+    const serialized = JSON.stringify(json);
+    expect(response.status).toBe(200);
+    expect(json.executionBlocked).toBe(true);
+    expect(serialized).not.toContain("metadata");
+    expect(serialized).not.toContain("\"snapshot\":");
+    expect(serialized).not.toContain("payload");
+    expect(serialized).not.toContain("preview_payload");
+    expect(serialized).not.toContain("intended_mutations");
+    expect(serialized).not.toContain("side_effects\":[{");
+    expect(serialized).not.toContain("ownerPinProofRef");
+    expect(serialized).not.toContain("owner_pin_verification_ref");
+    expect(serialized).not.toContain("token");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("hash");
+    expect(serialized).not.toContain("\"pin\":");
+    expect((json.recommendation as { id?: string; status?: string; recommendation_type?: string }).id).toBe("rec_1");
+    expect((json.recommendation as { status?: string }).status).toBe("acknowledged");
+    expect((json.recommendation as { recommendation_type?: string }).recommendation_type).toBe("dispatch_review");
+  });
+
+  it("work-order recommendation lifecycle PATCH keeps shop scoping and recommendation ownership checks", async () => {
+    getAiRecommendationMock.mockResolvedValue({
+      id: "rec_cross_shop",
+      shop_id: "shop_2",
+      domain: "work_orders",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+    });
+
+    const { PATCH } = await import("../app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route");
+    const response = await PATCH(
+      new Request("http://localhost", {
+        method: "PATCH",
+        body: JSON.stringify({ action: "dismiss" }),
+      }),
+      { params: Promise.resolve({ id: "wo_1", recommendationId: "rec_cross_shop" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(dismissAiRecommendationMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of raw ai_recommendations DB rows from the work-order recommendation lifecycle PATCH response by enforcing serializer output only.
- Preserve review-only semantics by ensuring lifecycle and related DTOs explicitly carry `executionBlocked: true` so UIs cannot infer execution permission.
- Harden approval inbox preview title/description logic to avoid reflecting unsafe or sensitive preview_payload values into display strings.

### Description
- Serializer-wrap `PATCH /api/work-orders/[id]/ai/recommendations/[recommendationId]` response using `serializeAiRecommendationForUi` and return `executionBlocked: true` instead of the raw DB row (file: `app/api/work-orders/[id]/ai/recommendations/[recommendationId]/route.ts`).
- Add strict preview-text allowlisting and blob/sensitive-pattern detection with safe fallback title/description generation and include `action_type` in the preview select to support deterministic fallback copy (file: `features/ai/server/dashboard/listAiActionApprovalsForReview.ts`).
- Add focused contract tests covering: lifecycle PATCH non-exposure and execution-blocked assertion, approval inbox unsafe preview payload fallback cases (sensitive token strings, non-string values, JSON/blob-like strings), and ownership/shop scoping checks (files: `tests/ai-review-layer-safety-routes.test.ts`, `features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts`).
- No DB migrations, no new execution paths, and no changes to business flows or domain mutations were introduced.

### Testing
- Ran TypeScript check with `npx tsc --noEmit` which passed (npm emitted a non-blocking `Unknown env config "http-proxy"` warning).
- Ran full unit test suite with `npm test` (`vitest`) and all tests passed: 132 tests passed (no failures).
- Targeted tests added/updated: `tests/ai-review-layer-safety-routes.test.ts` and `features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts`, and existing safety serializer tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec099950dc8328bf064871b94a7ac6)