### PR TITLE
Promote Onboarding Agent as primary owner/admin dashboard entry

### DIFF
--- a/features/dashboard/components/ShopBoostActivationPanel.tsx
+++ b/features/dashboard/components/ShopBoostActivationPanel.tsx
@@ -194,6 +194,9 @@ export default function ShopBoostActivationPanel({ eligible = false }: { eligibl
           <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-200/70">Shop Boost Operational Status</p>
           <h3 className="text-sm font-semibold text-neutral-100">{visibility.headline}</h3>
           <p className="mt-1 text-xs text-neutral-300">{visibility.explanation}</p>
+          <p className="mt-1 text-xs text-cyan-100/85">
+            New imports should use the staging-first Onboarding Agent. Legacy Shop Boost review remains available for diagnostics only.
+          </p>
           <p className="mt-1 text-xs text-neutral-400">
             Current stage: <span className="font-medium text-neutral-100">{fmtStep(intake.progress?.currentStep ?? intake.status)}</span>
           </p>
@@ -244,11 +247,14 @@ export default function ShopBoostActivationPanel({ eligible = false }: { eligibl
       ) : null}
 
       <div className="mt-3 flex flex-wrap gap-2 text-xs">
-        <Link href="/dashboard/setup/review" className="rounded-md border border-cyan-300/35 px-2.5 py-1 text-cyan-100 hover:bg-white/5">
-          Open guided review
+        <Link href="/dashboard/onboarding" className="rounded-md border border-cyan-300/40 bg-cyan-500/10 px-2.5 py-1 text-cyan-100 hover:bg-cyan-500/20">
+          Open Onboarding Agent
         </Link>
         <Link href="/dashboard/owner/reports" className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">
           Open Shop Health
+        </Link>
+        <Link href="/dashboard/setup/review" className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">
+          Open legacy guided review
         </Link>
         <Link href={`/api/shop-boost/intakes/${intake.id}/report?download=1`} className="rounded-md border border-white/25 px-2.5 py-1 text-neutral-100 hover:bg-white/5">
           Download migration report

--- a/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
@@ -30,6 +30,9 @@ export function OnboardingAgentDashboard() {
       <div className="rounded-2xl border border-cyan-500/30 bg-slate-950/60 p-5">
         <h1 className="text-xl font-semibold">Onboarding Agent</h1>
         <p className="mt-2 text-sm text-cyan-100/80">Uploaded files are staged as information first. No live customers, vehicles, work orders, invoices, staff, parts, vendors, menu items, or inspections are created until a future activation step.</p>
+        <p className="mt-2 text-xs text-slate-300">
+          Use this workspace to create sessions and register staged storage paths now. In-app direct file upload and expanded import intelligence are next.
+        </p>
         <button onClick={createSession} disabled={busy} className="mt-4 rounded-md border border-cyan-400/40 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50">{busy ? "Creating…" : "Create onboarding session"}</button>
       </div>
 
@@ -44,6 +47,13 @@ export function OnboardingAgentDashboard() {
           ))}
           {sessions.length === 0 ? <p className="text-sm text-slate-400">No sessions yet.</p> : null}
         </div>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-xs text-slate-300">
+        <p>
+          Need diagnostics from the legacy flow? Use <Link href="/dashboard/owner/reports" className="text-cyan-200 underline underline-offset-2">Shop Health</Link> and{" "}
+          <Link href="/dashboard/setup/review" className="text-cyan-200 underline underline-offset-2">legacy guided review</Link>.
+        </p>
       </div>
     </div>
   );

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -527,6 +527,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
   const openMenu = useCallback(() => router.push("/menu"), [router]);
   const openInspections = useCallback(() => router.push("/inspections/templates"), [router]);
   const openTeam = useCallback(() => router.push("/dashboard/owner/create-user"), [router]);
+  const openOnboardingAgent = useCallback(() => router.push("/dashboard/onboarding"), [router]);
   const openGuidedReview = useCallback(() => router.push("/dashboard/setup/review"), [router]);
 
   /** ✅ WIRED: calls /api/shop-health/accept-suggestion and handles per-createdType */
