### PR TITLE
Add AI review DTO safe-display guardrails and contract tests

### DIFF
--- a/features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts
+++ b/features/ai/server/dashboard/listAiActionApprovalsForReview.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as types from "@/features/ai/server/types";
 import { listAiActionApprovalsForReview } from "./listAiActionApprovalsForReview";
+import { expectNoBannedDtoKeys, sortedKeys } from "../../../../tests/ai-dto-test-helpers";
 
 const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
 
@@ -207,6 +208,31 @@ describe("listAiActionApprovalsForReview", () => {
     expect(first.owner_pin_verification_ref).toBeUndefined();
     expect(first.snapshot).toBeUndefined();
     expect(first.executionBlocked).toBe(true);
+    expect(sortedKeys(first)).toEqual([
+      "approvalRequired",
+      "decidedAt",
+      "decidedByLabel",
+      "description",
+      "domain",
+      "executionBlocked",
+      "id",
+      "ownerPinProofAttached",
+      "ownerPinRequired",
+      "previewId",
+      "previewStatus",
+      "recommendationId",
+      "recommendationStatus",
+      "requestedAt",
+      "requestedByLabel",
+      "riskLevel",
+      "status",
+      "subjectHref",
+      "subjectId",
+      "subjectType",
+      "title",
+    ]);
+    expectNoBannedDtoKeys(first);
+    expectNoBannedDtoKeys(result);
   });
 
   it("returns summary counts and supports domain + risk filters", async () => {

--- a/features/ai/server/dashboard/listAiActionApprovalsForReview.ts
+++ b/features/ai/server/dashboard/listAiActionApprovalsForReview.ts
@@ -1,5 +1,6 @@
 import type { Json } from "@shared/types/types/supabase";
 import { ensureActorContext, fromTable, type AiActorContext, type AiServerClient } from "@/features/ai/server/types";
+import { sanitizeDisplayText } from "@/features/ai/server/safeDisplay";
 
 export type AiApprovalInboxStatus = "pending" | "approved" | "rejected" | "expired";
 export type AiApprovalInboxDomainFilter = "all" | "work_orders" | "shop_boost";
@@ -125,22 +126,8 @@ function toApprovalStatus(status: string): AiApprovalInboxStatus | null {
   return null;
 }
 
-const SENSITIVE_PREVIEW_TEXT_PATTERN = /\b(token|secret|owner[_\s-]?pin|pin|hash|proof|owner[_\s-]?pin[_\s-]?verification[_\s-]?ref|ownerPinProofRef)\b/i;
-
-function looksLikeBlob(value: string): boolean {
-  const trimmed = value.trim();
-  if (trimmed.length > 280) return true;
-  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) return true;
-  return false;
-}
-
 function safePreviewText(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  if (SENSITIVE_PREVIEW_TEXT_PATTERN.test(trimmed)) return null;
-  if (looksLikeBlob(trimmed)) return null;
-  return trimmed;
+  return sanitizeDisplayText(value, "") || null;
 }
 
 function parsePreviewPayload(value: Json): { label: string | null; description: string | null; ownerPinProofAttached: boolean } {
@@ -286,8 +273,14 @@ export async function listAiActionApprovalsForReview(
       const recommendation = preview.recommendation_id ? recommendationsById.get(preview.recommendation_id) : undefined;
       const previewPayload = parsePreviewPayload(preview.preview_payload);
 
-      const title = recommendation?.title ?? previewPayload.label ?? fallbackInboxTitle(preview);
-      const description = recommendation?.summary ?? previewPayload.description ?? fallbackInboxDescription(preview);
+      const title = sanitizeDisplayText(
+        recommendation?.title ?? previewPayload.label,
+        fallbackInboxTitle(preview),
+      );
+      const description = sanitizeDisplayText(
+        recommendation?.summary ?? previewPayload.description,
+        fallbackInboxDescription(preview),
+      );
 
       const inboxRow: AiApprovalInboxRow = {
         id: row.id,

--- a/features/ai/server/dashboard/listAiRecommendationsForReview.test.ts
+++ b/features/ai/server/dashboard/listAiRecommendationsForReview.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as types from "@/features/ai/server/types";
 import { listAiRecommendationsForReview } from "./listAiRecommendationsForReview";
+import { expectNoBannedDtoKeys, sortedKeys } from "../../../../tests/ai-dto-test-helpers";
 
 const ACTOR = { shopId: "shop_1", actorId: "actor_1", source: "manual" as const };
 
@@ -132,6 +133,33 @@ describe("listAiRecommendationsForReview", () => {
     expect(urgent.recommendedActionType).toBe("advisor_review_needed");
     expect((urgent as unknown as Record<string, unknown>).recommended_action).toBeUndefined();
     expect((urgent as unknown as Record<string, unknown>).snapshot).toBeUndefined();
+    expect(sortedKeys(urgent as unknown as Record<string, unknown>)).toEqual([
+      "confidence",
+      "createdAt",
+      "domain",
+      "expiresAt",
+      "hasPreview",
+      "id",
+      "missingDataCount",
+      "pendingApprovalCount",
+      "previewStatus",
+      "priority",
+      "recommendationType",
+      "recommendedActionType",
+      "requiresApproval",
+      "riskTier",
+      "source",
+      "status",
+      "subjectId",
+      "subjectType",
+      "summary",
+      "targetHref",
+      "targetLabel",
+      "title",
+      "updatedAt",
+    ]);
+    expectNoBannedDtoKeys(urgent);
+    expectNoBannedDtoKeys(result);
   });
 
   it("filters by domain and requires approval", async () => {

--- a/features/ai/server/dashboard/listAiRecommendationsForReview.ts
+++ b/features/ai/server/dashboard/listAiRecommendationsForReview.ts
@@ -1,5 +1,6 @@
 import type { Json } from "@shared/types/types/supabase";
 import { ensureActorContext, fromTable, type AiActorContext, type AiRecommendationStatus, type AiServerClient } from "@/features/ai/server/types";
+import { sanitizeDisplayText } from "@/features/ai/server/safeDisplay";
 
 export type AiReviewDomainFilter = "all" | "work_orders" | "shop_boost";
 export type AiReviewStatusFilter = AiRecommendationStatus | "all";
@@ -306,8 +307,8 @@ export async function listAiRecommendationsForReview(
       domain: row.domain,
       subjectType: row.subject_type,
       subjectId: row.subject_id,
-      title: row.title,
-      summary: row.summary,
+      title: sanitizeDisplayText(row.title, "Recommendation"),
+      summary: row.summary ? sanitizeDisplayText(row.summary, "") || null : null,
       status: row.status,
       priority: row.priority,
       riskTier: row.risk_tier,

--- a/features/ai/server/index.ts
+++ b/features/ai/server/index.ts
@@ -8,6 +8,7 @@ export * from "./actionEvents";
 export * from "./safeActions";
 export * from "./ownerPinProof";
 export * from "./serializers";
+export * from "./safeDisplay";
 export * from "./domains/workOrders";
 export * from "./dashboard";
 export * from "./maintenance";

--- a/features/ai/server/safeDisplay.ts
+++ b/features/ai/server/safeDisplay.ts
@@ -1,0 +1,47 @@
+const DEFAULT_MAX_DISPLAY_TEXT_LENGTH = 320;
+
+const SENSITIVE_TEXT_PATTERN = /\b(token|secret|password|hash|pin|owner[_\s-]?pin|owner[_\s-]?pin[_\s-]?verification[_\s-]?ref|ownerPinProofRef|proofRef|metadata|snapshot|preview[_\s-]?payload|intended[_\s-]?mutations|side[_\s-]?effects|service[_\s-]?role|authorization|bearer)\b/i;
+
+function looksLikeStructuredBlob(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return true;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object") return true;
+  } catch {
+    // Ignore parse errors. Not all structured-looking text is valid JSON.
+  }
+
+  const structuralTokenCount = (trimmed.match(/[{}\[\]:,]/g) ?? []).length;
+  if (trimmed.length >= 160 && structuralTokenCount >= 12) return true;
+  return false;
+}
+
+export function isSafeDisplayText(
+  value: unknown,
+  options?: { maxLength?: number },
+): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  const maxLength = options?.maxLength ?? DEFAULT_MAX_DISPLAY_TEXT_LENGTH;
+  if (trimmed.length > maxLength) return false;
+  if (SENSITIVE_TEXT_PATTERN.test(trimmed)) return false;
+  if (looksLikeStructuredBlob(trimmed)) return false;
+
+  return true;
+}
+
+export function sanitizeDisplayText(
+  value: unknown,
+  fallback: string,
+  options?: { maxLength?: number },
+): string {
+  if (isSafeDisplayText(value, options)) return value.trim();
+  if (isSafeDisplayText(fallback, options)) return fallback.trim();
+  return "";
+}

--- a/features/ai/server/serializers.ts
+++ b/features/ai/server/serializers.ts
@@ -1,4 +1,5 @@
 import { normalizeArrayJson, normalizeObjectJson, type AiActionApprovalRecord, type AiActionPreviewRecord, type AiEvidenceSnapshotRecord, type AiRecommendationRecord } from "./types";
+import { sanitizeDisplayText } from "./safeDisplay";
 
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -79,16 +80,16 @@ export function serializeAiRecommendationForUi(recommendation: AiRecommendationR
 
   return {
     id: recommendation.id,
-    title: recommendation.title,
-    summary: recommendation.summary ?? null,
+    title: sanitizeDisplayText(recommendation.title, "Recommendation"),
+    summary: recommendation.summary ? sanitizeDisplayText(recommendation.summary, "") || null : null,
     priority: recommendation.priority,
     confidence: typeof recommendation.confidence === "number" ? recommendation.confidence : null,
     risk_tier: recommendation.risk_tier,
     status: recommendation.status,
     recommendation_type: recommendation.recommendation_type,
     recommended_action: {
-      label: typeof recommendedAction.label === "string" ? recommendedAction.label : undefined,
-      details: typeof recommendedAction.details === "string" ? recommendedAction.details : undefined,
+      label: sanitizeDisplayText(recommendedAction.label, "") || undefined,
+      details: sanitizeDisplayText(recommendedAction.details, "") || undefined,
     },
     missing_data: normalizeStringArray(recommendation.missing_data),
     created_at: recommendation.created_at,
@@ -126,13 +127,9 @@ export function serializeAiActionPreviewForUi(preview: AiActionPreviewRecord): A
   const persistedLabels = normalizeSideEffectLabels(preview.side_effects);
   const sideEffectLabels = persistedLabels.length > 0 ? persistedLabels : payloadLabels;
 
-  const title =
-    (typeof previewPayload.label === "string" && previewPayload.label.trim().length > 0 ? previewPayload.label.trim() : null)
-    ?? `Preview: ${preview.action_type}`;
+  const title = sanitizeDisplayText(previewPayload.label, `Preview: ${preview.action_type}`);
 
-  const description = typeof previewPayload.description === "string" && previewPayload.description.trim().length > 0
-    ? previewPayload.description.trim()
-    : null;
+  const description = sanitizeDisplayText(previewPayload.description, "") || null;
 
   return {
     previewId: preview.id,

--- a/tests/ai-dto-test-helpers.ts
+++ b/tests/ai-dto-test-helpers.ts
@@ -1,0 +1,53 @@
+import { expect } from "vitest";
+
+const BANNED_RESPONSE_KEYS = [
+  "metadata",
+  "snapshot",
+  "payload",
+  "preview_payload",
+  "intended_mutations",
+  "intendedMutations",
+  "side_effects",
+  "sideEffects",
+  "owner_pin",
+  "ownerPin",
+  "owner_pin_hash",
+  "owner_pin_verification_ref",
+  "ownerPinProofRef",
+  "proofRef",
+  "token",
+  "secret",
+  "password",
+  "hash",
+  "service_role",
+  "authorization",
+  "bearer",
+  "raw",
+  "record",
+] as const;
+
+const normalizeKey = (key: string): string => key.toLowerCase().replace(/[^a-z0-9]/g, "");
+const normalizedBannedKeySet = new Set(BANNED_RESPONSE_KEYS.map(normalizeKey));
+
+function collectBannedKeys(value: unknown, path = "root"): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => collectBannedKeys(item, `${path}[${index}]`));
+  }
+
+  if (!value || typeof value !== "object") return [];
+
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, nestedValue]) => {
+    const currentPath = `${path}.${key}`;
+    const hits = normalizedBannedKeySet.has(normalizeKey(key)) ? [currentPath] : [];
+    return [...hits, ...collectBannedKeys(nestedValue, currentPath)];
+  });
+}
+
+export function expectNoBannedDtoKeys(value: unknown): void {
+  const hits = collectBannedKeys(value);
+  expect(hits, `Found banned DTO keys: ${hits.join(", ")}`).toEqual([]);
+}
+
+export function sortedKeys(value: Record<string, unknown>): string[] {
+  return Object.keys(value).sort((a, b) => a.localeCompare(b));
+}

--- a/tests/ai-review-layer-safety-routes.test.ts
+++ b/tests/ai-review-layer-safety-routes.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextResponse } from "next/server";
+import { expectNoBannedDtoKeys } from "./ai-dto-test-helpers";
 
 const requireShopScopedApiAccessMock = vi.fn();
 const listAiEvidenceSnapshotsForSubjectMock = vi.fn();
@@ -72,15 +73,45 @@ vi.mock("../app/api/work-orders/[id]/_lib/reviewWorkOrder", () => ({
   reviewWorkOrder: reviewWorkOrderMock,
 }));
 
-function createScopedSupabase(workOrderExists = true) {
-  return {
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
+function createScopedSupabase(workOrderExists = true, previewRows: Record<string, unknown>[] = []) {
+  const eqByTable = (table: string, row: Record<string, unknown>) => {
+    if (table === "work_orders") {
+      return {
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(async () => ({ data: workOrderExists ? row : null, error: null })),
+        })),
+      };
+    }
+
+    if (table === "ai_action_previews") {
+      return {
         eq: vi.fn(() => ({
           eq: vi.fn(() => ({
-            maybeSingle: vi.fn(async () => ({ data: workOrderExists ? { id: "wo_1", shop_id: "shop_1" } : null, error: null })),
+            maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(async () => ({ data: previewRows, error: null })),
+              })),
+            })),
           })),
         })),
