### PR TITLE
Fix importer CSV download decoding across runtimes

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -962,7 +962,21 @@ async function downloadCsv(path: string | null): Promise<string | null> {
   const supabase = createAdminSupabase();
   const { data, error } = await supabase.storage.from(SHOP_IMPORT_BUCKET).download(path);
   if (error || !data) return null;
-  return data.text();
+  return decodeStorageDownloadToText(data);
+}
+
+async function decodeStorageDownloadToText(data: unknown): Promise<string | null> {
+  if (typeof data === "string") return data;
+  if (data && typeof (data as { text?: unknown }).text === "function") {
+    return (data as { text: () => Promise<string> }).text();
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+  return null;
 }
 
 async function stageSupplementalUploads(args: {


### PR DESCRIPTION
### Motivation
- The importer assumed a browser `Blob` and called `data.text()`, which fails in Node/Vitest runtimes when Supabase `download()` returns non-Blob payloads (e.g. `Buffer`/`ArrayBuffer`/typed arrays), producing `TypeError: data.text is not a function`.
- This change is a narrow compatibility fix limited to CSV download decoding so the Shop Boost onboarding replay can reach the real importer without changing importer lifecycle, schema, or UI.

### Description
- Replaced the unconditional `data.text()` call in `downloadCsv` with a new helper `decodeStorageDownloadToText(data: unknown): Promise<string | null>` that handles `string`, blob-like objects with `text()`, `ArrayBuffer`, and `ArrayBuffer` views (e.g. `Uint8Array`/`Buffer`) using `TextDecoder` and returns `null` for unsupported shapes.
- The `downloadCsv` behavior is preserved to return `null` on download error or unsupported payloads instead of throwing an unhandled `TypeError`.
- The change is scoped to `features/integrations/imports/runFullImport.ts` only and does not alter other CSV download helpers elsewhere.

### Testing
- Ran `npx eslint features/integrations/imports/runFullImport.ts tests/shop-boost-onboarding-replay.test.ts` which completed with one existing warning and no new errors.
- Invoked `pnpm test:shop-boost-replay` which executed but the replay test file is currently skipped by the harness, so progression past CSV download could not be observed in this run.
- Attempted `npx tsc --noEmit`; the command was started but did not complete in this environment before the manual process cleanup, and no compile errors were reported while it ran.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed836a087083288d0e08ebd2be77c3)