### PR TITLE
Add safe shop-scoped Shop Boost import reset tooling

### DIFF
--- a/app/api/shop-boost/import-reset/route.ts
+++ b/app/api/shop-boost/import-reset/route.ts
@@ -1,0 +1,496 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type ResetScope = "intake" | "shop";
+type Domain = "customer" | "vehicle" | "work_order" | "work_order_line" | "invoice";
+
+type ResetCounts = {
+  intakes: number;
+  reviewItems: number;
+  rowResults: number;
+  reviewAuditEvents: number;
+  integrityReports: number;
+  importFiles: number;
+  importRows: number;
+  staffInviteSuggestions: number;
+  staffInviteCandidates: number;
+  provenance: Record<Domain, number>;
+  legacyTagged: {
+    customers: number;
+    vehicles: number;
+    workOrders: number;
+    workOrderLines: number;
+    invoices: number;
+  };
+};
+
+const RESET_CONFIRM_PREFIX = "RESET SHOP BOOST IMPORT";
+const DOMAINS: Domain[] = ["customer", "vehicle", "work_order", "work_order_line", "invoice"];
+
+function parseScope(raw: string | null): ResetScope {
+  return raw === "shop" ? "shop" : "intake";
+}
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function buildExpectedConfirmation(scope: ResetScope, shopId: string, intakeId: string | null): string {
+  if (scope === "shop") return `${RESET_CONFIRM_PREFIX}S ${shopId}`;
+  return `${RESET_CONFIRM_PREFIX} ${intakeId ?? ""}`.trim();
+}
+
+async function countExact(query: PromiseLike<{ count: number | null; error: { message: string } | null }>): Promise<number> {
+  const { count, error } = await query;
+  if (error) throw new Error(error.message);
+  return Number(count ?? 0);
+}
+
+async function collectCounts(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  scope: ResetScope;
+  intakeId: string | null;
+}): Promise<ResetCounts> {
+  const { admin, shopId, scope, intakeId } = args;
+  const intakeScoped = scope === "intake" && intakeId;
+
+  const [
+    intakes,
+    reviewItems,
+    rowResults,
+    reviewAuditEvents,
+    integrityReports,
+    importFiles,
+    importRows,
+    staffInviteSuggestions,
+    staffInviteCandidates,
+    legacyCustomers,
+    legacyVehicles,
+    legacyWorkOrders,
+    legacyWorkOrderLines,
+    legacyInvoices,
+  ] = await Promise.all([
+    countExact(
+      (intakeScoped
+        ? admin.from("shop_boost_intakes").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("id", intakeId)
+        : admin.from("shop_boost_intakes").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("shop_boost_review_items").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : admin.from("shop_boost_review_items").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("shop_boost_row_results").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : admin.from("shop_boost_row_results").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? (admin as any).from("shop_boost_review_audit_events").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : (admin as any).from("shop_boost_review_audit_events").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? (admin as any).from("shop_boost_integrity_reports").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : (admin as any).from("shop_boost_integrity_reports").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("shop_import_files").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : admin.from("shop_import_files").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("shop_import_rows").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : admin.from("shop_import_rows").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("staff_invite_suggestions").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("intake_id", intakeId)
+        : admin.from("staff_invite_suggestions").select("id", { head: true, count: "exact" }).eq("shop_id", shopId)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin
+            .from("staff_invite_candidates")
+            .select("id", { head: true, count: "exact" })
+            .eq("shop_id", shopId)
+            .eq("intake_id", intakeId)
+            .eq("source", "shop_boost_import")
+        : admin
+            .from("staff_invite_candidates")
+            .select("id", { head: true, count: "exact" })
+            .eq("shop_id", shopId)
+            .eq("source", "shop_boost_import")) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("customers").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("source_intake_id", intakeId)
+        : admin.from("customers").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).not("source_intake_id", "is", null)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("vehicles").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("source_intake_id", intakeId)
+        : admin.from("vehicles").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).not("source_intake_id", "is", null)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("work_orders").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("source_intake_id", intakeId)
+        : admin.from("work_orders").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).not("source_intake_id", "is", null)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("work_order_lines").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).eq("source_intake_id", intakeId)
+        : admin.from("work_order_lines").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).not("source_intake_id", "is", null)) as any,
+    ),
+    countExact(
+      (intakeScoped
+        ? admin.from("invoices").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).contains("metadata", { source_intake_id: intakeId })
+        : admin.from("invoices").select("id", { head: true, count: "exact" }).eq("shop_id", shopId).contains("metadata", { imported: true })) as any,
+    ),
+  ]);
+
+  const provenance: Record<Domain, number> = {
+    customer: 0,
+    vehicle: 0,
+    work_order: 0,
+    work_order_line: 0,
+    invoice: 0,
+  };
+
+  for (const domain of DOMAINS) {
+    const query = (admin as any)
+      .from("shop_boost_import_provenance")
+      .select("id", { head: true, count: "exact" })
+      .eq("shop_id", shopId)
+      .eq("domain", domain);
+    if (intakeScoped) query.eq("intake_id", intakeId);
+    provenance[domain] = await countExact(query as any);
+  }
+
+  return {
+    intakes,
+    reviewItems,
+    rowResults,
+    reviewAuditEvents,
+    integrityReports,
+    importFiles,
+    importRows,
+    staffInviteSuggestions,
+    staffInviteCandidates,
+    provenance,
+    legacyTagged: {
+      customers: legacyCustomers,
+      vehicles: legacyVehicles,
+      workOrders: legacyWorkOrders,
+      workOrderLines: legacyWorkOrderLines,
+      invoices: legacyInvoices,
+    },
+  };
+}
+
+async function loadProvenanceRecordIds(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  scope: ResetScope;
+  intakeId: string | null;
+  domain: Domain;
+}): Promise<string[]> {
+  const { admin, shopId, scope, intakeId, domain } = args;
+  const intakeScoped = scope === "intake" && intakeId;
+  const query = (admin as any)
+    .from("shop_boost_import_provenance")
+    .select("record_id")
+    .eq("shop_id", shopId)
+    .eq("domain", domain)
+    .limit(100000);
+  if (intakeScoped) query.eq("intake_id", intakeId);
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row: { record_id?: string | null }) => String(row.record_id ?? "")).filter(Boolean);
+}
+
+async function deleteByIds(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  table: "customers" | "vehicles" | "work_orders" | "work_order_lines" | "invoices";
+  shopId: string;
+  ids: string[];
+}): Promise<number> {
+  const { admin, table, shopId, ids } = args;
+  if (ids.length === 0) return 0;
+  const chunkSize = 500;
+  let deleted = 0;
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    const chunk = ids.slice(i, i + chunkSize);
+    const { error } = await admin.from(table).delete().eq("shop_id", shopId).in("id", chunk);
+    if (error) throw new Error(error.message);
+    deleted += chunk.length;
+  }
+  return deleted;
+}
+
+async function writeAudit(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  intakeId: string | null;
+  actorUserId: string;
+  scope: ResetScope;
+  mode: "preview" | "execute";
+  confirmationText: string;
+  previewCounts: ResetCounts;
+  deletedCounts: Record<string, number>;
+}): Promise<void> {
+  const { error } = await (args.admin as any).from("shop_boost_import_reset_audit_events").insert({
+    shop_id: args.shopId,
+    intake_id: args.intakeId,
+    actor_user_id: args.actorUserId,
+    scope: args.scope,
+    mode: args.mode,
+    confirmation_text: args.confirmationText,
+    preview_counts: args.previewCounts,
+    deleted_counts: args.deletedCounts,
+  });
+  if (error) throw new Error(error.message);
+}
+
+async function validateScope(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  scope: ResetScope;
+  intakeId: string | null;
+}): Promise<void> {
+  if (args.scope !== "intake" || !args.intakeId) return;
+  const { data, error } = await args.admin
+    .from("shop_boost_intakes")
+    .select("id")
+    .eq("shop_id", args.shopId)
+    .eq("id", args.intakeId)
+    .maybeSingle<{ id: string }>();
+  if (error) throw new Error(error.message);
+  if (!data?.id) throw new Error("Intake not found for this shop");
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const url = new URL(req.url);
+  const scope = parseScope(url.searchParams.get("scope"));
+  const intakeId = normalizeId(url.searchParams.get("intakeId"));
+  if (scope === "intake" && !intakeId) {
+    return NextResponse.json({ ok: false, error: "intakeId is required when scope=intake" }, { status: 400 });
+  }
+
+  try {
+    const admin = createAdminSupabase();
+    await validateScope({ admin, shopId: access.profile.shop_id as string, scope, intakeId });
+    const counts = await collectCounts({ admin, shopId: access.profile.shop_id as string, scope, intakeId });
+    return NextResponse.json({
+      ok: true,
+      scope,
+      shopId: access.profile.shop_id,
+      intakeId,
+      expectedConfirmationText: buildExpectedConfirmation(scope, access.profile.shop_id as string, intakeId),
+      counts,
+      safety: {
+        strongDeletionUsesProvenance: true,
+        legacyTaggingCanBeAmbiguous: true,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load reset preview";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const body = (await req.json().catch(() => ({}))) as {
+    scope?: ResetScope;
+    intakeId?: string | null;
+    dryRun?: boolean;
+    confirmationText?: string;
+  };
+
+  const scope = body.scope === "shop" ? "shop" : "intake";
+  const intakeId = normalizeId(body.intakeId ?? null);
+  const dryRun = body.dryRun !== false;
+  const shopId = access.profile.shop_id as string;
+
+  if (scope === "intake" && !intakeId) {
+    return NextResponse.json({ ok: false, error: "intakeId is required when scope=intake" }, { status: 400 });
+  }
+
+  const expectedConfirmationText = buildExpectedConfirmation(scope, shopId, intakeId);
+  if (String(body.confirmationText ?? "").trim() !== expectedConfirmationText) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Confirmation text mismatch",
+        expectedConfirmationText,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const admin = createAdminSupabase();
+    await validateScope({ admin, shopId, scope, intakeId });
+    const counts = await collectCounts({ admin, shopId, scope, intakeId });
+
+    if (dryRun) {
+      await writeAudit({
+        admin,
+        shopId,
+        intakeId,
+        actorUserId: access.profile.id,
+        scope,
+        mode: "preview",
+        confirmationText: expectedConfirmationText,
+        previewCounts: counts,
+        deletedCounts: {},
+      });
+      return NextResponse.json({ ok: true, dryRun: true, scope, shopId, intakeId, expectedConfirmationText, counts });
+    }
+
+    const customerIds = await loadProvenanceRecordIds({ admin, shopId, scope, intakeId, domain: "customer" });
+    const vehicleIds = await loadProvenanceRecordIds({ admin, shopId, scope, intakeId, domain: "vehicle" });
+    const workOrderIds = await loadProvenanceRecordIds({ admin, shopId, scope, intakeId, domain: "work_order" });
+    const workOrderLineIds = await loadProvenanceRecordIds({ admin, shopId, scope, intakeId, domain: "work_order_line" });
+    const invoiceIds = await loadProvenanceRecordIds({ admin, shopId, scope, intakeId, domain: "invoice" });
+
+    const deletedCounts: Record<string, number> = {
+      reviewItems: 0,
+      rowResults: 0,
+      reviewAuditEvents: 0,
+      integrityReports: 0,
+      importRows: 0,
+      importFiles: 0,
+      staffInviteSuggestions: 0,
+      staffInviteCandidates: 0,
+      provenanceRows: 0,
+      customers: 0,
+      vehicles: 0,
+      workOrders: 0,
+      workOrderLines: 0,
+      invoices: 0,
+      intakes: 0,
+    };
+
+    deletedCounts.invoices = await deleteByIds({ admin, table: "invoices", shopId, ids: invoiceIds });
+    deletedCounts.workOrderLines = await deleteByIds({ admin, table: "work_order_lines", shopId, ids: workOrderLineIds });
+    deletedCounts.workOrders = await deleteByIds({ admin, table: "work_orders", shopId, ids: workOrderIds });
+    deletedCounts.vehicles = await deleteByIds({ admin, table: "vehicles", shopId, ids: vehicleIds });
+    deletedCounts.customers = await deleteByIds({ admin, table: "customers", shopId, ids: customerIds });
+
+    {
+      const q = (admin as any).from("shop_boost_import_provenance").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.provenanceRows =
+        customerIds.length + vehicleIds.length + workOrderIds.length + workOrderLineIds.length + invoiceIds.length;
+    }
+
+    {
+      const q = admin.from("staff_invite_candidates").delete().eq("shop_id", shopId).eq("source", "shop_boost_import");
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.staffInviteCandidates = counts.staffInviteCandidates;
+    }
+    {
+      const q = admin.from("staff_invite_suggestions").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.staffInviteSuggestions = counts.staffInviteSuggestions;
+    }
+    {
+      const q = admin.from("shop_import_rows").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.importRows = counts.importRows;
+    }
+    {
+      const q = admin.from("shop_import_files").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.importFiles = counts.importFiles;
+    }
+    {
+      const q = (admin as any).from("shop_boost_review_audit_events").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.reviewAuditEvents = counts.reviewAuditEvents;
+    }
+    {
+      const q = (admin as any).from("shop_boost_integrity_reports").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.integrityReports = counts.integrityReports;
+    }
+    {
+      const q = admin.from("shop_boost_row_results").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.rowResults = counts.rowResults;
+    }
+    {
+      const q = admin.from("shop_boost_review_items").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("intake_id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.reviewItems = counts.reviewItems;
+    }
+    {
+      const q = admin.from("shop_boost_intakes").delete().eq("shop_id", shopId);
+      if (scope === "intake" && intakeId) q.eq("id", intakeId);
+      const { error } = await q;
+      if (error) throw new Error(error.message);
+      deletedCounts.intakes = counts.intakes;
+    }
+
+    await writeAudit({
+      admin,
+      shopId,
+      intakeId,
+      actorUserId: access.profile.id,
+      scope,
+      mode: "execute",
+      confirmationText: expectedConfirmationText,
+      previewCounts: counts,
+      deletedCounts,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      dryRun: false,
+      scope,
+      shopId,
+      intakeId,
+      expectedConfirmationText,
+      previewCounts: counts,
+      deletedCounts,
+      notes: {
+        deletedUsingStrongProvenance: counts.provenance,
+        legacyTaggedNotDeleted: counts.legacyTagged,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Import reset failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/db/sql/2026-04-25_shop_boost_import_reset_safety.sql
+++ b/db/sql/2026-04-25_shop_boost_import_reset_safety.sql
@@ -1,0 +1,75 @@
+-- Safe Shop Boost reset support:
+-- 1) Provenance rows for import-created records (future-safe deletion)
+-- 2) Audit events for preview/execute reset actions
+
+create table if not exists public.shop_boost_import_provenance (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  intake_id uuid not null references public.shop_boost_intakes(id) on delete cascade,
+  domain text not null check (domain in ('customer', 'vehicle', 'work_order', 'work_order_line', 'invoice')),
+  record_id uuid not null,
+  created_at timestamptz not null default now(),
+  unique (shop_id, intake_id, domain, record_id)
+);
+
+create index if not exists idx_shop_boost_import_provenance_scope
+  on public.shop_boost_import_provenance(shop_id, intake_id, domain, created_at desc);
+
+create table if not exists public.shop_boost_import_reset_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  intake_id uuid references public.shop_boost_intakes(id) on delete set null,
+  actor_user_id uuid not null references public.profiles(id) on delete restrict,
+  scope text not null check (scope in ('intake', 'shop')),
+  mode text not null check (mode in ('preview', 'execute')),
+  confirmation_text text not null,
+  preview_counts jsonb not null default '{}'::jsonb,
+  deleted_counts jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_shop_boost_import_reset_audit_scope
+  on public.shop_boost_import_reset_audit_events(shop_id, intake_id, created_at desc);
+
+alter table public.shop_boost_import_provenance enable row level security;
+alter table public.shop_boost_import_reset_audit_events enable row level security;
+
+drop policy if exists "service-role-manage-shop-boost-import-provenance" on public.shop_boost_import_provenance;
+create policy "service-role-manage-shop-boost-import-provenance"
+  on public.shop_boost_import_provenance
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "shop-users-read-shop-boost-import-provenance" on public.shop_boost_import_provenance;
+create policy "shop-users-read-shop-boost-import-provenance"
+  on public.shop_boost_import_provenance
+  for select
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = shop_boost_import_provenance.shop_id
+    )
+  );
+
+drop policy if exists "service-role-manage-shop-boost-import-reset-audit-events" on public.shop_boost_import_reset_audit_events;
+create policy "service-role-manage-shop-boost-import-reset-audit-events"
+  on public.shop_boost_import_reset_audit_events
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "shop-users-read-shop-boost-import-reset-audit-events" on public.shop_boost_import_reset_audit_events;
+create policy "shop-users-read-shop-boost-import-reset-audit-events"
+  on public.shop_boost_import_reset_audit_events
+  for select
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = shop_boost_import_reset_audit_events.shop_id
+    )
+  );

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -170,6 +170,32 @@ type CacheVehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "v
 type CacheProfileRow = Pick<DB["public"]["Tables"]["profiles"]["Row"], "id" | "email" | "full_name">;
 type KeyFixRow = Pick<DB["public"]["Tables"]["shop_boost_review_items"]["Row"], "domain" | "issue_type" | "status" | "resolution_action">;
 type MaterializeDomain = NonNullable<RunArgs["options"]>["materializeDomain"];
+type ProvenanceDomain = "customer" | "vehicle" | "work_order" | "work_order_line" | "invoice";
+
+async function recordImportCreatedArtifact(args: {
+  supabase: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  intakeId: string;
+  domain: ProvenanceDomain;
+  recordId: string | null | undefined;
+}): Promise<void> {
+  if (!args.recordId) return;
+  const { error } = await (args.supabase as any).from("shop_boost_import_provenance").insert({
+    shop_id: args.shopId,
+    intake_id: args.intakeId,
+    domain: args.domain,
+    record_id: args.recordId,
+  });
+  if (error) {
+    console.warn("[shop-boost] failed to record import provenance", {
+      shopId: args.shopId,
+      intakeId: args.intakeId,
+      domain: args.domain,
+      recordId: args.recordId,
+      error: error.message,
+    });
+  }
+}
 
 function domainSourceFile(domain: MaterializeDomain): string | null {
   if (domain === "customers") return "customers";
@@ -1466,6 +1492,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           if (phone) customersByPhone.set(phone, id);
           if (sourceCustomerLookupKey) customersBySourceId.set(sourceCustomerLookupKey, id);
           if (normalizedName) addUniqueMatch(uniqueCustomersByName, conflictingCustomerNames, normalizedName, id);
+          await recordImportCreatedArtifact({
+            supabase,
+            shopId,
+            intakeId,
+            domain: "customer",
+            recordId: id,
+          });
         }
         rowOutcome.processedRows += 1;
         rowOutcome.successCount += 1;
@@ -1781,6 +1814,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           if (plate) vehiclesByPlate.set(plate, id);
           if (unit) vehiclesByUnit.set(lower(unit), id);
           if (sourceVehicleKey) vehiclesBySourceId.set(sourceVehicleKey, id);
+          await recordImportCreatedArtifact({
+            supabase,
+            shopId,
+            intakeId,
+            domain: "vehicle",
+            recordId: id,
+          });
           addUniqueMatch(
             uniqueVehiclesByCustomerUnit,
             conflictingVehiclesByCustomerUnit,
@@ -2220,6 +2260,15 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
 
       const workOrderId = (woInserted ?? [])[0]?.id as string | undefined;
       if (!workOrderId) continue;
+      if (!woByExternal?.id) {
+        await recordImportCreatedArtifact({
+          supabase,
+          shopId,
+          intakeId,
+          domain: "work_order",
+          recordId: workOrderId,
+        });
+      }
       if (sourceWorkOrderKey) workOrdersBySourceId.set(sourceWorkOrderKey, workOrderId);
 
       if (!vehicle_id) {
@@ -3083,6 +3132,13 @@ async function upsertHistoryLine(args: {
   }
 
   await supabase.from("work_order_lines").insert(payload);
+  await recordImportCreatedArtifact({
+    supabase,
+    shopId,
+    intakeId,
+    domain: "work_order_line",
+    recordId: payload.id,
+  });
 }
 
 async function upsertInvoiceIfNeeded(args: {
@@ -3151,9 +3207,22 @@ async function upsertInvoiceIfNeeded(args: {
     return;
   }
 
-  await supabase.from("invoices").insert({
-    shop_id: shopId,
-    work_order_id: workOrderId,
-    ...payload,
-  } as DB["public"]["Tables"]["invoices"]["Insert"]);
+  const inserted = await supabase
+    .from("invoices")
+    .insert({
+      shop_id: shopId,
+      work_order_id: workOrderId,
+      ...payload,
+    } as DB["public"]["Tables"]["invoices"]["Insert"])
+    .select("id")
+    .limit(1)
+    .maybeSingle<{ id: string }>();
+
+  await recordImportCreatedArtifact({
+    supabase,
+    shopId,
+    intakeId,
+    domain: "invoice",
+    recordId: inserted.data?.id ?? null,
+  });
 }


### PR DESCRIPTION
### Motivation
- Provide a safe, auditable tool to reset Shop Boost test imports so onboarding can be re-run without risking core shop/billing/user data.
- Existing markers like `source_intake_id` and invoice metadata are ambiguous for destructive deletes because imports also update existing rows. 
- Tooling must be owner/admin-only, shop-scoped (intake-scoped when possible), preview counts before delete, require explicit confirmation text, and be auditable.

### Description
- Added a SQL migration `db/sql/2026-04-25_shop_boost_import_reset_safety.sql` that creates `shop_boost_import_provenance` (strong provenance for import-created records) and `shop_boost_import_reset_audit_events` (preview/execute audit), plus indexes and RLS policies. 
- Implemented a new owner/admin-only API at `GET/POST /api/shop-boost/import-reset` (`app/api/shop-boost/import-reset/route.ts`) which returns dry-run preview counts, requires exact confirmation text to execute, supports `scope=intake|shop`, and only deletes import artifacts and provenance-backed records. 
- Updated the importer `features/integrations/imports/runFullImport.ts` to record provenance rows only when a record is newly created (not when existing records are updated) for `customers`, `vehicles`, `work_orders`, `work_order_lines`, and `invoices`. 
- Deletion flow is provenance-driven and also removes staging/review artifacts (`shop_import_files`, `shop_import_rows`, `shop_boost_review_items`, `shop_boost_row_results`, `shop_boost_integrity_reports`, `staff_invite_suggestions`, `staff_invite_candidates` with `source='shop_boost_import'`, and `shop_boost_intakes` when intake-scoped) while leaving shop row, profiles/users/auth, billing/stripe, and core settings intact. 

### Testing
- Ran TypeScript build check with `npx tsc --noEmit` and it passed. 
- No additional automated tests were introduced; manual/QA steps recommended before running execute-mode deletes on production data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eceb64eb608328afcb8c56e1c9b623)