### PR TITLE
Fix remaining create-user seat-limit failure at DB enforcement layer

### DIFF
--- a/db/sql/2026-04-26_shop_user_limit_alignment.sql
+++ b/db/sql/2026-04-26_shop_user_limit_alignment.sql
@@ -1,0 +1,61 @@
+-- Align DB-level shop seat enforcement inputs with canonical billing semantics.
+-- This fixes profile insert/upsert failures caused by stale shops.user_limit values
+-- while preserving database-side seat enforcement.
+
+-- 1) Canonical plan -> seat cap resolver (with trial + safe fallback).
+create or replace function public.plan_user_limit(p_plan text, p_stripe_subscription_status text default null)
+returns integer
+language plpgsql
+stable
+as $$
+declare
+  v_plan text := lower(trim(coalesce(p_plan, '')));
+  v_status text := lower(trim(coalesce(p_stripe_subscription_status, '')));
+begin
+  if v_plan in ('pro_plus', 'unlimited') then
+    return 2147483647;
+  end if;
+
+  if v_plan in ('pro', 'pro50') then
+    return 50;
+  end if;
+
+  if v_plan in ('starter', 'starter10', 'free', 'diy') then
+    return 10;
+  end if;
+
+  if v_status = 'trialing' then
+    return 10;
+  end if;
+
+  return 10;
+end;
+$$;
+
+comment on function public.plan_user_limit(text, text)
+is 'Canonical seat cap resolver: starter=10, pro=50, unlimited=uncapped, trial fallback=10.';
+
+-- 2) Keep shops.user_limit in sync with canonical plan semantics so existing DB triggers
+-- that enforce limits via shops.user_limit use the correct cap.
+create or replace function public.sync_shop_user_limit_from_billing()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.user_limit := public.plan_user_limit(new.plan, new.stripe_subscription_status);
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_sync_shop_user_limit_from_billing on public.shops;
+
+create trigger trg_sync_shop_user_limit_from_billing
+before insert or update of plan, stripe_subscription_status
+on public.shops
+for each row
+execute function public.sync_shop_user_limit_from_billing();
+
+-- 3) Backfill all existing shops to canonical caps.
+update public.shops s
+set user_limit = public.plan_user_limit(s.plan, s.stripe_subscription_status)
+where coalesce(s.user_limit, -1) is distinct from public.plan_user_limit(s.plan, s.stripe_subscription_status);

--- a/features/shared/lib/server/shop-seat-limit.ts
+++ b/features/shared/lib/server/shop-seat-limit.ts
@@ -52,7 +52,8 @@ export async function getShopSeatLimitSnapshot(
   const { count: activeUsers, error: countErr } = await admin
     .from("profiles")
     .select("id", { count: "exact", head: true })
-    .eq("shop_id", shopId);
+    .eq("shop_id", shopId)
+    .eq("is_active", true);
 
   if (countErr) {
     throw new Error(`Failed to count active shop users: ${countErr.message}`);


### PR DESCRIPTION
### Motivation
- Creating the first mechanic in a new trial shop still failed with “Profile upsert failed: Shop user limit reached” because DB-side enforcement was using stale/legacy `shops.user_limit` values and blocked the `profiles.upsert` after the route-level precheck.
- The fix must keep DB-side enforcement but make its inputs and semantics canonical (starter=10, pro=50, unlimited=uncapped, trial/missing-plan → starter), and must align app and DB counting semantics without adding redundant guards.

### Description
- Added an additive SQL migration `db/sql/2026-04-26_shop_user_limit_alignment.sql` that implements `public.plan_user_limit(p_plan, p_stripe_subscription_status)` with canonical mapping (`starter/starter10/free/diy → 10`, `pro/pro50 → 50`, `unlimited/pro_plus → uncapped sentinel`) and trial + safe fallbacks. 
- Added `public.sync_shop_user_limit_from_billing()` and trigger `trg_sync_shop_user_limit_from_billing` to keep `shops.user_limit` synced when `plan` or `stripe_subscription_status` are inserted/updated, and included a backfill `UPDATE public.shops` to correct existing rows.
- Aligned the server-side precheck by changing `features/shared/lib/server/shop-seat-limit.ts` to count only active profiles using `.eq("is_active", true)` so app-level snapshots and DB-level enforcement use the same active-user semantics.
- Files changed: `db/sql/2026-04-26_shop_user_limit_alignment.sql` and `features/shared/lib/server/shop-seat-limit.ts`.

### Testing
- Ran `npm run typecheck` and it completed successfully (no errors).
- Ran `npx tsc --noEmit` and it completed successfully (no errors).
- Ran `npm run lint` which failed due to pre-existing, repo-wide lint issues unrelated to this PR, and those failures did not block the focused type/compile validation for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed70c75c94832889890171623513bf)