### PR TITLE
Improve Stripe subscription reconciliation diagnostics and deterministic hydration

### DIFF
--- a/app/api/stripe/subscription/route.ts
+++ b/app/api/stripe/subscription/route.ts
@@ -13,6 +13,7 @@ import {
   resolveCanonicalPlanFromSubscription,
   toCanonicalShopBillingUpdate,
 } from "@/features/stripe/lib/server/canonical-shop-billing";
+import { collectCustomerSubscriptionDiagnostics } from "@/features/stripe/lib/server/subscription-discovery";
 
 type DB = Database;
 
@@ -50,14 +51,70 @@ type NormalizedSubscriptionPayload = {
   matching_subscription_ids?: string[];
   managed_subscription_ids?: string[];
   resolved_subscription_id?: string | null;
+  all_customer_subscription_ids?: string[];
+  subscription_diagnostics?: Array<{
+    subscription_id: string;
+    status: string;
+    customer_id: string | null;
+    livemode: boolean;
+    metadata_shop_id: string | null;
+    excluded_reasons: string[];
+  }>;
+  customer_exists_in_stripe?: boolean;
+  customer_deleted_in_stripe?: boolean;
+  customer_lookup_error?: string | null;
+  likely_mode_mismatch?: boolean;
+  stripe_mode?: "live" | "test" | "unknown";
+  customer_mode?: "live" | "test" | "unknown";
+  hydration_strategy?: "managed_filter" | "single_hydratable_subscription" | "none";
 };
 
 type CanonicalSubscriptionResolution =
