### PR TITLE
Fix Shop Boost historical import for work_order_lines and invoices

### DIFF
--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -2799,6 +2799,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         importSource: "history",
         sourceInvoiceStatus,
         sourcePaymentStatus,
+        sourceRowIndex: i + 1,
       });
       if (!invoiceUpsert.ok) {
         rowOutcome.processedRows += 1;
@@ -2997,6 +2998,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         importSource: "invoices",
         sourceInvoiceStatus,
         sourcePaymentStatus,
+        sourceRowIndex: i + 1,
       });
       if (!invoiceUpsert.ok) {
         rowOutcome.processedRows += 1;
@@ -3776,11 +3778,9 @@ async function upsertHistoryLine(args: {
     cause: cause ?? null,
     correction: correction ?? null,
     description: correction ?? complaint ?? "Imported history line",
-    status: "awaiting",
+    status: "completed",
     line_type: "info",
-    punchable: false,
     labor_time: normalizedLaborTime,
-    job_type: "repair",
     line_no: rowIndex,
     source_intake_id: intakeId,
     external_id,
@@ -3840,6 +3840,7 @@ async function upsertInvoiceIfNeeded(args: {
   importSource?: "history" | "invoices";
   sourceInvoiceStatus?: string | null;
   sourcePaymentStatus?: string | null;
+  sourceRowIndex?: number | null;
 }): Promise<{ ok: boolean; invoiceId: string | null; errorReason: string | null; action: "created" | "updated" | "skipped_no_amount" }> {
   const {
     supabase,
@@ -3856,6 +3857,7 @@ async function upsertInvoiceIfNeeded(args: {
     importSource,
     sourceInvoiceStatus,
     sourcePaymentStatus,
+    sourceRowIndex,
   } = args;
 
   const hasMoney = (total ?? 0) > 0 || (labor ?? 0) > 0 || (parts ?? 0) > 0;
@@ -3886,13 +3888,13 @@ async function upsertInvoiceIfNeeded(args: {
 
   const payload = {
     customer_id,
-    status: "open",
+    status: "paid",
     subtotal: Math.max(0, (labor ?? 0) + (parts ?? 0)),
     labor_cost: labor ?? 0,
     parts_cost: parts ?? 0,
     total: total ?? Math.max(0, (labor ?? 0) + (parts ?? 0)),
     issued_at: issuedAt,
-    paid_at: null,
+    paid_at: issuedAt,
     invoice_number: invoiceNumber ?? `IMP-${workOrderId.slice(0, 8)}`,
     currency: "USD",
     metadata: {
@@ -3903,6 +3905,7 @@ async function upsertInvoiceIfNeeded(args: {
       source_invoice_status: sourceInvoiceStatus ?? null,
       source_payment_status: sourcePaymentStatus ?? null,
       source_file: importSource ?? null,
+      source_row_index: sourceRowIndex ?? null,
       ...(externalId ? { source_external_id: externalId } : {}),
     },
   };

--- a/tests/shop-boost-onboarding-replay.test.ts
+++ b/tests/shop-boost-onboarding-replay.test.ts
@@ -192,14 +192,16 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
 
     const { data: lines } = await supabase!
       .from("work_order_lines")
-      .select("id,work_order_id,description,complaint,cause,correction,status,line_type,punchable,labor_time,source_intake_id")
+      .select("id,work_order_id,description,complaint,cause,correction,status,line_type,punchable,punched_in_at,punched_out_at,labor_time,source_intake_id")
       .eq("shop_id", shopId)
       .eq("work_order_id", workOrderId as string)
       .eq("source_intake_id", intakeId);
     expect((lines?.length ?? 0) >= 1).toBe(true);
-    expect(lines?.[0]?.status).toBe("awaiting");
+    expect(lines?.[0]?.status).toBe("completed");
     expect(lines?.[0]?.line_type).toBe("info");
-    expect(lines?.[0]?.punchable).toBe(false);
+    expect(lines?.[0]?.punchable).not.toBe(true);
+    expect(lines?.[0]?.punched_in_at).toBeNull();
+    expect(lines?.[0]?.punched_out_at).toBeNull();
 
     const { data: invoices } = await supabase!
       .from("invoices")
@@ -210,8 +212,8 @@ describeReplay("Shop Boost onboarding deterministic replay", () => {
     expect(invoices?.length).toBe(1);
     expect(invoices?.[0]?.customer_id).toBe(canonicalCustomerId);
     expect(invoices?.[0]?.total).toBe(275);
-    expect(invoices?.[0]?.status).toBe("open");
-    expect(invoices?.[0]?.paid_at).toBeNull();
+    expect(invoices?.[0]?.status).toBe("paid");
+    expect(invoices?.[0]?.paid_at).toBeTruthy();
     expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.imported_history).toBe(true);
     expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.imported_assumed_paid).toBe(true);
     expect((invoices?.[0]?.metadata as Record<string, unknown> | null)?.source_invoice_status).toBe("closed");


### PR DESCRIPTION
### Motivation
- Historical Shop Boost CSV rows are informational and must not set generated/default-only columns or invalid live workflow states.  The importer was writing `punchable` and an invalid invoice status which caused DB constraint failures.  

### Description
- Stop writing DB-generated/default-only `punchable` and remove `job_type` for history lines so DB defaults govern punch semantics.  Imported history lines are now `line_type: "info"` and `status: "completed"` to represent non-live informational records.  
- Thread `sourceRowIndex` into the invoice upsert path for both `history`-sourced and `invoices`-sourced materialization calls.  
- Use a valid invoice status for historical invoices by setting `status: "paid"` and `paid_at = issuedAt` (historical/assumed-paid semantics), and preserve original source truth in `metadata` (including `imported_history`, `imported_assumed_paid`, `source_invoice_status`, `source_payment_status`, `source_intake_id`, `source_file`, `source_row_index`).  
- Update replay assertions to check the new historical semantics (work order lines are informational/completed and not punchable/punched; invoice is recorded as `paid` with preserved metadata).  
- Files changed: `features/integrations/imports/runFullImport.ts`, `tests/shop-boost-onboarding-replay.test.ts`.  

### Testing
- Ran type check: `npx tsc --noEmit` — succeeded.  
- Linted changed files: `npx eslint features/integrations/imports/runFullImport.ts tests/shop-boost-onboarding-replay.test.ts tests/fixtures/shop-boost-onboarding-replay.fixture.ts` — completed with one pre-existing `@typescript-eslint/no-explicit-any` warning in `runFullImport.ts`.  
- Ran replay test script: `pnpm test:shop-boost-replay` — vitest executed but the Shop Boost replay tests were skipped in this environment because required runtime environment variables were not present, so no live DB replay failures were observed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed986fb67c8328a4e049965bb687f9)