### PR TITLE
Fix Shop Boost replay file discovery mismatch and zero-row readiness false-green

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -134,6 +134,17 @@ type MatchConfidence = "high" | "medium" | "low";
 type UploadManifestRecord = Partial<
   Record<ShopBoostUploadDatasetKey, { path?: string; fileName?: string | null; importMode?: "direct" | "staging" }>
 >;
+type ResolvedImportFilePaths = {
+  customersPath: string | null;
+  vehiclesPath: string | null;
+  partsPath: string | null;
+  historyPath: string | null;
+  staffPath: string | null;
+  invoicesPath: string | null;
+  vendorsPath: string | null;
+  serviceCatalogPath: string | null;
+  declaredUploadDomains: string[];
+};
 type MenuBridgeCandidate = {
   title: string;
   description: string | null;
@@ -277,6 +288,52 @@ function domainReviewItems(domain: MaterializeDomain): string[] {
   if (domain === "parts") return ["part"];
   if (domain === "staff") return [];
   return [];
+}
+
+function firstNonEmptyPath(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = String(value ?? "").trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}
+
+function resolveImportFilePaths(args: { intakeRow: IntakeRow; uploadManifest: UploadManifestRecord }): ResolvedImportFilePaths {
+  const customersPath = firstNonEmptyPath(args.uploadManifest.customers?.path, args.intakeRow.customers_file_path);
+  const vehiclesPath = firstNonEmptyPath(args.uploadManifest.vehicles?.path, args.intakeRow.vehicles_file_path);
+  const partsPath = firstNonEmptyPath(args.uploadManifest.parts?.path, args.intakeRow.parts_file_path);
+  const historyPath = firstNonEmptyPath(args.uploadManifest.history?.path, args.intakeRow.history_file_path);
+  const staffPath = firstNonEmptyPath(args.uploadManifest.staff?.path, args.intakeRow.staff_file_path);
+  const invoicesPath = firstNonEmptyPath(args.uploadManifest.invoices?.path);
+  const vendorsPath = firstNonEmptyPath(args.uploadManifest.vendors?.path);
+  const serviceCatalogPath = firstNonEmptyPath(args.uploadManifest.serviceCatalog?.path);
+
+  const declaredDomainPaths: Array<[string, string | null]> = [
+    ["customers", customersPath],
+    ["vehicles", vehiclesPath],
+    ["parts", partsPath],
+    ["history", historyPath],
+    ["staff", staffPath],
+    ["invoices", invoicesPath],
+    ["vendors", vendorsPath],
+    ["serviceCatalog", serviceCatalogPath],
+  ];
+  const declaredUploadDomains = declaredDomainPaths.reduce<string[]>((acc, [domain, path]) => {
+    if (path) acc.push(domain);
+    return acc;
+  }, []);
+
+  return {
+    customersPath,
+    vehiclesPath,
+    partsPath,
+    historyPath,
+    staffPath,
+    invoicesPath,
+    vendorsPath,
+    serviceCatalogPath,
+    declaredUploadDomains,
+  };
 }
 
 function norm(s: string): string {
@@ -1263,15 +1320,16 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   const uploadManifest = isRecord(intakeBasics.uploadManifest)
     ? (intakeBasics.uploadManifest as UploadManifestRecord)
     : {};
+  const resolvedFiles = resolveImportFilePaths({ intakeRow, uploadManifest });
 
   const [customersCsv, vehiclesCsv, partsCsv, historyCsv, staffCsv, invoicesCsvFromManifest, vendorsCsv] = await Promise.all([
-    downloadCsv(intakeRow.customers_file_path ?? null),
-    downloadCsv(intakeRow.vehicles_file_path ?? null),
-    downloadCsv(intakeRow.parts_file_path ?? null),
-    downloadCsv(intakeRow.history_file_path ?? null),
-    downloadCsv(intakeRow.staff_file_path ?? null),
-    downloadCsv(uploadManifest.invoices?.path ?? null),
-    downloadCsv(uploadManifest.vendors?.path ?? null),
+    downloadCsv(resolvedFiles.customersPath),
+    downloadCsv(resolvedFiles.vehiclesPath),
+    downloadCsv(resolvedFiles.partsPath),
+    downloadCsv(resolvedFiles.historyPath),
+    downloadCsv(resolvedFiles.staffPath),
+    downloadCsv(resolvedFiles.invoicesPath),
+    downloadCsv(resolvedFiles.vendorsPath),
   ]);
 
   const parsedCustomers = customersCsv ? parseCsv(customersCsv).rows : [];
@@ -1323,6 +1381,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
     vendors: createDomainDiagnostics(parsedVendors.length),
   };
 
+  const declaredDirectImportDomains = resolvedFiles.declaredUploadDomains.filter((domain) =>
+    ["customers", "vehicles", "parts", "history", "invoices"].includes(domain),
+  );
   if (!materializeDomain) {
     await Promise.all([
       supabase.from("shop_boost_row_results").delete().eq("shop_id", shopId).eq("intake_id", intakeId),
@@ -1352,7 +1413,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   if (!materializeDomain) {
     await stageSupplementalUploads({ shopId, intakeId, uploadManifest });
   }
-  const serviceCatalogCsv = !materializeDomain ? await downloadCsv(uploadManifest.serviceCatalog?.path ?? null) : null;
+  const serviceCatalogCsv = !materializeDomain ? await downloadCsv(resolvedFiles.serviceCatalogPath) : null;
   const shopBuildSummary = !materializeDomain
     ? await bridgeOperatingLayerFromCsv({
         supabase,
@@ -3107,6 +3168,11 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
   rowOutcome.ignoredCount = ignoredCount;
   const integrity = await runPostMigrationIntegrityValidation({ shopId, intakeId });
   const integrityErrors: string[] = integrity.integrityErrors;
+  if (declaredDirectImportDomains.length > 0 && rowOutcome.totalRows === 0) {
+    integrityErrors.push(
+      `import_input_empty_or_unreadable: declared_domains=${declaredDirectImportDomains.join(",")} processed_rows=0`,
+    );
+  }
 
   const sourceFileFilter = materializeDomain ? domainSourceFile(materializeDomain) : null;
   let totalCountQuery = supabase
@@ -3405,8 +3471,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       ? "partial"
       : "ok";
 
+  const hasDeclaredDirectInputsButNoRows = declaredDirectImportDomains.length > 0 && rowOutcome.totalRows === 0;
   const effectiveCompletionState: ShopBoostImportSummary["completionState"] =
-    canonicalMaterialization.status === "partial" &&
+    (hasDeclaredDirectInputsButNoRows || canonicalMaterialization.status === "partial") &&
     (completionState === "COMPLETED_CLEAN" ||
       completionState === "COMPLETED_WITH_REVIEW" ||
       completionState === "COMPLETED_WITH_WARNINGS" ||

--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -69,6 +69,21 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
       history_file_path: historyPath,
       intake_basics: {
         uploadManifest: {
+          customers: {
+            path: customersPath,
+            fileName: "customers.csv",
+            importMode: "direct",
+          },
+          vehicles: {
+            path: vehiclesPath,
+            fileName: "vehicles.csv",
+            importMode: "direct",
+          },
+          history: {
+            path: historyPath,
+            fileName: "history.csv",
+            importMode: "direct",
+          },
           invoices: {
             path: invoicesPath,
             fileName: "invoices.csv",
@@ -91,6 +106,12 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
     });
 
     console.info("[shop-boost-replay] diagnostics", JSON.stringify(diagnostics, null, 2));
+    expect(diagnostics.discoveredUploadDomains.sort()).toEqual(["customers", "history", "invoices", "vehicles"]);
+    expect(summary.rowResults.totalRows).toBeGreaterThan(0);
+    expect(summary.rowResults.domainDiagnostics?.customers.uploaded ?? 0).toBeGreaterThan(0);
+    if (diagnostics.discoveredUploadDomains.length > 0 && summary.rowResults.totalRows === 0) {
+      expect(summary.completionState).not.toBe("READY_FOR_GO_LIVE");
+    }
 
     const customers = diagnostics.customersByIntake;
     const canonicalCustomer = resolveCanonicalCustomerFromDiagnostics(diagnostics);
@@ -200,6 +221,42 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
     expect(summary.rowResults.domainDiagnostics?.invoices.skipped).toBeGreaterThanOrEqual(1);
     expect(summary.rowResults.outcomeBuckets?.mismatch).toBe(0);
   }, 120_000);
+
+  it("does not report READY_FOR_GO_LIVE when files exist but zero rows are processed", async () => {
+    const emptyIntakeId = randomUUID();
+    const emptyCustomersPath = `${storageRoot}/empty-customers.csv`;
+    await supabase!.storage.from("shop-imports").upload(emptyCustomersPath, "Customer ID,Email\n", {
+      contentType: "text/csv",
+      upsert: true,
+    });
+
+    const { error: emptyIntakeErr } = await supabase!.from("shop_boost_intakes").insert({
+      id: emptyIntakeId,
+      shop_id: shopId,
+      questionnaire: {},
+      status: "pending",
+      source: "shop_boost_replay_test",
+      customers_file_path: emptyCustomersPath,
+      intake_basics: {
+        uploadManifest: {
+          customers: {
+            path: emptyCustomersPath,
+            fileName: "empty-customers.csv",
+            importMode: "direct",
+          },
+        },
+      },
+    } as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]);
+    expect(emptyIntakeErr).toBeNull();
+
+    const summary = await runShopBoostImport({ shopId, intakeId: emptyIntakeId });
+    expect(summary.rowResults.totalRows).toBe(0);
+    expect(summary.completionState).not.toBe("READY_FOR_GO_LIVE");
+    expect(summary.completionState).toBe("NOT_READY");
+    expect((summary.rowResults.integrityErrors ?? []).some((msg) => msg.includes("import_input_empty_or_unreadable"))).toBe(
+      true,
+    );
+  }, 120_000);
 });
 
 function resolveCanonicalCustomerFromDiagnostics(diagnostics: ReplayDiagnostics): CustomerRow | null {
@@ -249,6 +306,7 @@ type ReplayDiagnostics = {
     ReviewItemRow,
     "domain" | "issue_type" | "status" | "summary" | "blocking_reason" | "resolution_action" | "recommended_action"
   >[];
+  discoveredUploadDomains: string[];
 };
 
 async function collectReplayDiagnostics(args: {
@@ -308,6 +366,13 @@ async function collectReplayDiagnostics(args: {
     return acc;
   }, {});
 
+  const intakeBasics = (intakeRes.data?.intake_basics ?? {}) as Record<string, unknown>;
+  const uploadManifest = (intakeBasics.uploadManifest ?? {}) as Record<string, unknown>;
+  const discoveredUploadDomains = ["customers", "vehicles", "history", "invoices"].filter((domain) => {
+    const entry = uploadManifest[domain];
+    return Boolean(entry && typeof entry === "object" && "path" in (entry as Record<string, unknown>));
+  });
+
   return {
     summary: args.summary,
     parserEvidence,
@@ -318,6 +383,7 @@ async function collectReplayDiagnostics(args: {
     customerRowResults: rowResults.filter((row) => row.target_domain === "customer"),
     rowResultsGrouped,
     reviewItems: reviewItemsRes.data ?? [],
+    discoveredUploadDomains,
   };
 }
 


### PR DESCRIPTION
### Motivation
- The DB-backed onboarding replay was providing top-level `customers_file_path`/`vehicles_file_path`/`history_file_path` but the importer was using `intake_basics.uploadManifest` as the canonical discovery, causing declared files to be ignored and `totalRows` to be 0 while the intake advanced to a misleading ready state.
- The change must preserve production shapes and surface a real failure when files exist but zero rows were parsed, without introducing schema/UI changes.

### Description
- Added a canonical file-discovery helper `resolveImportFilePaths` (and `firstNonEmptyPath`) in `runFullImport` to merge `intake_basics.uploadManifest` and legacy top-level columns (manifest-first, fallback to top-level) and produce resolved paths and declared domains.
- Switched all `downloadCsv(...)` calls in `runShopBoostImport` to use the resolved paths so files referenced in either manifest or top-level columns are discovered and parsed.
- Added detection of declared direct-import domains and, if such domains exist but `rowOutcome.totalRows === 0`, pushed an explicit integrity error message `import_input_empty_or_unreadable` and prevented the run from reaching `READY_FOR_GO_LIVE` by forcing `NOT_READY` via the existing completion-state logic.
- Updated the replay test fixture/insertion to include production-like `intake_basics.uploadManifest` entries for `customers`, `vehicles`, `history`, and `invoices` (top-level columns kept), strengthened assertions to verify discovered upload domains and `rowResults.totalRows > 0`, and added a regression test that an empty declared file produces `NOT_READY` and the explicit integrity message.
- Files changed: `features/integrations/imports/runFullImport.ts`, `tests/shop-boost-onboarding-replay.test.ts`.

### Testing
- Ran typecheck with `npx tsc --noEmit` and it passed with no errors.
- Ran linter: `npx eslint features/integrations/imports/runFullImport.ts tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` and it passed (one existing `any` warning remained in `runFullImport.ts`).
- Executed the targeted replay test runner `pnpm test:shop-boost-replay`; tests were invoked but skipped in this environment because required replay environment variables are not present, so full live materialization verification must be run in a replay-capable environment to confirm customer→vehicle→work order→invoice persistence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed87873820832896e2f8e692244a56)