### PR TITLE
Harden Shop Boost deterministic external-ID linkage for vehicles/history/invoices

### DIFF
--- a/app/api/shop-boost/review-items/[id]/route.ts
+++ b/app/api/shop-boost/review-items/[id]/route.ts
@@ -52,5 +52,16 @@ export async function PATCH(req: Request, context: RouteContext) {
     return NextResponse.json({ ok: false, error: result.error ?? "Materialization failed.", item: result.item }, { status: 500 });
   }
 
-  return NextResponse.json({ ok: true, item: result.item, materializedRecord: result.materializedRecord });
+  return NextResponse.json({
+    ok: true,
+    item: result.item,
+    materializedRecord: result.materializedRecord,
+    appliedResult: {
+      reviewItemId: result.item?.id ?? id,
+      domain: result.item?.domain ?? null,
+      status: result.item?.status ?? null,
+      resolutionAction: result.item?.resolution_action ?? body.resolution_action ?? "ignored",
+      materializedRecord: result.materializedRecord ?? null,
+    },
+  });
 }

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -334,15 +334,40 @@ function parseCsv(csv: string): { header: string[]; rows: CsvRow[] } {
     return out.map((s) => s.trim());
   };
 
-  const header = splitLine(lines[0]).map((h) => h.trim());
+  const normalizeHeader = (header: string): string =>
+    header
+      .replace(/^\uFEFF/, "")
+      .trim()
+      .replace(/^"(.*)"$/, "$1")
+      .trim();
+
+  const headerAliases = (header: string): string[] => {
+    const normalized = normalizeHeader(header);
+    if (!normalized) return [];
+    const canonical = normalized
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .replace(/_+/g, "_");
+    const spaced = canonical.replace(/_/g, " ").trim();
+    return Array.from(new Set([normalized, canonical, spaced].filter(Boolean)));
+  };
+
+  const header = splitLine(lines[0]).map((h) => normalizeHeader(h));
   const rows: CsvRow[] = [];
 
   for (let i = 1; i < lines.length; i += 1) {
     const cols = splitLine(lines[i]);
     const rec: CsvRow = {};
     for (let c = 0; c < header.length; c += 1) {
-      const key = header[c] || `col_${c + 1}`;
-      rec[key] = cols[c] ?? "";
+      const rawKey = header[c] || `col_${c + 1}`;
+      const value = cols[c] ?? "";
+      const aliases = headerAliases(rawKey);
+      if (aliases.length === 0) {
+        rec[`col_${c + 1}`] = value;
+      } else {
+        for (const alias of aliases) rec[alias] = value;
+      }
     }
     rows.push(rec);
   }
