### PR TITLE
Fix onboarding agent staged summary consistency and dry-run readiness

### DIFF
--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -6,14 +6,9 @@ function num(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-export function OnboardingActivationPlanPanel({ latestPlan }: { latestPlan?: Record<string, unknown> | null }) {
+export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary }: { latestPlan?: Record<string, unknown> | null; fallbackSummary?: Record<string, unknown> | null }) {
   const [showDevDetails, setShowDevDetails] = useState(false);
-  const summary = (latestPlan?.summary ?? latestPlan ?? {}) as Record<string, any>;
-  const creates = (summary.creates ?? summary.plan?.creates ?? {}) as Record<string, unknown>;
-  const links = (summary.links ?? summary.plan?.links ?? {}) as Record<string, unknown>;
-  const review = (summary.review ?? summary.plan?.review ?? {}) as Record<string, unknown>;
-  const blocking = num(review.blocking);
-  const nonblocking = num(review.nonblocking);
+  const summary = (latestPlan?.summary ?? latestPlan ?? fallbackSummary ?? {}) as Record<string, any>;
 
   return (
     <div className="rounded-2xl border border-amber-500/30 bg-amber-950/20 p-4">
@@ -22,18 +17,19 @@ export function OnboardingActivationPlanPanel({ latestPlan }: { latestPlan?: Rec
       <p className="text-xs text-amber-200/80">No live records have been created.</p>
       <p className="text-xs text-amber-200/80">This plan is a preview only.</p>
 
-      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3 text-sm">
-        <div>Customers ready: <span className="font-semibold text-white">{num(creates.customers)}</span></div>
-        <div>Vehicles ready: <span className="font-semibold text-white">{num(creates.vehicles)}</span></div>
-        <div>Historical work orders ready: <span className="font-semibold text-white">{num(creates.historicalWorkOrders)}</span></div>
-        <div>Historical invoices ready: <span className="font-semibold text-white">{num(creates.historicalInvoices)}</span></div>
-        <div>Parts ready: <span className="font-semibold text-white">{num(creates.parts)}</span></div>
-        <div>Vendors ready: <span className="font-semibold text-white">{num(creates.vendors)}</span></div>
-        <div>Staff candidates ready: <span className="font-semibold text-white">{num(creates.staffCandidates)}</span></div>
-        <div>Menu suggestions ready: <span className="font-semibold text-white">{num(creates.menuSuggestions)}</span></div>
-        <div>Links ready: <span className="font-semibold text-white">{num(links.customerVehicle) + num(links.vehicleWorkOrder) + num(links.workOrderInvoice)}</span></div>
-        <div>Blocking issues: <span className="font-semibold text-white">{blocking}</span></div>
-        <div>Review needed: <span className="font-semibold text-white">{nonblocking}</span></div>
+      <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
+        <div>Customers ready: <span className="font-semibold text-white">{num(summary.customersReady)}</span></div>
+        <div>Vehicles ready: <span className="font-semibold text-white">{num(summary.vehiclesReady)}</span></div>
+        <div>Historical work orders ready: <span className="font-semibold text-white">{num(summary.historicalWorkOrdersReady)}</span></div>
+        <div>Historical invoices ready: <span className="font-semibold text-white">{num(summary.historicalInvoicesReady)}</span></div>
+        <div>Parts ready: <span className="font-semibold text-white">{num(summary.partsReady)}</span></div>
+        <div>Vendors ready: <span className="font-semibold text-white">{num(summary.vendorsReady)}</span></div>
+        <div>Staff candidates ready: <span className="font-semibold text-white">{num(summary.staffCandidatesReady)}</span></div>
+        <div>Menu suggestions ready: <span className="font-semibold text-white">{num(summary.menuSuggestionsReady)}</span></div>
+        <div>Inspection suggestions ready: <span className="font-semibold text-white">{num(summary.inspectionSuggestionsReady)}</span></div>
+        <div>Links ready: <span className="font-semibold text-white">{num(summary.linksReady)}</span></div>
+        <div>Blocking issues: <span className="font-semibold text-white">{num(summary.blockingIssues)}</span></div>
+        <div>Review needed: <span className="font-semibold text-white">{num(summary.reviewNeeded)}</span></div>
       </div>
 
       <button
@@ -43,7 +39,7 @@ export function OnboardingActivationPlanPanel({ latestPlan }: { latestPlan?: Rec
         {showDevDetails ? "Hide" : "Show"} developer details
       </button>
       {showDevDetails ? (
-        <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify(latestPlan ?? { status: "not_prepared" }, null, 2)}</pre>
+        <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify(latestPlan ?? summary ?? { status: "not_prepared" }, null, 2)}</pre>
       ) : null}
     </div>
   );

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -3,8 +3,8 @@
 import { useMemo, useState } from "react";
 import type { OnboardingAgentReport } from "@/features/onboarding-agent/lib/agentTypes";
 
-function readinessTone(status: OnboardingAgentReport["activationReadiness"]["status"] | undefined) {
-  if (status === "ready_for_dry_run" || status === "activation_disabled") return "border-emerald-400/40 text-emerald-200";
+function readinessTone(status: OnboardingAgentReport["activationReadiness"]["status"] | string | undefined) {
+  if (status === "ready_for_dry_run") return "border-emerald-400/40 text-emerald-200";
   if (status === "review_required") return "border-amber-400/40 text-amber-200";
   return "border-rose-400/40 text-rose-200";
 }
@@ -13,13 +13,16 @@ export function OnboardingAgentInsightsPanel({
   sessionId,
   report,
   onRefresh,
+  fallbackReadiness,
 }: {
   sessionId: string;
   report?: OnboardingAgentReport | null;
+  fallbackReadiness?: string;
   onRefresh: () => Promise<void>;
 }) {
   const [running, setRunning] = useState(false);
   const findings = report?.findings ?? [];
+  const displayedReadiness = report?.activationReadiness?.status ?? fallbackReadiness ?? "not_ready";
   const recommendations = report?.recommendations ?? [];
 
   const groupedFindings = useMemo(() => {
@@ -71,9 +74,9 @@ export function OnboardingAgentInsightsPanel({
             <p className="mt-1 text-xs text-amber-200/90">AI reasoning unavailable; deterministic staging still completed.</p>
           ) : null}
         </div>
-        <div className={`rounded-lg border bg-slate-900/50 p-3 ${readinessTone(report?.activationReadiness?.status)}`}>
+        <div className={`rounded-lg border bg-slate-900/50 p-3 ${readinessTone(displayedReadiness)}`}>
           <p className="text-[11px] uppercase tracking-wide text-slate-400">Activation readiness</p>
-          <p className="text-sm">{report?.activationReadiness?.status ?? "not_ready"}</p>
+          <p className="text-sm">{displayedReadiness}</p>
         </div>
       </div>
 

--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -8,7 +8,6 @@ const ENTITY_ROWS: Array<{ key: string; label: string }> = [
   { key: "staff_candidate", label: "Staff candidates" },
   { key: "menu_suggestion", label: "Menu suggestions" },
   { key: "inspection_suggestion", label: "Inspection suggestions" },
-  { key: "unknown", label: "Unknown" },
 ];
 
 const LINK_ROWS: Array<{ key: string; label: string }> = [
@@ -20,7 +19,15 @@ const LINK_ROWS: Array<{ key: string; label: string }> = [
   { key: "service_menu_suggestion", label: "Service ↔ Menu suggestion" },
 ];
 
-export function OnboardingEntitiesPanel({ entityCounts, linkCounts }: { entityCounts: Record<string, number>; linkCounts: Record<string, number> }) {
+export function OnboardingEntitiesPanel({
+  entityCounts,
+  entityStatusCounts,
+  linkCounts,
+}: {
+  entityCounts: Record<string, number>;
+  entityStatusCounts: Record<string, Record<string, number>>;
+  linkCounts: Record<string, number>;
+}) {
   return (
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <h3 className="text-sm font-semibold text-white">Staged entities & links</h3>
@@ -28,12 +35,18 @@ export function OnboardingEntitiesPanel({ entityCounts, linkCounts }: { entityCo
         <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
           <p className="text-xs uppercase tracking-wide text-slate-400">Entities discovered</p>
           <ul className="mt-2 space-y-1 text-sm text-slate-200">
-            {ENTITY_ROWS.map((item) => (
-              <li key={item.key} className="flex items-center justify-between gap-2">
-                <span>{item.label}</span>
-                <span className="font-semibold text-white">{entityCounts[item.key] ?? 0}</span>
-              </li>
-            ))}
+            {ENTITY_ROWS.map((item) => {
+              const status = entityStatusCounts[item.key] ?? {};
+              return (
+                <li key={item.key} className="rounded border border-white/5 px-2 py-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <span>{item.label}</span>
+                    <span className="font-semibold text-white">{entityCounts[item.key] ?? 0}</span>
+                  </div>
+                  <p className="text-[11px] text-slate-400">ready: {status.ready ?? 0} • review: {(status.needs_review ?? 0) + (status.duplicate_candidate ?? 0)}</p>
+                </li>
+              );
+            })}
           </ul>
         </div>
 
@@ -41,7 +54,7 @@ export function OnboardingEntitiesPanel({ entityCounts, linkCounts }: { entityCo
           <p className="text-xs uppercase tracking-wide text-slate-400">Links found</p>
           <ul className="mt-2 space-y-1 text-sm text-slate-200">
             {LINK_ROWS.map((item) => (
-              <li key={item.key} className="flex items-center justify-between gap-2">
+              <li key={item.key} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1">
                 <span>{item.label}</span>
                 <span className="font-semibold text-white">{linkCounts[item.key] ?? 0}</span>
               </li>

--- a/features/onboarding-agent/components/OnboardingProgressCard.tsx
+++ b/features/onboarding-agent/components/OnboardingProgressCard.tsx
@@ -1,6 +1,6 @@
 export function OnboardingProgressCard({ summary }: { summary?: Record<string, unknown> | null }) {
   const rows = [
-    ["Uploaded files", String((summary?.fileCount as number) ?? 0)],
+    ["Uploaded files", String((summary?.uploadedFiles as number) ?? (summary?.fileCount as number) ?? 0)],
     ["Rows parsed", String((summary?.rowsParsed as number) ?? 0)],
     ["Entities discovered", String((summary?.entitiesDiscovered as number) ?? 0)],
     ["Links found", String((summary?.linksFound as number) ?? 0)],
@@ -11,6 +11,7 @@ export function OnboardingProgressCard({ summary }: { summary?: Record<string, u
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <h3 className="text-sm font-semibold text-white">Onboarding progress</h3>
       <p className="mt-1 text-xs text-cyan-100/80">Uploaded files are staged as information. No live records are created in this phase.</p>
+      <p className="mt-1 text-xs text-slate-300">Readiness: {String(summary?.activationReadiness ?? "not_ready")}</p>
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
         {rows.map(([label, value]) => (
           <div key={label} className="rounded-lg border border-white/10 bg-slate-900/60 px-3 py-2">

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -127,12 +127,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       </div>
 
       <OnboardingProgressCard summary={session?.summary ?? null} />
-      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} onRefresh={load} />
+      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} onRefresh={load} />
       <OnboardingFilesPanel files={files} />
-      <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
+      <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
       <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
 
-      <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} />
+      <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} />
     </div>
   );
 }

--- a/features/onboarding-agent/lib/activationPlan.ts
+++ b/features/onboarding-agent/lib/activationPlan.ts
@@ -1,39 +1,27 @@
+import { buildActivationPlanSummary } from "@/features/onboarding-agent/lib/summaries";
+
 export function buildDryRunActivationPlan(input: {
   sessionId: string;
-  entityCounts: Record<string, number>;
-  linkCounts: Record<string, number>;
-  reviewBlocking: number;
-  reviewNonBlocking: number;
+  entityStatusCountsByType: Record<string, Record<string, number>>;
+  linkRows: Array<{ link_type: string; status?: string | null }>;
+  reviewCountsBySeverity: Record<string, number>;
 }) {
+  const summary = buildActivationPlanSummary({
+    entityStatusCountsByType: input.entityStatusCountsByType,
+    linkRows: input.linkRows,
+    reviewCountsBySeverity: input.reviewCountsBySeverity,
+  });
+
   const risks: string[] = [];
-  if (input.reviewBlocking > 0) risks.push(`${input.reviewBlocking} blocking review items must be resolved before activation.`);
-  if ((input.entityCounts.historical_invoice ?? 0) > 0 && (input.linkCounts.work_order_invoice ?? 0) === 0) {
-    risks.push("Historical invoices have no work order links yet.");
+  if (summary.blockingIssues > 0) risks.push(`${summary.blockingIssues} high/blocking review items must be resolved before activation.`);
+  if (summary.historicalInvoicesReady > 0 && !input.linkRows.some((row) => row.link_type === "work_order_invoice")) {
+    risks.push("Historical invoices are staged but some work order links still need review.");
   }
 
   return {
     sessionId: input.sessionId,
-    mode: "dry_run",
-    creates: {
-      customers: input.entityCounts.customer ?? 0,
-      vehicles: input.entityCounts.vehicle ?? 0,
-      historicalWorkOrders: input.entityCounts.historical_work_order ?? 0,
-      historicalInvoices: input.entityCounts.historical_invoice ?? 0,
-      parts: input.entityCounts.part ?? 0,
-      vendors: input.entityCounts.vendor ?? 0,
-      staffCandidates: input.entityCounts.staff_candidate ?? 0,
-      menuSuggestions: input.entityCounts.menu_suggestion ?? 0,
-      inspectionSuggestions: input.entityCounts.inspection_suggestion ?? 0,
-    },
-    links: {
-      customerVehicle: input.linkCounts.customer_vehicle ?? 0,
-      vehicleWorkOrder: input.linkCounts.vehicle_work_order ?? 0,
-      workOrderInvoice: input.linkCounts.work_order_invoice ?? 0,
-    },
-    review: {
-      blocking: input.reviewBlocking,
-      nonblocking: input.reviewNonBlocking,
-    },
+    mode: "dry_run" as const,
+    ...summary,
     risks,
   };
 }

--- a/features/onboarding-agent/lib/agentTypes.ts
+++ b/features/onboarding-agent/lib/agentTypes.ts
@@ -33,7 +33,9 @@ export type OnboardingAgentInput = {
   }>;
   deterministicDomainDetections: Record<string, number>;
   deterministicStagedEntityCounts: Record<string, number>;
+  deterministicEntityStatusCountsByType: Record<string, Record<string, number>>;
   deterministicLinkCounts: Record<string, number>;
+  canonicalReadiness?: OnboardingAgentActivationStatus;
   deterministicReviewItems: Array<{
     id: string;
     severity: string;

--- a/features/onboarding-agent/lib/fingerprints.ts
+++ b/features/onboarding-agent/lib/fingerprints.ts
@@ -23,34 +23,53 @@ export function fingerprintForDomain(domain: OnboardingDomain, normalized: Recor
   }
 
   if (domain === "vehicles") {
+    const sourceVehicleId = text(normalized.sourceVehicleId);
+    if (sourceVehicleId) return `vehicle:source:${sourceVehicleId}`;
     const vin = text(normalized.vin).toUpperCase();
     if (vin) return `vehicle:vin:${vin}`;
     const plate = text(normalized.plate).toUpperCase();
     if (plate) return `vehicle:plate:${plate}`;
-    const sourceVehicleId = text(normalized.sourceVehicleId);
-    if (sourceVehicleId) return `vehicle:source:${sourceVehicleId}`;
     const unit = text(normalized.unitNumber);
     const customerId = text(normalized.sourceCustomerId);
     if (unit && customerId) return `vehicle:unit_customer:${unit}:${customerId}`;
+    const year = text(normalized.year);
+    const make = text(normalized.make);
+    const model = text(normalized.model);
+    if (year && make && model) return `vehicle:ymm:${year}:${make.toLowerCase()}:${model.toLowerCase()}`;
     return null;
   }
 
   if (domain === "history") {
     const sourceWorkOrderId = text(normalized.sourceWorkOrderId);
-    return sourceWorkOrderId ? `history:wo:${sourceWorkOrderId}` : null;
+    if (sourceWorkOrderId) return `history:wo:${sourceWorkOrderId}`;
+    const invoiceId = text(normalized.invoiceId);
+    if (invoiceId) return `history:invoice:${invoiceId}`;
+    const openedDate = text(normalized.openedDate);
+    const narrative = text(normalized.complaint) || text(normalized.correction) || text(normalized.serviceDescription);
+    const vin = text(normalized.vehicleVin).toUpperCase();
+    if (openedDate && narrative) return `history:date_text:${openedDate}:${narrative.toLowerCase().slice(0, 120)}`;
+    if (openedDate && vin) return `history:date_vin:${openedDate}:${vin}`;
+    return null;
   }
 
   if (domain === "invoices") {
     const invoice = text(normalized.invoiceNumber);
     if (invoice) return `invoice:number:${invoice}`;
     const sourceWorkOrderId = text(normalized.sourceWorkOrderId);
-    return sourceWorkOrderId ? `invoice:wo:${sourceWorkOrderId}` : null;
+    const invoiceDate = text(normalized.invoiceDate);
+    const totalRaw = text(normalized.totalRaw);
+    if (sourceWorkOrderId && invoiceDate) return `invoice:wo_date:${sourceWorkOrderId}:${invoiceDate}`;
+    if (sourceWorkOrderId) return `invoice:wo:${sourceWorkOrderId}`;
+    if (invoiceDate && totalRaw) return `invoice:date_total:${invoiceDate}:${totalRaw}`;
+    return null;
   }
 
   if (domain === "parts") {
     const sku = text(normalized.sku) || text(normalized.partNumber);
     if (sku) return `part:sku:${sku.toLowerCase()}`;
     const description = text(normalized.description) || text(normalized.name);
+    const vendor = text(normalized.vendorName);
+    if (description && vendor) return `part:vendor_desc:${vendor.toLowerCase()}:${description.toLowerCase()}`;
     return description ? `part:name:${description.toLowerCase()}` : null;
   }
 
@@ -78,7 +97,9 @@ export function fingerprintForDomain(domain: OnboardingDomain, normalized: Recor
     const serviceName = text(normalized.serviceName);
     if (serviceName) return `menu:name:${serviceName.toLowerCase()}`;
     const description = text(normalized.description);
-    return description ? `menu:description:${description.toLowerCase()}` : null;
+    const category = text(normalized.category);
+    if (description && category) return `menu:cat_desc:${category.toLowerCase()}:${description.toLowerCase().slice(0, 120)}`;
+    return description ? `menu:description:${description.toLowerCase().slice(0, 120)}` : null;
   }
 
   return null;

--- a/features/onboarding-agent/lib/graph.ts
+++ b/features/onboarding-agent/lib/graph.ts
@@ -46,6 +46,7 @@ export function buildStagedLinks(params: BuildLinksParams) {
   const vehiclesByUnit = new Map(vehicles.map((v) => [text(v.normalized.unitNumber).toUpperCase(), v]));
 
   const workOrdersBySourceId = new Map(workOrders.map((wo) => [text(wo.normalized.sourceWorkOrderId), wo]));
+  const workOrdersByInvoiceId = new Map(workOrders.map((wo) => [text(wo.normalized.invoiceId), wo]));
 
   const pushLink = (from: string, to: string, linkType: string, confidence: number, evidence: Record<string, unknown>) => {
     if (confidence < 0.6) return;
@@ -93,11 +94,11 @@ export function buildStagedLinks(params: BuildLinksParams) {
         makeReviewItem({
           shopId,
           sessionId,
-          severity: "high",
+          severity: "medium",
           domain: "vehicles",
           issueType: "missing_customer_link",
-          summary: "Vehicle could not be linked to customer",
-          details: { sourceCustomerId, customerEmail, customerPhone, customerName },
+          summary: "Vehicle identity staged but customer link is missing",
+          details: { sourceCustomerId, customerEmail, customerPhone, customerName, recommendedAction: "Provide customer identifier columns to improve vehicle linking." },
         }),
       );
       continue;
@@ -123,11 +124,11 @@ export function buildStagedLinks(params: BuildLinksParams) {
         makeReviewItem({
           shopId,
           sessionId,
-          severity: "high",
+          severity: "medium",
           domain: "history",
           issueType: "missing_customer_link",
-          summary: "Work order could not be linked to customer",
-          details: { sourceCustomerId, customerEmail, customerName },
+          summary: "Historical work order staged but customer link is missing",
+          details: { sourceCustomerId, customerEmail, customerName, recommendedAction: "Map customer identifiers in work order history for stronger linking." },
         }),
       );
     }
@@ -153,8 +154,8 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "medium",
           domain: "history",
           issueType: "missing_vehicle_link",
-          summary: "Work order could not be linked to vehicle",
-          details: { sourceVehicleId, vehicleVin, vehiclePlate, vehicleUnit },
+          summary: "Historical work order staged but vehicle link is missing",
+          details: { sourceVehicleId, vehicleVin, vehiclePlate, vehicleUnit, recommendedAction: "Map vehicle VIN, plate, or vehicle ID in work order history." },
         }),
       );
     }
@@ -162,9 +163,11 @@ export function buildStagedLinks(params: BuildLinksParams) {
 
   for (const invoice of invoices) {
     const sourceWorkOrderId = text(invoice.normalized.sourceWorkOrderId);
-    const workOrder = sourceWorkOrderId ? workOrdersBySourceId.get(sourceWorkOrderId) : undefined;
+    const invoiceNumber = text(invoice.normalized.invoiceNumber);
+    const workOrder = (sourceWorkOrderId ? workOrdersBySourceId.get(sourceWorkOrderId) : undefined)
+      || (invoiceNumber ? workOrdersByInvoiceId.get(invoiceNumber) : undefined);
     if (workOrder) {
-      pushLink(workOrder.id, invoice.id, "work_order_invoice", 0.95, { sourceWorkOrderId, matchStrategy: "source_id" });
+      pushLink(workOrder.id, invoice.id, "work_order_invoice", 0.95, { sourceWorkOrderId, invoiceNumber, matchStrategy: sourceWorkOrderId ? "source_id" : "invoice_number" });
     } else {
       reviewItems.push(
         makeReviewItem({
@@ -173,8 +176,8 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "high",
           domain: "invoices",
           issueType: "missing_work_order_link",
-          summary: "Invoice could not be linked to work order",
-          details: { sourceWorkOrderId },
+          summary: "Historical invoice staged but work order link is missing",
+          details: { sourceWorkOrderId, invoiceNumber, recommendedAction: "Include work order or repair order references in invoice data." },
         }),
       );
     }
@@ -194,15 +197,15 @@ export function buildStagedLinks(params: BuildLinksParams) {
           severity: "medium",
           domain: "parts",
           issueType: "missing_vendor_link",
-          summary: "Part is missing vendor match",
-          details: { vendorName },
+          summary: "Part staged but vendor link is missing",
+          details: { vendorName, recommendedAction: "Upload vendor master data or align vendor naming." },
         }),
       );
     }
   }
 
   for (const menu of menus) {
-    if (!text(menu.normalized.serviceName) && !text(menu.normalized.description)) {
+    if (!text(menu.normalized.serviceName) && !text(menu.normalized.description) && !text(menu.normalized.opCode)) {
       reviewItems.push(
         makeReviewItem({
           shopId,

--- a/features/onboarding-agent/lib/normalization.ts
+++ b/features/onboarding-agent/lib/normalization.ts
@@ -43,10 +43,12 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
     const make = value(row, ["make"]);
     const model = value(row, ["model"]);
     const vin = value(row, ["vin"]).toUpperCase().replace(/\s+/g, "");
+    const plate = value(row, ["plate", "license", "license plate"]).toUpperCase().replace(/\s+/g, "");
+    const unitNumber = value(row, ["unit", "unit number", "truck number"]);
 
     return {
       entityType: "vehicle",
-      displayName: `${year} ${make} ${model}`.trim() || vin || value(row, ["plate", "license"]),
+      displayName: `${year} ${make} ${model}`.trim() || vin || plate || unitNumber,
       normalized: {
         sourceVehicleId: value(row, ["vehicle id", "id", "external vehicle id"]),
         sourceCustomerId: value(row, ["customer id"]),
@@ -54,8 +56,8 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         customerEmail: value(row, ["customer email", "email"]),
         customerPhone: normalizePhone(value(row, ["customer phone", "phone"])),
         vin,
-        plate: value(row, ["plate", "license", "license plate"]).toUpperCase().replace(/\s+/g, ""),
-        unitNumber: value(row, ["unit", "unit number", "truck number"]),
+        plate,
+        unitNumber,
         year,
         make,
         model,
@@ -64,12 +66,18 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "history") {
+    const sourceWorkOrderId = value(row, ["work order", "ro id", "repair order", "ro number", "work order number"]);
+    const invoiceId = value(row, ["invoice id", "invoice number", "invoice"]);
+    const openedDate = value(row, ["opened", "opened date", "open date", "date", "service date"]);
+    const complaint = value(row, ["complaint", "description", "concern", "service text", "service performed"]);
+    const correction = value(row, ["correction", "resolution"]);
+
     return {
       entityType: "historical_work_order",
-      displayName: value(row, ["work order", "repair order", "ro", "ro id", "ro number"]),
+      displayName: sourceWorkOrderId || invoiceId || `${openedDate} ${complaint || correction}`.trim(),
       normalized: {
-        sourceWorkOrderId: value(row, ["work order", "ro id", "repair order", "ro number"]),
-        invoiceId: value(row, ["invoice id", "invoice number", "invoice"]),
+        sourceWorkOrderId,
+        invoiceId,
         sourceCustomerId: value(row, ["customer id"]),
         customerEmail: value(row, ["customer email", "email"]).toLowerCase(),
         customerName: value(row, ["customer name", "name"]),
@@ -77,11 +85,14 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         vehicleVin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
         vehiclePlate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
         vehicleUnitNumber: value(row, ["unit", "unit number"]),
-        complaint: value(row, ["complaint", "description", "concern"]),
+        complaint,
         cause: value(row, ["cause"]),
-        correction: value(row, ["correction", "resolution"]),
-        openedDate: value(row, ["opened", "opened date", "open date", "date"]),
+        correction,
+        serviceDescription: value(row, ["service", "service name", "line description", "service description"]),
+        openedDate,
         closedDate: value(row, ["closed", "completed date", "closed date"]),
+        laborRaw: value(row, ["labor", "labor total"]),
+        laborTotal: parseMoney(value(row, ["labor", "labor total"])),
         totalRaw: value(row, ["total", "amount"]),
         total: parseMoney(value(row, ["total", "amount"])),
       },
@@ -89,15 +100,22 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "invoices") {
-    const totalRaw = value(row, ["total", "amount"]);
+    const totalRaw = value(row, ["total", "amount", "invoice total"]);
+    const sourceWorkOrderId = value(row, ["work order", "ro", "ro id", "repair order", "work order number"]);
+    const invoiceNumber = value(row, ["invoice", "invoice number", "invoice id"]);
+    const invoiceDate = value(row, ["issue date", "invoice date", "date"]);
+
     return {
       entityType: "historical_invoice",
-      displayName: value(row, ["invoice", "invoice number"]),
+      displayName: invoiceNumber || `${sourceWorkOrderId} ${invoiceDate}`.trim(),
       normalized: {
-        invoiceNumber: value(row, ["invoice", "invoice number", "invoice id"]),
-        sourceWorkOrderId: value(row, ["work order", "ro", "ro id", "repair order"]),
+        invoiceNumber,
+        sourceWorkOrderId,
         sourceCustomerId: value(row, ["customer id"]),
-        invoiceDate: value(row, ["issue date", "invoice date", "date"]),
+        customerName: value(row, ["customer", "customer name", "name"]),
+        customerEmail: value(row, ["customer email", "email"]).toLowerCase(),
+        vehicleVin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
+        invoiceDate,
         paymentStatus: value(row, ["status", "payment status"]),
         totalRaw,
         total: parseMoney(totalRaw),
@@ -106,24 +124,33 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "parts") {
+    const description = value(row, ["description", "name", "part"]);
+    const partNumber = value(row, ["part number", "part #", "number"]);
+    const sku = value(row, ["sku", "part sku"]);
     return {
       entityType: "part",
-      displayName: value(row, ["description", "name", "part"]),
+      displayName: description || partNumber || sku,
       normalized: {
-        sku: value(row, ["sku", "part sku"]),
-        partNumber: value(row, ["part number", "part #", "number"]),
-        description: value(row, ["description", "name", "part"]),
+        sku,
+        partNumber,
+        description,
         vendorName: value(row, ["vendor", "supplier", "vendor name", "supplier name"]),
+        quantityOnHandRaw: value(row, ["qty", "quantity", "on hand", "quantity on hand"]),
+        costRaw: value(row, ["cost", "unit cost"]),
+        cost: parseMoney(value(row, ["cost", "unit cost"])),
+        priceRaw: value(row, ["price", "list price", "sale price"]),
+        price: parseMoney(value(row, ["price", "list price", "sale price"])),
       },
     };
   }
 
   if (domain === "vendors") {
+    const name = value(row, ["vendor", "supplier", "company", "vendor name", "supplier name"]);
     return {
       entityType: "vendor",
-      displayName: value(row, ["vendor", "supplier", "company", "vendor name", "supplier name"]),
+      displayName: name,
       normalized: {
-        name: value(row, ["vendor", "supplier", "company", "vendor name", "supplier name"]),
+        name,
         email: value(row, ["email", "vendor email"]).toLowerCase(),
         phone: normalizePhone(value(row, ["phone", "vendor phone"])),
         accountNumber: value(row, ["account", "account number", "vendor account"]),
@@ -132,12 +159,14 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "staff") {
+    const name = value(row, ["name", "full name", "employee"]);
+    const email = value(row, ["email", "email address"]).toLowerCase();
     return {
       entityType: "staff_candidate",
-      displayName: value(row, ["name", "full name", "employee"]),
+      displayName: name || email,
       normalized: {
-        name: value(row, ["name", "full name", "employee"]),
-        email: value(row, ["email", "email address"]).toLowerCase(),
+        name,
+        email,
         phone: normalizePhone(value(row, ["phone", "mobile"])),
         role: value(row, ["role", "job title", "position", "technician", "advisor"]),
       },
@@ -145,17 +174,22 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "menu") {
+    const serviceName = value(row, ["service", "service name", "name"]);
+    const description = value(row, ["description", "service description"]);
+    const laborPriceRaw = value(row, ["labor price", "price", "labor rate"]);
+
     return {
       entityType: "menu_suggestion",
-      displayName: value(row, ["service", "service name", "name", "description"]),
+      displayName: serviceName || description,
       normalized: {
-        serviceName: value(row, ["service", "service name", "name"]),
-        description: value(row, ["description"]),
+        serviceName,
+        description,
         category: value(row, ["category", "service category"]),
         laborHours: value(row, ["labor hours", "hours"]),
-        laborPriceRaw: value(row, ["labor price", "price", "labor rate"]),
-        laborPrice: parseMoney(value(row, ["labor price", "price", "labor rate"])),
+        laborPriceRaw,
+        laborPrice: parseMoney(laborPriceRaw),
         opCode: value(row, ["operation code", "op code", "labor operation", "canned job"]),
+        inspectionHint: value(row, ["inspection", "inspection hint", "recommended inspection"]),
       },
     };
   }

--- a/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
@@ -23,6 +23,7 @@ function makeInput(reviewSeverity: "blocking" | "high" = "blocking"): Onboarding
     ],
     deterministicDomainDetections: { customers: 1 },
     deterministicStagedEntityCounts: { customer: 10, vehicle: 5 },
+    deterministicEntityStatusCountsByType: { customer: { ready: 10 }, vehicle: { ready: 5 } },
     deterministicLinkCounts: { customer_vehicle: 4 },
     deterministicReviewItems: [
       {
@@ -36,6 +37,7 @@ function makeInput(reviewSeverity: "blocking" | "high" = "blocking"): Onboarding
       },
     ],
     activationPlanSummary: null,
+    canonicalReadiness: reviewSeverity === "blocking" || reviewSeverity === "high" ? "review_required" : "ready_for_dry_run",
   };
 }
 
@@ -112,8 +114,9 @@ describe("onboarding agent ai safeguards", () => {
   it("activation readiness is ready_for_dry_run with no blocking items", () => {
     const input = makeInput("high");
     input.deterministicReviewItems = [];
+    input.canonicalReadiness = "ready_for_dry_run";
     const report = buildDeterministicFallbackReport(input);
-    expect(report.activationReadiness.status).toBe("activation_disabled");
+    expect(report.activationReadiness.status).toBe("ready_for_dry_run");
     expect(report.activationReadiness.safeToProceed).toBe(true);
   });
 

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -126,6 +126,7 @@ describe("onboarding staging", () => {
       files: [],
       deterministicDomainDetections: {},
       deterministicStagedEntityCounts: {},
+      deterministicEntityStatusCountsByType: {},
       deterministicLinkCounts: {},
       deterministicReviewItems: [],
       activationPlanSummary: null,
@@ -151,6 +152,7 @@ describe("onboarding staging", () => {
       ],
       deterministicDomainDetections: { customers: 1 },
       deterministicStagedEntityCounts: { customer: 2 },
+      deterministicEntityStatusCountsByType: { customer: { ready: 2 } },
       deterministicLinkCounts: { customer_vehicle: 1 },
       deterministicReviewItems: [],
       activationPlanSummary: null,
@@ -159,4 +161,24 @@ describe("onboarding staging", () => {
     expect(report.summary).toContain("customers: 2");
     expect(report.summary).toContain("confident links: 1");
   });
+
+  it("stages historical work order without customer identity when work order/date/service data exists", () => {
+    const wo = stage("history", { "Open Date": "2025-04-01", Complaint: "No start", Correction: "Replaced starter" }).entity;
+    expect(wo?.entity_type).toBe("historical_work_order");
+    expect(wo?.status).toBe("ready");
+  });
+
+  it("stages invoice even when work order link is unresolved and creates grouped link review", () => {
+    const invoice = stage("invoices", { Invoice: "INV-404", "Invoice Date": "2025-05-04", Total: "199.99" }).entity;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [{ id: "invoice-404", entity_type: invoice!.entity_type, normalized: invoice!.normalized }],
+    });
+
+    expect(invoice?.entity_type).toBe("historical_invoice");
+    expect(invoice?.status).toBe("ready");
+    expect(graph.reviewItems.some((item) => item.issue_type === "missing_work_order_link")).toBe(true);
+  });
+
 });

--- a/features/onboarding-agent/lib/onboarding-agent.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent.test.ts
@@ -45,13 +45,17 @@ describe("onboarding agent helpers", () => {
   it("builds dry-run activation plan", () => {
     const plan = buildDryRunActivationPlan({
       sessionId: "s-1",
-      entityCounts: { customer: 2, vehicle: 1, historical_work_order: 3, historical_invoice: 1 },
-      linkCounts: { customer_vehicle: 1 },
-      reviewBlocking: 2,
-      reviewNonBlocking: 1,
+      entityStatusCountsByType: {
+        customer: { ready: 2, needs_review: 0, duplicate_candidate: 0 },
+        vehicle: { ready: 1, needs_review: 0, duplicate_candidate: 0 },
+        historical_work_order: { ready: 3, needs_review: 0, duplicate_candidate: 0 },
+        historical_invoice: { ready: 1, needs_review: 0, duplicate_candidate: 0 },
+      },
+      linkRows: [{ link_type: "customer_vehicle", status: "staged" }],
+      reviewCountsBySeverity: { blocking: 1, high: 1, medium: 1, low: 0 },
     });
     expect(plan.mode).toBe("dry_run");
-    expect(plan.creates.customers).toBe(2);
-    expect(plan.review.blocking).toBe(2);
+    expect(plan.customersReady).toBe(2);
+    expect(plan.blockingIssues).toBe(2);
   });
 });

--- a/features/onboarding-agent/lib/staging.ts
+++ b/features/onboarding-agent/lib/staging.ts
@@ -27,11 +27,11 @@ function hasNumber(value: unknown): boolean {
 
 function sourceExternalIdForDomain(domain: OnboardingDomain, normalized: Record<string, unknown>): string | null {
   if (domain === "customers") return text(normalized.sourceCustomerId) || null;
-  if (domain === "vehicles") return text(normalized.sourceVehicleId) || null;
-  if (domain === "history") return text(normalized.sourceWorkOrderId) || null;
-  if (domain === "invoices") return text(normalized.invoiceNumber) || null;
+  if (domain === "vehicles") return text(normalized.sourceVehicleId) || text(normalized.vin) || text(normalized.plate) || null;
+  if (domain === "history") return text(normalized.sourceWorkOrderId) || text(normalized.invoiceId) || null;
+  if (domain === "invoices") return text(normalized.invoiceNumber) || text(normalized.sourceWorkOrderId) || null;
   if (domain === "parts") return text(normalized.sku) || text(normalized.partNumber) || null;
-  if (domain === "vendors") return text(normalized.accountNumber) || null;
+  if (domain === "vendors") return text(normalized.accountNumber) || text(normalized.name) || null;
   if (domain === "staff") return text(normalized.email) || text(normalized.name) || null;
   if (domain === "menu") return text(normalized.opCode) || text(normalized.serviceName) || null;
   return null;
@@ -96,7 +96,8 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "vehicles") {
-    if (has(n.vin) || has(n.plate) || has(n.unitNumber) || has(n.sourceVehicleId)) {
+    const hasIdentity = has(n.vin) || has(n.plate) || has(n.unitNumber) || has(n.sourceVehicleId) || (has(n.year) && has(n.make) && has(n.model));
+    if (hasIdentity) {
       status = "ready";
       confidence = 0.88;
       reviewReason = null;
@@ -105,9 +106,10 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
 
   if (domain === "history") {
     const hasPrimary = has(n.sourceWorkOrderId) || has(n.invoiceId);
-    const hasContext = has(n.sourceCustomerId) || has(n.sourceVehicleId) || has(n.vehicleVin) || has(n.vehiclePlate);
-    const hasNarrative = has(n.complaint) || has(n.cause) || has(n.correction) || has(n.openedDate);
-    if (hasPrimary || (hasContext && hasNarrative)) {
+    const hasContext = has(n.sourceVehicleId) || has(n.vehicleVin) || has(n.vehiclePlate);
+    const hasNarrative = has(n.complaint) || has(n.cause) || has(n.correction) || has(n.serviceDescription);
+    const hasDate = has(n.openedDate) || has(n.closedDate);
+    if (hasPrimary || ((hasNarrative || hasContext) && hasDate)) {
       status = "ready";
       confidence = 0.86;
       reviewReason = null;
@@ -115,7 +117,10 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "invoices") {
-    const hasIdentity = has(n.invoiceNumber) || (hasNumber(n.total) && (has(n.invoiceDate) || has(n.sourceWorkOrderId) || has(n.sourceCustomerId)));
+    const hasIdentity = has(n.invoiceNumber)
+      || (has(n.sourceWorkOrderId) && has(n.invoiceDate))
+      || (has(n.invoiceDate) && hasNumber(n.total))
+      || (has(n.sourceCustomerId) && hasNumber(n.total));
     if (hasIdentity) {
       status = "ready";
       confidence = 0.86;
@@ -124,7 +129,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "parts") {
-    if (has(n.sku) || has(n.partNumber) || has(n.description)) {
+    if (has(n.sku) || has(n.partNumber) || has(n.description) || has(n.vendorName)) {
       status = "ready";
       confidence = 0.82;
       reviewReason = null;
@@ -148,7 +153,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "menu") {
-    if (has(n.serviceName) || has(n.description)) {
+    if (has(n.serviceName) || has(n.description) || has(n.opCode)) {
       status = "ready";
       confidence = 0.8;
       reviewReason = null;
@@ -167,7 +172,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
           domain,
           issueType: "missing_identity",
           summary: `${domain} row ${input.sourceRowIndex + 1} is missing identity fields`,
-          details: { sourceRowIndex: input.sourceRowIndex },
+          details: { sourceRowIndex: input.sourceRowIndex, normalized: n },
         }),
       ],
     };
@@ -182,6 +187,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
         domain,
         issueType: "needs_review",
         summary: `${domain} row ${input.sourceRowIndex + 1} needs review before activation planning`,
+        details: { sourceRowIndex: input.sourceRowIndex, normalized: n },
       }),
     );
   }
@@ -242,7 +248,7 @@ export function markDuplicateEntities(
           domain: entity.entity_type,
           issueType: "duplicate_candidate",
           summary: `${entity.entity_type} row ${entity.source_row_index + 1} is a duplicate candidate`,
-          details: { canonicalFingerprint: fingerprint, duplicateCount: count },
+          details: { canonicalFingerprint: fingerprint, duplicateCount: count, sourceRowIndex: entity.source_row_index },
         }),
       );
     }

--- a/features/onboarding-agent/lib/summaries.ts
+++ b/features/onboarding-agent/lib/summaries.ts
@@ -8,6 +8,9 @@ export type PendingReviewItem = {
   status?: string | null;
 };
 
+export type CanonicalEntityRow = { entity_type: string; status?: string | null };
+export type CanonicalLinkRow = { link_type: string; status?: string | null };
+
 export const ENTITY_BUCKETS = [
   "customer",
   "vehicle",
@@ -23,8 +26,97 @@ export const ENTITY_BUCKETS = [
 
 export const LINK_BUCKETS = ["customer_vehicle", "customer_work_order", "vehicle_work_order", "work_order_invoice", "vendor_part", "service_menu_suggestion"] as const;
 
+const ENTITY_STATUSES = ["ready", "needs_review", "duplicate_candidate", "rejected", "ignored"] as const;
+
 function topExamples(values: unknown[], max = 3) {
   return values.filter(Boolean).slice(0, max);
+}
+
+function toNumber(value: unknown): number {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function deriveReadiness(input: {
+  rowsParsed: number;
+  analysisCompleted: boolean;
+  readyEntities: number;
+  blockingOrHighReviewItems: number;
+  planReadyTotal: number;
+}) {
+  if (!input.analysisCompleted) return "not_ready" as const;
+  if (input.rowsParsed === 0) return "empty" as const;
+  if (input.readyEntities === 0) return "review_required" as const;
+  if (input.blockingOrHighReviewItems > 0) return "review_required" as const;
+  if (input.planReadyTotal === 0) return "review_required" as const;
+  return "ready_for_dry_run" as const;
+}
+
+function emptyEntityStatusCounts() {
+  return ENTITY_STATUSES.reduce<Record<string, number>>((acc, status) => {
+    acc[status] = 0;
+    return acc;
+  }, {});
+}
+
+function mapDomainReviewCount(entityStatusCountsByType: Record<string, Record<string, number>>) {
+  const domainCounts: Record<string, number> = {};
+  for (const [entityType, statusCounts] of Object.entries(entityStatusCountsByType)) {
+    const reviewCount = toNumber(statusCounts.needs_review) + toNumber(statusCounts.duplicate_candidate);
+    if (reviewCount > 0) domainCounts[entityType] = reviewCount;
+  }
+  return domainCounts;
+}
+
+export function buildActivationPlanSummary(input: {
+  entityStatusCountsByType: Record<string, Record<string, number>>;
+  linkRows: CanonicalLinkRow[];
+  reviewCountsBySeverity: Record<string, number>;
+}) {
+  const ready = (entityType: string) => toNumber(input.entityStatusCountsByType[entityType]?.ready);
+  const needsReview = (entityType: string) => toNumber(input.entityStatusCountsByType[entityType]?.needs_review);
+  const duplicateCandidate = (entityType: string) => toNumber(input.entityStatusCountsByType[entityType]?.duplicate_candidate);
+
+  const linksReady = input.linkRows.filter((row) => (row.status ?? "staged") === "staged").length;
+  const linksNeedReview = input.linkRows.filter((row) => (row.status ?? "staged") !== "staged").length;
+
+  const blockingIssues = toNumber(input.reviewCountsBySeverity.blocking) + toNumber(input.reviewCountsBySeverity.high);
+  const reviewNeeded =
+    toNumber(input.reviewCountsBySeverity.medium)
+    + toNumber(input.reviewCountsBySeverity.low)
+    + linksNeedReview
+    + Object.values(input.entityStatusCountsByType).reduce(
+      (sum, counts) => sum + toNumber(counts.needs_review) + toNumber(counts.duplicate_candidate),
+      0,
+    );
+
+  return {
+    customersReady: ready("customer"),
+    vehiclesReady: ready("vehicle"),
+    historicalWorkOrdersReady: ready("historical_work_order"),
+    historicalInvoicesReady: ready("historical_invoice"),
+    partsReady: ready("part"),
+    vendorsReady: ready("vendor"),
+    staffCandidatesReady: ready("staff_candidate"),
+    menuSuggestionsReady: ready("menu_suggestion"),
+    inspectionSuggestionsReady: ready("inspection_suggestion"),
+    linksReady,
+    blockingIssues,
+    reviewNeeded,
+    activationDisabled: true as const,
+    liveRecordsCreated: 0 as const,
+    byEntityType: {
+      customer: { ready: ready("customer"), needs_review: needsReview("customer"), duplicate_candidate: duplicateCandidate("customer") },
+      vehicle: { ready: ready("vehicle"), needs_review: needsReview("vehicle"), duplicate_candidate: duplicateCandidate("vehicle") },
+      historical_work_order: { ready: ready("historical_work_order"), needs_review: needsReview("historical_work_order"), duplicate_candidate: duplicateCandidate("historical_work_order") },
+      historical_invoice: { ready: ready("historical_invoice"), needs_review: needsReview("historical_invoice"), duplicate_candidate: duplicateCandidate("historical_invoice") },
+      part: { ready: ready("part"), needs_review: needsReview("part"), duplicate_candidate: duplicateCandidate("part") },
+      vendor: { ready: ready("vendor"), needs_review: needsReview("vendor"), duplicate_candidate: duplicateCandidate("vendor") },
+      staff_candidate: { ready: ready("staff_candidate"), needs_review: needsReview("staff_candidate"), duplicate_candidate: duplicateCandidate("staff_candidate") },
+      menu_suggestion: { ready: ready("menu_suggestion"), needs_review: needsReview("menu_suggestion"), duplicate_candidate: duplicateCandidate("menu_suggestion") },
+      inspection_suggestion: { ready: ready("inspection_suggestion"), needs_review: needsReview("inspection_suggestion"), duplicate_candidate: duplicateCandidate("inspection_suggestion") },
+    },
+  };
 }
 
 export function groupReviewItems(items: PendingReviewItem[]) {
@@ -83,17 +175,29 @@ export function groupReviewItems(items: PendingReviewItem[]) {
 export function buildOnboardingSummary(input: {
   filesCount: number;
   rowsParsed: number;
-  entityRows: Array<{ entity_type: string }>;
-  linkRows: Array<{ link_type: string }>;
+  entityRows: CanonicalEntityRow[];
+  linkRows: CanonicalLinkRow[];
   reviewRows: PendingReviewItem[];
   groupedExceptionCount?: number;
-  activationReadiness?: string;
+  analysisCompleted?: boolean;
 }) {
   const entityCounts = ENTITY_BUCKETS.reduce<Record<string, number>>((acc, key) => {
     acc[key] = 0;
     return acc;
   }, {});
-  for (const row of input.entityRows) entityCounts[row.entity_type] = (entityCounts[row.entity_type] ?? 0) + 1;
+
+  const entityStatusCountsByType = ENTITY_BUCKETS.reduce<Record<string, Record<string, number>>>((acc, key) => {
+    acc[key] = emptyEntityStatusCounts();
+    return acc;
+  }, {});
+
+  for (const row of input.entityRows) {
+    const entityType = row.entity_type;
+    entityCounts[entityType] = (entityCounts[entityType] ?? 0) + 1;
+    const status = String(row.status ?? "ready");
+    const statusCounts = entityStatusCountsByType[entityType] ?? (entityStatusCountsByType[entityType] = emptyEntityStatusCounts());
+    statusCounts[status] = (statusCounts[status] ?? 0) + 1;
+  }
 
   const linkCounts = LINK_BUCKETS.reduce<Record<string, number>>((acc, key) => {
     acc[key] = 0;
@@ -113,19 +217,57 @@ export function buildOnboardingSummary(input: {
   const totalEntities = Object.values(entityCounts).reduce((sum, count) => sum + count, 0);
   const totalLinks = Object.values(linkCounts).reduce((sum, count) => sum + count, 0);
   const totalReviewItems = Object.values(reviewCountsBySeverity).reduce((sum, count) => sum + count, 0);
+  const readyEntityTotal = Object.values(entityStatusCountsByType).reduce((sum, counts) => sum + toNumber(counts.ready), 0);
+
+  const activationPlanSummary = buildActivationPlanSummary({
+    entityStatusCountsByType,
+    linkRows: input.linkRows,
+    reviewCountsBySeverity,
+  });
+
+  const activationReadiness = deriveReadiness({
+    rowsParsed: input.rowsParsed,
+    analysisCompleted: Boolean(input.analysisCompleted ?? true),
+    readyEntities: readyEntityTotal,
+    blockingOrHighReviewItems: activationPlanSummary.blockingIssues,
+    planReadyTotal:
+      activationPlanSummary.customersReady
+      + activationPlanSummary.vehiclesReady
+      + activationPlanSummary.historicalWorkOrdersReady
+      + activationPlanSummary.historicalInvoicesReady
+      + activationPlanSummary.partsReady
+      + activationPlanSummary.vendorsReady
+      + activationPlanSummary.staffCandidatesReady
+      + activationPlanSummary.menuSuggestionsReady
+      + activationPlanSummary.inspectionSuggestionsReady,
+  });
 
   return {
     files_count: input.filesCount,
     rows_parsed: input.rowsParsed,
     total_entities: totalEntities,
     entity_counts_by_type: entityCounts,
+    entity_status_counts_by_type: entityStatusCountsByType,
     total_links: totalLinks,
     link_counts_by_type: linkCounts,
     total_review_items: totalReviewItems,
-    review_counts_by_domain: reviewCountsByDomain,
+    review_counts_by_domain: {
+      ...reviewCountsByDomain,
+      ...mapDomainReviewCount(entityStatusCountsByType),
+    },
     review_counts_by_severity: reviewCountsBySeverity,
     grouped_exception_count: input.groupedExceptionCount ?? 0,
-    activation_readiness: input.activationReadiness ?? "review_required",
+    activation_readiness: activationReadiness,
+    activation_plan_summary: activationPlanSummary,
     liveRecordsCreated: 0 as const,
+    summaryCounts: {
+      uploadedFiles: input.filesCount,
+      rowsParsed: input.rowsParsed,
+      entitiesDiscovered: totalEntities,
+      linksFound: totalLinks,
+      reviewExceptions: totalReviewItems,
+      groupedExceptionCount: input.groupedExceptionCount ?? 0,
+      liveRecordsCreated: 0 as const,
+    },
   };
 }

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -130,13 +130,13 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
     details: item.details,
   })));
 
-  const entities = await insertInChunks(sb, "onboarding_entities", stagedEntities, "id, entity_type, normalized, display_name, source_external_id");
+  const entities = await insertInChunks(sb, "onboarding_entities", stagedEntities, "id, entity_type, status, normalized, display_name, source_external_id");
 
   const graph = buildStagedLinks({ entities: entities.map((e: any) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
   reviewItems.push(...graph.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
 
   const linksToInsert = graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId }));
-  await insertInChunks(sb, "onboarding_entity_links", linksToInsert);
+  const insertedLinks = await insertInChunks(sb, "onboarding_entity_links", linksToInsert, "id, link_type, status");
 
   const groupedReviewItems = groupReviewItems(reviewItems as any).map((item) => ({
     shop_id: params.shopId,
@@ -157,26 +157,23 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
   }));
   await insertInChunks(sb, "onboarding_review_items", groupedReviewItems);
 
-  const blockingCount = groupedReviewItems.filter((item) => item.severity === "blocking").length;
-  const status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
-
   const canonical = buildOnboardingSummary({
     filesCount: (files ?? []).length,
     rowsParsed: totalRows,
-    entityRows: (entities ?? []).map((e: any) => ({ entity_type: e.entity_type })),
-    linkRows: graph.links.map((l) => ({ link_type: l.link_type })),
+    entityRows: (entities ?? []).map((e: any) => ({ entity_type: e.entity_type, status: e.status })),
+    linkRows: (insertedLinks ?? []).map((l: any) => ({ link_type: l.link_type, status: l.status })),
     reviewRows: groupedReviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details, status: item.status })),
     groupedExceptionCount: groupedReviewItems.length,
-    activationReadiness: blockingCount > 0 ? "review_required" : "ready_for_dry_run",
+    analysisCompleted: true,
   });
 
+  const blockingCount = (canonical.review_counts_by_severity.blocking ?? 0) + (canonical.review_counts_by_severity.high ?? 0);
+  const status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
+
   const summary = {
-    fileCount: canonical.files_count,
-    rowsParsed: canonical.rows_parsed,
-    entitiesDiscovered: canonical.total_entities,
-    linksFound: canonical.total_links,
-    reviewExceptions: canonical.total_review_items,
-    groupedExceptionCount: canonical.grouped_exception_count,
+    ...canonical.summaryCounts,
+    activationReadiness: canonical.activation_readiness,
+    activationPlanSummary: canonical.activation_plan_summary,
     liveRecordsCreated: 0 as const,
   };
 

--- a/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
+++ b/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
@@ -11,48 +11,75 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
     sessionId: params.sessionId,
   });
 
-  const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }, { data: sessionRow }] = await Promise.all([
-    sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_entity_links").select("link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_review_items").select("severity").eq("shop_id", params.shopId).eq("session_id", params.sessionId).eq("status", "pending"),
-    sb.from("onboarding_sessions").select("summary").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
+  const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }, { data: filesRows }, { data: sessionRow }] = await Promise.all([
+    sb.from("onboarding_entities").select("entity_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_review_items").select("severity, status, domain, issue_type, summary, details").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_files").select("row_count").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_sessions").select("summary, analyzed_at").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
   ]);
 
-  const entityCounts = (entityRows ?? []).reduce((acc: Record<string, number>, row: any) => {
-    acc[row.entity_type] = (acc[row.entity_type] ?? 0) + 1;
-    return acc;
-  }, {});
-  const linkCounts = (linkRows ?? []).reduce((acc: Record<string, number>, row: any) => {
-    acc[row.link_type] = (acc[row.link_type] ?? 0) + 1;
-    return acc;
-  }, {});
+  const filesCount = (filesRows ?? []).length;
+  const rowsParsed = (filesRows ?? []).reduce((sum: number, row: any) => sum + Number(row.row_count ?? 0), 0);
 
   const canonical = buildOnboardingSummary({
-    filesCount: 0,
-    rowsParsed: 0,
-    entityRows: (entityRows ?? []).map((row: any) => ({ entity_type: row.entity_type })),
-    linkRows: (linkRows ?? []).map((row: any) => ({ link_type: row.link_type })),
-    reviewRows: (reviewRows ?? []).map((row: any) => ({ severity: row.severity, summary: "", status: "pending" })),
+    filesCount,
+    rowsParsed,
+    entityRows: (entityRows ?? []).map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
+    linkRows: (linkRows ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
+    reviewRows: (reviewRows ?? []).map((row: any) => ({
+      severity: row.severity,
+      status: row.status,
+      domain: row.domain,
+      issue_type: row.issue_type,
+      summary: row.summary ?? "",
+      details: row.details ?? {},
+    })),
+    groupedExceptionCount: (reviewRows ?? []).length,
+    analysisCompleted: Boolean(sessionRow?.analyzed_at),
   });
-  const blocking = canonical.review_counts_by_severity.blocking ?? 0;
-  const nonblocking = canonical.total_review_items - blocking;
 
   const plan = buildDryRunActivationPlan({
     sessionId: params.sessionId,
-    entityCounts,
-    linkCounts,
-    reviewBlocking: blocking,
-    reviewNonBlocking: nonblocking,
+    entityStatusCountsByType: canonical.entity_status_counts_by_type,
+    linkRows: (linkRows ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
+    reviewCountsBySeverity: canonical.review_counts_by_severity,
   });
 
   const sessionSummary = (sessionRow?.summary ?? {}) as Record<string, unknown>;
-  const summaryWithAgent = { ...plan, agentReport: sessionSummary.agentReport ?? null, liveRecordsCreated: 0 };
+  const summaryWithAgent = {
+    ...plan,
+    readiness: canonical.activation_readiness,
+    agentReport: sessionSummary.agentReport ?? null,
+    liveRecordsCreated: 0,
+  };
 
   const { data } = await sb
     .from("onboarding_activation_plans")
-    .insert({ shop_id: params.shopId, session_id: params.sessionId, status: "ready", plan, summary: summaryWithAgent, risk_flags: { risks: plan.risks } })
+    .insert({
+      shop_id: params.shopId,
+      session_id: params.sessionId,
+      status: canonical.activation_readiness === "ready_for_dry_run" ? "ready" : "review_required",
+      plan,
+      summary: summaryWithAgent,
+      risk_flags: { risks: plan.risks },
+    })
     .select("id, status, summary, created_at")
     .single();
+
+  await sb
+    .from("onboarding_sessions")
+    .update({
+      summary: {
+        ...(sessionSummary ?? {}),
+        activationPlanSummary: plan,
+        activationReadiness: canonical.activation_readiness,
+        liveRecordsCreated: 0,
+      },
+      stats: canonical,
+    })
+    .eq("shop_id", params.shopId)
+    .eq("id", params.sessionId);
 
   return { plan: summaryWithAgent, record: data };
 }

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -13,7 +13,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
   const [{ data: session }, { data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }] = await Promise.all([
     sb.from("onboarding_sessions").select("*").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
     sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
-    sb.from("onboarding_entities").select("entity_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entities").select("entity_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb
       .from("onboarding_review_items")
@@ -28,8 +28,8 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
   const canonical = buildOnboardingSummary({
     filesCount: (files ?? []).length,
     rowsParsed: rowsParsedFromFiles,
-    entityRows: (entities ?? []).map((row: any) => ({ entity_type: row.entity_type })),
-    linkRows: (links ?? []).map((row: any) => ({ link_type: row.link_type })),
+    entityRows: (entities ?? []).map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
+    linkRows: (links ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
     reviewRows: (reviews ?? []).map((row: any) => ({
       id: row.id,
       severity: row.severity,
@@ -40,7 +40,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
       details: row.details ?? {},
     })),
     groupedExceptionCount: (reviews ?? []).length,
-    activationReadiness: ((session?.stats ?? {}) as Record<string, unknown>).activation_readiness as string | undefined,
+    analysisCompleted: Boolean(session?.analyzed_at),
   });
 
   const entityCounts = ENTITY_BUCKETS.reduce<Record<string, number>>((acc, key) => {
@@ -60,22 +60,25 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     byDomain: canonical.review_counts_by_domain,
   };
 
+  const canonicalSummary = {
+    ...canonical.summaryCounts,
+    activationReadiness: canonical.activation_readiness,
+    activationPlanSummary: canonical.activation_plan_summary,
+    liveRecordsCreated: 0 as const,
+    agentReport: (session?.summary ?? {})?.agentReport ?? null,
+  };
+
   return {
-    session,
+    session: session ? { ...session, summary: canonicalSummary, stats: canonical } : null,
     files: files ?? [],
     entityCounts,
+    entityStatusCounts: canonical.entity_status_counts_by_type,
     reviewCounts,
     reviewItems: reviews ?? [],
     linkCounts,
+    activationPlanSummary: canonical.activation_plan_summary,
+    readiness: canonical.activation_readiness,
     latestPlan,
-    summaryCounts: {
-      uploadedFiles: canonical.files_count,
-      rowsParsed: canonical.rows_parsed,
-      entitiesDiscovered: canonical.total_entities,
-      linksFound: canonical.total_links,
-      reviewExceptions: canonical.total_review_items,
-      groupedExceptionCount: canonical.grouped_exception_count,
-      liveRecordsCreated: 0 as const,
-    },
+    summaryCounts: canonical.summaryCounts,
   };
 }

--- a/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
+++ b/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
@@ -7,6 +7,7 @@ import type {
   OnboardingAgentReport,
 } from "@/features/onboarding-agent/lib/agentTypes";
 import { ONBOARDING_DOMAINS, type OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 import { buildOnboardingAgentSystemPrompt, buildOnboardingAgentUserPrompt } from "@/features/onboarding-agent/server/prompts";
 import { getOnboardingAgentEnabled, getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
@@ -65,19 +66,12 @@ function sanitizeIds(ids: unknown, allow: Set<string>) {
 }
 
 function buildActivationReadiness(input: OnboardingAgentInput) {
-  const blockingItems = input.deterministicReviewItems.filter((item) => item.severity === "blocking");
-  const warningItems = input.deterministicReviewItems.filter((item) => item.severity !== "blocking");
-  const entitiesTotal = Object.values(input.deterministicStagedEntityCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
   const rowsParsed = input.files.reduce((sum, file) => sum + file.rowCount, 0);
+  const entitiesTotal = Object.values(input.deterministicStagedEntityCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
+  const blockingItems = input.deterministicReviewItems.filter((item) => item.severity === "blocking" || item.severity === "high");
+  const warningItems = input.deterministicReviewItems.filter((item) => item.severity !== "blocking" && item.severity !== "high");
 
-  if (rowsParsed > 0 && entitiesTotal === 0) {
-    return {
-      status: "empty" as const,
-      blockers: ["Rows were parsed but no staged entities were detected."],
-      warnings: ["Upload better mapped CSVs or review header mappings before re-running analysis."],
-      safeToProceed: false,
-    };
-  }
+  const status = input.canonicalReadiness ?? "review_required";
 
   if (rowsParsed === 0) {
     return {
@@ -88,7 +82,16 @@ function buildActivationReadiness(input: OnboardingAgentInput) {
     };
   }
 
-  if (blockingItems.length > 0) {
+  if (rowsParsed > 0 && entitiesTotal === 0) {
+    return {
+      status: "empty" as const,
+      blockers: ["Rows were parsed but no staged entities were detected."],
+      warnings: ["Upload better mapped CSVs or review header mappings before re-running analysis."],
+      safeToProceed: false,
+    };
+  }
+
+  if (status === "review_required" || status === "not_ready") {
     return {
       status: "review_required" as const,
       blockers: blockingItems.map((item) => item.summary),
@@ -97,36 +100,38 @@ function buildActivationReadiness(input: OnboardingAgentInput) {
     };
   }
 
-  if (warningItems.length > 0) {
-    return {
-      status: "ready_for_dry_run" as const,
-      blockers: [],
-      warnings: warningItems.map((item) => item.summary),
-      safeToProceed: true,
-    };
-  }
-
   return {
-    status: "activation_disabled" as const,
+    status: status === "ready_for_dry_run" ? "ready_for_dry_run" as const : "activation_disabled" as const,
     blockers: [],
-    warnings: ["Activation remains disabled in this phase; dry-run only."],
-    safeToProceed: true,
+    warnings: warningItems.map((item) => item.summary).concat(["Activation remains disabled in this phase; dry-run only."]),
+    safeToProceed: status === "ready_for_dry_run",
   };
 }
 
 export function buildDeterministicFallbackReport(input: OnboardingAgentInput): OnboardingAgentReport {
   const rowsParsed = input.files.reduce((sum, file) => sum + file.rowCount, 0);
   const entitiesTotal = Object.values(input.deterministicStagedEntityCounts).reduce((sum, count) => sum + Number(count ?? 0), 0);
-  const blockingCount = input.deterministicReviewItems.filter((item) => item.severity === "blocking").length;
+  const blockingCount = input.deterministicReviewItems.filter((item) => item.severity === "blocking" || item.severity === "high").length;
   const readiness = buildActivationReadiness(input);
+
+  const entityTypesByDomain: Record<string, string[]> = {
+    customers: ["customer"],
+    vehicles: ["vehicle"],
+    history: ["historical_work_order"],
+    invoices: ["historical_invoice"],
+    parts: ["part"],
+    vendors: ["vendor"],
+    staff: ["staff_candidate"],
+    menu: ["menu_suggestion"],
+    inspections: ["inspection_suggestion"],
+  };
 
   const domainSummaries: OnboardingAgentDomainSummary[] = ONBOARDING_DOMAINS.map((domain) => {
     const fileRows = input.files.filter((file) => (file.detectedDomain ?? "unknown") === domain).reduce((sum, file) => sum + file.rowCount, 0);
     const reviewCount = input.deterministicReviewItems.filter((item) => (item.domain ?? "unknown") === domain).length;
-    const entitiesDetected = Object.entries(input.deterministicStagedEntityCounts)
-      .filter(([entityType]) => entityType.includes(domain.slice(0, -1)) || (domain === "history" && entityType === "historical_work_order") || (domain === "invoices" && entityType === "historical_invoice"))
-      .reduce((sum, [, count]) => sum + Number(count ?? 0), 0);
-    const readyCount = Math.max(0, entitiesDetected - reviewCount);
+    const domainEntityTypes = entityTypesByDomain[domain] ?? [];
+    const entitiesDetected = domainEntityTypes.reduce((sum, entityType) => sum + Number(input.deterministicStagedEntityCounts[entityType] ?? 0), 0);
+    const readyCount = domainEntityTypes.reduce((sum, entityType) => sum + Number(input.deterministicEntityStatusCountsByType[entityType]?.ready ?? 0), 0);
 
     return {
       domain,
@@ -328,8 +333,8 @@ export async function runOnboardingAgentAnalysis(params: RunParams): Promise<Onb
 
   const [{ data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }] = await Promise.all([
     sb.from("onboarding_files").select("id, original_filename, storage_path, declared_domain, detected_domain, parse_status, row_count, header_row").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: true }),
-    sb.from("onboarding_entities").select("id, entity_type, source_file_id").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_entity_links").select("id, link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entities").select("id, entity_type, status, source_file_id").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("onboarding_entity_links").select("id, link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_review_items").select("id, severity, domain, summary, issue_type, entity_id, details").eq("shop_id", params.shopId).eq("session_id", params.sessionId).eq("status", "pending"),
     sb.from("onboarding_activation_plans").select("summary").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
   ]);
@@ -355,10 +360,30 @@ export async function runOnboardingAgentAnalysis(params: RunParams): Promise<Onb
     }
   }
 
+  const canonical = buildOnboardingSummary({
+    filesCount: (files ?? []).length,
+    rowsParsed: (files ?? []).reduce((sum: number, file: any) => sum + Number(file.row_count ?? 0), 0),
+    entityRows: (entities ?? []).map((entity: any) => ({ entity_type: entity.entity_type, status: entity.status })),
+    linkRows: (links ?? []).map((link: any) => ({ link_type: link.link_type, status: link.status })),
+    reviewRows: (reviews ?? []).map((review: any) => ({
+      id: review.id,
+      severity: review.severity,
+      status: "pending",
+      domain: review.domain,
+      issue_type: review.issue_type,
+      summary: review.summary,
+      details: review.details ?? {},
+    })),
+    groupedExceptionCount: (reviews ?? []).length,
+    analysisCompleted: true,
+  });
+
   const deterministicStagedEntityCounts = (entities ?? []).reduce((acc: Record<string, number>, entity: any) => {
     acc[entity.entity_type] = (acc[entity.entity_type] ?? 0) + 1;
     return acc;
   }, {});
+
+  const deterministicEntityStatusCountsByType = canonical.entity_status_counts_by_type;
 
   const deterministicLinkCounts = (links ?? []).reduce((acc: Record<string, number>, link: any) => {
     acc[link.link_type] = (acc[link.link_type] ?? 0) + 1;
@@ -386,7 +411,9 @@ export async function runOnboardingAgentAnalysis(params: RunParams): Promise<Onb
     })),
     deterministicDomainDetections,
     deterministicStagedEntityCounts,
+    deterministicEntityStatusCountsByType,
     deterministicLinkCounts,
+    canonicalReadiness: canonical.activation_readiness,
     deterministicReviewItems: (reviews ?? []).map((review: any) => ({
       id: review.id,
       severity: review.severity,
@@ -427,11 +454,11 @@ export async function runOnboardingAgentAnalysis(params: RunParams): Promise<Onb
   }
 
   const existingSummary = asRecord(session.summary);
-  const nextSummary = { ...existingSummary, agentReport: report, liveRecordsCreated: 0 };
+  const nextSummary = { ...existingSummary, ...canonical.summaryCounts, activationReadiness: canonical.activation_readiness, activationPlanSummary: canonical.activation_plan_summary, agentReport: report, liveRecordsCreated: 0 };
 
   await sb
     .from("onboarding_sessions")
-    .update({ summary: nextSummary, stats: nextSummary })
+    .update({ summary: nextSummary, stats: canonical })
     .eq("shop_id", params.shopId)
     .eq("id", params.sessionId);
 


### PR DESCRIPTION
### Motivation
- The onboarding UI surfaces and agent reports were showing contradictory counts and an incorrect readiness state because they read different sources (session.summary, DB counts, agentReport) instead of a single canonical staged summary. 
- The goal is to make all analyzer outputs derive from one canonical staged summary computed from staging tables so progress, entities, reviews, agent insights, and dry-run plans always agree.

### Description
- Introduced a canonical summary pipeline (`buildOnboardingSummary`) and activation plan summary (`buildActivationPlanSummary`) that compute file/row/entity/link/review counts, per-entity status buckets, readiness, and a dry-run plan from staged tables, and return a single consistent summary shape. 
- Rewired server flows so `analyzeOnboardingSession`, `getOnboardingSession`, `runOnboardingAgentAnalysis`, and `buildOnboardingActivationPlan` rebuild and persist the canonical summary/stats from `onboarding_*` staging tables and use that summary for agent input and activation planning. 
- Strengthened domain-specific staging rules and fingerprints so valid rows (history, invoices, vehicles, parts, vendors, staff, menu) stage as entities when appropriate and unresolved dependencies become grouped link review items rather than causing mass domain failures. 
- Updated staged graph/link logic, grouped review semantics, and UI panels (`OnboardingProgressCard`, `OnboardingEntitiesPanel`, `OnboardingReviewPanel`, `OnboardingActivationPlanPanel`, `OnboardingAgentInsightsPanel`, session page) to display per-domain ready vs review counts, canonical readiness, activation plan summary, and developer details via a single source of truth; tests were added/adjusted for deterministic fallback and staging scenarios.

### Testing
- Ran `npx tsc --noEmit` and TypeScript validation passed. 
- Ran `npx eslint` on the modified onboarding files and it completed with warnings only (no lint errors). 
- Ran unit tests: `npx vitest run` for `onboarding-agent.test.ts`, `onboarding-agent-ai.test.ts`, `uploadOnboardingFiles.test.ts`, and `onboarding-agent-staging.test.ts` and all tests passed. 
- Attempted `pnpm build` but it failed in this environment due to external Google Fonts network fetch errors (Inter / Black Ops One); this is an environment/network issue and not related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeed62cf108328953599615455dcc2)