### PR TITLE
Canonical Stripe onboarding → shop billing reconciliation and linkage fix

### DIFF
--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -6,7 +6,10 @@ import type { Database } from "@shared/types/types/supabase";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 import { OWNER_PIN_PURPOSES, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
-import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
+import {
+  reconcileShopBillingFromCheckoutSession,
+  reconcileShopBillingFromUser,
+} from "@/features/stripe/lib/server/canonical-shop-billing";
 
 type DB = Database;
 
@@ -56,6 +59,7 @@ export async function POST(req: Request) {
       ? cleanUpper(raw.country)
       : "US";
     const timezone = cleanStr(raw.timezone) || "America/New_York";
+    const stripeCheckoutSessionId = cleanStr(raw.stripe_checkout_session_id);
 
     if (!businessName || !street || !city || !province || !postal_code || !pin) {
       return NextResponse.json(
@@ -114,6 +118,15 @@ export async function POST(req: Request) {
     if (process.env.STRIPE_SECRET_KEY?.trim()) {
       try {
         const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY);
+        if (stripeCheckoutSessionId) {
+          await reconcileShopBillingFromCheckoutSession({
+            stripe,
+            supabase,
+            userId: user.id,
+            shopId,
+            sessionId: stripeCheckoutSessionId,
+          });
+        }
         await reconcileShopBillingFromUser({
           stripe,
           supabase,

--- a/app/api/stripe/checkout/link-user/route.ts
+++ b/app/api/stripe/checkout/link-user/route.ts
@@ -1,0 +1,7 @@
+export const runtime = "nodejs";
+
+import { handleStripeCheckoutLinkUser } from "@/features/stripe/api/stripe/checkout/link-user/route";
+
+export async function POST(req: Request) {
+  return handleStripeCheckoutLinkUser(req);
+}

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -4,6 +4,8 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
@@ -145,9 +147,19 @@ async function createCustomerIfMissing(
   return customer.id;
 }
 
+function isUuid(v: unknown): v is string {
+  if (typeof v !== "string") return false;
+  const s = v.trim();
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s);
+}
+
 export async function POST(req: Request) {
   try {
     const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
+    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     const body = (await req.json().catch(() => null)) as CheckoutPayload | null;
     if (!body) {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -206,6 +218,9 @@ export async function POST(req: Request) {
     const couponId = String(process.env.STRIPE_FOUNDING_COUPON_ID ?? "").trim();
     const requestedMetadataShopId = String(body.shopId ?? "").trim();
     const requestedMetadataUserId = String(body.supabaseUserId ?? "").trim();
+    const metadataSupabaseUserId = requestedMetadataUserId || String(user?.id ?? "").trim();
+    const metadataPurpose = isAcquisitionCheckout ? "profixiq_acquisition" : "profixiq_subscription";
+    const metadataSource = source || (isAcquisitionCheckout ? "pricing_cta" : "owner_settings");
 
     const applyFoundingDiscount =
       Boolean(couponId) && body.applyFoundingDiscount !== false;
@@ -218,28 +233,29 @@ export async function POST(req: Request) {
         success_url: successUrl,
         cancel_url: cancelUrl,
         allow_promotion_codes: true,
+        ...(isUuid(metadataSupabaseUserId) ? { client_reference_id: metadataSupabaseUserId } : {}),
         ...(applyFoundingDiscount ? { discounts: [{ coupon: couponId }] } : {}),
         subscription_data: {
           ...(enableTrial ? { trial_period_days: trialDays } : {}),
           metadata: {
-            purpose: "profixiq_acquisition",
-            source: "pricing_cta",
+            purpose: metadataPurpose,
+            source: metadataSource,
             founding_discount_applied: applyFoundingDiscount ? "true" : "false",
             trial_enabled: enableTrial ? "true" : "false",
             trial_days: enableTrial ? String(trialDays) : "0",
             demo_id: String(body.demoId ?? "").trim() || "",
             intake_id: String(body.intakeId ?? "").trim() || "",
             shop_id: requestedMetadataShopId || "",
-            supabase_user_id: requestedMetadataUserId || "",
+            supabase_user_id: metadataSupabaseUserId || "",
           },
         },
         metadata: {
-          purpose: "profixiq_acquisition",
-          source: "pricing_cta",
+          purpose: metadataPurpose,
+          source: metadataSource,
           demo_id: String(body.demoId ?? "").trim() || "",
           intake_id: String(body.intakeId ?? "").trim() || "",
           shop_id: requestedMetadataShopId || "",
-          supabase_user_id: requestedMetadataUserId || "",
+          supabase_user_id: metadataSupabaseUserId || "",
         },
       });
 
@@ -290,7 +306,8 @@ export async function POST(req: Request) {
         metadata: {
           shop_id: shop.id,
           supabase_user_id: access.profile.id,
-          purpose: "profixiq_subscription",
+          purpose: metadataPurpose,
+          source: metadataSource,
           founding_discount_applied: applyFoundingDiscount ? "true" : "false",
           trial_enabled: enableTrial ? "true" : "false",
           trial_days: enableTrial ? String(trialDays) : "0",
@@ -299,7 +316,8 @@ export async function POST(req: Request) {
       metadata: {
         shop_id: shop.id,
         supabase_user_id: access.profile.id,
-        purpose: "profixiq_subscription",
+        purpose: metadataPurpose,
+        source: metadataSource,
       },
     });
 

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -99,8 +99,9 @@ export async function POST(req: Request) {
       const profile = await getProfileStripeArtifacts(access.supabase, access.profile.id);
       const profileCustomerId = String(profile?.stripe_customer_id ?? "").trim();
       const profileSubscriptionId = String(profile?.stripe_subscription_id ?? "").trim();
+      const profileCheckoutSessionId = String(profile?.stripe_checkout_session_id ?? "").trim();
 
-      if (profileCustomerId || profileSubscriptionId) {
+      if (profileCustomerId || profileSubscriptionId || profileCheckoutSessionId) {
         return NextResponse.json(
           {
             error: "Billing linkage is required before opening the portal.",
@@ -108,6 +109,7 @@ export async function POST(req: Request) {
             linkage_state: "unlinked_subscription",
             linked_customer_id: profileCustomerId || null,
             linked_subscription_id: profileSubscriptionId || null,
+            linked_checkout_session_id: profileCheckoutSessionId || null,
           },
           { status: 409 },
         );

--- a/app/api/stripe/subscription/route.ts
+++ b/app/api/stripe/subscription/route.ts
@@ -33,6 +33,7 @@ type NormalizedSubscriptionPayload = {
   linkage_state?: "unlinked_subscription";
   linked_customer_id?: string | null;
   linked_subscription_id?: string | null;
+  linked_checkout_session_id?: string | null;
 };
 
 function mustEnv(name: string): string {
@@ -128,18 +129,19 @@ async function findUnlinkedSubscriptionEvidence(args: {
   supabase: SupabaseClient<DB>;
   userId: string;
   shop: ShopStripeScope;
-}): Promise<{ customerId: string | null; subscriptionId: string | null } | null> {
+}): Promise<{ customerId: string | null; subscriptionId: string | null; checkoutSessionId: string | null } | null> {
   const { stripe, supabase, userId, shop } = args;
   const profile = await getProfileStripeArtifacts(supabase, userId);
   if (!profile) return null;
 
   const profileCustomerId = String(profile.stripe_customer_id ?? "").trim() || null;
   const profileSubscriptionId = String(profile.stripe_subscription_id ?? "").trim() || null;
+  const profileCheckoutSessionId = String(profile.stripe_checkout_session_id ?? "").trim() || null;
 
   const canonicalCustomerId = String(shop.stripe_customer_id ?? "").trim() || null;
   const canonicalSubscriptionId = String(shop.stripe_subscription_id ?? "").trim() || null;
 
-  if (!profileCustomerId && !profileSubscriptionId) return null;
+  if (!profileCustomerId && !profileSubscriptionId && !profileCheckoutSessionId) return null;
 
   if (
     profileCustomerId &&
@@ -159,6 +161,7 @@ async function findUnlinkedSubscriptionEvidence(args: {
     return {
       customerId: profileCustomerId ?? subscriptionCustomerId,
       subscriptionId: sub.id,
+      checkoutSessionId: profileCheckoutSessionId,
     };
   }
 
@@ -170,9 +173,22 @@ async function findUnlinkedSubscriptionEvidence(args: {
     });
     const latest = [...list.data].sort((a, b) => (b.created ?? 0) - (a.created ?? 0))[0] ?? null;
     if (latest) {
-      return { customerId: profileCustomerId, subscriptionId: latest.id };
+      return { customerId: profileCustomerId, subscriptionId: latest.id, checkoutSessionId: profileCheckoutSessionId };
     }
-    return { customerId: profileCustomerId, subscriptionId: null };
+    return { customerId: profileCustomerId, subscriptionId: null, checkoutSessionId: profileCheckoutSessionId };
+  }
+
+  if (profileCheckoutSessionId) {
+    const session = await stripe.checkout.sessions.retrieve(profileCheckoutSessionId);
+    const customerId =
+      typeof session.customer === "string" ? session.customer : null;
+    const subscriptionId =
+      typeof session.subscription === "string" ? session.subscription : null;
+    return {
+      customerId,
+      subscriptionId,
+      checkoutSessionId: profileCheckoutSessionId,
+    };
   }
 
   return null;
@@ -246,6 +262,7 @@ export async function GET() {
           linkage_state: "unlinked_subscription",
           linked_customer_id: unlinked.customerId,
           linked_subscription_id: unlinked.subscriptionId,
+          linked_checkout_session_id: unlinked.checkoutSessionId,
         } satisfies NormalizedSubscriptionPayload);
       }
 
@@ -309,6 +326,7 @@ export async function POST(req: Request) {
             linkage_state: "unlinked_subscription",
             linked_customer_id: unlinked.customerId,
             linked_subscription_id: unlinked.subscriptionId,
+            linked_checkout_session_id: unlinked.checkoutSessionId,
           },
           { status: 409 },
         );

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -122,7 +122,7 @@ export default function OnboardingPage() {
       const sid = searchParams.get("session_id");
       if (sid) {
         try {
-          await fetch("/api/stripe/link-user", {
+          await fetch("/api/stripe/checkout/link-user", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ sessionId: sid }),
@@ -242,6 +242,7 @@ export default function OnboardingPage() {
           pin: ownerPin,
           country,
           timezone,
+          stripe_checkout_session_id: searchParams.get("session_id"),
         }),
       });
 

--- a/features/auth/app/signup/SignUpClient.tsx
+++ b/features/auth/app/signup/SignUpClient.tsx
@@ -145,9 +145,13 @@ export default function SignUpClient() {
 
     const demoIdParam = sp.get("demoId");
     const intakeIdParam = sp.get("intakeId");
+    const sessionIdParam = sp.get("session_id");
+    const flowParam = sp.get("flow");
 
     if (demoIdParam) params.set("demoId", demoIdParam);
     if (intakeIdParam) params.set("intakeId", intakeIdParam);
+    if (sessionIdParam) params.set("session_id", sessionIdParam);
+    if (flowParam) params.set("flow", flowParam);
 
     const onboardingTarget = `/onboarding${
       params.toString() ? `?${params.toString()}` : ""

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -1017,6 +1017,17 @@ try {
   };
 
   const manageSubscription = async () => {
+    if (
+      billingDisplayStatus === "linkage_needed" ||
+      billingDisplayStatus === "subscription_found_not_linked" ||
+      billingDisplayStatus === "sync_needed"
+    ) {
+      toast.warning(
+        "Billing linkage is still syncing. Please refresh in a moment instead of starting a new subscription.",
+      );
+      return;
+    }
+
     const managedStatuses = new Set<StripeSubStatus>([
       "trialing",
       "active",

--- a/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
@@ -148,6 +148,10 @@ export default function OwnerSettingsSidebar({
     subStatus === "incomplete" ||
     subStatus === "paused" ||
     subStatus === "canceled";
+  const isLinkageState =
+    billingDisplayStatus === "linkage_needed" ||
+    billingDisplayStatus === "subscription_found_not_linked" ||
+    billingDisplayStatus === "sync_needed";
   const manageSubscriptionLoading = hasManagedSubscription ? portalLoading : checkoutLoading;
 
   return (
@@ -193,18 +197,22 @@ export default function OwnerSettingsSidebar({
             <Button
               variant="secondary"
               onClick={onStartSubscriptionCheckout}
-              disabled={!isUnlocked || manageSubscriptionLoading}
+              disabled={!isUnlocked || manageSubscriptionLoading || isLinkageState}
             >
               {manageSubscriptionLoading
                 ? hasManagedSubscription
                   ? "Opening portal..."
                   : "Opening checkout..."
+                : isLinkageState
+                  ? "Subscription sync pending"
                 : hasManagedSubscription
                   ? "Manage subscription"
                   : "Start subscription"}
             </Button>
             <p className="text-[11px] text-neutral-500">
-              {hasManagedSubscription
+              {isLinkageState
+                ? "An existing Stripe subscription was detected but must finish linking before checkout or portal actions."
+                : hasManagedSubscription
                 ? "Open Stripe billing portal to manage an existing subscription."
                 : "Start checkout to create a new ProFixIQ subscription for this location."}
             </p>

--- a/features/stripe/api/stripe/webhook/route.ts
+++ b/features/stripe/api/stripe/webhook/route.ts
@@ -223,7 +223,10 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
       const session = event.data.object as Stripe.Checkout.Session;
 
       if (session.mode === "subscription") {
-        const userId = session.metadata?.supabase_user_id ?? session.metadata?.supabaseUserId ?? null;
+        const userId =
+          session.metadata?.supabase_user_id ??
+          session.metadata?.supabaseUserId ??
+          (isUuid(session.client_reference_id) ? session.client_reference_id : null);
         const shopIdRaw = session.metadata?.shop_id ?? null;
 
         const stripeCustomerId = toStripeId(session.customer, "cus_");
@@ -245,6 +248,14 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
         }
 
         let resolvedShopId: string | null = isUuid(shopIdRaw) ? shopIdRaw : null;
+
+        if (!resolvedShopId && stripeSubscriptionId) {
+          const subscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+          const subscriptionShopId = String(subscription.metadata?.shop_id ?? "").trim();
+          if (isUuid(subscriptionShopId)) {
+            resolvedShopId = subscriptionShopId;
+          }
+        }
 
         if (!resolvedShopId && isUuid(userId)) {
           const { data: profile } = await supabase

--- a/features/stripe/lib/server/canonical-shop-billing.ts
+++ b/features/stripe/lib/server/canonical-shop-billing.ts
@@ -12,6 +12,7 @@ type ProfileStripeArtifacts = {
   shop_id: string | null;
   stripe_customer_id: string | null;
   stripe_subscription_id: string | null;
+  stripe_checkout_session_id: string | null;
 };
 
 function unixToIsoOrNull(v: number | null | undefined): string | null {
@@ -30,7 +31,7 @@ export async function getProfileStripeArtifacts(
 ): Promise<ProfileStripeArtifacts | null> {
   const { data, error } = await supabase
     .from("profiles")
-    .select("shop_id, stripe_customer_id, stripe_subscription_id")
+    .select("shop_id, stripe_customer_id, stripe_subscription_id, stripe_checkout_session_id")
     .eq("id", userId)
     .maybeSingle<ProfileStripeArtifacts>();
 
@@ -79,8 +80,19 @@ export async function reconcileShopBillingFromUser(params: {
   const profile = await getProfileStripeArtifacts(supabase, userId);
   if (!profile) return { linked: false, reason: "profile_not_found" };
 
-  const profileCustomerId = String(profile.stripe_customer_id ?? "").trim();
-  const profileSubscriptionId = String(profile.stripe_subscription_id ?? "").trim();
+  let profileCustomerId = String(profile.stripe_customer_id ?? "").trim();
+  let profileSubscriptionId = String(profile.stripe_subscription_id ?? "").trim();
+  const profileCheckoutSessionId = String(profile.stripe_checkout_session_id ?? "").trim();
+
+  if (!profileCustomerId && !profileSubscriptionId && profileCheckoutSessionId) {
+    const checkoutSession = await stripe.checkout.sessions.retrieve(profileCheckoutSessionId);
+    if (checkoutSession.mode === "subscription") {
+      profileCustomerId =
+        (typeof checkoutSession.customer === "string" ? checkoutSession.customer : "") || "";
+      profileSubscriptionId =
+        (typeof checkoutSession.subscription === "string" ? checkoutSession.subscription : "") || "";
+    }
+  }
 
   if (!profileCustomerId && !profileSubscriptionId) {
     return { linked: false, reason: "no_profile_stripe_artifacts" };
@@ -136,4 +148,87 @@ export async function reconcileShopBillingFromUser(params: {
   });
 
   return { linked: true };
+}
+
+export async function reconcileShopBillingFromCheckoutSession(params: {
+  stripe: Stripe;
+  supabase: SupabaseClient<DB>;
+  userId: string;
+  shopId: string;
+  sessionId: string;
+}): Promise<{ linked: boolean; reason?: string }> {
+  const { stripe, supabase, userId, shopId, sessionId } = params;
+  const trimmedSessionId = sessionId.trim();
+  if (!trimmedSessionId.startsWith("cs_")) {
+    return { linked: false, reason: "invalid_checkout_session_id" };
+  }
+
+  const session = await stripe.checkout.sessions.retrieve(trimmedSessionId);
+  if (session.mode !== "subscription") {
+    return { linked: false, reason: "not_subscription_checkout" };
+  }
+
+  const sessionCustomerId =
+    typeof session.customer === "string" ? session.customer : null;
+  const sessionSubscriptionId =
+    typeof session.subscription === "string" ? session.subscription : null;
+
+  if (!sessionCustomerId && !sessionSubscriptionId) {
+    return { linked: false, reason: "session_missing_billing_artifacts" };
+  }
+
+  const metadataUserId = String(session.metadata?.supabase_user_id ?? "").trim();
+  if (metadataUserId && metadataUserId !== userId) {
+    return { linked: false, reason: "session_user_mismatch" };
+  }
+
+  const { error: profileError } = await supabase
+    .from("profiles")
+    .update({
+      stripe_checkout_complete: true,
+      stripe_checkout_session_id: session.id,
+      stripe_customer_id: sessionCustomerId,
+      stripe_subscription_id: sessionSubscriptionId,
+    } as unknown as DB["public"]["Tables"]["profiles"]["Update"])
+    .eq("id", userId);
+
+  if (profileError) {
+    throw new Error(profileError.message);
+  }
+
+  if (sessionCustomerId) {
+    await stripe.customers.update(sessionCustomerId, {
+      metadata: {
+        shop_id: shopId,
+        supabase_user_id: userId,
+        source: "profixiq",
+      },
+    });
+  }
+
+  if (sessionSubscriptionId) {
+    const subscription = await stripe.subscriptions.retrieve(sessionSubscriptionId);
+    await stripe.subscriptions.update(sessionSubscriptionId, {
+      metadata: {
+        ...(subscription.metadata ?? {}),
+        shop_id: shopId,
+        supabase_user_id: userId,
+        source: "profixiq",
+      },
+    });
+  }
+
+  if (sessionSubscriptionId) {
+    await syncCanonicalShopBilling({
+      stripe,
+      supabase,
+      shopId,
+      customerId: sessionCustomerId,
+      subscriptionId: sessionSubscriptionId,
+      checkoutSessionId: session.id,
+    });
+    return { linked: true };
+  }
+
+  return { linked: false, reason: "no_subscription_found" };
 }


### PR DESCRIPTION
### Motivation
- Root cause: acquisition checkout `session_id` / handoff could be dropped during sign-up → onboarding, so onboarding created a shop without persisting canonical Stripe linkage (`shops.stripe_customer_id`, `stripe_subscription_id`, status fields) causing Owner Settings to show UNKNOWN and risk duplicate checkout flows. 
- Goal: deterministically reconcile any onboarding/acquisition checkout artifacts into the canonical shop billing fields once a `shop_id` exists, without cosmetic UI hacks or broad billing rewrites. 
- Constraints: preserve multi-tenant safety, keep changes additive/idempotent, and avoid creating parallel Stripe customer truth.

### Description
- Added a deterministic checkout-session reconciliation helper `reconcileShopBillingFromCheckoutSession` that reads a `cs_...` session, updates profile artifacts, backfills Stripe metadata (`shop_id`, `supabase_user_id`, `source`), and calls the existing `syncCanonicalShopBilling` to persist canonical `shops` Stripe fields. 
- Hardened checkout metadata handoff by consistently setting `purpose`, `source`, `supabase_user_id`, and `client_reference_id` where available, and created a mounted handler `/api/stripe/checkout/link-user` (kept legacy alias) so onboarding reliably calls the canonical link-user flow. 
- Hardened webhook `checkout.session.completed` resolution to use `client_reference_id` fallback and subscription metadata to resolve `shop_id` before profile fallback, and ensured `customer.subscription.*` events continue to hit the same canonical sync path. 
- Updated owner bootstrap onboarding to include `stripe_checkout_session_id` and run checkout-session reconciliation immediately after shop creation, adjusted `/api/stripe/subscription` and `/api/stripe/portal` to return explicit `linkage_needed` evidence (including checkout session) instead of silently creating new customers, and prevented Owner Settings from routing users into a re-subscribe flow while linkage/sync is pending. 
- Key files changed: `features/stripe/lib/server/canonical-shop-billing.ts`, `app/api/onboarding/bootstrap-owner/route.ts`, `app/api/stripe/checkout/route.ts`, new `app/api/stripe/checkout/link-user/route.ts`, `features/auth/app/onboarding/OnboardingPage.tsx`, `features/auth/app/signup/SignUpClient.tsx`, `features/stripe/api/stripe/webhook/route.ts`, `app/api/stripe/subscription/route.ts`, `app/api/stripe/portal/route.ts`, `features/dashboard/.../owner/settings/page.tsx`, and `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx`.

### Testing
- Type-checking passed: ran `npx tsc --noEmit` and it completed successfully. 
- Linting passed: ran `npx eslint` on all touched files (`app/api/onboarding/bootstrap-owner/route.ts`, `app/api/stripe/checkout/route.ts`, `app/api/stripe/checkout/link-user/route.ts`, `app/api/stripe/portal/route.ts`, `app/api/stripe/subscription/route.ts`, `features/auth/app/onboarding/OnboardingPage.tsx`, `features/auth/app/signup/SignUpClient.tsx`, `features/dashboard/app/dashboard/owner/settings/page.tsx`, `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx`, `features/stripe/api/stripe/webhook/route.ts`, `features/stripe/lib/server/canonical-shop-billing.ts`) and it completed without errors. 
- Result: automated validation succeeded, no schema changes were made, and reconciliation is additive and idempotent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec25f050f483289107b4a129866d83)