### PR TITLE
Add owner-facing Cancel Subscription flow (scheduled cancel at period end)

### DIFF
--- a/app/api/stripe/subscription/route.ts
+++ b/app/api/stripe/subscription/route.ts
@@ -1,0 +1,245 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
+
+type DB = Database;
+
+type ShopStripeScope = Pick<
+  DB["public"]["Tables"]["shops"]["Row"],
+  | "id"
+  | "stripe_customer_id"
+  | "stripe_subscription_id"
+  | "stripe_subscription_status"
+  | "stripe_current_period_end"
+  | "stripe_trial_end"
+>;
+
+type NormalizedSubscriptionPayload = {
+  success: boolean;
+  status: string | null;
+  cancel_at_period_end: boolean;
+  canceled_at: string | null;
+  current_period_end: string | null;
+};
+
+function mustEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return value;
+}
+
+function unixToIsoOrNull(value: number | null | undefined): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return new Date(value * 1000).toISOString();
+}
+
+function normalizeSubscription(subscription: Stripe.Subscription): NormalizedSubscriptionPayload {
+  return {
+    success: true,
+    status: String(subscription.status ?? "").trim() || null,
+    cancel_at_period_end: Boolean(subscription.cancel_at_period_end),
+    canceled_at: unixToIsoOrNull(subscription.canceled_at ?? null),
+    current_period_end: unixToIsoOrNull(subscription.current_period_end ?? null),
+  };
+}
+
+function normalizeShopFallback(shop: ShopStripeScope): NormalizedSubscriptionPayload {
+  return {
+    success: true,
+    status: String(shop.stripe_subscription_status ?? "").trim() || null,
+    cancel_at_period_end: false,
+    canceled_at: null,
+    current_period_end: shop.stripe_current_period_end ?? null,
+  };
+}
+
+async function findCanonicalSubscription(
+  stripe: Stripe,
+  shop: ShopStripeScope,
+): Promise<Stripe.Subscription | null> {
+  const subscriptionId = String(shop.stripe_subscription_id ?? "").trim();
+  const customerId = String(shop.stripe_customer_id ?? "").trim();
+
+  if (subscriptionId) {
+    const byId = await stripe.subscriptions.retrieve(subscriptionId);
+    const subscriptionCustomerId =
+      typeof byId.customer === "string" ? byId.customer : String(byId.customer?.id ?? "").trim();
+    const metadataShopId = String(byId.metadata?.shop_id ?? "").trim();
+
+    const customerMatches = !customerId || (subscriptionCustomerId && subscriptionCustomerId === customerId);
+    const metadataMatches = metadataShopId === "" || metadataShopId === shop.id;
+
+    if (customerMatches && metadataMatches) {
+      return byId;
+    }
+  }
+
+  if (!customerId) return null;
+
+  const list = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 10,
+  });
+
+  if (!Array.isArray(list.data) || list.data.length === 0) {
+    return null;
+  }
+
+  const preferredStatuses = new Set(["trialing", "active", "past_due", "unpaid", "paused"]);
+  const sorted = [...list.data].sort((a, b) => {
+    const aPreferred = preferredStatuses.has(String(a.status ?? ""));
+    const bPreferred = preferredStatuses.has(String(b.status ?? ""));
+    if (aPreferred !== bPreferred) return aPreferred ? -1 : 1;
+    return (b.created ?? 0) - (a.created ?? 0);
+  });
+
+  for (const subscription of sorted) {
+    const metadataShopId = String(subscription.metadata?.shop_id ?? "").trim();
+    if (!metadataShopId || metadataShopId === shop.id) {
+      return subscription;
+    }
+  }
+
+  return sorted[0] ?? null;
+}
+
+async function syncShopSubscription(
+  supabase: SupabaseClient<DB>,
+  shopId: string,
+  subscription: Stripe.Subscription,
+) {
+  const { error } = await supabase
+    .from("shops")
+    .update({
+      stripe_subscription_id: subscription.id,
+      stripe_subscription_status: String(subscription.status ?? "").trim() || null,
+      stripe_current_period_end: unixToIsoOrNull(subscription.current_period_end ?? null),
+      stripe_trial_end: unixToIsoOrNull(subscription.trial_end ?? null),
+    } as DB["public"]["Tables"]["shops"]["Update"])
+    .eq("id", shopId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+export async function GET() {
+  try {
+    const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBilling",
+      allowRoles: ["owner", "admin"],
+    });
+    if (!access.ok) return access.response;
+
+    const { data: shop, error: shopError } = await access.supabase
+      .from("shops")
+      .select(
+        "id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_current_period_end, stripe_trial_end",
+      )
+      .eq("id", access.profile.shop_id)
+      .maybeSingle<ShopStripeScope>();
+
+    if (shopError) {
+      return NextResponse.json({ error: shopError.message }, { status: 500 });
+    }
+
+    if (!shop) {
+      return NextResponse.json({ error: "Shop not found." }, { status: 404 });
+    }
+
+    const canonicalSubscription = await findCanonicalSubscription(stripe, shop);
+
+    if (!canonicalSubscription) {
+      return NextResponse.json(normalizeShopFallback(shop));
+    }
+
+    await syncShopSubscription(access.supabase, shop.id, canonicalSubscription);
+
+    return NextResponse.json(normalizeSubscription(canonicalSubscription));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to resolve subscription.";
+    console.error("[stripe/subscription:get] error", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageBilling",
+      allowRoles: ["owner", "admin"],
+      requireOwnerPin: true,
+      ownerPinRequest: req,
+      ownerPinAllowedPurposes: [OWNER_PIN_PURPOSES.BILLING, OWNER_PIN_PURPOSES.PRIVILEGED],
+    });
+    if (!access.ok) return access.response;
+
+    const { data: shop, error: shopError } = await access.supabase
+      .from("shops")
+      .select(
+        "id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_current_period_end, stripe_trial_end",
+      )
+      .eq("id", access.profile.shop_id)
+      .maybeSingle<ShopStripeScope>();
+
+    if (shopError) {
+      return NextResponse.json({ error: shopError.message }, { status: 500 });
+    }
+
+    if (!shop) {
+      return NextResponse.json({ error: "Shop not found." }, { status: 404 });
+    }
+
+    const canonicalSubscription = await findCanonicalSubscription(stripe, shop);
+
+    if (!canonicalSubscription) {
+      return NextResponse.json(
+        {
+          error: "No active or trialing subscription was found for this shop.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (canonicalSubscription.status !== "active" && canonicalSubscription.status !== "trialing") {
+      return NextResponse.json(
+        {
+          error: "Only active or trialing subscriptions can be scheduled for cancellation.",
+          ...normalizeSubscription(canonicalSubscription),
+        },
+        { status: 409 },
+      );
+    }
+
+    if (canonicalSubscription.cancel_at_period_end) {
+      await syncShopSubscription(access.supabase, shop.id, canonicalSubscription);
+      return NextResponse.json(normalizeSubscription(canonicalSubscription));
+    }
+
+    const updated = await stripe.subscriptions.update(canonicalSubscription.id, {
+      cancel_at_period_end: true,
+    });
+
+    await syncShopSubscription(access.supabase, shop.id, updated);
+
+    return NextResponse.json(normalizeSubscription(updated));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to schedule cancellation.";
+    console.error("[stripe/subscription:cancel] error", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -9,6 +9,15 @@ import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
 import { Input } from "@shared/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/features/shared/components/ui/dialog";
+import { Button } from "@shared/components/ui/Button";
 import OwnerPinModal from "@shared/components/OwnerPinModal";
 import OwnerSettingsHeader from "@/features/dashboard/components/owner-settings/OwnerSettingsHeader";
 import OwnerSettingsBusinessSection from "@/features/dashboard/components/owner-settings/OwnerSettingsBusinessSection";
@@ -19,6 +28,7 @@ import { OwnerSettingsPanel, OwnerSettingsSectionIntro, OwnerSettingsStat } from
 import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSummaryCard";
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
 import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   parseStripeSubscriptionStatus,
   type StripeSubscriptionStatusWithUnknown,
@@ -65,6 +75,15 @@ type ShopBillingScope = Pick<
   Database["public"]["Tables"]["shops"]["Row"],
   "stripe_subscription_status" | "stripe_trial_end" | "stripe_current_period_end" | "stripe_account_id"
 >;
+
+type StripeSubscriptionApiResponse = {
+  success?: boolean;
+  status?: string | null;
+  cancel_at_period_end?: boolean;
+  canceled_at?: string | null;
+  current_period_end?: string | null;
+  error?: string;
+};
 
 type OrgScope = Pick<
   Database["public"]["Tables"]["organizations"]["Row"],
@@ -171,6 +190,10 @@ export default function OwnerSettingsPage() {
   const [connectLoading, setConnectLoading] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
+  const [cancelLoading, setCancelLoading] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [cancelAtPeriodEnd, setCancelAtPeriodEnd] = useState(false);
+  const [canManageBilling, setCanManageBilling] = useState(false);
 
   const trialDaysLeft = daysUntil(trialEndIso);
   const periodDaysLeft = daysUntil(periodEndIso);
@@ -308,6 +331,46 @@ export default function OwnerSettingsPage() {
     }
   };
 
+  const refreshBillingState = useCallback(
+    async (sid: string) => {
+      const { data: billing } = await supabase
+        .from("shops")
+        .select("stripe_subscription_status, stripe_trial_end, stripe_current_period_end, stripe_account_id")
+        .eq("id", sid)
+        .maybeSingle<ShopBillingScope>();
+
+      setStripeAccountId((billing?.stripe_account_id as string | null) ?? null);
+      setSubStatus(parseStripeSubscriptionStatus(billing?.stripe_subscription_status));
+      setTrialEndIso((billing?.stripe_trial_end as string | null) ?? null);
+      setPeriodEndIso((billing?.stripe_current_period_end as string | null) ?? null);
+
+      try {
+        const res = await fetch("/api/stripe/subscription", {
+          method: "GET",
+          cache: "no-store",
+        });
+        const j = (await res.json().catch(() => ({}))) as StripeSubscriptionApiResponse;
+
+        if (!res.ok) {
+          setCancelAtPeriodEnd(false);
+          return;
+        }
+
+        setCancelAtPeriodEnd(Boolean(j.cancel_at_period_end));
+
+        if (j.status) {
+          setSubStatus(parseStripeSubscriptionStatus(j.status));
+        }
+        if (j.current_period_end !== undefined) {
+          setPeriodEndIso(j.current_period_end ?? null);
+        }
+      } catch {
+        setCancelAtPeriodEnd(false);
+      }
+    },
+    [supabase],
+  );
+
   const fetchSettings = useCallback(async () => {
     setLoading(true);
 
@@ -325,7 +388,7 @@ export default function OwnerSettingsPage() {
 
     const { data: profile, error: profErr } = await supabase
       .from("profiles")
-      .select("shop_id, organization_id, full_name, email, avatar_url")
+      .select("shop_id, organization_id, full_name, email, avatar_url, role")
       .eq("id", uid)
       .maybeSingle<{
         shop_id: string | null;
@@ -333,6 +396,7 @@ export default function OwnerSettingsPage() {
         full_name: string | null;
         email: string | null;
         avatar_url: string | null;
+        role: string | null;
       }>();
 
     if (profErr) {
@@ -349,6 +413,7 @@ export default function OwnerSettingsPage() {
     setOwnerName(profile.full_name ?? "");
     setOwnerEmail(profile.email ?? "");
     setOwnerAvatarUrl(profile.avatar_url ?? null);
+    setCanManageBilling(getActorCapabilities({ role: profile.role }).canManageBilling);
 
     const sid = profile.shop_id;
     setShopId(sid);
@@ -430,17 +495,7 @@ try {
       setAutoSendQuoteEmail(!!shop.auto_send_quote_email);
     }
 
-    // billing fields
-    const { data: billing } = await supabase
-      .from("shops")
-      .select("stripe_subscription_status, stripe_trial_end, stripe_current_period_end, stripe_account_id")
-      .eq("id", sid)
-      .maybeSingle<ShopBillingScope>();
-
-    setStripeAccountId((billing?.stripe_account_id as string | null) ?? null);
-    setSubStatus(parseStripeSubscriptionStatus(billing?.stripe_subscription_status));
-    setTrialEndIso((billing?.stripe_trial_end as string | null) ?? null);
-    setPeriodEndIso((billing?.stripe_current_period_end as string | null) ?? null);
+    await refreshBillingState(sid);
 
     // pricing validity days
     try {
@@ -542,7 +597,7 @@ try {
     }
 
     setLoading(false);
-  }, [supabase, fetchEmailLogs]);
+  }, [supabase, fetchEmailLogs, refreshBillingState]);
 
   // initial load
   useEffect(() => {
@@ -921,6 +976,40 @@ try {
     }
   };
 
+  const confirmCancelSubscription = async () => {
+    if (!shopId) return;
+    if (!guardUnlock()) return;
+
+    try {
+      setCancelLoading(true);
+      const res = await fetch("/api/stripe/subscription", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const j = (await res.json().catch(() => ({}))) as StripeSubscriptionApiResponse;
+
+      if (!res.ok) {
+        toast.error(j?.error || "Failed to schedule cancellation.");
+        return;
+      }
+
+      setCancelAtPeriodEnd(Boolean(j.cancel_at_period_end));
+      if (j.status) {
+        setSubStatus(parseStripeSubscriptionStatus(j.status));
+      }
+      if (j.current_period_end !== undefined) {
+        setPeriodEndIso(j.current_period_end ?? null);
+      }
+      setCancelDialogOpen(false);
+
+      await refreshBillingState(shopId);
+      toast.success("Cancellation scheduled for the end of the current billing period.");
+    } finally {
+      setCancelLoading(false);
+    }
+  };
+
 
   const lockOwnerSettings = async () => {
     const res = await fetch("/api/shop/owner-pin/clear", { method: "POST" });
@@ -1185,14 +1274,17 @@ try {
         <OwnerSettingsSidebar
           shopId={shopId}
           isUnlocked={isUnlocked}
+          canManageBilling={canManageBilling}
           billingPill={billingPill}
           subStatus={subStatus}
           stripeAccountId={stripeAccountId}
           trialEndIso={trialEndIso}
           periodEndIso={periodEndIso}
+          cancelAtPeriodEnd={cancelAtPeriodEnd}
           connectLoading={connectLoading}
           checkoutLoading={checkoutLoading}
           portalLoading={portalLoading}
+          cancelLoading={cancelLoading}
           plan={plan}
           seatsUsed={seatsUsed}
           seatsLimit={seatsLimit}
@@ -1214,6 +1306,7 @@ try {
           onOpenStripeConnect={openStripeConnect}
           onStartSubscriptionCheckout={startSubscriptionCheckout}
           onOpenStripePortal={openStripePortal}
+          onRequestCancelSubscription={() => setCancelDialogOpen(true)}
           onCreateOrganization={() => router.push("/dashboard/owner/organization/create")}
           onSwitchLocation={(id) => void switchLocation(id)}
           onRefreshEmailLogs={() => void fetchEmailLogs()}
@@ -1224,6 +1317,42 @@ try {
           locationName={locationName}
         />
       </div>
+
+      <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <DialogContent className="border-white/15 bg-neutral-950/95 text-neutral-100">
+          <DialogHeader>
+            <DialogTitle>Cancel subscription</DialogTitle>
+            <DialogDescription className="text-neutral-300">
+              You are currently on the {planLabel(plan)} plan.
+              {" "}Cancellation is scheduled for the end of your current billing period by default.
+              {" "}Your access and seats remain active until that date.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-sm text-neutral-300">
+            After the period ends, paid subscription features stop renewing for this location
+            until you subscribe again.
+            {periodEndIso ? ` Current period end: ${formatDate(periodEndIso)}.` : ""}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="secondary"
+              onClick={() => setCancelDialogOpen(false)}
+              disabled={cancelLoading}
+            >
+              Keep subscription
+            </Button>
+            <Button
+              onClick={() => void confirmCancelSubscription()}
+              disabled={cancelLoading}
+              className="bg-red-600 text-white hover:bg-red-500"
+            >
+              {cancelLoading ? "Scheduling..." : "Cancel at period end"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <OwnerPinModal
         shopId={shopId}

--- a/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
@@ -43,14 +43,17 @@ type EmailLogRow = {
 type Props = {
   shopId: string | null;
   isUnlocked: boolean;
+  canManageBilling: boolean;
   billingPill: React.ReactNode;
   subStatus: StripeSubStatus;
   stripeAccountId: string | null;
   trialEndIso: string | null;
   periodEndIso: string | null;
+  cancelAtPeriodEnd: boolean;
   connectLoading: boolean;
   checkoutLoading: boolean;
   portalLoading: boolean;
+  cancelLoading: boolean;
   plan: "starter" | "pro" | "enterprise" | "unlimited" | "unknown";
   seatsUsed: number;
   seatsLimit: number | null;
@@ -72,6 +75,7 @@ type Props = {
   onOpenStripeConnect: () => void;
   onStartSubscriptionCheckout: () => void;
   onOpenStripePortal: () => void;
+  onRequestCancelSubscription: () => void;
   onCreateOrganization: () => void;
   onSwitchLocation: (id: string) => void;
   onRefreshEmailLogs: () => void;
@@ -85,14 +89,17 @@ type Props = {
 export default function OwnerSettingsSidebar({
   shopId,
   isUnlocked,
+  canManageBilling,
   billingPill,
   subStatus,
   stripeAccountId,
   trialEndIso,
   periodEndIso,
+  cancelAtPeriodEnd,
   connectLoading,
   checkoutLoading,
   portalLoading,
+  cancelLoading,
   plan,
   seatsUsed,
   seatsLimit,
@@ -114,6 +121,7 @@ export default function OwnerSettingsSidebar({
   onOpenStripeConnect,
   onStartSubscriptionCheckout,
   onOpenStripePortal,
+  onRequestCancelSubscription,
   onCreateOrganization,
   onSwitchLocation,
   onRefreshEmailLogs,
@@ -123,6 +131,8 @@ export default function OwnerSettingsSidebar({
   formatLocationLine,
   locationName,
 }: Props) {
+  const isCancelableStatus = subStatus === "active" || subStatus === "trialing";
+
   return (
     <div className="space-y-5 lg:sticky lg:top-20">
       <OwnerSettingsPanel
@@ -181,6 +191,33 @@ export default function OwnerSettingsSidebar({
             <p className="text-[11px] text-neutral-500">
               Review invoices, payment methods, and subscription billing history.
             </p>
+
+            {canManageBilling && isCancelableStatus ? (
+              cancelAtPeriodEnd ? (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+                  <p>
+                    Cancellation takes effect at the end of the current billing period.
+                    {periodEndIso
+                      ? ` Your subscription will end on ${formatDate(periodEndIso)}.`
+                      : ""}
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <Button
+                    variant="secondary"
+                    onClick={onRequestCancelSubscription}
+                    disabled={!isUnlocked || cancelLoading}
+                    className="border-red-400/40 text-red-100 hover:bg-red-950/25"
+                  >
+                    {cancelLoading ? "Scheduling cancellation..." : "Cancel subscription"}
+                  </Button>
+                  <p className="text-[11px] text-neutral-500">
+                    Schedule cancellation at period end. Access stays active until then.
+                  </p>
+                </>
+              )
+            ) : null}
           </div>
         </div>
       </OwnerSettingsPanel>


### PR DESCRIPTION
### Motivation
- Provide a clear, owner-scoped way to schedule subscription cancellation from Owner Settings while preserving existing billing flows and Stripe canonical paths.
- Keep the change additive, permission-gated, and non-destructive by defaulting to `cancel_at_period_end` semantics and requiring owner billing capability and Owner PIN.

### Description
- Added a canonical shop-scoped Stripe subscription API at `app/api/stripe/subscription/route.ts` with `GET` to resolve & sync the canonical subscription and `POST` to schedule cancellation via `cancel_at_period_end: true`, returning a normalized payload (`success`, `status`, `cancel_at_period_end`, `canceled_at`, `current_period_end`).
- Updated owner settings UI state and logic in `features/dashboard/app/dashboard/owner/settings/page.tsx` to fetch/refresh canonical subscription state, derive `canManageBilling` from role capabilities, open a confirmation `Dialog`, call the API, and immediately refresh the billing card after success.
- Added owner-facing cancel UX in `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx` including a controlled `Cancel subscription` button only visible for `active`/`trialing` subscriptions and owners who can manage billing, plus scheduled-cancellation messaging that shows: `"Cancellation takes effect at the end of the current billing period."` and the period end date when available.
- Permission and safety: all server-side calls use `requireShopScopedApiAccess` with `requiredCapability: "canManageBilling"` and `requireOwnerPin` on the POST path to avoid cross-shop mutations and unauthorized use.
- Resume support was intentionally omitted in this patch to remain additive and avoid introducing reverse-cancel mutation paths.

Files changed: `app/api/stripe/subscription/route.ts`, `features/dashboard/app/dashboard/owner/settings/page.tsx`, `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx`.

### Testing
- Ran TypeScript check: `npx tsc --noEmit` which completed successfully.
- Ran targeted lint: `npx eslint app/api/stripe/subscription/route.ts features/dashboard/app/dashboard/owner/settings/page.tsx features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx` which completed successfully.
- Manual verification steps exercised in code: UI shows cancel button only for `active`/`trialing` and `canManageBilling` actors, confirmation dialog opens, API POST schedules `cancel_at_period_end` and UI refreshes to show scheduled-cancellation messaging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0a3653dc83289bc8358029b312ae)