### PR TITLE
Fix canonical Stripe subscription linkage from acquisition checkout to shop billing

### DIFF
--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -5,6 +5,8 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 import { OWNER_PIN_PURPOSES, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 type DB = Database;
 
@@ -107,6 +109,24 @@ export async function POST(req: Request) {
         { msg },
         { status: 400 },
       );
+    }
+
+    if (process.env.STRIPE_SECRET_KEY?.trim()) {
+      try {
+        const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY);
+        await reconcileShopBillingFromUser({
+          stripe,
+          supabase,
+          userId: user.id,
+          shopId,
+        });
+      } catch (billingLinkErr) {
+        console.error("onboarding.bootstrap_owner billing reconciliation failed", {
+          userId: user.id,
+          shopId,
+          error: billingLinkErr,
+        });
+      }
     }
 
     const res = NextResponse.json({ ok: true, shop_id: shopId }, { status: 200 });

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -16,6 +16,7 @@ type CheckoutPayload = {
   planKey?: string;
   priceId?: string;
   shopId?: string | null;
+  supabaseUserId?: string | null;
   successPath?: string;
   cancelPath?: string;
   enableTrial?: boolean;
@@ -203,6 +204,9 @@ export async function POST(req: Request) {
     const trialDays = clampTrialDays(body.trialDays, envTrialDays());
 
     const couponId = String(process.env.STRIPE_FOUNDING_COUPON_ID ?? "").trim();
+    const requestedMetadataShopId = String(body.shopId ?? "").trim();
+    const requestedMetadataUserId = String(body.supabaseUserId ?? "").trim();
+
     const applyFoundingDiscount =
       Boolean(couponId) && body.applyFoundingDiscount !== false;
 
@@ -225,6 +229,8 @@ export async function POST(req: Request) {
             trial_days: enableTrial ? String(trialDays) : "0",
             demo_id: String(body.demoId ?? "").trim() || "",
             intake_id: String(body.intakeId ?? "").trim() || "",
+            shop_id: requestedMetadataShopId || "",
+            supabase_user_id: requestedMetadataUserId || "",
           },
         },
         metadata: {
@@ -232,6 +238,8 @@ export async function POST(req: Request) {
           source: "pricing_cta",
           demo_id: String(body.demoId ?? "").trim() || "",
           intake_id: String(body.intakeId ?? "").trim() || "",
+          shop_id: requestedMetadataShopId || "",
+          supabase_user_id: requestedMetadataUserId || "",
         },
       });
 

--- a/app/api/stripe/link-user/route.ts
+++ b/app/api/stripe/link-user/route.ts
@@ -1,0 +1,7 @@
+export const runtime = "nodejs";
+
+import { handleStripeCheckoutLinkUser } from "@/features/stripe/api/stripe/checkout/link-user/route";
+
+export async function POST(req: Request) {
+  return handleStripeCheckoutLinkUser(req);
+}

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
+import { getProfileStripeArtifacts } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 type DB = Database;
 