-  | { state: "resolved"; subscription: Stripe.Subscription; metadataMatches: boolean; managedSubscriptionIds: string[] }
-  | { state: "no_subscription_found"; managedSubscriptionIds: string[] }
-  | { state: "ambiguous_customer_subscriptions"; subscriptionIds: string[] };
-
-const MANAGED_SUBSCRIPTION_STATUSES = new Set(["trialing", "active", "past_due", "unpaid", "paused"]);
+  | {
+      state: "resolved";
+      subscription: Stripe.Subscription;
+      metadataMatches: boolean;
+      managedSubscriptionIds: string[];
+      allSubscriptionIds: string[];
+      subscriptionDiagnostics: NormalizedSubscriptionPayload["subscription_diagnostics"];
+      customerDiagnostics: {
+        customer_exists_in_stripe: boolean;
+        customer_deleted_in_stripe: boolean;
+        customer_lookup_error: string | null;
+        likely_mode_mismatch: boolean;
+        stripe_mode: "live" | "test" | "unknown";
+        customer_mode: "live" | "test" | "unknown";
+      };
+      hydrationStrategy: "managed_filter" | "single_hydratable_subscription";
+    }
+  | {
+      state: "no_subscription_found";
+      managedSubscriptionIds: string[];
+      allSubscriptionIds: string[];
+      subscriptionDiagnostics: NormalizedSubscriptionPayload["subscription_diagnostics"];
+      customerDiagnostics: {
+        customer_exists_in_stripe: boolean;
+        customer_deleted_in_stripe: boolean;
+        customer_lookup_error: string | null;
+        likely_mode_mismatch: boolean;
+        stripe_mode: "live" | "test" | "unknown";
+        customer_mode: "live" | "test" | "unknown";
+      };
+    }
+  | {
+      state: "ambiguous_customer_subscriptions";
+      subscriptionIds: string[];
+      allSubscriptionIds: string[];
+      subscriptionDiagnostics: NormalizedSubscriptionPayload["subscription_diagnostics"];
+      customerDiagnostics: {
+        customer_exists_in_stripe: boolean;
+        customer_deleted_in_stripe: boolean;
+        customer_lookup_error: string | null;
+        likely_mode_mismatch: boolean;
+        stripe_mode: "live" | "test" | "unknown";
+        customer_mode: "live" | "test" | "unknown";
+      };
+    };
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -113,49 +170,149 @@ async function findCanonicalSubscription(
 ): Promise<CanonicalSubscriptionResolution> {
   const subscriptionId = String(shop.stripe_subscription_id ?? "").trim();
   const customerId = String(shop.stripe_customer_id ?? "").trim();
+  let linkedSubscriptionMismatchDiagnostic: NormalizedSubscriptionPayload["subscription_diagnostics"] = [];
 
   if (subscriptionId) {
-    const byId = await stripe.subscriptions.retrieve(subscriptionId);
-    if (subscriptionMetadataMatchesShop(byId, shop)) {
-      return { state: "resolved", subscription: byId, metadataMatches: true, managedSubscriptionIds: [byId.id] };
+    try {
+      const byId = await stripe.subscriptions.retrieve(subscriptionId);
+      if (subscriptionMetadataMatchesShop(byId, shop)) {
+        return {
+          state: "resolved",
+          subscription: byId,
+          metadataMatches: true,
+          managedSubscriptionIds: [byId.id],
+          allSubscriptionIds: [byId.id],
+          subscriptionDiagnostics: [
+            {
+              subscription_id: byId.id,
+              status: String(byId.status ?? "").trim().toLowerCase() || "unknown",
+              customer_id:
+                typeof byId.customer === "string" ? byId.customer : String(byId.customer?.id ?? "") || null,
+              livemode: Boolean(byId.livemode),
+              metadata_shop_id: String(byId.metadata?.shop_id ?? "").trim() || null,
+              excluded_reasons: [],
+            },
+          ],
+          customerDiagnostics: {
+            customer_exists_in_stripe: true,
+            customer_deleted_in_stripe: false,
+            customer_lookup_error: null,
+            likely_mode_mismatch: false,
+            stripe_mode: byId.livemode ? "live" : "test",
+            customer_mode: "unknown",
+          },
+          hydrationStrategy: "managed_filter",
+        };
+      }
+      linkedSubscriptionMismatchDiagnostic = [
+        {
+          subscription_id: byId.id,
+          status: String(byId.status ?? "").trim().toLowerCase() || "unknown",
+          customer_id: typeof byId.customer === "string" ? byId.customer : String(byId.customer?.id ?? "") || null,
+          livemode: Boolean(byId.livemode),
+          metadata_shop_id: String(byId.metadata?.shop_id ?? "").trim() || null,
+          excluded_reasons: ["subscription_id_mismatch_with_shop_customer_or_metadata"],
+        },
+      ];
+    } catch {
+      // Ignore retrieve failures and continue with deterministic customer-based diagnostics.
     }
   }
 
-  if (!customerId) return { state: "no_subscription_found", managedSubscriptionIds: [] };
-
-  const list = await stripe.subscriptions.list({
-    customer: customerId,
-    status: "all",
-    limit: 20,
-  });
-
-  if (!Array.isArray(list.data) || list.data.length === 0) {
-    return { state: "no_subscription_found", managedSubscriptionIds: [] };
-  }
-
-  const managed = list.data.filter(
-    (subscription) =>
-      MANAGED_SUBSCRIPTION_STATUSES.has(String(subscription.status ?? "").trim().toLowerCase()),
-  );
-
-  const managedSubscriptionIds = managed.map((subscription) => subscription.id);
-
-  if (managed.length === 1) {
+  if (!customerId) {
     return {
-      state: "resolved",
-      subscription: managed[0],
-      metadataMatches: subscriptionMetadataMatchesShop(managed[0], shop),
-      managedSubscriptionIds,
+      state: "no_subscription_found",
+      managedSubscriptionIds: [],
+      allSubscriptionIds: [],
+      subscriptionDiagnostics: [],
+      customerDiagnostics: {
+        customer_exists_in_stripe: false,
+        customer_deleted_in_stripe: false,
+        customer_lookup_error: null,
+        likely_mode_mismatch: false,
+        stripe_mode: "unknown",
+        customer_mode: "unknown",
+      },
     };
   }
 
-  if (managed.length === 0) {
-    return { state: "no_subscription_found", managedSubscriptionIds: [] };
+  const diagnostics = await collectCustomerSubscriptionDiagnostics({
+    stripe,
+    customerId,
+  });
+
+  if (diagnostics.managed_subscription_ids.length === 1) {
+    const managedSub = await stripe.subscriptions.retrieve(diagnostics.managed_subscription_ids[0]!);
+    return {
+      state: "resolved",
+      subscription: managedSub,
+      metadataMatches: subscriptionMetadataMatchesShop(managedSub, shop),
+      managedSubscriptionIds: diagnostics.managed_subscription_ids,
+      allSubscriptionIds: diagnostics.all_subscription_ids,
+      subscriptionDiagnostics: [...(linkedSubscriptionMismatchDiagnostic ?? []), ...diagnostics.subscription_diagnostics],
+      customerDiagnostics: {
+        customer_exists_in_stripe: diagnostics.customer.customer_exists,
+        customer_deleted_in_stripe: diagnostics.customer.customer_deleted,
+        customer_lookup_error: diagnostics.customer.customer_lookup_error,
+        likely_mode_mismatch: diagnostics.customer.likely_mode_mismatch,
+        stripe_mode: diagnostics.customer.stripe_mode,
+        customer_mode: diagnostics.customer.customer_mode,
+      },
+      hydrationStrategy: "managed_filter",
+    };
+  }
+
+  if (diagnostics.managed_subscription_ids.length === 0 && diagnostics.single_hydratable_subscription_id) {
+    const hydratableSub = await stripe.subscriptions.retrieve(diagnostics.single_hydratable_subscription_id);
+    return {
+      state: "resolved",
+      subscription: hydratableSub,
+      metadataMatches: subscriptionMetadataMatchesShop(hydratableSub, shop),
+      managedSubscriptionIds: diagnostics.managed_subscription_ids,
+      allSubscriptionIds: diagnostics.all_subscription_ids,
+      subscriptionDiagnostics: [...(linkedSubscriptionMismatchDiagnostic ?? []), ...diagnostics.subscription_diagnostics],
+      customerDiagnostics: {
+        customer_exists_in_stripe: diagnostics.customer.customer_exists,
+        customer_deleted_in_stripe: diagnostics.customer.customer_deleted,
+        customer_lookup_error: diagnostics.customer.customer_lookup_error,
+        likely_mode_mismatch: diagnostics.customer.likely_mode_mismatch,
+        stripe_mode: diagnostics.customer.stripe_mode,
+        customer_mode: diagnostics.customer.customer_mode,
+      },
+      hydrationStrategy: "single_hydratable_subscription",
+    };
+  }
+
+  if (diagnostics.managed_subscription_ids.length > 1) {
+    return {
+      state: "ambiguous_customer_subscriptions",
+      subscriptionIds: diagnostics.managed_subscription_ids,
+      allSubscriptionIds: diagnostics.all_subscription_ids,
+      subscriptionDiagnostics: [...(linkedSubscriptionMismatchDiagnostic ?? []), ...diagnostics.subscription_diagnostics],
+      customerDiagnostics: {
+        customer_exists_in_stripe: diagnostics.customer.customer_exists,
+        customer_deleted_in_stripe: diagnostics.customer.customer_deleted,
+        customer_lookup_error: diagnostics.customer.customer_lookup_error,
+        likely_mode_mismatch: diagnostics.customer.likely_mode_mismatch,
+        stripe_mode: diagnostics.customer.stripe_mode,
+        customer_mode: diagnostics.customer.customer_mode,
+      },
+    };
   }
 
   return {
-    state: "ambiguous_customer_subscriptions",
-    subscriptionIds: managedSubscriptionIds,
+    state: "no_subscription_found",
+    managedSubscriptionIds: diagnostics.managed_subscription_ids,
+    allSubscriptionIds: diagnostics.all_subscription_ids,
+    subscriptionDiagnostics: [...(linkedSubscriptionMismatchDiagnostic ?? []), ...diagnostics.subscription_diagnostics],
+    customerDiagnostics: {
+      customer_exists_in_stripe: diagnostics.customer.customer_exists,
+      customer_deleted_in_stripe: diagnostics.customer.customer_deleted,
+      customer_lookup_error: diagnostics.customer.customer_lookup_error,
+      likely_mode_mismatch: diagnostics.customer.likely_mode_mismatch,
+      stripe_mode: diagnostics.customer.stripe_mode,
+      customer_mode: diagnostics.customer.customer_mode,
+    },
   };
 }
 
@@ -295,6 +452,15 @@ export async function GET() {
         matching_subscription_ids: [resolution.subscription.id],
         managed_subscription_ids: resolution.managedSubscriptionIds,
         resolved_subscription_id: resolution.subscription.id,
+        all_customer_subscription_ids: resolution.allSubscriptionIds,
+        subscription_diagnostics: resolution.subscriptionDiagnostics,
+        customer_exists_in_stripe: resolution.customerDiagnostics.customer_exists_in_stripe,
+        customer_deleted_in_stripe: resolution.customerDiagnostics.customer_deleted_in_stripe,
+        customer_lookup_error: resolution.customerDiagnostics.customer_lookup_error,
+        likely_mode_mismatch: resolution.customerDiagnostics.likely_mode_mismatch,
+        stripe_mode: resolution.customerDiagnostics.stripe_mode,
+        customer_mode: resolution.customerDiagnostics.customer_mode,
+        hydration_strategy: resolution.hydrationStrategy,
       } satisfies NormalizedSubscriptionPayload);
     }
 
@@ -311,6 +477,15 @@ export async function GET() {
         matching_subscription_ids: [],
         managed_subscription_ids: resolution.subscriptionIds,
         resolved_subscription_id: null,
+        all_customer_subscription_ids: resolution.allSubscriptionIds,
+        subscription_diagnostics: resolution.subscriptionDiagnostics,
+        customer_exists_in_stripe: resolution.customerDiagnostics.customer_exists_in_stripe,
+        customer_deleted_in_stripe: resolution.customerDiagnostics.customer_deleted_in_stripe,
+        customer_lookup_error: resolution.customerDiagnostics.customer_lookup_error,
+        likely_mode_mismatch: resolution.customerDiagnostics.likely_mode_mismatch,
+        stripe_mode: resolution.customerDiagnostics.stripe_mode,
+        customer_mode: resolution.customerDiagnostics.customer_mode,
+        hydration_strategy: "none",
       } satisfies NormalizedSubscriptionPayload);
     }
 
