### PR TITLE
Stabilize Shop Boost canonical import truth and lifecycle accounting

### DIFF
--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -18,8 +18,6 @@ type IntakeReportRow = Pick<
   DB["public"]["Tables"]["shop_boost_intakes"]["Row"],
   "id" | "shop_id" | "status" | "created_at" | "processed_at" | "intake_basics"
 >;
-const REPORT_DOMAINS = ["customer", "vehicle", "work_order", "history", "invoice", "part"] as const;
-const REPORT_STATUSES = ["pending", "failed_materialization", "materialized", "ignored", "resolved"] as const;
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
@@ -124,95 +122,40 @@ export async function GET(req: Request, context: RouteContext) {
     intakeId: id,
   });
 
-  const [reviewStatusCounts, reviewActionCounts, domainProcessedCounts, domainReviewCounts, domainFailedCounts] = await Promise.all([
-    Promise.all(
-      REPORT_STATUSES.map((status) =>
-        admin
-          .from("shop_boost_review_items")
-          .select("id", { count: "exact", head: true })
-          .eq("shop_id", profile.shop_id)
-          .eq("intake_id", id)
-          .eq("status", status),
-      ),
-    ),
-    Promise.all(
-      ["linked_to_existing", "created_new", "ignored"].map((action) =>
-        admin
-          .from("shop_boost_review_items")
-          .select("id", { count: "exact", head: true })
-          .eq("shop_id", profile.shop_id)
-          .eq("intake_id", id)
-          .eq("resolution_action", action),
-      ),
-    ),
-    Promise.all(
-      REPORT_DOMAINS.map((domain) =>
-        admin
-          .from("shop_boost_row_results")
-          .select("id", { count: "exact", head: true })
-          .eq("shop_id", profile.shop_id)
-          .eq("intake_id", id)
-          .eq("target_domain", domain),
-      ),
-    ),
-    Promise.all(
-      REPORT_DOMAINS.map((domain) =>
-        admin
-          .from("shop_boost_row_results")
-          .select("id", { count: "exact", head: true })
-          .eq("shop_id", profile.shop_id)
-          .eq("intake_id", id)
-          .eq("target_domain", domain)
-          .eq("review_required", true),
-      ),
-    ),
-    Promise.all(
-      REPORT_DOMAINS.map((domain) =>
-        admin
-          .from("shop_boost_row_results")
-          .select("id", { count: "exact", head: true })
-          .eq("shop_id", profile.shop_id)
-          .eq("intake_id", id)
-          .eq("target_domain", domain)
-          .or("error_reason.not.is.null,match_status.eq.invalid"),
-      ),
-    ),
-  ]);
-  if (
-    reviewStatusCounts.some((row) => row.error) ||
-    reviewActionCounts.some((row) => row.error) ||
-    domainProcessedCounts.some((row) => row.error) ||
-    domainReviewCounts.some((row) => row.error) ||
-    domainFailedCounts.some((row) => row.error)
-  ) {
-    console.error("[shop-boost][intakes/report] failed to load report aggregates", {
-      intakeId: id,
-      shopId: profile.shop_id,
-      reviewRowsError: reviewStatusCounts.find((row) => row.error)?.error?.message ?? null,
-      byDomainRowsError: domainProcessedCounts.find((row) => row.error)?.error?.message ?? null,
-    });
-  }
-
-  const reviewOutcomes = REPORT_STATUSES.reduce((acc: Record<string, number>, status, index) => {
-    acc[`status:${status}`] = Number(reviewStatusCounts[index]?.count ?? 0);
-    return acc;
-  }, {});
-  (["linked_to_existing", "created_new", "ignored"] as const).forEach((action, index) => {
-    reviewOutcomes[`action:${action}`] = Number(reviewActionCounts[index]?.count ?? 0);
-  });
+  const reviewOutcomes: Record<string, number> = {
+    "status:pending": canonicalTruth.review.pending,
+    "status:failed_materialization": canonicalTruth.review.failedMaterialization,
+    "status:materialized": canonicalTruth.review.materialized,
+    "status:ignored": canonicalTruth.review.ignored,
+    "status:resolved": canonicalTruth.review.resolved,
+    "action:linked_to_existing": canonicalTruth.rowCounts.linked,
+    "action:created_new": canonicalTruth.rowCounts.materialized,
+    "action:ignored": canonicalTruth.rowCounts.ignored,
+  };
   reviewOutcomes["action:none"] = Math.max(
     0,
-    (reviewOutcomes["status:pending"] ?? 0) - (reviewOutcomes["action:linked_to_existing"] ?? 0) - (reviewOutcomes["action:created_new"] ?? 0) - (reviewOutcomes["action:ignored"] ?? 0),
+    reviewOutcomes["status:pending"] -
+      reviewOutcomes["action:linked_to_existing"] -
+      reviewOutcomes["action:created_new"] -
+      reviewOutcomes["action:ignored"],
   );
 
