### PR TITLE
Deterministic Stripe subscription reconciliation and plan hydration for existing shops

### DIFF
--- a/app/api/stripe/subscription/route.ts
+++ b/app/api/stripe/subscription/route.ts
@@ -8,7 +8,11 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { OWNER_PIN_PURPOSES } from "@/features/shared/lib/server/owner-pin";
-import { getProfileStripeArtifacts } from "@/features/stripe/lib/server/canonical-shop-billing";
+import {
+  getProfileStripeArtifacts,
+  resolveCanonicalPlanFromSubscription,
+  toCanonicalShopBillingUpdate,
+} from "@/features/stripe/lib/server/canonical-shop-billing";
 
 type DB = Database;
 
@@ -29,17 +33,28 @@ type NormalizedSubscriptionPayload = {
   canceled_at: string | null;
   current_period_end: string | null;
   trial_end: string | null;
+  resolved_plan?: string | null;
   linkage_needed?: boolean;
-  linkage_state?: "unlinked_subscription" | "no_subscription_found" | "ambiguous_customer_subscriptions";
+  linkage_state?:
+    | "no_subscription_found"
+    | "ambiguous_customer_subscriptions"
+    | "subscription_found_not_linked"
+    | "metadata_mismatch"
+    | "sync_needed"
+    | "linked_and_synced";
+  sync_performed?: boolean;
+  sync_skipped_reason?: string | null;
   linked_customer_id?: string | null;
   linked_subscription_id?: string | null;
   linked_checkout_session_id?: string | null;
+  matching_subscription_ids?: string[];
   managed_subscription_ids?: string[];
+  resolved_subscription_id?: string | null;
 };
 
 type CanonicalSubscriptionResolution =
-  | { state: "resolved"; subscription: Stripe.Subscription }
-  | { state: "no_subscription_found" }
+  | { state: "resolved"; subscription: Stripe.Subscription; metadataMatches: boolean; managedSubscriptionIds: string[] }
+  | { state: "no_subscription_found"; managedSubscriptionIds: string[] }
   | { state: "ambiguous_customer_subscriptions"; subscriptionIds: string[] };
 
 const MANAGED_SUBSCRIPTION_STATUSES = new Set(["trialing", "active", "past_due", "unpaid", "paused"]);
@@ -67,6 +82,7 @@ function normalizeSubscription(subscription: Stripe.Subscription): NormalizedSub
     canceled_at: unixToIsoOrNull(subscription.canceled_at ?? null),
     current_period_end: unixToIsoOrNull(subscription.current_period_end ?? null),
     trial_end: unixToIsoOrNull(subscription.trial_end ?? null),
+    resolved_plan: resolveCanonicalPlanFromSubscription(subscription),
   };
 }
 
@@ -81,7 +97,7 @@ function normalizeShopFallback(shop: ShopStripeScope): NormalizedSubscriptionPay
   };
 }
 