@@ -815,12 +816,13 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
               <div className="flex flex-wrap items-center gap-2">
                 {activationReadiness.statusLabel === "Activation not ready" ? (
                   <>
-                    <QuickLinkButton label="Open Guided Review" onClick={openGuidedReview} />
-                    <QuickLinkButton label="Review unresolved records" onClick={openGuidedReview} />
+                    <QuickLinkButton label="Open Onboarding Agent" onClick={openOnboardingAgent} />
+                    <QuickLinkButton label="Open legacy guided review" onClick={openGuidedReview} />
                     <QuickLinkButton label="Apply setup suggestions" onClick={openMenu} />
                   </>
                 ) : (
                   <>
+                    <QuickLinkButton label="Open Onboarding Agent" onClick={openOnboardingAgent} />
                     <QuickLinkButton label="Open Menu Builder" onClick={openMenu} />
                     <QuickLinkButton label="Open Inspections" onClick={openInspections} />
                     <QuickLinkButton label="Open Team" onClick={openTeam} />
@@ -833,8 +835,8 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
               <div className="grid gap-3 md:grid-cols-3">
                 <StepCard
                   step="1"
-                  title="Upload files"
-                  body="Upload history once (customers/vehicles/parts/etc). Future runs can reuse your latest intake files."
+                  title="Open Onboarding Agent"
+                  body="Stage files and review onboarding sessions first. Staged analysis does not create live records until activation is explicitly approved."
                   tone="watch"
                 />
                 <StepCard
@@ -852,7 +854,7 @@ export default function ReportsShopHealthPanel({ shopId }: Props) {
               </div>
 
               <div className="mt-3 text-[11px] text-neutral-400">
-                Recommendation: <b>start with Menu items</b>, then <b>Inspections</b>, then <b>Staff invites</b>.
+                Recommendation: <b>start in Onboarding Agent</b>, then use Shop Health and legacy guided review for diagnostics and follow-up checks.
               </div>
             </div>
           </section>

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -137,6 +137,14 @@ export const TILES: Tile[] = [
     scopes: ["management", "settings", "all"],
     section: "Tools",
   },
+  {
+    href: "/dashboard/onboarding",
+    title: "Onboarding Agent",
+    subtitle: "Stage files and prepare activation safely",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Tools",
+  },
 
   /* ---------------------------------------------------------------------- */
   /* APPOINTMENTS                                                            */


### PR DESCRIPTION
### Motivation
- Make the new staging-first Onboarding Agent discoverable as a first-class owner/admin workspace from the dashboard and sidebar while keeping the legacy Shop Boost guided review available for diagnostics only.
- Ensure technician-only users do not see owner/admin onboarding controls and preserve multi-tenant and role/capability gates.
- Keep this change UI/navigation-only (no activation/live imports), preserving existing staged-only analyze behavior.

### Description
- Added a Tools sidebar tile for Onboarding Agent (`/dashboard/onboarding`) visible to `owner` and `admin` roles by updating `features/shared/config/tiles.ts`.
- Made Onboarding Agent the primary CTA in the Shop Boost operational card and labeled the old guided review as legacy by modifying `features/dashboard/components/ShopBoostActivationPanel.tsx`.
- Updated Shop Health owner/report flows and step copy to point owners/admins toward the Onboarding Agent and to mark guided review as legacy in `features/owner/reports/ReportsShopHealthPanel.tsx`.
- Improved the onboarding landing workspace copy and added links/back-navigation to diagnostics in `features/onboarding-agent/components/OnboardingAgentDashboard.tsx`; preserved session create/listing flows and route protections in `app/dashboard/onboarding/page.tsx`, `app/dashboard/onboarding/[sessionId]/page.tsx` and the onboarding-agent API routes under `app/api/onboarding-agent/*`.
- No legacy Shop Boost code was removed and no backend activation/live-record creation logic was changed; the analyze path remains staged-only.

### Testing
- Ran `npx tsc --noEmit` and it passed without errors.
- Ran `npx eslint` against the touched files and observed 1 existing warning (`no-explicit-any` in `app/api/onboarding-agent/sessions/route.ts`) but no new errors.
- Ran unit tests with `npx vitest run features/onboarding-agent/lib/onboarding-agent.test.ts` and all tests passed.
- Ran `pnpm build` in this environment but the Next build was blocked by network font fetch failures (Google Fonts) and failed for that reason; this is an environment/network issue rather than a code-type error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed00cf8cc8328be73a5fb9d0592e6)