@@ -802,6 +827,37 @@ function pickSourceId(row: CsvRow, patterns: RegExp[]): string | null {
   if (!raw) return null;
   const normalized = raw.trim();
   return normalized.length ? normalized : null;
+}
+
+function hasCustomerIdHeader(row: CsvRow): boolean {
+  return Object.keys(row).some((key) => {
+    const normalized = key
+      .replace(/^\uFEFF/, "")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return normalized === "customer id" || normalized === "customer external id";
+  });
+}
+
+function classifyDeterministicCustomerMiss(args: {
+  sourceCustomerId: string | null;
+  sourceMatchedCustomerId: string | null;
+  row: CsvRow;
+  fallbackCustomerId: string | null;
+}): "external_customer_id_not_found" | "customer_external_id_not_persisted" | "csv_alias_parse_miss" | "missing_customer_match" {
+  if (args.sourceCustomerId && !args.sourceMatchedCustomerId) {
+    return "customer_external_id_not_persisted";
+  }
+  if (!args.sourceCustomerId && hasCustomerIdHeader(args.row)) {
+    return "csv_alias_parse_miss";
+  }
+  if (!args.sourceCustomerId && args.fallbackCustomerId) {
+    return "external_customer_id_not_found";
+  }
+  return "missing_customer_match";
 }
 
 function sourceExternalId(domain: "customer" | "vehicle" | "work_order" | "invoice", sourceId: string): string {
@@ -1550,6 +1606,12 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         (customerNameKey && !conflictingCustomerNames.has(customerNameKey) && uniqueCustomersByName.get(customerNameKey)) ||
         null;
       const customer_id = sourceMatchedCustomerId || fallbackCustomerId || null;
+      const deterministicMissReason = classifyDeterministicCustomerMiss({
+        sourceCustomerId,
+        sourceMatchedCustomerId: sourceMatchedCustomerId ?? null,
+        row,
+        fallbackCustomerId: fallbackCustomerId ?? null,
+      });
 
       if (!customer_id) {
         rowOutcome.processedRows += 1;
@@ -1561,9 +1623,21 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           intakeId,
           domain: "vehicle",
           issueType: "missing_dependency",
-          summary: "Vehicle could not be imported because customer was not confidently matched.",
+          summary: `Vehicle could not be imported because customer linkage failed (${deterministicMissReason}).`,
           rawPayload: row,
-          suggestedMatches: [{ customerEmail: custEmail || null, customerPhone: custPhone || null }],
+          normalizedPayload: {
+            sourceCustomerId,
+            sourceMatchedCustomerId,
+            fallbackCustomerId,
+            deterministicMissReason,
+          },
+          blockingReason: deterministicMissReason,
+          suggestedMatches: [{
+            customerEmail: custEmail || null,
+            customerPhone: custPhone || null,
+            sourceCustomerId: sourceCustomerId ?? null,
+            sourceMatchedCustomerId: sourceMatchedCustomerId ?? null,
+          }],
         });
         await insertRowResult({
           supabase,
@@ -1572,11 +1646,24 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           sourceFile: "vehicles",
           sourceRowIndex: i + 1,
           rawPayload: row,
-          normalizedPayload: { vin, plate, unit, year, make, model, custEmail, custPhone },
+          normalizedPayload: {
+            vin,
+            plate,
+            unit,
+            year,
+            make,
+            model,
+            custEmail,
+            custPhone,
+            sourceCustomerId,
+            sourceMatchedCustomerId,
+            fallbackCustomerId,
+            deterministicMissReason,
+          },
           targetDomain: "vehicle",
           matchStatus: "unmatched",
           matchConfidence: "low",
-          errorReason: "missing_customer_match",
+          errorReason: deterministicMissReason,
           reviewRequired: true,
         });
         continue;
@@ -1910,6 +1997,12 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           uniqueCustomersByName.get(normalizedCustomerName)) ||
         null;
       const customer_id = sourceMatchedCustomerId || fallbackCustomerId || null;
+      const deterministicMissReason = classifyDeterministicCustomerMiss({
+        sourceCustomerId,
+        sourceMatchedCustomerId: sourceMatchedCustomerId ?? null,
+        row,
+        fallbackCustomerId: fallbackCustomerId ?? null,
+      });
 
       const rowUnit = lower(pick(row, [/unit/, /unit number/, /truck number/]) ?? "");
       const sourceMatchedVehicleId = sourceVehicleKey ? vehiclesBySourceId.get(sourceVehicleKey) : null;
@@ -1930,9 +2023,16 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           intakeId,
           domain: "work_order",
           issueType: "missing_dependency",
-          summary: "History row skipped because customer could not be matched.",
+          summary: `History row skipped because customer linkage failed (${deterministicMissReason}).`,
           rawPayload: row,
-          suggestedMatches: [{ customerEmail, customerPhone, vin, plate }],
+          normalizedPayload: {
+            sourceCustomerId,
+            sourceMatchedCustomerId,
+            fallbackCustomerId,
+            deterministicMissReason,
+          },
+          blockingReason: deterministicMissReason,
+          suggestedMatches: [{ customerEmail, customerPhone, vin, plate, sourceCustomerId }],
         });
         await insertRowResult({
           supabase,
@@ -1958,7 +2058,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           targetDomain: "work_order",
           matchStatus: "unmatched",
           matchConfidence: "low",
-          errorReason: "missing_customer_match",
+          errorReason: deterministicMissReason,
           reviewRequired: true,
         });
         continue;
