### PR TITLE
Stabilize Shop Boost replay materialization for VIN/history lines/invoices

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -2160,19 +2160,33 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
           (plate && vehiclesByPlate.get(plate)));
 
       if (existingId) {
+        const { data: existingVehicle } = await supabase
+          .from("vehicles")
+          .select("vin,license_plate,unit_number,year,make,model,mileage,engine_hours")
+          .eq("id", existingId)
+          .maybeSingle<{
+            vin: string | null;
+            license_plate: string | null;
+            unit_number: string | null;
+            year: number | null;
+            make: string | null;
+            model: string | null;
+            mileage: string | null;
+            engine_hours: number | null;
+          }>();
         await supabase
           .from("vehicles")
           .update({
             shop_id: shopId,
             customer_id,
-            vin: vin || null,
-            license_plate: plate || null,
-            unit_number: unit ?? null,
-            year: year ?? null,
-            make: make ?? null,
-            model: model ?? null,
-            mileage: mileage ?? null,
-            engine_hours: engineHours ?? null,
+            vin: vin || existingVehicle?.vin || null,
+            license_plate: plate || existingVehicle?.license_plate || null,
+            unit_number: unit ?? existingVehicle?.unit_number ?? null,
+            year: year ?? existingVehicle?.year ?? null,
+            make: make ?? existingVehicle?.make ?? null,
+            model: model ?? existingVehicle?.model ?? null,
+            mileage: mileage ?? existingVehicle?.mileage ?? null,
+            engine_hours: engineHours ?? existingVehicle?.engine_hours ?? null,
             source_intake_id: intakeId,
             external_id,
             import_confidence: 0.75,
@@ -2457,6 +2471,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const parts = parseMoney(
         pick(row, [/^parts[_\s-]*sale$/, /^parts[_\s-]*total$/, /parts sale/, /parts amount/, /^parts$/]),
       );
+      const laborTimeHours = parseLaborHours(
+        pick(row, [/^labor[_\s-]*(hours|hrs|time)$/, /labor hours?/, /labor hrs?/, /flat rate hours?/]),
+      );
 
       const vin = lower(pick(row, [/vin/]) ?? "");
       const plate = lower(pick(row, [/plate/, /license/]) ?? "");
@@ -2730,6 +2747,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         cause,
         correction,
         vehicle_id,
+        laborTimeHours,
       });
       if (!historyLineUpsert.ok) {
         rowOutcome.processedRows += 1;
@@ -3731,11 +3749,13 @@ async function upsertHistoryLine(args: {
   cause: string | null;
   correction: string | null;
   vehicle_id: string | null;
+  laborTimeHours: number | null;
 }): Promise<{ ok: boolean; lineId: string | null; action: "created" | "updated"; errorReason: string | null }> {
-  const { supabase, shopId, intakeId, workOrderId, rowIndex, complaint, cause, correction, vehicle_id } =
+  const { supabase, shopId, intakeId, workOrderId, rowIndex, complaint, cause, correction, vehicle_id, laborTimeHours } =
     args;
 
   const external_id = `import:${intakeId}:wol:${workOrderId}:${rowIndex}`;
+  const hasCompletedLaborTime = typeof laborTimeHours === "number" && Number.isFinite(laborTimeHours) && laborTimeHours > 0;
 
   const payload = {
     shop_id: shopId,
@@ -3745,7 +3765,8 @@ async function upsertHistoryLine(args: {
     cause: cause ?? null,
     correction: correction ?? null,
     description: correction ?? complaint ?? "Imported history line",
-    status: "completed",
+    status: hasCompletedLaborTime ? "completed" : "awaiting",
+    labor_time: hasCompletedLaborTime ? laborTimeHours : null,
     job_type: "repair",
     line_no: rowIndex,
     source_intake_id: intakeId,
@@ -3814,7 +3835,7 @@ async function upsertInvoiceIfNeeded(args: {
         .from("invoices")
         .select("id")
         .eq("shop_id", shopId)
-        .eq("external_id", externalId)
+        .contains("metadata", { source_external_id: externalId })
         .maybeSingle<{ id: string }>()
     : null;
   const byInvoiceNumber = invoiceNumber
@@ -3843,8 +3864,11 @@ async function upsertInvoiceIfNeeded(args: {
     paid_at: issuedAt,
     invoice_number: invoiceNumber ?? `IMP-${workOrderId.slice(0, 8)}`,
     currency: "USD",
-    external_id: externalId ?? null,
-    metadata: { imported: true, source_intake_id: intakeId },
+    metadata: {
+      imported: true,
+      source_intake_id: intakeId,
+      ...(externalId ? { source_external_id: externalId } : {}),
+    },
   };
 
   const existingId = byExternal?.data?.id ?? byInvoiceNumber?.data?.id ?? byWorkOrder.data?.id ?? null;

--- a/tests/fixtures/shop-boost-onboarding-replay.fixture.ts
+++ b/tests/fixtures/shop-boost-onboarding-replay.fixture.ts
@@ -9,8 +9,8 @@ VEH-001,CUST-001,1FTFW1E50PFA00001,PLT-901,U-9,2020,Ford,F-150,CASEY.DRIVER@EXAM
 ,CUST-001, , plt-901 , u-9 ,2020,Ford,F-150,casey.driver@example.com,(555)111-2222,Casey Driver
 ,,2HGES16555H000002,UNKNOWN-PLATE,U-404,2019,Honda,Civic,,,
 `,
-  historyCsv: `RO ID,Customer ID,Vehicle ID,Invoice Number,Service Date,Complaint,Cause,Correction,Total,Labor Total,Parts Total,Customer Email,Customer Phone,VIN,License Plate,Unit Number,Customer Name
-WO-001,CUST-001,VEH-001,INV-1001,2025-02-10,No start,Battery failed,Replaced battery,250.00,150.00,100.00, casey.driver@example.com ,5551112222,1FTFW1E50PFA00001,PLT-901,U-9,Casey Driver
+  historyCsv: `RO ID,Customer ID,Vehicle ID,Invoice Number,Service Date,Complaint,Cause,Correction,Total,Labor Total,Labor Hours,Parts Total,Customer Email,Customer Phone,VIN,License Plate,Unit Number,Customer Name
+WO-001,CUST-001,VEH-001,INV-1001,2025-02-10,No start,Battery failed,Replaced battery,250.00,150.00,1.5,100.00, casey.driver@example.com ,5551112222,1FTFW1E50PFA00001,PLT-901,U-9,Casey Driver
 `,
   invoicesCsv: `Invoice ID,Work Order ID,Customer ID,Invoice Number,Date,Total,Labor Total,Parts Total,Customer Email,Customer Phone,RO
 INV-1001,WO-001,CUST-001,INV-1001,2025-02-10,275.00,175.00,100.00,CASEY.DRIVER@EXAMPLE.COM,(555) 111-2222,RO-1001


### PR DESCRIPTION
### Motivation
- The replay importer reached real materialization and exposed three deterministic failures: VIN values were being nulled by later updates, history lines were inserted as `completed` without labor time (violating DB check constraints), and invoice upserts referenced a non-existent `invoices.external_id` column.  
- The change aims to make the importer behave safely and deterministically so the replay can prove the canonical customer→vehicle→work order→invoice graph without changing production schema or shop-scoping rules.  

### Description
- Preserve existing vehicle fields when updating a matched vehicle by reading the existing row and only overwriting fields when the incoming value is present, preventing blank updates from nulling a prior VIN/plate/unit (`features/integrations/imports/runFullImport.ts`).  
- Parse `Labor Hours` (and common aliases) from history rows and pass normalized labor hours into the history line upsert, and only set line `status` to `completed` when a positive `labor_time` is present otherwise import as `awaiting` to satisfy production constraints (`features/integrations/imports/runFullImport.ts`).  
- Stop querying/writing `invoices.external_id` and instead persist the source identity in `invoices.metadata.source_external_id`, using `metadata` containment to find existing invoices so no DB migration is required (`features/integrations/imports/runFullImport.ts`).  
- Add `Labor Hours` to the deterministic replay fixture so the replay can materialize a completed history line deterministically (`tests/fixtures/shop-boost-onboarding-replay.fixture.ts`).  

### Testing
- Ran type check with `npx tsc --noEmit` and it completed successfully.  
- Ran ESLint on the changed files with `npx eslint features/integrations/imports/runFullImport.ts tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` which passed (one existing `any` warning reported).  
- Ran the replay test command `pnpm test:shop-boost-replay`, which executed successfully in this environment but the suite was skipped because required Supabase replay env vars are not set, so a live replay run was not possible here.  
- No schema migrations were added and all changes are contained to importer logic and the replay fixture files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed91aa1ff08328a94e5831a168b2e7)