### PR TITLE
Add one-time safe Stripe billing reconciliation backfill endpoint

### DIFF
--- a/app/api/internal/stripe/reconcile-shop-billing/route.ts
+++ b/app/api/internal/stripe/reconcile-shop-billing/route.ts
@@ -1,0 +1,66 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { supabaseAdmin } from "@/features/shared/lib/supabase/admin";
+import { reconcileCanonicalShopBillingByShopId } from "@/features/stripe/lib/server/shop-billing-reconciliation";
+
+type ReconcileRequestBody = {
+  shop_id?: string;
+  expected_customer_id?: string;
+  dry_run?: boolean;
+};
+
+function mustEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return value;
+}
+
+function normalizeBearerToken(req: Request): string | null {
+  const authHeader = String(req.headers.get("authorization") ?? "").trim();
+  if (!authHeader.toLowerCase().startsWith("bearer ")) return null;
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const expectedToken = mustEnv("STRIPE_BILLING_RECONCILE_TOKEN");
+    const providedToken = normalizeBearerToken(req);
+
+    if (!providedToken || providedToken !== expectedToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => ({}))) as ReconcileRequestBody;
+    const shopId = String(body.shop_id ?? "").trim();
+    const expectedCustomerId = String(body.expected_customer_id ?? "").trim() || null;
+    const dryRun = Boolean(body.dry_run);
+
+    if (!shopId) {
+      return NextResponse.json({ error: "shop_id is required" }, { status: 400 });
+    }
+
+    const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
+
+    const result = await reconcileCanonicalShopBillingByShopId({
+      stripe,
+      supabase: supabaseAdmin,
+      shopId,
+      expectedCustomerId,
+      applyUpdate: !dryRun,
+    });
+
+    console.info("[stripe/billing/reconcile-shop] result", result);
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to reconcile shop billing.";
+    console.error("[stripe/billing/reconcile-shop] error", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/features/stripe/lib/server/shop-billing-reconciliation.ts
+++ b/features/stripe/lib/server/shop-billing-reconciliation.ts
@@ -1,0 +1,196 @@
+import type Stripe from "stripe";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { toCanonicalShopBillingUpdate } from "@/features/stripe/lib/server/canonical-shop-billing";
+
+type DB = Database;
+
+type ShopBillingRow = Pick<
+  DB["public"]["Tables"]["shops"]["Row"],
+  | "id"
+  | "stripe_customer_id"
+  | "stripe_subscription_id"
+  | "stripe_subscription_status"
+  | "stripe_trial_end"
+  | "stripe_current_period_end"
+  | "plan"
+>;
+
+const MANAGED_SUBSCRIPTION_STATUSES = new Set([
+  "trialing",
+  "active",
+  "past_due",
+  "unpaid",
+  "paused",
+]);
+
+export type ShopBillingReconciliationState =
+  | "updated"
+  | "already_hydrated"
+  | "no_subscription_found"
+  | "ambiguous_customer_subscriptions"
+  | "shop_not_found"
+  | "missing_customer_id"
+  | "customer_id_mismatch";
+
+export type ShopBillingReconciliationResult = {
+  state: ShopBillingReconciliationState;
+  shop_id: string;
+  stripe_customer_id: string | null;
+  qualifying_subscription_ids: string[];
+  chosen_subscription_id: string | null;
+  derived_plan: string | null;
+  update_applied: boolean;
+  reason?: string;
+};
+
+function normalizeText(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function isSameCanonicalState(
+  shop: ShopBillingRow,
+  update: DB["public"]["Tables"]["shops"]["Update"],
+): boolean {
+  return (
+    normalizeText(shop.stripe_subscription_id) === normalizeText(update.stripe_subscription_id) &&
+    normalizeText(shop.stripe_subscription_status) === normalizeText(update.stripe_subscription_status) &&
+    normalizeText(shop.stripe_trial_end) === normalizeText(update.stripe_trial_end) &&
+    normalizeText(shop.stripe_current_period_end) === normalizeText(update.stripe_current_period_end) &&
+    normalizeText(shop.plan) === normalizeText(update.plan)
+  );
+}
+
+export async function reconcileCanonicalShopBillingByShopId(params: {
+  stripe: Stripe;
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  expectedCustomerId?: string | null;
+  applyUpdate?: boolean;
+}): Promise<ShopBillingReconciliationResult> {
+  const { stripe, supabase, shopId, expectedCustomerId = null, applyUpdate = true } = params;
+
+  const { data: shop, error: shopError } = await supabase
+    .from("shops")
+    .select(
+      "id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_trial_end, stripe_current_period_end, plan",
+    )
+    .eq("id", shopId)
+    .maybeSingle<ShopBillingRow>();
+
+  if (shopError) {
+    throw new Error(shopError.message);
+  }
+
+  if (!shop) {
+    return {
+      state: "shop_not_found",
+      shop_id: shopId,
+      stripe_customer_id: null,
+      qualifying_subscription_ids: [],
+      chosen_subscription_id: null,
+      derived_plan: null,
+      update_applied: false,
+      reason: "shop_not_found",
+    };
+  }
+
+  const stripeCustomerId = normalizeText(shop.stripe_customer_id);
+  if (!stripeCustomerId) {
+    return {
+      state: "missing_customer_id",
+      shop_id: shop.id,
+      stripe_customer_id: null,
+      qualifying_subscription_ids: [],
+      chosen_subscription_id: null,
+      derived_plan: null,
+      update_applied: false,
+      reason: "missing_customer_id",
+    };
+  }
+
+  const expected = normalizeText(expectedCustomerId);
+  if (expected && expected !== stripeCustomerId) {
+    return {
+      state: "customer_id_mismatch",
+      shop_id: shop.id,
+      stripe_customer_id: stripeCustomerId,
+      qualifying_subscription_ids: [],
+      chosen_subscription_id: null,
+      derived_plan: null,
+      update_applied: false,
+      reason: "customer_id_mismatch",
+    };
+  }
+
+  const subscriptionList = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "all",
+    limit: 20,
+  });
+
+  const qualifying = subscriptionList.data.filter((subscription) =>
+    MANAGED_SUBSCRIPTION_STATUSES.has(String(subscription.status ?? "").trim().toLowerCase()),
+  );
+
+  const qualifyingIds = qualifying.map((subscription) => subscription.id);
+
+  if (qualifying.length === 0) {
+    return {
+      state: "no_subscription_found",
+      shop_id: shop.id,
+      stripe_customer_id: stripeCustomerId,
+      qualifying_subscription_ids: qualifyingIds,
+      chosen_subscription_id: null,
+      derived_plan: null,
+      update_applied: false,
+      reason: "no_subscription_found",
+    };
+  }
+
+  if (qualifying.length > 1) {
+    return {
+      state: "ambiguous_customer_subscriptions",
+      shop_id: shop.id,
+      stripe_customer_id: stripeCustomerId,
+      qualifying_subscription_ids: qualifyingIds,
+      chosen_subscription_id: null,
+      derived_plan: null,
+      update_applied: false,
+      reason: "ambiguous_customer_subscriptions",
+    };
+  }
+
+  const chosen = qualifying[0];
+
+  const canonicalUpdate = toCanonicalShopBillingUpdate({
+    customerId: stripeCustomerId,
+    subscription: chosen,
+  });
+
+  const sameState = isSameCanonicalState(shop, canonicalUpdate);
+  const shouldWrite = applyUpdate && !sameState;
+
+  if (shouldWrite) {
+    const { error: updateError } = await supabase
+      .from("shops")
+      .update(canonicalUpdate)
+      .eq("id", shop.id);
+
+    if (updateError) {
+      throw new Error(updateError.message);
+    }
+  }
+
+  return {
+    state: sameState ? "already_hydrated" : "updated",
+    shop_id: shop.id,
+    stripe_customer_id: stripeCustomerId,
+    qualifying_subscription_ids: qualifyingIds,
+    chosen_subscription_id: chosen.id,
+    derived_plan: normalizeText(canonicalUpdate.plan),
+    update_applied: shouldWrite,
+    reason: sameState ? "already_hydrated" : shouldWrite ? "canonical_shop_billing_updated" : "dry_run",
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide a safe, one-time server-side path to hydrate canonical billing fields on `public.shops` for shops that already have a Stripe customer but missing subscription hydration so Owner Settings no longer shows UNKNOWN when a single managed subscription exists. 
- Avoid heuristic/fuzzy matching and prevent duplicate Stripe customers by requiring exact `shops.stripe_customer_id` and aborting on ambiguity. 
- Keep the change additive, scoped, and idempotent so it can be run per-shop with minimal blast radius.

### Description

- Added a deterministic reconciliation helper `reconcileCanonicalShopBillingByShopId` that loads a shop, requires `stripe_customer_id`, lists Stripe subscriptions for that exact customer, filters only managed statuses (`trialing`, `active`, `past_due`, `unpaid`, `paused`), and returns explicit states for zero/one/many qualifying subscriptions. 
- When exactly one qualifying subscription exists the helper derives canonical fields via the existing `toCanonicalShopBillingUpdate` (reusing price/lookup-key/nickname mapping) and optionally writes the canonical fields `stripe_subscription_id`, `stripe_subscription_status`, `stripe_trial_end`, `stripe_current_period_end`, and `plan` to `public.shops`, while being idempotent if fields already match. 
- Added an admin/internal API route `POST /api/internal/stripe/reconcile-shop-billing` protected by a bearer token (`STRIPE_BILLING_RECONCILE_TOKEN`) that accepts `shop_id`, optional `expected_customer_id` guard, and `dry_run` (no-write) and returns a focused diagnostic payload containing `shop_id`, `stripe_customer_id`, `qualifying_subscription_ids`, `chosen_subscription_id`, `derived_plan`, `update_applied`, `state`, and `reason`. 
- The implementation strictly avoids guessing: if zero qualifying subscriptions exist it returns `no_subscription_found`, if multiple exist it returns `ambiguous_customer_subscriptions`, and it does not mutate the DB in those cases.

### Testing

- Ran type checking with `npx tsc --noEmit` and it completed successfully. 
- No unit tests were added in this patch; the route supports `dry_run:true` for safe preview before applying writes in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3789eaac8328bc1bcae68b45a39f)