### PR TITLE
Stage onboarding entities/links/reviews from parsed CSV rows

### DIFF
--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -1,8 +1,53 @@
+const ENTITY_ROWS: Array<{ key: string; label: string }> = [
+  { key: "customer", label: "Customers" },
+  { key: "vehicle", label: "Vehicles" },
+  { key: "historical_work_order", label: "Historical work orders" },
+  { key: "historical_invoice", label: "Historical invoices" },
+  { key: "part", label: "Parts" },
+  { key: "vendor", label: "Vendors" },
+  { key: "staff_candidate", label: "Staff candidates" },
+  { key: "menu_suggestion", label: "Menu suggestions" },
+  { key: "inspection_suggestion", label: "Inspection suggestions" },
+  { key: "unknown", label: "Unknown" },
+];
+
+const LINK_ROWS: Array<{ key: string; label: string }> = [
+  { key: "customer_vehicle", label: "Customer ↔ Vehicle" },
+  { key: "customer_work_order", label: "Customer ↔ Work order" },
+  { key: "vehicle_work_order", label: "Vehicle ↔ Work order" },
+  { key: "work_order_invoice", label: "Work order ↔ Invoice" },
+  { key: "vendor_part", label: "Vendor ↔ Part" },
+];
+
 export function OnboardingEntitiesPanel({ entityCounts, linkCounts }: { entityCounts: Record<string, number>; linkCounts: Record<string, number> }) {
   return (
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <h3 className="text-sm font-semibold text-white">Staged entities & links</h3>
-      <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/70 p-3 text-xs text-slate-200">{JSON.stringify({ entityCounts, linkCounts }, null, 2)}</pre>
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
+          <p className="text-xs uppercase tracking-wide text-slate-400">Entities discovered</p>
+          <ul className="mt-2 space-y-1 text-sm text-slate-200">
+            {ENTITY_ROWS.map((item) => (
+              <li key={item.key} className="flex items-center justify-between gap-2">
+                <span>{item.label}</span>
+                <span className="font-semibold text-white">{entityCounts[item.key] ?? 0}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
+          <p className="text-xs uppercase tracking-wide text-slate-400">Links found</p>
+          <ul className="mt-2 space-y-1 text-sm text-slate-200">
+            {LINK_ROWS.map((item) => (
+              <li key={item.key} className="flex items-center justify-between gap-2">
+                <span>{item.label}</span>
+                <span className="font-semibold text-white">{linkCounts[item.key] ?? 0}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
   );
 }

--- a/features/onboarding-agent/components/OnboardingReviewPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingReviewPanel.tsx
@@ -1,9 +1,46 @@
-export function OnboardingReviewPanel({ reviewCounts }: { reviewCounts: Record<string, number> }) {
+export function OnboardingReviewPanel({
+  reviewCounts,
+  reviewItems,
+}: {
+  reviewCounts: { blocking?: number; high?: number; medium?: number; low?: number; byDomain?: Record<string, number> };
+  reviewItems: Array<{ id: string; severity: string; domain?: string | null; issue_type?: string; summary: string }>;
+}) {
+  const topItems = reviewItems.filter((item) => item).slice(0, 10);
+  const domainCounts = reviewCounts.byDomain ?? {};
+
   return (
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <h3 className="text-sm font-semibold text-white">Review exceptions</h3>
-      <p className="mt-2 text-sm text-slate-300">Blocking: {reviewCounts.blocking ?? 0} • Nonblocking: {reviewCounts.nonblocking ?? 0}</p>
-      <p className="mt-2 text-xs text-slate-400">Only exceptions require review. Parse and linkage issues are highlighted here.</p>
+      <p className="mt-2 text-sm text-slate-300">
+        Blocking: {reviewCounts.blocking ?? 0} • High: {reviewCounts.high ?? 0} • Medium: {reviewCounts.medium ?? 0} • Low: {reviewCounts.low ?? 0}
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-slate-900/60 p-3">
+        <p className="text-xs uppercase tracking-wide text-slate-400">By domain</p>
+        <ul className="mt-2 grid gap-1 text-xs text-slate-300 sm:grid-cols-2">
+          {Object.entries(domainCounts).map(([domain, count]) => (
+            <li key={domain} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1">
+              <span>{domain}</span>
+              <span className="text-white">{count}</span>
+            </li>
+          ))}
+          {Object.keys(domainCounts).length === 0 ? <li className="text-slate-400">No pending exceptions.</li> : null}
+        </ul>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        <p className="text-xs uppercase tracking-wide text-slate-400">Top pending exceptions</p>
+        {topItems.map((item) => (
+          <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
+            <p className="text-xs uppercase tracking-wide text-slate-400">
+              {item.severity} • {item.domain ?? "unknown"} • {item.issue_type ?? "issue"}
+            </p>
+            <p className="text-sm text-white">{item.summary}</p>
+            <p className="text-xs text-slate-400">Recommended action: resolve or map this item before activation dry-run.</p>
+          </div>
+        ))}
+        {topItems.length === 0 ? <p className="text-xs text-slate-400">No pending review exceptions.</p> : null}
+      </div>
     </div>
   );
 }

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -130,23 +130,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} onRefresh={load} />
       <OnboardingFilesPanel files={files} />
       <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
-      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} />
-
-      <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-        <h3 className="text-sm font-semibold text-white">Pending review exceptions</h3>
-        <div className="mt-2 space-y-2">
-          {(payload?.reviewItems ?? []).slice(0, 25).map((item: any) => (
-            <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-400">
-                {item.severity} • {item.domain ?? "unknown"}
-              </p>
-              <p className="text-sm text-white">{item.summary}</p>
-              <p className="text-xs text-slate-400">Recommended action: review exception before activation planning.</p>
-            </div>
-          ))}
-          {(payload?.reviewItems ?? []).length === 0 ? <p className="text-xs text-slate-400">No pending review exceptions.</p> : null}
-        </div>
-      </div>
+      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
 
       <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} />
     </div>

--- a/features/onboarding-agent/lib/agentTypes.ts
+++ b/features/onboarding-agent/lib/agentTypes.ts
@@ -13,6 +13,7 @@ export type OnboardingAgentRecommendationActionType =
 
 export type OnboardingAgentActivationStatus =
   | "not_ready"
+  | "empty"
   | "review_required"
   | "ready_for_dry_run"
   | "ready_for_activation_later";

--- a/features/onboarding-agent/lib/fingerprints.ts
+++ b/features/onboarding-agent/lib/fingerprints.ts
@@ -5,18 +5,72 @@ export function normalizePhone(phone?: string | null): string | null {
   return digits.length >= 7 ? digits : null;
 }
 
+function text(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 export function fingerprintForDomain(domain: OnboardingDomain, normalized: Record<string, unknown>): string | null {
   if (domain === "customers") {
-    return String(normalized.sourceCustomerId ?? normalized.email ?? normalized.phone ?? normalized.name ?? "").trim() || null;
+    const source = text(normalized.sourceCustomerId);
+    if (source) return `customer:source:${source}`;
+    const email = text(normalized.email).toLowerCase();
+    if (email) return `customer:email:${email}`;
+    const phone = normalizePhone(text(normalized.phone));
+    if (phone) return `customer:phone:${phone}`;
+    const name = text(normalized.name) || text(normalized.businessName);
+    if (name) return `customer:name:${name.toLowerCase()}`;
+    return null;
   }
+
   if (domain === "vehicles") {
-    return String(normalized.vin ?? normalized.plate ?? normalized.unitNumber ?? normalized.sourceVehicleId ?? "").trim() || null;
+    const vin = text(normalized.vin).toUpperCase();
+    if (vin) return `vehicle:vin:${vin}`;
+    const plate = text(normalized.plate).toUpperCase();
+    if (plate) return `vehicle:plate:${plate}`;
+    const sourceVehicleId = text(normalized.sourceVehicleId);
+    if (sourceVehicleId) return `vehicle:source:${sourceVehicleId}`;
+    const unit = text(normalized.unitNumber);
+    const customerId = text(normalized.sourceCustomerId);
+    if (unit && customerId) return `vehicle:unit_customer:${unit}:${customerId}`;
+    return null;
   }
+
   if (domain === "history") {
-    return String(normalized.sourceWorkOrderId ?? normalized.roNumber ?? "").trim() || null;
+    const sourceWorkOrderId = text(normalized.sourceWorkOrderId);
+    return sourceWorkOrderId ? `history:wo:${sourceWorkOrderId}` : null;
   }
+
   if (domain === "invoices") {
-    return String(normalized.invoiceNumber ?? normalized.sourceWorkOrderId ?? "").trim() || null;
+    const invoice = text(normalized.invoiceNumber);
+    if (invoice) return `invoice:number:${invoice}`;
+    const sourceWorkOrderId = text(normalized.sourceWorkOrderId);
+    return sourceWorkOrderId ? `invoice:wo:${sourceWorkOrderId}` : null;
   }
-  return String(normalized.sourceExternalId ?? "").trim() || null;
+
+  if (domain === "parts") {
+    const sku = text(normalized.sku) || text(normalized.partNumber);
+    if (sku) return `part:sku:${sku.toLowerCase()}`;
+    const description = text(normalized.description) || text(normalized.name);
+    return description ? `part:name:${description.toLowerCase()}` : null;
+  }
+
+  if (domain === "vendors") {
+    const account = text(normalized.accountNumber);
+    if (account) return `vendor:account:${account.toLowerCase()}`;
+    const email = text(normalized.email).toLowerCase();
+    if (email) return `vendor:email:${email}`;
+    const phone = normalizePhone(text(normalized.phone));
+    if (phone) return `vendor:phone:${phone}`;
+    const name = text(normalized.name);
+    return name ? `vendor:name:${name.toLowerCase()}` : null;
+  }
+
+  if (domain === "staff") {
+    const email = text(normalized.email).toLowerCase();
+    if (email) return `staff:email:${email}`;
+    const name = text(normalized.name);
+    return name ? `staff:name:${name.toLowerCase()}` : null;
+  }
+
+  return null;
 }

--- a/features/onboarding-agent/lib/graph.ts
+++ b/features/onboarding-agent/lib/graph.ts
@@ -1,36 +1,204 @@
-export function buildSimpleLinks(entities: Array<{ id: string; entity_type: string; normalized: Record<string, unknown> }>) {
-  const customersBySourceId = new Map<string, string>();
-  const workOrdersBySourceId = new Map<string, string>();
+import { makeReviewItem } from "@/features/onboarding-agent/lib/staging";
 
-  for (const entity of entities) {
-    if (entity.entity_type === "customer") {
-      const sourceCustomerId = String(entity.normalized.sourceCustomerId ?? "").trim();
-      if (sourceCustomerId) customersBySourceId.set(sourceCustomerId, entity.id);
+type Entity = {
+  id: string;
+  entity_type: string;
+  display_name?: string | null;
+  normalized: Record<string, unknown>;
+  source_external_id?: string | null;
+};
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeName(value: unknown): string {
+  return text(value).toLowerCase();
+}
+
+type BuildLinksParams = {
+  entities: Entity[];
+  shopId: string;
+  sessionId: string;
+};
+
+export function buildStagedLinks(params: BuildLinksParams) {
+  const { entities, shopId, sessionId } = params;
+  const links: Array<{ from_entity_id: string; to_entity_id: string; link_type: string; confidence: number; evidence: Record<string, unknown>; status: string }> = [];
+  const reviewItems: ReturnType<typeof makeReviewItem>[] = [];
+
+  const customers = entities.filter((entity) => entity.entity_type === "customer");
+  const vehicles = entities.filter((entity) => entity.entity_type === "vehicle");
+  const workOrders = entities.filter((entity) => entity.entity_type === "historical_work_order");
+  const invoices = entities.filter((entity) => entity.entity_type === "historical_invoice");
+  const parts = entities.filter((entity) => entity.entity_type === "part");
+  const vendors = entities.filter((entity) => entity.entity_type === "vendor");
+
+  const customersBySourceId = new Map(customers.map((c) => [text(c.normalized.sourceCustomerId), c]));
+  const customersByEmail = new Map(customers.map((c) => [text(c.normalized.email).toLowerCase(), c]));
+  const customersByPhone = new Map(customers.map((c) => [text(c.normalized.phone), c]));
+  const customersByName = new Map(customers.map((c) => [normalizeName(c.normalized.name || c.normalized.businessName), c]));
+
+  const vehiclesBySourceId = new Map(vehicles.map((v) => [text(v.normalized.sourceVehicleId), v]));
+  const vehiclesByVin = new Map(vehicles.map((v) => [text(v.normalized.vin).toUpperCase(), v]));
+  const vehiclesByPlate = new Map(vehicles.map((v) => [text(v.normalized.plate).toUpperCase(), v]));
+
+  const workOrdersBySourceId = new Map(workOrders.map((wo) => [text(wo.normalized.sourceWorkOrderId), wo]));
+
+  const pushLink = (from: string, to: string, linkType: string, confidence: number, evidence: Record<string, unknown>) => {
+    if (confidence < 0.75) {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "medium",
+          domain: linkType,
+          issueType: "low_confidence_mapping",
+          summary: `${linkType} mapping confidence too low`,
+          details: evidence,
+        }),
+      );
+      return;
     }
-    if (entity.entity_type === "historical_work_order") {
-      const workOrderId = String(entity.normalized.sourceWorkOrderId ?? "").trim();
-      if (workOrderId) workOrdersBySourceId.set(workOrderId, entity.id);
+
+    links.push({
+      from_entity_id: from,
+      to_entity_id: to,
+      link_type: linkType,
+      confidence,
+      evidence,
+      status: confidence >= 0.75 ? "staged" : "needs_review",
+    });
+  };
+
+  for (const vehicle of vehicles) {
+    const sourceCustomerId = text(vehicle.normalized.sourceCustomerId);
+    const customerEmail = text(vehicle.normalized.customerEmail).toLowerCase();
+    const customerPhone = text(vehicle.normalized.customerPhone);
+    const customerName = normalizeName(vehicle.normalized.customerName);
+
+    let matched: Entity | undefined;
+    let confidence = 0;
+    let evidence: Record<string, unknown> = {};
+
+    if (sourceCustomerId && customersBySourceId.get(sourceCustomerId)) {
+      matched = customersBySourceId.get(sourceCustomerId);
+      confidence = 0.95;
+      evidence = { sourceCustomerId };
+    } else if (customerEmail && customersByEmail.get(customerEmail)) {
+      matched = customersByEmail.get(customerEmail);
+      confidence = 0.85;
+      evidence = { customerEmail };
+    } else if (customerPhone && customersByPhone.get(customerPhone)) {
+      matched = customersByPhone.get(customerPhone);
+      confidence = 0.85;
+      evidence = { customerPhone };
+    } else if (customerName && customersByName.get(customerName)) {
+      matched = customersByName.get(customerName);
+      confidence = 0.75;
+      evidence = { customerName };
+    }
+
+    if (!matched) {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "high",
+          domain: "vehicles",
+          issueType: "missing_customer_link",
+          summary: "Vehicle is missing a confident customer link",
+          details: { vehicleId: vehicle.id, sourceCustomerId, customerEmail, customerPhone, customerName },
+        }),
+      );
+      continue;
+    }
+
+    pushLink(matched.id, vehicle.id, "customer_vehicle", confidence, evidence);
+  }
+
+  for (const workOrder of workOrders) {
+    const sourceCustomerId = text(workOrder.normalized.sourceCustomerId);
+    const sourceVehicleId = text(workOrder.normalized.sourceVehicleId);
+    const vehicleVin = text(workOrder.normalized.vehicleVin).toUpperCase();
+    const vehiclePlate = text(workOrder.normalized.vehiclePlate).toUpperCase();
+
+    const customer = sourceCustomerId ? customersBySourceId.get(sourceCustomerId) : undefined;
+    if (customer) {
+      pushLink(customer.id, workOrder.id, "customer_work_order", 0.95, { sourceCustomerId });
+    } else {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "high",
+          domain: "history",
+          issueType: "missing_customer_link",
+          summary: "Work order is missing customer linkage",
+          details: { workOrderId: workOrder.id, sourceCustomerId },
+        }),
+      );
+    }
+
+    const vehicle = vehiclesBySourceId.get(sourceVehicleId) || vehiclesByVin.get(vehicleVin) || vehiclesByPlate.get(vehiclePlate);
+    if (vehicle) {
+      const confidence = sourceVehicleId ? 0.95 : vehicleVin ? 0.9 : 0.75;
+      pushLink(vehicle.id, workOrder.id, "vehicle_work_order", confidence, { sourceVehicleId, vehicleVin, vehiclePlate });
+    } else {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "medium",
+          domain: "history",
+          issueType: "missing_vehicle_link",
+          summary: "Work order is missing vehicle linkage",
+          details: { workOrderId: workOrder.id, sourceVehicleId, vehicleVin, vehiclePlate },
+        }),
+      );
     }
   }
 
