### PR TITLE
Stabilize Shop Boost replay for historical lines and invoices

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -2455,6 +2455,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const ro =
         pick(row, [/^invoice[_\s-]*number$/, /^ro$/, /ro number/, /work order/, /order number/, /invoice number/]) ?? null;
       const invoiceNumber = pick(row, [/^invoice[_\s-]*number$/, /^invoice number$/, /^invoice #$/, /^invoice$/]);
+      const sourceInvoiceStatus = pick(row, [/invoice status/, /^status$/, /closed status/, /document status/]);
+      const sourcePaymentStatus = pick(row, [/payment status/, /paid status/, /balance status/, /ar status/]);
 
       const dateIso =
         parseDateIso(pick(row, [/date/, /service date/, /closed/, /completed/])) ??
@@ -2794,6 +2796,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         parts,
         issuedAt: dateIso,
         invoiceNumber: invoiceNumber ?? ro,
+        importSource: "history",
+        sourceInvoiceStatus,
+        sourcePaymentStatus,
       });
       if (!invoiceUpsert.ok) {
         rowOutcome.processedRows += 1;
@@ -2881,6 +2886,8 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       const sourceWorkOrderKeys = sourceIdentityHashes(sourceWorkOrderId);
       const invoiceNumber = pick(row, [/^invoice[_\s-]*number$/, /^invoice number$/, /^invoice #$/, /^invoice$/, /inv number/]);
       const ro = pick(row, [/^ro$/, /ro number/, /work order/, /order number/]) ?? null;
+      const sourceInvoiceStatus = pick(row, [/invoice status/, /^status$/, /closed status/, /document status/]);
+      const sourcePaymentStatus = pick(row, [/payment status/, /paid status/, /balance status/, /ar status/]);
       const issuedAt = parseDateIso(pick(row, [/date/, /issued/, /closed/, /completed/])) ?? new Date().toISOString();
       const total = parseMoney(pick(row, [/total/, /grand total/, /invoice total/, /amount due/]));
       const labor = parseMoney(
@@ -2987,6 +2994,9 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         issuedAt,
         invoiceNumber: invoiceNumber ?? null,
         externalId: derivedInvoiceExternalId,
+        importSource: "invoices",
+        sourceInvoiceStatus,
+        sourcePaymentStatus,
       });
       if (!invoiceUpsert.ok) {
         rowOutcome.processedRows += 1;
@@ -3755,7 +3765,8 @@ async function upsertHistoryLine(args: {
     args;
 
   const external_id = `import:${intakeId}:wol:${workOrderId}:${rowIndex}`;
-  const hasCompletedLaborTime = typeof laborTimeHours === "number" && Number.isFinite(laborTimeHours) && laborTimeHours > 0;
+  const normalizedLaborTime =
+    typeof laborTimeHours === "number" && Number.isFinite(laborTimeHours) && laborTimeHours > 0 ? laborTimeHours : null;
 
   const payload = {
     shop_id: shopId,
@@ -3765,8 +3776,10 @@ async function upsertHistoryLine(args: {
     cause: cause ?? null,
     correction: correction ?? null,
     description: correction ?? complaint ?? "Imported history line",
-    status: hasCompletedLaborTime ? "completed" : "awaiting",
-    labor_time: hasCompletedLaborTime ? laborTimeHours : null,
+    status: "awaiting",
+    line_type: "info",
+    punchable: false,
+    labor_time: normalizedLaborTime,
     job_type: "repair",
     line_no: rowIndex,
     source_intake_id: intakeId,
@@ -3824,8 +3837,26 @@ async function upsertInvoiceIfNeeded(args: {
   issuedAt: string | null;
   invoiceNumber?: string | null;
   externalId?: string | null;
+  importSource?: "history" | "invoices";
+  sourceInvoiceStatus?: string | null;
+  sourcePaymentStatus?: string | null;
 }): Promise<{ ok: boolean; invoiceId: string | null; errorReason: string | null; action: "created" | "updated" | "skipped_no_amount" }> {
-  const { supabase, shopId, intakeId, workOrderId, customer_id, total, labor, parts, issuedAt, invoiceNumber, externalId } = args;
+  const {
+    supabase,
+    shopId,
+    intakeId,
+    workOrderId,
+    customer_id,
+    total,
+    labor,
+    parts,
+    issuedAt,
+    invoiceNumber,
+    externalId,
+    importSource,
+    sourceInvoiceStatus,
+    sourcePaymentStatus,
+  } = args;
 
   const hasMoney = (total ?? 0) > 0 || (labor ?? 0) > 0 || (parts ?? 0) > 0;
   if (!hasMoney) return { ok: true, invoiceId: null, errorReason: null, action: "skipped_no_amount" };
@@ -3855,18 +3886,23 @@ async function upsertInvoiceIfNeeded(args: {
 
   const payload = {
     customer_id,
-    status: "paid",
+    status: "open",
     subtotal: Math.max(0, (labor ?? 0) + (parts ?? 0)),
     labor_cost: labor ?? 0,
     parts_cost: parts ?? 0,
     total: total ?? Math.max(0, (labor ?? 0) + (parts ?? 0)),
     issued_at: issuedAt,
-    paid_at: issuedAt,
+    paid_at: null,
     invoice_number: invoiceNumber ?? `IMP-${workOrderId.slice(0, 8)}`,
     currency: "USD",
     metadata: {
       imported: true,
+      imported_history: true,
+      imported_assumed_paid: true,
       source_intake_id: intakeId,
+      source_invoice_status: sourceInvoiceStatus ?? null,
+      source_payment_status: sourcePaymentStatus ?? null,
+      source_file: importSource ?? null,
       ...(externalId ? { source_external_id: externalId } : {}),
     },
   };

--- a/tests/fixtures/shop-boost-onboarding-replay.fixture.ts
+++ b/tests/fixtures/shop-boost-onboarding-replay.fixture.ts
@@ -9,12 +9,12 @@ VEH-001,CUST-001,1FTFW1E50PFA00001,PLT-901,U-9,2020,Ford,F-150,CASEY.DRIVER@EXAM
 ,CUST-001, , plt-901 , u-9 ,2020,Ford,F-150,casey.driver@example.com,(555)111-2222,Casey Driver
 ,,2HGES16555H000002,UNKNOWN-PLATE,U-404,2019,Honda,Civic,,,
 `,
-  historyCsv: `RO ID,Customer ID,Vehicle ID,Invoice Number,Service Date,Complaint,Cause,Correction,Total,Labor Total,Labor Hours,Parts Total,Customer Email,Customer Phone,VIN,License Plate,Unit Number,Customer Name
-WO-001,CUST-001,VEH-001,INV-1001,2025-02-10,No start,Battery failed,Replaced battery,250.00,150.00,1.5,100.00, casey.driver@example.com ,5551112222,1FTFW1E50PFA00001,PLT-901,U-9,Casey Driver
+  historyCsv: `RO ID,Customer ID,Vehicle ID,Invoice Number,Service Date,Complaint,Cause,Correction,Total,Labor Total,Labor Hours,Parts Total,Invoice Status,Payment Status,Customer Email,Customer Phone,VIN,License Plate,Unit Number,Customer Name
+WO-001,CUST-001,VEH-001,INV-1001,2025-02-10,No start,Battery failed,Replaced battery,250.00,150.00,1.5,100.00,closed,paid, casey.driver@example.com ,5551112222,1FTFW1E50PFA00001,PLT-901,U-9,Casey Driver
 `,
-  invoicesCsv: `Invoice ID,Work Order ID,Customer ID,Invoice Number,Date,Total,Labor Total,Parts Total,Customer Email,Customer Phone,RO
-INV-1001,WO-001,CUST-001,INV-1001,2025-02-10,275.00,175.00,100.00,CASEY.DRIVER@EXAMPLE.COM,(555) 111-2222,RO-1001
-INV-1002,WO-001,CUST-001,INV-1002,2025-02-10,0,0,0,casey.driver@example.com,5551112222,RO-1001
-INV-404,WO-404,CUST-404,INV-404,2025-02-10,120.00,50.00,70.00,missing@example.com,5550000000,RO-404
+  invoicesCsv: `Invoice ID,Work Order ID,Customer ID,Invoice Number,Date,Total,Labor Total,Parts Total,Invoice Status,Payment Status,Customer Email,Customer Phone,RO
+INV-1001,WO-001,CUST-001,INV-1001,2025-02-10,275.00,175.00,100.00,closed,paid,CASEY.DRIVER@EXAMPLE.COM,(555) 111-2222,RO-1001
+INV-1002,WO-001,CUST-001,INV-1002,2025-02-10,0,0,0,open,unpaid,casey.driver@example.com,5551112222,RO-1001
+INV-404,WO-404,CUST-404,INV-404,2025-02-10,120.00,50.00,70.00,closed,paid,missing@example.com,5550000000,RO-404
 `,
 } as const;

--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -192,21 +192,30 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
 
     const { data: lines } = await supabase!
       .from("work_order_lines")
-      .select("id,work_order_id,description,concern,cause,correction,source_intake_id")
+      .select("id,work_order_id,description,complaint,cause,correction,status,line_type,punchable,labor_time,source_intake_id")
       .eq("shop_id", shopId)
       .eq("work_order_id", workOrderId as string)
       .eq("source_intake_id", intakeId);
     expect((lines?.length ?? 0) >= 1).toBe(true);
+    expect(lines?.[0]?.status).toBe("awaiting");
+    expect(lines?.[0]?.line_type).toBe("info");
+    expect(lines?.[0]?.punchable).toBe(false);
 
     const { data: invoices } = await supabase!
       .from("invoices")
-      .select("id,shop_id,work_order_id,customer_id,total,labor_cost,parts_cost,invoice_number,metadata")
+      .select("id,shop_id,work_order_id,customer_id,total,labor_cost,parts_cost,invoice_number,status,paid_at,metadata")
       .eq("shop_id", shopId)
       .eq("work_order_id", workOrderId as string)
       .contains("metadata", { source_intake_id: intakeId });
     expect(invoices?.length).toBe(1);
     expect(invoices?.[0]?.customer_id).toBe(canonicalCustomerId);
     expect(invoices?.[0]?.total).toBe(275);
+    expect(invoices?.[0]?.status).toBe("open");
+    expect(invoices?.[0]?.paid_at).toBeNull();
+    expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.imported_history).toBe(true);
+    expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.imported_assumed_paid).toBe(true);
+    expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.source_invoice_status).toBe("closed");
+    expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.source_payment_status).toBe("paid");
 
     const { data: rowResults } = await supabase!
       .from("shop_boost_row_results")


### PR DESCRIPTION
### Motivation
- Imported Shop Boost history are archival records and must not be treated as live ProFixIQ jobs or payment lifecycle events, because historical rows should be stored for lookup/reporting without triggering live guardrails.  
- The replay was failing because imported lines were written as `completed` (triggering `work_order_lines_completed_requires_punch_out_chk`) and invoices were written as `paid` against completed work orders (triggering invoice/payment vs work_order guardrails).  
- The goal is a narrow importer posture that preserves source detail and provenance while remaining compatible with existing DB constraints and multi-tenant scoping.

### Description
- Change history line materialization in `upsertHistoryLine` to create non-operational lines (`status: "awaiting"`, `line_type: "info"`, `punchable: false`) while preserving `complaint`/`cause`/`correction`/`description` and optional `labor_time`.  
- Change invoice materialization in `upsertInvoiceIfNeeded` to use a safe canonical state (`status: "open"`, `paid_at: null`) and attach provenance metadata (`imported_history`, `imported_assumed_paid`, `source_invoice_status`, `source_payment_status`, `source_file`, `source_intake_id`) so source-paid semantics are preserved for reporting.  
- Thread source invoice/payment status parsing from both `history` and `invoices` CSV domains into the invoice upsert payload, and skip zero-amount invoices as before.  
- Update replay fixture and assertions to include `Invoice Status` and `Payment Status` columns and to assert the historical semantics for `work_order_lines` and `invoices` (files changed: `features/integrations/imports/runFullImport.ts`, `tests/fixtures/shop-boost-onboarding-replay.fixture.ts`, `tests/shop-boost-onboarding-replay.test.ts`).

### Testing
- Ran `npx tsc --noEmit` and typecheck passed.  
- Ran `npx eslint features/integrations/imports/runFullImport.ts tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` and lint passed with one pre-existing `@typescript-eslint/no-explicit-any` warning in `runFullImport.ts`.  
- Ran `pnpm test:shop-boost-replay`; the test harness executed successfully but the replay tests are skipped in this environment when replay env vars are not provided (behavior unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed95207b94832895371e4305170c83)