@@ -335,6 +510,15 @@ export async function GET() {
           matching_subscription_ids: unlinked.subscriptionId ? [unlinked.subscriptionId] : [],
           managed_subscription_ids: resolution.managedSubscriptionIds,
           resolved_subscription_id: null,
+          all_customer_subscription_ids: resolution.allSubscriptionIds,
+          subscription_diagnostics: resolution.subscriptionDiagnostics,
+          customer_exists_in_stripe: resolution.customerDiagnostics.customer_exists_in_stripe,
+          customer_deleted_in_stripe: resolution.customerDiagnostics.customer_deleted_in_stripe,
+          customer_lookup_error: resolution.customerDiagnostics.customer_lookup_error,
+          likely_mode_mismatch: resolution.customerDiagnostics.likely_mode_mismatch,
+          stripe_mode: resolution.customerDiagnostics.stripe_mode,
+          customer_mode: resolution.customerDiagnostics.customer_mode,
+          hydration_strategy: "none",
         } satisfies NormalizedSubscriptionPayload);
       }
 
@@ -350,6 +534,15 @@ export async function GET() {
         matching_subscription_ids: [],
         managed_subscription_ids: resolution.managedSubscriptionIds,
         resolved_subscription_id: null,
+        all_customer_subscription_ids: resolution.allSubscriptionIds,
+        subscription_diagnostics: resolution.subscriptionDiagnostics,
+        customer_exists_in_stripe: resolution.customerDiagnostics.customer_exists_in_stripe,
+        customer_deleted_in_stripe: resolution.customerDiagnostics.customer_deleted_in_stripe,
+        customer_lookup_error: resolution.customerDiagnostics.customer_lookup_error,
+        likely_mode_mismatch: resolution.customerDiagnostics.likely_mode_mismatch,
+        stripe_mode: resolution.customerDiagnostics.stripe_mode,
+        customer_mode: resolution.customerDiagnostics.customer_mode,
+        hydration_strategy: "none",
       } satisfies NormalizedSubscriptionPayload);
     }
 