-  const links: Array<{ from_entity_id: string; to_entity_id: string; link_type: string; confidence: number; evidence: Record<string, unknown> }> = [];
-
-  for (const entity of entities) {
-    if (entity.entity_type === "vehicle") {
-      const customerSourceId = String(entity.normalized.sourceCustomerId ?? "").trim();
-      const customerId = customersBySourceId.get(customerSourceId);
-      if (customerId) {
-        links.push({ from_entity_id: customerId, to_entity_id: entity.id, link_type: "customer_vehicle", confidence: 0.95, evidence: { sourceCustomerId: customerSourceId } });
-      }
-    }
-    if (entity.entity_type === "historical_invoice") {
-      const sourceWorkOrderId = String(entity.normalized.sourceWorkOrderId ?? "").trim();
-      const workOrderEntityId = workOrdersBySourceId.get(sourceWorkOrderId);
-      if (workOrderEntityId) {
-        links.push({ from_entity_id: workOrderEntityId, to_entity_id: entity.id, link_type: "work_order_invoice", confidence: 0.95, evidence: { sourceWorkOrderId } });
-      }
+  for (const invoice of invoices) {
+    const sourceWorkOrderId = text(invoice.normalized.sourceWorkOrderId);
+    const workOrder = sourceWorkOrderId ? workOrdersBySourceId.get(sourceWorkOrderId) : undefined;
+    if (workOrder) {
+      pushLink(workOrder.id, invoice.id, "work_order_invoice", 0.95, { sourceWorkOrderId });
+    } else {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "high",
+          domain: "invoices",
+          issueType: "missing_work_order_link",
+          summary: "Invoice is missing work-order linkage",
+          details: { invoiceId: invoice.id, sourceWorkOrderId },
+        }),
+      );
     }
   }
 