@@ -2212,6 +2312,16 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         (customerPhone && !conflictingCustomerPhones.has(customerPhone) && uniqueCustomersByPhone.get(customerPhone)) ||
         (customerName && !conflictingCustomerNames.has(customerName) && uniqueCustomersByName.get(customerName)) ||
         null;
+      const deterministicCustomerMissReason = classifyDeterministicCustomerMiss({
+        sourceCustomerId,
+        sourceMatchedCustomerId: (sourceCustomerKey && customersBySourceId.get(sourceCustomerKey)) ?? null,
+        row,
+        fallbackCustomerId:
+          (customerEmail && !conflictingCustomerEmails.has(customerEmail) && uniqueCustomersByEmail.get(customerEmail)) ||
+          (customerPhone && !conflictingCustomerPhones.has(customerPhone) && uniqueCustomersByPhone.get(customerPhone)) ||
+          (customerName && !conflictingCustomerNames.has(customerName) && uniqueCustomersByName.get(customerName)) ||
+          null,
+      });
 
       let workOrderId: string | null =
         (sourceWorkOrderKey && workOrdersBySourceId.get(sourceWorkOrderKey)) || null;
@@ -2239,8 +2349,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           issueType: "missing_dependency",
           summary: !workOrderId
             ? "Invoice row staged for review because work order linkage was unresolved."
-            : "Invoice row staged for review because customer linkage was unresolved.",
+            : `Invoice row staged for review because customer linkage failed (${deterministicCustomerMissReason}).`,
           rawPayload: row,
+          blockingReason: !workOrderId ? "missing_work_order_match" : deterministicCustomerMissReason,
           suggestedMatches: [{ sourceInvoiceId, sourceWorkOrderId, sourceCustomerId, invoiceNumber, ro }],
         });
         await insertRowResult({
@@ -2258,6 +2369,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
             ro,
             workOrderId,
             resolvedCustomerId,
+            deterministicCustomerMissReason,
             total,
             labor,
             parts,
@@ -2265,7 +2377,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           targetDomain: "invoice",
           matchStatus: "unmatched",
           matchConfidence: "low",
-          errorReason: !workOrderId ? "missing_work_order_match" : "missing_customer_match",
+          errorReason: !workOrderId ? "missing_work_order_match" : deterministicCustomerMissReason,
           reviewRequired: true,
         });
         continue;

--- a/features/integrations/shopBoost/reviewMaterialization.ts
+++ b/features/integrations/shopBoost/reviewMaterialization.ts
@@ -24,6 +24,7 @@ type ReviewItemRow = {
   status: string;
   summary: string;
   raw_payload: Record<string, unknown>;
+  normalized_payload?: Record<string, unknown>;
   suggested_matches: unknown;
   resolution_action: ResolutionAction | null;
   materialized_at: string | null;
@@ -132,14 +133,21 @@ async function logReviewAuditEvent(args: {
   });
 }
 