-  const domainSummaries = REPORT_DOMAINS.reduce((acc: Record<string, { review: number; failed: number; processed: number }>, domain, index) => {
-    acc[domain] = {
-      processed: Number(domainProcessedCounts[index]?.count ?? 0),
-      review: Number(domainReviewCounts[index]?.count ?? 0),
-      failed: Number(domainFailedCounts[index]?.count ?? 0),
-    };
-    return acc;
-  }, {});
+  const domainSummaries = Object.fromEntries(
+    Object.entries(canonicalTruth.byDomain).map(([domain, value]) => [
+      domain,
+      {
+        processed: value.parsed,
+        review: value.reviewRequired,
+        failed: value.failed,
+        deterministic_identity: value.deterministicIdentity,
+        linked_existing: value.linkedExisting,
+        materialized_new: value.materializedNew,
+        skipped: value.skipped,
+        mismatch: value.mismatch,
+        reasons: value.reasons,
+      },
+    ]),
+  );
 
   const legacyOrchestrator = asRecord(basics.orchestrator);
   let orchestrator: Record<string, unknown> | null = null;
@@ -343,7 +286,9 @@ export async function GET(req: Request, context: RouteContext) {
     readiness: {
       snapshot_complete: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).snapshot_complete : false),
       import_complete: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).import_complete : false),