-  return links;
+  for (const part of parts) {
+    const vendorName = normalizeName(part.normalized.vendorName);
+    const match = vendors.find((vendor) => {
+      const vendorKey = normalizeName(vendor.normalized.name);
+      return vendorName && vendorKey && vendorName === vendorKey;
+    });
+    if (match) {
+      pushLink(match.id, part.id, "vendor_part", 0.75, { vendorName });
+    }
+  }
+
+  const dedupedLinks = links.filter(
+    (link, index, all) =>
+      all.findIndex(
+        (candidate) =>
+          candidate.link_type === link.link_type &&
+          candidate.from_entity_id === link.from_entity_id &&
+          candidate.to_entity_id === link.to_entity_id,
+      ) === index,
+  );
+
+  return { links: dedupedLinks, reviewItems };
 }

--- a/features/onboarding-agent/lib/normalization.ts
+++ b/features/onboarding-agent/lib/normalization.ts
@@ -1,13 +1,23 @@
 import type { OnboardingDomain } from "./domains";
 import { normalizePhone } from "./fingerprints";
 
+const normalizeKey = (value: string) => value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+
 const value = (row: Record<string, string>, keys: string[]): string => {
-  for (const key of keys) {
-    const found = Object.entries(row).find(([header]) => header.toLowerCase().replace(/[_-]+/g, " ").trim() === key);
-    if (found?.[1]) return found[1].trim();
+  const normalizedKeys = keys.map(normalizeKey);
+  for (const [header, rawValue] of Object.entries(row)) {
+    const key = normalizeKey(header);
+    if (normalizedKeys.includes(key) && rawValue) return rawValue.trim();
   }
   return "";
 };
+
+function parseMoney(raw: string): number | null {
+  if (!raw) return null;
+  const cleaned = raw.replace(/[$,\s]/g, "");
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+}
 
 export function normalizeRow(domain: OnboardingDomain, row: Record<string, string>) {
   if (domain === "customers") {
@@ -15,32 +25,45 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
     const [firstName = "", ...rest] = name.split(" ");
     return {
       entityType: "customer",
-      displayName: name || value(row, ["company name", "company"]),
+      displayName: name || value(row, ["company name", "company", "business"]),
       normalized: {
         sourceCustomerId: value(row, ["customer id", "id"]),
         name,
         firstName,
         lastName: rest.join(" "),
         businessName: value(row, ["company", "company name", "business"]),
-        email: value(row, ["email"]).toLowerCase(),
-        phone: normalizePhone(value(row, ["phone", "phone number"])),
+        email: value(row, ["email", "email address"]).toLowerCase(),
+        phone: normalizePhone(value(row, ["phone", "phone number", "mobile"])),
+        address: value(row, ["address", "street", "street address"]),
+        city: value(row, ["city", "town"]),
+        province: value(row, ["province", "state", "region"]),
+        postalCode: value(row, ["postal", "postal code", "zip", "zip code"]),
+        fleetFlag: ["1", "true", "yes", "fleet"].includes(value(row, ["fleet", "is fleet", "company flag"]).toLowerCase()),
       },
     };
   }
 
   if (domain === "vehicles") {
+    const year = value(row, ["year"]);
+    const make = value(row, ["make"]);
+    const model = value(row, ["model"]);
+    const vin = value(row, ["vin"]).toUpperCase().replace(/\s+/g, "");
+
     return {
       entityType: "vehicle",
-      displayName: `${value(row, ["year"])} ${value(row, ["make"])} ${value(row, ["model"])} ${value(row, ["vin"])}`.trim(),
+      displayName: `${year} ${make} ${model}`.trim() || vin || value(row, ["plate", "license"]),
       normalized: {
         sourceVehicleId: value(row, ["vehicle id", "id"]),
         sourceCustomerId: value(row, ["customer id"]),
-        vin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
-        plate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
-        unitNumber: value(row, ["unit", "unit number"]),
-        year: value(row, ["year"]),
-        make: value(row, ["make"]),
-        model: value(row, ["model"]),
+        customerName: value(row, ["customer name", "name"]),
+        customerEmail: value(row, ["customer email", "email"]),
+        customerPhone: normalizePhone(value(row, ["customer phone", "phone"])),
+        vin,
+        plate: value(row, ["plate", "license", "license plate"]).toUpperCase().replace(/\s+/g, ""),
+        unitNumber: value(row, ["unit", "unit number", "truck number"]),
+        year,
+        make,
+        model,
       },
     };
   }
@@ -50,32 +73,81 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       entityType: "historical_work_order",
       displayName: value(row, ["work order", "repair order", "ro", "ro id"]),
       normalized: {
-        sourceWorkOrderId: value(row, ["work order", "ro id", "repair order"]),
+        sourceWorkOrderId: value(row, ["work order", "ro id", "repair order", "ro number"]),
         sourceCustomerId: value(row, ["customer id"]),
         sourceVehicleId: value(row, ["vehicle id"]),
-        complaint: value(row, ["complaint", "description"]),
+        vehicleVin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
+        vehiclePlate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
+        invoiceId: value(row, ["invoice id", "invoice number", "invoice"]),
+        complaint: value(row, ["complaint", "description", "concern"]),
         cause: value(row, ["cause"]),
-        correction: value(row, ["correction"]),
-        laborAmount: value(row, ["labor"]),
-        total: value(row, ["total"]),
+        correction: value(row, ["correction", "resolution"]),
+        openedDate: value(row, ["opened", "opened date", "open date"]),
         closedDate: value(row, ["closed", "completed date", "closed date"]),
+        mileage: value(row, ["mileage", "odometer"]),
+        totalRaw: value(row, ["total", "amount"]),
+        total: parseMoney(value(row, ["total", "amount"])),
+        laborRaw: value(row, ["labor", "labor amount"]),
+        laborAmount: parseMoney(value(row, ["labor", "labor amount"])),
+        partsRaw: value(row, ["parts", "parts amount"]),
+        partsAmount: parseMoney(value(row, ["parts", "parts amount"])),
       },
     };
   }
 
   if (domain === "invoices") {
+    const totalRaw = value(row, ["total", "amount"]);
     return {
       entityType: "historical_invoice",
       displayName: value(row, ["invoice", "invoice number"]),
       normalized: {
-        invoiceNumber: value(row, ["invoice", "invoice number"]),
-        sourceWorkOrderId: value(row, ["work order", "ro", "ro id"]),
+        invoiceNumber: value(row, ["invoice", "invoice number", "invoice id"]),
+        sourceWorkOrderId: value(row, ["work order", "ro", "ro id", "repair order"]),
         sourceCustomerId: value(row, ["customer id"]),
-        total: value(row, ["total", "amount"]),
-        laborAmount: value(row, ["labor"]),
-        partsAmount: value(row, ["parts"]),
+        subtotalRaw: value(row, ["subtotal"]),
+        subtotal: parseMoney(value(row, ["subtotal"])),
+        taxRaw: value(row, ["tax", "tax amount"]),
+        tax: parseMoney(value(row, ["tax", "tax amount"])),
+        laborRaw: value(row, ["labor", "labor amount"]),
+        laborAmount: parseMoney(value(row, ["labor", "labor amount"])),
+        partsRaw: value(row, ["parts", "parts amount"]),
+        partsAmount: parseMoney(value(row, ["parts", "parts amount"])),
+        totalRaw,
+        total: parseMoney(totalRaw),
         issueDate: value(row, ["issue date", "date"]),
+        paidDate: value(row, ["paid date", "closed", "closed date"]),
         paymentStatus: value(row, ["status", "payment status"]),
+      },
+    };
+  }
+
+  if (domain === "parts") {
+    return {
+      entityType: "part",
+      displayName: value(row, ["description", "name", "part"]),
+      normalized: {
+        sku: value(row, ["sku", "part sku"]),
+        partNumber: value(row, ["part number", "part #", "number"]),
+        description: value(row, ["description", "name", "part"]),
+        vendorName: value(row, ["vendor", "supplier", "vendor name"]),
+        quantity: value(row, ["qty", "quantity", "on hand"]),
+        costRaw: value(row, ["cost"]),
+        cost: parseMoney(value(row, ["cost"])),
+        priceRaw: value(row, ["price", "retail"]),
+        price: parseMoney(value(row, ["price", "retail"])),
+      },
+    };
+  }
+
+  if (domain === "vendors") {
+    return {
+      entityType: "vendor",
+      displayName: value(row, ["vendor", "supplier", "company", "vendor name"]),
+      normalized: {
+        name: value(row, ["vendor", "supplier", "company", "vendor name"]),
+        email: value(row, ["email", "vendor email"]).toLowerCase(),
+        phone: normalizePhone(value(row, ["phone", "vendor phone"])),
+        accountNumber: value(row, ["account", "account number", "vendor account"]),
       },
     };
   }