@@ -92,6 +93,25 @@ export async function POST(req: Request) {
 
     if (!shop) {
       return NextResponse.json({ error: "Shop not found." }, { status: 404 });
+    }
+
+    if (!String(shop.stripe_customer_id ?? "").trim()) {
+      const profile = await getProfileStripeArtifacts(access.supabase, access.profile.id);
+      const profileCustomerId = String(profile?.stripe_customer_id ?? "").trim();
+      const profileSubscriptionId = String(profile?.stripe_subscription_id ?? "").trim();
+
+      if (profileCustomerId || profileSubscriptionId) {
+        return NextResponse.json(
+          {
+            error: "Billing linkage is required before opening the portal.",
+            linkage_needed: true,
+            linkage_state: "unlinked_subscription",
+            linked_customer_id: profileCustomerId || null,
+            linked_subscription_id: profileSubscriptionId || null,
+          },
+          { status: 409 },
+        );
+      }
     }
 
     const customerId = await createCustomerIfMissing(stripe, access.supabase, shop);

--- a/app/api/stripe/subscription/route.ts
+++ b/app/api/stripe/subscription/route.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
+import { getProfileStripeArtifacts } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 type DB = Database;
 
@@ -27,6 +28,10 @@ type NormalizedSubscriptionPayload = {
   cancel_at_period_end: boolean;
   canceled_at: string | null;
   current_period_end: string | null;
+  linkage_needed?: boolean;
+  linkage_state?: "unlinked_subscription";
+  linked_customer_id?: string | null;
+  linked_subscription_id?: string | null;
 };
 
 function mustEnv(name: string): string {
@@ -115,14 +120,75 @@ async function findCanonicalSubscription(
   return sorted[0] ?? null;
 }
 
+async function findUnlinkedSubscriptionEvidence(args: {
+  stripe: Stripe;
+  supabase: SupabaseClient<DB>;
+  userId: string;
+  shop: ShopStripeScope;
+}): Promise<{ customerId: string | null; subscriptionId: string | null } | null> {
+  const { stripe, supabase, userId, shop } = args;
+  const profile = await getProfileStripeArtifacts(supabase, userId);
+  if (!profile) return null;
+
+  const profileCustomerId = String(profile.stripe_customer_id ?? "").trim() || null;
+  const profileSubscriptionId = String(profile.stripe_subscription_id ?? "").trim() || null;
+
+  const canonicalCustomerId = String(shop.stripe_customer_id ?? "").trim() || null;
+  const canonicalSubscriptionId = String(shop.stripe_subscription_id ?? "").trim() || null;
+
+  if (!profileCustomerId && !profileSubscriptionId) return null;
+
+  if (
+    profileCustomerId &&
+    canonicalCustomerId &&
+    profileCustomerId === canonicalCustomerId &&
+    profileSubscriptionId &&
+    canonicalSubscriptionId &&
+    profileSubscriptionId === canonicalSubscriptionId
+  ) {
+    return null;
+  }
+
+  if (profileSubscriptionId) {
+    const sub = await stripe.subscriptions.retrieve(profileSubscriptionId);
+    const subscriptionCustomerId =
+      typeof sub.customer === "string" ? sub.customer : String(sub.customer?.id ?? "").trim() || null;
+    return {
+      customerId: profileCustomerId ?? subscriptionCustomerId,
+      subscriptionId: sub.id,
+    };
+  }
+
+  if (profileCustomerId) {
+    const list = await stripe.subscriptions.list({
+      customer: profileCustomerId,
+      status: "all",
+      limit: 5,
+    });
+    const latest = [...list.data].sort((a, b) => (b.created ?? 0) - (a.created ?? 0))[0] ?? null;
+    if (latest) {
+      return { customerId: profileCustomerId, subscriptionId: latest.id };
+    }
+    return { customerId: profileCustomerId, subscriptionId: null };
+  }
+
+  return null;
+}
+
 async function syncShopSubscription(
   supabase: SupabaseClient<DB>,
   shopId: string,
   subscription: Stripe.Subscription,
 ) {
+  const stripeCustomerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : String(subscription.customer?.id ?? "").trim() || null;
+
   const { error } = await supabase
     .from("shops")
     .update({
+      stripe_customer_id: stripeCustomerId,
       stripe_subscription_id: subscription.id,
       stripe_subscription_status: String(subscription.status ?? "").trim() || null,
       stripe_current_period_end: unixToIsoOrNull(subscription.current_period_end ?? null),
@@ -163,6 +229,23 @@ export async function GET() {
     const canonicalSubscription = await findCanonicalSubscription(stripe, shop);
 
     if (!canonicalSubscription) {
+      const unlinked = await findUnlinkedSubscriptionEvidence({
+        stripe,
+        supabase: access.supabase,
+        userId: access.profile.id,
+        shop,
+      });
+
+      if (unlinked) {
+        return NextResponse.json({
+          ...normalizeShopFallback(shop),
+          linkage_needed: true,
+          linkage_state: "unlinked_subscription",
+          linked_customer_id: unlinked.customerId,
+          linked_subscription_id: unlinked.subscriptionId,
+        } satisfies NormalizedSubscriptionPayload);
+      }
+
       return NextResponse.json(normalizeShopFallback(shop));
     }
 
@@ -207,6 +290,27 @@ export async function POST(req: Request) {
     const canonicalSubscription = await findCanonicalSubscription(stripe, shop);
 
     if (!canonicalSubscription) {
+      const unlinked = await findUnlinkedSubscriptionEvidence({
+        stripe,
+        supabase: access.supabase,
+        userId: access.profile.id,
+        shop,
+      });
+
+      if (unlinked) {
+        return NextResponse.json(
+          {
+            error: "Billing linkage is required before managing this subscription.",
+            ...normalizeShopFallback(shop),
+            linkage_needed: true,
+            linkage_state: "unlinked_subscription",
+            linked_customer_id: unlinked.customerId,
+            linked_subscription_id: unlinked.subscriptionId,
+          },
+          { status: 409 },
+        );
+      }
+
       return NextResponse.json(
         {
           error: "No active or trialing subscription was found for this shop.",

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -125,7 +125,7 @@ export default function OnboardingPage() {
           await fetch("/api/stripe/link-user", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ sessionId: sid, userId: user.id }),
+            body: JSON.stringify({ sessionId: sid }),
           });
         } catch {
           //

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -1,54 +1,125 @@
-//features/stripe/api/stripe/checkout/link-user/route.ts
-
 import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import type { Database } from "@shared/types/types/supabase";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
-const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY!);
+type DB = Database;
 
-export async function POST(req: Request) {
+function toStripeId(v: unknown, prefix: string): string | null {
+  if (typeof v === "string" && v.startsWith(prefix)) return v;
+  if (v && typeof v === "object") {
+    const maybeId = (v as { id?: unknown }).id;
+    if (typeof maybeId === "string" && maybeId.startsWith(prefix)) return maybeId;
+  }
+  return null;
+}
+
+export async function handleStripeCheckoutLinkUser(req: Request) {
   try {
-    const body = await req.json();
-    const { sessionId, userId } = body as {
-      sessionId?: string;
-      userId?: string;
-    };
-
-    console.log("📩 Received request to link user:", { sessionId, userId });
-
-    if (!sessionId || !userId) {
-      console.warn("⚠️ Missing sessionId or userId in request body");
-      return NextResponse.json(
-        { error: "Missing sessionId or userId" },
-        { status: 400 },
-      );
+    if (!process.env.STRIPE_SECRET_KEY?.trim()) {
+      return NextResponse.json({ error: "Stripe is not configured" }, { status: 500 });
     }
 
-    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
 
-    if (!session || !session.customer) {
-      console.error("❌ No Stripe customer found in session:", sessionId);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => null)) as { sessionId?: string } | null;
+    const sessionId = String(body?.sessionId ?? "").trim();
+
+    if (!sessionId) {
+      return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
+    }
+
+    const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY);
+    const session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ["subscription"],
+    });
+
+    const customerId = toStripeId(session.customer, "cus_");
+    const subscriptionId = toStripeId(session.subscription, "sub_");
+
+    if (!customerId && !subscriptionId) {
       return NextResponse.json(
-        { error: "No customer found in session" },
+        { error: "No Stripe billing artifacts found in checkout session" },
         { status: 404 },
       );
     }
 
-    const updated = await stripe.customers.update(session.customer.toString(), {
-      metadata: { supabaseUserId: userId },
-    });
+    if (customerId) {
+      await stripe.customers.update(customerId, {
+        metadata: {
+          supabase_user_id: user.id,
+          supabaseUserId: user.id,
+          source: "profixiq",
+        },
+      });
+    }
 
-    console.log("✅ Successfully linked Stripe customer to userId:", {
-      customerId: updated.id,
-      userId,
-    });
+    if (subscriptionId) {
+      const currentSub =
+        typeof session.subscription === "object" && session.subscription
+          ? session.subscription
+          : await stripe.subscriptions.retrieve(subscriptionId);
 
-    return NextResponse.json({ success: true });
+      await stripe.subscriptions.update(subscriptionId, {
+        metadata: {
+          ...(currentSub.metadata ?? {}),
+          supabase_user_id: user.id,
+          source: "profixiq",
+        },
+      });
+    }
+
+    const { error: profileError } = await supabase
+      .from("profiles")
+      .update({
+        stripe_checkout_complete: true,
+        stripe_checkout_session_id: sessionId,
+        stripe_customer_id: customerId,
+        stripe_subscription_id: subscriptionId,
+      } as unknown as DB["public"]["Tables"]["profiles"]["Update"])
+      .eq("id", user.id);
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 });
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("id", user.id)
+      .maybeSingle<{ shop_id: string | null }>();
+
+    if (profile?.shop_id) {
+      await reconcileShopBillingFromUser({
+        stripe,
+        supabase,
+        userId: user.id,
+        shopId: profile.shop_id,
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      customerId,
+      subscriptionId,
+      shopLinked: Boolean(profile?.shop_id),
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("❌ Stripe Link User Error:", message);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 },
-    );
+    console.error("[stripe/checkout/link-user] error", err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
+}
+
+export async function POST(req: Request) {
+  return handleStripeCheckoutLinkUser(req);
 }

--- a/features/stripe/api/stripe/webhook/route.ts
+++ b/features/stripe/api/stripe/webhook/route.ts
@@ -5,10 +5,7 @@ import Stripe from "stripe";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import {
-  parseStripeSubscriptionStatus,
-  type StripeSubscriptionStatus,
-} from "../../../lib/stripe/subscriptionStatus";
+import { syncCanonicalShopBilling } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 type DB = Database;
 
@@ -44,15 +41,6 @@ function toStripeId(v: unknown, prefix: string): string | null {
   return null;
 }
 
-function unixToIsoOrNull(v: number | null | undefined): string | null {
-  if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return null;
-  return new Date(v * 1000).toISOString();
-}
-
-function toShopStripeStatus(v: unknown): StripeSubscriptionStatus | null {
-  const parsed = parseStripeSubscriptionStatus(v);
-  return parsed === "unknown" ? null : parsed;
-}
 
 async function syncShopConnectFlagsByAccountId(ctx: {
   stripe: Stripe;
@@ -89,32 +77,63 @@ async function syncShopConnectFlagsByAccountId(ctx: {
   if (updErr) console.error("[stripe/webhook] Failed to sync connect flags:", updErr.message);
 }
 
-async function syncShopBillingFromSubscription(params: {
+async function resolveShopIdForSubscription(params: {
   stripe: Stripe;
   supabase: ReturnType<typeof createClient<DB>>;
-  shopId: string;
+  subscription: Stripe.Subscription;
   customerId: string | null;
-  subscriptionId: string;
-}): Promise<void> {
-  const { shopId, customerId, stripe, subscriptionId, supabase } = params;
+}): Promise<string | null> {
+  const { stripe, supabase, subscription, customerId } = params;
 
-  const sub = await stripe.subscriptions.retrieve(subscriptionId);
-  const status = toShopStripeStatus(sub.status);
-  const trialEndIso = unixToIsoOrNull(sub.trial_end ?? null);
-  const periodEndIso = unixToIsoOrNull(sub.current_period_end ?? null);
+  const metadataShopId = String(subscription.metadata?.shop_id ?? "").trim();
+  if (isUuid(metadataShopId)) return metadataShopId;
 
-  const { error } = await supabase
-    .from("shops")
-    .update({
-      stripe_customer_id: customerId,
-      stripe_subscription_id: subscriptionId,
-      stripe_subscription_status: status,
-      stripe_trial_end: trialEndIso,
-      stripe_current_period_end: periodEndIso,
-    } as unknown as DB["public"]["Tables"]["shops"]["Update"])
-    .eq("id", shopId);
+  if (customerId) {
+    const { data: byCustomer, error: customerErr } = await supabase
+      .from("shops")
+      .select("id")
+      .eq("stripe_customer_id", customerId)
+      .limit(2);
 
-  if (error) console.error("[stripe/webhook] Failed to sync shop subscription:", error.message);
+    if (!customerErr && Array.isArray(byCustomer) && byCustomer.length === 1 && byCustomer[0]?.id) {
+      return byCustomer[0].id;
+    }
+
+    const customer = await stripe.customers.retrieve(customerId);
+    const metadataUserId =
+      customer && !("deleted" in customer && customer.deleted)
+        ? String(
+            customer.metadata?.supabase_user_id ?? customer.metadata?.supabaseUserId ?? "",
+          ).trim()
+        : "";
+
+    if (isUuid(metadataUserId)) {
+      const { data: profile, error: profileErr } = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", metadataUserId)
+        .maybeSingle<{ shop_id: string | null }>();
+
+      if (!profileErr && isUuid(profile?.shop_id)) {
+        return profile.shop_id;
+      }
+    }
+  }
+
+  const metadataUserId = String(subscription.metadata?.supabase_user_id ?? "").trim();
+  if (isUuid(metadataUserId)) {
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("id", metadataUserId)
+      .maybeSingle<{ shop_id: string | null }>();
+
+    if (!profileErr && isUuid(profile?.shop_id)) {
+      return profile.shop_id;
+    }
+  }
+
+  return null;
 }
 
 async function upsertPaymentFromCheckout(ctx: {
@@ -225,9 +244,18 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
           if (error) console.error("[stripe/webhook] Failed to update profile:", error.message);
         }
 
-        if (isUuid(shopIdRaw)) {
-          const shopId = shopIdRaw;
+        let resolvedShopId: string | null = isUuid(shopIdRaw) ? shopIdRaw : null;
 
+        if (!resolvedShopId && isUuid(userId)) {
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("shop_id")
+            .eq("id", userId)
+            .maybeSingle<{ shop_id: string | null }>();
+          if (isUuid(profile?.shop_id)) resolvedShopId = profile.shop_id;
+        }
+
+        if (resolvedShopId) {
           const { error } = await supabase
             .from("shops")
             .update({
@@ -235,17 +263,18 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
               stripe_subscription_id: stripeSubscriptionId,
               stripe_checkout_session_id: checkoutSessionId,
             } as unknown as DB["public"]["Tables"]["shops"]["Update"])
-            .eq("id", shopId);
+            .eq("id", resolvedShopId);
 
           if (error) console.error("[stripe/webhook] Failed to update shop billing ids:", error.message);
 
           if (stripeSubscriptionId) {
-            await syncShopBillingFromSubscription({
+            await syncCanonicalShopBilling({
               stripe,
               supabase,
-              shopId,
+              shopId: resolvedShopId,
               customerId: stripeCustomerId,
               subscriptionId: stripeSubscriptionId,
+              checkoutSessionId,
             });
           }
         }
@@ -259,6 +288,7 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
       return;
     }
 
+    case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted": {
       const sub = event.data.object as Stripe.Subscription;
@@ -267,36 +297,26 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
       const customerId = toStripeId(sub.customer, "cus_");
 
       if (!isNonEmptyString(subscriptionId)) return;
+      const resolvedShopId = await resolveShopIdForSubscription({
+        stripe,
+        supabase,
+        subscription: sub,
+        customerId,
+      });
 
-      const filters = [
-        `stripe_subscription_id.eq.${subscriptionId}`,
-        customerId ? `stripe_customer_id.eq.${customerId}` : "",
-      ].filter((x) => x.length > 0);
+      if (!resolvedShopId) return;
 
-      const { data: shop, error: sErr } = await supabase
-        .from("shops")
-        .select("id, stripe_subscription_id, stripe_customer_id")
-        .or(filters.join(","))
-        .maybeSingle<{ id: string; stripe_subscription_id: string | null; stripe_customer_id: string | null }>();
-
-      if (sErr || !shop?.id) return;
-
-      const status = toShopStripeStatus(sub.status);
-      const trialEndIso = unixToIsoOrNull(sub.trial_end ?? null);
-      const periodEndIso = unixToIsoOrNull(sub.current_period_end ?? null);
-
-      const { error: updErr } = await supabase
-        .from("shops")
-        .update({
-          stripe_subscription_id: subscriptionId,
-          stripe_customer_id: customerId ?? shop.stripe_customer_id ?? null,
-          stripe_subscription_status: status,
-          stripe_trial_end: trialEndIso,
-          stripe_current_period_end: periodEndIso,
-        } as unknown as DB["public"]["Tables"]["shops"]["Update"])
-        .eq("id", shop.id);
-
-      if (updErr) console.error("[stripe/webhook] Failed to update shop subscription status:", updErr.message);
+      try {
+        await syncCanonicalShopBilling({
+          stripe,
+          supabase,
+          shopId: resolvedShopId,
+          customerId,
+          subscriptionId,
+        });
+      } catch (syncErr) {
+        console.error("[stripe/webhook] Failed to sync shop subscription status:", syncErr);
+      }
       return;
     }
 

--- a/features/stripe/lib/server/canonical-shop-billing.ts
+++ b/features/stripe/lib/server/canonical-shop-billing.ts
@@ -1,0 +1,139 @@
+import Stripe from "stripe";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  parseStripeSubscriptionStatus,
+  type StripeSubscriptionStatus,
+} from "@/features/stripe/lib/stripe/subscriptionStatus";
+
+type DB = Database;
+
+type ProfileStripeArtifacts = {
+  shop_id: string | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+};
+
+function unixToIsoOrNull(v: number | null | undefined): string | null {
+  if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return null;
+  return new Date(v * 1000).toISOString();
+}
+
+function toShopStripeStatus(v: unknown): StripeSubscriptionStatus | null {
+  const parsed = parseStripeSubscriptionStatus(v);
+  return parsed === "unknown" ? null : parsed;
+}
+
+export async function getProfileStripeArtifacts(
+  supabase: SupabaseClient<DB>,
+  userId: string,
+): Promise<ProfileStripeArtifacts | null> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("shop_id, stripe_customer_id, stripe_subscription_id")
+    .eq("id", userId)
+    .maybeSingle<ProfileStripeArtifacts>();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+}
+
+export async function syncCanonicalShopBilling(params: {
+  stripe: Stripe;
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  customerId: string | null;
+  subscriptionId: string;
+  checkoutSessionId?: string | null;
+}): Promise<void> {
+  const { stripe, supabase, shopId, customerId, subscriptionId, checkoutSessionId } = params;
+  const sub = await stripe.subscriptions.retrieve(subscriptionId);
+
+  const { error } = await supabase
+    .from("shops")
+    .update({
+      stripe_customer_id: customerId,
+      stripe_subscription_id: subscriptionId,
+      stripe_subscription_status: toShopStripeStatus(sub.status),
+      stripe_trial_end: unixToIsoOrNull(sub.trial_end ?? null),
+      stripe_current_period_end: unixToIsoOrNull(sub.current_period_end ?? null),
+      ...(checkoutSessionId ? { stripe_checkout_session_id: checkoutSessionId } : {}),
+    } as unknown as DB["public"]["Tables"]["shops"]["Update"])
+    .eq("id", shopId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+export async function reconcileShopBillingFromUser(params: {
+  stripe: Stripe;
+  supabase: SupabaseClient<DB>;
+  userId: string;
+  shopId: string;
+}): Promise<{ linked: boolean; reason?: string }> {
+  const { stripe, supabase, userId, shopId } = params;
+  const profile = await getProfileStripeArtifacts(supabase, userId);
+  if (!profile) return { linked: false, reason: "profile_not_found" };
+
+  const profileCustomerId = String(profile.stripe_customer_id ?? "").trim();
+  const profileSubscriptionId = String(profile.stripe_subscription_id ?? "").trim();
+
+  if (!profileCustomerId && !profileSubscriptionId) {
+    return { linked: false, reason: "no_profile_stripe_artifacts" };
+  }
+
+  let customerId = profileCustomerId || null;
+  let subscriptionId = profileSubscriptionId;
+
+  if (!subscriptionId && customerId) {
+    const list = await stripe.subscriptions.list({
+      customer: customerId,
+      status: "all",
+      limit: 10,
+    });
+    const sorted = [...list.data].sort((a, b) => (b.created ?? 0) - (a.created ?? 0));
+    subscriptionId = sorted[0]?.id ?? "";
+  }
+
+  if (!subscriptionId) {
+    return { linked: false, reason: "no_subscription_found" };
+  }
+
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  customerId =
+    customerId ||
+    (typeof subscription.customer === "string" ? subscription.customer : subscription.customer?.id ?? null);
+
+  if (customerId) {
+    await stripe.customers.update(customerId, {
+      metadata: {
+        shop_id: shopId,
+        supabase_user_id: userId,
+        source: "profixiq",
+      },
+    });
+  }
+
+  await stripe.subscriptions.update(subscriptionId, {
+    metadata: {
+      ...(subscription.metadata ?? {}),
+      shop_id: shopId,
+      supabase_user_id: userId,
+      source: "profixiq",
+    },
+  });
+
+  await syncCanonicalShopBilling({
+    stripe,
+    supabase,
+    shopId,
+    customerId,
+    subscriptionId,
+  });
+
+  return { linked: true };
+}


### PR DESCRIPTION
### Motivation
- Onboarding/acquisition checkouts sometimes created Stripe subscriptions that were not recognized by Owner Settings because checkout did not include deterministic `shop_id`/`supabase_user_id` metadata and webhook sync could not attach the Stripe artifacts to the canonical `shops` row.
- The goal is a minimal, additive fix to ensure onboarding-created subscriptions are reconciled into `shops` (the single canonical billing source) without changing pricing UI, labels, or broad billing flows.

### Description
- Add a canonical reconciliation helper `features/stripe/lib/server/canonical-shop-billing.ts` that can sync Stripe customer/subscription metadata and write `shops` billing fields (`stripe_customer_id`, `stripe_subscription_id`, `stripe_subscription_status`, trial/current-period fields).
- Harden acquisition checkout metadata in `app/api/stripe/checkout/route.ts` to carry optional `shop_id` and `supabase_user_id` when available so created sessions/subscriptions include deterministic linkage data.
- Mount and align onboarding link-user flow by adding `app/api/stripe/link-user/route.ts` and refactoring the handler in `features/stripe/api/stripe/checkout/link-user/route.ts` to require an authenticated user, persist profile stripe artifacts, update Stripe metadata, and run reconciliation to the newly created shop when present.
- Run reconciliation after owner bootstrap in `app/api/onboarding/bootstrap-owner/route.ts` to cover the case where checkout happened before shop creation.
- Harden webhook sync in `features/stripe/api/stripe/webhook/route.ts` to include `customer.subscription.created` and resolve shop using a safe, tenant-scoped sequence: subscription `metadata.shop_id`, single-match `shops.stripe_customer_id`, and controlled fallback via customer/profile `supabase_user_id` only when unambiguous.
- Make resolver and portal explicit about missing canonical linkage by returning an additive linkage-needed state from `app/api/stripe/subscription/route.ts` and by blocking silent parallel customer creation in `app/api/stripe/portal/route.ts` when unlinked managed artifacts are detected.

Files changed (high-level):
- `app/api/stripe/checkout/route.ts` (metadata handoff)
- `features/stripe/lib/server/canonical-shop-billing.ts` (new)
- `app/api/onboarding/bootstrap-owner/route.ts` (post-bootstrap reconciliation)
- `features/stripe/api/stripe/webhook/route.ts` (mapping and created-event handling)
- `features/stripe/api/stripe/checkout/link-user/route.ts` (link-user handler)
- `app/api/stripe/link-user/route.ts` (mounted route)
- `app/api/stripe/subscription/route.ts` (linkage-needed responses)
- `app/api/stripe/portal/route.ts` (prevent parallel customer creation)
- `features/auth/app/onboarding/OnboardingPage.tsx` (onboarding now posts to mounted link-user route)

### Testing
- Typecheck: ran `npx tsc --noEmit`, which completed successfully with no type errors.
- Focused lint: ran `npx eslint` against touched files (checkout, webhook, subscription, portal, onboarding, link-user, bootstrap routes) and there were no blocking lint errors (only a benign npm env warning surfaced during the run).
- Built and committed changes locally; code compiles and targeted server routes align with the onboarding flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1e0164208328b8237276b2b77162)