### PR TITLE
Fix replay harness storage download decoding in onboarding test

### DIFF
--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -12,6 +12,20 @@ type ReviewItemRow = DB["public"]["Tables"]["shop_boost_review_items"]["Row"];
 type IntakeRow = DB["public"]["Tables"]["shop_boost_intakes"]["Row"];
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 
+async function decodeStorageDownloadToText(data: unknown): Promise<string | null> {
+  if (typeof data === "string") return data;
+  if (data && typeof (data as { text?: unknown }).text === "function") {
+    return await (data as { text: () => Promise<string> }).text();
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+  return null;
+}
+
 const shouldRunReplay =
   process.env.RUN_SHOP_BOOST_REPLAY_TEST === "true" &&
   !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
@@ -78,10 +92,12 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
       const { data, error: downloadError } = await supabase!.storage.from(SHOP_IMPORT_BUCKET).download(target.path);
       expect(downloadError, `${target.domain} pre-import download failed for ${target.path}`).toBeNull();
       expect(data, `${target.domain} pre-import download missing data for ${target.path}`).toBeTruthy();
-      const csvText = await data!.text();
-      expect(csvText.trim().length, `${target.domain} pre-import download was empty for ${target.path}`).toBeGreaterThan(0);
+      const csvText = await decodeStorageDownloadToText(data);
+      expect(csvText, `${target.domain} pre-import download could not be decoded for ${target.path}`).toBeTruthy();
+      const decodedCsvText = csvText ?? "";
+      expect(decodedCsvText.trim().length, `${target.domain} pre-import download was empty for ${target.path}`).toBeGreaterThan(0);
       expect(
-        target.expectedHeaders.some((header) => csvText.includes(header)),
+        target.expectedHeaders.some((header) => decodedCsvText.includes(header)),
         `${target.domain} pre-import download missing expected header (${target.expectedHeaders.join(" or ")})`,
       ).toBe(true);
     }


### PR DESCRIPTION
### Motivation
- The replay test assumed Supabase `download` payload always supported `Blob.text()`, which in Node/Vitest can be an `ArrayBuffer`, `Uint8Array/Buffer`, or `string`, causing `TypeError: data.text is not a function`. 
- The intent is to make the pre-import storage proof decoding robust without changing importer behavior, schema, or assertions.

### Description
- Add a small test-local helper `decodeStorageDownloadToText(data: unknown): Promise<string | null>` that handles `string`, Blob-like `.text()`, `ArrayBuffer`, and `ArrayBufferView` payloads. 
- Replace the direct `data!.text()` call in `tests/shop-boost-onboarding-replay.test.ts` with the new `decodeStorageDownloadToText` helper and preserve existing assertions for non-empty CSV content and expected headers. 
- No changes were made to importer materialization, database schema, UI, or onboarding agent logic.

### Testing
- Ran type check with `npx tsc --noEmit`, which completed successfully. 
- Ran lint for the modified test with `npx eslint tests/shop-boost-onboarding-replay.test.ts`, which completed successfully. 
- Ran the replay test command `pnpm test:shop-boost-replay`, which executed but the test file was skipped in this environment due to missing replay environment variables/credentials so runtime import paths were not exercised. 
- Files changed: `tests/shop-boost-onboarding-replay.test.ts`. 
- Root cause: test assumed `.text()` existed on download payloads in Node runtime. 
- Pre-import storage proof status: not conclusively verified here because the replay suite was skipped, but the decoding helper addresses the `TypeError` and should allow the pre-import checks to run when replay env vars are present. 
- Next failure: if the replay proceeds to importer execution and fails later, report the next error and classify it as one of: harness storage bug, parser/header bug, importer materialization bug, schema mismatch, or readiness/accounting bug.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8e1393e4832883572ab801731c6e)