@@ -86,9 +158,9 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       displayName: value(row, ["name", "full name", "employee"]),
       normalized: {
         name: value(row, ["name", "full name", "employee"]),
-        email: value(row, ["email"]).toLowerCase(),
-        phone: normalizePhone(value(row, ["phone"])),
-        role: value(row, ["role"]),
+        email: value(row, ["email", "email address"]).toLowerCase(),
+        phone: normalizePhone(value(row, ["phone", "mobile"])),
+        role: value(row, ["role", "job title", "position"]),
       },
     };
   }

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprints";
+import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
+import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
+import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { buildDeterministicFallbackReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
+
+function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
+  const normalized = normalizeRow(domain, row);
+  return stageEntityFromNormalized({
+    domain,
+    normalized: normalized.normalized,
+    displayName: normalized.displayName,
+    sourceFileId: "file-1",
+    sourceRowId: `row-${sourceRowIndex}`,
+    sourceRowIndex,
+    shopId: "shop-1",
+    sessionId: "session-1",
+    canonicalFingerprint: fingerprintForDomain(domain, normalized.normalized),
+  });
+}
+
+describe("onboarding staging", () => {
+  it("analyze creates staged entities from customer rows", () => {
+    const staged = stage("customers", { "Customer ID": "C-1", "Full Name": "Jane Doe", Email: "jane@example.com" });
+    expect(staged.entity?.entity_type).toBe("customer");
+    expect(staged.entity?.status).toBe("ready");
+  });
+
+  it("creates vehicle entities and customer_vehicle links when source ids match", () => {
+    const customer = stage("customers", { "Customer ID": "C-1", Name: "Jane", Email: "jane@example.com" }).entity;
+    const vehicle = stage("vehicles", { "Vehicle ID": "V-1", "Customer ID": "C-1", VIN: "1HGCM82633A004352" }).entity;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [
+        { id: "customer-1", entity_type: customer!.entity_type, normalized: customer!.normalized, source_external_id: customer!.source_external_id },
+        { id: "vehicle-1", entity_type: vehicle!.entity_type, normalized: vehicle!.normalized, source_external_id: vehicle!.source_external_id },
+      ],
+    });
+
+    expect(graph.links.some((link) => link.link_type === "customer_vehicle")).toBe(true);
+  });
+
+  it("creates historical_work_order and historical_invoice entities", () => {
+    const wo = stage("history", { "Work Order": "RO-1", "Customer ID": "C-1", Complaint: "noise" }).entity;
+    const invoice = stage("invoices", { Invoice: "INV-1", "Work Order": "RO-1", Total: "500" }).entity;
+    expect(wo?.entity_type).toBe("historical_work_order");
+    expect(invoice?.entity_type).toBe("historical_invoice");
+  });
+
+  it("creates work_order_invoice links when invoice references work order id", () => {
+    const wo = stage("history", { "Work Order": "RO-1", "Customer ID": "C-1", Complaint: "noise" }).entity;
+    const invoice = stage("invoices", { Invoice: "INV-1", "Work Order": "RO-1", Total: "500" }).entity;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [
+        { id: "wo-1", entity_type: wo!.entity_type, normalized: wo!.normalized },
+        { id: "invoice-1", entity_type: invoice!.entity_type, normalized: invoice!.normalized },
+      ],
+    });
+    expect(graph.links.some((link) => link.link_type === "work_order_invoice")).toBe(true);
+  });
+
+  it("missing identity creates review item instead of fake entity", () => {
+    const staged = stage("customers", { Notes: "no identifying data" });
+    expect(staged.entity).toBeNull();
+    expect(staged.reviewItems.some((item) => item.issue_type === "missing_identity")).toBe(true);
+  });
+
+  it("repeated analysis inputs produce deterministic non-duplicated link set", () => {
+    const customer = stage("customers", { "Customer ID": "C-1", Name: "Jane", Email: "jane@example.com" }).entity;
+    const vehicle = stage("vehicles", { "Vehicle ID": "V-1", "Customer ID": "C-1", VIN: "1HGCM82633A004352" }).entity;
+
+    const entities = [
+      { id: "customer-1", entity_type: customer!.entity_type, normalized: customer!.normalized },
+      { id: "vehicle-1", entity_type: vehicle!.entity_type, normalized: vehicle!.normalized },
+      { id: "vehicle-1-dup", entity_type: vehicle!.entity_type, normalized: vehicle!.normalized },
+    ];
+
+    const graph = buildStagedLinks({ shopId: "shop-1", sessionId: "session-1", entities });
+    expect(graph.links.filter((link) => link.link_type === "customer_vehicle").length).toBe(2);
+
+    const graphAgain = buildStagedLinks({ shopId: "shop-1", sessionId: "session-1", entities });
+    expect(graphAgain.links.length).toBe(graph.links.length);
+  });
+
+  it("liveRecordsCreated remains 0", () => {
+    const report = buildDeterministicFallbackReport({
+      sessionId: "session-1",
+      shopId: "shop-1",
+      files: [],
+      deterministicDomainDetections: {},
+      deterministicStagedEntityCounts: {},
+      deterministicLinkCounts: {},
+      deterministicReviewItems: [],
+      activationPlanSummary: null,
+    });
+    expect(report.liveRecordsCreated).toBe(0);
+  });
+
+  it("deterministic report carries non-empty entity/link count input", () => {
+    const report = buildDeterministicFallbackReport({
+      sessionId: "session-1",
+      shopId: "shop-1",
+      files: [
+        {
+          id: "file-1",
+          filename: "customers.csv",
+          declaredDomain: "customers",
+          detectedDomain: "customers",
+          parseStatus: "parsed",
+          headers: ["Customer ID"],
+          rowCount: 2,
+          sampleRows: [],
+        },
+      ],
+      deterministicDomainDetections: { customers: 1 },
+      deterministicStagedEntityCounts: { customer: 2 },
+      deterministicLinkCounts: { customer_vehicle: 1 },
+      deterministicReviewItems: [],
+      activationPlanSummary: null,
+    });
+
+    expect(report.summary).toContain("customers: 2");
+    expect(report.summary).toContain("confident links: 1");
+  });
+});

