### PR TITLE
Stabilize Shop Boost importer execution path accounting and linkage continuity

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -121,6 +121,7 @@ export type ShopBoostImportSummary = {
       total_input: number;
       mismatch: number;
     };
+    domainDiagnostics?: DomainDiagnosticsMap;
     byDomain: Record<string, { success: number; review: number; failed: number }>;
   };
   completionState: CompletionState;
@@ -189,6 +190,39 @@ type CanonicalLifecycleStage =
   | "review_required"
   | "failed"
   | "skipped";
+
+type DomainDiagnostics = {
+  uploaded: number;
+  parsed: number;
+  normalized: number;
+  deterministic_identity: number;
+  linked_existing: number;
+  materialized_new: number;
+  review_required: number;
+  failed: number;
+  skipped: number;
+  mismatch: number;
+};
+
+type DomainDiagnosticsMap = Record<
+  "customers" | "vehicles" | "history" | "invoices" | "parts" | "vendors",
+  DomainDiagnostics
+>;
+
+function createDomainDiagnostics(uploaded: number): DomainDiagnostics {
+  return {
+    uploaded,
+    parsed: uploaded,
+    normalized: 0,
+    deterministic_identity: 0,
+    linked_existing: 0,
+    materialized_new: 0,
+    review_required: 0,
+    failed: 0,
+    skipped: 0,
+    mismatch: 0,
+  };
+}
 
 async function recordImportCreatedArtifact(args: {
   supabase: ReturnType<typeof createAdminSupabase>;
@@ -991,6 +1025,14 @@ function classifyLifecycleStage(args: {
   return "normalized";
 }
 
+function markDomainOutcome(diagnostics: DomainDiagnostics, stage: CanonicalLifecycleStage): void {
+  if (stage === "linked_existing") diagnostics.linked_existing += 1;
+  else if (stage === "materialized_new") diagnostics.materialized_new += 1;
+  else if (stage === "review_required") diagnostics.review_required += 1;
+  else if (stage === "failed") diagnostics.failed += 1;
+  else if (stage === "skipped") diagnostics.skipped += 1;
+}
+
 async function insertRowResult(args: {
   supabase: ReturnType<typeof createAdminSupabase>;
   shopId: string;
@@ -1005,7 +1047,21 @@ async function insertRowResult(args: {
   matchDetails?: Record<string, unknown> | null;
   errorReason?: string | null;
   reviewRequired: boolean;
+  domainDiagnostics?: DomainDiagnostics;
+  deterministicResolved?: boolean;
 }): Promise<void> {
+  if (args.domainDiagnostics) {
+    args.domainDiagnostics.normalized += 1;
+    if (args.deterministicResolved) args.domainDiagnostics.deterministic_identity += 1;
+  }
+  const lifecycleStage = classifyLifecycleStage({
+    matchStatus: args.matchStatus,
+    reviewRequired: args.reviewRequired,
+    errorReason: args.errorReason ?? null,
+  });
+  if (args.domainDiagnostics) {
+    markDomainOutcome(args.domainDiagnostics, lifecycleStage);
+  }
   const cluster = buildClusterDescriptor({
     domain: args.targetDomain,
     rawPayload: args.rawPayload,
@@ -1023,11 +1079,7 @@ async function insertRowResult(args: {
     match_confidence: confidenceScore(args.matchConfidence),
     match_details: {
       resolution_order: DETERMINISTIC_LINKAGE_ORDER,
-      lifecycle_stage: classifyLifecycleStage({
-        matchStatus: args.matchStatus,
-        reviewRequired: args.reviewRequired,
-        errorReason: args.errorReason ?? null,
-      }),
+      lifecycle_stage: lifecycleStage,
       reason_code: args.errorReason ?? null,
       ...(args.matchDetails ?? {}),
     },
@@ -1178,13 +1230,14 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     ? (intakeBasics.uploadManifest as UploadManifestRecord)
     : {};
 
-  const [customersCsv, vehiclesCsv, partsCsv, historyCsv, staffCsv, invoicesCsvFromManifest] = await Promise.all([
+  const [customersCsv, vehiclesCsv, partsCsv, historyCsv, staffCsv, invoicesCsvFromManifest, vendorsCsv] = await Promise.all([
     downloadCsv(intakeRow.customers_file_path ?? null),
     downloadCsv(intakeRow.vehicles_file_path ?? null),
     downloadCsv(intakeRow.parts_file_path ?? null),
     downloadCsv(intakeRow.history_file_path ?? null),
     downloadCsv(intakeRow.staff_file_path ?? null),
     downloadCsv(uploadManifest.invoices?.path ?? null),
+    downloadCsv(uploadManifest.vendors?.path ?? null),
   ]);
 
   const parsedCustomers = customersCsv ? parseCsv(customersCsv).rows : [];
@@ -1192,6 +1245,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const parsedParts = partsCsv ? parseCsv(partsCsv).rows : [];
   const parsedHistory = historyCsv ? parseCsv(historyCsv).rows : [];
   const parsedInvoices = invoicesCsvFromManifest ? parseCsv(invoicesCsvFromManifest).rows : [];
+  const parsedVendors = vendorsCsv ? parseCsv(vendorsCsv).rows : [];
   const totalRows =
     (runCustomers ? parsedCustomers.length : 0) +
     (runVehicles ? parsedVehicles.length : 0) +
@@ -1199,7 +1253,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     (runHistory ? parsedHistory.length : 0) +
     (runInvoices ? parsedInvoices.length : 0);
 
-  const rowOutcome = {
+  const rowOutcome: ShopBoostImportSummary["rowResults"] = {
     totalRows,
     processedRows: 0,
     successCount: 0,
@@ -1217,6 +1271,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       total_input: totalRows,
       mismatch: 0,
     },
+    domainDiagnostics: undefined,
     byDomain: {
       customers: { success: 0, review: 0, failed: 0 },
       vehicles: { success: 0, review: 0, failed: 0 },
@@ -1224,6 +1279,14 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       history: { success: 0, review: 0, failed: 0 },
       invoices: { success: 0, review: 0, failed: 0 },
     },
+  };
+  const domainDiagnostics: DomainDiagnosticsMap = {
+    customers: createDomainDiagnostics(runCustomers ? parsedCustomers.length : 0),
+    vehicles: createDomainDiagnostics(runVehicles ? parsedVehicles.length : 0),
+    history: createDomainDiagnostics(runHistory ? parsedHistory.length : 0),
+    invoices: createDomainDiagnostics(runInvoices ? parsedInvoices.length : 0),
+    parts: createDomainDiagnostics(runParts ? parsedParts.length : 0),
+    vendors: createDomainDiagnostics(parsedVendors.length),
   };
 
   if (!materializeDomain) {
@@ -1390,6 +1453,30 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     }
   }
 
+  const registerCustomerIndexes = (args: {
+    customerId: string;
+    sourceCustomerId?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    normalizedName?: string | null;
+  }): void => {
+    const id = args.customerId;
+    if (!id) return;
+    const email = normalizeEmail(args.email ?? "");
+    const phone = normalizePhone(args.phone ?? "");
+    const normalizedName = normalizeNameKey(args.normalizedName ?? "");
+    if (email) {
+      customersByEmail.set(email, id);
+      addUniqueMatch(uniqueCustomersByEmail, conflictingCustomerEmails, email, id);
+    }
+    if (phone) {
+      customersByPhone.set(phone, id);
+      addUniqueMatch(uniqueCustomersByPhone, conflictingCustomerPhones, phone, id);
+    }
+    if (normalizedName) addUniqueMatch(uniqueCustomersByName, conflictingCustomerNames, normalizedName, id);
+    rememberSourceLinkedId(customersBySourceId, args.sourceCustomerId, id);
+  };
+
   let partsPipelineSummary: PartsPipelineSummary | undefined;
 
   // 1) Import customers
@@ -1406,7 +1493,6 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const name =
         pick(row, [/^display[_\s-]*name$/, /^company[_\s-]*name$/, /^name$/, /customer name/]) ??
         [first ?? "", last ?? ""].filter(Boolean).join(" ");
-      const normalizedName = normalizeNameKey(name);
 
       const customerType = lower(
         pick(row, [/^customer[_\s-]*type$/, /^type$/, /account type/, /customer class/, /segment/]) ?? "",
@@ -1491,8 +1577,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           },
           reviewRequired: false,
         });
-        rememberSourceLinkedId(customersBySourceId, sourceCustomerId, existingId);
-        if (normalizedName) addUniqueMatch(uniqueCustomersByName, conflictingCustomerNames, normalizedName, existingId);
+        registerCustomerIndexes({
+          customerId: existingId,
+          sourceCustomerId,
+          email,
+          phone,
+          normalizedName: name,
+        });
         continue;
       }
 
@@ -1552,10 +1643,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       if (!error) {
         const id = (inserted ?? [])[0]?.id as string | undefined;
         if (id) {
-          if (email) customersByEmail.set(email, id);
-          if (phone) customersByPhone.set(phone, id);
-          rememberSourceLinkedId(customersBySourceId, sourceCustomerId, id);
-          if (normalizedName) addUniqueMatch(uniqueCustomersByName, conflictingCustomerNames, normalizedName, id);
+          registerCustomerIndexes({
+            customerId: id,
+            sourceCustomerId,
+            email,
+            phone,
+            normalizedName: name,
+          });
           await recordImportCreatedArtifact({
             supabase,
             shopId,
@@ -1631,6 +1725,13 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
               updated_at: new Date().toISOString(),
             } as DB["public"]["Tables"]["customers"]["Update"])
             .eq("id", deterministicFallback.id);
+          registerCustomerIndexes({
+            customerId: deterministicFallback.id,
+            sourceCustomerId,
+            email,
+            phone,
+            normalizedName: name,
+          });
           rowOutcome.processedRows += 1;
           rowOutcome.successCount += 1;
           rowOutcome.byDomain.customers.success += 1;
@@ -2373,7 +2474,37 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       }
 
       const workOrderId = (woInserted ?? [])[0]?.id as string | undefined;
-      if (!workOrderId) continue;
+      if (!workOrderId) {
+        rowOutcome.processedRows += 1;
+        rowOutcome.failedCount += 1;
+        rowOutcome.byDomain.history.failed += 1;
+        await createReviewItem({
+          supabase,
+          shopId,
+          intakeId,
+          domain: "work_order",
+          issueType: "conflict",
+          summary: "History row did not return a work order id after materialization attempt.",
+          rawPayload: row,
+          normalizedPayload: { ro, sourceWorkOrderId, external_id, customer_id, vehicle_id },
+          blockingReason: "work_order_id_missing_after_write",
+        });
+        await insertRowResult({
+          supabase,
+          shopId,
+          intakeId,
+          sourceFile: "history",
+          sourceRowIndex: i + 1,
+          rawPayload: row,
+          normalizedPayload: { ro, sourceWorkOrderId, customer_id, vehicle_id, external_id },
+          targetDomain: "work_order",
+          matchStatus: "invalid",
+          matchConfidence: "low",
+          errorReason: "work_order_id_missing_after_write",
+          reviewRequired: true,
+        });
+        continue;
+      }
       if (!woByExternal?.id) {
         await recordImportCreatedArtifact({
           supabase,
@@ -2975,6 +3106,66 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   }
   rowOutcome.integrityErrors = integrityErrors;
   rowOutcome.outcomeBuckets = outcomeBuckets;
+  rowOutcome.domainDiagnostics = domainDiagnostics;
+
+  const { data: lifecycleRows } = await supabase
+    .from("shop_boost_row_results")
+    .select("source_file,match_status,review_required,error_reason,match_details")
+    .eq("shop_id", shopId)
+    .eq("intake_id", intakeId)
+    .limit(100000);
+
+  const domainBySourceFile: Record<string, keyof DomainDiagnosticsMap> = {
+    customers: "customers",
+    vehicles: "vehicles",
+    history: "history",
+    invoices: "invoices",
+    parts: "parts",
+    vendors: "vendors",
+  };
+
+  for (const row of lifecycleRows ?? []) {
+    const sourceFile = String((row as Record<string, unknown>).source_file ?? "");
+    const mappedDomain = domainBySourceFile[sourceFile];
+    if (!mappedDomain) continue;
+    const diagnostics = domainDiagnostics[mappedDomain];
+    diagnostics.normalized += 1;
+    const matchStatus = String((row as Record<string, unknown>).match_status ?? "");
+    const reviewRequired = Boolean((row as Record<string, unknown>).review_required);
+    const errorReason = String((row as Record<string, unknown>).error_reason ?? "") || null;
+    const matchDetails = (row as Record<string, unknown>).match_details;
+    const hasDeterministicSignal =
+      (isRecord(matchDetails) && typeof matchDetails.strategy === "string") ||
+      (isRecord(matchDetails) && typeof matchDetails.resolutionType === "string");
+    if (hasDeterministicSignal) diagnostics.deterministic_identity += 1;
+    const stage = classifyLifecycleStage({
+      matchStatus: matchStatus as MatchStatus,
+      reviewRequired,
+      errorReason,
+    });
+    markDomainOutcome(diagnostics, stage);
+  }
+
+  if (partsPipelineSummary) {
+    const partsDiagnostics = domainDiagnostics.parts;
+    partsDiagnostics.uploaded = partsPipelineSummary.rawRows;
+    partsDiagnostics.parsed = partsPipelineSummary.rawRows;
+    partsDiagnostics.normalized = Math.max(partsDiagnostics.normalized, partsPipelineSummary.normalizedRows);
+    partsDiagnostics.deterministic_identity = Math.max(partsDiagnostics.deterministic_identity, partsPipelineSummary.matchedRows);
+    partsDiagnostics.materialized_new = Math.max(partsDiagnostics.materialized_new, partsPipelineSummary.promotedRows);
+    partsDiagnostics.review_required = Math.max(partsDiagnostics.review_required, partsPipelineSummary.ambiguousRows);
+    partsDiagnostics.failed = Math.max(partsDiagnostics.failed, partsPipelineSummary.rejectedRows);
+  }
+
+  for (const diagnostics of Object.values(domainDiagnostics)) {
+    const bucketed =
+      diagnostics.linked_existing +
+      diagnostics.materialized_new +
+      diagnostics.review_required +
+      diagnostics.failed +
+      diagnostics.skipped;
+    diagnostics.mismatch = Math.abs(diagnostics.parsed - bucketed);
+  }
 
   const { data: keyFixRows } = await supabase
     .from("shop_boost_review_items")

--- a/features/integrations/imports/runPartsImportPipeline.ts
+++ b/features/integrations/imports/runPartsImportPipeline.ts
@@ -108,15 +108,40 @@ function parseCsv(csv: string): { header: string[]; rows: CsvRow[] } {
     return out.map((s) => s.trim());
   };
 
-  const header = splitLine(lines[0]).map((h) => h.trim());
+  const normalizeHeader = (header: string): string =>
+    header
+      .replace(/^\uFEFF/, "")
+      .trim()
+      .replace(/^"(.*)"$/, "$1")
+      .trim();
+
+  const headerAliases = (header: string): string[] => {
+    const normalized = normalizeHeader(header);
+    if (!normalized) return [];
+    const canonical = normalized
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .replace(/_+/g, "_");
+    const spaced = canonical.replace(/_/g, " ").trim();
+    return Array.from(new Set([normalized, canonical, spaced].filter(Boolean)));
+  };
+
+  const header = splitLine(lines[0]).map((h) => normalizeHeader(h));
   const rows: CsvRow[] = [];
 
   for (let i = 1; i < lines.length; i += 1) {
     const cols = splitLine(lines[i]);
     const rec: CsvRow = {};
     for (let c = 0; c < header.length; c += 1) {
-      const key = header[c] || `col_${c + 1}`;
-      rec[key] = cols[c] ?? "";
+      const rawKey = header[c] || `col_${c + 1}`;
+      const value = cols[c] ?? "";
+      const aliases = headerAliases(rawKey);
+      if (aliases.length === 0) {
+        rec[`col_${c + 1}`] = value;
+      } else {
+        for (const alias of aliases) rec[alias] = value;
+      }
     }
     rows.push(rec);
   }


### PR DESCRIPTION
### Motivation

- The importer was producing misleading health signals: customers/vehicles/history/invoices/parts could be staged or counted without reliable end-to-end materialization, and some rows were silently lost during materialization.
- The goal was a focused, non-breaking stabilization pass on the actual importer execution path (CSV → parse → normalize → deterministic identity → materialize → row_result/review) to find and fix real defects rather than add more UI-level summaries.
- Changes are limited to small, targeted runtime/accounting fixes and better diagnostics to surface remaining gaps without changing tenant boundaries or broad architecture.

### Description

- Added per-domain lifecycle diagnostics types and collection for `customers`, `vehicles`, `history`, `invoices`, `parts`, and `vendors`, and persisted them into import `rowResults` to make uploaded→parsed→materialized gaps auditable.
- Fixed in-run customer index continuity by introducing `registerCustomerIndexes` to update email/phone/name unique maps and source-id maps immediately after customer `insert`/`update`, preventing downstream linkage misses for vehicles/history/invoices in the same run.
- Hardened history/work-order handling so a missing work-order id after a materialization attempt is now recorded as an explicit failure: a review item + an `invalid` `shop_boost_row_results` entry and failure counters, eliminating a silent-drop path.
- Improved parts CSV parsing header normalization by adding header alias generation so underscored/quoted/BOM/variant headers map to canonical keys, reducing under-parse and ambiguous staging; added vendors CSV parsing + diagnostics tracking (vendors remain staged by design).

Files changed:
- `features/integrations/imports/runFullImport.ts`
- `features/integrations/imports/runPartsImportPipeline.ts`

### Testing

- Ran TypeScript type-check: `npx tsc --noEmit` — succeeded with no type errors.
- Ran lint on changed files: `npx eslint features/integrations/imports/runFullImport.ts features/integrations/imports/runPartsImportPipeline.ts` — passed (1 pre-existing `no-explicit-any` warning in an unrelated helper area).
- Performed code inspection and grep traces to validate new diagnostics are populated from persisted `shop_boost_row_results` and that the parts parser now exposes header aliases for normalization.
- Note: full runtime replay (end-to-end import against a Supabase instance) was not executed here because that requires a live DB/storage environment; the changes are validated by static checks and targeted code-path instrumentation added to the importer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed716cc1588328a3010b39ecbd66aa)