### PR TITLE
Make Create User usernames shop-scoped and collision-safe

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -6,6 +6,11 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  buildShopUsernameNamespace,
+  normalizeProvisioningUsername,
+  withShopUsernameSuffix,
+} from "@/features/users/lib/username";
 
 type Body = {
   username: string;
@@ -28,16 +33,12 @@ export async function POST(req: Request) {
   try {
     const raw = (await req.json()) as Partial<Body>;
 
-    const username = (raw.username ?? "").trim().toLowerCase();
     const password = (raw.password ?? "").trim();
     const full_name = (raw.full_name ?? null) || null;
     const requestedRole = (raw.role ?? null) || null;
     const phone = (raw.phone ?? null) || null;
     const inputEmail = (raw.email ?? "").trim().toLowerCase();
 
-    if (!username) {
-      return NextResponse.json({ error: "Username is required." }, { status: 400 });
-    }
     if (!password) {
       return NextResponse.json({ error: "Temporary password is required." }, { status: 400 });
     }
@@ -51,17 +52,34 @@ export async function POST(req: Request) {
     // Always force the creator's shop_id to preserve tenant boundaries.
     const effectiveShopId = access.profile.shop_id;
 
-    // 4) build service client to actually create auth user
+    // build service client to actually create auth user
     const url = mustEnv("NEXT_PUBLIC_SUPABASE_URL");
     const service = mustEnv("SUPABASE_SERVICE_ROLE_KEY");
     const serviceSupabase = createClient<Database>(url, service);
 
-    // 5) ensure username is unique
-    const { data: existingProfile, error: existingErr } = await serviceSupabase
+    const { data: shop } = await serviceSupabase
+      .from("shops")
+      .select("name, shop_name")
+      .eq("id", effectiveShopId)
+      .maybeSingle<{ name: string | null; shop_name: string | null }>();
+
+    const shopDisplayName = (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || "shop";
+    const shopNamespace = buildShopUsernameNamespace(shopDisplayName);
+    const requestedUsername = String(raw.username ?? "").trim();
+
+    if (!requestedUsername) {
+      return NextResponse.json({ error: "Username is required." }, { status: 400 });
+    }
+
+    const username = normalizeProvisioningUsername(requestedUsername, shopNamespace);
+
+    // ensure username is unique inside the current shop only
+    const { data: sameShopProfiles, error: existingErr } = await serviceSupabase
       .from("profiles")
       .select("id, username")
-      .eq("username", username)
-      .maybeSingle();
+      .eq("shop_id", effectiveShopId)
+      .ilike("username", username)
+      .limit(1);
 
     if (existingErr) {
       return NextResponse.json(
@@ -70,18 +88,19 @@ export async function POST(req: Request) {
       );
     }
 
-    if (existingProfile) {
+    if ((sameShopProfiles ?? []).length > 0) {
       return NextResponse.json(
-        { error: "That username is already in use. Pick a different one." },
+        { error: "A user with this username already exists in this shop." },
         { status: 400 }
       );
     }
 
-    // 6) real email or synthetic
+    // Username-only auth still signs in as username@local.profix-internal.
+    // We enforce a shop namespace in username normalization so this backing identity remains collision-safe.
     const syntheticEmail = `${username}@local.profix-internal`;
     const email = inputEmail || syntheticEmail;
 
-    // 7) create auth user with service client
+    // create auth user with service client
     const { data: created, error: createErr } = await serviceSupabase.auth.admin.createUser({
       email,
       password,
@@ -96,15 +115,16 @@ export async function POST(req: Request) {
     });
 
     if (createErr || !created?.user) {
-      return NextResponse.json(
-        { error: createErr?.message ?? "Failed to create user." },
-        { status: 400 }
-      );
+      const safeMessage = createErr?.message?.toLowerCase().includes("already been registered")
+        ? "Unable to provision this username. Try the suggested shop-prefixed username."
+        : (createErr?.message ?? "Failed to create user.");
+
+      return NextResponse.json({ error: safeMessage }, { status: 400 });
     }
 
     const newUserId = created.user.id;
 
-    // 8) upsert profile for the new user
+    // upsert profile for the new user
     const { error: profileErr } = await serviceSupabase
       .from("profiles")
       .upsert(
@@ -114,7 +134,7 @@ export async function POST(req: Request) {
           full_name,
           phone,
           role: requestedRole,
-          shop_id: effectiveShopId, // force caller's shop
+          shop_id: effectiveShopId,
           shop_name: null,
           username,
           must_change_password: true,
@@ -157,6 +177,7 @@ export async function POST(req: Request) {
       ok: true,
       user_id: newUserId,
       username,
+      suggested_alternate_username: withShopUsernameSuffix(username, 1),
       email,
       must_change_password: true,
       shop_id: effectiveShopId,

--- a/app/api/admin/reset-user-password/route.ts
+++ b/app/api/admin/reset-user-password/route.ts
@@ -34,15 +34,12 @@ export async function POST(req: Request) {
   const { data: profile, error: profileErr } = await supabase
     .from("profiles")
     .select("id, shop_id")
-    .eq("username", username.toLowerCase())
+    .eq("shop_id", access.profile.shop_id)
+    .ilike("username", username.toLowerCase())
     .maybeSingle();
 
   if (profileErr || !profile) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
-  }
-
-  if (profile.shop_id !== access.profile.shop_id) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const { error: updateErr } = await supabase.auth.admin.updateUserById(profile.id, {

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -8,6 +8,11 @@ import UsersList from "@/features/admin/components/UsersList";
 import InviteCandidatesList from "@/features/admin/components/InviteCandidatesList";
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  buildShopUsernameNamespace,
+  buildUsernameSuggestions,
+  normalizeProvisioningUsername,
+} from "@/features/users/lib/username";
 
 type UserRole = Database["public"]["Enums"]["user_role_enum"];
 
@@ -60,6 +65,8 @@ export default function CreateUserPage(): JSX.Element {
 
   // creator’s shop id (for auto-fill)
   const [creatorShopId, setCreatorShopId] = useState<string | null>(null);
+  const [creatorShopName, setCreatorShopName] = useState<string | null>(null);
+  const [usernameTouched, setUsernameTouched] = useState(false);
 
   // load current user's shop_id once
   useEffect(() => {
@@ -79,6 +86,15 @@ export default function CreateUserPage(): JSX.Element {
       setCreatorShopId(shopId);
 
       if (shopId) {
+        const { data: shop } = await supabase
+          .from("shops")
+          .select("name, shop_name")
+          .eq("id", shopId)
+          .maybeSingle<{ name: string | null; shop_name: string | null }>();
+
+        const displayName = (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || null;
+        setCreatorShopName(displayName);
+
         setForm((prev) => ({
           ...prev,
           shop_id: shopId,
@@ -89,6 +105,21 @@ export default function CreateUserPage(): JSX.Element {
     void load();
   }, []);
 
+  useEffect(() => {
+    if (usernameTouched) return;
+
+    const [firstSuggestion] = buildUsernameSuggestions({
+      shopName: creatorShopName,
+      fullName: form.full_name,
+    });
+    if (!firstSuggestion) return;
+
+    setForm((prev) => {
+      if ((prev.username ?? "").trim().length > 0) return prev;
+      return { ...prev, username: firstSuggestion };
+    });
+  }, [creatorShopName, form.full_name, usernameTouched]);
+
   async function submit(): Promise<void> {
     setSubmitting(true);
     setError(null);
@@ -98,7 +129,10 @@ export default function CreateUserPage(): JSX.Element {
 
     try {
       const body: CreatePayload = {
-        username: form.username.trim().toLowerCase(),
+        username: normalizeProvisioningUsername(
+          form.username.trim(),
+          buildShopUsernameNamespace(creatorShopName),
+        ),
         password: form.password.trim(),
         full_name: (form.full_name ?? "").trim() || null,
         role: form.role ?? null,
@@ -149,6 +183,7 @@ export default function CreateUserPage(): JSX.Element {
         phone: "",
         shop_id: body.shop_id ?? creatorShopId ?? null,
       }));
+      setUsernameTouched(false);
 
       // refresh list below
       setListRefreshKey((k) => k + 1);
@@ -278,14 +313,15 @@ export default function CreateUserPage(): JSX.Element {
               </label>
               <input
                 className={INPUT_CLASS}
-                placeholder="e.g. jsmith"
+                placeholder="e.g. ProFixLucas"
                 value={form.username}
-                onChange={(e) =>
-                  setForm({ ...form, username: e.target.value })
-                }
+                onChange={(e) => {
+                  setUsernameTouched(true);
+                  setForm({ ...form, username: e.target.value });
+                }}
               />
               <p className="text-[11px] text-neutral-500">
-                Use lowercase letters / numbers only. This becomes their login.
+                Username is normalized to letters/numbers and shop-prefixed for collision-safe login.
               </p>
             </div>
 

--- a/features/users/lib/username.ts
+++ b/features/users/lib/username.ts
@@ -1,0 +1,73 @@
+const MAX_USERNAME_LENGTH = 32;
+
+function toAlphaNumericLower(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+export function buildShopUsernameNamespace(shopName: string | null | undefined): string {
+  const cleaned = toAlphaNumericLower(shopName ?? "");
+  if (cleaned.length >= 3) return cleaned.slice(0, 12);
+  return "shop";
+}
+
+export function normalizeProvisioningUsername(input: string, shopNamespace: string): string {
+  const normalized = toAlphaNumericLower(input);
+  const namespace = toAlphaNumericLower(shopNamespace) || "shop";
+
+  if (!normalized) return namespace;
+
+  const withNamespace = normalized.startsWith(namespace)
+    ? normalized
+    : `${namespace}${normalized}`;
+
+  return withNamespace.slice(0, MAX_USERNAME_LENGTH);
+}
+
+function splitName(fullName: string | null | undefined): { first: string; last: string } {
+  const parts = String(fullName ?? "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((p) => toAlphaNumericLower(p));
+
+  return {
+    first: parts[0] ?? "",
+    last: parts.length > 1 ? parts[parts.length - 1] ?? "" : "",
+  };
+}
+
+export function buildUsernameSuggestions(params: {
+  shopName: string | null | undefined;
+  fullName: string | null | undefined;
+}): string[] {
+  const namespace = buildShopUsernameNamespace(params.shopName);
+  const { first, last } = splitName(params.fullName);
+
+  const seeds = [
+    `${namespace}${first}`,
+    `${namespace}${first}${last.slice(0, 1)}`,
+    `${namespace}${first.slice(0, 1)}${last}`,
+    `${namespace}${first || last || "user"}`,
+  ];
+
+  const unique = Array.from(
+    new Set(
+      seeds
+        .map((value) => normalizeProvisioningUsername(value, namespace))
+        .filter(Boolean),
+    ),
+  );
+
+  if (unique.length === 0) {
+    return [normalizeProvisioningUsername("user", namespace)];
+  }
+
+  return unique;
+}
+
+export function withShopUsernameSuffix(baseUsername: string, suffixNumber: number): string {
+  if (suffixNumber <= 0) return baseUsername;
+  const suffix = String(suffixNumber).padStart(2, "0");
+  const trimmedBase = baseUsername.slice(0, Math.max(1, MAX_USERNAME_LENGTH - suffix.length));
+  return `${trimmedBase}${suffix}`;
+}


### PR DESCRIPTION
### Motivation
- Fix a provisioning failure where username-only creation was blocked by a global/auth collision from a deleted/other shop and showed an "email already registered" error. 
- Ensure visible/login usernames are scoped to the current shop so shops can reuse the same visible username independently. 
- Preserve existing Supabase Auth requirements by making the underlying synthetic email globally unique via a stable shop namespace while avoiding any auth redesign.

### Description
- Added a focused helper module `features/users/lib/username.ts` to build a stable shop namespace, normalize usernames, generate suggestion seeds, and produce deterministic suffixes. 
- Updated the create-user API `app/api/admin/create-user/route.ts` to normalize requested usernames with a shop-derived namespace, check uniqueness scoped to `shop_id`, and keep the synthetic email pattern (now using the namespaced username) so Supabase Auth collisions are avoided. 
- Updated owner UI `features/dashboard/app/dashboard/owner/create-user/page.tsx` to auto-suggest a shop-prefixed username from shop name + full name, normalize on submit, surface clearer wording, and avoid exposing email-style errors. 
- Scoped the internal password-reset lookup `app/api/admin/reset-user-password/route.ts` to the caller's `shop_id` and used case-insensitive match to align with the new username scoping; profile/workforce upsert behavior remains unchanged.

### Testing
- Ran `npm run typecheck` which completed successfully. 
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `npm run lint` which reported pre-existing repository-wide lint errors unrelated to this change and did not pass; the lint failures were not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed67c4d66883288671bc16ed3639e2)