--- a/features/onboarding-agent/lib/staging.ts
+++ b/features/onboarding-agent/lib/staging.ts
@@ -1,3 +1,40 @@
+import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+
+export type EntityStatus = "ready" | "needs_review" | "duplicate_candidate";
+
+export type StageEntityInput = {
+  domain: OnboardingDomain;
+  normalized: Record<string, unknown>;
+  displayName: string | null;
+  sourceFileId: string;
+  sourceRowId: string | null;
+  sourceRowIndex: number;
+  shopId: string;
+  sessionId: string;
+};
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function has(value: unknown): boolean {
+  return text(value).length > 0;
+}
+
+function hasNumber(value: unknown): boolean {
+  return typeof value === "number" ? Number.isFinite(value) : has(value);
+}
+
+function sourceExternalIdForDomain(domain: OnboardingDomain, normalized: Record<string, unknown>): string | null {
+  if (domain === "customers") return text(normalized.sourceCustomerId) || null;
+  if (domain === "vehicles") return text(normalized.sourceVehicleId) || null;
+  if (domain === "history") return text(normalized.sourceWorkOrderId) || null;
+  if (domain === "invoices") return text(normalized.invoiceNumber) || null;
+  if (domain === "parts") return text(normalized.sku) || text(normalized.partNumber) || null;
+  if (domain === "vendors") return text(normalized.accountNumber) || null;
+  return null;
+}
+
 export function makeReviewItem(params: {
   shopId: string;
   sessionId: string;
@@ -19,4 +56,208 @@ export function makeReviewItem(params: {
     details: params.details ?? {},
     status: "pending",
   };
+}
+
+export function stageEntityFromNormalized(input: StageEntityInput & { canonicalFingerprint: string | null }) {
+  const n = input.normalized;
+  const domain = input.domain;
+
+  if (domain === "unknown" || domain === "menu" || domain === "inspections") {
+    return {
+      entity: null,
+      reviewItems: [
+        makeReviewItem({
+          shopId: input.shopId,
+          sessionId: input.sessionId,
+          severity: "medium",
+          domain,
+          issueType: "unsupported_row",
+          summary: "Row could not be mapped to a staged entity in this phase.",
+          details: { sourceRowIndex: input.sourceRowIndex },
+        }),
+      ],
+    };
+  }
+
+  let status: EntityStatus = "needs_review";
+  let confidence = 0.6;
+  let reviewReason: string | null = "missing_identity";
+  const reviewItems: ReturnType<typeof makeReviewItem>[] = [];
+
+  if (domain === "customers") {
+    const identityName = has(n.name) || has(n.businessName);
+    const identityContact = has(n.email) || has(n.phone);
+    if (identityName && identityContact) {
+      status = "ready";
+      confidence = 0.9;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "vehicles") {
+    const hasIdentity = has(n.vin) || has(n.plate) || has(n.unitNumber);
+    const hasCustomerHint = has(n.sourceCustomerId) || has(n.customerEmail) || has(n.customerPhone) || has(n.customerName);
+    if (hasIdentity && hasCustomerHint) {
+      status = "ready";
+      confidence = 0.9;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "history") {
+    const hasWorkOrderId = has(n.sourceWorkOrderId);
+    const hasLinkHint = has(n.sourceCustomerId) || has(n.sourceVehicleId) || has(n.vehicleVin) || has(n.vehiclePlate);
+    const hasDescription = has(n.complaint) || has(n.cause) || has(n.correction);
+    if (hasWorkOrderId && hasLinkHint && hasDescription) {
+      status = "ready";
+      confidence = 0.88;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "invoices") {
+    const hasInvoiceId = has(n.invoiceNumber);
+    const hasAmountOrRo = hasNumber(n.total) || has(n.sourceWorkOrderId);
+    const invalidMoney = has(n.totalRaw) && typeof n.total === "number" && !Number.isFinite(n.total);
+    if (invalidMoney) {
+      reviewItems.push(
+        makeReviewItem({
+          shopId: input.shopId,
+          sessionId: input.sessionId,
+          severity: "high",
+          domain: "invoices",
+          issueType: "invalid_money",
+          summary: `Invoice row ${input.sourceRowIndex + 1} has invalid money format`,
+          details: { value: n.totalRaw },
+        }),
+      );
+    }
+    if (hasInvoiceId && hasAmountOrRo) {
+      status = "ready";
+      confidence = 0.88;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "parts") {
+    if (has(n.sku) || has(n.partNumber) || has(n.description) || has(n.name)) {
+      status = "ready";
+      confidence = 0.82;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "vendors") {
+    const hasName = has(n.name);
+    const hasIdentity = has(n.email) || has(n.phone) || has(n.accountNumber);
+    if (hasName && hasIdentity) {
+      status = "ready";
+      confidence = 0.86;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "staff") {
+    const hasIdentity = has(n.email) || (has(n.name) && has(n.role));
+    if (hasIdentity) {
+      status = "ready";
+      confidence = 0.84;
+      reviewReason = null;
+    }
+  }
+
+  if (!input.canonicalFingerprint && !has(input.displayName)) {
+    return {
+      entity: null,
+      reviewItems: [
+        ...reviewItems,
+        makeReviewItem({
+          shopId: input.shopId,
+          sessionId: input.sessionId,
+          severity: "high",
+          domain,
+          issueType: "missing_identity",
+          summary: `${domain} row ${input.sourceRowIndex + 1} is missing identity fields`,
+          details: { sourceRowIndex: input.sourceRowIndex },
+        }),
+      ],
+    };
+  }
+
+  if (status === "needs_review") {
+    reviewItems.push(
+      makeReviewItem({
+        shopId: input.shopId,
+        sessionId: input.sessionId,
+        severity: "medium",
+        domain,
+        issueType: "needs_review",
+        summary: `${domain} row ${input.sourceRowIndex + 1} needs review before activation planning`,
+      }),
+    );
+  }
+
+  return {
+    entity: {
+      shop_id: input.shopId,
+      session_id: input.sessionId,
+      entity_type:
+        domain === "history"
+          ? "historical_work_order"
+          : domain === "invoices"
+            ? "historical_invoice"
+            : domain === "parts"
+              ? "part"
+              : domain === "vendors"
+                ? "vendor"
+                : domain === "staff"
+                  ? "staff_candidate"
+                  : domain.slice(0, -1),
+      source_file_id: input.sourceFileId,
+      source_row_id: input.sourceRowId,
+      source_row_index: input.sourceRowIndex,
+      source_external_id: sourceExternalIdForDomain(domain, n),
+      canonical_fingerprint: input.canonicalFingerprint,
+      display_name: input.displayName,
+      normalized: n,
+      confidence,
+      status,
+      review_reason: reviewReason,
+    },
+    reviewItems,
+  };
+}
+
+export function markDuplicateEntities(
+  entities: Array<{ canonical_fingerprint: string | null; status: string; source_row_index: number; entity_type: string }>,
+  context: { shopId: string; sessionId: string },
+) {
+  const reviews: ReturnType<typeof makeReviewItem>[] = [];
+  const counts = new Map<string, number>();
+  for (const entity of entities) {
+    const fingerprint = text(entity.canonical_fingerprint);
+    if (!fingerprint) continue;
+    counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1);
+  }
+
+  for (const entity of entities) {
+    const fingerprint = text(entity.canonical_fingerprint);
+    const count = fingerprint ? counts.get(fingerprint) ?? 0 : 0;
+    if (count > 1) {
+      entity.status = "duplicate_candidate";
+      reviews.push(
+        makeReviewItem({
+          shopId: context.shopId,
+          sessionId: context.sessionId,
+          severity: "medium",
+          domain: entity.entity_type,
+          issueType: "duplicate_candidate",
+          summary: `${entity.entity_type} row ${entity.source_row_index + 1} is a duplicate candidate`,
+          details: { canonicalFingerprint: fingerprint, duplicateCount: count },
+        }),
+      );
+    }
+  }
+
+  return reviews;
 }

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -2,10 +2,10 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { parseCsvText } from "@/features/onboarding-agent/lib/csvParsing";
 import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
 import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprints";
-import { buildSimpleLinks } from "@/features/onboarding-agent/lib/graph";
+import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
 import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
-import { makeReviewItem } from "@/features/onboarding-agent/lib/staging";
+import { makeReviewItem, markDuplicateEntities, stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
 export async function analyzeOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
@@ -25,6 +25,8 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
   if (filesError) throw new Error(filesError.message);
 
   await sb.from("onboarding_sessions").update({ status: "analyzing" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+
+  // Analyze is intentionally repeatable. We clear only staged analysis artifacts and recreate them.
   await sb.from("onboarding_raw_rows").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
   await sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
   await sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
@@ -37,14 +39,32 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
   for (const file of files ?? []) {
     const dl = await sb.storage.from(file.storage_bucket).download(file.storage_path);
     if (dl.error || !dl.data) {
-      reviewItems.push(makeReviewItem({ shopId: params.shopId, sessionId: params.sessionId, severity: "blocking", domain: "unknown", issueType: "parse_error", summary: `Failed to read ${file.original_filename ?? file.storage_path}` }));
-      await sb.from("onboarding_files").update({ parse_status: "failed", parse_error: dl.error?.message ?? "download failed" }).eq("id", file.id).eq("shop_id", params.shopId);
+      reviewItems.push(
+        makeReviewItem({
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          severity: "blocking",
+          domain: "unknown",
+          issueType: "parse_error",
+          summary: `Failed to read ${file.original_filename ?? file.storage_path}`,
+        }),
+      );
+      const { error: updateError } = await sb
+        .from("onboarding_files")
+        .update({ parse_status: "failed", parse_error: dl.error?.message ?? "download failed" })
+        .eq("id", file.id)
+        .eq("shop_id", params.shopId);
+      if (updateError) throw new Error(updateError.message);
       continue;
     }
 
     const text = await dl.data.text();
     const parsed = parseCsvText(text);
-    const detectedDomain = detectFileDomain({ filename: file.original_filename ?? file.storage_path, headers: parsed.headers, declaredDomain: file.declared_domain });
+    const detectedDomain = detectFileDomain({
+      filename: file.original_filename ?? file.storage_path,
+      headers: parsed.headers,
+      declaredDomain: file.declared_domain,
+    });
     totalRows += parsed.rows.length;
 
     const rawRowsPayload = parsed.rows.map((row, index) => ({
@@ -59,52 +79,80 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       parse_status: "parsed",
     }));
 
-    const { data: rawRows } = await sb.from("onboarding_raw_rows").insert(rawRowsPayload).select("id, source_row_index");
+    const { data: rawRows, error: rawRowsError } = await sb
+      .from("onboarding_raw_rows")
+      .insert(rawRowsPayload)
+      .select("id, source_row_index");
+    if (rawRowsError) throw new Error(rawRowsError.message);
 
-    for (const row of parsed.rows) {
+    const rawRowsByIndex = new Map<number, string>((rawRows ?? []).map((row: any) => [Number(row.source_row_index), row.id]));
+
+    parsed.rows.forEach((row, index) => {
       const normalized = normalizeRow(detectedDomain as any, row);
       const fingerprint = fingerprintForDomain(detectedDomain as any, normalized.normalized);
-      stagedEntities.push({
-        shop_id: params.shopId,
-        session_id: params.sessionId,
-        entity_type: normalized.entityType,
-        source_file_id: file.id,
-        source_row_index: 0,
-        source_external_id: String((normalized.normalized as any).sourceCustomerId ?? (normalized.normalized as any).sourceWorkOrderId ?? "") || null,
-        canonical_fingerprint: fingerprint,
-        display_name: normalized.displayName,
+      const staged = stageEntityFromNormalized({
+        domain: detectedDomain as any,
         normalized: normalized.normalized,
-        confidence: 0.7,
-        status: "staged",
+        displayName: normalized.displayName,
+        sourceFileId: file.id,
+        sourceRowId: rawRowsByIndex.get(index) ?? null,
+        sourceRowIndex: index,
+        shopId: params.shopId,
+        sessionId: params.sessionId,
+        canonicalFingerprint: fingerprint,
       });
-    }
 
-    await sb.from("onboarding_files").update({ parse_status: "parsed", row_count: parsed.rows.length, detected_domain: detectedDomain, header_row: parsed.headers }).eq("id", file.id).eq("shop_id", params.shopId);
+      if (staged.entity) stagedEntities.push(staged.entity);
+      reviewItems.push(...staged.reviewItems);
+    });
+
+    const { error: fileUpdateError } = await sb
+      .from("onboarding_files")
+      .update({ parse_status: "parsed", row_count: parsed.rows.length, detected_domain: detectedDomain, header_row: parsed.headers })
+      .eq("id", file.id)
+      .eq("shop_id", params.shopId);
+    if (fileUpdateError) throw new Error(fileUpdateError.message);
 
     if (detectedDomain === "unknown") {
-      reviewItems.push(makeReviewItem({ shopId: params.shopId, sessionId: params.sessionId, severity: "blocking", domain: "unknown", issueType: "unsupported_file", summary: `Unsupported file type for ${file.original_filename ?? file.storage_path}` }));
-    }
-
-    void rawRows;
-  }
-
-  const { data: entities } = await sb.from("onboarding_entities").insert(stagedEntities).select("id, entity_type, normalized");
-
-  const links = buildSimpleLinks((entities ?? []).map((entity: any) => ({ ...entity, normalized: entity.normalized ?? {} })));
-  if (links.length) {
-    await sb.from("onboarding_entity_links").insert(links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId, status: "staged" })));
-  }
-
-  for (const entity of entities ?? []) {
-    if (entity.entity_type === "customer") {
-      const normalized = entity.normalized ?? {};
-      if (!normalized.name && !normalized.email && !normalized.phone && !normalized.businessName && !normalized.sourceCustomerId) {
-        reviewItems.push(makeReviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, severity: "blocking", domain: "customers", issueType: "missing_identity", summary: "Customer row missing identity fields" }));
-      }
+      reviewItems.push(
+        makeReviewItem({
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          severity: "medium",
+          domain: "unknown",
+          issueType: "unsupported_file",
+          summary: `Unsupported file type for ${file.original_filename ?? file.storage_path}`,
+        }),
+      );
     }
   }
 
-  if (reviewItems.length) await sb.from("onboarding_review_items").insert(reviewItems);
+  reviewItems.push(...markDuplicateEntities(stagedEntities, { shopId: params.shopId, sessionId: params.sessionId }));
+
+  let entities: Array<{ id: string; entity_type: string; normalized: Record<string, unknown>; display_name?: string | null; source_external_id?: string | null }> = [];
+  if (stagedEntities.length) {
+    const { data: insertedEntities, error: entitiesError } = await sb
+      .from("onboarding_entities")
+      .insert(stagedEntities)
+      .select("id, entity_type, normalized, display_name, source_external_id");
+    if (entitiesError) throw new Error(entitiesError.message);
+    entities = insertedEntities ?? [];
+  }
+
+  const graph = buildStagedLinks({ entities: entities.map((e) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
+  reviewItems.push(...graph.reviewItems);
+
+  if (graph.links.length) {
+    const { error: linksError } = await sb
+      .from("onboarding_entity_links")
+      .insert(graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId })));
+    if (linksError) throw new Error(linksError.message);
+  }
+
+  if (reviewItems.length) {
+    const { error: reviewError } = await sb.from("onboarding_review_items").insert(reviewItems);
+    if (reviewError) throw new Error(reviewError.message);
+  }
 
   const blockingCount = reviewItems.filter((item) => item.severity === "blocking").length;
   const status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
@@ -112,13 +160,17 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
   const summary = {
     fileCount: (files ?? []).length,
     rowsParsed: totalRows,
-    entitiesDiscovered: (entities ?? []).length,
-    linksFound: links.length,
+    entitiesDiscovered: entities.length,
+    linksFound: graph.links.length,
     reviewExceptions: reviewItems.length,
-    liveRecordsCreated: 0,
+    liveRecordsCreated: 0 as const,
   };
 
-  await sb.from("onboarding_sessions").update({ status, analyzed_at: new Date().toISOString(), summary, stats: summary }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+  await sb
+    .from("onboarding_sessions")
+    .update({ status, analyzed_at: new Date().toISOString(), summary, stats: summary })
+    .eq("id", params.sessionId)
+    .eq("shop_id", params.shopId);
 
   return summary;
 }

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -1,6 +1,21 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
+const ENTITY_BUCKETS = [
+  "customer",
+  "vehicle",
+  "historical_work_order",
+  "historical_invoice",
+  "part",
+  "vendor",
+  "staff_candidate",
+  "menu_suggestion",
+  "inspection_suggestion",
+  "unknown",
+] as const;
+
+const LINK_BUCKETS = ["customer_vehicle", "customer_work_order", "vehicle_work_order", "work_order_invoice", "vendor_part"] as const;
+
 export async function getOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
   await assertOnboardingSessionOwnership({
@@ -14,25 +29,53 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
     sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_review_items").select("id, severity, status, domain, summary, issue_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
+    sb
+      .from("onboarding_review_items")
+      .select("id, severity, status, domain, summary, issue_type, details")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .order("created_at", { ascending: false }),
     sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
   ]);
 
-  const entityCounts = (entities ?? []).reduce((acc: Record<string, number>, row: any) => {
-    acc[row.entity_type] = (acc[row.entity_type] ?? 0) + 1;
+  const entityCounts = ENTITY_BUCKETS.reduce<Record<string, number>>((acc, key) => {
+    acc[key] = 0;
     return acc;
   }, {});
+  for (const row of entities ?? []) {
+    entityCounts[row.entity_type] = (entityCounts[row.entity_type] ?? 0) + 1;
+  }
 
-  const reviewCounts = (reviews ?? []).reduce((acc: Record<string, number>, row: any) => {
-    const key = row.severity === "blocking" ? "blocking" : "nonblocking";
-    acc[key] = (acc[key] ?? 0) + 1;
-    return acc;
-  }, {});
+  const reviewCounts = {
+    blocking: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    byDomain: {} as Record<string, number>,
+  };
+  for (const row of reviews ?? []) {
+    if (row.status !== "pending") continue;
+    if (row.severity === "blocking") reviewCounts.blocking += 1;
+    if (row.severity === "high") reviewCounts.high += 1;
+    if (row.severity === "medium") reviewCounts.medium += 1;
+    if (row.severity === "low") reviewCounts.low += 1;
+    const domain = row.domain ?? "unknown";
+    reviewCounts.byDomain[domain] = (reviewCounts.byDomain[domain] ?? 0) + 1;
+  }
 
-  const linkCounts = (links ?? []).reduce((acc: Record<string, number>, row: any) => {
-    acc[row.link_type] = (acc[row.link_type] ?? 0) + 1;
+  const linkCounts = LINK_BUCKETS.reduce<Record<string, number>>((acc, key) => {
+    acc[key] = 0;
     return acc;
   }, {});
+  for (const row of links ?? []) {
+    linkCounts[row.link_type] = (linkCounts[row.link_type] ?? 0) + 1;
+  }
+
+  const uploadedFiles = (files ?? []).length;
+  const rowsParsedFromFiles = (files ?? []).reduce((sum: number, file: any) => sum + Number(file.row_count ?? 0), 0);
+  const entitiesDiscovered = Object.values(entityCounts).reduce((sum, count) => sum + count, 0);
+  const linksFound = Object.values(linkCounts).reduce((sum, count) => sum + count, 0);
+  const reviewExceptions = reviewCounts.blocking + reviewCounts.high + reviewCounts.medium + reviewCounts.low;
 
   return {
     session,
@@ -42,5 +85,13 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     reviewItems: reviews ?? [],
     linkCounts,
     latestPlan,
+    summaryCounts: {
+      uploadedFiles,
+      rowsParsed: rowsParsedFromFiles,
+      entitiesDiscovered,
+      linksFound,
+      reviewExceptions,
+      liveRecordsCreated: 0 as const,
+    },
   };
 }

--- a/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
+++ b/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
@@ -28,7 +28,7 @@ const VALID_ACTION_TYPES = new Set([
   "ignore_row",
   "prepare_activation",
 ]);
-const VALID_READINESS = new Set(["not_ready", "review_required", "ready_for_dry_run", "ready_for_activation_later"]);
+const VALID_READINESS = new Set(["not_ready", "empty", "review_required", "ready_for_dry_run", "ready_for_activation_later"]);
 const VALID_DOMAINS = new Set<string>([...ONBOARDING_DOMAINS, "all"]);
 
 function stripJsonFences(raw: string) {
@@ -67,6 +67,17 @@ function sanitizeIds(ids: unknown, allow: Set<string>) {
 function buildActivationReadiness(input: OnboardingAgentInput) {
   const blockingItems = input.deterministicReviewItems.filter((item) => item.severity === "blocking");
   const warningItems = input.deterministicReviewItems.filter((item) => item.severity !== "blocking");
+  const entitiesTotal = Object.values(input.deterministicStagedEntityCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
+  const rowsParsed = input.files.reduce((sum, file) => sum + file.rowCount, 0);
+
+  if (rowsParsed > 0 && entitiesTotal === 0) {
+    return {
+      status: "empty" as const,
+      blockers: ["Rows were parsed but no staged entities were detected."],
+      warnings: ["Upload better mapped CSVs or review header mappings before re-running analysis."],
+      safeToProceed: false,
+    };
+  }
 
   if (blockingItems.length > 0) {
     return {
@@ -119,12 +130,21 @@ export function buildDeterministicFallbackReport(input: OnboardingAgentInput): O
     };
   }).filter((item) => item.rowsSeen > 0 || item.entitiesDetected > 0 || item.reviewCount > 0);
 
+  const stagedCustomers = Number(input.deterministicStagedEntityCounts.customer ?? 0);
+  const stagedVehicles = Number(input.deterministicStagedEntityCounts.vehicle ?? 0);
+  const stagedWorkOrders = Number(input.deterministicStagedEntityCounts.historical_work_order ?? 0);
+  const stagedInvoices = Number(input.deterministicStagedEntityCounts.historical_invoice ?? 0);
+  const stagedParts = Number(input.deterministicStagedEntityCounts.part ?? 0);
+  const stagedVendors = Number(input.deterministicStagedEntityCounts.vendor ?? 0);
+  const stagedStaff = Number(input.deterministicStagedEntityCounts.staff_candidate ?? 0);
+  const confidentLinks = Object.values(input.deterministicLinkCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
+
   const findings: OnboardingAgentFinding[] = [
     {
       severity: "info",
       domain: "all",
       title: "Staged analysis completed",
-      explanation: `${input.files.length} files registered, ${rowsParsed} rows parsed, ${entitiesTotal} staged entities detected.`,
+      explanation: `${input.files.length} files analyzed, ${rowsParsed} rows parsed, ${entitiesTotal} staged entities detected, ${confidentLinks} confident links found.`,
       evidence: [
         `Files: ${input.files.length}`,
         `Rows parsed: ${rowsParsed}`,
@@ -173,7 +193,7 @@ export function buildDeterministicFallbackReport(input: OnboardingAgentInput): O
   return {
     model: getOnboardingAgentModel(),
     mode: "deterministic_fallback",
-    summary: `Staged onboarding analysis completed. ${input.files.length} files, ${rowsParsed} rows, ${entitiesTotal} staged entities. No live records have been created.`,
+    summary: `Staged onboarding analysis completed. Files: ${input.files.length}, rows: ${rowsParsed}, customers: ${stagedCustomers}, vehicles: ${stagedVehicles}, historical work orders: ${stagedWorkOrders}, historical invoices: ${stagedInvoices}, parts: ${stagedParts}, vendors: ${stagedVendors}, staff candidates: ${stagedStaff}, confident links: ${confidentLinks}, review exceptions: ${input.deterministicReviewItems.length}. No live records have been created.`,
     domainSummaries,
     findings,
     recommendations,


### PR DESCRIPTION
### Motivation
- The analyzer previously parsed files and raw rows but did not produce staged entities, links, or review items so the UI showed zero discovered entities despite rowsParsed > 0.
- The goal is to deterministically stage entities and links from normalized CSV rows while keeping everything staged-only, idempotent, shop-scoped, and owner/admin-only.
- Staging must produce explainable review exceptions for missing/ambiguous data and enable meaningful agent insights and UI counts.

### Description
- Implemented row-level staging: `analyzeOnboardingSession` now normalizes each parsed row, computes fingerprints, calls `stageEntityFromNormalized`, inserts `onboarding_raw_rows`, inserts staged `onboarding_entities`, computes links via `buildStagedLinks`, inserts `onboarding_entity_links`, and inserts `onboarding_review_items` when needed (files: `features/onboarding-agent/server/analyzeOnboardingSession.ts`).
- Added deterministic domain-aware staging, fingerprinting, duplicate detection, and review rules for customers, vehicles, historical work orders, invoices, parts, vendors, and staff (files: `lib/staging.ts`, `lib/fingerprints.ts`, `lib/normalization.ts`).
- Replaced the simple link builder with a confidence-based staged link graph that creates `customer_vehicle`, `customer_work_order`, `vehicle_work_order`, `work_order_invoice`, and `vendor_part` links or generates review items for low-confidence mappings (file: `lib/graph.ts`).
- Updated session retrieval, deterministic fallback reporting, and UI panels to use real staged counts and grouped summaries so the dashboard shows entityCounts, linkCounts, and reviewCounts from staged tables and the agent report reflects staged results (files: `server/getOnboardingSession.ts`, `server/runOnboardingAgentAnalysis.ts`, `components/OnboardingEntitiesPanel.tsx`, `components/OnboardingReviewPanel.tsx`, `components/OnboardingSessionPage.tsx`, `lib/agentTypes.ts`).
- The analyze flow is explicit about idempotency by clearing only staged artifacts (raw rows, entities, links, reviews) at the start of an analysis and rebuilding them, and all inserts/updates now surface errors instead of being silently ignored; shop_id and session_id scoping and admin-only server flow are preserved.

### Testing
- Ran `npx tsc --noEmit` which succeeded with no type errors.
- Ran `npx eslint` against the modified onboarding-agent files which completed with warnings but no errors.
- Ran unit tests with `npx vitest` and the existing onboarding-agent tests plus the new staging test all passed: `onboarding-agent.test.ts`, `onboarding-agent-ai.test.ts`, `uploadOnboardingFiles.test.ts`, and new `onboarding-agent-staging.test.ts` (all green).
- Attempted `pnpm build` which failed due to external Google Fonts network fetches in this environment and is unrelated to the changes (documented as an environment/network limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee05853148328b44cdc1ad2f3157f)