-function subscriptionMatchesShop(subscription: Stripe.Subscription, shop: ShopStripeScope): boolean {
+function subscriptionMetadataMatchesShop(subscription: Stripe.Subscription, shop: ShopStripeScope): boolean {
   const customerId = String(shop.stripe_customer_id ?? "").trim();
   const subscriptionCustomerId =
     typeof subscription.customer === "string" ? subscription.customer : String(subscription.customer?.id ?? "").trim();
@@ -100,12 +116,12 @@ async function findCanonicalSubscription(
 
   if (subscriptionId) {
     const byId = await stripe.subscriptions.retrieve(subscriptionId);
-    if (subscriptionMatchesShop(byId, shop)) {
-      return { state: "resolved", subscription: byId };
+    if (subscriptionMetadataMatchesShop(byId, shop)) {
+      return { state: "resolved", subscription: byId, metadataMatches: true, managedSubscriptionIds: [byId.id] };
     }
   }
 
-  if (!customerId) return { state: "no_subscription_found" };
+  if (!customerId) return { state: "no_subscription_found", managedSubscriptionIds: [] };
 
   const list = await stripe.subscriptions.list({
     customer: customerId,
@@ -114,27 +130,32 @@ async function findCanonicalSubscription(
   });
 
   if (!Array.isArray(list.data) || list.data.length === 0) {
-    return { state: "no_subscription_found" };
+    return { state: "no_subscription_found", managedSubscriptionIds: [] };
   }
 
   const managed = list.data.filter(
     (subscription) =>
-      MANAGED_SUBSCRIPTION_STATUSES.has(String(subscription.status ?? "").trim().toLowerCase()) &&
-      subscriptionMatchesShop(subscription, shop),
+      MANAGED_SUBSCRIPTION_STATUSES.has(String(subscription.status ?? "").trim().toLowerCase()),
   );
 
+  const managedSubscriptionIds = managed.map((subscription) => subscription.id);
+
   if (managed.length === 1) {
-    return { state: "resolved", subscription: managed[0] };
+    return {
+      state: "resolved",
+      subscription: managed[0],
+      metadataMatches: subscriptionMetadataMatchesShop(managed[0], shop),
+      managedSubscriptionIds,
+    };
   }
 
   if (managed.length === 0) {
-    return { state: "no_subscription_found" };
+    return { state: "no_subscription_found", managedSubscriptionIds: [] };
   }
 
-  const subscriptionIds = managed.map((subscription) => subscription.id);
   return {
     state: "ambiguous_customer_subscriptions",
-    subscriptionIds,
+    subscriptionIds: managedSubscriptionIds,
   };
 }
 
@@ -220,13 +241,12 @@ async function syncShopSubscription(
 
   const { error } = await supabase
     .from("shops")
-    .update({
-      stripe_customer_id: stripeCustomerId,
-      stripe_subscription_id: subscription.id,
-      stripe_subscription_status: String(subscription.status ?? "").trim() || null,
-      stripe_current_period_end: unixToIsoOrNull(subscription.current_period_end ?? null),
-      stripe_trial_end: unixToIsoOrNull(subscription.trial_end ?? null),
-    } as DB["public"]["Tables"]["shops"]["Update"])
+    .update(
+      toCanonicalShopBillingUpdate({
+        customerId: stripeCustomerId,
+        subscription,
+      }),
+    )
     .eq("id", shopId);
 
   if (error) {
@@ -263,7 +283,19 @@ export async function GET() {
 
     if (resolution.state === "resolved") {
       await syncShopSubscription(access.supabase, shop.id, resolution.subscription);
-      return NextResponse.json(normalizeSubscription(resolution.subscription));
+      return NextResponse.json({
+        ...normalizeSubscription(resolution.subscription),
+        linkage_needed: false,
+        linkage_state: resolution.metadataMatches ? "linked_and_synced" : "metadata_mismatch",
+        sync_performed: true,
+        sync_skipped_reason: null,
+        linked_customer_id: String(shop.stripe_customer_id ?? "").trim() || null,
+        linked_subscription_id: resolution.subscription.id,
+        linked_checkout_session_id: null,
+        matching_subscription_ids: [resolution.subscription.id],
+        managed_subscription_ids: resolution.managedSubscriptionIds,
+        resolved_subscription_id: resolution.subscription.id,
+      } satisfies NormalizedSubscriptionPayload);
     }
 
     if (resolution.state === "ambiguous_customer_subscriptions") {
@@ -271,10 +303,14 @@ export async function GET() {
         ...normalizeShopFallback(shop),
         linkage_needed: true,
         linkage_state: "ambiguous_customer_subscriptions",
+        sync_performed: false,
+        sync_skipped_reason: "ambiguous_customer_subscriptions",
         linked_customer_id: String(shop.stripe_customer_id ?? "").trim() || null,
         linked_subscription_id: null,
         linked_checkout_session_id: null,
+        matching_subscription_ids: [],
         managed_subscription_ids: resolution.subscriptionIds,
+        resolved_subscription_id: null,
       } satisfies NormalizedSubscriptionPayload);
     }
 
@@ -290,10 +326,15 @@ export async function GET() {
         return NextResponse.json({
           ...normalizeShopFallback(shop),
           linkage_needed: true,
-          linkage_state: "unlinked_subscription",
+          linkage_state: "subscription_found_not_linked",
+          sync_performed: false,
+          sync_skipped_reason: "no_customer_subscription_match",
           linked_customer_id: unlinked.customerId,
           linked_subscription_id: unlinked.subscriptionId,
           linked_checkout_session_id: unlinked.checkoutSessionId,
+          matching_subscription_ids: unlinked.subscriptionId ? [unlinked.subscriptionId] : [],
+          managed_subscription_ids: resolution.managedSubscriptionIds,
+          resolved_subscription_id: null,
         } satisfies NormalizedSubscriptionPayload);
       }
 
@@ -301,9 +342,14 @@ export async function GET() {
         ...normalizeShopFallback(shop),
         linkage_needed: true,
         linkage_state: "no_subscription_found",
+        sync_performed: false,
+        sync_skipped_reason: "no_subscription_found",
         linked_customer_id: String(shop.stripe_customer_id ?? "").trim() || null,
         linked_subscription_id: null,
         linked_checkout_session_id: null,
+        matching_subscription_ids: [],
+        managed_subscription_ids: resolution.managedSubscriptionIds,
+        resolved_subscription_id: null,
       } satisfies NormalizedSubscriptionPayload);
     }
 
@@ -359,7 +405,7 @@ export async function POST(req: Request) {
             error: "Billing linkage is required before managing this subscription.",
             ...normalizeShopFallback(shop),
             linkage_needed: true,
-            linkage_state: "unlinked_subscription",
+            linkage_state: "subscription_found_not_linked",
             linked_customer_id: unlinked.customerId,
             linked_subscription_id: unlinked.subscriptionId,
             linked_checkout_session_id: unlinked.checkoutSessionId,

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -83,8 +83,20 @@ type StripeSubscriptionApiResponse = {
   canceled_at?: string | null;
   current_period_end?: string | null;
   trial_end?: string | null;
+  resolved_plan?: string | null;
   linkage_needed?: boolean;
-  linkage_state?: "unlinked_subscription";
+  linkage_state?:
+    | "no_subscription_found"
+    | "ambiguous_customer_subscriptions"
+    | "subscription_found_not_linked"
+    | "metadata_mismatch"
+    | "sync_needed"
+    | "linked_and_synced";
+  sync_performed?: boolean;
+  sync_skipped_reason?: string | null;
+  matching_subscription_ids?: string[];
+  managed_subscription_ids?: string[];
+  resolved_subscription_id?: string | null;
   linked_customer_id?: string | null;
   linked_subscription_id?: string | null;
   error?: string;
@@ -94,6 +106,9 @@ type BillingDisplayStatus =
   | StripeSubStatus
   | "linkage_needed"
   | "subscription_found_not_linked"
+  | "ambiguous_customer_subscriptions"
+  | "no_subscription_found"
+  | "metadata_mismatch"
   | "sync_needed";
 
 type OrgScope = Pick<
@@ -391,14 +406,30 @@ export default function OwnerSettingsPage() {
         }
 
         if (j.linkage_needed) {
-          setBillingDisplayStatus(
-            j.linked_subscription_id ? "subscription_found_not_linked" : "linkage_needed",
-          );
+          if (j.linkage_state === "ambiguous_customer_subscriptions") {
+            setBillingDisplayStatus("ambiguous_customer_subscriptions");
+            return;
+          }
+          if (j.linkage_state === "no_subscription_found") {
+            setBillingDisplayStatus("no_subscription_found");
+            return;
+          }
+          setBillingDisplayStatus("subscription_found_not_linked");
           return;
         }
 
+        const resolvedPlan = parsePlan(j.resolved_plan);
+        if (resolvedPlan !== "unknown") {
+          setPlan(resolvedPlan);
+          setSeatsLimit(planSeatLimit(resolvedPlan));
+        }
+
         setBillingDisplayStatus(
-          canonicalStatus === "unknown" && planSignal !== "unknown" ? "sync_needed" : canonicalStatus,
+          j.linkage_state === "metadata_mismatch"
+            ? "metadata_mismatch"
+            : canonicalStatus === "unknown" && planSignal !== "unknown"
+              ? "sync_needed"
+              : canonicalStatus,
         );
       } catch {
         setSubStatus(shopStatus);
@@ -1018,13 +1049,33 @@ try {
 
   const manageSubscription = async () => {
     if (
-      billingDisplayStatus === "linkage_needed" ||
       billingDisplayStatus === "subscription_found_not_linked" ||
+      billingDisplayStatus === "ambiguous_customer_subscriptions" ||
+      billingDisplayStatus === "no_subscription_found" ||
+      billingDisplayStatus === "metadata_mismatch" ||
       billingDisplayStatus === "sync_needed"
     ) {
-      toast.warning(
-        "Billing linkage is still syncing. Please refresh in a moment instead of starting a new subscription.",
-      );
+      if (billingDisplayStatus === "subscription_found_not_linked") {
+        toast.warning(
+          "A Stripe subscription was found but is not linked to this shop yet. Refresh Billing & Stripe before retrying.",
+        );
+      } else if (billingDisplayStatus === "ambiguous_customer_subscriptions") {
+        toast.warning(
+          "Multiple managed subscriptions were found for this Stripe customer. Resolve linkage before continuing.",
+        );
+      } else if (billingDisplayStatus === "no_subscription_found") {
+        toast.warning(
+          "No managed subscription is linked to this shop yet. Start checkout only if this location truly has no subscription.",
+        );
+      } else if (billingDisplayStatus === "metadata_mismatch") {
+        toast.warning(
+          "Billing was reconciled using a deterministic customer match. Refresh to confirm linked status.",
+        );
+      } else {
+        toast.warning(
+          "Billing linkage is still syncing. Please refresh in a moment instead of starting a new subscription.",
+        );
+      }
       return;
     }
 
@@ -1115,6 +1166,30 @@ try {
       return (
         <span className={`${base} border-amber-500/30 bg-amber-950/20 text-amber-100`}>
           Subscription found, link required
+        </span>
+      );
+    }
+
+    if (billingDisplayStatus === "ambiguous_customer_subscriptions") {
+      return (
+        <span className={`${base} border-amber-500/30 bg-amber-950/20 text-amber-100`}>
+          Ambiguous subscriptions
+        </span>
+      );
+    }
+
+    if (billingDisplayStatus === "no_subscription_found") {
+      return (
+        <span className={`${base} border-amber-500/30 bg-amber-950/20 text-amber-100`}>
+          No subscription found
+        </span>
+      );
+    }
+
+    if (billingDisplayStatus === "metadata_mismatch") {
+      return (
+        <span className={`${base} border-emerald-500/30 bg-emerald-950/20 text-emerald-100`}>
+          Reconciled from customer
         </span>
       );
     }

--- a/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
@@ -20,6 +20,9 @@ type BillingDisplayStatus =
   | StripeSubStatus
   | "linkage_needed"
   | "subscription_found_not_linked"
+  | "ambiguous_customer_subscriptions"
+  | "no_subscription_found"
+  | "metadata_mismatch"
   | "sync_needed";
 
 type ShopLocationRow = {
@@ -151,6 +154,8 @@ export default function OwnerSettingsSidebar({
   const isLinkageState =
     billingDisplayStatus === "linkage_needed" ||
     billingDisplayStatus === "subscription_found_not_linked" ||
+    billingDisplayStatus === "ambiguous_customer_subscriptions" ||
+    billingDisplayStatus === "no_subscription_found" ||
     billingDisplayStatus === "sync_needed";
   const manageSubscriptionLoading = hasManagedSubscription ? portalLoading : checkoutLoading;
 

--- a/features/stripe/lib/server/canonical-shop-billing.ts
+++ b/features/stripe/lib/server/canonical-shop-billing.ts
@@ -5,6 +5,7 @@ import {
   parseStripeSubscriptionStatus,
   type StripeSubscriptionStatus,
 } from "@/features/stripe/lib/stripe/subscriptionStatus";
+import { PLAN_LOOKUP_KEYS } from "@/features/stripe/lib/stripe/constants";
 
 type DB = Database;
 
@@ -23,6 +24,8 @@ const MANAGED_SUBSCRIPTION_STATUSES = new Set([
   "paused",
 ]);
 
+type CanonicalPlan = "starter" | "pro" | "enterprise" | "unlimited";
+
 function unixToIsoOrNull(v: number | null | undefined): string | null {
   if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return null;
   return new Date(v * 1000).toISOString();
@@ -31,6 +34,66 @@ function unixToIsoOrNull(v: number | null | undefined): string | null {
 function toShopStripeStatus(v: unknown): StripeSubscriptionStatus | null {
   const parsed = parseStripeSubscriptionStatus(v);
   return parsed === "unknown" ? null : parsed;
+}
+
+function planFromLookupKey(lookupKey: string | null | undefined): CanonicalPlan | null {
+  const normalized = String(lookupKey ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === PLAN_LOOKUP_KEYS.starter10) return "starter";
+  if (normalized === PLAN_LOOKUP_KEYS.pro50) return "pro";
+  if (normalized === PLAN_LOOKUP_KEYS.unlimited) return "unlimited";
+  return null;
+}
+
+function planFromPriceId(priceId: string | null | undefined): CanonicalPlan | null {
+  const normalized = String(priceId ?? "").trim();
+  if (!normalized) return null;
+  if (normalized === String(process.env.STRIPE_PRICE_STARTER_MONTHLY ?? "").trim()) return "starter";
+  if (normalized === String(process.env.STRIPE_PRICE_PRO_MONTHLY ?? "").trim()) return "pro";
+  if (normalized === String(process.env.STRIPE_PRICE_UNLIMITED_MONTHLY ?? "").trim()) return "unlimited";
+  return null;
+}
+
+function planFromPriceNickname(nickname: string | null | undefined): CanonicalPlan | null {
+  const normalized = String(nickname ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized.includes("starter")) return "starter";
+  if (normalized.includes("enterprise")) return "enterprise";
+  if (normalized.includes("unlimited")) return "unlimited";
+  if (normalized.includes("pro")) return "pro";
+  return null;
+}
+
+export function resolveCanonicalPlanFromSubscription(subscription: Stripe.Subscription): CanonicalPlan | null {
+  const firstItem = subscription.items.data[0]?.price ?? null;
+  const byPriceId = planFromPriceId(firstItem?.id ?? null);
+  if (byPriceId) return byPriceId;
+
+  const byLookupKey = planFromLookupKey(firstItem?.lookup_key ?? null);
+  if (byLookupKey) return byLookupKey;
+
+  const byNickname = planFromPriceNickname(firstItem?.nickname ?? null);
+  if (byNickname) return byNickname;
+
+  return null;
+}
+
+export function toCanonicalShopBillingUpdate(args: {
+  customerId: string | null;
+  subscription: Stripe.Subscription;
+  checkoutSessionId?: string | null;
+}): DB["public"]["Tables"]["shops"]["Update"] {
+  const { customerId, subscription, checkoutSessionId } = args;
+  const resolvedPlan = resolveCanonicalPlanFromSubscription(subscription);
+  return {
+    stripe_customer_id: customerId,
+    stripe_subscription_id: subscription.id,
+    stripe_subscription_status: toShopStripeStatus(subscription.status),
+    stripe_trial_end: unixToIsoOrNull(subscription.trial_end ?? null),
+    stripe_current_period_end: unixToIsoOrNull(subscription.current_period_end ?? null),
+    plan: resolvedPlan,
+    ...(checkoutSessionId ? { stripe_checkout_session_id: checkoutSessionId } : {}),
+  } as unknown as DB["public"]["Tables"]["shops"]["Update"];
 }
 
 export async function getProfileStripeArtifacts(
@@ -63,14 +126,13 @@ export async function syncCanonicalShopBilling(params: {
 
   const { error } = await supabase
     .from("shops")
-    .update({
-      stripe_customer_id: customerId,
-      stripe_subscription_id: subscriptionId,
-      stripe_subscription_status: toShopStripeStatus(sub.status),
-      stripe_trial_end: unixToIsoOrNull(sub.trial_end ?? null),
-      stripe_current_period_end: unixToIsoOrNull(sub.current_period_end ?? null),
-      ...(checkoutSessionId ? { stripe_checkout_session_id: checkoutSessionId } : {}),
-    } as unknown as DB["public"]["Tables"]["shops"]["Update"])
+    .update(
+      toCanonicalShopBillingUpdate({
+        customerId,
+        subscription: sub,
+        checkoutSessionId,
+      }),
+    )
     .eq("id", shopId);
 
   if (error) {


### PR DESCRIPTION
### Motivation
- Existing shops with a `stripe_customer_id` but null canonical subscription fields were left in UNKNOWN state because the resolver required metadata.shop_id to match, preventing safe backfill from Stripe when a unique customer subscription existed.
- Provide a small, safe reconciliation so already-completed checkouts (customer + subscription in Stripe) can hydrate `shops.*` (including `plan`) without forcing a new checkout.

### Description
- Allow deterministic customer-based reconciliation when exactly one managed subscription exists for the shop's `stripe_customer_id`, and perform an idempotent `shops` update on GET (no fuzzy or cross-tenant matching). (changed `findCanonicalSubscription` and GET handler behavior). Files: `app/api/stripe/subscription/route.ts`.
- Add canonical plan resolution and a helper that composes the full `shops` update payload (including `plan`) from a Stripe `Subscription` (resolves from price id, lookup key, or price nickname), and reuse it in both webhook and sync flows. Files: `features/stripe/lib/server/canonical-shop-billing.ts`.
- Expand `/api/stripe/subscription` response to return explicit reconciliation diagnostics (`linkage_state`, `sync_performed`, `sync_skipped_reason`, `matching_subscription_ids`, `managed_subscription_ids`, `resolved_subscription_id`, `resolved_plan`) and set `linkage_state` values like `linked_and_synced`, `metadata_mismatch`, `subscription_found_not_linked`, `ambiguous_customer_subscriptions`, and `no_subscription_found`. Files: `app/api/stripe/subscription/route.ts`.
- Update Owner Settings UI to consume the explicit linkage/sync states, surface clearer badges/messages, and immediately update `plan`/seat limits when reconciliation determines a plan. Files: `features/dashboard/app/dashboard/owner/settings/page.tsx`, `features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx`.
- All writes remain scoped to the authenticated `shop_id` and are idempotent updates to `shops` (no schema changes).

Files changed:
- app/api/stripe/subscription/route.ts
- features/stripe/lib/server/canonical-shop-billing.ts
- features/dashboard/app/dashboard/owner/settings/page.tsx
- features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx

### Testing
- Ran TypeScript check: `npx tsc --noEmit` — succeeded.
- Linted touched files: `npx eslint app/api/stripe/subscription/route.ts features/stripe/lib/server/canonical-shop-billing.ts features/dashboard/app/dashboard/owner/settings/page.tsx features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx` — succeeded.
- No unit tests were added; change is a safe, incremental server-side reconciliation plus UI consumption and is idempotent by design.

Commands run:
- `npx tsc --noEmit`
- `npx eslint app/api/stripe/subscription/route.ts features/stripe/lib/server/canonical-shop-billing.ts features/dashboard/app/dashboard/owner/settings/page.tsx features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx`

Notes on behavior for the affected shop (e9e87cda-3cbe-4785-956f-e8d05fcde539): on Owner Settings refresh the system will now attempt a deterministic customer-based lookup for `cus_UOhiJSTVAfRpDC` and will hydrate `shops.stripe_subscription_id`, `shops.stripe_subscription_status`, `shops.stripe_trial_end`, `shops.stripe_current_period_end`, and `shops.plan` when exactly one managed subscription is present; otherwise it will return a clear linkage state explaining why sync was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec325f18708328b6ede59267dbc69d)