### PR TITLE
Fix work-order line pricing display consistency and approval fallback

### DIFF
--- a/app/api/quotes/approval-webhook/route.ts
+++ b/app/api/quotes/approval-webhook/route.ts
@@ -63,24 +63,10 @@ export async function POST(req: Request) {
     );
   }
 
-  const { data: customer, error: customerErr } = await supabase
-    .from("customers")
-    .select("id")
-    .eq("user_id", user.id)
-    .maybeSingle<{ id: string }>();
-
-  if (customerErr || !customer?.id) {
-    return NextResponse.json(
-      { error: "Customer account not found for this user" } satisfies Json,
-      { status: 404 },
-    );
-  }
-
-  const { data: workOrder, error: woErr } = await supabase
+  const { data: rawWorkOrder, error: woErr } = await supabase
     .from("work_orders")
     .select("id, shop_id, customer_id, approval_state, status, customer_approval_at, customer_approved_by")
     .eq("id", workOrderId)
-    .eq("customer_id", customer.id)
     .maybeSingle<{
       id: string;
       shop_id: string | null;
@@ -91,7 +77,42 @@ export async function POST(req: Request) {
       customer_approved_by: string | null;
     }>();
 
-  if (woErr || !workOrder) {
+  if (woErr || !rawWorkOrder) {
+    return NextResponse.json({ error: "Work order not found" } satisfies Json, { status: 404 });
+  }
+
+  const { data: customer, error: customerErr } = await supabase
+    .from("customers")
+    .select("id, shop_id")
+    .eq("user_id", user.id)
+    .maybeSingle<{ id: string; shop_id: string | null }>();
+
+  const workOrder = rawWorkOrder;
+
+  let requesterIsShopStaff = false;
+  if (!customer?.id) {
+    const { data: requesterProfile, error: requesterProfileErr } = await supabase
+      .from("profiles")
+      .select("shop_id, role")
+      .eq("user_id", user.id)
+      .maybeSingle<{ shop_id: string | null; role: string | null }>();
+
+    if (!requesterProfileErr && requesterProfile?.shop_id && workOrder.shop_id) {
+      const role = (requesterProfile.role ?? "").toLowerCase();
+      const canActForShop =
+        role === "owner" || role === "admin" || role === "manager" || role === "advisor";
+      requesterIsShopStaff = canActForShop && requesterProfile.shop_id === workOrder.shop_id;
+    }
+  }
+
+  if (customerErr || (!customer?.id && !requesterIsShopStaff)) {
+    return NextResponse.json(
+      { error: "Customer account not found for this user" } satisfies Json,
+      { status: 404 },
+    );
+  }
+
+  if (customer?.id && workOrder.customer_id !== customer.id) {
     return NextResponse.json(
       { error: "Work order not found for this customer" } satisfies Json,
       { status: 404 },
@@ -158,7 +179,7 @@ export async function POST(req: Request) {
         ? "queued"
         : (workOrder.status ?? "queued");
 
-    const { error: woUpdateErr } = await supabase
+    let woUpdateQuery = supabase
       .from("work_orders")
       .update({
         customer_approval_at: approvedAt,
@@ -169,8 +190,13 @@ export async function POST(req: Request) {
         approval_state: "approved",
         status: nextStatus,
       })
-      .eq("id", workOrderId)
-      .eq("customer_id", customer.id);
+      .eq("id", workOrderId);
+
+    if (customer?.id) {
+      woUpdateQuery = woUpdateQuery.eq("customer_id", customer.id);
+    }
+
+    const { error: woUpdateErr } = await woUpdateQuery;
 
     if (woUpdateErr) throw new Error(woUpdateErr.message);
 

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -48,6 +48,7 @@ type WorkOrderQuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"
 type WorkOrderQuoteLineWithLineId = WorkOrderQuoteLine & {
   work_order_line_id?: string | null;
 };
+type WorkOrderShopRateRow = Pick<DB["public"]["Tables"]["shops"]["Row"], "labor_rate">;
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
 type Profile = DB["public"]["Tables"]["profiles"]["Row"];
@@ -190,6 +191,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   );
   const [vehicle, setVehicle] = useTabState<Vehicle | null>("wo:id:veh", null);
   const [customer, setCustomer] = useTabState<Customer | null>("wo:id:cust", null);
+  const [shopLaborRate, setShopLaborRate] = useState<number | null>(null);
 
   const [allocsByLine, setAllocsByLine] = useState<Record<string, AllocationRow[]>>({});
   const [stagedPartsByLine, setStagedPartsByLine] = useState<Record<string, WorkOrderPartRow[]>>({});
@@ -470,6 +472,7 @@ export default function WorkOrderIdClient(): JSX.Element {
             setQuoteLines([]);
             setVehicle(null);
             setCustomer(null);
+            setShopLaborRate(null);
             setAllocsByLine({});
             setStagedPartsByLine({});
             setLineTechsByLine({});
@@ -498,7 +501,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           setWarnedMissing(true);
         }
 
-        const [linesRes, quoteRes, vehRes, custRes] = await Promise.all([
+        const [linesRes, quoteRes, vehRes, custRes, shopRes] = await Promise.all([
           supabase
             .from("work_order_lines")
             .select("*")
@@ -523,6 +526,13 @@ export default function WorkOrderIdClient(): JSX.Element {
                 .eq("id", woRow.customer_id)
                 .maybeSingle()
             : Promise.resolve({ data: null, error: null } as const),
+          woRow.shop_id
+            ? supabase
+                .from("shops")
+                .select("labor_rate")
+                .eq("id", woRow.shop_id)
+                .maybeSingle<WorkOrderShopRateRow>()
+            : Promise.resolve({ data: null, error: null } as const),
         ]);
 
         if (linesRes.error) throw linesRes.error;
@@ -538,6 +548,13 @@ export default function WorkOrderIdClient(): JSX.Element {
 
         if (custRes?.error) throw custRes.error;
         setCustomer((custRes?.data as Customer | null) ?? null);
+
+        if (shopRes?.error) throw shopRes.error;
+        setShopLaborRate(
+          typeof shopRes?.data?.labor_rate === "number" && Number.isFinite(shopRes.data.labor_rate)
+            ? shopRes.data.labor_rate
+            : null,
+        );
 
         // allocations + line techs
         if (lineRows.length) {
@@ -623,6 +640,7 @@ export default function WorkOrderIdClient(): JSX.Element {
       setQuoteLines,
       setVehicle,
       setCustomer,
+      setShopLaborRate,
       fetchLatestReview,
       loadedOnce,
       setReviewChecked,
@@ -802,6 +820,57 @@ export default function WorkOrderIdClient(): JSX.Element {
 
     return m;
   }, [quoteLines]);
+
+  const pricingByLine = useMemo(() => {
+    const toNum = (value: unknown): number | null => {
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+      if (typeof value === "string") {
+        const n = Number(value);
+        if (Number.isFinite(n)) return n;
+      }
+      return null;
+    };
+
+    const byLine: Record<string, { laborTotal: number; partsTotal: number; lineTotal: number }> = {};
+    for (const line of lines) {
+      const quoteCandidates = activeQuotesByLine[line.id] ?? [];
+      const quote = quoteCandidates[quoteCandidates.length - 1];
+
+      const lineHours = toNum(line.labor_time) ?? 0;
+      const quotedHours = toNum(quote?.est_labor_hours) ?? toNum(quote?.labor_hours);
+      const effectiveHours = quotedHours ?? lineHours;
+
+      const quotedLaborTotal = toNum(quote?.labor_total);
+      const laborTotal = quotedLaborTotal ?? effectiveHours * (shopLaborRate ?? 0);
+
+      const stagedPartsTotal = (stagedPartsByLine[line.id] ?? []).reduce((sum, part) => {
+        const total = toNum(part.total_price);
+        if (total != null) return sum + total;
+        return sum + (toNum(part.quantity) ?? 0) * (toNum(part.unit_price) ?? 0);
+      }, 0);
+
+      const allocPartsTotal = (allocsByLine[line.id] ?? []).reduce((sum, part) => {
+        const allocPart = part as AllocationRow & {
+          total_price?: number | null;
+          quantity?: number | null;
+          unit_price?: number | null;
+        };
+        const total = toNum(allocPart.total_price);
+        if (total != null) return sum + total;
+        return (
+          sum +
+          (toNum(allocPart.quantity) ?? 0) *
+            ((toNum(allocPart.unit_price) ?? toNum(part.unit_cost)) ?? 0)
+        );
+      }, 0);
+
+      const partsTotal = toNum(quote?.parts_total) ?? stagedPartsTotal + allocPartsTotal;
+      const lineTotal = toNum(quote?.grand_total) ?? toNum(quote?.subtotal) ?? laborTotal + partsTotal;
+
+      byLine[line.id] = { laborTotal, partsTotal, lineTotal };
+    }
+    return byLine;
+  }, [activeQuotesByLine, allocsByLine, lines, shopLaborRate, stagedPartsByLine]);
 
   const isPendingApprovalLine = (l: WorkOrderLine) => {
     const a = (l.approval_state ?? "").toLowerCase();
@@ -1811,6 +1880,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                             : undefined
                         }
                         onAddPart={() => setPartsLineId(ln.id)}
+                        pricing={pricingByLine[ln.id] ?? null}
                         reviewOk={reviewOk}
                         reviewIssues={reviewIssuesByLine[ln.id] ?? []}
                         canDelete={canDeleteLine}

--- a/app/work-orders/[id]/approve/page.tsx
+++ b/app/work-orders/[id]/approve/page.tsx
@@ -110,7 +110,7 @@ export default function ApproveWorkOrderPage() {
     });
 
   // Canonical labor pricing source is shops.labor_rate (owner/shop settings).
-  const hourlyRate = getNum(shop, "labor_rate") ?? 120;
+  const hourlyRate = getNum(shop, "labor_rate") ?? 0;
   const currencyCode = (getStr(shop, "currency") ?? "USD").toUpperCase();
   const fmt = useMemo(
     () =>


### PR DESCRIPTION
### Motivation

- Job cards were displaying labor/parts/line totals as zero even when `labor_time` (hours) existed on the line because the work-order detail did not compute or pass pricing into the `JobCard`. The goal is to ensure labor hours, labor rate, labor total, parts totals, and line totals are consistently derived and shown across create → detail/card → approval → invoice flows while preserving existing semantics and tenancy.

### Description

- Load the canonical shop labor rate (`shops.labor_rate`) when loading a work order and use it as the default hourly source for deriving labor totals; this value is now stored in the work-order client as `shopLaborRate` (file: `app/work-orders/[id]/Client.tsx`).
- Compute a `pricingByLine` map that derives `laborTotal`, `partsTotal`, and `lineTotal` per work-order line from the active quote (if present), saved `labor_time`, staged `work_order_parts`, and allocated `work_order_part_allocations`, and pass the computed pricing into `JobCard` via the `pricing` prop (file: `app/work-orders/[id]/Client.tsx`).
- Remove the prior hardcoded `$120` fallback on the approval review page and use the shop labor rate (or `0` when missing) so approval totals reflect the canonical source (`app/work-orders/[id]/approve/page.tsx`).
- Harden the approval webhook so that portal/customer-authenticated flows still require the mapped `customers.user_id`, while authorized shop staff (`owner|admin|manager|advisor`) in the same shop can act as a fallback (and the later `work_orders` update applies `.eq('customer_id', ...)` only when a customer mapping exists) to avoid “Customer account not found for this user” failures for internal approvals (file: `app/api/quotes/approval-webhook/route.ts`).
- Files changed: `app/work-orders/[id]/Client.tsx`, `app/work-orders/[id]/approve/page.tsx`, `app/api/quotes/approval-webhook/route.ts`.

### Testing

- Ran type checking with `npm run typecheck` and `npx tsc --noEmit`, both completed successfully with no new type errors after the changes. 
- Ran lint via `npm run lint`; lint reports pre-existing repo-wide warnings/errors unrelated to this targeted patch (these are not introduced by this change). 
- Verified locally (code inspection) that line creation still writes `labor_time` and that the create customer/vehicle flow remains shop-scoped and sets `work_orders.customer_id`, so the persistence shape is unchanged; the new pricing path only derives and surfaces totals rather than changing persisted pricing semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5fbcdf748328a77511a8d8060209)