-      canonical_ready: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).canonical_ready : false),
+      canonical_readiness: canonicalTruth.readiness,
+      canonical_ready: canonicalTruth.readiness === "ready",
+      integrity_flags: canonicalTruth.integrityFlags,
       activation_eligible: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).activation_eligible : false),
       activated: Boolean(asRecord(orchestrator ?? {}).truthStates ? asRecord(asRecord(orchestrator ?? {}).truthStates).activated : false),
       ui_should_route_forward: Boolean(asRecord(orchestrator ?? {}).uiShouldRouteForward ?? asRecord(orchestrator ?? {}).ui_should_route_forward ?? false),

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -184,11 +184,7 @@ export async function GET() {
   const orchestratorRecord = asRecord(orchestrator);
   const truthStates = asRecord(orchestratorRecord.truthStates ?? orchestratorRecord.truth_states);
   const canonicalReadyFromRun = Boolean(truthStates.canonical_ready);
-  const canonicalReadyFromRows =
-    canonicalTruth.rowCounts.total > 0 &&
-    canonicalTruth.rowCounts.unresolved === 0 &&
-    canonicalTruth.rowCounts.failed === 0 &&
-    canonicalTruth.rowCounts.mismatch === 0;
+  const canonicalReadyFromRows = canonicalTruth.readiness === "ready";
   const canonicalReady = canonicalReadyFromRun && canonicalReadyFromRows;
 
   return NextResponse.json({
@@ -204,6 +200,8 @@ export async function GET() {
       canonicalTruth,
       readiness: orchestrator
         ? {
+            canonical_readiness: canonicalTruth.readiness,
+            integrity_flags: canonicalTruth.integrityFlags,
             snapshot_complete: Boolean(truthStates.snapshot_complete),
             import_complete: Boolean(truthStates.import_complete),
             canonical_ready: canonicalReady,
@@ -219,6 +217,8 @@ export async function GET() {
             ui_should_route_forward: Boolean(orchestratorRecord.uiShouldRouteForward ?? orchestratorRecord.ui_should_route_forward ?? false) && canonicalReady,
           }
         : {
+            canonical_readiness: canonicalTruth.readiness,
+            integrity_flags: canonicalTruth.integrityFlags,
             snapshot_complete: false,
             import_complete: false,
             canonical_ready: canonicalReadyFromRows,

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -29,6 +29,9 @@ type ReviewListItem = ReviewItemRow & {
 type ReviewCountsSummary = {
   intake_id: string | null;
   domain_counts: Record<string, number>;
+  lifecycle: readonly string[];
+  by_domain_lifecycle: Record<string, unknown>;
+  reason_counts: Record<string, number>;
   status_counts: Record<string, number>;
   unresolved_total: number;
   blockers_total: number;
@@ -141,6 +144,9 @@ export async function GET(req: Request) {
       summary: {
         intake_id: null,
         domain_counts: { customer: 0, vehicle: 0, work_order: 0, history: 0, invoice: 0, part: 0 },
+        lifecycle: [],
+        by_domain_lifecycle: {},
+        reason_counts: {},
         status_counts: { pending: 0, failed_materialization: 0, materialized: 0, ignored: 0, resolved: 0 },
         unresolved_total: 0,
         blockers_total: 0,
@@ -250,11 +256,11 @@ export async function GET(req: Request) {
   }
 
   const state =
-    canonicalTruth.rowCounts.total === 0
+    canonicalTruth.readiness === "empty"
       ? "empty_reset"
-      : canonicalTruth.rowCounts.unresolved > 0
+      : canonicalTruth.readiness === "review_required"
         ? "review_required"
-        : canonicalTruth.rowCounts.failed > 0 || canonicalTruth.rowCounts.mismatch > 0
+        : canonicalTruth.readiness === "blocked"
           ? "failed_inconsistent"
           : "complete";
 
@@ -265,6 +271,9 @@ export async function GET(req: Request) {
     summary: {
       intake_id: resolvedIntakeId,
       domain_counts: canonicalTruth.domainCounts,
+      lifecycle: canonicalTruth.lifecycle,
+      by_domain_lifecycle: canonicalTruth.byDomain,
+      reason_counts: canonicalTruth.reasons,
       status_counts: {
         pending: canonicalTruth.review.pending,
         failed_materialization: canonicalTruth.review.failedMaterialization,
@@ -295,6 +304,8 @@ export async function GET(req: Request) {
       high_risk_actions_count: highRiskActions,
       integrity_errors: integrityErrors,
       materialized_entities: canonicalTruth.materializedEntities,
+      canonical_readiness: canonicalTruth.readiness,
+      integrity_flags: canonicalTruth.integrityFlags,
     },
   });
 }

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -129,7 +129,7 @@ export type ShopBoostImportSummary = {
 
 type CsvRow = Record<string, string>;
 type RowDomain = "customer" | "vehicle" | "part" | "work_order" | "invoice" | "history";
-type MatchStatus = "matched_existing" | "created_new" | "partial_match" | "unmatched" | "invalid";
+type MatchStatus = "matched_existing" | "created_new" | "partial_match" | "unmatched" | "invalid" | "ignored";
 type MatchConfidence = "high" | "medium" | "low";
 type UploadManifestRecord = Partial<
   Record<ShopBoostUploadDatasetKey, { path?: string; fileName?: string | null; importMode?: "direct" | "staging" }>
@@ -171,6 +171,25 @@ type CacheProfileRow = Pick<DB["public"]["Tables"]["profiles"]["Row"], "id" | "e
 type KeyFixRow = Pick<DB["public"]["Tables"]["shop_boost_review_items"]["Row"], "domain" | "issue_type" | "status" | "resolution_action">;
 type MaterializeDomain = NonNullable<RunArgs["options"]>["materializeDomain"];
 type ProvenanceDomain = "customer" | "vehicle" | "work_order" | "work_order_line" | "invoice";
+
+const DETERMINISTIC_LINKAGE_ORDER = [
+  "exact_source_or_external_id",
+  "exact_shop_scoped_canonical_identifier",
+  "durable_dependency_linkage",
+  "explicit_review",
+  "safe_fallback_logic",
+] as const;
+
+type CanonicalLifecycleStage =
+  | "uploaded"
+  | "parsed"
+  | "normalized"
+  | "deterministic_identity"
+  | "linked_existing"
+  | "materialized_new"
+  | "review_required"
+  | "failed"
+  | "skipped";
 
 async function recordImportCreatedArtifact(args: {
   supabase: ReturnType<typeof createAdminSupabase>;
@@ -934,6 +953,19 @@ async function stageSupplementalUploads(args: {
   }
 }
 
+function classifyLifecycleStage(args: {
+  matchStatus: MatchStatus;
+  reviewRequired: boolean;
+  errorReason?: string | null;
+}): CanonicalLifecycleStage {
+  if (args.matchStatus === "ignored") return "skipped";
+  if (args.reviewRequired) return "review_required";
+  if (args.matchStatus === "created_new") return "materialized_new";
+  if (args.matchStatus === "matched_existing" || args.matchStatus === "partial_match") return "linked_existing";
+  if (args.matchStatus === "invalid" || args.errorReason) return "failed";
+  return "normalized";
+}
+
 async function insertRowResult(args: {
   supabase: ReturnType<typeof createAdminSupabase>;
   shopId: string;
@@ -964,7 +996,16 @@ async function insertRowResult(args: {
     target_domain: args.targetDomain,
     match_status: args.matchStatus,
     match_confidence: confidenceScore(args.matchConfidence),
-    match_details: args.matchDetails ?? {},
+    match_details: {
+      resolution_order: DETERMINISTIC_LINKAGE_ORDER,
+      lifecycle_stage: classifyLifecycleStage({
+        matchStatus: args.matchStatus,
+        reviewRequired: args.reviewRequired,
+        errorReason: args.errorReason ?? null,
+      }),
+      reason_code: args.errorReason ?? null,
+      ...(args.matchDetails ?? {}),
+    },
     cluster_key: cluster.clusterKey,
     cluster_confidence: cluster.confidence,
     error_reason: args.errorReason ?? null,

--- a/features/integrations/shopBoost/canonicalTruth.ts
+++ b/features/integrations/shopBoost/canonicalTruth.ts
@@ -1,9 +1,37 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/features/shared/types/types/supabase";
 
-type CanonicalDomain = "customer" | "vehicle" | "work_order" | "history" | "invoice" | "part";
+type DB = Database;
+
+export const CANONICAL_ROW_LIFECYCLE = [
+  "uploaded",
+  "parsed",
+  "normalized",
+  "deterministic_identity",
+  "linked_existing",
+  "materialized_new",
+  "review_required",
+  "failed",
+  "skipped",
+] as const;
+
+export type CanonicalLifecycleStage = (typeof CANONICAL_ROW_LIFECYCLE)[number];
+export type CanonicalDomain = "customer" | "vehicle" | "work_order" | "history" | "invoice" | "part" | "vendor";
+
+type CanonicalRow = Pick<
+  DB["public"]["Tables"]["shop_boost_row_results"]["Row"],
+  "target_domain" | "source_file" | "match_status" | "error_reason" | "review_required" | "match_details" | "normalized_payload"
+>;
+
+type ImportFileRow = Pick<
+  DB["public"]["Tables"]["shop_import_files"]["Row"],
+  "kind" | "parsed_row_count"
+>;
 
 export type CanonicalIntakeTruth = {
   intakeId: string;
+  lifecycle: readonly CanonicalLifecycleStage[];
+  readiness: "empty" | "in_progress" | "review_required" | "blocked" | "ready";
   rowCounts: {
     total: number;
     materialized: number;
@@ -11,10 +39,10 @@ export type CanonicalIntakeTruth = {
     ignored: number;
     unresolved: number;
     failed: number;
+    skipped: number;
     totalCounted: number;
     mismatch: number;
   };
-  domainCounts: Record<CanonicalDomain, number>;
   review: {
     pending: number;
     failedMaterialization: number;
@@ -22,6 +50,22 @@ export type CanonicalIntakeTruth = {
     resolved: number;
     materialized: number;
   };
+  domainCounts: Record<CanonicalDomain, number>;
+  byDomain: Record<CanonicalDomain, {
+    uploaded: number;
+    parsed: number;
+    normalized: number;
+    deterministicIdentity: number;
+    linkedExisting: number;
+    materializedNew: number;
+    reviewRequired: number;
+    failed: number;
+    skipped: number;
+    mismatch: number;
+    reasons: Record<string, number>;
+  }>;
+  reasons: Record<string, number>;
+  integrityFlags: string[];
   materializedEntities: {
     customers: number;
     vehicles: number;
@@ -30,8 +74,72 @@ export type CanonicalIntakeTruth = {
   };
 };
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
 function countOf(result: { count: number | null } | null | undefined): number {
   return Number(result?.count ?? 0);
+}
+
+function mapToCanonicalDomain(domainOrFile: string): CanonicalDomain | null {
+  const key = String(domainOrFile ?? "").trim().toLowerCase();
+  if (!key) return null;
+  if (key === "customer" || key === "customers") return "customer";
+  if (key === "vehicle" || key === "vehicles") return "vehicle";
+  if (key === "work_order" || key === "work_orders") return "work_order";
+  if (key === "history") return "history";
+  if (key === "invoice" || key === "invoices") return "invoice";
+  if (key === "part" || key === "parts") return "part";
+  if (key === "vendor" || key === "vendors") return "vendor";
+  return null;
+}
+
+function normalizeReasonCode(row: CanonicalRow): string {
+  const matchDetails = asRecord(row.match_details);
+  const raw = String(matchDetails.reason_code ?? row.error_reason ?? "").trim().toLowerCase();
+  if (!raw) return "none";
+  return raw
+    .replace(/[^a-z0-9_\-\s]+/g, "_")
+    .replace(/[\s\-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "") || "unknown";
+}
+
+function hasNormalizedPayload(row: CanonicalRow): boolean {
+  const normalized = asRecord(row.normalized_payload);
+  return Object.keys(normalized).length > 0;
+}
+
+function hasDeterministicIdentity(row: CanonicalRow): boolean {
+  const details = asRecord(row.match_details);
+  const strategy = String(details.strategy ?? "").trim().toLowerCase();
+  const resolutionType = String(details.resolutionType ?? "").trim().toLowerCase();
+  const hasSourceId = Boolean(details.sourceCustomerId || details.sourceVehicleId || details.sourceVendorId || details.sourceInvoiceId);
+  return (
+    hasSourceId ||
+    strategy.includes("id") ||
+    strategy.includes("email") ||
+    strategy.includes("phone") ||
+    strategy.includes("vin") ||
+    resolutionType.includes("matched_existing_by_")
+  );
+}
+
+function baseDomainCounters() {
+  return {
+    uploaded: 0,
+    parsed: 0,
+    normalized: 0,
+    deterministicIdentity: 0,
+    linkedExisting: 0,
+    materializedNew: 0,
+    reviewRequired: 0,
+    failed: 0,
+    skipped: 0,
+    mismatch: 0,
+    reasons: {} as Record<string, number>,
+  };
 }
 
 export async function buildCanonicalIntakeTruth(args: {
@@ -41,109 +149,140 @@ export async function buildCanonicalIntakeTruth(args: {
 }): Promise<CanonicalIntakeTruth> {
   const { admin, shopId, intakeId } = args;
 
-  const [
-    totalRows,
-    reviewRequiredRows,
-    failedRows,
-    linkedRows,
-    materializedRows,
-    ignoredRows,
-    reviewPending,
-    reviewFailedMaterialization,
-    reviewIgnored,
-    reviewResolved,
-    reviewMaterialized,
-    customerDomain,
-    vehicleDomain,
-    workOrderDomain,
-    historyDomain,
-    invoiceDomain,
-    partDomain,
-    customersMaterialized,
-    vehiclesMaterialized,
-    workOrdersMaterialized,
-    invoicesMaterialized,
-  ] = await Promise.all([
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId),
+  const [rowsRes, filesRes, reviewPending, reviewFailedMaterialization, reviewIgnored, reviewResolved, reviewMaterialized, customersMaterialized, vehiclesMaterialized, workOrdersMaterialized, invoicesMaterialized] = await Promise.all([
     admin
       .from("shop_boost_row_results")
-      .select("id", { count: "exact", head: true })
+      .select("target_domain,source_file,match_status,error_reason,review_required,match_details,normalized_payload")
       .eq("shop_id", shopId)
-      .eq("intake_id", intakeId)
-      .eq("review_required", true),
-    admin
-      .from("shop_boost_row_results")
-      .select("id", { count: "exact", head: true })
-      .eq("shop_id", shopId)
-      .eq("intake_id", intakeId)
-      .eq("review_required", false)
-      .or("error_reason.not.is.null,match_status.eq.invalid"),
-    admin
-      .from("shop_boost_row_results")
-      .select("id", { count: "exact", head: true })
-      .eq("shop_id", shopId)
-      .eq("intake_id", intakeId)
-      .eq("review_required", false)
-      .is("error_reason", null)
-      .in("match_status", ["matched_existing", "partial_match"]),
-    admin
-      .from("shop_boost_row_results")
-      .select("id", { count: "exact", head: true })
-      .eq("shop_id", shopId)
-      .eq("intake_id", intakeId)
-      .eq("review_required", false)
-      .is("error_reason", null)
-      .eq("match_status", "created_new"),
-    admin
-      .from("shop_boost_row_results")
-      .select("id", { count: "exact", head: true })
-      .eq("shop_id", shopId)
-      .eq("intake_id", intakeId)
-      .eq("match_status", "ignored"),
+      .eq("intake_id", intakeId),
+    admin.from("shop_import_files").select("kind,parsed_row_count").eq("intake_id", intakeId),
     admin.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "pending"),
     admin.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "failed_materialization"),
     admin.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "ignored"),
     admin.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "resolved"),
     admin.from("shop_boost_review_items").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("status", "materialized"),
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("target_domain", "customer"),
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("target_domain", "vehicle"),
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("target_domain", "work_order"),
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("target_domain", "history"),
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("target_domain", "invoice"),
-    admin.from("shop_boost_row_results").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("intake_id", intakeId).eq("target_domain", "part"),
     admin.from("customers").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
     admin.from("vehicles").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
     admin.from("work_orders").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("source_intake_id", intakeId),
     admin.from("invoices").select("id", { count: "exact", head: true }).eq("shop_id", shopId).contains("metadata", { source_intake_id: intakeId }),
   ]);
 
-  const total = countOf(totalRows);
-  const reviewRequired = countOf(reviewRequiredRows);
-  const failed = countOf(failedRows);
-  const linked = countOf(linkedRows);
-  const materialized = countOf(materializedRows);
-  const ignored = countOf(ignoredRows);
-  const totalCounted = materialized + linked + ignored + reviewRequired + failed;
+  const rows = (rowsRes.data ?? []) as CanonicalRow[];
+  const files = (filesRes.data ?? []) as ImportFileRow[];
+
+  const byDomain: CanonicalIntakeTruth["byDomain"] = {
+    customer: baseDomainCounters(),
+    vehicle: baseDomainCounters(),
+    work_order: baseDomainCounters(),
+    history: baseDomainCounters(),
+    invoice: baseDomainCounters(),
+    part: baseDomainCounters(),
+    vendor: baseDomainCounters(),
+  };
+
+  for (const file of files) {
+    const domain = mapToCanonicalDomain(file.kind ?? "");
+    if (!domain) continue;
+    byDomain[domain].uploaded += Number(file.parsed_row_count ?? 0);
+  }
+
+  const reasons: Record<string, number> = {};
+  let linked = 0;
+  let materialized = 0;
+  let ignored = 0;
+  let unresolved = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const domain = mapToCanonicalDomain(row.target_domain || row.source_file || "");
+    if (!domain) continue;
+    const bucket = byDomain[domain];
+    bucket.parsed += 1;
+
+    if (hasNormalizedPayload(row)) bucket.normalized += 1;
+    if (hasDeterministicIdentity(row)) bucket.deterministicIdentity += 1;
+
+    const status = String(row.match_status ?? "").trim().toLowerCase();
+    const reason = normalizeReasonCode(row);
+
+    if (row.review_required) {
+      unresolved += 1;
+      bucket.reviewRequired += 1;
+      reasons[reason] = (reasons[reason] ?? 0) + 1;
+      bucket.reasons[reason] = (bucket.reasons[reason] ?? 0) + 1;
+    } else if (status === "created_new") {
+      materialized += 1;
+      bucket.materializedNew += 1;
+    } else if (status === "matched_existing" || status === "partial_match") {
+      linked += 1;
+      bucket.linkedExisting += 1;
+    } else if (status === "ignored") {
+      ignored += 1;
+      skipped += 1;
+      bucket.skipped += 1;
+    } else if (status === "invalid" || row.error_reason) {
+      failed += 1;
+      bucket.failed += 1;
+      reasons[reason] = (reasons[reason] ?? 0) + 1;
+      bucket.reasons[reason] = (bucket.reasons[reason] ?? 0) + 1;
+    }
+  }
+
+  const domainCounts = {
+    customer: byDomain.customer.parsed,
+    vehicle: byDomain.vehicle.parsed,
+    work_order: byDomain.work_order.parsed,
+    history: byDomain.history.parsed,
+    invoice: byDomain.invoice.parsed,
+    part: byDomain.part.parsed,
+    vendor: byDomain.vendor.parsed,
+  };
+
+  for (const domain of Object.keys(byDomain) as CanonicalDomain[]) {
+    const counters = byDomain[domain];
+    const totalCounted =
+      counters.linkedExisting +
+      counters.materializedNew +
+      counters.reviewRequired +
+      counters.failed +
+      counters.skipped;
+    counters.mismatch = Math.max(0, counters.parsed - totalCounted);
+  }
+
+  const total = rows.length;
+  const totalCounted = materialized + linked + unresolved + failed + skipped;
+  const mismatch = Math.max(0, total - totalCounted);
+
+  const integrityFlags: string[] = [];
+  if (mismatch > 0) integrityFlags.push("row_bucket_mismatch");
+  if (Object.values(byDomain).some((domain) => domain.mismatch > 0)) integrityFlags.push("domain_bucket_mismatch");
+  if (rowsRes.error) integrityFlags.push("row_results_read_failed");
+  if (filesRes.error) integrityFlags.push("upload_counts_read_failed");
+
+  const readiness: CanonicalIntakeTruth["readiness"] =
+    total === 0
+      ? "empty"
+      : mismatch > 0 || failed > 0
+        ? "blocked"
+        : unresolved > 0
+          ? "review_required"
+          : "ready";
 
   return {
     intakeId,
+    lifecycle: CANONICAL_ROW_LIFECYCLE,
+    readiness,
     rowCounts: {
       total,
       materialized,
       linked,
       ignored,
-      unresolved: countOf(reviewPending) + countOf(reviewFailedMaterialization),
+      unresolved,
       failed,
+      skipped,
       totalCounted,
-      mismatch: Math.max(0, total - totalCounted),
-    },
-    domainCounts: {
-      customer: countOf(customerDomain),
-      vehicle: countOf(vehicleDomain),
-      work_order: countOf(workOrderDomain),
-      history: countOf(historyDomain),
-      invoice: countOf(invoiceDomain),
-      part: countOf(partDomain),
+      mismatch,
     },
     review: {
       pending: countOf(reviewPending),
@@ -152,6 +291,10 @@ export async function buildCanonicalIntakeTruth(args: {
       resolved: countOf(reviewResolved),
       materialized: countOf(reviewMaterialized),
     },
+    domainCounts,
+    byDomain,
+    reasons,
+    integrityFlags,
     materializedEntities: {
       customers: countOf(customersMaterialized),
       vehicles: countOf(vehiclesMaterialized),


### PR DESCRIPTION
### Motivation
- The Shop Boost import pipeline had split-truth summaries, missing lifecycle semantics, and weak per-row diagnostics that made replay, debugging, and readiness determination unreliable.  
- The change consolidates one canonical truth source so review, dashboard, and report surfaces read identical, auditable counts and reasons for every non-success row.  

### Description
- Add a canonical intake truth builder that computes per-intake lifecycle, per-domain counters (uploaded/parsed/normalized/deterministic_identity/linked/materialized/review/failed/skipped), reason-code tallies, integrity flags, and a single `readiness` value consumed by UI and report endpoints (`features/integrations/shopBoost/canonicalTruth.ts`).  
- Define a shared canonical row lifecycle and persist deterministic linkage metadata by recording `resolution_order`, `lifecycle_stage`, and `reason_code` into `shop_boost_row_results.match_details` at write time via the shared `insertRowResult` helper and a `classifyLifecycleStage` function (`features/integrations/imports/runFullImport.ts`).  
- Refactor review, latest-intake and intake-report endpoints to consume the canonical truth (instead of ad-hoc DB aggregates) and to expose lifecycle, by-domain lifecycle, reason counts, canonical readiness and integrity flags (`app/api/shop-boost/review-items/route.ts`, `app/api/shop-boost/intakes/latest/route.ts`, `app/api/shop-boost/intakes/[id]/report/route.ts`).  
- Files changed: `features/integrations/shopBoost/canonicalTruth.ts`, `features/integrations/imports/runFullImport.ts`, `app/api/shop-boost/review-items/route.ts`, `app/api/shop-boost/intakes/latest/route.ts`, `app/api/shop-boost/intakes/[id]/report/route.ts` (small, additive, tenant-scoped changes; no DB migration).  

### Testing
- Type-check: ran `npx tsc --noEmit` and the build succeeded (no errors).  
- Lint: ran `npx eslint` targeted at touched files and it passed with only pre-existing `@typescript-eslint/no-explicit-any` warnings (no new errors).  
- Commit: changes were committed after validating type-check and lint outcome.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6ab743248328bb2c7ed665607f6b)