### PR TITLE
Add staging-first Onboarding Agent foundation, DB schema, API routes, and owner UI

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activation-plan/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activation-plan/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { buildOnboardingActivationPlan } from "@/features/onboarding-agent/server/buildOnboardingActivationPlan";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function POST(_: Request, { params }: { params: { sessionId: string } }) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  try {
+    const plan = await buildOnboardingActivationPlan({ supabase: access.supabase, shopId: access.profile.shop_id as string, sessionId: params.sessionId });
+    return NextResponse.json({ ok: true, mode: "dry_run", ...plan });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Failed to build activation plan" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { analyzeOnboardingSession } from "@/features/onboarding-agent/server/analyzeOnboardingSession";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function POST(_: Request, { params }: { params: { sessionId: string } }) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  try {
+    const summary = await analyzeOnboardingSession({ supabase: access.supabase, shopId: access.profile.shop_id as string, sessionId: params.sessionId });
+    return NextResponse.json({ ok: true, summary, liveRecordsCreated: 0 });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Analysis failed" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-agent/sessions/[sessionId]/files/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/files/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { registerOnboardingFile } from "@/features/onboarding-agent/server/registerOnboardingFile";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function POST(req: Request, { params }: { params: { sessionId: string } }) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const body = (await req.json().catch(() => ({}))) as {
+    storageBucket?: string;
+    storagePath?: string;
+    originalFilename?: string;
+    declaredDomain?: string;
+  };
+
+  if (!body.storageBucket || !body.storagePath) {
+    return NextResponse.json({ ok: false, error: "storageBucket and storagePath are required" }, { status: 400 });
+  }
+
+  try {
+    const result = await registerOnboardingFile({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id as string,
+      sessionId: params.sessionId,
+      storageBucket: body.storageBucket,
+      storagePath: body.storagePath,
+      originalFilename: body.originalFilename,
+      declaredDomain: body.declaredDomain,
+    });
+    return NextResponse.json({ ok: true, fileId: result.fileId });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Failed to register file" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-agent/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getOnboardingSession } from "@/features/onboarding-agent/server/getOnboardingSession";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function GET(_: Request, { params }: { params: { sessionId: string } }) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  try {
+    const payload = await getOnboardingSession({ supabase: access.supabase, shopId: access.profile.shop_id as string, sessionId: params.sessionId });
+    if (!payload.session) return NextResponse.json({ ok: false, error: "Session not found" }, { status: 404 });
+    return NextResponse.json({ ok: true, ...payload });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Failed to load session" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-agent/sessions/route.ts
+++ b/app/api/onboarding-agent/sessions/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { createOnboardingSession } from "@/features/onboarding-agent/server/createOnboardingSession";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const body = (await req.json().catch(() => ({}))) as { title?: string; source?: string; notes?: string };
+
+  try {
+    const result = await createOnboardingSession({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id as string,
+      createdBy: access.profile.id,
+      title: body.title,
+      source: body.source,
+      notes: body.notes,
+    });
+    return NextResponse.json({ ok: true, sessionId: result.sessionId });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Failed to create session" }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const { data, error } = await (access.supabase as any)
+    .from("onboarding_sessions")
+    .select("id, title, source, status, summary, stats, created_at, updated_at")
+    .eq("shop_id", access.profile.shop_id)
+    .order("created_at", { ascending: false })
+    .limit(30);
+
+  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true, sessions: data ?? [] });
+}

--- a/app/dashboard/onboarding/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding/[sessionId]/page.tsx
@@ -1,0 +1,7 @@
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { OnboardingSessionPage } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+
+export default async function OnboardingSessionRoute({ params }: { params: { sessionId: string } }) {
+  await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
+  return <OnboardingSessionPage sessionId={params.sessionId} />;
+}

--- a/app/dashboard/onboarding/page.tsx
+++ b/app/dashboard/onboarding/page.tsx
@@ -1,0 +1,7 @@
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { OnboardingAgentDashboard } from "@/features/onboarding-agent/components/OnboardingAgentDashboard";
+
+export default async function OnboardingPage() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
+  return <OnboardingAgentDashboard />;
+}

--- a/app/dashboard/setup/review/page.tsx
+++ b/app/dashboard/setup/review/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 
@@ -443,7 +444,7 @@ export default function ShopBoostReviewPage() {
       const json = (await res.json().catch(() => ({}))) as ResetPreviewResponse;
       if (!res.ok || !json.ok) {
         setResetPreview(null);
-        setResetFeedback(json.error ?? "Failed to load reset preview.");
+        setResetFeedback("Legacy reset preview failed. Use Onboarding Agent for staged onboarding. Existing data was not changed.");
         return;
       }
       setResetPreview(json);
@@ -536,7 +537,7 @@ export default function ShopBoostReviewPage() {
       }}
     >
       <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-        <h1 className="text-xl font-semibold text-white">Shop Boost Guided Review</h1>
+        <h1 className="text-xl font-semibold text-white">Shop Boost Guided Review (Legacy)</h1>
         <p className="mt-1 text-sm text-neutral-300">Resolve migration issues in guided steps with transparent reasoning and confidence-backed actions.</p>
         <p className="mt-1 text-xs text-neutral-400">This page keeps checking readiness in the background and will auto-continue once activation truth flips ready.</p>
         <div className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-300">
@@ -557,6 +558,9 @@ export default function ShopBoostReviewPage() {
           </div>
         ) : null}
         {feedback ? <div className="mt-3 rounded-lg border border-sky-400/30 bg-sky-950/20 px-3 py-2 text-sm text-sky-100">{feedback}</div> : null}