+      };
+    }
+
+    return {
+      eq: vi.fn(() => ({
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+      })),
+    };
+  };
+
+  return {
+    from: vi.fn((table: string) => ({
+      select: vi.fn(() => ({
+        eq: vi.fn((column: string, value: string) => {
+          const row = column === "id" && value ? { id: value, shop_id: "shop_1" } : { id: "wo_1", shop_id: "shop_1" };
+          return eqByTable(table, row);
+        }),
       })),
     })),
   };
@@ -142,6 +173,59 @@ describe("review-layer route safe contracts", () => {
     expect(serialized).not.toContain("\"snapshot\":");
     expect(serialized).not.toContain("metadata");
     expect(serialized).toContain("evidenceSnapshotId");
+    expectNoBannedDtoKeys(json);
+  });
+
+  it("preview GET happy path returns serialized previews only with executionBlocked true", async () => {
+    const previewRows = [{
+      id: "preview_1",
+      shop_id: "shop_1",
+      recommendation_id: "rec_1",
+      domain: "work_orders",
+      action_type: "advisor_review_needed",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+      status: "approval_required",
+      preview_payload: {
+        label: "Review technician dispatch",
+        description: "metadata payload should not leak",
+        ownerPinProofRef: "/proof/path",
+        token: "secret",
+      },
+      intended_mutations: [{ op: "update", raw: true }],
+      affected_records: [{ id: "wo_1", record: true }],
+      side_effects: ["queue_update"],
+      requires_approval: true,
+      requires_owner_pin: true,
+      risk_tier: "high",
+      evidence_snapshot_id: "ev_1",
+      created_at: "2026-04-24T00:00:00.000Z",
+      updated_at: "2026-04-24T00:00:00.000Z",
+      expires_at: null,
+      metadata: { snapshot: { hidden: true } },
+    }];
+    requireShopScopedApiAccessMock.mockResolvedValueOnce({
+      ok: true,
+      profile: { id: "actor_1", role: "manager", shop_id: "shop_1" },
+      supabase: createScopedSupabase(true, previewRows),
+    });
+    getAiRecommendationMock.mockResolvedValue({
+      id: "rec_1",
+      shop_id: "shop_1",
+      domain: "work_orders",
+      subject_type: "work_order",
+      subject_id: "wo_1",
+    });
+
+    const { GET } = await import("../app/api/work-orders/[id]/ai/recommendations/[recommendationId]/preview/route");
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "wo_1", recommendationId: "rec_1" }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json() as Record<string, unknown>;
+    expect(json.executionBlocked).toBe(true);
+    expectNoBannedDtoKeys(json);
   });
 
   it("preview route GET/POST omit raw preview payload internals", async () => {
@@ -177,6 +261,7 @@ describe("review-layer route safe contracts", () => {
     });
     const getJson = await getResponse.json() as Record<string, unknown>;
     expect(JSON.stringify(getJson)).not.toContain("preview_payload");
+    expectNoBannedDtoKeys(getJson);
 
     const postResponse = await POST(new Request("http://localhost", { method: "POST" }), {
       params: Promise.resolve({ id: "wo_1", recommendationId: "rec_1" }),
@@ -186,7 +271,7 @@ describe("review-layer route safe contracts", () => {
     expect(serialized).not.toContain("intended_mutations");
     expect(serialized).not.toContain("ownerPinProofRef");
     expect(serialized).not.toContain("side_effects\":[{");
-    expect(postJson.executionBlocked).toBe(true);
+    expectNoBannedDtoKeys(postJson);
   });
 
   it("approval-request route returns minimal DTO and hides owner pin proof refs", async () => {
@@ -219,6 +304,7 @@ describe("review-layer route safe contracts", () => {
     expect(serialized).not.toContain("metadata");
     expect(serialized).toContain("approvalId");
     expect((json.approval as { executionBlocked?: boolean }).executionBlocked).toBe(true);
+    expectNoBannedDtoKeys(json);
   });
 
   it("shop boost recommendations POST omits raw evidence snapshot payload", async () => {
@@ -252,6 +338,7 @@ describe("review-layer route safe contracts", () => {
     expect(serialized).not.toContain("importPayload");
     expect(serialized).not.toContain("materializationPayload");
     expect(serialized).toContain("evidenceSnapshotId");
+    expectNoBannedDtoKeys(json);
   });
 
   it("legacy ai-review rejects unauthenticated and cross-shop access", async () => {
@@ -308,6 +395,7 @@ describe("review-layer route safe contracts", () => {
     const json = await response.json() as Record<string, unknown>;
     expect(response.status).toBe(200);
     expect(json.executionBlocked).toBe(true);
+    expectNoBannedDtoKeys(json);
   });
 
   it("work-order recommendation lifecycle PATCH returns serialized recommendation only", async () => {
@@ -388,6 +476,7 @@ describe("review-layer route safe contracts", () => {
     expect((json.recommendation as { id?: string; status?: string; recommendation_type?: string }).id).toBe("rec_1");
     expect((json.recommendation as { status?: string }).status).toBe("acknowledged");
     expect((json.recommendation as { recommendation_type?: string }).recommendation_type).toBe("dispatch_review");
+    expectNoBannedDtoKeys(json);
   });
 
   it("work-order recommendation lifecycle PATCH keeps shop scoping and recommendation ownership checks", async () => {

--- a/tests/ai-safe-display.test.ts
+++ b/tests/ai-safe-display.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isSafeDisplayText, sanitizeDisplayText } from "@/features/ai/server/safeDisplay";
+
+describe("AI safe display text guardrail", () => {
+  it("accepts normal display-safe strings", () => {
+    expect(isSafeDisplayText("Review technician dispatch queue.")).toBe(true);
+    expect(isSafeDisplayText("  Priority follow-up needed  ")).toBe(true);
+    expect(isSafeDisplayText("x".repeat(320))).toBe(true);
+  });
+
+  it("rejects unsafe or blob-like strings", () => {
+    expect(isSafeDisplayText("   ")).toBe(false);
+    expect(isSafeDisplayText("{\"token\":\"secret\"}")).toBe(false);
+    expect(isSafeDisplayText("[\"preview_payload\"]")).toBe(false);
+    expect(isSafeDisplayText("owner_pin_verification_ref=proof")).toBe(false);
+    expect(isSafeDisplayText("Bearer token abc123")).toBe(false);
+    expect(isSafeDisplayText("x".repeat(321))).toBe(false);
+  });
+
+  it("sanitizes values with deterministic fallback", () => {
+    expect(sanitizeDisplayText(" Safe title ", "Fallback")).toBe("Safe title");
+    expect(sanitizeDisplayText("{\"snapshot\":true}", "Fallback title")).toBe("Fallback title");
+    expect(sanitizeDisplayText("token:abc", "fallback_value")).toBe("fallback_value");
+    expect(sanitizeDisplayText("token:abc", "  ")).toBe("");
+  });
+});

--- a/tests/ai-safe-serializers.test.ts
+++ b/tests/ai-safe-serializers.test.ts
@@ -5,9 +5,10 @@ import {
   serializeAiEvidenceSnapshotForUi,
   serializeAiRecommendationForUi,
 } from "@/features/ai/server";
+import { expectNoBannedDtoKeys, sortedKeys } from "./ai-dto-test-helpers";
 
 describe("AI safe serializers", () => {
-  it("strips raw evidence payloads and metadata", () => {
+  it("serializes evidence snapshot with allowlisted keys only", () => {
     const dto = serializeAiEvidenceSnapshotForUi({
       id: "ev_1",
       shop_id: "shop_1",
@@ -25,19 +26,23 @@ describe("AI safe serializers", () => {
       metadata: { internalRef: "do-not-leak" },
     });
 
-    expect(dto).toMatchObject({
-      evidenceSnapshotId: "ev_1",
-      evidenceKind: "work_order_operational",
-      missingDataCount: 2,
-    });
-    const serialized = JSON.stringify(dto);
-    expect(serialized).not.toContain("snapshot");
-    expect(serialized).not.toContain("source_refs");
-    expect(serialized).not.toContain("metadata");
-    expect(serialized).not.toContain("internalRef");
+    expect(dto).not.toBeNull();
+    expect(sortedKeys(dto as unknown as Record<string, unknown>)).toEqual([
+      "confidence",
+      "domain",
+      "evidenceKind",
+      "evidenceSnapshotId",
+      "freshnessAt",
+      "generatedAt",
+      "missingData",
+      "missingDataCount",
+      "subjectId",
+      "subjectType",
+    ]);
+    expectNoBannedDtoKeys(dto);
   });
 
-  it("strips preview payload internals and keeps execution blocked", () => {
+  it("serializes preview DTO with executionBlocked and safe display fields", () => {
     const dto = serializeAiActionPreviewForUi({
       id: "preview_1",
       shop_id: "shop_1",
@@ -48,8 +53,8 @@ describe("AI safe serializers", () => {
       subject_id: "wo_1",
       status: "approval_required",
       preview_payload: {
-        label: "Review technician dispatch",
-        description: "Internal review only.",
+        label: '{"token":"nope"}',
+        description: "owner_pin_verification_ref should not show",
         side_effects: ["queue_update"],
         ownerPinProofRef: "/proof/path",
       },
@@ -68,25 +73,40 @@ describe("AI safe serializers", () => {
       expires_at: null,
       metadata: {
         token: "sensitive",
-        secret: "sensitive",
-        hash: "sensitive",
-        pin: "sensitive",
       },
     });
 
     expect(dto.executionBlocked).toBe(true);
     expect(dto.intendedMutationCount).toBe(1);
     expect(dto.sideEffectLabels).toEqual(["queue_update"]);
-    const serialized = JSON.stringify(dto);
-    expect(serialized).not.toContain("intended_mutations");
-    expect(serialized).not.toContain("ownerPinProofRef");
-    expect(serialized).not.toContain("token");
-    expect(serialized).not.toContain("secret");
-    expect(serialized).not.toContain("hash");
-    expect(serialized).not.toContain("pin");
+    expect(dto.title).toBe("Preview: advisor_review_needed");
+    expect(dto.description).toBeNull();
+
+    expect(sortedKeys(dto as unknown as Record<string, unknown>)).toEqual([
+      "actionType",
+      "affectedRecordCount",
+      "approvalRequired",
+      "createdAt",
+      "description",
+      "evidenceSnapshotId",
+      "executionBlocked",
+      "expiresAt",
+      "intendedMutationCount",
+      "previewId",
+      "recommendationId",
+      "requiresOwnerPin",
+      "riskTier",
+      "severitySummary",
+      "sideEffectLabels",
+      "status",
+      "subjectId",
+      "subjectType",
+      "title",
+    ]);
+    expectNoBannedDtoKeys(dto);
   });
 
-  it("returns minimal approval request DTO without proof references", () => {
+  it("serializes approval request with minimal review-only contract", () => {
     const dto = serializeAiApprovalRequestForUi({
       approval: {
         id: "approval_1",
@@ -104,7 +124,6 @@ describe("AI safe serializers", () => {
         expires_at: null,
         metadata: {
           ownerPinProofRef: "/internal/path",
-          token: "nope",
         },
       },
       preview: {
@@ -134,18 +153,21 @@ describe("AI safe serializers", () => {
       },
     });
 
-    expect(dto).toMatchObject({
-      approvalId: "approval_1",
-      previewId: "preview_1",
-      executionBlocked: true,
-      requiresOwnerPin: true,
-    });
-    expect(JSON.stringify(dto)).not.toContain("owner_pin_verification_ref");
-    expect(JSON.stringify(dto)).not.toContain("ownerPinProofRef");
-    expect(JSON.stringify(dto)).not.toContain("token");
+    expect(dto.executionBlocked).toBe(true);
+    expect(sortedKeys(dto as unknown as Record<string, unknown>)).toEqual([
+      "approvalId",
+      "approvalRequired",
+      "executionBlocked",
+      "message",
+      "previewId",
+      "requestedAt",
+      "requiresOwnerPin",
+      "status",
+    ]);
+    expectNoBannedDtoKeys(dto);
   });
 
-  it("serializes recommendation with allowlisted fields only", () => {
+  it("serializes recommendation with allowlisted keys only", () => {
     const dto = serializeAiRecommendationForUi({
       id: "rec_1",
       shop_id: "shop_1",
@@ -153,7 +175,7 @@ describe("AI safe serializers", () => {
       recommendation_type: "dispatch_review",
       subject_type: "work_order",
       subject_id: "wo_1",
-      title: "Dispatch review",
+      title: "{\"metadata\":true}",
       summary: "Review dispatch",
       status: "open",
       priority: "high",
@@ -162,7 +184,11 @@ describe("AI safe serializers", () => {
       evidence_snapshot_id: "ev_1",
       evidence_snapshot_ids: ["ev_1"],
       missing_data: ["tech_assignment"],
-      recommended_action: { label: "Review", details: "Review queue", token: "internal" },
+      recommended_action: {
+        label: "token should be removed",
+        details: "Review queue",
+        token: "internal",
+      },
       side_effects: ["internal_effect"],
       requires_approval: true,
       requires_owner_pin: false,
@@ -180,10 +206,24 @@ describe("AI safe serializers", () => {
       metadata: { secret: "nope" },
     });
 
-    const serialized = JSON.stringify(dto);
-    expect(serialized).not.toContain("metadata");
-    expect(serialized).not.toContain("side_effects");
-    expect(serialized).not.toContain("token");
-    expect(dto.requires_approval).toBe(true);
+    expect(dto.title).toBe("Recommendation");
+    expect(dto.recommended_action).toEqual({ details: "Review queue", label: undefined });
+    expect(sortedKeys(dto as unknown as Record<string, unknown>)).toEqual([
+      "confidence",
+      "created_at",
+      "evidence_snapshot_id",
+      "id",
+      "missing_data",
+      "priority",
+      "recommendation_type",
+      "recommended_action",
+      "requires_approval",
+      "requires_owner_pin",
+      "risk_tier",
+      "status",
+      "summary",
+      "title",
+    ]);
+    expectNoBannedDtoKeys(dto);
   });
 });


### PR DESCRIPTION
### Motivation

- Centralize a deterministic, bounded sanitizer to prevent display-copy drift and accidental leakage of structured/sensitive payloads into AI review-layer UI/DTOs.
- Ensure external API/DTO responses never expose raw/internal keys like `preview_payload`, `metadata`, `intended_mutations`, owner PIN refs, tokens, or other sensitive blobs.
- Provide regression protection via explicit DTO key-shape assertions and a reusable banned-key detector for future AI review routes and dashboard helpers.

### Description

- Added a canonical safe-display utility `features/ai/server/safeDisplay.ts` that exports `isSafeDisplayText(value, { maxLength? })` and `sanitizeDisplayText(value, fallback, { maxLength? })` with rules for empty/whitespace, JSON/blob-like content, sensitive term rejection, and configurable max length. 
- Wired `sanitizeDisplayText` into existing serializers and dashboard list helpers so all display text derived from persisted AI payloads is sanitized; updates made to `features/ai/server/serializers.ts`, `features/ai/server/dashboard/listAiActionApprovalsForReview.ts`, and `features/ai/server/dashboard/listAiRecommendationsForReview.ts`, and exported via `features/ai/server/index.ts`.
- Added a recursive banned-key test helper `tests/ai-dto-test-helpers.ts` and focused unit tests: `tests/ai-safe-display.test.ts`, updated `tests/ai-safe-serializers.test.ts` to assert explicit allowed key sets, and enhanced `tests/ai-review-layer-safety-routes.test.ts` with a focused `GET /api/work-orders/[id]/ai/recommendations/[recommendationId]/preview` happy-path test that mocks preview rows and asserts `executionBlocked: true` and absence of banned keys.
- Strengthened dashboard unit tests to assert explicit DTO key-order/allowlists and applied `expectNoBannedDtoKeys` across serializer/route/dashboard test coverage.

### Testing

- Ran typecheck with `npx tsc --noEmit` which completed successfully (repo emits a known non-blocking npm warning about `http-proxy`).
- Ran full test suite with `npm test` / `vitest run` and all tests passed: `32` test files / `136` tests passed in this environment.
- New/modified tests exercised: `tests/ai-safe-display.test.ts`, `tests/ai-safe-serializers.test.ts`, `tests/ai-review-layer-safety-routes.test.ts`, and dashboard/list tests under `features/ai/server/dashboard/*.test.ts` and used `tests/ai-dto-test-helpers.ts` to assert banned-key absence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0cf9053483289f413ed3a21c86ee)