### PR TITLE
Fix Manage subscription action to open billing portal for existing subscriptions

### DIFF
--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -976,6 +976,25 @@ try {
     }
   };
 
+  const manageSubscription = async () => {
+    const managedStatuses = new Set<StripeSubStatus>([
+      "trialing",
+      "active",
+      "past_due",
+      "unpaid",
+      "incomplete",
+      "canceled",
+      "paused",
+    ]);
+
+    if (managedStatuses.has(subStatus)) {
+      await openStripePortal();
+      return;
+    }
+
+    await startSubscriptionCheckout();
+  };
+
   const confirmCancelSubscription = async () => {
     if (!shopId) return;
     if (!guardUnlock()) return;
@@ -1304,7 +1323,7 @@ try {
           emailLogs={emailLogs}
           emailLogsLoading={emailLogsLoading}
           onOpenStripeConnect={openStripeConnect}
-          onStartSubscriptionCheckout={startSubscriptionCheckout}
+          onStartSubscriptionCheckout={manageSubscription}
           onOpenStripePortal={openStripePortal}
           onRequestCancelSubscription={() => setCancelDialogOpen(true)}
           onCreateOrganization={() => router.push("/dashboard/owner/organization/create")}

--- a/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
@@ -132,6 +132,15 @@ export default function OwnerSettingsSidebar({
   locationName,
 }: Props) {
   const isCancelableStatus = subStatus === "active" || subStatus === "trialing";
+  const hasManagedSubscription =
+    subStatus === "active" ||
+    subStatus === "trialing" ||
+    subStatus === "past_due" ||
+    subStatus === "unpaid" ||
+    subStatus === "incomplete" ||
+    subStatus === "paused" ||
+    subStatus === "canceled";
+  const manageSubscriptionLoading = hasManagedSubscription ? portalLoading : checkoutLoading;
 
   return (
     <div className="space-y-5 lg:sticky lg:top-20">
@@ -173,12 +182,20 @@ export default function OwnerSettingsSidebar({
             <Button
               variant="secondary"
               onClick={onStartSubscriptionCheckout}
-              disabled={!isUnlocked || checkoutLoading}
+              disabled={!isUnlocked || manageSubscriptionLoading}
             >
-              {checkoutLoading ? "Opening checkout..." : "Manage subscription"}
+              {manageSubscriptionLoading
+                ? hasManagedSubscription
+                  ? "Opening portal..."
+                  : "Opening checkout..."
+                : hasManagedSubscription
+                  ? "Manage subscription"
+                  : "Start subscription"}
             </Button>
             <p className="text-[11px] text-neutral-500">
-              Start or update the ProFixIQ subscription for this location.
+              {hasManagedSubscription
+                ? "Open Stripe billing portal to manage an existing subscription."
+                : "Start checkout to create a new ProFixIQ subscription for this location."}
             </p>
 
             <Button


### PR DESCRIPTION
### Motivation
- The Owner Settings billing card always invoked checkout which requires a configured price ID, causing the "Stripe checkout is not configured for the starter plan yet" error when starter price env is missing.
- The intent is to use the billing portal for managing existing subscriptions and only invoke checkout when creating a new subscription.
- Make the minimal, non-breaking client-side change so portal/cancel flows are not blocked by missing checkout price config.

### Description
- Added a `manageSubscription()` handler in `features/dashboard/app/dashboard/owner/settings/page.tsx` that routes to `openStripePortal()` for shops with an existing/subscription-like status and falls back to `startSubscriptionCheckout()` for new subscriptions. (file changed)
- Rewired the sidebar prop to call `manageSubscription()` instead of calling the checkout handler directly. (file changed)
- Updated `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx` to: reflect portal-vs-checkout behavior in button label, disabled/loading state, and explanatory copy so users see the correct action and loading text. (file changed)
- Preserved cancel flow and gating: cancellation still uses `/api/stripe/subscription` and the cancel button is still shown only when `subStatus` is `active` or `trialing` and `canManageBilling` is true.
- Files changed: `features/dashboard/app/dashboard/owner/settings/page.tsx`, `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx`.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully.
- Ran `npx eslint features/dashboard/app/dashboard/owner/settings/page.tsx features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx` and it completed successfully.
- No automated unit tests were modified; only targeted typecheck and lint validations were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0ee5fb68832889727e325274e2be)