### PR TITLE
Fix Shop Boost replay harness UUID formatting

### DIFF
--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -25,8 +25,10 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
     : null;
 
   const shopId = process.env.SHOP_BOOST_REPLAY_SHOP_ID as string;
-  const intakeId = `replay-${randomUUID()}`;
-  const storageRoot = `replays/${shopId}/${intakeId}`;
+  const replayRunId = randomUUID();
+  const replayLabel = `replay-${replayRunId}`;
+  const intakeId = replayRunId;
+  const storageRoot = `replays/${shopId}/${replayLabel}`;
 
   beforeAll(async () => {
     const customersPath = `${storageRoot}/customers.csv`;


### PR DESCRIPTION
### Motivation
- The test harness inserted `replay-<uuid>` into the `shop_boost_intakes.id` UUID column which Postgres rejected, so the DB-backed replay cannot start; the fix makes the DB id a plain UUID while keeping a prefixed replay label for storage paths.

### Description
- Updated `tests/shop-boost-onboarding-replay.test.ts` to introduce `replayRunId = randomUUID()` and `replayLabel = \\`replay-${replayRunId}\\``, set `intakeId = replayRunId` for UUID-column inserts, and use `replayLabel` for `storageRoot` paths so the UUID column receives a valid UUID only.

### Testing
- Ran `npx tsc --noEmit` (pass), `npx eslint tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` (pass), and `pnpm test:shop-boost-replay` which executed but the test file was skipped due to the environment gate so DB-backed importer execution could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7f1d62648328b640188cdf01fb79)