### PR TITLE
Add staged multi-file onboarding uploader and session UX guardrails

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
@@ -17,6 +17,20 @@ export async function POST(_: Request, context: RouteContext) {
   const { sessionId } = await context.params;
 
   try {
+    const { count, error: countError } = await (access.supabase as any)
+      .from("onboarding_files")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", access.profile.shop_id)
+      .eq("session_id", sessionId);
+
+    if (countError) throw new Error(countError.message);
+    if (!count || count < 1) {
+      return NextResponse.json(
+        { ok: false, error: "Upload at least one file before analysis." },
+        { status: 400 },
+      );
+    }
+
     const summary = await analyzeOnboardingSession({
       supabase: access.supabase,
       shopId: access.profile.shop_id as string,
@@ -24,6 +38,7 @@ export async function POST(_: Request, context: RouteContext) {
     });
 
     let agentReport = null;
+    let aiUnavailable = false;
     const shouldAutoAnalyze = process.env.ONBOARDING_AGENT_AUTO_ANALYZE === "false"
       ? false
       : getOnboardingAgentEnabled();
@@ -36,6 +51,7 @@ export async function POST(_: Request, context: RouteContext) {
           sessionId,
         });
       } catch (error) {
+        aiUnavailable = true;
         console.warn("[onboarding-agent] auto agent analysis warning", {
           sessionId,
           shopId: access.profile.shop_id,
@@ -44,7 +60,13 @@ export async function POST(_: Request, context: RouteContext) {
       }
     }
 
-    return NextResponse.json({ ok: true, summary, agentReport, liveRecordsCreated: 0 });
+    return NextResponse.json({
+      ok: true,
+      summary,
+      agentReport,
+      aiUnavailable,
+      liveRecordsCreated: 0,
+    });
   } catch (error) {
     return NextResponse.json(
       { ok: false, error: error instanceof Error ? error.message : "Analysis failed" },

--- a/app/api/onboarding-agent/sessions/[sessionId]/upload-files/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/upload-files/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { registerOnboardingFile } from "@/features/onboarding-agent/server/registerOnboardingFile";
+import {
+  assertOnboardingUploadFile,
+  buildOnboardingStoragePath,
+  ONBOARDING_UPLOAD_BUCKET,
+} from "@/features/onboarding-agent/server/uploadOnboardingFiles";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const { sessionId } = await context.params;
+
+  const formData = await req.formData().catch(() => null);
+  if (!formData) {
+    return NextResponse.json({ ok: false, error: "Expected multipart/form-data" }, { status: 400 });
+  }
+
+  const { data: session, error: sessionError } = await (access.supabase as any)
+    .from("onboarding_sessions")
+    .select("id")
+    .eq("id", sessionId)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+
+  if (sessionError || !session) {
+    return NextResponse.json({ ok: false, error: "Session not found for this shop" }, { status: 404 });
+  }
+
+  const files = formData
+    .getAll("files")
+    .filter((entry): entry is File => entry instanceof File);
+
+  if (files.length === 0) {
+    return NextResponse.json({ ok: false, error: "At least one file is required" }, { status: 400 });
+  }
+
+  const results: Array<{
+    fileId: string | null;
+    originalFilename: string;
+    storageBucket: string | null;
+    storagePath: string | null;
+    detectedDomain: string | null;
+    status: "pending" | "failed";
+    error?: string;
+  }> = [];
+
+  for (const [index, file] of files.entries()) {
+    try {
+      const { safeName } = assertOnboardingUploadFile(file);
+      const storagePath = buildOnboardingStoragePath({
+        shopId: access.profile.shop_id as string,
+        sessionId,
+        filename: safeName,
+        index,
+      });
+
+      const bytes = Buffer.from(await file.arrayBuffer());
+      const { error: uploadError } = await access.supabase.storage
+        .from(ONBOARDING_UPLOAD_BUCKET)
+        .upload(storagePath, bytes, {
+          contentType: file.type || "text/csv",
+          upsert: false,
+        });
+
+      if (uploadError) {
+        throw new Error(uploadError.message || "Storage upload failed");
+      }
+
+      const registration = await registerOnboardingFile({
+        supabase: access.supabase,
+        shopId: access.profile.shop_id as string,
+        sessionId,
+        storageBucket: ONBOARDING_UPLOAD_BUCKET,
+        storagePath,
+        originalFilename: file.name || safeName,
+      });
+
+      results.push({
+        fileId: registration.fileId,
+        originalFilename: file.name || safeName,
+        storageBucket: ONBOARDING_UPLOAD_BUCKET,
+        storagePath,
+        detectedDomain: null,
+        status: "pending",
+      });
+    } catch (error) {
+      results.push({
+        fileId: null,
+        originalFilename: file.name || "unknown.csv",
+        storageBucket: null,
+        storagePath: null,
+        detectedDomain: null,
+        status: "failed",
+        error: error instanceof Error ? error.message : "Failed to upload file",
+      });
+    }
+  }
+
+  const hasFailure = results.some((result) => result.status === "failed");
+
+  return NextResponse.json(
+    {
+      ok: !hasFailure,
+      files: results,
+    },
+    { status: hasFailure ? 207 : 200 },
+  );
+}

--- a/app/api/onboarding-agent/sessions/route.ts
+++ b/app/api/onboarding-agent/sessions/route.ts
@@ -19,7 +19,10 @@ export async function POST(req: Request) {
     });
     return NextResponse.json({ ok: true, sessionId: result.sessionId });
   } catch (error) {
-    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Failed to create session" }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : "Failed to create session" },
+      { status: 500 },
+    );
   }
 }
 
