### PR TITLE
Fix Shop Boost replay harness intake status mismatch

### DIFF
--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -59,7 +59,7 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
       id: intakeId,
       shop_id: shopId,
       questionnaire: {},
-      status: "uploaded",
+      status: "pending",
       source: "shop_boost_replay_test",
       customers_file_path: customersPath,
       vehicles_file_path: vehiclesPath,


### PR DESCRIPTION
### Motivation
- The DB-backed replay harness was inserting `status: "uploaded"` into `public.shop_boost_intakes`, which violates the table's status check constraint and prevents the replay from proceeding; production intake creation uses a different initial status, so the harness must match the schema.

### Description
- Updated the replay harness insert in `tests/shop-boost-onboarding-replay.test.ts` to use `status: "pending"` instead of `"uploaded"`.  This keeps the change narrowly scoped to the test harness and preserves production schema and importer behavior.
- Audited intake lifecycle and allowed status values used by production flows and importer code and found the active intake statuses: `pending`, `processing`, `completed`, `failed`.
- Chosen status: `pending`, because production intake creation flows insert `pending` as the initial intake status and subsequent lifecycle transitions follow `pending -> processing -> completed|failed`.
- Files changed: `tests/shop-boost-onboarding-replay.test.ts`.

### Testing
- Ran `npx tsc --noEmit` and it succeeded.
- Ran `npx eslint tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` and it succeeded.
- Ran `pnpm test:shop-boost-replay`; Vitest ran but the replay test is environment-gated and was skipped in this environment (output: "1 skipped (1)").
- Outcome: the harness insertion now matches production schema and will allow the DB-backed replay to proceed to importer execution when the required env vars are present; in this run importer execution was not reached because the test remained skipped due to env gating.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed81c275dc83289a9a05bed957b1bf)