### PR TITLE
Use service-role Supabase client for onboarding-agent staging writes and validate session ownership

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activation-plan/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activation-plan/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildOnboardingActivationPlan } from "@/features/onboarding-agent/server/buildOnboardingActivationPlan";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = {
   params: Promise<{
@@ -11,13 +12,17 @@ type RouteContext = {
 export async function POST(_: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
   const { sessionId } = await context.params;
 
   try {
     const plan = await buildOnboardingActivationPlan({
-      supabase: access.supabase,
-      shopId: access.profile.shop_id as string,
+      supabase: admin,
+      shopId,
       sessionId,
     });
 

--- a/app/api/onboarding-agent/sessions/[sessionId]/agent-analysis/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/agent-analysis/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { runOnboardingAgentAnalysis } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = {
   params: Promise<{
@@ -11,13 +12,17 @@ type RouteContext = {
 export async function POST(_: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
   const { sessionId } = await context.params;
 
   try {
     const report = await runOnboardingAgentAnalysis({
-      supabase: access.supabase,
-      shopId: access.profile.shop_id as string,
+      supabase: admin,
+      shopId,
       sessionId,
     });
 

--- a/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
@@ -3,6 +3,7 @@ import { analyzeOnboardingSession } from "@/features/onboarding-agent/server/ana
 import { getOnboardingAgentEnabled } from "@/features/onboarding-agent/server/model";
 import { runOnboardingAgentAnalysis } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = {
   params: Promise<{
@@ -13,14 +14,29 @@ type RouteContext = {
 export async function POST(_: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
   const { sessionId } = await context.params;
 
   try {
-    const { count, error: countError } = await (access.supabase as any)
+    const { data: session, error: sessionError } = await (admin as any)
+      .from("onboarding_sessions")
+      .select("id")
+      .eq("id", sessionId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (sessionError) throw new Error(sessionError.message);
+    if (!session) {
+      return NextResponse.json({ ok: false, error: "Session not found for this shop" }, { status: 404 });
+    }
+
+    const { count, error: countError } = await (admin as any)
       .from("onboarding_files")
       .select("id", { count: "exact", head: true })
-      .eq("shop_id", access.profile.shop_id)
+      .eq("shop_id", shopId)
       .eq("session_id", sessionId);
 
     if (countError) throw new Error(countError.message);
@@ -32,8 +48,8 @@ export async function POST(_: Request, context: RouteContext) {
     }
 
     const summary = await analyzeOnboardingSession({
-      supabase: access.supabase,
-      shopId: access.profile.shop_id as string,
+      supabase: admin,
+      shopId,
       sessionId,
     });
 
@@ -46,8 +62,8 @@ export async function POST(_: Request, context: RouteContext) {
     if (shouldAutoAnalyze) {
       try {
         agentReport = await runOnboardingAgentAnalysis({
-          supabase: access.supabase,
-          shopId: access.profile.shop_id as string,
+          supabase: admin,
+          shopId,
           sessionId,
         });
       } catch (error) {

--- a/app/api/onboarding-agent/sessions/[sessionId]/files/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/files/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { registerOnboardingFile } from "@/features/onboarding-agent/server/registerOnboardingFile";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = {
   params: Promise<{
@@ -11,6 +12,10 @@ type RouteContext = {
 export async function POST(req: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
   const { sessionId } = await context.params;
 
@@ -27,8 +32,8 @@ export async function POST(req: Request, context: RouteContext) {
 
   try {
     const result = await registerOnboardingFile({
-      supabase: access.supabase,
-      shopId: access.profile.shop_id as string,
+      supabase: admin,
+      shopId,
       sessionId,
       storageBucket: body.storageBucket,
       storagePath: body.storagePath,

--- a/app/api/onboarding-agent/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getOnboardingSession } from "@/features/onboarding-agent/server/getOnboardingSession";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = {
   params: Promise<{
@@ -11,13 +12,17 @@ type RouteContext = {
 export async function GET(_: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
   const { sessionId } = await context.params;
 
   try {
     const payload = await getOnboardingSession({
-      supabase: access.supabase,
-      shopId: access.profile.shop_id as string,
+      supabase: admin,
+      shopId,
       sessionId,
     });
 

--- a/app/api/onboarding-agent/sessions/[sessionId]/upload-files/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/upload-files/route.ts
@@ -6,6 +6,7 @@ import {
   ONBOARDING_UPLOAD_BUCKET,
 } from "@/features/onboarding-agent/server/uploadOnboardingFiles";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = {
   params: Promise<{
@@ -18,6 +19,10 @@ export const runtime = "nodejs";
 export async function POST(req: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
   const { sessionId } = await context.params;
 
@@ -26,11 +31,11 @@ export async function POST(req: Request, context: RouteContext) {
     return NextResponse.json({ ok: false, error: "Expected multipart/form-data" }, { status: 400 });
   }
 
-  const { data: session, error: sessionError } = await (access.supabase as any)
+  const { data: session, error: sessionError } = await (admin as any)
     .from("onboarding_sessions")
     .select("id")
     .eq("id", sessionId)
-    .eq("shop_id", access.profile.shop_id)
+    .eq("shop_id", shopId)
     .maybeSingle();
 
   if (sessionError || !session) {
@@ -59,14 +64,14 @@ export async function POST(req: Request, context: RouteContext) {
     try {
       const { safeName } = assertOnboardingUploadFile(file);
       const storagePath = buildOnboardingStoragePath({
-        shopId: access.profile.shop_id as string,
+        shopId,
         sessionId,
         filename: safeName,
         index,
       });
 
       const bytes = Buffer.from(await file.arrayBuffer());
-      const { error: uploadError } = await access.supabase.storage
+      const { error: uploadError } = await admin.storage
         .from(ONBOARDING_UPLOAD_BUCKET)
         .upload(storagePath, bytes, {
           contentType: file.type || "text/csv",
@@ -78,8 +83,8 @@ export async function POST(req: Request, context: RouteContext) {
       }
 
       const registration = await registerOnboardingFile({
-        supabase: access.supabase,
-        shopId: access.profile.shop_id as string,
+        supabase: admin,
+        shopId,
         sessionId,
         storageBucket: ONBOARDING_UPLOAD_BUCKET,
         storagePath,

--- a/app/api/onboarding-agent/sessions/route.ts
+++ b/app/api/onboarding-agent/sessions/route.ts
@@ -1,18 +1,22 @@
 import { NextResponse } from "next/server";
 import { createOnboardingSession } from "@/features/onboarding-agent/server/createOnboardingSession";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 export async function POST(req: Request) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  const admin = createAdminSupabase();
 
   const body = (await req.json().catch(() => ({}))) as { title?: string; source?: string; notes?: string };
 
   try {
     const result = await createOnboardingSession({
-      supabase: access.supabase,
-      shopId: access.profile.shop_id as string,
-      createdBy: access.profile.id,
+      supabase: admin,
+      shopId,
+      createdBy: actorId,
       title: body.title,
       source: body.source,
       notes: body.notes,
@@ -29,11 +33,15 @@ export async function POST(req: Request) {
 export async function GET() {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  void actorId;
+  const admin = createAdminSupabase();
 
-  const { data, error } = await (access.supabase as any)
+  const { data, error } = await (admin as any)
     .from("onboarding_sessions")
     .select("id, title, source, status, summary, stats, created_at, updated_at")
-    .eq("shop_id", access.profile.shop_id)
+    .eq("shop_id", shopId)
     .order("created_at", { ascending: false })
     .limit(30);
 
@@ -43,10 +51,10 @@ export async function GET() {
   const fileCounts = new Map<string, number>();
 
   if (sessionIds.length) {
-    const { data: files } = await (access.supabase as any)
+    const { data: files } = await (admin as any)
       .from("onboarding_files")
       .select("session_id")
-      .eq("shop_id", access.profile.shop_id)
+      .eq("shop_id", shopId)
       .in("session_id", sessionIds);
 
     for (const file of files ?? []) {

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -6,9 +6,15 @@ import { buildSimpleLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
 import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
 import { makeReviewItem } from "@/features/onboarding-agent/lib/staging";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
 export async function analyzeOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
 
   const { data: files, error: filesError } = await sb
     .from("onboarding_files")

--- a/features/onboarding-agent/server/assertOnboardingSessionOwnership.ts
+++ b/features/onboarding-agent/server/assertOnboardingSessionOwnership.ts
@@ -1,0 +1,17 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function assertOnboardingSessionOwnership(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+}) {
+  const { data: session, error } = await (params.supabase as any)
+    .from("onboarding_sessions")
+    .select("id")
+    .eq("id", params.sessionId)
+    .eq("shop_id", params.shopId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!session) throw new Error("Session not found for this shop");
+}

--- a/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
+++ b/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
@@ -1,8 +1,14 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildDryRunActivationPlan } from "@/features/onboarding-agent/lib/activationPlan";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
 export async function buildOnboardingActivationPlan(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
 
   const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }, { data: sessionRow }] = await Promise.all([
     sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -1,7 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
 export async function getOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
 
   const [{ data: session }, { data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }] = await Promise.all([
     sb.from("onboarding_sessions").select("*").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),

--- a/features/onboarding-agent/server/registerOnboardingFile.ts
+++ b/features/onboarding-agent/server/registerOnboardingFile.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
 export async function registerOnboardingFile(params: {
   supabase: SupabaseClient;
@@ -9,14 +10,11 @@ export async function registerOnboardingFile(params: {
   originalFilename?: string | null;
   declaredDomain?: string | null;
 }) {
-  const { data: session, error: sessionError } = await (params.supabase as any)
-    .from("onboarding_sessions")
-    .select("id")
-    .eq("id", params.sessionId)
-    .eq("shop_id", params.shopId)
-    .maybeSingle();
-
-  if (sessionError || !session) throw new Error("Session not found for this shop");
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
 
   const { data, error } = await (params.supabase as any)
     .from("onboarding_files")

--- a/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
+++ b/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
@@ -7,6 +7,7 @@ import type {
   OnboardingAgentReport,
 } from "@/features/onboarding-agent/lib/agentTypes";
 import { ONBOARDING_DOMAINS, type OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 import { buildOnboardingAgentSystemPrompt, buildOnboardingAgentUserPrompt } from "@/features/onboarding-agent/server/prompts";
 import { getOnboardingAgentEnabled, getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
 
@@ -278,6 +279,11 @@ export async function runOnboardingAgentAnalysis(params: RunParams): Promise<Onb
   const sb = params.supabase as any;
   const configuredSampleSize = params.sampleRowsPerFile ?? Number(process.env.ONBOARDING_AGENT_SAMPLE_ROWS ?? 20);
   const sampleRowsPerFile = Math.max(1, Math.min(50, configuredSampleSize || 20));
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
 
   const { data: session } = await sb
     .from("onboarding_sessions")


### PR DESCRIPTION
### Motivation
- Multi-file uploads were failing with RLS errors because routes validated access with a user-scoped client but performed storage/table writes with that same user client. This change ensures trusted staging writes run with the project service-role client while preserving shop-scoped authorization.

### Description
- After `requireShopScopedApiAccess` the routes derive `shopId` and `actorId` from the validated access and create an admin client via existing `createAdminSupabase()` for server-side operations. 
- Switched upload, file-registration, analyze, agent-analysis, activation-plan, session create/list/get routes to use the admin client for storage uploads and all staging table writes/updates while keeping every query/write filtered by `shop_id` and `session_id`.
- Added `features/onboarding-agent/server/assertOnboardingSessionOwnership.ts` and call it from staging helpers (`registerOnboardingFile`, `analyzeOnboardingSession`, `buildOnboardingActivationPlan`, `getOnboardingSession`, `runOnboardingAgentAnalysis`) so every session operation first validates the session belongs to the shop.
- Preserved per-file partial success/failure behavior in the upload route and preserved dry-run behavior: analysis/agent analysis/activation plan remain staged-only and continue reporting `liveRecordsCreated: 0`.
- Files changed (key ones): `app/api/onboarding-agent/sessions/[sessionId]/upload-files/route.ts`, `.../analyze/route.ts`, `.../activation-plan/route.ts`, `.../files/route.ts`, `.../agent-analysis/route.ts`, `app/api/onboarding-agent/sessions/route.ts`, `app/api/onboarding-agent/sessions/[sessionId]/route.ts`, plus server helpers under `features/onboarding-agent/server/*` (new `assertOnboardingSessionOwnership.ts` and updates to `registerOnboardingFile.ts`, `analyzeOnboardingSession.ts`, `buildOnboardingActivationPlan.ts`, `getOnboardingSession.ts`, `runOnboardingAgentAnalysis.ts`).
- Admin/service client used: existing `createAdminSupabase()` from `features/shared/lib/supabase/server.ts` (backed by `SUPABASE_SERVICE_ROLE_KEY`).
- No RLS policy changes were made and no live operational records are created by these routes.

### Testing
- Ran TypeScript typecheck: `npx tsc --noEmit` — succeeded.
- Ran ESLint on the changed routes and related files: `npx eslint ...` — passed with warnings only (existing `@typescript-eslint/no-explicit-any` warnings), no new errors.
- Unit tests: `npx vitest run features/onboarding-agent/lib/onboarding-agent.test.ts` — passed; `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts` — passed; `npx vitest run features/onboarding-agent/lib/uploadOnboardingFiles.test.ts` — passed.
- Attempted production build: `pnpm build` — failed in this sandbox due to external Google Fonts fetch errors from `next/font` (network/font fetch issue), unrelated to the onboarding logic.
- Summary: typecheck and targeted tests passed; lint yields warnings only; full Next build failure is environmental (font fetch), not a functional regression for the onboarding changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedcd4740c8328a7ac3d038e3aa71b)