+        <div className="mt-3 rounded-lg border border-amber-400/30 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">
+          Legacy Shop Boost import tools are being replaced by the staging-first Onboarding Agent. Existing snapshots remain available for diagnostics. <Link href="/dashboard/onboarding" className="underline underline-offset-2">Open Onboarding Agent workspace</Link>.
+        </div>
       </div>
 
       {isOwnerOrAdmin ? (

--- a/db/sql/2026-04-27_onboarding_agent_foundation.sql
+++ b/db/sql/2026-04-27_onboarding_agent_foundation.sql
@@ -1,0 +1,235 @@
+-- Onboarding Agent foundation (staging-first, additive, shop-scoped)
+-- Uploaded files remain staged information until a future explicit activation phase.
+
+begin;
+
+create table if not exists public.onboarding_sessions (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  created_by uuid null references auth.users(id) on delete set null,
+  status text not null default 'draft' check (status in (
+    'draft','files_uploaded','analyzing','analysis_ready','review_required','activation_ready','activating','activated','blocked','cancelled'
+  )),
+  source text null,
+  title text null,
+  notes text null,
+  summary jsonb not null default '{}'::jsonb,
+  stats jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  analyzed_at timestamptz null,
+  activated_at timestamptz null
+);
+
+create index if not exists onboarding_sessions_shop_created_idx on public.onboarding_sessions(shop_id, created_at desc);
+create index if not exists onboarding_sessions_shop_status_idx on public.onboarding_sessions(shop_id, status);
+
+create table if not exists public.onboarding_files (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  storage_bucket text not null,
+  storage_path text not null,
+  original_filename text null,
+  detected_domain text null,
+  declared_domain text null,
+  mime_type text null,
+  file_size_bytes bigint null,
+  header_row jsonb not null default '[]'::jsonb,
+  parse_status text not null default 'pending' check (parse_status in ('pending','parsed','failed','ignored')),
+  parse_error text null,
+  row_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, session_id, storage_path)
+);
+
+create index if not exists onboarding_files_shop_session_idx on public.onboarding_files(shop_id, session_id);
+create index if not exists onboarding_files_shop_domain_idx on public.onboarding_files(shop_id, detected_domain);
+
+create table if not exists public.onboarding_raw_rows (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  file_id uuid not null references public.onboarding_files(id) on delete cascade,
+  source_row_index integer not null,
+  raw jsonb not null default '{}'::jsonb,
+  normalized_preview jsonb not null default '{}'::jsonb,
+  detected_domain text null,
+  row_hash text null,
+  parse_status text not null default 'parsed' check (parse_status in ('parsed','skipped','failed')),
+  error_reason text null,
+  created_at timestamptz not null default now(),
+  unique (shop_id, file_id, source_row_index)
+);
+
+create index if not exists onboarding_raw_rows_shop_session_idx on public.onboarding_raw_rows(shop_id, session_id);
+create index if not exists onboarding_raw_rows_shop_file_idx on public.onboarding_raw_rows(shop_id, file_id);
+create index if not exists onboarding_raw_rows_shop_domain_idx on public.onboarding_raw_rows(shop_id, detected_domain);
+
+create table if not exists public.onboarding_entities (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  entity_type text not null,
+  source_file_id uuid null references public.onboarding_files(id) on delete set null,
+  source_row_id uuid null references public.onboarding_raw_rows(id) on delete set null,
+  source_row_index integer null,
+  source_external_id text null,
+  canonical_fingerprint text null,
+  display_name text null,
+  normalized jsonb not null default '{}'::jsonb,
+  confidence numeric null,
+  status text not null default 'staged' check (status in (
+    'staged','duplicate_candidate','needs_review','ready','accepted','rejected','activated','failed'
+  )),
+  review_reason text null,
+  canonical_table text null,
+  canonical_id uuid null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists onboarding_entities_shop_type_idx on public.onboarding_entities(shop_id, session_id, entity_type);
+create index if not exists onboarding_entities_shop_status_idx on public.onboarding_entities(shop_id, session_id, status);
+create index if not exists onboarding_entities_shop_canonical_idx on public.onboarding_entities(shop_id, canonical_table, canonical_id);
+create index if not exists onboarding_entities_shop_fingerprint_idx on public.onboarding_entities(shop_id, canonical_fingerprint);
+
+create table if not exists public.onboarding_entity_links (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  from_entity_id uuid not null references public.onboarding_entities(id) on delete cascade,
+  to_entity_id uuid not null references public.onboarding_entities(id) on delete cascade,
+  link_type text not null,
+  confidence numeric null,
+  status text not null default 'staged' check (status in ('staged','needs_review','accepted','rejected','activated','failed')),
+  evidence jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists onboarding_entity_links_shop_session_idx on public.onboarding_entity_links(shop_id, session_id);
+create index if not exists onboarding_entity_links_shop_link_type_idx on public.onboarding_entity_links(shop_id, link_type);
+create index if not exists onboarding_entity_links_shop_status_idx on public.onboarding_entity_links(shop_id, status);
+
+create table if not exists public.onboarding_review_items (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  entity_id uuid null references public.onboarding_entities(id) on delete cascade,
+  link_id uuid null references public.onboarding_entity_links(id) on delete cascade,
+  severity text not null default 'medium' check (severity in ('low','medium','high','blocking')),
+  domain text null,
+  issue_type text not null,
+  summary text not null,
+  details jsonb not null default '{}'::jsonb,
+  recommended_action text null,
+  status text not null default 'pending' check (status in ('pending','resolved','ignored','accepted','rejected')),
+  resolved_by uuid null references auth.users(id) on delete set null,
+  resolved_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists onboarding_review_items_shop_status_idx on public.onboarding_review_items(shop_id, session_id, status);
+create index if not exists onboarding_review_items_shop_severity_idx on public.onboarding_review_items(shop_id, severity);
+create index if not exists onboarding_review_items_shop_domain_idx on public.onboarding_review_items(shop_id, domain);
+
+create table if not exists public.onboarding_activation_plans (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  status text not null default 'draft' check (status in ('draft','ready','approved','running','completed','failed','cancelled')),
+  plan jsonb not null default '{}'::jsonb,
+  summary jsonb not null default '{}'::jsonb,
+  risk_flags jsonb not null default '{}'::jsonb,
+  approved_by uuid null references auth.users(id) on delete set null,
+  approved_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists onboarding_activation_plans_shop_session_idx on public.onboarding_activation_plans(shop_id, session_id);
+create index if not exists onboarding_activation_plans_shop_status_idx on public.onboarding_activation_plans(shop_id, status);
+
+create table if not exists public.onboarding_activation_events (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  session_id uuid not null references public.onboarding_sessions(id) on delete cascade,
+  plan_id uuid null references public.onboarding_activation_plans(id) on delete set null,
+  entity_id uuid null references public.onboarding_entities(id) on delete set null,
+  event_type text not null,
+  canonical_table text null,
+  canonical_id uuid null,
+  status text not null default 'recorded',
+  message text null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists onboarding_activation_events_shop_session_idx on public.onboarding_activation_events(shop_id, session_id);
+create index if not exists onboarding_activation_events_shop_event_type_idx on public.onboarding_activation_events(shop_id, event_type);
+create index if not exists onboarding_activation_events_shop_canonical_idx on public.onboarding_activation_events(shop_id, canonical_table, canonical_id);
+
+-- updated_at triggers
+DO $$
+DECLARE t record;
+BEGIN
+  FOR t IN SELECT unnest(array[
+    'onboarding_sessions','onboarding_files','onboarding_entities','onboarding_review_items','onboarding_activation_plans'
+  ]) as tbl
+  LOOP
+    EXECUTE format('drop trigger if exists trg_%I_updated_at on public.%I', t.tbl, t.tbl);
+    EXECUTE format('create trigger trg_%I_updated_at before update on public.%I for each row execute function public.set_updated_at()', t.tbl, t.tbl);
+  END LOOP;
+END $$;
+
+-- RLS
+alter table public.onboarding_sessions enable row level security;
+alter table public.onboarding_files enable row level security;
+alter table public.onboarding_raw_rows enable row level security;
+alter table public.onboarding_entities enable row level security;
+alter table public.onboarding_entity_links enable row level security;
+alter table public.onboarding_review_items enable row level security;
+alter table public.onboarding_activation_plans enable row level security;
+alter table public.onboarding_activation_events enable row level security;
+
+-- service role full access
+DO $$
+DECLARE tbl text;
+BEGIN
+  FOREACH tbl IN ARRAY ARRAY[
+    'onboarding_sessions','onboarding_files','onboarding_raw_rows','onboarding_entities','onboarding_entity_links','onboarding_review_items','onboarding_activation_plans','onboarding_activation_events'
+  ]
+  LOOP
+    EXECUTE format('drop policy if exists service_role_manage_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy service_role_manage_%I on public.%I to service_role using (auth.role() = ''service_role'') with check (auth.role() = ''service_role'')', tbl, tbl);
+    EXECUTE format('grant all on public.%I to service_role', tbl);
+  END LOOP;
+END $$;
+
+-- authenticated scoped shop access (owner/admin only)
+DO $$
+DECLARE tbl text;
+BEGIN
+  FOREACH tbl IN ARRAY ARRAY[
+    'onboarding_sessions','onboarding_files','onboarding_raw_rows','onboarding_entities','onboarding_entity_links','onboarding_review_items','onboarding_activation_plans','onboarding_activation_events'
+  ]
+  LOOP
+    EXECUTE format('drop policy if exists onboarding_owner_admin_select_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy onboarding_owner_admin_select_%I on public.%I for select to authenticated using (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'',''admin'')))', tbl, tbl, tbl);
+
+    EXECUTE format('drop policy if exists onboarding_owner_admin_insert_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy onboarding_owner_admin_insert_%I on public.%I for insert to authenticated with check (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'',''admin'')))', tbl, tbl, tbl);
+
+    EXECUTE format('drop policy if exists onboarding_owner_admin_update_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy onboarding_owner_admin_update_%I on public.%I for update to authenticated using (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'',''admin''))) with check (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'',''admin'')))', tbl, tbl, tbl, tbl);
+
+    EXECUTE format('drop policy if exists onboarding_owner_admin_delete_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy onboarding_owner_admin_delete_%I on public.%I for delete to authenticated using (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'',''admin'')))', tbl, tbl, tbl);
+
+    EXECUTE format('grant select, insert, update, delete on public.%I to authenticated', tbl);
+  END LOOP;
+END $$;
+
+commit;

--- a/features/dashboard/app/dashboard/owner/reports/page.tsx
+++ b/features/dashboard/app/dashboard/owner/reports/page.tsx
@@ -375,16 +375,16 @@ export default function ReportsPage() {
           ) : (
             <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4">
               <div className="text-[11px] text-neutral-400">
-                Shop Health reads your latest snapshot + suggestions and highlights where onboarding can be automated.
+                Shop Health is a diagnostics surface. Snapshot health does not mean onboarding activation readiness.
               </div>
 
               {/* Upload + Run Snapshot buttons */}
               <div className="flex items-center gap-2">
                 <Link
-                  href="/onboarding/shop-boost"
+                  href="/dashboard/onboarding"
                   className="rounded-full border border-white/10 bg-black/20 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-200 transition hover:bg-black/35 hover:text-white"
                 >
-                  ⬆️ Upload files
+                  🧭 Onboarding Agent
                 </Link>
 
                 <button

--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -1,0 +1,9 @@
+export function OnboardingActivationPlanPanel({ latestPlan }: { latestPlan?: Record<string, unknown> | null }) {
+  return (
+    <div className="rounded-2xl border border-amber-500/30 bg-amber-950/20 p-4">
+      <h3 className="text-sm font-semibold text-amber-100">Activation plan (dry-run only)</h3>
+      <p className="mt-2 text-xs text-amber-200/80">Activation is not enabled in this foundation phase. This workspace stages, explains, and prepares an activation plan.</p>
+      <pre className="mt-3 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify(latestPlan ?? { status: "not_prepared" }, null, 2)}</pre>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+type SessionRow = { id: string; title: string | null; status: string; created_at: string; summary?: Record<string, unknown> | null };
+
+export function OnboardingAgentDashboard() {
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const load = async () => {
+    const res = await fetch("/api/onboarding-agent/sessions", { cache: "no-store" });
+    const json = await res.json();
+    setSessions(json.sessions ?? []);
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  const createSession = async () => {
+    setBusy(true);
+    const res = await fetch("/api/onboarding-agent/sessions", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ source: "manual_upload" }) });
+    const json = await res.json();
+    setBusy(false);
+    if (json?.sessionId) window.location.href = `/dashboard/onboarding/${json.sessionId}`;
+  };
+
+  return (
+    <div className="space-y-4 p-6 text-white">
+      <div className="rounded-2xl border border-cyan-500/30 bg-slate-950/60 p-5">
+        <h1 className="text-xl font-semibold">Onboarding Agent</h1>
+        <p className="mt-2 text-sm text-cyan-100/80">Uploaded files are staged as information first. No live customers, vehicles, work orders, invoices, staff, parts, vendors, menu items, or inspections are created until a future activation step.</p>
+        <button onClick={createSession} disabled={busy} className="mt-4 rounded-md border border-cyan-400/40 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50">{busy ? "Creating…" : "Create onboarding session"}</button>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+        <h2 className="text-sm font-semibold">Recent sessions</h2>
+        <div className="mt-3 space-y-2">
+          {sessions.map((session) => (
+            <Link key={session.id} href={`/dashboard/onboarding/${session.id}`} className="block rounded-lg border border-white/10 bg-slate-900/50 p-3 hover:border-cyan-400/40">
+              <p>{session.title || "Untitled session"}</p>
+              <p className="text-xs text-slate-400">{session.status} • {new Date(session.created_at).toLocaleString()}</p>
+            </Link>
+          ))}
+          {sessions.length === 0 ? <p className="text-sm text-slate-400">No sessions yet.</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -1,0 +1,8 @@
+export function OnboardingEntitiesPanel({ entityCounts, linkCounts }: { entityCounts: Record<string, number>; linkCounts: Record<string, number> }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+      <h3 className="text-sm font-semibold text-white">Staged entities & links</h3>
+      <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/70 p-3 text-xs text-slate-200">{JSON.stringify({ entityCounts, linkCounts }, null, 2)}</pre>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingFilesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingFilesPanel.tsx
@@ -1,0 +1,15 @@
+export function OnboardingFilesPanel({ files }: { files: Array<Record<string, unknown>> }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+      <h3 className="text-sm font-semibold text-white">Staged files</h3>
+      <div className="mt-3 space-y-2 text-sm">
+        {files.length === 0 ? <p className="text-slate-400">No files registered yet.</p> : files.map((file) => (
+          <div key={String(file.id)} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
+            <p className="text-white">{String(file.original_filename ?? file.storage_path)}</p>
+            <p className="text-xs text-slate-400">{String(file.detected_domain ?? "unknown")} • rows: {String(file.row_count ?? 0)} • {String(file.parse_status ?? "pending")}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingProgressCard.tsx
+++ b/features/onboarding-agent/components/OnboardingProgressCard.tsx
@@ -1,0 +1,24 @@
+export function OnboardingProgressCard({ summary }: { summary?: Record<string, unknown> | null }) {
+  const rows = [
+    ["Uploaded files", String((summary?.fileCount as number) ?? 0)],
+    ["Rows parsed", String((summary?.rowsParsed as number) ?? 0)],
+    ["Entities discovered", String((summary?.entitiesDiscovered as number) ?? 0)],
+    ["Links found", String((summary?.linksFound as number) ?? 0)],
+    ["Review exceptions", String((summary?.reviewExceptions as number) ?? 0)],
+  ];
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+      <h3 className="text-sm font-semibold text-white">Onboarding progress</h3>
+      <p className="mt-1 text-xs text-cyan-100/80">Uploaded files are staged as information. No live records are created in this phase.</p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="rounded-lg border border-white/10 bg-slate-900/60 px-3 py-2">
+            <p className="text-[11px] uppercase tracking-wide text-slate-400">{label}</p>
+            <p className="text-sm text-white">{value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingReviewPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingReviewPanel.tsx
@@ -1,0 +1,9 @@
+export function OnboardingReviewPanel({ reviewCounts }: { reviewCounts: Record<string, number> }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+      <h3 className="text-sm font-semibold text-white">Review exceptions</h3>
+      <p className="mt-2 text-sm text-slate-300">Blocking: {reviewCounts.blocking ?? 0} • Nonblocking: {reviewCounts.nonblocking ?? 0}</p>
+      <p className="mt-2 text-xs text-slate-400">Only exceptions require review. Parse and linkage issues are highlighted here.</p>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { OnboardingActivationPlanPanel } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
+import { OnboardingEntitiesPanel } from "@/features/onboarding-agent/components/OnboardingEntitiesPanel";
+import { OnboardingFilesPanel } from "@/features/onboarding-agent/components/OnboardingFilesPanel";
+import { OnboardingProgressCard } from "@/features/onboarding-agent/components/OnboardingProgressCard";
+import { OnboardingReviewPanel } from "@/features/onboarding-agent/components/OnboardingReviewPanel";
+
+export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
+  const [payload, setPayload] = useState<any>(null);
+  const [storageBucket, setStorageBucket] = useState("shop-boost-uploads");
+  const [storagePath, setStoragePath] = useState("");
+
+  const load = async () => {
+    const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { cache: "no-store" });
+    const json = await res.json();
+    setPayload(json);
+  };
+
+  useEffect(() => { void load(); }, [sessionId]);
+
+  const registerFile = async () => {
+    await fetch(`/api/onboarding-agent/sessions/${sessionId}/files`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ storageBucket, storagePath, originalFilename: storagePath.split("/").pop() }),
+    });
+    setStoragePath("");
+    await load();
+  };
+
+  const analyze = async () => {
+    await fetch(`/api/onboarding-agent/sessions/${sessionId}/analyze`, { method: "POST" });
+    await load();
+  };
+
+  const plan = async () => {
+    await fetch(`/api/onboarding-agent/sessions/${sessionId}/activation-plan`, { method: "POST" });
+    await load();
+  };
+
+  const session = payload?.session;
+
+  return (
+    <div className="space-y-4 p-6 text-white">
+      <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+        <h1 className="text-xl font-semibold">Onboarding session</h1>
+        <p className="text-sm text-slate-300">Status: {session?.status ?? "loading"}</p>
+        <p className="mt-2 text-xs text-cyan-100/80">Historical work orders remain historical (not active jobs). Historical invoices remain imported historical billing records.</p>
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-[1fr_auto_auto]">
+        <input value={storageBucket} onChange={(e) => setStorageBucket(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="Storage bucket" />
+        <input value={storagePath} onChange={(e) => setStoragePath(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="storage/path/file.csv" />
+        <button onClick={registerFile} className="rounded border border-white/20 px-3 py-2 text-sm">Register staged file</button>
+      </div>
+
+      <div className="flex gap-2">
+        <button onClick={analyze} className="rounded border border-cyan-400/40 px-3 py-2 text-sm">Analyze staged files</button>
+        <button onClick={plan} className="rounded border border-amber-400/40 px-3 py-2 text-sm">Prepare activation plan</button>
+      </div>
+
+      <OnboardingProgressCard summary={session?.summary ?? null} />
+      <OnboardingFilesPanel files={payload?.files ?? []} />
+      <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
+      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} />
+      <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} />
+    </div>
+  );
+}

--- a/features/onboarding-agent/lib/activationPlan.ts
+++ b/features/onboarding-agent/lib/activationPlan.ts
@@ -1,0 +1,39 @@
+export function buildDryRunActivationPlan(input: {
+  sessionId: string;
+  entityCounts: Record<string, number>;
+  linkCounts: Record<string, number>;
+  reviewBlocking: number;
+  reviewNonBlocking: number;
+}) {
+  const risks: string[] = [];
+  if (input.reviewBlocking > 0) risks.push(`${input.reviewBlocking} blocking review items must be resolved before activation.`);
+  if ((input.entityCounts.historical_invoice ?? 0) > 0 && (input.linkCounts.work_order_invoice ?? 0) === 0) {
+    risks.push("Historical invoices have no work order links yet.");
+  }
+
+  return {
+    sessionId: input.sessionId,
+    mode: "dry_run",
+    creates: {
+      customers: input.entityCounts.customer ?? 0,
+      vehicles: input.entityCounts.vehicle ?? 0,
+      historicalWorkOrders: input.entityCounts.historical_work_order ?? 0,
+      historicalInvoices: input.entityCounts.historical_invoice ?? 0,
+      parts: input.entityCounts.part ?? 0,
+      vendors: input.entityCounts.vendor ?? 0,
+      staffCandidates: input.entityCounts.staff_candidate ?? 0,
+      menuSuggestions: input.entityCounts.menu_suggestion ?? 0,
+      inspectionSuggestions: input.entityCounts.inspection_suggestion ?? 0,
+    },
+    links: {
+      customerVehicle: input.linkCounts.customer_vehicle ?? 0,
+      vehicleWorkOrder: input.linkCounts.vehicle_work_order ?? 0,
+      workOrderInvoice: input.linkCounts.work_order_invoice ?? 0,
+    },
+    review: {
+      blocking: input.reviewBlocking,
+      nonblocking: input.reviewNonBlocking,
+    },
+    risks,
+  };
+}

--- a/features/onboarding-agent/lib/csvParsing.ts
+++ b/features/onboarding-agent/lib/csvParsing.ts
@@ -1,0 +1,49 @@
+export type ParsedCsv = { headers: string[]; rows: Array<Record<string, string>> };
+
+function splitCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+    if (char === "," && !inQuotes) {
+      out.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  out.push(current.trim());
+  return out;
+}
+
+export function parseCsvText(input: string): ParsedCsv {
+  const lines = input
+    .replace(/^\uFEFF/, "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) return { headers: [], rows: [] };
+
+  const headers = splitCsvLine(lines[0]).map((header) => header.trim());
+  const rows = lines.slice(1).map((line) => {
+    const cells = splitCsvLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((header, idx) => {
+      row[header] = (cells[idx] ?? "").trim();
+    });
+    return row;
+  });
+
+  return { headers, rows };
+}

--- a/features/onboarding-agent/lib/domains.ts
+++ b/features/onboarding-agent/lib/domains.ts
@@ -1,0 +1,44 @@
+export const ONBOARDING_DOMAINS = [
+  "customers",
+  "vehicles",
+  "history",
+  "invoices",
+  "parts",
+  "vendors",
+  "staff",
+  "inspections",
+  "menu",
+  "unknown",
+] as const;
+
+export type OnboardingDomain = (typeof ONBOARDING_DOMAINS)[number];
+
+const DOMAIN_HINTS: Array<{ domain: OnboardingDomain; hints: string[] }> = [
+  { domain: "customers", hints: ["customer id", "customer name", "full name", "company", "email", "phone"] },
+  { domain: "vehicles", hints: ["vin", "plate", "license", "year", "make", "model", "unit", "customer id"] },
+  { domain: "history", hints: ["work order", "repair order", "ro", "complaint", "cause", "correction", "labor", "total"] },
+  { domain: "invoices", hints: ["invoice", "invoice number", "amount", "payment status", "paid", "closed", "work order"] },
+  { domain: "parts", hints: ["part", "sku", "part number", "description", "cost", "price", "qty"] },
+  { domain: "vendors", hints: ["vendor", "supplier", "company", "vendor phone", "vendor email"] },
+  { domain: "staff", hints: ["employee", "staff", "technician", "advisor", "role", "email"] },
+  { domain: "inspections", hints: ["inspection", "checklist", "item", "condition"] },
+  { domain: "menu", hints: ["service menu", "service", "package", "labor op"] },
+];
+
+export function normalizeHeader(value: string): string {
+  return value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+export function detectDomain(input: { filename?: string | null; headers?: string[] }): OnboardingDomain {
+  const filename = normalizeHeader(input.filename ?? "");
+  const headers = (input.headers ?? []).map(normalizeHeader);
+  const corpus = [filename, ...headers].join(" | ");
+
+  let best: { domain: OnboardingDomain; score: number } = { domain: "unknown", score: 0 };
+  for (const candidate of DOMAIN_HINTS) {
+    const score = candidate.hints.reduce((acc, hint) => (corpus.includes(hint) ? acc + 1 : acc), 0);
+    if (score > best.score) best = { domain: candidate.domain, score };
+  }
+
+  return best.score > 0 ? best.domain : "unknown";
+}

--- a/features/onboarding-agent/lib/fileDetection.ts
+++ b/features/onboarding-agent/lib/fileDetection.ts
@@ -1,0 +1,6 @@
+import { detectDomain } from "./domains";
+
+export function detectFileDomain(params: { filename?: string | null; headers?: string[]; declaredDomain?: string | null }) {
+  if (params.declaredDomain && params.declaredDomain !== "unknown") return params.declaredDomain;
+  return detectDomain({ filename: params.filename, headers: params.headers });
+}

--- a/features/onboarding-agent/lib/fingerprints.ts
+++ b/features/onboarding-agent/lib/fingerprints.ts
@@ -1,0 +1,22 @@
+import type { OnboardingDomain } from "./domains";
+
+export function normalizePhone(phone?: string | null): string | null {
+  const digits = String(phone ?? "").replace(/\D+/g, "");
+  return digits.length >= 7 ? digits : null;
+}
+
+export function fingerprintForDomain(domain: OnboardingDomain, normalized: Record<string, unknown>): string | null {
+  if (domain === "customers") {
+    return String(normalized.sourceCustomerId ?? normalized.email ?? normalized.phone ?? normalized.name ?? "").trim() || null;
+  }
+  if (domain === "vehicles") {
+    return String(normalized.vin ?? normalized.plate ?? normalized.unitNumber ?? normalized.sourceVehicleId ?? "").trim() || null;
+  }
+  if (domain === "history") {
+    return String(normalized.sourceWorkOrderId ?? normalized.roNumber ?? "").trim() || null;
+  }
+  if (domain === "invoices") {
+    return String(normalized.invoiceNumber ?? normalized.sourceWorkOrderId ?? "").trim() || null;
+  }
+  return String(normalized.sourceExternalId ?? "").trim() || null;
+}

--- a/features/onboarding-agent/lib/graph.ts
+++ b/features/onboarding-agent/lib/graph.ts
@@ -1,0 +1,36 @@
+export function buildSimpleLinks(entities: Array<{ id: string; entity_type: string; normalized: Record<string, unknown> }>) {
+  const customersBySourceId = new Map<string, string>();
+  const workOrdersBySourceId = new Map<string, string>();
+
+  for (const entity of entities) {
+    if (entity.entity_type === "customer") {
+      const sourceCustomerId = String(entity.normalized.sourceCustomerId ?? "").trim();
+      if (sourceCustomerId) customersBySourceId.set(sourceCustomerId, entity.id);
+    }
+    if (entity.entity_type === "historical_work_order") {
+      const workOrderId = String(entity.normalized.sourceWorkOrderId ?? "").trim();
+      if (workOrderId) workOrdersBySourceId.set(workOrderId, entity.id);
+    }
+  }
+
+  const links: Array<{ from_entity_id: string; to_entity_id: string; link_type: string; confidence: number; evidence: Record<string, unknown> }> = [];
+
+  for (const entity of entities) {
+    if (entity.entity_type === "vehicle") {
+      const customerSourceId = String(entity.normalized.sourceCustomerId ?? "").trim();
+      const customerId = customersBySourceId.get(customerSourceId);
+      if (customerId) {
+        links.push({ from_entity_id: customerId, to_entity_id: entity.id, link_type: "customer_vehicle", confidence: 0.95, evidence: { sourceCustomerId: customerSourceId } });
+      }
+    }
+    if (entity.entity_type === "historical_invoice") {
+      const sourceWorkOrderId = String(entity.normalized.sourceWorkOrderId ?? "").trim();
+      const workOrderEntityId = workOrdersBySourceId.get(sourceWorkOrderId);
+      if (workOrderEntityId) {
+        links.push({ from_entity_id: workOrderEntityId, to_entity_id: entity.id, link_type: "work_order_invoice", confidence: 0.95, evidence: { sourceWorkOrderId } });
+      }
+    }
+  }
+
+  return links;
+}

--- a/features/onboarding-agent/lib/normalization.ts
+++ b/features/onboarding-agent/lib/normalization.ts
@@ -1,0 +1,101 @@
+import type { OnboardingDomain } from "./domains";
+import { normalizePhone } from "./fingerprints";
+
+const value = (row: Record<string, string>, keys: string[]): string => {
+  for (const key of keys) {
+    const found = Object.entries(row).find(([header]) => header.toLowerCase().replace(/[_-]+/g, " ").trim() === key);
+    if (found?.[1]) return found[1].trim();
+  }
+  return "";
+};
+
+export function normalizeRow(domain: OnboardingDomain, row: Record<string, string>) {
+  if (domain === "customers") {
+    const name = value(row, ["customer name", "full name", "name"]);
+    const [firstName = "", ...rest] = name.split(" ");
+    return {
+      entityType: "customer",
+      displayName: name || value(row, ["company name", "company"]),
+      normalized: {
+        sourceCustomerId: value(row, ["customer id", "id"]),
+        name,
+        firstName,
+        lastName: rest.join(" "),
+        businessName: value(row, ["company", "company name", "business"]),
+        email: value(row, ["email"]).toLowerCase(),
+        phone: normalizePhone(value(row, ["phone", "phone number"])),
+      },
+    };
+  }
+
+  if (domain === "vehicles") {
+    return {
+      entityType: "vehicle",
+      displayName: `${value(row, ["year"])} ${value(row, ["make"])} ${value(row, ["model"])} ${value(row, ["vin"])}`.trim(),
+      normalized: {
+        sourceVehicleId: value(row, ["vehicle id", "id"]),
+        sourceCustomerId: value(row, ["customer id"]),
+        vin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
+        plate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
+        unitNumber: value(row, ["unit", "unit number"]),
+        year: value(row, ["year"]),
+        make: value(row, ["make"]),
+        model: value(row, ["model"]),
+      },
+    };
+  }
+
+  if (domain === "history") {
+    return {
+      entityType: "historical_work_order",
+      displayName: value(row, ["work order", "repair order", "ro", "ro id"]),
+      normalized: {
+        sourceWorkOrderId: value(row, ["work order", "ro id", "repair order"]),
+        sourceCustomerId: value(row, ["customer id"]),
+        sourceVehicleId: value(row, ["vehicle id"]),
+        complaint: value(row, ["complaint", "description"]),
+        cause: value(row, ["cause"]),
+        correction: value(row, ["correction"]),
+        laborAmount: value(row, ["labor"]),
+        total: value(row, ["total"]),
+        closedDate: value(row, ["closed", "completed date", "closed date"]),
+      },
+    };
+  }
+
+  if (domain === "invoices") {
+    return {
+      entityType: "historical_invoice",
+      displayName: value(row, ["invoice", "invoice number"]),
+      normalized: {
+        invoiceNumber: value(row, ["invoice", "invoice number"]),
+        sourceWorkOrderId: value(row, ["work order", "ro", "ro id"]),
+        sourceCustomerId: value(row, ["customer id"]),
+        total: value(row, ["total", "amount"]),
+        laborAmount: value(row, ["labor"]),
+        partsAmount: value(row, ["parts"]),
+        issueDate: value(row, ["issue date", "date"]),
+        paymentStatus: value(row, ["status", "payment status"]),
+      },
+    };
+  }
+
+  if (domain === "staff") {
+    return {
+      entityType: "staff_candidate",
+      displayName: value(row, ["name", "full name", "employee"]),
+      normalized: {
+        name: value(row, ["name", "full name", "employee"]),
+        email: value(row, ["email"]).toLowerCase(),
+        phone: normalizePhone(value(row, ["phone"])),
+        role: value(row, ["role"]),
+      },
+    };
+  }
+
+  return {
+    entityType: "unknown",
+    displayName: null,
+    normalized: row,
+  };
+}

--- a/features/onboarding-agent/lib/onboarding-agent.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildDryRunActivationPlan } from "@/features/onboarding-agent/lib/activationPlan";
+import { parseCsvText } from "@/features/onboarding-agent/lib/csvParsing";
+import { detectDomain } from "@/features/onboarding-agent/lib/domains";
+import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
+
+describe("onboarding agent helpers", () => {
+  it("detects customer domain from headers", () => {
+    expect(detectDomain({ filename: "customers.csv", headers: ["Customer ID", "Full NAME", "EMAIL", "Phone Number", "Company Name"] })).toBe("customers");
+  });
+
+  it("parses csv with mixed-case headers", () => {
+    const parsed = parseCsvText("Customer ID,Full NAME,EMAIL\n1,Jane Doe,jane@example.com");
+    expect(parsed.headers).toEqual(["Customer ID", "Full NAME", "EMAIL"]);
+    expect(parsed.rows[0]["Full NAME"]).toBe("Jane Doe");
+  });
+
+  it("normalizes vehicle/history/invoice rows", () => {
+    const vehicle = normalizeRow("vehicles", { VIN: " 1hgcm82633a004352 ", Plate: "ca 123", "Customer ID": "C-1", Year: "2020", Make: "Ford", Model: "F150" });
+    expect((vehicle.normalized as any).vin).toBe("1HGCM82633A004352");
+
+    const history = normalizeRow("history", { "Work Order": "RO-9", "Customer ID": "C-1", "Vehicle ID": "V-1", Complaint: "noise", Labor: "100", Total: "500" });
+    expect(history.entityType).toBe("historical_work_order");
+
+    const invoice = normalizeRow("invoices", { Invoice: "INV-1", "Work Order": "RO-9", Total: "500", Status: "closed" });
+    expect(invoice.entityType).toBe("historical_invoice");
+  });
+
+  it("builds dry-run activation plan", () => {
+    const plan = buildDryRunActivationPlan({
+      sessionId: "s-1",
+      entityCounts: { customer: 2, vehicle: 1, historical_work_order: 3, historical_invoice: 1 },
+      linkCounts: { customer_vehicle: 1 },
+      reviewBlocking: 2,
+      reviewNonBlocking: 1,
+    });
+    expect(plan.mode).toBe("dry_run");
+    expect(plan.creates.customers).toBe(2);
+    expect(plan.review.blocking).toBe(2);
+  });
+});

--- a/features/onboarding-agent/lib/sessionStatus.ts
+++ b/features/onboarding-agent/lib/sessionStatus.ts
@@ -1,0 +1,17 @@
+export type OnboardingSessionStatus =
+  | "draft"
+  | "files_uploaded"
+  | "analyzing"
+  | "analysis_ready"
+  | "review_required"
+  | "activation_ready"
+  | "activating"
+  | "activated"
+  | "blocked"
+  | "cancelled";
+
+export function nextStatusFromCounts(input: { fileCount: number; blockingReviewCount: number }): OnboardingSessionStatus {
+  if (input.fileCount <= 0) return "draft";
+  if (input.blockingReviewCount > 0) return "review_required";
+  return "analysis_ready";
+}

--- a/features/onboarding-agent/lib/staging.ts
+++ b/features/onboarding-agent/lib/staging.ts
@@ -1,0 +1,22 @@
+export function makeReviewItem(params: {
+  shopId: string;
+  sessionId: string;
+  entityId?: string;
+  severity: "low" | "medium" | "high" | "blocking";
+  domain?: string;
+  issueType: string;
+  summary: string;
+  details?: Record<string, unknown>;
+}) {
+  return {
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+    entity_id: params.entityId ?? null,
+    severity: params.severity,
+    domain: params.domain ?? null,
+    issue_type: params.issueType,
+    summary: params.summary,
+    details: params.details ?? {},
+    status: "pending",
+  };
+}

--- a/features/onboarding-agent/lib/summaries.ts
+++ b/features/onboarding-agent/lib/summaries.ts
@@ -1,0 +1,6 @@
+export function toCountMap(rows: Array<{ key: string; count: number }>): Record<string, number> {
+  return rows.reduce<Record<string, number>>((acc, row) => {
+    acc[row.key] = row.count;
+    return acc;
+  }, {});
+}

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -1,0 +1,118 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { parseCsvText } from "@/features/onboarding-agent/lib/csvParsing";
+import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
+import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprints";
+import { buildSimpleLinks } from "@/features/onboarding-agent/lib/graph";
+import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
+import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
+import { makeReviewItem } from "@/features/onboarding-agent/lib/staging";
+
+export async function analyzeOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
+  const sb = params.supabase as any;
+
+  const { data: files, error: filesError } = await sb
+    .from("onboarding_files")
+    .select("id, storage_bucket, storage_path, original_filename, declared_domain")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .order("created_at", { ascending: true });
+  if (filesError) throw new Error(filesError.message);
+
+  await sb.from("onboarding_sessions").update({ status: "analyzing" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+  await sb.from("onboarding_raw_rows").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  await sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  await sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  await sb.from("onboarding_review_items").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+
+  const stagedEntities: any[] = [];
+  const reviewItems: any[] = [];
+  let totalRows = 0;
+
+  for (const file of files ?? []) {
+    const dl = await sb.storage.from(file.storage_bucket).download(file.storage_path);
+    if (dl.error || !dl.data) {
+      reviewItems.push(makeReviewItem({ shopId: params.shopId, sessionId: params.sessionId, severity: "blocking", domain: "unknown", issueType: "parse_error", summary: `Failed to read ${file.original_filename ?? file.storage_path}` }));
+      await sb.from("onboarding_files").update({ parse_status: "failed", parse_error: dl.error?.message ?? "download failed" }).eq("id", file.id).eq("shop_id", params.shopId);
+      continue;
+    }
+
+    const text = await dl.data.text();
+    const parsed = parseCsvText(text);
+    const detectedDomain = detectFileDomain({ filename: file.original_filename ?? file.storage_path, headers: parsed.headers, declaredDomain: file.declared_domain });
+    totalRows += parsed.rows.length;
+
+    const rawRowsPayload = parsed.rows.map((row, index) => ({
+      shop_id: params.shopId,
+      session_id: params.sessionId,
+      file_id: file.id,
+      source_row_index: index,
+      raw: row,
+      normalized_preview: {},
+      detected_domain: detectedDomain,
+      row_hash: `${file.id}:${index}`,
+      parse_status: "parsed",
+    }));
+
+    const { data: rawRows } = await sb.from("onboarding_raw_rows").insert(rawRowsPayload).select("id, source_row_index");
+
+    for (const row of parsed.rows) {
+      const normalized = normalizeRow(detectedDomain as any, row);
+      const fingerprint = fingerprintForDomain(detectedDomain as any, normalized.normalized);
+      stagedEntities.push({
+        shop_id: params.shopId,
+        session_id: params.sessionId,
+        entity_type: normalized.entityType,
+        source_file_id: file.id,
+        source_row_index: 0,
+        source_external_id: String((normalized.normalized as any).sourceCustomerId ?? (normalized.normalized as any).sourceWorkOrderId ?? "") || null,
+        canonical_fingerprint: fingerprint,
+        display_name: normalized.displayName,
+        normalized: normalized.normalized,
+        confidence: 0.7,
+        status: "staged",
+      });
+    }
+
+    await sb.from("onboarding_files").update({ parse_status: "parsed", row_count: parsed.rows.length, detected_domain: detectedDomain, header_row: parsed.headers }).eq("id", file.id).eq("shop_id", params.shopId);
+
+    if (detectedDomain === "unknown") {
+      reviewItems.push(makeReviewItem({ shopId: params.shopId, sessionId: params.sessionId, severity: "blocking", domain: "unknown", issueType: "unsupported_file", summary: `Unsupported file type for ${file.original_filename ?? file.storage_path}` }));
+    }
+
+    void rawRows;
+  }
+
+  const { data: entities } = await sb.from("onboarding_entities").insert(stagedEntities).select("id, entity_type, normalized");
+
+  const links = buildSimpleLinks((entities ?? []).map((entity: any) => ({ ...entity, normalized: entity.normalized ?? {} })));
+  if (links.length) {
+    await sb.from("onboarding_entity_links").insert(links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId, status: "staged" })));
+  }
+
+  for (const entity of entities ?? []) {
+    if (entity.entity_type === "customer") {
+      const normalized = entity.normalized ?? {};
+      if (!normalized.name && !normalized.email && !normalized.phone && !normalized.businessName && !normalized.sourceCustomerId) {
+        reviewItems.push(makeReviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, severity: "blocking", domain: "customers", issueType: "missing_identity", summary: "Customer row missing identity fields" }));
+      }
+    }
+  }
+
+  if (reviewItems.length) await sb.from("onboarding_review_items").insert(reviewItems);
+
+  const blockingCount = reviewItems.filter((item) => item.severity === "blocking").length;
+  const status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
+
+  const summary = {
+    fileCount: (files ?? []).length,
+    rowsParsed: totalRows,
+    entitiesDiscovered: (entities ?? []).length,
+    linksFound: links.length,
+    reviewExceptions: reviewItems.length,
+    liveRecordsCreated: 0,
+  };
+
+  await sb.from("onboarding_sessions").update({ status, analyzed_at: new Date().toISOString(), summary, stats: summary }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+
+  return summary;
+}

--- a/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
+++ b/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
@@ -1,0 +1,40 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildDryRunActivationPlan } from "@/features/onboarding-agent/lib/activationPlan";
+
+export async function buildOnboardingActivationPlan(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
+  const sb = params.supabase as any;
+
+  const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }] = await Promise.all([
+    sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entity_links").select("link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_review_items").select("severity").eq("shop_id", params.shopId).eq("session_id", params.sessionId).eq("status", "pending"),
+  ]);
+
+  const entityCounts = (entityRows ?? []).reduce((acc: Record<string, number>, row: any) => {
+    acc[row.entity_type] = (acc[row.entity_type] ?? 0) + 1;
+    return acc;
+  }, {});
+  const linkCounts = (linkRows ?? []).reduce((acc: Record<string, number>, row: any) => {
+    acc[row.link_type] = (acc[row.link_type] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const blocking = (reviewRows ?? []).filter((row: any) => row.severity === "blocking").length;
+  const nonblocking = (reviewRows ?? []).length - blocking;
+
+  const plan = buildDryRunActivationPlan({
+    sessionId: params.sessionId,
+    entityCounts,
+    linkCounts,
+    reviewBlocking: blocking,
+    reviewNonBlocking: nonblocking,
+  });
+
+  const { data } = await sb
+    .from("onboarding_activation_plans")
+    .insert({ shop_id: params.shopId, session_id: params.sessionId, status: "ready", plan, summary: plan, risk_flags: { risks: plan.risks } })
+    .select("id, status, summary, created_at")
+    .single();
+
+  return { plan, record: data };
+}

--- a/features/onboarding-agent/server/createOnboardingSession.ts
+++ b/features/onboarding-agent/server/createOnboardingSession.ts
@@ -1,0 +1,26 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function createOnboardingSession(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  createdBy?: string | null;
+  title?: string | null;
+  source?: string | null;
+  notes?: string | null;
+}) {
+  const { data, error } = await (params.supabase as any)
+    .from("onboarding_sessions")
+    .insert({
+      shop_id: params.shopId,
+      created_by: params.createdBy ?? null,
+      title: params.title ?? null,
+      source: params.source ?? "manual_upload",
+      notes: params.notes ?? null,
+      status: "draft",
+    })
+    .select("id")
+    .single();
+
+  if (error) throw new Error(error.message);
+  return { sessionId: data.id as string };
+}

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -1,0 +1,32 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function getOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
+  const sb = params.supabase as any;
+
+  const [{ data: session }, { data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }] = await Promise.all([
+    sb.from("onboarding_sessions").select("*").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
+    sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
+    sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_review_items").select("severity, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+  ]);
+
+  const entityCounts = (entities ?? []).reduce((acc: Record<string, number>, row: any) => {
+    acc[row.entity_type] = (acc[row.entity_type] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const reviewCounts = (reviews ?? []).reduce((acc: Record<string, number>, row: any) => {
+    const key = row.severity === "blocking" ? "blocking" : "nonblocking";
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const linkCounts = (links ?? []).reduce((acc: Record<string, number>, row: any) => {
+    acc[row.link_type] = (acc[row.link_type] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return { session, files: files ?? [], entityCounts, reviewCounts, linkCounts, latestPlan };
+}

--- a/features/onboarding-agent/server/registerOnboardingFile.ts
+++ b/features/onboarding-agent/server/registerOnboardingFile.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function registerOnboardingFile(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  storageBucket: string;
+  storagePath: string;
+  originalFilename?: string | null;
+  declaredDomain?: string | null;
+}) {
+  const { data: session, error: sessionError } = await (params.supabase as any)
+    .from("onboarding_sessions")
+    .select("id")
+    .eq("id", params.sessionId)
+    .eq("shop_id", params.shopId)
+    .maybeSingle();
+
+  if (sessionError || !session) throw new Error("Session not found for this shop");
+
+  const { data, error } = await (params.supabase as any)
+    .from("onboarding_files")
+    .insert({
+      shop_id: params.shopId,
+      session_id: params.sessionId,
+      storage_bucket: params.storageBucket,
+      storage_path: params.storagePath,
+      original_filename: params.originalFilename ?? null,
+      declared_domain: params.declaredDomain ?? null,
+      parse_status: "pending",
+    })
+    .select("id")
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  await (params.supabase as any)
+    .from("onboarding_sessions")
+    .update({ status: "files_uploaded" })
+    .eq("id", params.sessionId)
+    .eq("shop_id", params.shopId);
+
+  return { fileId: data.id as string };
+}

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -37,6 +37,11 @@ const ALL_ROLES: UserRole[] | undefined = undefined;
 
 export const ROUTE_META: Record<string, RouteMeta> = {
   "/dashboard": { title: () => "Dashboard", icon: "🏠", roles: ALL_ROLES },
+  "/dashboard/onboarding": {
+    title: () => "Onboarding Agent",
+    icon: "🧭",
+    roles: ["owner", "admin"],
+  },
 
   // ----------------------------------------------------------------
   // Work Orders


### PR DESCRIPTION
### Motivation
- The existing Shop Boost materialization flow is brittle and mixes staging, scoring, and canonical writes, so we need a safe, staging-first workspace to ingest and review uploaded files without creating live records. 
- Preserve tenant boundaries and Supabase RLS semantics while making owner/admin onboarding work visible and reviewable. 
- Provide a clear, additive foundation that stages raw rows → normalized entities → links → review items → dry-run activation plans before any canonical activation step.

### Description
- Added an additive SQL migration `db/sql/2026-04-27_onboarding_agent_foundation.sql` that creates shop-scoped tables (`onboarding_sessions`, `onboarding_files`, `onboarding_raw_rows`, `onboarding_entities`, `onboarding_entity_links`, `onboarding_review_items`, `onboarding_activation_plans`, `onboarding_activation_events`), `updated_at` triggers, indexes, and RLS policies scoped to `shop_id` with service-role access. 
- Implemented server-side library and handlers under `features/onboarding-agent/` including detection/CSV parsing/normalization/fingerprinting/graphing and staging logic, and server helpers: `createOnboardingSession`, `registerOnboardingFile`, `analyzeOnboardingSession`, `getOnboardingSession`, and `buildOnboardingActivationPlan`. 
- Added owner/admin API routes under `app/api/onboarding-agent/*` for creating/listing sessions, registering files, running analysis, reading session summaries, and preparing dry-run activation plans. 
- Added an owner/admin UI workspace at `app/dashboard/onboarding` and `app/dashboard/onboarding/[sessionId]` with components under `features/onboarding-agent/components/` that show uploaded files, parsed rows, staged entities, links, review exceptions, and a dry-run activation plan, and include copy that makes staging-first semantics explicit. 
- De-emphasized legacy Shop Boost activation paths by labeling the guided review as legacy, adding safer fallback copy when reset preview fails, and pointing owner CTAs to the new Onboarding Agent; also added a route meta entry for owner/admin visibility at `/dashboard/onboarding`. 
- Important safety: the `analyze` path writes only to staging tables and the activation plan is a dry-run (`mode: "dry_run"`); no live customers/vehicles/work_orders/invoices/staff/parts/vendors/menu/inspection records or inventory/auth side effects are created by this phase. 

### Testing
- Type check: ran `npx tsc --noEmit` which completed successfully. 
- Lint: ran `npx eslint <touched files>` which completed with warnings but no errors. 
- Unit tests: ran `npx vitest run features/onboarding-agent/lib/onboarding-agent.test.ts` and all tests passed. 
- Replay tests: ran `npx vitest run tests/shop-boost-onboarding-replay.test.ts` which is present in the suite but the tests were skipped in this environment (not failing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec5b596e88328bb5f11d2ba1dcbd9)