### PR TITLE
Use canonical shops.labor_rate for approval labor totals

### DIFF
--- a/app/work-orders/[id]/approve/page.tsx
+++ b/app/work-orders/[id]/approve/page.tsx
@@ -109,7 +109,8 @@ export default function ApproveWorkOrderPage() {
       return next;
     });
 
-  const hourlyRate = getNum(wo, "hourly_rate") ?? getNum(shop, "hourly_rate") ?? 120;
+  // Canonical labor pricing source is shops.labor_rate (owner/shop settings).
+  const hourlyRate = getNum(shop, "labor_rate") ?? 120;
   const currencyCode = (getStr(shop, "currency") ?? "USD").toUpperCase();
   const fmt = useMemo(
     () =>


### PR DESCRIPTION
### Motivation
- Ensure approval review totals use the owner/shop-configured labor rate (the canonical `shops.labor_rate`) so create → save → approval totals remain consistent and avoid stale/legacy `hourly_rate` lookups.

### Description
- Switch the approval page to source labor pricing from `shops.labor_rate` with the existing fallback (`120`) and keep all other behavior unchanged (file changed: `app/work-orders/[id]/approve/page.tsx`).

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5bec683483288a8d3f45d62e30ca)