@@ -35,5 +38,27 @@ export async function GET() {
     .limit(30);
 
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
-  return NextResponse.json({ ok: true, sessions: data ?? [] });
+
+  const sessionIds = (data ?? []).map((session: any) => session.id as string);
+  const fileCounts = new Map<string, number>();
+
+  if (sessionIds.length) {
+    const { data: files } = await (access.supabase as any)
+      .from("onboarding_files")
+      .select("session_id")
+      .eq("shop_id", access.profile.shop_id)
+      .in("session_id", sessionIds);
+
+    for (const file of files ?? []) {
+      const key = String(file.session_id);
+      fileCounts.set(key, (fileCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  const sessions = (data ?? []).map((session: any) => ({
+    ...session,
+    file_count: fileCounts.get(String(session.id)) ?? 0,
+  }));
+
+  return NextResponse.json({ ok: true, sessions });
 }

--- a/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
@@ -3,7 +3,20 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-type SessionRow = { id: string; title: string | null; status: string; created_at: string; summary?: Record<string, unknown> | null };
+type SessionRow = {
+  id: string;
+  title: string | null;
+  source: string | null;
+  status: string;
+  updated_at: string;
+  summary?: Record<string, unknown> | null;
+  file_count?: number;
+};
+
+function asCount(value: unknown) {
+  const num = Number(value ?? 0);
+  return Number.isFinite(num) ? num : 0;
+}
 
 export function OnboardingAgentDashboard() {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
@@ -15,11 +28,17 @@ export function OnboardingAgentDashboard() {
     setSessions(json.sessions ?? []);
   };
 
-  useEffect(() => { void load(); }, []);
+  useEffect(() => {
+    void load();
+  }, []);
 
   const createSession = async () => {
     setBusy(true);
-    const res = await fetch("/api/onboarding-agent/sessions", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ source: "manual_upload" }) });
+    const res = await fetch("/api/onboarding-agent/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ source: "manual_upload" }),
+    });
     const json = await res.json();
     setBusy(false);
     if (json?.sessionId) window.location.href = `/dashboard/onboarding/${json.sessionId}`;
@@ -29,30 +48,63 @@ export function OnboardingAgentDashboard() {
     <div className="space-y-4 p-6 text-white">
       <div className="rounded-2xl border border-cyan-500/30 bg-slate-950/60 p-5">
         <h1 className="text-xl font-semibold">Onboarding Agent</h1>
-        <p className="mt-2 text-sm text-cyan-100/80">Uploaded files are staged as information first. No live customers, vehicles, work orders, invoices, staff, parts, vendors, menu items, or inspections are created until a future activation step.</p>
-        <p className="mt-2 text-xs text-slate-300">
-          Use this workspace to create sessions and register staged storage paths now. In-app direct file upload and expanded import intelligence are next.
+        <p className="mt-2 text-sm text-cyan-100/80">
+          Uploaded files are staged as information first. No live customers, vehicles, work orders, invoices, staff, parts, vendors, menu items, or inspections are created until a future activation step.
         </p>
-        <button onClick={createSession} disabled={busy} className="mt-4 rounded-md border border-cyan-400/40 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50">{busy ? "Creating…" : "Create onboarding session"}</button>
+        <button
+          onClick={createSession}
+          disabled={busy}
+          className="mt-4 rounded-md border border-cyan-400/40 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10 disabled:opacity-50"
+        >
+          {busy ? "Starting…" : "Start onboarding session"}
+        </button>
       </div>
 
       <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
         <h2 className="text-sm font-semibold">Recent sessions</h2>
         <div className="mt-3 space-y-2">
-          {sessions.map((session) => (
-            <Link key={session.id} href={`/dashboard/onboarding/${session.id}`} className="block rounded-lg border border-white/10 bg-slate-900/50 p-3 hover:border-cyan-400/40">
-              <p>{session.title || "Untitled session"}</p>
-              <p className="text-xs text-slate-400">{session.status} • {new Date(session.created_at).toLocaleString()}</p>
-            </Link>
-          ))}
+          {sessions.map((session) => {
+            const summary = session.summary ?? {};
+            return (
+              <div key={session.id} className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium text-white">{session.title || session.source || "Untitled session"}</p>
+                    <p className="text-xs text-slate-400">
+                      Status: {session.status} • Last updated {new Date(session.updated_at).toLocaleString()}
+                    </p>
+                  </div>
+                  <Link
+                    href={`/dashboard/onboarding/${session.id}`}
+                    className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs text-cyan-100 hover:bg-cyan-500/10"
+                  >
+                    Open
+                  </Link>
+                </div>
+                <div className="mt-2 grid gap-2 text-xs text-slate-300 sm:grid-cols-3 lg:grid-cols-4">
+                  <p>Files: {asCount(session.file_count)}</p>
+                  <p>Rows parsed: {asCount(summary.rowsParsed)}</p>
+                  <p>Review exceptions: {asCount(summary.reviewExceptions)}</p>
+                  <p>Source: {session.source || "manual"}</p>
+                </div>
+              </div>
+            );
+          })}
           {sessions.length === 0 ? <p className="text-sm text-slate-400">No sessions yet.</p> : null}
         </div>
       </div>
 
       <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-xs text-slate-300">
         <p>
-          Need diagnostics from the legacy flow? Use <Link href="/dashboard/owner/reports" className="text-cyan-200 underline underline-offset-2">Shop Health</Link> and{" "}
-          <Link href="/dashboard/setup/review" className="text-cyan-200 underline underline-offset-2">legacy guided review</Link>.
+          Need diagnostics from the legacy flow? Use{" "}
+          <Link href="/dashboard/owner/reports" className="text-cyan-200 underline underline-offset-2">
+            Shop Health
+          </Link>{" "}
+          and{" "}
+          <Link href="/dashboard/setup/review" className="text-cyan-200 underline underline-offset-2">
+            legacy guided review
+          </Link>
+          .
         </p>
       </div>
     </div>

--- a/features/onboarding-agent/components/OnboardingFileUploadPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingFileUploadPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { type ChangeEvent, useMemo, useState } from "react";
+
+type UploadState = "pending" | "uploading" | "uploaded" | "failed";
+
+type SelectedFile = {
+  key: string;
+  file: File;
+  state: UploadState;
+  message?: string;
+};
+
+export function OnboardingFileUploadPanel({
+  sessionId,
+  onUploaded,
+}: {
+  sessionId: string;
+  onUploaded: () => Promise<void>;
+}) {
+  const [selected, setSelected] = useState<SelectedFile[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const hasPending = useMemo(
+    () => selected.some((entry) => entry.state === "pending" || entry.state === "failed"),
+    [selected],
+  );
+
+  const onSelectFiles = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    if (!files.length) return;
+
+    setFeedback(null);
+    setSelected((current) => [
+      ...current,
+      ...files.map((file, idx) => ({
+        key: `${Date.now()}-${idx}-${file.name}`,
+        file,
+        state: "pending" as const,
+      })),
+    ]);
+
+    event.target.value = "";
+  };
+
+  const uploadSelectedFiles = async () => {
+    const targets = selected.filter((entry) => entry.state === "pending" || entry.state === "failed");
+    if (!targets.length) {
+      setFeedback("Choose at least one CSV file to upload.");
+      return;
+    }
+
+    setBusy(true);
+    setFeedback(null);
+
+    setSelected((current) =>
+      current.map((entry) =>
+        targets.some((target) => target.key === entry.key)
+          ? { ...entry, state: "uploading", message: undefined }
+          : entry,
+      ),
+    );
+
+    const form = new FormData();
+    for (const target of targets) form.append("files", target.file);
+
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/upload-files`, {
+        method: "POST",
+        body: form,
+      });
+      const json = await res.json();
+
+      const byName = new Map<string, { status: string; error?: string }>();
+      for (const result of json.files ?? []) {
+        byName.set(String(result.originalFilename), {
+          status: String(result.status),
+          error: typeof result.error === "string" ? result.error : undefined,
+        });
+      }
+
+      setSelected((current) =>
+        current.map((entry) => {
+          if (!targets.some((target) => target.key === entry.key)) return entry;
+          const outcome = byName.get(entry.file.name);
+          if (!outcome) return { ...entry, state: "failed", message: "Upload did not return a result." };
+          if (outcome.status === "failed") return { ...entry, state: "failed", message: outcome.error || "Upload failed." };
+          return { ...entry, state: "uploaded", message: "Staged and registered." };
+        }),
+      );
+
+      if (!json.ok) {
+        setFeedback("Some files could not be uploaded. Fix errors and try again.");
+      } else {
+        setFeedback("Files uploaded and staged successfully.");
+      }
+
+      await onUploaded();
+    } catch {
+      setSelected((current) =>
+        current.map((entry) =>
+          targets.some((target) => target.key === entry.key)
+            ? { ...entry, state: "failed", message: "Upload request failed." }
+            : entry,
+        ),
+      );
+      setFeedback("Upload failed. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+      <h2 className="text-sm font-semibold">Upload staged files</h2>
+      <p className="mt-2 text-xs text-slate-300">
+        Upload CSV exports from your old system. Files are staged for analysis only. No live ProFixIQ records are created during upload or analysis.
+      </p>
+      <p className="mt-1 text-xs text-cyan-200/80">CSV is supported in this phase. Spreadsheet support can be added next.</p>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <input
+          type="file"
+          multiple
+          accept=".csv,text/csv"
+          onChange={onSelectFiles}
+          className="block text-sm text-slate-200 file:mr-4 file:rounded-md file:border file:border-cyan-400/40 file:bg-slate-900 file:px-3 file:py-2 file:text-sm file:text-cyan-100 hover:file:bg-cyan-500/10"
+        />
+        <button
+          onClick={uploadSelectedFiles}
+          disabled={!hasPending || busy}
+          className="rounded-md border border-cyan-400/40 px-3 py-2 text-sm text-cyan-100 hover:bg-cyan-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? "Uploading…" : "Upload staged files"}
+        </button>
+      </div>
+
+      {feedback ? <p className="mt-3 text-xs text-slate-300">{feedback}</p> : null}
+
+      <div className="mt-3 space-y-2">
+        {selected.map((entry) => (
+          <div key={entry.key} className="rounded-lg border border-white/10 bg-slate-900/40 p-3 text-xs">
+            <p className="text-slate-100">{entry.file.name}</p>
+            <p className="text-slate-400">{Math.max(1, Math.round(entry.file.size / 1024))} KB</p>
+            <p className="mt-1 capitalize text-cyan-200">{entry.state}</p>
+            {entry.message ? <p className="mt-1 text-rose-200/90">{entry.message}</p> : null}
+          </div>
+        ))}
+        {selected.length === 0 ? <p className="text-xs text-slate-400">No files selected yet.</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -1,53 +1,90 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { OnboardingActivationPlanPanel } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
 import { OnboardingAgentInsightsPanel } from "@/features/onboarding-agent/components/OnboardingAgentInsightsPanel";
 import { OnboardingEntitiesPanel } from "@/features/onboarding-agent/components/OnboardingEntitiesPanel";
+import { OnboardingFileUploadPanel } from "@/features/onboarding-agent/components/OnboardingFileUploadPanel";
 import { OnboardingFilesPanel } from "@/features/onboarding-agent/components/OnboardingFilesPanel";
 import { OnboardingProgressCard } from "@/features/onboarding-agent/components/OnboardingProgressCard";
 import { OnboardingReviewPanel } from "@/features/onboarding-agent/components/OnboardingReviewPanel";
 
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [payload, setPayload] = useState<any>(null);
-  const [storageBucket, setStorageBucket] = useState("shop-boost-uploads");
-  const [storagePath, setStoragePath] = useState("");
-  const [declaredDomain, setDeclaredDomain] = useState("");
+  const [analyzing, setAnalyzing] = useState(false);
+  const [planning, setPlanning] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { cache: "no-store" });
     const json = await res.json();
     setPayload(json);
-  };
+  }, [sessionId]);
 
-  useEffect(() => { void load(); }, [sessionId]);
-
-  const registerFile = async () => {
-    await fetch(`/api/onboarding-agent/sessions/${sessionId}/files`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        storageBucket,
-        storagePath,
-        declaredDomain: declaredDomain || undefined,
-        originalFilename: storagePath.split("/").pop(),
-      }),
-    });
-    setStoragePath("");
-    await load();
-  };
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const analyze = async () => {
-    await fetch(`/api/onboarding-agent/sessions/${sessionId}/analyze`, { method: "POST" });
-    await load();
+    setAnalyzing(true);
+    setError(null);
+    setNotice(null);
+
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/analyze`, { method: "POST" });
+      const json = await res.json();
+
+      if (!res.ok || !json.ok) {
+        setError(json?.error || "Analysis failed. Please retry.");
+      } else {
+        const mode = json?.agentReport?.mode;
+        if (!json?.agentReport) {
+          setNotice("Analysis complete. Agent insights may be unavailable right now, but deterministic results are staged.");
+        } else if (mode === "deterministic_fallback") {
+          setNotice("Analysis complete. AI is unavailable, so deterministic fallback insights were generated.");
+        } else {
+          setNotice("Analysis complete.");
+        }
+      }
+
+      await load();
+    } catch {
+      setError("Analysis failed. Please retry.");
+    } finally {
+      setAnalyzing(false);
+    }
   };
 
   const plan = async () => {
-    await fetch(`/api/onboarding-agent/sessions/${sessionId}/activation-plan`, { method: "POST" });
-    await load();
+    setPlanning(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/activation-plan`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setError(json?.error || "Failed to prepare activation plan.");
+      }
+      await load();
+    } catch {
+      setError("Failed to prepare activation plan.");
+    } finally {
+      setPlanning(false);
+    }
   };
 
   const session = payload?.session;
+  const files = payload?.files ?? [];
+  const hasFiles = files.length > 0;
+  const hasAnalysis = useMemo(() => {
+    if (!session) return false;
+    if (session.analyzed_at) return true;
+    if (session.summary && typeof session.summary === "object") {
+      return Number((session.summary as Record<string, unknown>).rowsParsed ?? 0) > 0;
+    }
+    return false;
+  }, [session]);
 
   return (
     <div className="space-y-4 p-6 text-white">
@@ -58,27 +95,40 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
           <span className="rounded-full border border-cyan-400/50 px-2 py-1 text-cyan-200">Staged-only</span>
           <span className="rounded-full border border-emerald-400/40 px-2 py-1 text-emerald-200">No live records created</span>
         </div>
-        <p className="mt-2 text-xs text-cyan-100/80">Historical work orders remain historical (not active jobs). Historical invoices remain imported historical billing records.</p>
+        <p className="mt-2 text-xs text-cyan-100/80">
+          Historical work orders remain historical (not active jobs). Historical invoices remain imported historical billing records.
+        </p>
       </div>
+
+      <OnboardingFileUploadPanel sessionId={sessionId} onUploaded={load} />
 
       <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-        <h2 className="text-sm font-semibold">File registration</h2>
-        <div className="mt-3 grid gap-2 md:grid-cols-4">
-          <input value={storageBucket} onChange={(e) => setStorageBucket(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="Storage bucket" />
-          <input value={storagePath} onChange={(e) => setStoragePath(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="storage/path/file.csv" />
-          <input value={declaredDomain} onChange={(e) => setDeclaredDomain(e.target.value)} className="rounded border border-white/20 bg-slate-900 px-3 py-2 text-sm" placeholder="Declared domain (optional)" />
-          <button onClick={registerFile} className="rounded border border-white/20 px-3 py-2 text-sm">Register staged file</button>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={analyze}
+            disabled={!hasFiles || analyzing}
+            className="rounded border border-cyan-400/40 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {analyzing ? "Analyzing…" : "Analyze staged files"}
+          </button>
+          <button
+            onClick={plan}
+            disabled={!hasAnalysis || planning}
+            className="rounded border border-amber-400/40 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {planning ? "Preparing…" : "Prepare activation plan"}
+          </button>
         </div>
-      </div>
 
-      <div className="flex gap-2">
-        <button onClick={analyze} className="rounded border border-cyan-400/40 px-3 py-2 text-sm">Analyze staged files</button>
-        <button onClick={plan} className="rounded border border-amber-400/40 px-3 py-2 text-sm">Prepare activation plan</button>
+        {!hasFiles ? <p className="mt-2 text-xs text-slate-400">Upload at least one file before analysis.</p> : null}
+        {!hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analyze staged files before preparing an activation plan.</p> : null}
+        {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
+        {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
       </div>
 
       <OnboardingProgressCard summary={session?.summary ?? null} />
       <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} onRefresh={load} />
-      <OnboardingFilesPanel files={payload?.files ?? []} />
+      <OnboardingFilesPanel files={files} />
       <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
       <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} />
 
@@ -87,7 +137,9 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         <div className="mt-2 space-y-2">
           {(payload?.reviewItems ?? []).slice(0, 25).map((item: any) => (
             <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-400">{item.severity} • {item.domain ?? "unknown"}</p>
+              <p className="text-xs uppercase tracking-wide text-slate-400">
+                {item.severity} • {item.domain ?? "unknown"}
+              </p>
               <p className="text-sm text-white">{item.summary}</p>
               <p className="text-xs text-slate-400">Recommended action: review exception before activation planning.</p>
             </div>

--- a/features/onboarding-agent/lib/uploadOnboardingFiles.test.ts
+++ b/features/onboarding-agent/lib/uploadOnboardingFiles.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertOnboardingUploadFile,
+  buildOnboardingStoragePath,
+  sanitizeOnboardingFilename,
+} from "@/features/onboarding-agent/server/uploadOnboardingFiles";
+
+describe("onboarding upload helpers", () => {
+  it("sanitizes path traversal from filename", () => {
+    const sanitized = sanitizeOnboardingFilename("../../etc/passwd.csv");
+    expect(sanitized).toBe("passwd.csv");
+  });
+
+  it("builds deterministic scoped storage path", () => {
+    const path = buildOnboardingStoragePath({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      filename: "customers.csv",
+      index: 0,
+    });
+
+    expect(path).toContain("onboarding-agent/shop-1/session-1/");
+    expect(path.endsWith("customers.csv")).toBe(true);
+  });
+
+  it("rejects unsupported files", () => {
+    const file = new File(["x"], "customers.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+
+    expect(() => assertOnboardingUploadFile(file)).toThrow("CSV is supported in this phase");
+  });
+});

--- a/features/onboarding-agent/server/uploadOnboardingFiles.ts
+++ b/features/onboarding-agent/server/uploadOnboardingFiles.ts
@@ -1,0 +1,49 @@
+import crypto from "crypto";
+
+export const ONBOARDING_UPLOAD_BUCKET = "shop-boost-uploads";
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const CSV_EXTENSIONS = new Set(["csv"]);
+
+function safePathSegment(value: string) {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+export function sanitizeOnboardingFilename(filename: string) {
+  const nameOnly = filename.split(/[\\/]/).pop() ?? "file.csv";
+  const trimmed = nameOnly.trim();
+  const safe = safePathSegment(trimmed || "file.csv");
+  return safe || "file.csv";
+}
+
+export function assertOnboardingUploadFile(file: File) {
+  if (file.size <= 0) throw new Error("Empty files are not allowed");
+  if (file.size > MAX_FILE_SIZE_BYTES) throw new Error("File exceeds 10MB limit");
+
+  const safeName = sanitizeOnboardingFilename(file.name || "file.csv");
+  const extension = safeName.includes(".") ? safeName.split(".").pop()?.toLowerCase() ?? "" : "";
+
+  if (!CSV_EXTENSIONS.has(extension)) {
+    throw new Error("Unsupported file format. CSV is supported in this phase.");
+  }
+
+  return { safeName };
+}
+
+export function buildOnboardingStoragePath(params: {
+  shopId: string;
+  sessionId: string;
+  filename: string;
+  index: number;
+}) {
+  const safeShopId = safePathSegment(params.shopId) || "shop";
+  const safeSessionId = safePathSegment(params.sessionId) || "session";
+  const safeName = sanitizeOnboardingFilename(params.filename);
+  const stamp = Date.now();
+  const digest = crypto
+    .createHash("sha1")
+    .update(`${stamp}:${params.index}:${params.filename}`)
+    .digest("hex")
+    .slice(0, 8);
+
+  return `onboarding-agent/${safeShopId}/${safeSessionId}/${stamp}-${params.index}-${digest}-${safeName}`;
+}


### PR DESCRIPTION
### Motivation
- Replace the developer-style manual bucket/path registration on the onboarding session page with a safe, owner/admin-only multi-file upload flow. 
- Provide a simple CSV-first file picker/upload experience that stages files for analysis without creating any live ProFixIQ records. 
- Ensure uploads are shop/session scoped, deterministic, and protected against path traversal and oversized/unsupported files. 

### Description
- Added a new owner/admin multipart upload API at `POST /api/onboarding-agent/sessions/[sessionId]/upload-files` that accepts `multipart/form-data`, uploads files to Supabase Storage under `onboarding-agent/{shopId}/{sessionId}/...`, and registers each upload in `onboarding_files` via `registerOnboardingFile` (staged-only). 
- Implemented server-side helpers in `features/onboarding-agent/server/uploadOnboardingFiles.ts` providing filename sanitization, deterministic storage path building, CSV-only enforcement, and a 10MB file-size limit. 
- Created `OnboardingFileUploadPanel` (`features/onboarding-agent/components/OnboardingFileUploadPanel.tsx`) which provides a multi-file `<input type="file" multiple />`, per-file states (`pending`, `uploading`, `uploaded`, `failed`), upload action, feedback copy, and refresh hook to reload session payload after upload. 
- Integrated the uploader and improved UX on the session and dashboard pages: `OnboardingSessionPage` now embeds the uploader, disables `Analyze` until at least one staged file exists, disables `Prepare activation plan` until analysis has run, and surfaces user-friendly AI fallback/notice messages; `OnboardingAgentDashboard` now shows file counts and richer session metadata. 

### Testing
- Ran typecheck with `npx tsc --noEmit` and it passed. 
- Ran ESLint for the changed files with `npx eslint <paths>`; no errors introduced, there are existing `@typescript-eslint/no-explicit-any` warnings remaining in onboarding modules. 
- Unit tests executed with `npx vitest run` for relevant suites and all passed: `features/onboarding-agent/lib/onboarding-agent.test.ts`, `features/onboarding-agent/lib/onboarding-agent-ai.test.ts`, and `features/onboarding-agent/lib/uploadOnboardingFiles.test.ts`. 
- Attempted production build with `pnpm build`, which failed in this environment due to external Google Fonts fetch errors (`Inter` and `Black Ops One`) during Next.js font fetching; CI/build should succeed in network-enabled environments or with fonts cached.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed65903fc8328bfdd438652b2bb3a)