--- a/features/stripe/lib/server/canonical-shop-billing.ts
+++ b/features/stripe/lib/server/canonical-shop-billing.ts
@@ -6,6 +6,7 @@ import {
   type StripeSubscriptionStatus,
 } from "@/features/stripe/lib/stripe/subscriptionStatus";
 import { PLAN_LOOKUP_KEYS } from "@/features/stripe/lib/stripe/constants";
+import { collectCustomerSubscriptionDiagnostics } from "@/features/stripe/lib/server/subscription-discovery";
 
 type DB = Database;
 
@@ -15,14 +16,6 @@ type ProfileStripeArtifacts = {
   stripe_subscription_id: string | null;
   stripe_checkout_session_id: string | null;
 };
-
-const MANAGED_SUBSCRIPTION_STATUSES = new Set([
-  "trialing",
-  "active",
-  "past_due",
-  "unpaid",
-  "paused",
-]);
 
 type CanonicalPlan = "starter" | "pro" | "enterprise" | "unlimited";
 
@@ -172,18 +165,16 @@ export async function reconcileShopBillingFromUser(params: {
   let subscriptionId = profileSubscriptionId;
 
   if (!subscriptionId && customerId) {
-    const list = await stripe.subscriptions.list({
-      customer: customerId,
-      status: "all",
-      limit: 20,
+    const diagnostics = await collectCustomerSubscriptionDiagnostics({
+      stripe,
+      customerId,
     });
-    const managed = list.data.filter((sub) =>
-      MANAGED_SUBSCRIPTION_STATUSES.has(String(sub.status ?? "").trim().toLowerCase()),
-    );
 
-    if (managed.length === 1) {
-      subscriptionId = managed[0]?.id ?? "";
-    } else if (managed.length === 0) {
+    if (diagnostics.managed_subscription_ids.length === 1) {
+      subscriptionId = diagnostics.managed_subscription_ids[0] ?? "";
+    } else if (diagnostics.managed_subscription_ids.length === 0 && diagnostics.single_hydratable_subscription_id) {
+      subscriptionId = diagnostics.single_hydratable_subscription_id;
+    } else if (diagnostics.managed_subscription_ids.length === 0) {
       return { linked: false, reason: "no_subscription_found" };
     } else {
       return { linked: false, reason: "ambiguous_customer_subscriptions" };

--- a/features/stripe/lib/server/shop-billing-reconciliation.ts
+++ b/features/stripe/lib/server/shop-billing-reconciliation.ts
@@ -2,6 +2,7 @@ import type Stripe from "stripe";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { toCanonicalShopBillingUpdate } from "@/features/stripe/lib/server/canonical-shop-billing";
+import { collectCustomerSubscriptionDiagnostics } from "@/features/stripe/lib/server/subscription-discovery";
 
 type DB = Database;
 
@@ -15,14 +16,6 @@ type ShopBillingRow = Pick<
   | "stripe_current_period_end"
   | "plan"
 >;
-
-const MANAGED_SUBSCRIPTION_STATUSES = new Set([
-  "trialing",
-  "active",
-  "past_due",
-  "unpaid",
-  "paused",
-]);
 
 export type ShopBillingReconciliationState =
   | "updated"
@@ -42,6 +35,24 @@ export type ShopBillingReconciliationResult = {
   derived_plan: string | null;
   update_applied: boolean;
   reason?: string;
+  all_customer_subscription_ids: string[];
+  subscription_diagnostics: Array<{
+    subscription_id: string;
+    status: string;
+    customer_id: string | null;
+    livemode: boolean;
+    metadata_shop_id: string | null;
+    excluded_reasons: string[];
+  }>;
+  has_any_customer_subscriptions: boolean;
+  subscriptions_exist_but_none_managed: boolean;
+  customer_exists_in_stripe: boolean;
+  customer_deleted_in_stripe: boolean;
+  customer_lookup_error: string | null;
+  likely_mode_mismatch: boolean;
+  stripe_mode: "live" | "test" | "unknown";
+  customer_mode: "live" | "test" | "unknown";
+  hydration_strategy: "managed_filter" | "single_hydratable_subscription" | "none";
 };
 
 function normalizeText(value: unknown): string | null {
@@ -93,6 +104,17 @@ export async function reconcileCanonicalShopBillingByShopId(params: {
       derived_plan: null,
       update_applied: false,
       reason: "shop_not_found",
+      all_customer_subscription_ids: [],
+      subscription_diagnostics: [],
+      has_any_customer_subscriptions: false,
+      subscriptions_exist_but_none_managed: false,
+      customer_exists_in_stripe: false,
+      customer_deleted_in_stripe: false,
+      customer_lookup_error: null,
+      likely_mode_mismatch: false,
+      stripe_mode: "unknown",
+      customer_mode: "unknown",
+      hydration_strategy: "none",
     };
   }
 
@@ -107,6 +129,17 @@ export async function reconcileCanonicalShopBillingByShopId(params: {
       derived_plan: null,
       update_applied: false,
       reason: "missing_customer_id",
+      all_customer_subscription_ids: [],
+      subscription_diagnostics: [],
+      has_any_customer_subscriptions: false,
+      subscriptions_exist_but_none_managed: false,
+      customer_exists_in_stripe: false,
+      customer_deleted_in_stripe: false,
+      customer_lookup_error: null,
+      likely_mode_mismatch: false,
+      stripe_mode: "unknown",
+      customer_mode: "unknown",
+      hydration_strategy: "none",
     };
   }
 
@@ -121,48 +154,101 @@ export async function reconcileCanonicalShopBillingByShopId(params: {
       derived_plan: null,
       update_applied: false,
       reason: "customer_id_mismatch",
+      all_customer_subscription_ids: [],
+      subscription_diagnostics: [],
+      has_any_customer_subscriptions: false,
+      subscriptions_exist_but_none_managed: false,
+      customer_exists_in_stripe: false,
+      customer_deleted_in_stripe: false,
+      customer_lookup_error: null,
+      likely_mode_mismatch: false,
+      stripe_mode: "unknown",
+      customer_mode: "unknown",
+      hydration_strategy: "none",
     };
   }
 
-  const subscriptionList = await stripe.subscriptions.list({
-    customer: stripeCustomerId,
-    status: "all",
-    limit: 20,
+  const diagnostics = await collectCustomerSubscriptionDiagnostics({
+    stripe,
+    customerId: stripeCustomerId,
   });
+  let linkedSubscriptionMismatchDiagnostic: ShopBillingReconciliationResult["subscription_diagnostics"] = [];
+  const linkedSubscriptionId = normalizeText(shop.stripe_subscription_id);
+  if (linkedSubscriptionId) {
+    try {
+      const linkedSubscription = await stripe.subscriptions.retrieve(linkedSubscriptionId);
+      const linkedCustomerId =
+        typeof linkedSubscription.customer === "string"
+          ? linkedSubscription.customer
+          : String(linkedSubscription.customer?.id ?? "").trim() || null;
+      const linkedMetadataShopId = String(linkedSubscription.metadata?.shop_id ?? "").trim() || null;
+      const customerMatches = linkedCustomerId === stripeCustomerId;
+      const metadataMatches = !linkedMetadataShopId || linkedMetadataShopId === shop.id;
+      if (!customerMatches || !metadataMatches) {
+        linkedSubscriptionMismatchDiagnostic = [
+          {
+            subscription_id: linkedSubscription.id,
+            status: String(linkedSubscription.status ?? "").trim().toLowerCase() || "unknown",
+            customer_id: linkedCustomerId,
+            livemode: Boolean(linkedSubscription.livemode),
+            metadata_shop_id: linkedMetadataShopId,
+            excluded_reasons: ["subscription_id_mismatch_with_shop_customer_or_metadata"],
+          },
+        ];
+      }
+    } catch {
+      // Best-effort diagnostics only.
+    }
+  }
 
-  const qualifying = subscriptionList.data.filter((subscription) =>
-    MANAGED_SUBSCRIPTION_STATUSES.has(String(subscription.status ?? "").trim().toLowerCase()),
-  );
+  const qualifyingIds = diagnostics.managed_subscription_ids;
 
-  const qualifyingIds = qualifying.map((subscription) => subscription.id);
+  let chosenSubscriptionId: string | null = null;
+  let hydrationStrategy: ShopBillingReconciliationResult["hydration_strategy"] = "none";
 
-  if (qualifying.length === 0) {
+  if (qualifyingIds.length === 1) {
+    chosenSubscriptionId = qualifyingIds[0] ?? null;
+    hydrationStrategy = "managed_filter";
+  } else if (qualifyingIds.length === 0 && diagnostics.single_hydratable_subscription_id) {
+    chosenSubscriptionId = diagnostics.single_hydratable_subscription_id;
+    hydrationStrategy = "single_hydratable_subscription";
+  }
+
+  if (!chosenSubscriptionId) {
     return {
-      state: "no_subscription_found",
+      state:
+        qualifyingIds.length > 1
+          ? "ambiguous_customer_subscriptions"
+          : "no_subscription_found",
       shop_id: shop.id,
       stripe_customer_id: stripeCustomerId,
       qualifying_subscription_ids: qualifyingIds,
       chosen_subscription_id: null,
       derived_plan: null,
       update_applied: false,
-      reason: "no_subscription_found",
+      reason:
+        qualifyingIds.length > 1
+          ? "ambiguous_customer_subscriptions"
+          : diagnostics.no_subscriptions_found
+            ? "customer_has_no_subscriptions"
+            : diagnostics.subscriptions_exist_but_none_managed
+              ? "subscriptions_exist_but_none_managed"
+              : "no_subscription_found",
+      all_customer_subscription_ids: diagnostics.all_subscription_ids,
+      subscription_diagnostics: [...linkedSubscriptionMismatchDiagnostic, ...diagnostics.subscription_diagnostics],
+      has_any_customer_subscriptions: !diagnostics.no_subscriptions_found,
+      subscriptions_exist_but_none_managed: diagnostics.subscriptions_exist_but_none_managed,
+      customer_exists_in_stripe: diagnostics.customer.customer_exists,
+      customer_deleted_in_stripe: diagnostics.customer.customer_deleted,
+      customer_lookup_error: diagnostics.customer.customer_lookup_error,
+      likely_mode_mismatch: diagnostics.customer.likely_mode_mismatch,
+      stripe_mode: diagnostics.customer.stripe_mode,
+      customer_mode: diagnostics.customer.customer_mode,
+      hydration_strategy: "none",
     };
   }
 
-  if (qualifying.length > 1) {
-    return {
-      state: "ambiguous_customer_subscriptions",
-      shop_id: shop.id,
-      stripe_customer_id: stripeCustomerId,
-      qualifying_subscription_ids: qualifyingIds,
-      chosen_subscription_id: null,
-      derived_plan: null,
-      update_applied: false,
-      reason: "ambiguous_customer_subscriptions",
-    };
-  }
-
-  const chosen = qualifying[0];
+  const chosen = await stripe.subscriptions.retrieve(chosenSubscriptionId);
 
   const canonicalUpdate = toCanonicalShopBillingUpdate({
     customerId: stripeCustomerId,
@@ -192,5 +278,16 @@ export async function reconcileCanonicalShopBillingByShopId(params: {
     derived_plan: normalizeText(canonicalUpdate.plan),
     update_applied: shouldWrite,
     reason: sameState ? "already_hydrated" : shouldWrite ? "canonical_shop_billing_updated" : "dry_run",
+    all_customer_subscription_ids: diagnostics.all_subscription_ids,
+    subscription_diagnostics: [...linkedSubscriptionMismatchDiagnostic, ...diagnostics.subscription_diagnostics],
+    has_any_customer_subscriptions: !diagnostics.no_subscriptions_found,
+    subscriptions_exist_but_none_managed: diagnostics.subscriptions_exist_but_none_managed,
+    customer_exists_in_stripe: diagnostics.customer.customer_exists,
+    customer_deleted_in_stripe: diagnostics.customer.customer_deleted,
+    customer_lookup_error: diagnostics.customer.customer_lookup_error,
+    likely_mode_mismatch: diagnostics.customer.likely_mode_mismatch,
+    stripe_mode: diagnostics.customer.stripe_mode,
+    customer_mode: diagnostics.customer.customer_mode,
+    hydration_strategy: hydrationStrategy,
   };
 }

--- a/features/stripe/lib/server/subscription-discovery.ts
+++ b/features/stripe/lib/server/subscription-discovery.ts
@@ -1,0 +1,180 @@
+import Stripe from "stripe";
+
+export const MANAGED_SUBSCRIPTION_STATUSES = new Set([
+  "trialing",
+  "active",
+  "past_due",
+  "unpaid",
+  "paused",
+]);
+
+const HYDRATABLE_SINGLE_SUBSCRIPTION_STATUSES = new Set([
+  "trialing",
+  "active",
+  "past_due",
+  "unpaid",
+  "paused",
+  "incomplete",
+]);
+
+function normalizeStatus(status: unknown): string {
+  return String(status ?? "").trim().toLowerCase();
+}
+
+function toSubscriptionCustomerId(subscription: Stripe.Subscription): string | null {
+  if (typeof subscription.customer === "string") {
+    return subscription.customer.trim() || null;
+  }
+  const id = String(subscription.customer?.id ?? "").trim();
+  return id || null;
+}
+
+function detectExclusionReasons(args: {
+  subscription: Stripe.Subscription;
+  expectedCustomerId: string;
+}): string[] {
+  const { subscription, expectedCustomerId } = args;
+  const reasons: string[] = [];
+  const normalizedStatus = normalizeStatus(subscription.status);
+  const subscriptionCustomerId = toSubscriptionCustomerId(subscription);
+
+  if (!MANAGED_SUBSCRIPTION_STATUSES.has(normalizedStatus)) {
+    reasons.push("status_not_managed");
+  }
+
+  if (!HYDRATABLE_SINGLE_SUBSCRIPTION_STATUSES.has(normalizedStatus)) {
+    reasons.push("status_not_single_subscription_hydratable");
+  }
+
+  if (subscriptionCustomerId !== expectedCustomerId) {
+    reasons.push("subscription_customer_mismatch");
+  }
+
+  return reasons;
+}
+
+export type StripeCustomerDiagnostics = {
+  customer_id: string;
+  customer_exists: boolean;
+  customer_deleted: boolean;
+  stripe_mode: "live" | "test" | "unknown";
+  customer_mode: "live" | "test" | "unknown";
+  customer_lookup_error: string | null;
+  likely_mode_mismatch: boolean;
+};
+
+export type SubscriptionDiagnosticEntry = {
+  subscription_id: string;
+  status: string;
+  customer_id: string | null;
+  livemode: boolean;
+  metadata_shop_id: string | null;
+  excluded_reasons: string[];
+};
+
+export type CustomerSubscriptionDiagnostics = {
+  customer: StripeCustomerDiagnostics;
+  all_subscription_ids: string[];
+  managed_subscription_ids: string[];
+  single_hydratable_subscription_id: string | null;
+  subscription_diagnostics: SubscriptionDiagnosticEntry[];
+  no_subscriptions_found: boolean;
+  subscriptions_exist_but_none_managed: boolean;
+};
+
+export async function collectCustomerSubscriptionDiagnostics(args: {
+  stripe: Stripe;
+  customerId: string;
+}): Promise<CustomerSubscriptionDiagnostics> {
+  const { stripe, customerId } = args;
+
+  const customerDiagnostics: StripeCustomerDiagnostics = {
+    customer_id: customerId,
+    customer_exists: false,
+    customer_deleted: false,
+    stripe_mode: "unknown",
+    customer_mode: "unknown",
+    customer_lookup_error: null,
+    likely_mode_mismatch: false,
+  };
+
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    if ("deleted" in customer && customer.deleted) {
+      customerDiagnostics.customer_exists = true;
+      customerDiagnostics.customer_deleted = true;
+    } else {
+      customerDiagnostics.customer_exists = true;
+      customerDiagnostics.customer_mode = customer.livemode ? "live" : "test";
+    }
+  } catch (error) {
+    if (error instanceof Stripe.errors.StripeError) {
+      customerDiagnostics.customer_lookup_error = error.message;
+      if (error.code === "resource_missing") {
+        customerDiagnostics.likely_mode_mismatch = true;
+      }
+    } else {
+      customerDiagnostics.customer_lookup_error = "unknown_customer_lookup_error";
+    }
+  }
+
+  const list = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 100,
+  });
+
+  const allIds = list.data.map((subscription) => subscription.id);
+  const stripeMode = list.data[0]?.livemode;
+  customerDiagnostics.stripe_mode =
+    typeof stripeMode === "boolean" ? (stripeMode ? "live" : "test") : customerDiagnostics.stripe_mode;
+
+  if (customerDiagnostics.customer_mode !== "unknown" && customerDiagnostics.stripe_mode !== "unknown") {
+    customerDiagnostics.likely_mode_mismatch = customerDiagnostics.customer_mode !== customerDiagnostics.stripe_mode;
+  }
+
+  const subscriptionDiagnostics = list.data.map((subscription) => {
+    const normalizedStatus = normalizeStatus(subscription.status);
+    const customer_id = toSubscriptionCustomerId(subscription);
+    return {
+      subscription_id: subscription.id,
+      status: normalizedStatus || "unknown",
+      customer_id,
+      livemode: Boolean(subscription.livemode),
+      metadata_shop_id: String(subscription.metadata?.shop_id ?? "").trim() || null,
+      excluded_reasons: detectExclusionReasons({
+        subscription,
+        expectedCustomerId: customerId,
+      }),
+    } satisfies SubscriptionDiagnosticEntry;
+  });
+
+  const managedIds = subscriptionDiagnostics
+    .filter((entry) => entry.excluded_reasons.every((reason) => reason !== "status_not_managed"))
+    .map((entry) => entry.subscription_id);
+
+  const singleHydratable = subscriptionDiagnostics.filter(
+    (entry) =>
+      entry.excluded_reasons.every(
+        (reason) => reason !== "status_not_single_subscription_hydratable" && reason !== "subscription_customer_mismatch",
+      ),
+  );
+
+  return {
+    customer: customerDiagnostics,
+    all_subscription_ids: allIds,
+    managed_subscription_ids: managedIds,
+    single_hydratable_subscription_id: singleHydratable.length === 1 ? singleHydratable[0]?.subscription_id ?? null : null,
+    subscription_diagnostics: subscriptionDiagnostics,
+    no_subscriptions_found: allIds.length === 0,
+    subscriptions_exist_but_none_managed: allIds.length > 0 && managedIds.length === 0,
+  };
+}
+
+export function isManagedSubscriptionStatus(status: unknown): boolean {
+  return MANAGED_SUBSCRIPTION_STATUSES.has(normalizeStatus(status));
+}
+
+export function isSingleSubscriptionHydratableStatus(status: unknown): boolean {
+  return HYDRATABLE_SINGLE_SUBSCRIPTION_STATUSES.has(normalizeStatus(status));
+}


### PR DESCRIPTION
### Motivation
- Reconcile why a known Stripe customer returned `no_subscription_found` by making subscription discovery transparent and deterministic. 
- The prior flow only surfaced “managed” statuses and returned minimal diagnostics, which hid cases where a single non-managed-but-valid subscription (e.g. `incomplete`) existed and should be considered.
- Make reconciliation safe for automated hydration while avoiding any fuzzy cross-customer or cross-shop linking.

### Description
- Root cause: multiple code paths filtered subscriptions to an overly narrow managed set (`trialing|active|past_due|unpaid|paused`) and returned minimal information, so single `incomplete` or other non-managed-but-real subscriptions were treated as "no_subscription_found" and the route provided no per-subscription reasons.
- Added a new shared helper `features/stripe/lib/server/subscription-discovery.ts` that lists `status: "all"` (limit 100) and returns per-subscription diagnostics, customer existence/mode diagnostics, and a deterministic `single_hydratable_subscription_id` fallback when exactly one hydratable subscription exists for the exact customer.
- Updated reconciliation and canonical flows to use the new helper and expanded response contract to include `all_customer_subscription_ids`, `subscription_diagnostics`, customer lookup details (exists/deleted/lookup error, stripe_mode/customer_mode, likely_mode_mismatch), and `hydration_strategy`.
- Implemented a safe deterministic hydration fallback: when the managed set is empty but there is exactly one hydratable subscription for the exact customer (hydratable set includes `incomplete`), the route will treat that subscription as canonical and may hydrate `shops.*` accordingly; ambiguous multi-subscription cases remain non-writing.
- Files changed: added `features/stripe/lib/server/subscription-discovery.ts`; modified `features/stripe/lib/server/shop-billing-reconciliation.ts`, `app/api/stripe/subscription/route.ts`, and `features/stripe/lib/server/canonical-shop-billing.ts` to consume diagnostics and return richer responses.

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` — success.
- Ran targeted linting: `npx eslint app/api/stripe/subscription/route.ts features/stripe/lib/server/shop-billing-reconciliation.ts features/stripe/lib/server/canonical-shop-billing.ts features/stripe/lib/server/subscription-discovery.ts` — success.
- No runtime Stripe calls were executed as part of tests here; diagnostic collection runs at runtime against Stripe and will now reveal per-subscription reasons so operators can observe whether `cus_UOhiJSTVAfRpDC` has subscriptions and why they were excluded.

Additional deliverables (behavioral notes)
- For shop_id `e9e87cda-3cbe-4785-956f-e8d05fcde539` / customer `cus_UOhiJSTVAfRpDC`: after deploying this patch the reconcile route will either hydrate the shop if Stripe returns exactly one hydratable subscription for that exact customer, or it will return a diagnostic payload indicating one of: `customer_has_no_subscriptions`, `subscriptions_exist_but_none_managed`, `ambiguous_customer_subscriptions`, or `subscription_id_mismatch_with_shop_customer_or_metadata`, plus complete per-subscription exclusion reasons and likely mode mismatch flags.
- No schema changes or destructive operations were made; no cross-customer linking or ambiguous auto-linking was introduced.

Commands run
- `npx tsc --noEmit` (succeeded)
- `npx eslint app/api/stripe/subscription/route.ts features/stripe/lib/server/shop-billing-reconciliation.ts features/stripe/lib/server/canonical-shop-billing.ts features/stripe/lib/server/subscription-discovery.ts` (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3d1e5dec83288585d7acbca9bf7e)