### PR TITLE
Improve onboarding-agent domain detection, staging, links, summaries, and owner-facing review/plan UIs

### DIFF
--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -1,9 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+function num(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 export function OnboardingActivationPlanPanel({ latestPlan }: { latestPlan?: Record<string, unknown> | null }) {
+  const [showDevDetails, setShowDevDetails] = useState(false);
+  const summary = (latestPlan?.summary ?? latestPlan ?? {}) as Record<string, any>;
+  const creates = (summary.creates ?? summary.plan?.creates ?? {}) as Record<string, unknown>;
+  const links = (summary.links ?? summary.plan?.links ?? {}) as Record<string, unknown>;
+  const review = (summary.review ?? summary.plan?.review ?? {}) as Record<string, unknown>;
+  const blocking = num(review.blocking);
+  const nonblocking = num(review.nonblocking);
+
   return (
     <div className="rounded-2xl border border-amber-500/30 bg-amber-950/20 p-4">
-      <h3 className="text-sm font-semibold text-amber-100">Activation plan (dry-run only)</h3>
-      <p className="mt-2 text-xs text-amber-200/80">Activation is not enabled in this foundation phase. This workspace stages, explains, and prepares an activation plan.</p>
-      <pre className="mt-3 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify(latestPlan ?? { status: "not_prepared" }, null, 2)}</pre>
+      <h3 className="text-sm font-semibold text-amber-100">Dry-run activation plan</h3>
+      <p className="mt-2 text-xs text-amber-200/80">Activation remains disabled in this phase.</p>
+      <p className="text-xs text-amber-200/80">No live records have been created.</p>
+      <p className="text-xs text-amber-200/80">This plan is a preview only.</p>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3 text-sm">
+        <div>Customers ready: <span className="font-semibold text-white">{num(creates.customers)}</span></div>
+        <div>Vehicles ready: <span className="font-semibold text-white">{num(creates.vehicles)}</span></div>
+        <div>Historical work orders ready: <span className="font-semibold text-white">{num(creates.historicalWorkOrders)}</span></div>
+        <div>Historical invoices ready: <span className="font-semibold text-white">{num(creates.historicalInvoices)}</span></div>
+        <div>Parts ready: <span className="font-semibold text-white">{num(creates.parts)}</span></div>
+        <div>Vendors ready: <span className="font-semibold text-white">{num(creates.vendors)}</span></div>
+        <div>Staff candidates ready: <span className="font-semibold text-white">{num(creates.staffCandidates)}</span></div>
+        <div>Menu suggestions ready: <span className="font-semibold text-white">{num(creates.menuSuggestions)}</span></div>
+        <div>Links ready: <span className="font-semibold text-white">{num(links.customerVehicle) + num(links.vehicleWorkOrder) + num(links.workOrderInvoice)}</span></div>
+        <div>Blocking issues: <span className="font-semibold text-white">{blocking}</span></div>
+        <div>Review needed: <span className="font-semibold text-white">{nonblocking}</span></div>
+      </div>
+
+      <button
+        onClick={() => setShowDevDetails((v) => !v)}
+        className="mt-3 rounded border border-white/20 px-2 py-1 text-xs text-slate-200"
+      >
+        {showDevDetails ? "Hide" : "Show"} developer details
+      </button>
+      {showDevDetails ? (
+        <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify(latestPlan ?? { status: "not_prepared" }, null, 2)}</pre>
+      ) : null}
     </div>
   );
 }

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import type { OnboardingAgentReport } from "@/features/onboarding-agent/lib/agentTypes";
 
 function readinessTone(status: OnboardingAgentReport["activationReadiness"]["status"] | undefined) {
-  if (status === "ready_for_dry_run" || status === "ready_for_activation_later") return "border-emerald-400/40 text-emerald-200";
+  if (status === "ready_for_dry_run" || status === "activation_disabled") return "border-emerald-400/40 text-emerald-200";
   if (status === "review_required") return "border-amber-400/40 text-amber-200";
   return "border-rose-400/40 text-rose-200";
 }

