### PR TITLE
Add staged AI reasoning layer for onboarding agent sessions

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/agent-analysis/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/agent-analysis/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { runOnboardingAgentAnalysis } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const { sessionId } = await context.params;
+
+  try {
+    const report = await runOnboardingAgentAnalysis({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id as string,
+      sessionId,
+    });
+
+    return NextResponse.json({ ok: true, report, liveRecordsCreated: 0 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Agent analysis failed";
+    if (message === "Session not found") {
+      return NextResponse.json({ ok: false, error: message }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { analyzeOnboardingSession } from "@/features/onboarding-agent/server/analyzeOnboardingSession";
+import { getOnboardingAgentEnabled } from "@/features/onboarding-agent/server/model";
+import { runOnboardingAgentAnalysis } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type RouteContext = {
@@ -21,7 +23,28 @@ export async function POST(_: Request, context: RouteContext) {
       sessionId,
     });
 
-    return NextResponse.json({ ok: true, summary, liveRecordsCreated: 0 });
+    let agentReport = null;
+    const shouldAutoAnalyze = process.env.ONBOARDING_AGENT_AUTO_ANALYZE === "false"
+      ? false
+      : getOnboardingAgentEnabled();
+
+    if (shouldAutoAnalyze) {
+      try {
+        agentReport = await runOnboardingAgentAnalysis({
+          supabase: access.supabase,
+          shopId: access.profile.shop_id as string,
+          sessionId,
+        });
+      } catch (error) {
+        console.warn("[onboarding-agent] auto agent analysis warning", {
+          sessionId,
+          shopId: access.profile.shop_id,
+          error: error instanceof Error ? error.message : "unknown",
+        });
+      }
+    }
+
+    return NextResponse.json({ ok: true, summary, agentReport, liveRecordsCreated: 0 });
   } catch (error) {
     return NextResponse.json(
       { ok: false, error: error instanceof Error ? error.message : "Analysis failed" },

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { OnboardingAgentReport } from "@/features/onboarding-agent/lib/agentTypes";
+
+function readinessTone(status: OnboardingAgentReport["activationReadiness"]["status"] | undefined) {
+  if (status === "ready_for_dry_run" || status === "ready_for_activation_later") return "border-emerald-400/40 text-emerald-200";
+  if (status === "review_required") return "border-amber-400/40 text-amber-200";
+  return "border-rose-400/40 text-rose-200";
+}
+
+export function OnboardingAgentInsightsPanel({
+  sessionId,
+  report,
+  onRefresh,
+}: {
+  sessionId: string;
+  report?: OnboardingAgentReport | null;
+  onRefresh: () => Promise<void>;
+}) {
+  const [running, setRunning] = useState(false);
+  const findings = report?.findings ?? [];
+  const recommendations = report?.recommendations ?? [];
+
+  const groupedFindings = useMemo(() => {
+    const buckets: Record<string, typeof findings> = {};
+    for (const finding of findings) {
+      buckets[finding.severity] = [...(buckets[finding.severity] ?? []), finding];
+    }
+    return buckets;
+  }, [findings]);
+
+  const groupedRecommendations = useMemo(() => {
+    const buckets: Record<string, typeof recommendations> = {};
+    for (const rec of recommendations) {
+      const key = `${rec.actionType} • ${rec.domain}`;
+      buckets[key] = [...(buckets[key] ?? []), rec];
+    }
+    return buckets;
+  }, [recommendations]);
+
+  const runAnalysis = async () => {
+    setRunning(true);
+    try {
+      await fetch(`/api/onboarding-agent/sessions/${sessionId}/agent-analysis`, { method: "POST" });
+      await onRefresh();
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-cyan-500/30 bg-cyan-950/10 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-cyan-100">Agent insights</h3>
+          <p className="mt-1 text-xs text-cyan-100/70">No live records have been created. This is a staged analysis.</p>
+        </div>
+        <button onClick={runAnalysis} disabled={running} className="rounded border border-cyan-400/40 px-3 py-2 text-xs text-cyan-100 disabled:opacity-60">
+          {running ? "Running..." : "Run AI analysis"}
+        </button>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <div className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Mode</p>
+          <p className="text-sm text-white">
+            {!report ? "Not run yet" : report.mode === "ai" ? "AI analysis" : "Deterministic fallback"}
+          </p>
+          {report?.mode === "deterministic_fallback" ? (
+            <p className="mt-1 text-xs text-amber-200/90">AI reasoning unavailable; deterministic staging still completed.</p>
+          ) : null}
+        </div>
+        <div className={`rounded-lg border bg-slate-900/50 p-3 ${readinessTone(report?.activationReadiness?.status)}`}>
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Activation readiness</p>
+          <p className="text-sm">{report?.activationReadiness?.status ?? "not_ready"}</p>
+        </div>
+      </div>
+
+      <p className="mt-3 text-sm text-slate-200">{report?.summary ?? "Run analysis to get explainable onboarding insights."}</p>
+
+      {(report?.findings?.length ?? 0) > 0 ? (
+        <div className="mt-3 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-300">Findings</p>
+          {Object.entries(groupedFindings).map(([severity, findings]) => (
+            <div key={severity} className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
+              <p className="text-xs uppercase tracking-wide text-slate-400">{severity}</p>
+              <ul className="mt-2 space-y-2 text-sm text-slate-200">
+                {findings.map((finding, idx) => (
+                  <li key={`${finding.title}-${idx}`}>
+                    <p className="font-medium text-white">{finding.title}</p>
+                    <p>{finding.explanation}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {(report?.recommendations?.length ?? 0) > 0 ? (
+        <div className="mt-3 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-300">Recommendations</p>
+          {Object.entries(groupedRecommendations).map(([key, recs]) => (
+            <div key={key} className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
+              <p className="text-xs uppercase tracking-wide text-slate-400">{key}</p>
+              <ul className="mt-2 space-y-2 text-sm text-slate-200">
+                {recs.map((rec, idx) => (
+                  <li key={`${rec.title}-${idx}`}>
+                    <p className="font-medium text-white">{rec.title}</p>
+                    <p>{rec.explanation}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { OnboardingActivationPlanPanel } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
+import { OnboardingAgentInsightsPanel } from "@/features/onboarding-agent/components/OnboardingAgentInsightsPanel";
 import { OnboardingEntitiesPanel } from "@/features/onboarding-agent/components/OnboardingEntitiesPanel";
 import { OnboardingFilesPanel } from "@/features/onboarding-agent/components/OnboardingFilesPanel";
 import { OnboardingProgressCard } from "@/features/onboarding-agent/components/OnboardingProgressCard";
@@ -11,6 +12,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [payload, setPayload] = useState<any>(null);
   const [storageBucket, setStorageBucket] = useState("shop-boost-uploads");
   const [storagePath, setStoragePath] = useState("");
+  const [declaredDomain, setDeclaredDomain] = useState("");
 
   const load = async () => {
     const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { cache: "no-store" });
@@ -24,7 +26,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     await fetch(`/api/onboarding-agent/sessions/${sessionId}/files`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ storageBucket, storagePath, originalFilename: storagePath.split("/").pop() }),
+      body: JSON.stringify({
+        storageBucket,
+        storagePath,
+        declaredDomain: declaredDomain || undefined,
+        originalFilename: storagePath.split("/").pop(),
+      }),
     });
     setStoragePath("");
     await load();
@@ -47,13 +54,21 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
         <h1 className="text-xl font-semibold">Onboarding session</h1>
         <p className="text-sm text-slate-300">Status: {session?.status ?? "loading"}</p>
+        <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+          <span className="rounded-full border border-cyan-400/50 px-2 py-1 text-cyan-200">Staged-only</span>
+          <span className="rounded-full border border-emerald-400/40 px-2 py-1 text-emerald-200">No live records created</span>
+        </div>
         <p className="mt-2 text-xs text-cyan-100/80">Historical work orders remain historical (not active jobs). Historical invoices remain imported historical billing records.</p>
       </div>
 
-      <div className="grid gap-2 md:grid-cols-[1fr_auto_auto]">
-        <input value={storageBucket} onChange={(e) => setStorageBucket(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="Storage bucket" />
-        <input value={storagePath} onChange={(e) => setStoragePath(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="storage/path/file.csv" />
-        <button onClick={registerFile} className="rounded border border-white/20 px-3 py-2 text-sm">Register staged file</button>
+      <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+        <h2 className="text-sm font-semibold">File registration</h2>
+        <div className="mt-3 grid gap-2 md:grid-cols-4">
+          <input value={storageBucket} onChange={(e) => setStorageBucket(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="Storage bucket" />
+          <input value={storagePath} onChange={(e) => setStoragePath(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="storage/path/file.csv" />
+          <input value={declaredDomain} onChange={(e) => setDeclaredDomain(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="Declared domain (optional)" />
+          <button onClick={registerFile} className="rounded border border-white/20 px-3 py-2 text-sm">Register staged file</button>
+        </div>
       </div>
 
       <div className="flex gap-2">
@@ -62,9 +77,25 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       </div>
 
       <OnboardingProgressCard summary={session?.summary ?? null} />
+      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} onRefresh={load} />
       <OnboardingFilesPanel files={payload?.files ?? []} />
       <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
       <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} />
+
+      <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+        <h3 className="text-sm font-semibold text-white">Pending review exceptions</h3>
+        <div className="mt-2 space-y-2">
+          {(payload?.reviewItems ?? []).slice(0, 25).map((item: any) => (
+            <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
+              <p className="text-xs uppercase tracking-wide text-slate-400">{item.severity} • {item.domain ?? "unknown"}</p>
+              <p className="text-sm text-white">{item.summary}</p>
+              <p className="text-xs text-slate-400">Recommended action: review exception before activation planning.</p>
+            </div>
+          ))}
+          {(payload?.reviewItems ?? []).length === 0 ? <p className="text-xs text-slate-400">No pending review exceptions.</p> : null}
+        </div>
+      </div>
+
       <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} />
     </div>
   );

--- a/features/onboarding-agent/lib/agentTypes.ts
+++ b/features/onboarding-agent/lib/agentTypes.ts
@@ -1,0 +1,93 @@
+import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+
+export type OnboardingAgentSeverity = "info" | "low" | "medium" | "high" | "blocking";
+
+export type OnboardingAgentRecommendationActionType =
+  | "accept_high_confidence"
+  | "review_exception"
+  | "upload_better_file"
+  | "map_column"
+  | "merge_duplicate"
+  | "ignore_row"
+  | "prepare_activation";
+
+export type OnboardingAgentActivationStatus =
+  | "not_ready"
+  | "review_required"
+  | "ready_for_dry_run"
+  | "ready_for_activation_later";
+
+export type OnboardingAgentInput = {
+  sessionId: string;
+  shopId: string;
+  files: Array<{
+    id: string;
+    filename: string;
+    declaredDomain: string | null;
+    detectedDomain: string | null;
+    parseStatus: string | null;
+    headers: string[];
+    rowCount: number;
+    sampleRows: Record<string, unknown>[];
+  }>;
+  deterministicDomainDetections: Record<string, number>;
+  deterministicStagedEntityCounts: Record<string, number>;
+  deterministicLinkCounts: Record<string, number>;
+  deterministicReviewItems: Array<{
+    id: string;
+    severity: string;
+    domain: string | null;
+    summary: string;
+    issueType: string;
+    entityId: string | null;
+    details: Record<string, unknown>;
+  }>;
+  activationPlanSummary: Record<string, unknown> | null;
+};
+
+export type OnboardingAgentFinding = {
+  severity: OnboardingAgentSeverity;
+  domain: OnboardingDomain | "all";
+  title: string;
+  explanation: string;
+  evidence: string[];
+  recommendedAction: string;
+};
+
+export type OnboardingAgentDomainSummary = {
+  domain: OnboardingDomain;
+  confidence: number;
+  rowsSeen: number;
+  entitiesDetected: number;
+  readyCount: number;
+  reviewCount: number;
+  notes: string[];
+};
+
+export type OnboardingAgentRecommendation = {
+  actionType: OnboardingAgentRecommendationActionType;
+  domain: OnboardingDomain | "all";
+  confidence: number;
+  title: string;
+  explanation: string;
+  affectedEntityIds?: string[];
+  affectedRowIds?: string[];
+  riskLevel: "low" | "medium" | "high";
+};
+
+export type OnboardingAgentReport = {
+  model: string;
+  mode: "ai" | "deterministic_fallback";
+  summary: string;
+  domainSummaries: OnboardingAgentDomainSummary[];
+  findings: OnboardingAgentFinding[];
+  recommendations: OnboardingAgentRecommendation[];
+  activationReadiness: {
+    status: OnboardingAgentActivationStatus;
+    blockers: string[];
+    warnings: string[];
+    safeToProceed: boolean;
+  };
+  generatedAt: string;
+  liveRecordsCreated: 0;
+};

--- a/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { OnboardingAgentInput, OnboardingAgentReport } from "@/features/onboarding-agent/lib/agentTypes";
+import {
+  buildDeterministicFallbackReport,
+  sanitizeAgentReport,
+} from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
+
+function makeInput(reviewSeverity: "blocking" | "high" = "blocking"): OnboardingAgentInput {
+  return {
+    sessionId: "session-1",
+    shopId: "shop-1",
+    files: [
+      {
+        id: "file-1",
+        filename: "customers.csv",
+        declaredDomain: "customers",
+        detectedDomain: "customers",
+        parseStatus: "parsed",
+        headers: ["Customer ID", "Name"],
+        rowCount: 12,
+        sampleRows: [{ id: "row-1", name: "Jane" }],
+      },
+    ],
+    deterministicDomainDetections: { customers: 1 },
+    deterministicStagedEntityCounts: { customer: 10, vehicle: 5 },
+    deterministicLinkCounts: { customer_vehicle: 4 },
+    deterministicReviewItems: [
+      {
+        id: "review-1",
+        severity: reviewSeverity,
+        domain: "vehicles",
+        summary: "Missing vehicle linkage",
+        issueType: "missing_link",
+        entityId: "entity-1",
+        details: {},
+      },
+    ],
+    activationPlanSummary: null,
+  };
+}
+
+describe("onboarding agent ai safeguards", () => {
+  it("deterministic fallback produces a non-empty report", () => {
+    const report = buildDeterministicFallbackReport(makeInput());
+    expect(report.summary.length).toBeGreaterThan(10);
+    expect(report.domainSummaries.length).toBeGreaterThan(0);
+    expect(report.findings.length).toBeGreaterThan(0);
+    expect(report.recommendations.length).toBeGreaterThan(0);
+    expect(report.liveRecordsCreated).toBe(0);
+  });
+
+  it("malformed ai json falls back safely", () => {
+    const fallback = buildDeterministicFallbackReport(makeInput());
+    const report = sanitizeAgentReport({
+      candidate: "not-json",
+      fallback,
+      validEntityIds: new Set(["entity-1"]),
+      validRowIds: new Set(["row-1"]),
+    });
+    expect(report.mode).toBe("deterministic_fallback");
+    expect(report.summary).toBe(fallback.summary);
+  });
+
+  it("sanitizer removes invalid ids", () => {
+    const fallback = buildDeterministicFallbackReport(makeInput());
+    const candidate: Partial<OnboardingAgentReport> = {
+      mode: "ai",
+      summary: "test",
+      domainSummaries: [],
+      findings: [],
+      recommendations: [
+        {
+          actionType: "review_exception",
+          domain: "customers",
+          confidence: 0.9,
+          title: "Review",
+          explanation: "x",
+          affectedEntityIds: ["entity-1", "entity-2"],
+          affectedRowIds: ["row-1", "row-2"],
+          riskLevel: "low",
+        },
+      ],
+      activationReadiness: {
+        status: "review_required",
+        blockers: [],
+        warnings: [],
+        safeToProceed: true,
+      },
+      model: "gpt-test",
+      generatedAt: new Date().toISOString(),
+      liveRecordsCreated: 9 as never,
+    };
+
+    const report = sanitizeAgentReport({
+      candidate,
+      fallback,
+      validEntityIds: new Set(["entity-1"]),
+      validRowIds: new Set(["row-1"]),
+    });
+
+    expect(report.recommendations[0].affectedEntityIds).toEqual(["entity-1"]);
+    expect(report.recommendations[0].affectedRowIds).toEqual(["row-1"]);
+    expect(report.liveRecordsCreated).toBe(0);
+  });
+
+  it("activation readiness is not ready with blocking items", () => {
+    const report = buildDeterministicFallbackReport(makeInput("blocking"));
+    expect(report.activationReadiness.status).toBe("not_ready");
+    expect(report.activationReadiness.safeToProceed).toBe(false);
+  });
+
+  it("activation readiness is ready_for_dry_run with no blocking items", () => {
+    const input = makeInput("high");
+    input.deterministicReviewItems = [];
+    const report = buildDeterministicFallbackReport(input);
+    expect(report.activationReadiness.status).toBe("ready_for_dry_run");
+    expect(report.activationReadiness.safeToProceed).toBe(true);
+  });
+
+  it("no report can set liveRecordsCreated above zero", () => {
+    const fallback = buildDeterministicFallbackReport(makeInput());
+    const report = sanitizeAgentReport({
+      candidate: {
+        ...fallback,
+        mode: "ai",
+        liveRecordsCreated: 4,
+      },
+      fallback,
+      validEntityIds: new Set(["entity-1"]),
+      validRowIds: new Set(["row-1"]),
+    });
+
+    expect(report.liveRecordsCreated).toBe(0);
+  });
+});

--- a/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
+++ b/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
@@ -4,10 +4,11 @@ import { buildDryRunActivationPlan } from "@/features/onboarding-agent/lib/activ
 export async function buildOnboardingActivationPlan(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
 
-  const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }] = await Promise.all([
+  const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }, { data: sessionRow }] = await Promise.all([
     sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_entity_links").select("link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_review_items").select("severity").eq("shop_id", params.shopId).eq("session_id", params.sessionId).eq("status", "pending"),
+    sb.from("onboarding_sessions").select("summary").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
   ]);
 
   const entityCounts = (entityRows ?? []).reduce((acc: Record<string, number>, row: any) => {
@@ -30,11 +31,14 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
     reviewNonBlocking: nonblocking,
   });
 
+  const sessionSummary = (sessionRow?.summary ?? {}) as Record<string, unknown>;
+  const summaryWithAgent = { ...plan, agentReport: sessionSummary.agentReport ?? null, liveRecordsCreated: 0 };
+
   const { data } = await sb
     .from("onboarding_activation_plans")
-    .insert({ shop_id: params.shopId, session_id: params.sessionId, status: "ready", plan, summary: plan, risk_flags: { risks: plan.risks } })
+    .insert({ shop_id: params.shopId, session_id: params.sessionId, status: "ready", plan, summary: summaryWithAgent, risk_flags: { risks: plan.risks } })
     .select("id, status, summary, created_at")
     .single();
 
-  return { plan, record: data };
+  return { plan: summaryWithAgent, record: data };
 }

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -8,7 +8,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
     sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_review_items").select("severity, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_review_items").select("id, severity, status, domain, summary, issue_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
     sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
   ]);
 
@@ -28,5 +28,13 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     return acc;
   }, {});
 
-  return { session, files: files ?? [], entityCounts, reviewCounts, linkCounts, latestPlan };
+  return {
+    session,
+    files: files ?? [],
+    entityCounts,
+    reviewCounts,
+    reviewItems: reviews ?? [],
+    linkCounts,
+    latestPlan,
+  };
 }

--- a/features/onboarding-agent/server/model.ts
+++ b/features/onboarding-agent/server/model.ts
@@ -1,0 +1,13 @@
+const DEFAULT_ONBOARDING_MODEL = "gpt-5-mini";
+
+export function getOnboardingAgentModel() {
+  return (
+    process.env.ONBOARDING_AGENT_MODEL?.trim() ||
+    process.env.OPENAI_MODEL?.trim() ||
+    DEFAULT_ONBOARDING_MODEL
+  );
+}
+
+export function getOnboardingAgentEnabled() {
+  return Boolean(process.env.OPENAI_API_KEY?.trim());
+}

--- a/features/onboarding-agent/server/prompts.ts
+++ b/features/onboarding-agent/server/prompts.ts
@@ -1,0 +1,49 @@
+import type { OnboardingAgentInput } from "@/features/onboarding-agent/lib/agentTypes";
+
+export function buildOnboardingAgentSystemPrompt() {
+  return [
+    "You are ProFixIQ's Onboarding Agent.",
+    "You analyze staged automotive shop data and return explainable onboarding guidance.",
+    "You must not create live records.",
+    "You must not claim activation happened.",
+    "Historical work orders are historical_work_order and not active jobs.",
+    "Historical work order lines are not punchable operations.",
+    "Historical invoices are imported historical billing records, not live invoice workflow.",
+    "Staff rows are staff_candidate suggestions only.",
+    "Menu and inspection rows are staged suggestions only.",
+    "You only use staged evidence and must be conservative about confidence.",
+    "Output JSON only, no markdown, no prose outside JSON.",
+  ].join(" ");
+}
+
+export function buildOnboardingAgentUserPrompt(input: OnboardingAgentInput) {
+  return JSON.stringify(
+    {
+      task: "Analyze staged onboarding data and produce an OnboardingAgentReport JSON object.",
+      requirements: {
+        infer_domains: true,
+        explain_confidence: true,
+        identify_mismatches: true,
+        identify_missing_links: true,
+        identify_duplicate_risks: true,
+        suggest_review_actions: true,
+        summarize_activation_readiness: true,
+        never_claim_live_records_created: true,
+        output_contract: {
+          model: "string",
+          mode: "ai",
+          summary: "string",
+          domainSummaries: "array",
+          findings: "array",
+          recommendations: "array",
+          activationReadiness: "object",
+          generatedAt: "ISO timestamp",
+          liveRecordsCreated: 0,
+        },
+      },
+      input,
+    },
+    null,
+    2,
+  );
+}

--- a/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
+++ b/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
@@ -1,0 +1,403 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  OnboardingAgentDomainSummary,
+  OnboardingAgentFinding,
+  OnboardingAgentInput,
+  OnboardingAgentRecommendation,
+  OnboardingAgentReport,
+} from "@/features/onboarding-agent/lib/agentTypes";
+import { ONBOARDING_DOMAINS, type OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+import { buildOnboardingAgentSystemPrompt, buildOnboardingAgentUserPrompt } from "@/features/onboarding-agent/server/prompts";
+import { getOnboardingAgentEnabled, getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
+
+type RunParams = {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  sampleRowsPerFile?: number;
+};
+
+const VALID_SEVERITY = new Set(["info", "low", "medium", "high", "blocking"]);
+const VALID_ACTION_TYPES = new Set([
+  "accept_high_confidence",
+  "review_exception",
+  "upload_better_file",
+  "map_column",
+  "merge_duplicate",
+  "ignore_row",
+  "prepare_activation",
+]);
+const VALID_READINESS = new Set(["not_ready", "review_required", "ready_for_dry_run", "ready_for_activation_later"]);
+const VALID_DOMAINS = new Set<string>([...ONBOARDING_DOMAINS, "all"]);
+
+function stripJsonFences(raw: string) {
+  return raw.replace(/^```json\s*/i, "").replace(/^```\s*/i, "").replace(/```\s*$/i, "").trim();
+}
+
+function parseModelJson(raw: string): unknown {
+  return JSON.parse(stripJsonFences(raw));
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function toDomain(value: unknown, fallback: OnboardingDomain | "all" = "all"): OnboardingDomain | "all" {
+  const maybe = typeof value === "string" ? value : "";
+  return VALID_DOMAINS.has(maybe) ? (maybe as OnboardingDomain | "all") : fallback;
+}
+
+function boundedConfidence(value: unknown, fallback = 0.5) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(1, n));
+}
+
+function sanitizeIds(ids: unknown, allow: Set<string>) {
+  return asArray<unknown>(ids)
+    .map((v) => (typeof v === "string" ? v : ""))
+    .filter((id) => id && allow.has(id));
+}
+
+function buildActivationReadiness(input: OnboardingAgentInput) {
+  const blockingItems = input.deterministicReviewItems.filter((item) => item.severity === "blocking");
+  const warningItems = input.deterministicReviewItems.filter((item) => item.severity !== "blocking");
+
+  if (blockingItems.length > 0) {
+    return {
+      status: "not_ready" as const,
+      blockers: blockingItems.map((item) => item.summary),
+      warnings: warningItems.map((item) => item.summary),
+      safeToProceed: false,
+    };
+  }
+
+  if (warningItems.length > 0) {
+    return {
+      status: "review_required" as const,
+      blockers: [],
+      warnings: warningItems.map((item) => item.summary),
+      safeToProceed: true,
+    };
+  }
+
+  return {
+    status: "ready_for_dry_run" as const,
+    blockers: [],
+    warnings: ["Activation remains disabled in this phase; dry-run only."],
+    safeToProceed: true,
+  };
+}
+
+export function buildDeterministicFallbackReport(input: OnboardingAgentInput): OnboardingAgentReport {
+  const rowsParsed = input.files.reduce((sum, file) => sum + file.rowCount, 0);
+  const entitiesTotal = Object.values(input.deterministicStagedEntityCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
+  const blockingCount = input.deterministicReviewItems.filter((item) => item.severity === "blocking").length;
+  const readiness = buildActivationReadiness(input);
+
+  const domainSummaries: OnboardingAgentDomainSummary[] = ONBOARDING_DOMAINS.map((domain) => {
+    const fileRows = input.files.filter((file) => (file.detectedDomain ?? "unknown") === domain).reduce((sum, file) => sum + file.rowCount, 0);
+    const reviewCount = input.deterministicReviewItems.filter((item) => (item.domain ?? "unknown") === domain).length;
+    const entitiesDetected = Object.entries(input.deterministicStagedEntityCounts)
+      .filter(([entityType]) => entityType.includes(domain.slice(0, -1)) || (domain === "history" && entityType === "historical_work_order") || (domain === "invoices" && entityType === "historical_invoice"))
+      .reduce((sum, [, count]) => sum + Number(count ?? 0), 0);
+    const readyCount = Math.max(0, entitiesDetected - reviewCount);
+
+    return {
+      domain,
+      confidence: fileRows > 0 ? 0.8 : 0,
+      rowsSeen: fileRows,
+      entitiesDetected,
+      readyCount,
+      reviewCount,
+      notes: fileRows > 0 ? ["Deterministic domain detection and normalization completed."] : [],
+    };
+  }).filter((item) => item.rowsSeen > 0 || item.entitiesDetected > 0 || item.reviewCount > 0);
+
+  const findings: OnboardingAgentFinding[] = [
+    {
+      severity: "info",
+      domain: "all",
+      title: "Staged analysis completed",
+      explanation: `${input.files.length} files registered, ${rowsParsed} rows parsed, ${entitiesTotal} staged entities detected.`,
+      evidence: [
+        `Files: ${input.files.length}`,
+        `Rows parsed: ${rowsParsed}`,
+        `Staged entities: ${entitiesTotal}`,
+      ],
+      recommendedAction: "Review exceptions and proceed with dry-run planning.",
+    },
+    {
+      severity: blockingCount > 0 ? "blocking" : "low",
+      domain: "all",
+      title: blockingCount > 0 ? "Blocking review items found" : "No blocking review items found",
+      explanation: blockingCount > 0
+        ? `${blockingCount} blocking review items must be resolved before activation later.`
+        : "No blocking review items remain; dry-run planning can proceed.",
+      evidence: [`Blocking review count: ${blockingCount}`],
+      recommendedAction: blockingCount > 0 ? "Resolve blocking review exceptions." : "Prepare activation dry-run summary.",
+    },
+  ];
+
+  if (input.deterministicReviewItems.length > 0) {
+    const topReview = input.deterministicReviewItems[0];
+    findings.push({
+      severity: topReview.severity === "blocking" ? "high" : "medium",
+      domain: toDomain(topReview.domain, "all"),
+      title: "Review exceptions require operator attention",
+      explanation: `${input.deterministicReviewItems.length} review exceptions are pending.`,
+      evidence: input.deterministicReviewItems.slice(0, 3).map((item) => item.summary),
+      recommendedAction: "Review exception list and confirm data mappings.",
+    });
+  }
+
+  const recommendations: OnboardingAgentRecommendation[] = [
+    {
+      actionType: blockingCount > 0 ? "review_exception" : "prepare_activation",
+      domain: "all",
+      confidence: 0.9,
+      title: blockingCount > 0 ? "Resolve blocking exceptions" : "Prepare dry-run activation",
+      explanation: blockingCount > 0
+        ? "Blocking staged issues are preventing readiness. Resolve exceptions first."
+        : "Data is ready for dry-run planning. Activation stays disabled in this phase.",
+      riskLevel: blockingCount > 0 ? "high" : "low",
+      affectedRowIds: input.deterministicReviewItems.map((item) => item.id),
+    },
+  ];
+
+  return {
+    model: getOnboardingAgentModel(),
+    mode: "deterministic_fallback",
+    summary: `Staged onboarding analysis completed. ${input.files.length} files, ${rowsParsed} rows, ${entitiesTotal} staged entities. No live records have been created.`,
+    domainSummaries,
+    findings,
+    recommendations,
+    activationReadiness: readiness,
+    generatedAt: new Date().toISOString(),
+    liveRecordsCreated: 0,
+  };
+}
+
+export function sanitizeAgentReport(params: {
+  candidate: unknown;
+  fallback: OnboardingAgentReport;
+  validEntityIds: Set<string>;
+  validRowIds: Set<string>;
+}): OnboardingAgentReport {
+  const root = asRecord(params.candidate);
+  const fallback = params.fallback;
+
+  const readinessRoot = asRecord(root.activationReadiness);
+  const readinessStatus = typeof readinessRoot.status === "string" && VALID_READINESS.has(readinessRoot.status)
+    ? readinessRoot.status
+    : fallback.activationReadiness.status;
+
+  return {
+    model: typeof root.model === "string" && root.model ? root.model : fallback.model,
+    mode: root.mode === "ai" ? "ai" : fallback.mode,
+    summary: typeof root.summary === "string" && root.summary ? root.summary : fallback.summary,
+    domainSummaries: asArray<unknown>(root.domainSummaries).map((raw) => {
+      const item = asRecord(raw);
+      return {
+        domain: toDomain(item.domain, "unknown") as OnboardingDomain,
+        confidence: boundedConfidence(item.confidence, 0.5),
+        rowsSeen: Number(item.rowsSeen ?? 0) || 0,
+        entitiesDetected: Number(item.entitiesDetected ?? 0) || 0,
+        readyCount: Number(item.readyCount ?? 0) || 0,
+        reviewCount: Number(item.reviewCount ?? 0) || 0,
+        notes: asArray<unknown>(item.notes).map((v) => String(v)),
+      };
+    }).filter((item) => ONBOARDING_DOMAINS.includes(item.domain)),
+    findings: asArray<unknown>(root.findings).map((raw) => {
+      const item = asRecord(raw);
+      const severity = typeof item.severity === "string" && VALID_SEVERITY.has(item.severity) ? item.severity : "low";
+      return {
+        severity: severity as OnboardingAgentFinding["severity"],
+        domain: toDomain(item.domain, "all"),
+        title: String(item.title ?? "Untitled finding"),
+        explanation: String(item.explanation ?? ""),
+        evidence: asArray<unknown>(item.evidence).map((v) => String(v)),
+        recommendedAction: String(item.recommendedAction ?? "Review staged data."),
+      };
+    }),
+    recommendations: asArray<unknown>(root.recommendations).map((raw) => {
+      const item = asRecord(raw);
+      const actionType = typeof item.actionType === "string" && VALID_ACTION_TYPES.has(item.actionType)
+        ? item.actionType
+        : "review_exception";
+      const risk = item.riskLevel === "high" || item.riskLevel === "medium" || item.riskLevel === "low" ? item.riskLevel : "medium";
+      return {
+        actionType: actionType as OnboardingAgentRecommendation["actionType"],
+        domain: toDomain(item.domain, "all"),
+        confidence: boundedConfidence(item.confidence, 0.5),
+        title: String(item.title ?? "Untitled recommendation"),
+        explanation: String(item.explanation ?? ""),
+        affectedEntityIds: sanitizeIds(item.affectedEntityIds, params.validEntityIds),
+        affectedRowIds: sanitizeIds(item.affectedRowIds, params.validRowIds),
+        riskLevel: risk,
+      };
+    }),
+    activationReadiness: {
+      status: readinessStatus as OnboardingAgentReport["activationReadiness"]["status"],
+      blockers: asArray<unknown>(readinessRoot.blockers).map((v) => String(v)),
+      warnings: asArray<unknown>(readinessRoot.warnings).map((v) => String(v)),
+      safeToProceed: Boolean(readinessRoot.safeToProceed),
+    },
+    generatedAt: typeof root.generatedAt === "string" && root.generatedAt ? root.generatedAt : fallback.generatedAt,
+    liveRecordsCreated: 0,
+  };
+}
+
+export async function callOnboardingAgentModel(input: OnboardingAgentInput): Promise<OnboardingAgentReport | null> {
+  if (!getOnboardingAgentEnabled()) return null;
+  const { openai } = await import("../../../lib/server/openai");
+
+  const model = getOnboardingAgentModel();
+  const completion = await openai.chat.completions.create({
+    model,
+    temperature: 0.1,
+    messages: [
+      { role: "system", content: buildOnboardingAgentSystemPrompt() },
+      { role: "user", content: buildOnboardingAgentUserPrompt(input) },
+    ],
+    response_format: { type: "json_object" },
+  });
+
+  const text = completion.choices?.[0]?.message?.content;
+  if (!text) return null;
+
+  const parsed = parseModelJson(text);
+  return parsed as OnboardingAgentReport;
+}
+
+export async function runOnboardingAgentAnalysis(params: RunParams): Promise<OnboardingAgentReport> {
+  const sb = params.supabase as any;
+  const configuredSampleSize = params.sampleRowsPerFile ?? Number(process.env.ONBOARDING_AGENT_SAMPLE_ROWS ?? 20);
+  const sampleRowsPerFile = Math.max(1, Math.min(50, configuredSampleSize || 20));
+
+  const { data: session } = await sb
+    .from("onboarding_sessions")
+    .select("id, shop_id, summary")
+    .eq("shop_id", params.shopId)
+    .eq("id", params.sessionId)
+    .maybeSingle();
+
+  if (!session) {
+    throw new Error("Session not found");
+  }
+
+  const [{ data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }] = await Promise.all([
+    sb.from("onboarding_files").select("id, original_filename, storage_path, declared_domain, detected_domain, parse_status, row_count, header_row").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: true }),
+    sb.from("onboarding_entities").select("id, entity_type, source_file_id").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entity_links").select("id, link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_review_items").select("id, severity, domain, summary, issue_type, entity_id, details").eq("shop_id", params.shopId).eq("session_id", params.sessionId).eq("status", "pending"),
+    sb.from("onboarding_activation_plans").select("summary").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+  ]);
+
+  const fileIds = (files ?? []).map((file: any) => file.id);
+  const rowsByFileId = new Map<string, Record<string, unknown>[]>();
+
+  if (fileIds.length > 0) {
+    const { data: rawRows } = await sb
+      .from("onboarding_raw_rows")
+      .select("id, file_id, source_row_index, raw")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .in("file_id", fileIds)
+      .order("source_row_index", { ascending: true });
+
+    for (const row of rawRows ?? []) {
+      const list = rowsByFileId.get(row.file_id) ?? [];
+      if (list.length < sampleRowsPerFile) {
+        list.push({ id: row.id, sourceRowIndex: row.source_row_index, ...(row.raw ?? {}) });
+        rowsByFileId.set(row.file_id, list);
+      }
+    }
+  }
+
+  const deterministicStagedEntityCounts = (entities ?? []).reduce((acc: Record<string, number>, entity: any) => {
+    acc[entity.entity_type] = (acc[entity.entity_type] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const deterministicLinkCounts = (links ?? []).reduce((acc: Record<string, number>, link: any) => {
+    acc[link.link_type] = (acc[link.link_type] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const deterministicDomainDetections = (files ?? []).reduce((acc: Record<string, number>, file: any) => {
+    const key = file.detected_domain ?? "unknown";
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const input: OnboardingAgentInput = {
+    sessionId: params.sessionId,
+    shopId: params.shopId,
+    files: (files ?? []).map((file: any) => ({
+      id: file.id,
+      filename: file.original_filename ?? file.storage_path,
+      declaredDomain: file.declared_domain,
+      detectedDomain: file.detected_domain,
+      parseStatus: file.parse_status,
+      headers: Array.isArray(file.header_row) ? file.header_row : [],
+      rowCount: Number(file.row_count ?? 0),
+      sampleRows: rowsByFileId.get(file.id) ?? [],
+    })),
+    deterministicDomainDetections,
+    deterministicStagedEntityCounts,
+    deterministicLinkCounts,
+    deterministicReviewItems: (reviews ?? []).map((review: any) => ({
+      id: review.id,
+      severity: review.severity,
+      domain: review.domain,
+      summary: review.summary,
+      issueType: review.issue_type,
+      entityId: review.entity_id,
+      details: review.details ?? {},
+    })),
+    activationPlanSummary: latestPlan?.summary ?? null,
+  };
+
+  const fallback = buildDeterministicFallbackReport(input);
+  const validEntityIds = new Set<string>(
+    (entities ?? [])
+      .map((entity: any) => (typeof entity.id === "string" ? entity.id : ""))
+      .filter((id: string): id is string => Boolean(id)),
+  );
+  const validRowIds = new Set<string>(
+    input.files
+      .flatMap((file) => file.sampleRows.map((row) => String(row.id ?? "")))
+      .filter((id: string): id is string => Boolean(id)),
+  );
+
+  let report: OnboardingAgentReport = fallback;
+  try {
+    const modelReport = await callOnboardingAgentModel(input);
+    if (modelReport) {
+      report = sanitizeAgentReport({ candidate: modelReport, fallback, validEntityIds, validRowIds });
+      report.mode = "ai";
+    }
+  } catch (error) {
+    console.warn("[onboarding-agent] AI analysis fallback", {
+      sessionId: params.sessionId,
+      shopId: params.shopId,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+  }
+
+  const existingSummary = asRecord(session.summary);
+  const nextSummary = { ...existingSummary, agentReport: report, liveRecordsCreated: 0 };
+
+  await sb
+    .from("onboarding_sessions")
+    .update({ summary: nextSummary, stats: nextSummary })
+    .eq("shop_id", params.shopId)
+    .eq("id", params.sessionId);
+
+  return report;
+}


### PR DESCRIPTION
### Motivation

- Provide an explainable, operator-friendly AI layer for staged onboarding sessions that analyzes uploaded files and produces an advisory report without creating live records. 
- Keep the onboarding path safe, multi-tenant scoped, owner/admin-only, and able to operate when OpenAI is missing via a deterministic fallback.

### Description

- Introduces a typed AI analysis contract in `features/onboarding-agent/lib/agentTypes.ts` and a model resolver in `features/onboarding-agent/server/model.ts` which picks `ONBOARDING_AGENT_MODEL` → `OPENAI_MODEL` → `gpt-5-mini` and exposes `getOnboardingAgentEnabled()`.
- Implements the orchestrator `features/onboarding-agent/server/runOnboardingAgentAnalysis.ts` that loads session-scoped staged data, builds a compact input (sampled rows), calls the model when enabled, sanitizes/validates model JSON, falls back to a deterministic report, and persists the report to `onboarding_sessions.summary.agentReport` (with `liveRecordsCreated: 0`).
- Adds prompts `features/onboarding-agent/server/prompts.ts` to require JSON-only responses and enforce staged-only / historical semantics and a new API endpoint `POST /api/onboarding-agent/sessions/[sessionId]/agent-analysis` (owner/admin only) to run analysis on demand.
- Updates analyze flow to optionally auto-run agent analysis (`app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts`), surfaces agent insights in the UI via `features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx` and integrates the panel into the session page, and carries agent context into activation plans while preserving dry-run semantics.

### Testing

- Ran typecheck: `npx tsc --noEmit` — passed.
- Ran ESLint for changed files — passed with warnings only (mostly `any` usage and React hook deps), no blocking errors.
- Unit tests: `npx vitest run features/onboarding-agent/lib/onboarding-agent.test.ts` and `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts` — both suites passed (all tests green).
- Build: `pnpm build` — failed due to external network font fetches for Google Fonts in `app/layout.tsx` (Inter / Black Ops One), unrelated to onboarding-agent code; this is a known external-network validation limitation and the non-network validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed302c4488328a8a9f4fc458ad562)