### PR TITLE
Harden Shop Boost replay storage bucket/path verification

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -25,7 +25,7 @@ import {
 
 type DB = Database;
 
-const SHOP_IMPORT_BUCKET = "shop-imports";
+export const SHOP_IMPORT_BUCKET = "shop-imports";
 
 type IntakeRow = DB["public"]["Tables"]["shop_boost_intakes"]["Row"] & {
   customers_file_path?: string | null;

--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 import { beforeAll, describe, expect, it } from "vitest";
-import { runShopBoostImport } from "@/features/integrations/imports/runFullImport";
+import { SHOP_IMPORT_BUCKET, runShopBoostImport } from "@/features/integrations/imports/runFullImport";
 import type { Database } from "@shared/types/types/supabase";
 import { SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE } from "./fixtures/shop-boost-onboarding-replay.fixture";
 
@@ -38,25 +38,53 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
     const vehiclesPath = `${storageRoot}/vehicles.csv`;
     const historyPath = `${storageRoot}/history.csv`;
     const invoicesPath = `${storageRoot}/invoices.csv`;
+    const uploadTargets = [
+      {
+        domain: "customers",
+        path: customersPath,
+        csv: SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.customersCsv,
+        expectedHeaders: ["Customer ID"],
+      },
+      {
+        domain: "vehicles",
+        path: vehiclesPath,
+        csv: SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.vehiclesCsv,
+        expectedHeaders: ["VIN"],
+      },
+      {
+        domain: "history",
+        path: historyPath,
+        csv: SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.historyCsv,
+        expectedHeaders: ["Work Order", "RO ID"],
+      },
+      {
+        domain: "invoices",
+        path: invoicesPath,
+        csv: SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.invoicesCsv,
+        expectedHeaders: ["Invoice"],
+      },
+    ] as const;
 
-    await Promise.all([
-      supabase!.storage.from("shop-imports").upload(customersPath, SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.customersCsv, {
+    for (const target of uploadTargets) {
+      expect(target.csv.trim().length, `${target.domain} fixture CSV must be non-empty`).toBeGreaterThan(0);
+      const { error: uploadError } = await supabase!.storage.from(SHOP_IMPORT_BUCKET).upload(target.path, target.csv, {
         contentType: "text/csv",
         upsert: true,
-      }),
-      supabase!.storage.from("shop-imports").upload(vehiclesPath, SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.vehiclesCsv, {
-        contentType: "text/csv",
-        upsert: true,
-      }),
-      supabase!.storage.from("shop-imports").upload(historyPath, SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.historyCsv, {
-        contentType: "text/csv",
-        upsert: true,
-      }),
-      supabase!.storage.from("shop-imports").upload(invoicesPath, SHOP_BOOST_ONBOARDING_REPLAY_FIXTURE.invoicesCsv, {
-        contentType: "text/csv",
-        upsert: true,
-      }),
-    ]);
+      });
+      expect(uploadError, `${target.domain} upload failed for ${target.path}`).toBeNull();
+    }
+
+    for (const target of uploadTargets) {
+      const { data, error: downloadError } = await supabase!.storage.from(SHOP_IMPORT_BUCKET).download(target.path);
+      expect(downloadError, `${target.domain} pre-import download failed for ${target.path}`).toBeNull();
+      expect(data, `${target.domain} pre-import download missing data for ${target.path}`).toBeTruthy();
+      const csvText = await data!.text();
+      expect(csvText.trim().length, `${target.domain} pre-import download was empty for ${target.path}`).toBeGreaterThan(0);
+      expect(
+        target.expectedHeaders.some((header) => csvText.includes(header)),
+        `${target.domain} pre-import download missing expected header (${target.expectedHeaders.join(" or ")})`,
+      ).toBe(true);
+    }
 
     const { error: intakeError } = await supabase!.from("shop_boost_intakes").insert({
       id: intakeId,
@@ -229,10 +257,13 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
   it("does not report READY_FOR_GO_LIVE when files exist but zero rows are processed", async () => {
     const emptyIntakeId = randomUUID();
     const emptyCustomersPath = `${storageRoot}/empty-customers.csv`;
-    await supabase!.storage.from("shop-imports").upload(emptyCustomersPath, "Customer ID,Email\n", {
+    const emptyCustomersCsv = "Customer ID,Email\n";
+    expect(emptyCustomersCsv.trim().length).toBeGreaterThan(0);
+    const { error: emptyUploadError } = await supabase!.storage.from(SHOP_IMPORT_BUCKET).upload(emptyCustomersPath, emptyCustomersCsv, {
       contentType: "text/csv",
       upsert: true,
     });
+    expect(emptyUploadError).toBeNull();
 
     const { error: emptyIntakeErr } = await supabase!.from("shop_boost_intakes").insert({
       id: emptyIntakeId,


### PR DESCRIPTION
### Motivation
- Root cause: replay harness uploaded fixture CSVs without checking upload errors or verifying readable content, so `runShopBoostImport` saw discovered domains but downloads returned missing/empty data (`download_failed_or_empty`).
- The goal is to make the replay harness and importer use the same canonical bucket constant and fail fast when storage wiring is broken so importer failures surface earlier and more clearly.

### Description
- Export `SHOP_IMPORT_BUCKET` from `features/integrations/imports/runFullImport.ts` so tests can reference the canonical importer bucket constant (value unchanged: `"shop-imports"`).
- Update `tests/shop-boost-onboarding-replay.test.ts` to assert each fixture CSV is non-empty before upload and that every `supabase.storage.upload` returns `error === null`.
- Add pre-import proof: after upload the test downloads each uploaded object from `SHOP_IMPORT_BUCKET` and asserts the downloaded text is non-empty and contains expected domain headers (customers/vehicles/history/invoices).
- Harden the empty-input test to assert upload success and non-empty fixture content before inserting the intake row.
- Files changed: `features/integrations/imports/runFullImport.ts` and `tests/shop-boost-onboarding-replay.test.ts`.

### Testing
- Ran `npx tsc --noEmit` which completed successfully.
- Ran `npx eslint features/integrations/imports/runFullImport.ts tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` which passed with one pre-existing `@typescript-eslint/no-explicit-any` warning in the importer file.
- Ran `pnpm test:shop-boost-replay` which executed the replay test file but both tests were skipped in this environment due to missing replay environment variables (so runtime importer processing could not be observed here).
- Result: typecheck and lint validation passed (one warning), and the test harness is now fail-fast for any storage upload/download problems when replay env is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8cc265548328a551486d8d7c6b41)