--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -17,6 +17,7 @@ const LINK_ROWS: Array<{ key: string; label: string }> = [
   { key: "vehicle_work_order", label: "Vehicle ↔ Work order" },
   { key: "work_order_invoice", label: "Work order ↔ Invoice" },
   { key: "vendor_part", label: "Vendor ↔ Part" },
+  { key: "service_menu_suggestion", label: "Service ↔ Menu suggestion" },
 ];
 
 export function OnboardingEntitiesPanel({ entityCounts, linkCounts }: { entityCounts: Record<string, number>; linkCounts: Record<string, number> }) {

--- a/features/onboarding-agent/components/OnboardingReviewPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingReviewPanel.tsx
@@ -1,11 +1,25 @@
+"use client";
+
+import { useState } from "react";
+
+type ReviewItem = {
+  id: string;
+  severity: string;
+  domain?: string | null;
+  issue_type?: string;
+  summary: string;
+  details?: Record<string, unknown>;
+};
+
 export function OnboardingReviewPanel({
   reviewCounts,
   reviewItems,
 }: {
   reviewCounts: { blocking?: number; high?: number; medium?: number; low?: number; byDomain?: Record<string, number> };
-  reviewItems: Array<{ id: string; severity: string; domain?: string | null; issue_type?: string; summary: string }>;
+  reviewItems: ReviewItem[];
 }) {
-  const topItems = reviewItems.filter((item) => item).slice(0, 10);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const topItems = reviewItems.filter((item) => item).slice(0, 12);
   const domainCounts = reviewCounts.byDomain ?? {};
 
   return (
@@ -29,16 +43,39 @@ export function OnboardingReviewPanel({
       </div>
 
       <div className="mt-3 space-y-2">
-        <p className="text-xs uppercase tracking-wide text-slate-400">Top pending exceptions</p>
-        {topItems.map((item) => (
-          <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-            <p className="text-xs uppercase tracking-wide text-slate-400">
-              {item.severity} • {item.domain ?? "unknown"} • {item.issue_type ?? "issue"}
-            </p>
-            <p className="text-sm text-white">{item.summary}</p>
-            <p className="text-xs text-slate-400">Recommended action: resolve or map this item before activation dry-run.</p>
-          </div>
-        ))}
+        <p className="text-xs uppercase tracking-wide text-slate-400">Top grouped exceptions</p>
+        {topItems.map((item) => {
+          const details = (item.details ?? {}) as Record<string, any>;
+          const examples = Array.isArray(details.examples) ? details.examples : [];
+          const key = item.id;
+          return (
+            <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
+              <p className="text-xs uppercase tracking-wide text-slate-400">
+                {item.severity} • {item.domain ?? "unknown"} • {item.issue_type ?? "issue"}
+              </p>
+              <p className="text-sm text-white">{item.summary}</p>
+              {typeof details.count === "number" ? <p className="text-xs text-slate-300">Affected rows: {details.count}</p> : null}
+              {Array.isArray(details.sampleRowIndexes) && details.sampleRowIndexes.length > 0 ? (
+                <p className="text-xs text-slate-400">Sample rows: {details.sampleRowIndexes.slice(0, 5).join(", ")}</p>
+              ) : null}
+              <p className="text-xs text-slate-400">Recommended action: {details.recommendedAction ?? "Review examples and resolve before activation planning."}</p>
+              {examples.length > 0 ? (
+                <>
+                  <button className="mt-2 text-xs text-cyan-200 underline" onClick={() => setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))}>
+                    {expanded[key] ? "Hide examples" : "Show examples"}
+                  </button>
+                  {expanded[key] ? (
+                    <ul className="mt-2 space-y-1 text-xs text-slate-300">
+                      {examples.slice(0, 3).map((example: any, idx: number) => (
+                        <li key={`${key}-${idx}`}>• {example.summary}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          );
+        })}
         {topItems.length === 0 ? <p className="text-xs text-slate-400">No pending review exceptions.</p> : null}
       </div>
     </div>

--- a/features/onboarding-agent/lib/agentTypes.ts
+++ b/features/onboarding-agent/lib/agentTypes.ts
@@ -16,7 +16,7 @@ export type OnboardingAgentActivationStatus =
   | "empty"
   | "review_required"
   | "ready_for_dry_run"
-  | "ready_for_activation_later";
+  | "activation_disabled";
 
 export type OnboardingAgentInput = {
   sessionId: string;

--- a/features/onboarding-agent/lib/domains.ts
+++ b/features/onboarding-agent/lib/domains.ts
@@ -13,32 +13,92 @@ export const ONBOARDING_DOMAINS = [
 
 export type OnboardingDomain = (typeof ONBOARDING_DOMAINS)[number];
 
-const DOMAIN_HINTS: Array<{ domain: OnboardingDomain; hints: string[] }> = [
-  { domain: "customers", hints: ["customer id", "customer name", "full name", "company", "email", "phone"] },
-  { domain: "vehicles", hints: ["vin", "plate", "license", "year", "make", "model", "unit", "customer id"] },
-  { domain: "history", hints: ["work order", "repair order", "ro", "complaint", "cause", "correction", "labor", "total"] },
-  { domain: "invoices", hints: ["invoice", "invoice number", "amount", "payment status", "paid", "closed", "work order"] },
-  { domain: "parts", hints: ["part", "sku", "part number", "description", "cost", "price", "qty"] },
-  { domain: "vendors", hints: ["vendor", "supplier", "company", "vendor phone", "vendor email"] },
-  { domain: "staff", hints: ["employee", "staff", "technician", "advisor", "role", "email"] },
-  { domain: "inspections", hints: ["inspection", "checklist", "item", "condition"] },
-  { domain: "menu", hints: ["service menu", "service", "package", "labor op"] },
-];
+type DomainScore = Record<OnboardingDomain, number>;
 
 export function normalizeHeader(value: string): string {
   return value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
+const FILENAME_HINTS: Array<{ domain: OnboardingDomain; hints: string[]; weight: number }> = [
+  { domain: "vendors", hints: ["vendor", "vendors", "supplier", "suppliers"], weight: 12 },
+  { domain: "staff", hints: ["staff", "users", "employee", "employees", "technician", "tech", "advisor"], weight: 12 },
+  { domain: "vehicles", hints: ["vehicle", "vehicles", "vin", "fleet"], weight: 12 },
+  { domain: "invoices", hints: ["invoice", "invoices", "billing"], weight: 12 },
+  { domain: "history", hints: ["work order", "work orders", "repair order", "ro", "history", "historical"], weight: 12 },
+  { domain: "parts", hints: ["parts inventory", "inventory", "sku", "part number", "part"], weight: 12 },
+  { domain: "menu", hints: ["service catalog", "service menu", "menu", "labor operation", "canned job"], weight: 14 },
+  { domain: "customers", hints: ["customer", "customers"], weight: 9 },
+];
+
+const HEADER_HINTS: Array<{ domain: OnboardingDomain; hints: string[]; weight: number }> = [
+  { domain: "customers", hints: ["customer id", "customer name", "full name", "company name", "business", "email", "phone"], weight: 3 },
+  { domain: "vehicles", hints: ["vehicle id", "vin", "plate", "license", "year", "make", "model", "unit", "customer id"], weight: 3 },
+  { domain: "history", hints: ["work order", "repair order", "ro", "complaint", "cause", "correction", "labor", "total", "opened", "closed"], weight: 3 },
+  { domain: "invoices", hints: ["invoice", "invoice number", "payment status", "paid", "subtotal", "tax", "work order"], weight: 3 },
+  { domain: "parts", hints: ["part", "sku", "part number", "description", "cost", "price", "qty", "on hand"], weight: 3 },
+  { domain: "vendors", hints: ["vendor", "supplier", "account number", "vendor phone", "vendor email"], weight: 3 },
+  { domain: "staff", hints: ["employee", "staff", "technician", "advisor", "role", "job title", "email"], weight: 3 },
+  { domain: "menu", hints: ["service", "service name", "service catalog", "labor operation", "canned job", "labor hours", "labor rate"], weight: 3 },
+  { domain: "inspections", hints: ["inspection", "checklist", "condition"], weight: 3 },
+];
+
+function tokenizeFilename(filename: string) {
+  return normalizeHeader(filename.replace(/\.csv$/i, "")).split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function hasHint(haystack: string, hint: string) {
+  const normalizedHint = normalizeHeader(hint);
+  return haystack.includes(normalizedHint);
+}
+
 export function detectDomain(input: { filename?: string | null; headers?: string[] }): OnboardingDomain {
   const filename = normalizeHeader(input.filename ?? "");
+  const filenameTokens = tokenizeFilename(filename).join(" ");
   const headers = (input.headers ?? []).map(normalizeHeader);
-  const corpus = [filename, ...headers].join(" | ");
+  const headerCorpus = headers.join(" | ");
 
-  let best: { domain: OnboardingDomain; score: number } = { domain: "unknown", score: 0 };
-  for (const candidate of DOMAIN_HINTS) {
-    const score = candidate.hints.reduce((acc, hint) => (corpus.includes(hint) ? acc + 1 : acc), 0);
-    if (score > best.score) best = { domain: candidate.domain, score };
+  const scores: DomainScore = {
+    customers: 0,
+    vehicles: 0,
+    history: 0,
+    invoices: 0,
+    parts: 0,
+    vendors: 0,
+    staff: 0,
+    inspections: 0,
+    menu: 0,
+    unknown: 0,
+  };
+
+  for (const candidate of FILENAME_HINTS) {
+    for (const hint of candidate.hints) {
+      if (hasHint(filename, hint) || hasHint(filenameTokens, hint)) {
+        scores[candidate.domain] += candidate.weight;
+      }
+    }
   }
 
-  return best.score > 0 ? best.domain : "unknown";
+  for (const candidate of HEADER_HINTS) {
+    for (const hint of candidate.hints) {
+      if (hasHint(headerCorpus, hint)) {
+        scores[candidate.domain] += candidate.weight;
+      }
+    }
+  }
+
+  if (scores.menu > 0 && scores.parts > 0 && scores.menu >= scores.parts) {
+    scores.parts = Math.max(0, scores.parts - 4);
+  }
+
+  let bestDomain: OnboardingDomain = "unknown";
+  let bestScore = 0;
+  for (const domain of ONBOARDING_DOMAINS) {
+    if (domain === "unknown") continue;
+    if (scores[domain] > bestScore) {
+      bestDomain = domain;
+      bestScore = scores[domain];
+    }
+  }
+
+  return bestScore > 0 ? bestDomain : "unknown";
 }

--- a/features/onboarding-agent/lib/fingerprints.ts
+++ b/features/onboarding-agent/lib/fingerprints.ts
@@ -72,5 +72,14 @@ export function fingerprintForDomain(domain: OnboardingDomain, normalized: Recor
     return name ? `staff:name:${name.toLowerCase()}` : null;
   }
 
+  if (domain === "menu") {
+    const opCode = text(normalized.opCode);
+    if (opCode) return `menu:op:${opCode.toLowerCase()}`;
+    const serviceName = text(normalized.serviceName);
+    if (serviceName) return `menu:name:${serviceName.toLowerCase()}`;
+    const description = text(normalized.description);
+    return description ? `menu:description:${description.toLowerCase()}` : null;
+  }
+
   return null;
 }

--- a/features/onboarding-agent/lib/graph.ts
+++ b/features/onboarding-agent/lib/graph.ts
@@ -33,6 +33,7 @@ export function buildStagedLinks(params: BuildLinksParams) {
   const invoices = entities.filter((entity) => entity.entity_type === "historical_invoice");
   const parts = entities.filter((entity) => entity.entity_type === "part");
   const vendors = entities.filter((entity) => entity.entity_type === "vendor");
+  const menus = entities.filter((entity) => entity.entity_type === "menu_suggestion");
 
   const customersBySourceId = new Map(customers.map((c) => [text(c.normalized.sourceCustomerId), c]));
   const customersByEmail = new Map(customers.map((c) => [text(c.normalized.email).toLowerCase(), c]));
@@ -42,24 +43,12 @@ export function buildStagedLinks(params: BuildLinksParams) {
   const vehiclesBySourceId = new Map(vehicles.map((v) => [text(v.normalized.sourceVehicleId), v]));
   const vehiclesByVin = new Map(vehicles.map((v) => [text(v.normalized.vin).toUpperCase(), v]));
   const vehiclesByPlate = new Map(vehicles.map((v) => [text(v.normalized.plate).toUpperCase(), v]));
+  const vehiclesByUnit = new Map(vehicles.map((v) => [text(v.normalized.unitNumber).toUpperCase(), v]));
 
   const workOrdersBySourceId = new Map(workOrders.map((wo) => [text(wo.normalized.sourceWorkOrderId), wo]));
 
   const pushLink = (from: string, to: string, linkType: string, confidence: number, evidence: Record<string, unknown>) => {
-    if (confidence < 0.75) {
-      reviewItems.push(
-        makeReviewItem({
-          shopId,
-          sessionId,
-          severity: "medium",
-          domain: linkType,
-          issueType: "low_confidence_mapping",
-          summary: `${linkType} mapping confidence too low`,
-          details: evidence,
-        }),
-      );
-      return;
-    }
+    if (confidence < 0.6) return;
 
     links.push({
       from_entity_id: from,
@@ -84,19 +73,19 @@ export function buildStagedLinks(params: BuildLinksParams) {
     if (sourceCustomerId && customersBySourceId.get(sourceCustomerId)) {
       matched = customersBySourceId.get(sourceCustomerId);
       confidence = 0.95;
-      evidence = { sourceCustomerId };
+      evidence = { sourceCustomerId, matchStrategy: "source_id" };
     } else if (customerEmail && customersByEmail.get(customerEmail)) {
       matched = customersByEmail.get(customerEmail);
       confidence = 0.85;
-      evidence = { customerEmail };
+      evidence = { customerEmail, matchStrategy: "email" };
     } else if (customerPhone && customersByPhone.get(customerPhone)) {
       matched = customersByPhone.get(customerPhone);
-      confidence = 0.85;
-      evidence = { customerPhone };
+      confidence = 0.84;
+      evidence = { customerPhone, matchStrategy: "phone" };
     } else if (customerName && customersByName.get(customerName)) {
       matched = customersByName.get(customerName);
-      confidence = 0.75;
-      evidence = { customerName };
+      confidence = 0.72;
+      evidence = { customerName, matchStrategy: "name" };
     }
 
     if (!matched) {
@@ -107,8 +96,8 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "high",
           domain: "vehicles",
           issueType: "missing_customer_link",
-          summary: "Vehicle is missing a confident customer link",
-          details: { vehicleId: vehicle.id, sourceCustomerId, customerEmail, customerPhone, customerName },
+          summary: "Vehicle could not be linked to customer",
+          details: { sourceCustomerId, customerEmail, customerPhone, customerName },
         }),
       );
       continue;
@@ -119,13 +108,16 @@ export function buildStagedLinks(params: BuildLinksParams) {
 
   for (const workOrder of workOrders) {
     const sourceCustomerId = text(workOrder.normalized.sourceCustomerId);
-    const sourceVehicleId = text(workOrder.normalized.sourceVehicleId);
-    const vehicleVin = text(workOrder.normalized.vehicleVin).toUpperCase();
-    const vehiclePlate = text(workOrder.normalized.vehiclePlate).toUpperCase();
+    const customerEmail = text(workOrder.normalized.customerEmail).toLowerCase();
+    const customerName = normalizeName(workOrder.normalized.customerName);
 
-    const customer = sourceCustomerId ? customersBySourceId.get(sourceCustomerId) : undefined;
+    const customer = customersBySourceId.get(sourceCustomerId)
+      || customersByEmail.get(customerEmail)
+      || customersByName.get(customerName);
+
     if (customer) {
-      pushLink(customer.id, workOrder.id, "customer_work_order", 0.95, { sourceCustomerId });
+      const confidence = sourceCustomerId ? 0.95 : customerEmail ? 0.84 : 0.7;
+      pushLink(customer.id, workOrder.id, "customer_work_order", confidence, { sourceCustomerId, customerEmail, customerName });
     } else {
       reviewItems.push(
         makeReviewItem({
@@ -134,16 +126,25 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "high",
           domain: "history",
           issueType: "missing_customer_link",
-          summary: "Work order is missing customer linkage",
-          details: { workOrderId: workOrder.id, sourceCustomerId },
+          summary: "Work order could not be linked to customer",
+          details: { sourceCustomerId, customerEmail, customerName },
         }),
       );
     }
 
-    const vehicle = vehiclesBySourceId.get(sourceVehicleId) || vehiclesByVin.get(vehicleVin) || vehiclesByPlate.get(vehiclePlate);
+    const sourceVehicleId = text(workOrder.normalized.sourceVehicleId);
+    const vehicleVin = text(workOrder.normalized.vehicleVin).toUpperCase();
+    const vehiclePlate = text(workOrder.normalized.vehiclePlate).toUpperCase();
+    const vehicleUnit = text(workOrder.normalized.vehicleUnitNumber).toUpperCase();
+
+    const vehicle = vehiclesBySourceId.get(sourceVehicleId)
+      || vehiclesByVin.get(vehicleVin)
+      || vehiclesByPlate.get(vehiclePlate)
+      || vehiclesByUnit.get(vehicleUnit);
+
     if (vehicle) {
-      const confidence = sourceVehicleId ? 0.95 : vehicleVin ? 0.9 : 0.75;
-      pushLink(vehicle.id, workOrder.id, "vehicle_work_order", confidence, { sourceVehicleId, vehicleVin, vehiclePlate });
+      const confidence = sourceVehicleId ? 0.95 : vehicleVin || vehiclePlate ? 0.86 : 0.72;
+      pushLink(vehicle.id, workOrder.id, "vehicle_work_order", confidence, { sourceVehicleId, vehicleVin, vehiclePlate, vehicleUnit });
     } else {
       reviewItems.push(
         makeReviewItem({
@@ -152,8 +153,8 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "medium",
           domain: "history",
           issueType: "missing_vehicle_link",
-          summary: "Work order is missing vehicle linkage",
-          details: { workOrderId: workOrder.id, sourceVehicleId, vehicleVin, vehiclePlate },
+          summary: "Work order could not be linked to vehicle",
+          details: { sourceVehicleId, vehicleVin, vehiclePlate, vehicleUnit },
         }),
       );
     }
@@ -163,7 +164,7 @@ export function buildStagedLinks(params: BuildLinksParams) {
     const sourceWorkOrderId = text(invoice.normalized.sourceWorkOrderId);
     const workOrder = sourceWorkOrderId ? workOrdersBySourceId.get(sourceWorkOrderId) : undefined;
     if (workOrder) {
-      pushLink(workOrder.id, invoice.id, "work_order_invoice", 0.95, { sourceWorkOrderId });
+      pushLink(workOrder.id, invoice.id, "work_order_invoice", 0.95, { sourceWorkOrderId, matchStrategy: "source_id" });
     } else {
       reviewItems.push(
         makeReviewItem({
@@ -172,8 +173,8 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "high",
           domain: "invoices",
           issueType: "missing_work_order_link",
-          summary: "Invoice is missing work-order linkage",
-          details: { invoiceId: invoice.id, sourceWorkOrderId },
+          summary: "Invoice could not be linked to work order",
+          details: { sourceWorkOrderId },
         }),
       );
     }
@@ -181,22 +182,51 @@ export function buildStagedLinks(params: BuildLinksParams) {
 
   for (const part of parts) {
     const vendorName = normalizeName(part.normalized.vendorName);
-    const match = vendors.find((vendor) => {
-      const vendorKey = normalizeName(vendor.normalized.name);
-      return vendorName && vendorKey && vendorName === vendorKey;
-    });
+    if (!vendorName) continue;
+    const match = vendors.find((vendor) => normalizeName(vendor.normalized.name) === vendorName);
     if (match) {
-      pushLink(match.id, part.id, "vendor_part", 0.75, { vendorName });
+      pushLink(match.id, part.id, "vendor_part", 0.8, { vendorName, matchStrategy: "vendor_name" });
+    } else {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "medium",
+          domain: "parts",
+          issueType: "missing_vendor_link",
+          summary: "Part is missing vendor match",
+          details: { vendorName },
+        }),
+      );
     }
+  }
+
+  for (const menu of menus) {
+    if (!text(menu.normalized.serviceName) && !text(menu.normalized.description)) {
+      reviewItems.push(
+        makeReviewItem({
+          shopId,
+          sessionId,
+          severity: "medium",
+          domain: "menu",
+          issueType: "missing_service_identity",
+          summary: "Service catalog row is missing service identity",
+          details: { opCode: menu.normalized.opCode },
+        }),
+      );
+      continue;
+    }
+
+    pushLink(menu.id, menu.id, "service_menu_suggestion", 1, { type: "self" });
   }
 
   const dedupedLinks = links.filter(
     (link, index, all) =>
       all.findIndex(
         (candidate) =>
-          candidate.link_type === link.link_type &&
-          candidate.from_entity_id === link.from_entity_id &&
-          candidate.to_entity_id === link.to_entity_id,
+          candidate.link_type === link.link_type
+          && candidate.from_entity_id === link.from_entity_id
+          && candidate.to_entity_id === link.to_entity_id,
       ) === index,
   );
 

--- a/features/onboarding-agent/lib/normalization.ts
+++ b/features/onboarding-agent/lib/normalization.ts
@@ -27,18 +27,13 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       entityType: "customer",
       displayName: name || value(row, ["company name", "company", "business"]),
       normalized: {
-        sourceCustomerId: value(row, ["customer id", "id"]),
+        sourceCustomerId: value(row, ["customer id", "id", "external customer id"]),
         name,
         firstName,
         lastName: rest.join(" "),
         businessName: value(row, ["company", "company name", "business"]),
         email: value(row, ["email", "email address"]).toLowerCase(),
         phone: normalizePhone(value(row, ["phone", "phone number", "mobile"])),
-        address: value(row, ["address", "street", "street address"]),
-        city: value(row, ["city", "town"]),
-        province: value(row, ["province", "state", "region"]),
-        postalCode: value(row, ["postal", "postal code", "zip", "zip code"]),
-        fleetFlag: ["1", "true", "yes", "fleet"].includes(value(row, ["fleet", "is fleet", "company flag"]).toLowerCase()),
       },
     };
   }
@@ -53,7 +48,7 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       entityType: "vehicle",
       displayName: `${year} ${make} ${model}`.trim() || vin || value(row, ["plate", "license"]),
       normalized: {
-        sourceVehicleId: value(row, ["vehicle id", "id"]),
+        sourceVehicleId: value(row, ["vehicle id", "id", "external vehicle id"]),
         sourceCustomerId: value(row, ["customer id"]),
         customerName: value(row, ["customer name", "name"]),
         customerEmail: value(row, ["customer email", "email"]),
@@ -71,26 +66,24 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   if (domain === "history") {
     return {
       entityType: "historical_work_order",
-      displayName: value(row, ["work order", "repair order", "ro", "ro id"]),
+      displayName: value(row, ["work order", "repair order", "ro", "ro id", "ro number"]),
       normalized: {
         sourceWorkOrderId: value(row, ["work order", "ro id", "repair order", "ro number"]),
+        invoiceId: value(row, ["invoice id", "invoice number", "invoice"]),
         sourceCustomerId: value(row, ["customer id"]),
+        customerEmail: value(row, ["customer email", "email"]).toLowerCase(),
+        customerName: value(row, ["customer name", "name"]),
         sourceVehicleId: value(row, ["vehicle id"]),
         vehicleVin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
         vehiclePlate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
-        invoiceId: value(row, ["invoice id", "invoice number", "invoice"]),
+        vehicleUnitNumber: value(row, ["unit", "unit number"]),
         complaint: value(row, ["complaint", "description", "concern"]),
         cause: value(row, ["cause"]),
         correction: value(row, ["correction", "resolution"]),
-        openedDate: value(row, ["opened", "opened date", "open date"]),
+        openedDate: value(row, ["opened", "opened date", "open date", "date"]),
         closedDate: value(row, ["closed", "completed date", "closed date"]),
-        mileage: value(row, ["mileage", "odometer"]),
         totalRaw: value(row, ["total", "amount"]),
         total: parseMoney(value(row, ["total", "amount"])),
-        laborRaw: value(row, ["labor", "labor amount"]),
-        laborAmount: parseMoney(value(row, ["labor", "labor amount"])),
-        partsRaw: value(row, ["parts", "parts amount"]),
-        partsAmount: parseMoney(value(row, ["parts", "parts amount"])),
       },
     };
   }
@@ -104,19 +97,10 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         invoiceNumber: value(row, ["invoice", "invoice number", "invoice id"]),
         sourceWorkOrderId: value(row, ["work order", "ro", "ro id", "repair order"]),
         sourceCustomerId: value(row, ["customer id"]),
-        subtotalRaw: value(row, ["subtotal"]),
-        subtotal: parseMoney(value(row, ["subtotal"])),
-        taxRaw: value(row, ["tax", "tax amount"]),
-        tax: parseMoney(value(row, ["tax", "tax amount"])),
-        laborRaw: value(row, ["labor", "labor amount"]),
-        laborAmount: parseMoney(value(row, ["labor", "labor amount"])),
-        partsRaw: value(row, ["parts", "parts amount"]),
-        partsAmount: parseMoney(value(row, ["parts", "parts amount"])),
+        invoiceDate: value(row, ["issue date", "invoice date", "date"]),
+        paymentStatus: value(row, ["status", "payment status"]),
         totalRaw,
         total: parseMoney(totalRaw),
-        issueDate: value(row, ["issue date", "date"]),
-        paidDate: value(row, ["paid date", "closed", "closed date"]),
-        paymentStatus: value(row, ["status", "payment status"]),
       },
     };
   }
@@ -129,12 +113,7 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         sku: value(row, ["sku", "part sku"]),
         partNumber: value(row, ["part number", "part #", "number"]),
         description: value(row, ["description", "name", "part"]),
-        vendorName: value(row, ["vendor", "supplier", "vendor name"]),
-        quantity: value(row, ["qty", "quantity", "on hand"]),
-        costRaw: value(row, ["cost"]),
-        cost: parseMoney(value(row, ["cost"])),
-        priceRaw: value(row, ["price", "retail"]),
-        price: parseMoney(value(row, ["price", "retail"])),
+        vendorName: value(row, ["vendor", "supplier", "vendor name", "supplier name"]),
       },
     };
   }
@@ -142,9 +121,9 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   if (domain === "vendors") {
     return {
       entityType: "vendor",
-      displayName: value(row, ["vendor", "supplier", "company", "vendor name"]),
+      displayName: value(row, ["vendor", "supplier", "company", "vendor name", "supplier name"]),
       normalized: {
-        name: value(row, ["vendor", "supplier", "company", "vendor name"]),
+        name: value(row, ["vendor", "supplier", "company", "vendor name", "supplier name"]),
         email: value(row, ["email", "vendor email"]).toLowerCase(),
         phone: normalizePhone(value(row, ["phone", "vendor phone"])),
         accountNumber: value(row, ["account", "account number", "vendor account"]),
@@ -160,7 +139,23 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         name: value(row, ["name", "full name", "employee"]),
         email: value(row, ["email", "email address"]).toLowerCase(),
         phone: normalizePhone(value(row, ["phone", "mobile"])),
-        role: value(row, ["role", "job title", "position"]),
+        role: value(row, ["role", "job title", "position", "technician", "advisor"]),
+      },
+    };
+  }
+
+  if (domain === "menu") {
+    return {
+      entityType: "menu_suggestion",
+      displayName: value(row, ["service", "service name", "name", "description"]),
+      normalized: {
+        serviceName: value(row, ["service", "service name", "name"]),
+        description: value(row, ["description"]),
+        category: value(row, ["category", "service category"]),
+        laborHours: value(row, ["labor hours", "hours"]),
+        laborPriceRaw: value(row, ["labor price", "price", "labor rate"]),
+        laborPrice: parseMoney(value(row, ["labor price", "price", "labor rate"])),
+        opCode: value(row, ["operation code", "op code", "labor operation", "canned job"]),
       },
     };
   }

--- a/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
@@ -105,7 +105,7 @@ describe("onboarding agent ai safeguards", () => {
 
   it("activation readiness is not ready with blocking items", () => {
     const report = buildDeterministicFallbackReport(makeInput("blocking"));
-    expect(report.activationReadiness.status).toBe("not_ready");
+    expect(report.activationReadiness.status).toBe("review_required");
     expect(report.activationReadiness.safeToProceed).toBe(false);
   });
 
@@ -113,7 +113,7 @@ describe("onboarding agent ai safeguards", () => {
     const input = makeInput("high");
     input.deterministicReviewItems = [];
     const report = buildDeterministicFallbackReport(input);
-    expect(report.activationReadiness.status).toBe("ready_for_dry_run");
+    expect(report.activationReadiness.status).toBe("activation_disabled");
     expect(report.activationReadiness.safeToProceed).toBe(true);
   });
 

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -49,6 +49,17 @@ describe("onboarding staging", () => {
     expect(invoice?.entity_type).toBe("historical_invoice");
   });
 
+  it("stages vendors, parts, staff, and menu suggestions", () => {
+    const vendor = stage("vendors", { "Vendor Name": "North Supply", Email: "orders@north.test" }).entity;
+    const part = stage("parts", { SKU: "P-1", Description: "Brake Pad", Vendor: "North Supply" }).entity;
+    const staff = stage("staff", { Name: "Alex Tech", Email: "alex@shop.test" }).entity;
+    const menu = stage("menu", { "Service Name": "Alignment", Description: "4 wheel alignment" }).entity;
+    expect(vendor?.entity_type).toBe("vendor");
+    expect(part?.entity_type).toBe("part");
+    expect(staff?.entity_type).toBe("staff_candidate");
+    expect(menu?.entity_type).toBe("menu_suggestion");
+  });
+
   it("creates work_order_invoice links when invoice references work order id", () => {
     const wo = stage("history", { "Work Order": "RO-1", "Customer ID": "C-1", Complaint: "noise" }).entity;
     const invoice = stage("invoices", { Invoice: "INV-1", "Work Order": "RO-1", Total: "500" }).entity;
@@ -61,6 +72,28 @@ describe("onboarding staging", () => {
       ],
     });
     expect(graph.links.some((link) => link.link_type === "work_order_invoice")).toBe(true);
+  });
+
+  it("creates customer_work_order, vehicle_work_order, and vendor_part links", () => {
+    const customer = stage("customers", { "Customer ID": "C-2", Name: "John Doe", Email: "john@example.com" }).entity!;
+    const vehicle = stage("vehicles", { "Vehicle ID": "V-2", "Customer ID": "C-2", VIN: "1HGCM82633A004353" }).entity!;
+    const wo = stage("history", { "Work Order": "RO-2", "Customer ID": "C-2", "Vehicle ID": "V-2", Complaint: "pulling" }).entity!;
+    const vendor = stage("vendors", { "Vendor Name": "Parts Co", Email: "parts@co.test" }).entity!;
+    const part = stage("parts", { SKU: "P-2", Description: "Rotor", Vendor: "Parts Co" }).entity!;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [
+        { id: "c-2", entity_type: customer.entity_type, normalized: customer.normalized },
+        { id: "v-2", entity_type: vehicle.entity_type, normalized: vehicle.normalized },
+        { id: "wo-2", entity_type: wo.entity_type, normalized: wo.normalized },
+        { id: "vendor-2", entity_type: vendor.entity_type, normalized: vendor.normalized },
+        { id: "part-2", entity_type: part.entity_type, normalized: part.normalized },
+      ],
+    });
+    expect(graph.links.some((link) => link.link_type === "customer_work_order")).toBe(true);
+    expect(graph.links.some((link) => link.link_type === "vehicle_work_order")).toBe(true);
+    expect(graph.links.some((link) => link.link_type === "vendor_part")).toBe(true);
   });
 
   it("missing identity creates review item instead of fake entity", () => {

--- a/features/onboarding-agent/lib/onboarding-agent.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent.test.ts
@@ -9,6 +9,15 @@ describe("onboarding agent helpers", () => {
     expect(detectDomain({ filename: "customers.csv", headers: ["Customer ID", "Full NAME", "EMAIL", "Phone Number", "Company Name"] })).toBe("customers");
   });
 
+  it("detects known domain files using filename hints", () => {
+    expect(detectDomain({ filename: "vendors.csv", headers: ["Vendor Name", "Vendor Email"] })).toBe("vendors");
+    expect(detectDomain({ filename: "staff_users.csv", headers: ["Full Name", "Role", "Email"] })).toBe("staff");
+    expect(detectDomain({ filename: "vehicles.csv", headers: ["VIN", "Plate"] })).toBe("vehicles");
+    expect(detectDomain({ filename: "invoices.csv", headers: ["Invoice Number", "Total"] })).toBe("invoices");
+    expect(detectDomain({ filename: "work_orders_history.csv", headers: ["Work Order", "Complaint"] })).toBe("history");
+    expect(detectDomain({ filename: "service_catalog.csv", headers: ["Service Name", "Labor Hours"] })).toBe("menu");
+  });
+
   it("parses csv with mixed-case headers", () => {
     const parsed = parseCsvText("Customer ID,Full NAME,EMAIL\n1,Jane Doe,jane@example.com");
     expect(parsed.headers).toEqual(["Customer ID", "Full NAME", "EMAIL"]);
@@ -24,6 +33,13 @@ describe("onboarding agent helpers", () => {
 
     const invoice = normalizeRow("invoices", { Invoice: "INV-1", "Work Order": "RO-9", Total: "500", Status: "closed" });
     expect(invoice.entityType).toBe("historical_invoice");
+  });
+
+  it("normalizes parts/vendors/staff/menu rows", () => {
+    expect(normalizeRow("parts", { SKU: "SKU-1", Description: "Filter" }).entityType).toBe("part");
+    expect(normalizeRow("vendors", { "Vendor Name": "Acme Supply" }).entityType).toBe("vendor");
+    expect(normalizeRow("staff", { Name: "Tech A", Email: "tech@example.com" }).entityType).toBe("staff_candidate");
+    expect(normalizeRow("menu", { "Service Name": "Oil Change", "Labor Hours": "1.0" }).entityType).toBe("menu_suggestion");
   });
 
   it("builds dry-run activation plan", () => {

--- a/features/onboarding-agent/lib/staging.ts
+++ b/features/onboarding-agent/lib/staging.ts
@@ -32,6 +32,8 @@ function sourceExternalIdForDomain(domain: OnboardingDomain, normalized: Record<
   if (domain === "invoices") return text(normalized.invoiceNumber) || null;
   if (domain === "parts") return text(normalized.sku) || text(normalized.partNumber) || null;
   if (domain === "vendors") return text(normalized.accountNumber) || null;
+  if (domain === "staff") return text(normalized.email) || text(normalized.name) || null;
+  if (domain === "menu") return text(normalized.opCode) || text(normalized.serviceName) || null;
   return null;
 }
 
@@ -62,7 +64,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   const n = input.normalized;
   const domain = input.domain;
 
-  if (domain === "unknown" || domain === "menu" || domain === "inspections") {
+  if (domain === "unknown" || domain === "inspections") {
     return {
       entity: null,
       reviewItems: [
@@ -80,14 +82,13 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   let status: EntityStatus = "needs_review";
-  let confidence = 0.6;
+  let confidence = 0.62;
   let reviewReason: string | null = "missing_identity";
   const reviewItems: ReturnType<typeof makeReviewItem>[] = [];
 
   if (domain === "customers") {
-    const identityName = has(n.name) || has(n.businessName);
-    const identityContact = has(n.email) || has(n.phone);
-    if (identityName && identityContact) {
+    const hasIdentity = has(n.email) || has(n.phone) || has(n.sourceCustomerId) || has(n.name) || has(n.businessName);
+    if (hasIdentity) {
       status = "ready";
       confidence = 0.9;
       reviewReason = null;
@@ -95,52 +96,35 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "vehicles") {
-    const hasIdentity = has(n.vin) || has(n.plate) || has(n.unitNumber);
-    const hasCustomerHint = has(n.sourceCustomerId) || has(n.customerEmail) || has(n.customerPhone) || has(n.customerName);
-    if (hasIdentity && hasCustomerHint) {
+    if (has(n.vin) || has(n.plate) || has(n.unitNumber) || has(n.sourceVehicleId)) {
       status = "ready";
-      confidence = 0.9;
+      confidence = 0.88;
       reviewReason = null;
     }
   }
 
   if (domain === "history") {
-    const hasWorkOrderId = has(n.sourceWorkOrderId);
-    const hasLinkHint = has(n.sourceCustomerId) || has(n.sourceVehicleId) || has(n.vehicleVin) || has(n.vehiclePlate);
-    const hasDescription = has(n.complaint) || has(n.cause) || has(n.correction);
-    if (hasWorkOrderId && hasLinkHint && hasDescription) {
+    const hasPrimary = has(n.sourceWorkOrderId) || has(n.invoiceId);
+    const hasContext = has(n.sourceCustomerId) || has(n.sourceVehicleId) || has(n.vehicleVin) || has(n.vehiclePlate);
+    const hasNarrative = has(n.complaint) || has(n.cause) || has(n.correction) || has(n.openedDate);
+    if (hasPrimary || (hasContext && hasNarrative)) {
       status = "ready";
-      confidence = 0.88;
+      confidence = 0.86;
       reviewReason = null;
     }
   }
 
   if (domain === "invoices") {
-    const hasInvoiceId = has(n.invoiceNumber);
-    const hasAmountOrRo = hasNumber(n.total) || has(n.sourceWorkOrderId);
-    const invalidMoney = has(n.totalRaw) && typeof n.total === "number" && !Number.isFinite(n.total);
-    if (invalidMoney) {
-      reviewItems.push(
-        makeReviewItem({
-          shopId: input.shopId,
-          sessionId: input.sessionId,
-          severity: "high",
-          domain: "invoices",
-          issueType: "invalid_money",
-          summary: `Invoice row ${input.sourceRowIndex + 1} has invalid money format`,
-          details: { value: n.totalRaw },
-        }),
-      );
-    }
-    if (hasInvoiceId && hasAmountOrRo) {
+    const hasIdentity = has(n.invoiceNumber) || (hasNumber(n.total) && (has(n.invoiceDate) || has(n.sourceWorkOrderId) || has(n.sourceCustomerId)));
+    if (hasIdentity) {
       status = "ready";
-      confidence = 0.88;
+      confidence = 0.86;
       reviewReason = null;
     }
   }
 
   if (domain === "parts") {
-    if (has(n.sku) || has(n.partNumber) || has(n.description) || has(n.name)) {
+    if (has(n.sku) || has(n.partNumber) || has(n.description)) {
       status = "ready";
       confidence = 0.82;
       reviewReason = null;
@@ -148,20 +132,25 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "vendors") {
-    const hasName = has(n.name);
-    const hasIdentity = has(n.email) || has(n.phone) || has(n.accountNumber);
-    if (hasName && hasIdentity) {
+    if (has(n.name) || has(n.email) || has(n.phone)) {
       status = "ready";
-      confidence = 0.86;
+      confidence = 0.84;
       reviewReason = null;
     }
   }
 
   if (domain === "staff") {
-    const hasIdentity = has(n.email) || (has(n.name) && has(n.role));
-    if (hasIdentity) {
+    if (has(n.name) || has(n.email)) {
       status = "ready";
-      confidence = 0.84;
+      confidence = 0.82;
+      reviewReason = null;
+    }
+  }
+
+  if (domain === "menu") {
+    if (has(n.serviceName) || has(n.description)) {
+      status = "ready";
+      confidence = 0.8;
       reviewReason = null;
     }
   }
@@ -197,22 +186,22 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
     );
   }
 
+  const entityTypeByDomain: Record<string, string> = {
+    customers: "customer",
+    vehicles: "vehicle",
+    history: "historical_work_order",
+    invoices: "historical_invoice",
+    parts: "part",
+    vendors: "vendor",
+    staff: "staff_candidate",
+    menu: "menu_suggestion",
+  };
+
   return {
     entity: {
       shop_id: input.shopId,
       session_id: input.sessionId,
-      entity_type:
-        domain === "history"
-          ? "historical_work_order"
-          : domain === "invoices"
-            ? "historical_invoice"
-            : domain === "parts"
-              ? "part"
-              : domain === "vendors"
-                ? "vendor"
-                : domain === "staff"
-                  ? "staff_candidate"
-                  : domain.slice(0, -1),
+      entity_type: entityTypeByDomain[domain] ?? "unknown",
       source_file_id: input.sourceFileId,
       source_row_id: input.sourceRowId,
       source_row_index: input.sourceRowIndex,

--- a/features/onboarding-agent/lib/summaries.ts
+++ b/features/onboarding-agent/lib/summaries.ts
@@ -1,6 +1,131 @@
-export function toCountMap(rows: Array<{ key: string; count: number }>): Record<string, number> {
-  return rows.reduce<Record<string, number>>((acc, row) => {
-    acc[row.key] = row.count;
+export type PendingReviewItem = {
+  id?: string;
+  severity: "low" | "medium" | "high" | "blocking";
+  domain?: string | null;
+  issue_type?: string | null;
+  summary: string;
+  details?: Record<string, unknown> | null;
+  status?: string | null;
+};
+
+export const ENTITY_BUCKETS = [
+  "customer",
+  "vehicle",
+  "historical_work_order",
+  "historical_invoice",
+  "part",
+  "vendor",
+  "staff_candidate",
+  "menu_suggestion",
+  "inspection_suggestion",
+  "unknown",
+] as const;
+
+export const LINK_BUCKETS = ["customer_vehicle", "customer_work_order", "vehicle_work_order", "work_order_invoice", "vendor_part", "service_menu_suggestion"] as const;
+
+function topExamples(values: unknown[], max = 3) {
+  return values.filter(Boolean).slice(0, max);
+}
+
+export function groupReviewItems(items: PendingReviewItem[]) {
+  const grouped = new Map<string, {
+    severity: PendingReviewItem["severity"];
+    domain: string;
+    issue_type: string;
+    count: number;
+    sampleRows: number[];
+    sampleValues: unknown[];
+    examples: Array<{ summary: string; details: Record<string, unknown> }>;
+  }>();
+
+  for (const item of items) {
+    const domain = item.domain ?? "unknown";
+    const issueType = item.issue_type ?? "issue";
+    const key = `${domain}|${issueType}|${item.severity}`;
+    const details = (item.details ?? {}) as Record<string, unknown>;
+    const sourceRowIndex = Number(details.sourceRowIndex ?? -1);
+    const sampleValue = details.value ?? details.sourceCustomerId ?? details.sourceWorkOrderId ?? details.vendorName ?? details.customerEmail;
+
+    if (!grouped.has(key)) {
+      grouped.set(key, {
+        severity: item.severity,
+        domain,
+        issue_type: issueType,
+        count: 0,
+        sampleRows: [],
+        sampleValues: [],
+        examples: [],
+      });
+    }
+    const target = grouped.get(key)!;
+    target.count += 1;
+    if (sourceRowIndex >= 0 && target.sampleRows.length < 5) target.sampleRows.push(sourceRowIndex + 1);
+    if (sampleValue && target.sampleValues.length < 5) target.sampleValues.push(sampleValue);
+    if (target.examples.length < 3) target.examples.push({ summary: item.summary, details });
+  }
+
+  return Array.from(grouped.values())
+    .sort((a, b) => b.count - a.count)
+    .map((group) => ({
+      id: `${group.domain}:${group.issue_type}:${group.severity}`,
+      severity: group.severity,
+      domain: group.domain,
+      issue_type: group.issue_type,
+      summary: `${group.count.toLocaleString()} ${group.domain} rows: ${group.issue_type.replace(/_/g, " ")}`,
+      count: group.count,
+      sampleRowIndexes: group.sampleRows,
+      sampleNormalizedValues: topExamples(group.sampleValues),
+      recommended_action: "Review examples, adjust mappings where needed, then rerun analysis.",
+      details: { examples: group.examples },
+    }));
+}
+
+export function buildOnboardingSummary(input: {
+  filesCount: number;
+  rowsParsed: number;
+  entityRows: Array<{ entity_type: string }>;
+  linkRows: Array<{ link_type: string }>;
+  reviewRows: PendingReviewItem[];
+  groupedExceptionCount?: number;
+  activationReadiness?: string;
+}) {
+  const entityCounts = ENTITY_BUCKETS.reduce<Record<string, number>>((acc, key) => {
+    acc[key] = 0;
     return acc;
   }, {});
+  for (const row of input.entityRows) entityCounts[row.entity_type] = (entityCounts[row.entity_type] ?? 0) + 1;
+
+  const linkCounts = LINK_BUCKETS.reduce<Record<string, number>>((acc, key) => {
+    acc[key] = 0;
+    return acc;
+  }, {});
+  for (const row of input.linkRows) linkCounts[row.link_type] = (linkCounts[row.link_type] ?? 0) + 1;
+
+  const pending = input.reviewRows.filter((row) => !row.status || row.status === "pending");
+  const reviewCountsByDomain: Record<string, number> = {};
+  const reviewCountsBySeverity: Record<string, number> = { blocking: 0, high: 0, medium: 0, low: 0 };
+  for (const row of pending) {
+    reviewCountsBySeverity[row.severity] = (reviewCountsBySeverity[row.severity] ?? 0) + 1;
+    const domain = row.domain ?? "unknown";
+    reviewCountsByDomain[domain] = (reviewCountsByDomain[domain] ?? 0) + 1;
+  }
+
+  const totalEntities = Object.values(entityCounts).reduce((sum, count) => sum + count, 0);
+  const totalLinks = Object.values(linkCounts).reduce((sum, count) => sum + count, 0);
+  const totalReviewItems = Object.values(reviewCountsBySeverity).reduce((sum, count) => sum + count, 0);
+
+  return {
+    files_count: input.filesCount,
+    rows_parsed: input.rowsParsed,
+    total_entities: totalEntities,
+    entity_counts_by_type: entityCounts,
+    total_links: totalLinks,
+    link_counts_by_type: linkCounts,
+    total_review_items: totalReviewItems,
+    review_counts_by_domain: reviewCountsByDomain,
+    review_counts_by_severity: reviewCountsBySeverity,
+    grouped_exception_count: input.groupedExceptionCount ?? 0,
+    activation_readiness: input.activationReadiness ?? "review_required",
+    liveRecordsCreated: 0 as const,
+  };
 }

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -5,8 +5,25 @@ import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprin
 import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
 import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
-import { makeReviewItem, markDuplicateEntities, stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { markDuplicateEntities, stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+
+const INSERT_CHUNK_SIZE = 1000;
+
+async function insertInChunks(sb: any, table: string, rows: any[], returning?: string) {
+  if (!rows.length) return [];
+  const output: any[] = [];
+  for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
+    let query = sb.from(table).insert(chunk);
+    if (returning) query = query.select(returning);
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+    if (Array.isArray(data)) output.push(...data);
+  }
+  return output;
+}
 
 export async function analyzeOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
@@ -26,7 +43,6 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
 
   await sb.from("onboarding_sessions").update({ status: "analyzing" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
 
-  // Analyze is intentionally repeatable. We clear only staged analysis artifacts and recreate them.
   await sb.from("onboarding_raw_rows").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
   await sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
   await sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
@@ -39,16 +55,13 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
   for (const file of files ?? []) {
     const dl = await sb.storage.from(file.storage_bucket).download(file.storage_path);
     if (dl.error || !dl.data) {
-      reviewItems.push(
-        makeReviewItem({
-          shopId: params.shopId,
-          sessionId: params.sessionId,
-          severity: "blocking",
-          domain: "unknown",
-          issueType: "parse_error",
-          summary: `Failed to read ${file.original_filename ?? file.storage_path}`,
-        }),
-      );
+      reviewItems.push({
+        severity: "blocking",
+        domain: "unknown",
+        issue_type: "parse_error",
+        summary: `Failed to read ${file.original_filename ?? file.storage_path}`,
+        details: {},
+      });
       const { error: updateError } = await sb
         .from("onboarding_files")
         .update({ parse_status: "failed", parse_error: dl.error?.message ?? "download failed" })
@@ -79,12 +92,7 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       parse_status: "parsed",
     }));
 
-    const { data: rawRows, error: rawRowsError } = await sb
-      .from("onboarding_raw_rows")
-      .insert(rawRowsPayload)
-      .select("id, source_row_index");
-    if (rawRowsError) throw new Error(rawRowsError.message);
-
+    const rawRows = await insertInChunks(sb, "onboarding_raw_rows", rawRowsPayload, "id, source_row_index");
     const rawRowsByIndex = new Map<number, string>((rawRows ?? []).map((row: any) => [Number(row.source_row_index), row.id]));
 
     parsed.rows.forEach((row, index) => {
@@ -103,7 +111,7 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       });
 
       if (staged.entity) stagedEntities.push(staged.entity);
-      reviewItems.push(...staged.reviewItems);
+      reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
     });
 
     const { error: fileUpdateError } = await sb
@@ -112,63 +120,69 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       .eq("id", file.id)
       .eq("shop_id", params.shopId);
     if (fileUpdateError) throw new Error(fileUpdateError.message);
-
-    if (detectedDomain === "unknown") {
-      reviewItems.push(
-        makeReviewItem({
-          shopId: params.shopId,
-          sessionId: params.sessionId,
-          severity: "medium",
-          domain: "unknown",
-          issueType: "unsupported_file",
-          summary: `Unsupported file type for ${file.original_filename ?? file.storage_path}`,
-        }),
-      );
-    }
   }
 
-  reviewItems.push(...markDuplicateEntities(stagedEntities, { shopId: params.shopId, sessionId: params.sessionId }));
+  reviewItems.push(...markDuplicateEntities(stagedEntities, { shopId: params.shopId, sessionId: params.sessionId }).map((item) => ({
+    severity: item.severity,
+    domain: item.domain,
+    issue_type: item.issue_type,
+    summary: item.summary,
+    details: item.details,
+  })));
 
-  let entities: Array<{ id: string; entity_type: string; normalized: Record<string, unknown>; display_name?: string | null; source_external_id?: string | null }> = [];
-  if (stagedEntities.length) {
-    const { data: insertedEntities, error: entitiesError } = await sb
-      .from("onboarding_entities")
-      .insert(stagedEntities)
-      .select("id, entity_type, normalized, display_name, source_external_id");
-    if (entitiesError) throw new Error(entitiesError.message);
-    entities = insertedEntities ?? [];
-  }
+  const entities = await insertInChunks(sb, "onboarding_entities", stagedEntities, "id, entity_type, normalized, display_name, source_external_id");
 
-  const graph = buildStagedLinks({ entities: entities.map((e) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
-  reviewItems.push(...graph.reviewItems);
+  const graph = buildStagedLinks({ entities: entities.map((e: any) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
+  reviewItems.push(...graph.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
 
-  if (graph.links.length) {
-    const { error: linksError } = await sb
-      .from("onboarding_entity_links")
-      .insert(graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId })));
-    if (linksError) throw new Error(linksError.message);
-  }
+  const linksToInsert = graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId }));
+  await insertInChunks(sb, "onboarding_entity_links", linksToInsert);
 
-  if (reviewItems.length) {
-    const { error: reviewError } = await sb.from("onboarding_review_items").insert(reviewItems);
-    if (reviewError) throw new Error(reviewError.message);
-  }
+  const groupedReviewItems = groupReviewItems(reviewItems as any).map((item) => ({
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+    entity_id: null,
+    severity: item.severity,
+    domain: item.domain,
+    issue_type: item.issue_type,
+    summary: item.summary,
+    details: {
+      count: item.count,
+      sampleRowIndexes: item.sampleRowIndexes,
+      sampleNormalizedValues: item.sampleNormalizedValues,
+      recommendedAction: item.recommended_action,
+      ...item.details,
+    },
+    status: "pending",
+  }));
+  await insertInChunks(sb, "onboarding_review_items", groupedReviewItems);
 
-  const blockingCount = reviewItems.filter((item) => item.severity === "blocking").length;
+  const blockingCount = groupedReviewItems.filter((item) => item.severity === "blocking").length;
   const status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
 
-  const summary = {
-    fileCount: (files ?? []).length,
+  const canonical = buildOnboardingSummary({
+    filesCount: (files ?? []).length,
     rowsParsed: totalRows,
-    entitiesDiscovered: entities.length,
-    linksFound: graph.links.length,
-    reviewExceptions: reviewItems.length,
+    entityRows: (entities ?? []).map((e: any) => ({ entity_type: e.entity_type })),
+    linkRows: graph.links.map((l) => ({ link_type: l.link_type })),
+    reviewRows: groupedReviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details, status: item.status })),
+    groupedExceptionCount: groupedReviewItems.length,
+    activationReadiness: blockingCount > 0 ? "review_required" : "ready_for_dry_run",
+  });
+
+  const summary = {
+    fileCount: canonical.files_count,
+    rowsParsed: canonical.rows_parsed,
+    entitiesDiscovered: canonical.total_entities,
+    linksFound: canonical.total_links,
+    reviewExceptions: canonical.total_review_items,
+    groupedExceptionCount: canonical.grouped_exception_count,
     liveRecordsCreated: 0 as const,
   };
 
   await sb
     .from("onboarding_sessions")
-    .update({ status, analyzed_at: new Date().toISOString(), summary, stats: summary })
+    .update({ status, analyzed_at: new Date().toISOString(), summary, stats: canonical })
     .eq("id", params.sessionId)
     .eq("shop_id", params.shopId);
 

--- a/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
+++ b/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildDryRunActivationPlan } from "@/features/onboarding-agent/lib/activationPlan";
+import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 
 export async function buildOnboardingActivationPlan(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
@@ -26,8 +27,15 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
     return acc;
   }, {});
 
-  const blocking = (reviewRows ?? []).filter((row: any) => row.severity === "blocking").length;
-  const nonblocking = (reviewRows ?? []).length - blocking;
+  const canonical = buildOnboardingSummary({
+    filesCount: 0,
+    rowsParsed: 0,
+    entityRows: (entityRows ?? []).map((row: any) => ({ entity_type: row.entity_type })),
+    linkRows: (linkRows ?? []).map((row: any) => ({ link_type: row.link_type })),
+    reviewRows: (reviewRows ?? []).map((row: any) => ({ severity: row.severity, summary: "", status: "pending" })),
+  });
+  const blocking = canonical.review_counts_by_severity.blocking ?? 0;
+  const nonblocking = canonical.total_review_items - blocking;
 
   const plan = buildDryRunActivationPlan({
     sessionId: params.sessionId,

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -1,20 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildOnboardingSummary, ENTITY_BUCKETS, LINK_BUCKETS } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
-
-const ENTITY_BUCKETS = [
-  "customer",
-  "vehicle",
-  "historical_work_order",
-  "historical_invoice",
-  "part",
-  "vendor",
-  "staff_candidate",
-  "menu_suggestion",
-  "inspection_suggestion",
-  "unknown",
-] as const;
-
-const LINK_BUCKETS = ["customer_vehicle", "customer_work_order", "vehicle_work_order", "work_order_invoice", "vendor_part"] as const;
 
 export async function getOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
@@ -38,44 +24,41 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
   ]);
 
+  const rowsParsedFromFiles = (files ?? []).reduce((sum: number, file: any) => sum + Number(file.row_count ?? 0), 0);
+  const canonical = buildOnboardingSummary({
+    filesCount: (files ?? []).length,
+    rowsParsed: rowsParsedFromFiles,
+    entityRows: (entities ?? []).map((row: any) => ({ entity_type: row.entity_type })),
+    linkRows: (links ?? []).map((row: any) => ({ link_type: row.link_type })),
+    reviewRows: (reviews ?? []).map((row: any) => ({
+      id: row.id,
+      severity: row.severity,
+      status: row.status,
+      domain: row.domain,
+      issue_type: row.issue_type,
+      summary: row.summary,
+      details: row.details ?? {},
+    })),
+    groupedExceptionCount: (reviews ?? []).length,
+    activationReadiness: ((session?.stats ?? {}) as Record<string, unknown>).activation_readiness as string | undefined,
+  });
+
   const entityCounts = ENTITY_BUCKETS.reduce<Record<string, number>>((acc, key) => {
-    acc[key] = 0;
+    acc[key] = canonical.entity_counts_by_type[key] ?? 0;
     return acc;
   }, {});
-  for (const row of entities ?? []) {
-    entityCounts[row.entity_type] = (entityCounts[row.entity_type] ?? 0) + 1;
-  }
+  const linkCounts = LINK_BUCKETS.reduce<Record<string, number>>((acc, key) => {
+    acc[key] = canonical.link_counts_by_type[key] ?? 0;
+    return acc;
+  }, {});
 
   const reviewCounts = {
-    blocking: 0,
-    high: 0,
-    medium: 0,
-    low: 0,
-    byDomain: {} as Record<string, number>,
+    blocking: canonical.review_counts_by_severity.blocking ?? 0,
+    high: canonical.review_counts_by_severity.high ?? 0,
+    medium: canonical.review_counts_by_severity.medium ?? 0,
+    low: canonical.review_counts_by_severity.low ?? 0,
+    byDomain: canonical.review_counts_by_domain,
   };
-  for (const row of reviews ?? []) {
-    if (row.status !== "pending") continue;
-    if (row.severity === "blocking") reviewCounts.blocking += 1;
-    if (row.severity === "high") reviewCounts.high += 1;
-    if (row.severity === "medium") reviewCounts.medium += 1;
-    if (row.severity === "low") reviewCounts.low += 1;
-    const domain = row.domain ?? "unknown";
-    reviewCounts.byDomain[domain] = (reviewCounts.byDomain[domain] ?? 0) + 1;
-  }
-
-  const linkCounts = LINK_BUCKETS.reduce<Record<string, number>>((acc, key) => {
-    acc[key] = 0;
-    return acc;
-  }, {});
-  for (const row of links ?? []) {
-    linkCounts[row.link_type] = (linkCounts[row.link_type] ?? 0) + 1;
-  }
-
-  const uploadedFiles = (files ?? []).length;
-  const rowsParsedFromFiles = (files ?? []).reduce((sum: number, file: any) => sum + Number(file.row_count ?? 0), 0);
-  const entitiesDiscovered = Object.values(entityCounts).reduce((sum, count) => sum + count, 0);
-  const linksFound = Object.values(linkCounts).reduce((sum, count) => sum + count, 0);
-  const reviewExceptions = reviewCounts.blocking + reviewCounts.high + reviewCounts.medium + reviewCounts.low;
 
   return {
     session,
@@ -86,11 +69,12 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     linkCounts,
     latestPlan,
     summaryCounts: {
-      uploadedFiles,
-      rowsParsed: rowsParsedFromFiles,
-      entitiesDiscovered,
-      linksFound,
-      reviewExceptions,
+      uploadedFiles: canonical.files_count,
+      rowsParsed: canonical.rows_parsed,
+      entitiesDiscovered: canonical.total_entities,
+      linksFound: canonical.total_links,
+      reviewExceptions: canonical.total_review_items,
+      groupedExceptionCount: canonical.grouped_exception_count,
       liveRecordsCreated: 0 as const,
     },
   };

--- a/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
+++ b/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
@@ -28,7 +28,7 @@ const VALID_ACTION_TYPES = new Set([
   "ignore_row",
   "prepare_activation",
 ]);
-const VALID_READINESS = new Set(["not_ready", "empty", "review_required", "ready_for_dry_run", "ready_for_activation_later"]);
+const VALID_READINESS = new Set(["not_ready", "empty", "review_required", "ready_for_dry_run", "activation_disabled"]);
 const VALID_DOMAINS = new Set<string>([...ONBOARDING_DOMAINS, "all"]);
 
 function stripJsonFences(raw: string) {
@@ -79,9 +79,18 @@ function buildActivationReadiness(input: OnboardingAgentInput) {
     };
   }
 
+  if (rowsParsed === 0) {
+    return {
+      status: "empty" as const,
+      blockers: [],
+      warnings: ["Upload one or more CSV files to stage onboarding data."],
+      safeToProceed: false,
+    };
+  }
+
   if (blockingItems.length > 0) {
     return {
-      status: "not_ready" as const,
+      status: "review_required" as const,
       blockers: blockingItems.map((item) => item.summary),
       warnings: warningItems.map((item) => item.summary),
       safeToProceed: false,
@@ -90,7 +99,7 @@ function buildActivationReadiness(input: OnboardingAgentInput) {
 
   if (warningItems.length > 0) {
     return {
-      status: "review_required" as const,
+      status: "ready_for_dry_run" as const,
       blockers: [],
       warnings: warningItems.map((item) => item.summary),
       safeToProceed: true,
@@ -98,7 +107,7 @@ function buildActivationReadiness(input: OnboardingAgentInput) {
   }
 
   return {
-    status: "ready_for_dry_run" as const,
+    status: "activation_disabled" as const,
     blockers: [],
     warnings: ["Activation remains disabled in this phase; dry-run only."],
     safeToProceed: true,
@@ -137,6 +146,7 @@ export function buildDeterministicFallbackReport(input: OnboardingAgentInput): O
   const stagedParts = Number(input.deterministicStagedEntityCounts.part ?? 0);
   const stagedVendors = Number(input.deterministicStagedEntityCounts.vendor ?? 0);
   const stagedStaff = Number(input.deterministicStagedEntityCounts.staff_candidate ?? 0);
+  const stagedMenu = Number(input.deterministicStagedEntityCounts.menu_suggestion ?? 0);
   const confidentLinks = Object.values(input.deterministicLinkCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
 
   const findings: OnboardingAgentFinding[] = [
@@ -186,14 +196,14 @@ export function buildDeterministicFallbackReport(input: OnboardingAgentInput): O
         ? "Blocking staged issues are preventing readiness. Resolve exceptions first."
         : "Data is ready for dry-run planning. Activation stays disabled in this phase.",
       riskLevel: blockingCount > 0 ? "high" : "low",
-      affectedRowIds: input.deterministicReviewItems.map((item) => item.id),
+      affectedRowIds: input.deterministicReviewItems.slice(0, 20).map((item) => item.id),
     },
   ];
 
   return {
     model: getOnboardingAgentModel(),
     mode: "deterministic_fallback",
-    summary: `Staged onboarding analysis completed. Files: ${input.files.length}, rows: ${rowsParsed}, customers: ${stagedCustomers}, vehicles: ${stagedVehicles}, historical work orders: ${stagedWorkOrders}, historical invoices: ${stagedInvoices}, parts: ${stagedParts}, vendors: ${stagedVendors}, staff candidates: ${stagedStaff}, confident links: ${confidentLinks}, review exceptions: ${input.deterministicReviewItems.length}. No live records have been created.`,
+    summary: `Staged onboarding analysis completed. Files: ${input.files.length}, rows: ${rowsParsed}, customers: ${stagedCustomers}, vehicles: ${stagedVehicles}, historical work orders: ${stagedWorkOrders}, historical invoices: ${stagedInvoices}, parts: ${stagedParts}, vendors: ${stagedVendors}, staff candidates: ${stagedStaff}, menu suggestions: ${stagedMenu}, confident links: ${confidentLinks}, review exceptions: ${input.deterministicReviewItems.length}. No live records have been created.`,
     domainSummaries,
     findings,
     recommendations,


### PR DESCRIPTION
### Motivation
- The staged onboarding analysis was producing inconsistent, owner-unfriendly results (wrong domain detection, undercounted/stubbed staged entities, link gaps, and noisy per-row review spam) and UI surfaces were showing raw JSON and mismatched counts. This change makes staged analysis truthful, domain-aware, and owner-readable while preserving staged-only safety.

### Description
- Improved domain detection using filename hints + header scoring to prioritize obvious filenames (e.g., `vendors`, `staff_users`, `vehicles`, `invoices`, `work_orders_history`, `service_catalog`) and reduced menu-vs-parts misclassification (edited `lib/domains.ts`).
- Expanded normalization and staging rules to reliably produce the expected staged entity types and identity checks (customers, vehicles, historical_work_orders, historical_invoices, parts, vendors, staff_candidates, menu_suggestions) and moved to an explicit domain→entity_type mapping (edited `lib/normalization.ts`, `lib/staging.ts`).
- Broadened staged link generation with multi-strategy matching and confidence/evidence, supporting `customer_vehicle`, `customer_work_order`, `vehicle_work_order`, `work_order_invoice`, `vendor_part`, and a `service_menu_suggestion` placeholder, and improved low-confidence handling (edited `lib/graph.ts`, `lib/fingerprints.ts`).
- Replaced noisy row-level review items with grouped, actionable exceptions that include counts, sample rows, examples and recommended actions; review grouping and canonical summary building were added and made the single source of truth for counts (new/edited `lib/summaries.ts`, `server/analyzeOnboardingSession.ts`).
- Reworked analysis insertion to safe chunked inserts/batching for raw rows, entities, links, and review items to protect performance on ~20k-row datasets (edited `server/analyzeOnboardingSession.ts`).
- Unified session payload/summary calculations so the progress card, entities panel, agent insights, and activation-plan dry-run all use the same canonical summary (edited `server/getOnboardingSession.ts`, `server/buildOnboardingActivationPlan.ts`, `server/runOnboardingAgentAnalysis.ts`).
- Improved owner-facing UI: grouped review exceptions panel, human-readable dry-run activation plan (with explicit “activation disabled / no live records” messaging and collapsed developer JSON), and entity/link rows updated (edited `components/OnboardingReviewPanel.tsx`, `OnboardingActivationPlanPanel.tsx`, `OnboardingEntitiesPanel.tsx`, `OnboardingAgentInsightsPanel.tsx`).
- Kept safety/tenancy rules intact: all server routes remain owner/admin-scoped, `shop_id`/`session_id` filters preserved, and `liveRecordsCreated` remains pinned to `0` across reports (no live records created).

### Testing
- Typecheck: `npx tsc --noEmit` — passed (no type errors).
- Lint: `npx eslint <onboarding files...>` — ran targeted ESLint on changed files; result: warnings only (no errors) for `no-explicit-any` and a couple of hook/warnings.
- Unit tests: ran focused onboarding tests with Vitest and all tests passed:
  - `npx vitest run features/onboarding-agent/lib/onboarding-agent.test.ts` — passed
  - `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts` — passed (readiness semantics updated)
  - `npx vitest run features/onboarding-agent/lib/uploadOnboardingFiles.test.ts` — passed
  - `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts` — passed (staging and link coverage expanded)
- Full build: `pnpm build` — failed in this environment due to external Google Fonts fetch errors (failed to fetch `Inter` / `Black Ops One`); this is a network/font fetch issue and not caused by code logic.

Notes/limitations: ESLint warnings remain (no-explicit-any / react-hooks reminders) but are non-blocking; I did not run a live re-analysis against your tenant dataset in this environment, so numeric “after” totals are what the code will produce (expected) rather than captured screenshot outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee71c36e083289dec56d663fd5afe)