### PR TITLE
Fix Shop Boost 500s from onboarding attempt timestamp mismatch

### DIFF
--- a/app/api/shop-boost/import-reset/route.ts
+++ b/app/api/shop-boost/import-reset/route.ts
@@ -288,20 +288,58 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   try {
     const admin = createAdminSupabase();
-    await validateScope({ admin, shopId: access.profile.shop_id as string, scope, intakeId });
-    const counts = await collectCounts({ admin, shopId: access.profile.shop_id as string, scope, intakeId });
-    return NextResponse.json({
-      ok: true,
-      scope,
-      shopId: access.profile.shop_id,
-      intakeId,
-      expectedConfirmationText: buildExpectedConfirmation(scope, access.profile.shop_id as string, intakeId),
-      counts,
-      safety: {
-        strongDeletionUsesProvenance: true,
-        legacyTaggingCanBeAmbiguous: true,
-      },
-    });
+    const shopId = access.profile.shop_id as string;
+    const expectedConfirmationText = buildExpectedConfirmation(scope, shopId, intakeId);
+    await validateScope({ admin, shopId, scope, intakeId });
+
+    try {
+      const counts = await collectCounts({ admin, shopId, scope, intakeId });
+      return NextResponse.json({
+        ok: true,
+        scope,
+        shopId,
+        intakeId,
+        expectedConfirmationText,
+        counts,
+        safety: {
+          strongDeletionUsesProvenance: true,
+          legacyTaggingCanBeAmbiguous: true,
+        },
+        diagnostics: {
+          degraded: false,
+          errors: [],
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to load reset preview";
+      console.error("[shop-boost/import-reset] preview collection failed", {
+        shopId,
+        scope,
+        intakeId,
+        error: message,
+      });
+      return NextResponse.json({
+        ok: true,
+        scope,
+        shopId,
+        intakeId,
+        expectedConfirmationText,
+        counts: null,
+        safety: {
+          strongDeletionUsesProvenance: true,
+          legacyTaggingCanBeAmbiguous: true,
+        },
+        diagnostics: {
+          degraded: true,
+          errors: [
+            {
+              source: "collectCounts",
+              message,
+            },
+          ],
+        },
+      });
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to load reset preview";
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -13,6 +13,28 @@ import {
 } from "@/features/integrations/shopBoost/orchestrator";
 
 type DB = Database;
+
+
+type OrchestratorDiagnostic = {
+  source: string;
+  message: string;
+};
+
+async function safeOrchestratorQuery<T>(
+  source: string,
+  diagnostics: OrchestratorDiagnostic[],
+  fn: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    diagnostics.push({ source, message });
+    console.error(`[shop-boost/orchestrator] ${source} failed`, { error: message });
+    return fallback;
+  }
+}
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
@@ -37,19 +59,20 @@ export async function GET() {
   if (!profile?.shop_id) {
     return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
   }
+  const shopId = profile.shop_id as string;
 
   const admin = createAdminSupabase();
   const { data: intake, error } = await admin
     .from("shop_boost_intakes")
     .select("id,shop_id,status,processed_at,created_at,intake_basics")
-    .eq("shop_id", profile.shop_id)
+    .eq("shop_id", shopId)
     .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle();
 
   if (error) {
     console.error("[shop-boost][intakes/latest] failed to load latest intake", {
-      shopId: profile.shop_id,
+      shopId,
       error: error.message,
     });
     return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
@@ -60,15 +83,22 @@ export async function GET() {
   const basicsOrchestrator = asRecord(basics.orchestrator);
 
   let orchestrator: Record<string, unknown> | null = null;
+  const orchestratorDiagnostics: OrchestratorDiagnostic[] = [];
 
   try {
-    const run = await getRunByShopIntake({
-      shopId: profile.shop_id,
-      intakeId: intake.id,
-    });
+    const run = await safeOrchestratorQuery(
+      "getRunByShopIntake",
+      orchestratorDiagnostics,
+      () =>
+        getRunByShopIntake({
+          shopId,
+          intakeId: intake.id,
+        }),
+      null,
+    );
 
     if (run?.id) {
-      const jobs = await getRunJobs(run.id);
+      const jobs = await safeOrchestratorQuery("getRunJobs", orchestratorDiagnostics, () => getRunJobs(run.id), []);
       const verifyJob = jobs.find((job) => job.job_type === "verify" && String(job.domain ?? "global") === "global");
       const activateJob = jobs.find((job) => job.job_type === "activate" && String(job.domain ?? "global") === "global");
       const verifyResult = asRecord(verifyJob?.result);
@@ -80,9 +110,28 @@ export async function GET() {
       const activationEligible = run.activation_status === "eligible" || run.activation_status === "activated";
       const activated = run.activation_status === "activated";
       const uiShouldRouteForward = verifyPassed && activationEligible;
-      const jobSummary = await summarizeRunJobs(run.id);
-      const jobSummaryDetailed = await summarizeRunJobsDetailed(run.id);
-      const lastAttempt = await getLatestRunAttemptSummary(run.id);
+      const jobSummary = await safeOrchestratorQuery("summarizeRunJobs", orchestratorDiagnostics, () => summarizeRunJobs(run.id), null);
+      const jobSummaryDetailed = await safeOrchestratorQuery(
+        "summarizeRunJobsDetailed",
+        orchestratorDiagnostics,
+        () => summarizeRunJobsDetailed(run.id),
+        {
+          byStatus: {},
+          byDomainStatus: {},
+          domains: {
+            blocked: [],
+            failed: [],
+            pending: [],
+            succeeded: [],
+          },
+        },
+      );
+      const lastAttempt = await safeOrchestratorQuery(
+        "getLatestRunAttemptSummary",
+        orchestratorDiagnostics,
+        () => getLatestRunAttemptSummary(run.id),
+        null,
+      );
       orchestrator = {
         runId: run.id,
         runState: run.state,
@@ -136,7 +185,7 @@ export async function GET() {
     }
   } catch (orchestratorErr) {
     console.error("[shop-boost/orchestrator] latest status enrichment failed", {
-      shopId: profile.shop_id,
+      shopId,
       intakeId: intake.id,
       error: orchestratorErr instanceof Error ? orchestratorErr.message : String(orchestratorErr),
     });
@@ -170,6 +219,9 @@ export async function GET() {
 
   return NextResponse.json({
     ok: true,
+    diagnostics: {
+      orchestrator: orchestratorDiagnostics,
+    },
     intake: {
       id: intake.id,
       status: intake.status,

--- a/features/integrations/shopBoost/orchestrator/index.ts
+++ b/features/integrations/shopBoost/orchestrator/index.ts
@@ -55,7 +55,7 @@ type OnboardingAttemptRow = {
   status: string;
   error_code: string | null;
   error_message: string | null;
-  created_at: string;
+  started_at: string;
   completed_at: string | null;
 };
 
@@ -748,9 +748,9 @@ export async function getLatestRunAttemptSummary(runId: string): Promise<RunAtte
   const supabase = adminAny();
   const { data, error } = await supabase
     .from("shop_onboarding_attempts")
-    .select("id,job_id,status,error_code,error_message,created_at,completed_at")
+    .select("id,job_id,status,error_code,error_message,started_at,completed_at")
     .eq("run_id", runId)
-    .order("created_at", { ascending: false })
+    .order("started_at", { ascending: false, nullsFirst: false })
     .limit(1)
     .maybeSingle();
 
@@ -779,7 +779,7 @@ export async function getLatestRunAttemptSummary(runId: string): Promise<RunAtte
     status: attempt.status,
     errorCode: attempt.error_code,
     errorMessage: attempt.error_message,
-    createdAt: attempt.created_at,
+    createdAt: attempt.started_at,
     completedAt: attempt.completed_at,
   };
 }


### PR DESCRIPTION
### Motivation
- Production API 500s were caused by a schema mismatch: code queried `shop_onboarding_attempts.created_at` but the production table has no `created_at` column. This needed a minimal, non-breaking fix to match production while making the UI endpoints more resilient.
- Keep behavior additive and minimal: preserve `completed_at` for completion semantics and avoid any DB migrations.

### Description
- Root cause: `getLatestRunAttemptSummary` selected and ordered by `shop_onboarding_attempts.created_at` which does not exist in production; the code now uses `started_at` for attempt start ordering and still uses `completed_at` for completion semantics.
- Files changed: `features/integrations/shopBoost/orchestrator/index.ts`, `app/api/shop-boost/intakes/latest/route.ts`, `app/api/shop-boost/import-reset/route.ts`.
- Exact created_at fixes applied: updated `OnboardingAttemptRow` type `created_at` -> `started_at`; updated the `select` to request `started_at` instead of `created_at`; changed `.order("created_at", ...)` -> `.order("started_at", { ascending: false, nullsFirst: false })`; mapped returned `createdAt: attempt.created_at` -> `createdAt: attempt.started_at`.
- Resilience improvements: added `safeOrchestratorQuery(...)` wrapper in `intakes/latest` to isolate orchestrator sub-queries and collect structured diagnostics so a single failing subquery no longer hard-500s the route; responses now include `diagnostics.orchestrator`.
- Import-reset preview resilience: `GET /api/shop-boost/import-reset` now wraps `collectCounts` in a try/catch and returns `ok: true` with `counts: null` plus structured `diagnostics` when collection fails, avoiding avoidable 500s while preserving strong validation for scope errors.
- Import-reset causality: `/api/shop-boost/import-reset` did not call `getLatestRunAttemptSummary` nor query `shop_onboarding_attempts`, so its 500s were not directly caused by the `created_at` orchestrator bug; the change ensures the preview panel degrades gracefully if unrelated collection errors occur.
- No DB migration or manual SQL required; change aligns queries to the existing production schema.

### Testing
- Ran TypeScript compile check: `npx tsc --noEmit` — succeeded.
- Ran ESLint on touched files: `npx eslint app/api/shop-boost/intakes/latest/route.ts app/api/shop-boost/import-reset/route.ts features/integrations/shopBoost/orchestrator/index.ts` — warnings only, no errors.
- Confirmed repository changes committed and include: the orchestrator timestamp fix and the two endpoint resilience changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed518b283c8328bdcd10ba657c0dea)