### PR TITLE
Fix Shop Boost 500s: use started_at for onboarding attempts and add diagnostics

### DIFF
--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -5,7 +5,7 @@ import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { toIntakeProgress } from "@/features/integrations/shopBoost/status";
 import {
-  getLatestRunAttemptSummary,
+  getLatestRunAttemptSummaryWithDiagnostics,
   getRunByShopIntake,
   getRunJobs,
   summarizeRunJobs,
@@ -60,6 +60,7 @@ export async function GET() {
   const basicsOrchestrator = asRecord(basics.orchestrator);
 
   let orchestrator: Record<string, unknown> | null = null;
+  const diagnostics: Array<{ scope: string; code: string; message: string; hint?: string }> = [];
 
   try {
     const run = await getRunByShopIntake({
@@ -82,7 +83,15 @@ export async function GET() {
       const uiShouldRouteForward = verifyPassed && activationEligible;
       const jobSummary = await summarizeRunJobs(run.id);
       const jobSummaryDetailed = await summarizeRunJobsDetailed(run.id);
-      const lastAttempt = await getLatestRunAttemptSummary(run.id);
+      const { summary: lastAttempt, diagnostics: attemptDiagnostics } = await getLatestRunAttemptSummaryWithDiagnostics(run.id);
+      if (attemptDiagnostics) {
+        diagnostics.push({
+          scope: "orchestrator.lastAttempt",
+          code: attemptDiagnostics.code,
+          message: attemptDiagnostics.message,
+          hint: attemptDiagnostics.hint,
+        });
+      }
       orchestrator = {
         runId: run.id,
         runState: run.state,
@@ -170,6 +179,7 @@ export async function GET() {
 
   return NextResponse.json({
     ok: true,
+    diagnostics,
     intake: {
       id: intake.id,
       status: intake.status,

--- a/features/integrations/shopBoost/orchestrator/index.ts
+++ b/features/integrations/shopBoost/orchestrator/index.ts
@@ -55,7 +55,7 @@ type OnboardingAttemptRow = {
   status: string;
   error_code: string | null;
   error_message: string | null;
-  created_at: string;
+  started_at: string;
   completed_at: string | null;
 };
 
@@ -114,6 +114,12 @@ export type RunAttemptSummary = {
   errorMessage: string | null;
   createdAt: string;
   completedAt: string | null;
+};
+
+export type RunAttemptSummaryDiagnostics = {
+  code: "RUN_ATTEMPT_SUMMARY_QUERY_FAILED";
+  message: string;
+  hint?: string;
 };
 
 export type ClaimableJobType = "profile" | "materialize" | "verify" | "activate";
@@ -745,12 +751,19 @@ export async function summarizeRunJobsDetailed(runId: string): Promise<{
 }
 
 export async function getLatestRunAttemptSummary(runId: string): Promise<RunAttemptSummary | null> {
+  const { summary } = await getLatestRunAttemptSummaryWithDiagnostics(runId);
+  return summary;
+}
+
+export async function getLatestRunAttemptSummaryWithDiagnostics(
+  runId: string,
+): Promise<{ summary: RunAttemptSummary | null; diagnostics: RunAttemptSummaryDiagnostics | null }> {
   const supabase = adminAny();
   const { data, error } = await supabase
     .from("shop_onboarding_attempts")
-    .select("id,job_id,status,error_code,error_message,created_at,completed_at")
+    .select("id,job_id,status,error_code,error_message,started_at,completed_at")
     .eq("run_id", runId)
-    .order("created_at", { ascending: false })
+    .order("started_at", { ascending: false })
     .limit(1)
     .maybeSingle();
 
@@ -759,11 +772,21 @@ export async function getLatestRunAttemptSummary(runId: string): Promise<RunAtte
       runId,
       error: error.message,
     });
-    return null;
+    return {
+      summary: null,
+      diagnostics: {
+        code: "RUN_ATTEMPT_SUMMARY_QUERY_FAILED",
+        message: error.message,
+        hint:
+          error.message.includes("shop_onboarding_attempts.created_at")
+            ? "shop_onboarding_attempts uses started_at (not created_at) for attempt timestamps."
+            : undefined,
+      },
+    };
   }
 
   const attempt = (data as OnboardingAttemptRow | null) ?? null;
-  if (!attempt?.id) return null;
+  if (!attempt?.id) return { summary: null, diagnostics: null };
 
   const { data: job } = await supabase
     .from("shop_onboarding_jobs")
@@ -772,15 +795,18 @@ export async function getLatestRunAttemptSummary(runId: string): Promise<RunAtte
     .maybeSingle<{ job_type: string | null; domain: string | null }>();
 
   return {
-    attemptId: attempt.id,
-    jobId: attempt.job_id,
-    jobType: job?.job_type ?? null,
-    domain: job?.domain ?? null,
-    status: attempt.status,
-    errorCode: attempt.error_code,
-    errorMessage: attempt.error_message,
-    createdAt: attempt.created_at,
-    completedAt: attempt.completed_at,
+    summary: {
+      attemptId: attempt.id,
+      jobId: attempt.job_id,
+      jobType: job?.job_type ?? null,
+      domain: job?.domain ?? null,
+      status: attempt.status,
+      errorCode: attempt.error_code,
+      errorMessage: attempt.error_message,
+      createdAt: attempt.started_at,
+      completedAt: attempt.completed_at,
+    },
+    diagnostics: null,
   };
 }
 


### PR DESCRIPTION
### Motivation
- Production 500s were caused by a query that referenced `shop_onboarding_attempts.created_at`, which does not exist in the schema (attempts use `started_at`).
- The goal is to fix the codepath used by `GET /api/shop-boost/intakes/latest` (and related orchestrator helpers) so the UI does not hard-fail when a single summary subquery fails.
- Changes must be minimal, additive, and non-breaking to avoid any DB migrations or tenant changes.

### Description
- Updated the orchestrator attempt model and query to use `started_at` instead of `created_at`, and mapped the outward `createdAt` field from `started_at` in responses; added `getLatestRunAttemptSummaryWithDiagnostics` which returns structured diagnostics on query failure, while keeping `getLatestRunAttemptSummary` for compatibility. (changed `features/integrations/shopBoost/orchestrator/index.ts`)
- Updated `GET /api/shop-boost/intakes/latest` to call the diagnostics-capable helper, collect any diagnostics, and return them in the endpoint payload so the intake UI can degrade gracefully. (changed `app/api/shop-boost/intakes/latest/route.ts`)
- No schema or migration changes were added, and existing call sites remain functional because the original helper is preserved and delegates to the new helper.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` which completed successfully.
- Ran linting on touched files with `npx eslint app/api/shop-boost/intakes/latest/route.ts features/integrations/shopBoost/orchestrator/index.ts`, which produced no errors (only pre-existing `no-explicit-any` warnings in the orchestrator file).
- Verified the change is a code-only fix and no SQL migration or manual prod SQL run is required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed510c25f083288b9d23ce7478dbb8)