-async function findCustomerId(args: { supabase: AdminClient; shopId: string; raw: Record<string, unknown>; suggested: unknown; }): Promise<string | null> {
-  const { supabase, shopId, raw, suggested } = args;
+async function findCustomerId(args: {
+  supabase: AdminClient;
+  shopId: string;
+  raw: Record<string, unknown>;
+  normalized?: Record<string, unknown>;
+  suggested: unknown;
+}): Promise<string | null> {
+  const { supabase, shopId, raw, normalized, suggested } = args;
+  const payload = { ...(raw ?? {}), ...(normalized ?? {}) };
   const suggestedCustomerId = typeof suggested === "object" && suggested && "customerId" in (suggested as Record<string, unknown>)
     ? String((suggested as Record<string, unknown>).customerId ?? "")
     : "";
 
   if (suggestedCustomerId) return suggestedCustomerId;
-  const sourceCustomerId = pick(raw, [/^customer[_\s-]*id$/, /external customer id/]);
+  const sourceCustomerId = pick(payload, [/^customer[_\s-]*id$/, /external customer id/]);
   if (sourceCustomerId) {
     const { data } = await supabase
       .from("customers")
@@ -150,13 +158,13 @@ async function findCustomerId(args: { supabase: AdminClient; shopId: string; raw
     if (data?.id) return String(data.id);
   }
 
-  const email = normalizeEmail(pick(raw, [/customer email/, /^email$/]));
+  const email = normalizeEmail(pick(payload, [/customer email/, /^email$/]));
   if (email) {
     const { data } = await supabase.from("customers").select("id").eq("shop_id", shopId).eq("email", email).limit(1).maybeSingle();
     if (data?.id) return String(data.id);
   }
 
-  const phone = normalizePhone(pick(raw, [/customer phone/, /^phone$/]));
+  const phone = normalizePhone(pick(payload, [/customer phone/, /^phone$/]));
   if (phone) {
     const { data } = await supabase.from("customers").select("id,phone,phone_number").eq("shop_id", shopId).limit(3000);
     const matched = ((data ?? []) as CustomerPhoneLookupRow[]).find((item) => normalizePhone(item.phone ?? item.phone_number) === phone);
@@ -171,6 +179,7 @@ async function materializeCustomer(args: { supabase: AdminClient; item: ReviewIt
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
   const raw = item.raw_payload ?? {};
+  const normalized = item.normalized_payload ?? {};
   const email = normalizeEmail(pick(raw, [/^email$/, /customer email/]));
   const phone = normalizePhone(pick(raw, [/^phone$/, /customer phone/, /mobile/]));
   const first = pick(raw, [/^first/, /first name/]);
@@ -182,7 +191,7 @@ async function materializeCustomer(args: { supabase: AdminClient; item: ReviewIt
 
   let customerId: string | null = null;
   if (resolutionAction === "linked_to_existing") {
-    customerId = await findCustomerId({ supabase, shopId: item.shop_id, raw, suggested: item.suggested_matches });
+    customerId = await findCustomerId({ supabase, shopId: item.shop_id, raw, normalized, suggested: item.suggested_matches });
     if (!customerId) return { status: "failed_materialization", materializedRecord: null, error: "Unable to locate selected existing customer." };
 
     await supabase.from("customers").update({ source_intake_id: item.intake_id, external_id: externalId }).eq("id", customerId).eq("shop_id", item.shop_id);
@@ -215,7 +224,8 @@ async function materializeVehicle(args: { supabase: AdminClient; item: ReviewIte
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
   const raw = item.raw_payload ?? {};
-  const customerId = await findCustomerId({ supabase, shopId: item.shop_id, raw, suggested: item.suggested_matches });
+  const normalized = item.normalized_payload ?? {};
+  const customerId = await findCustomerId({ supabase, shopId: item.shop_id, raw, normalized, suggested: item.suggested_matches });
   if (!customerId) return { status: "failed_materialization", materializedRecord: null, error: "Customer dependency is still unresolved for this vehicle." };
 
   const vin = lower(pick(raw, [/^vin$/, /vehicle vin/]));
@@ -287,7 +297,8 @@ async function materializeWorkOrder(args: { supabase: AdminClient; item: ReviewI
   if (resolutionAction === "ignored") return { status: "materialized", materializedRecord: { ignored: true }, error: null };
 
   const raw = item.raw_payload ?? {};
-  const customerId = await findCustomerId({ supabase, shopId: item.shop_id, raw, suggested: item.suggested_matches });
+  const normalized = item.normalized_payload ?? {};
+  const customerId = await findCustomerId({ supabase, shopId: item.shop_id, raw, normalized, suggested: item.suggested_matches });
   if (!customerId) return { status: "failed_materialization", materializedRecord: null, error: "Missing customer dependency for work order." };
 
   const sourceVehicleId = pick(raw, [/^vehicle[_\s-]*id$/, /external vehicle id/]);
@@ -599,7 +610,7 @@ export async function resolveAndMaterializeReviewItem(args: {
 
   const { data: item } = await supabase
     .from("shop_boost_review_items")
-    .select("id,shop_id,intake_id,domain,issue_type,status,summary,raw_payload,suggested_matches,resolution_action,materialized_at,materialization_error,recommended_action,recommendation_reason,recommendation_confidence")
+    .select("id,shop_id,intake_id,domain,issue_type,status,summary,raw_payload,normalized_payload,suggested_matches,resolution_action,materialized_at,materialization_error,recommended_action,recommendation_reason,recommendation_confidence")
     .eq("shop_id", args.shopId)
     .eq("id", args.reviewItemId)
     .maybeSingle();
@@ -688,7 +699,7 @@ export async function resolveAndMaterializeReviewItem(args: {
 
   const { data: updatedItem } = await supabase
     .from("shop_boost_review_items")
-    .select("id,shop_id,intake_id,domain,issue_type,status,summary,raw_payload,suggested_matches,resolution_action,materialized_at,materialization_error,recommended_action,recommendation_reason,recommendation_confidence")
+    .select("id,shop_id,intake_id,domain,issue_type,status,summary,raw_payload,normalized_payload,suggested_matches,resolution_action,materialized_at,materialization_error,recommended_action,recommendation_reason,recommendation_confidence")
     .eq("id", item.id)
     .eq("shop_id", args.shopId)
     .maybeSingle();
@@ -705,7 +716,7 @@ async function replayDependentRows(args: { supabase: AdminClient; shopId: string
   const { supabase, shopId, intakeId } = args;
   const { data: replayCandidates } = await supabase
     .from("shop_boost_review_items")
-    .select("id,shop_id,intake_id,domain,issue_type,status,summary,raw_payload,suggested_matches,resolution_action,materialized_at,materialization_error,recommended_action,recommendation_reason,recommendation_confidence")
+    .select("id,shop_id,intake_id,domain,issue_type,status,summary,raw_payload,normalized_payload,suggested_matches,resolution_action,materialized_at,materialization_error,recommended_action,recommendation_reason,recommendation_confidence")
     .eq("shop_id", shopId)
     .eq("intake_id", intakeId)
     .eq("issue_type", "missing_dependency")


### PR DESCRIPTION
### Motivation
- Root cause: CSV header parsing was brittle (BOM/quoted/variant headers) so deterministic IDs like `customer_id`/`vehicle_id` could be missed at parse time and the importer fell back to fuzzy matching, creating many unnecessary `missing_dependency` review items. 
- Goal: ensure deterministic source-id linkage is honored first (and preserved through import/review materialization) and surface precise diagnostics when deterministic linkage still fails.

### Description
- Canonical CSV header normalization and aliasing: `parseCsv` now strips BOM/quotes and generates stable aliases (`original`, `snake_case`, and `spaced` variants) so underscore-style headers such as `customer_id` and `vehicle_id` are consistently discoverable; implemented in `features/integrations/imports/runFullImport.ts`.
- Deterministic-miss classification and richer diagnostics: added logic to classify unresolved customer linkage reasons (`customer_external_id_not_persisted`, `csv_alias_parse_miss`, `external_customer_id_not_found`, `missing_customer_match`) and surface them in `normalized_payload`, `blocking_reason`, and `error_reason` when creating review items and row results in `runFullImport`.
- Preserve deterministic evidence across review/apply: review materialization now merges `normalized_payload` with `raw_payload` when resolving customer IDs so manual `link_existing`/replay can use deterministic IDs captured at import time; changed selects to include `normalized_payload` and updated lookup to consult the merged payload in `features/integrations/shopBoost/reviewMaterialization.ts`.
- Clearer apply response: guided-review PATCH now returns an `appliedResult` envelope with structured outcome (`reviewItemId`, `domain`, `status`, `resolutionAction`, `materializedRecord`) to avoid opaque empty apply responses in `app/api/shop-boost/review-items/[id]/route.ts`.
- Files changed: `features/integrations/imports/runFullImport.ts`, `features/integrations/shopBoost/reviewMaterialization.ts`, and `app/api/shop-boost/review-items/[id]/route.ts`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully (no new type errors introduced). 
- Notes: an alternate `npm run tsc` invocation produced non-actionable output so `npx tsc --noEmit` was used per project validation rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece3e6bc688328be994862fbfb89a1)