### PR TITLE
Add AI-planned onboarding: server planner, validator, deterministic executor, and UI surfaces

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 import { analyzeOnboardingSession } from "@/features/onboarding-agent/server/analyzeOnboardingSession";
-import { getOnboardingAgentEnabled } from "@/features/onboarding-agent/server/model";
-import { runOnboardingAgentAnalysis } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
@@ -15,10 +13,7 @@ export async function POST(_: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
   const shopId = access.profile.shop_id as string;
-  const actorId = access.profile.id;
-  void actorId;
   const admin = createAdminSupabase();
-
   const { sessionId } = await context.params;
 
   try {
@@ -29,9 +24,7 @@ export async function POST(_: Request, context: RouteContext) {
       .eq("shop_id", shopId)
       .maybeSingle();
     if (sessionError) throw new Error(sessionError.message);
-    if (!session) {
-      return NextResponse.json({ ok: false, error: "Session not found for this shop" }, { status: 404 });
-    }
+    if (!session) return NextResponse.json({ ok: false, error: "Session not found for this shop" }, { status: 404 });
 
     const { count, error: countError } = await (admin as any)
       .from("onboarding_files")
@@ -40,53 +33,19 @@ export async function POST(_: Request, context: RouteContext) {
       .eq("session_id", sessionId);
 
     if (countError) throw new Error(countError.message);
-    if (!count || count < 1) {
-      return NextResponse.json(
-        { ok: false, error: "Upload at least one file before analysis." },
-        { status: 400 },
-      );
-    }
+    if (!count || count < 1) return NextResponse.json({ ok: false, error: "Upload at least one file before analysis." }, { status: 400 });
 
-    const summary = await analyzeOnboardingSession({
-      supabase: admin,
-      shopId,
-      sessionId,
-    });
-
-    let agentReport = null;
-    let aiUnavailable = false;
-    const shouldAutoAnalyze = process.env.ONBOARDING_AGENT_AUTO_ANALYZE === "false"
-      ? false
-      : getOnboardingAgentEnabled();
-
-    if (shouldAutoAnalyze) {
-      try {
-        agentReport = await runOnboardingAgentAnalysis({
-          supabase: admin,
-          shopId,
-          sessionId,
-        });
-      } catch (error) {
-        aiUnavailable = true;
-        console.warn("[onboarding-agent] auto agent analysis warning", {
-          sessionId,
-          shopId: access.profile.shop_id,
-          error: error instanceof Error ? error.message : "unknown",
-        });
-      }
-    }
+    const result = await analyzeOnboardingSession({ supabase: admin, shopId, sessionId });
 
     return NextResponse.json({
       ok: true,
-      summary,
-      agentReport,
-      aiUnavailable,
+      mode: result.mode,
       liveRecordsCreated: 0,
+      planSummary: result.planSummary,
+      sessionSummary: result.sessionSummary,
+      warnings: result.warning ? [result.warning] : [],
     });
   } catch (error) {
-    return NextResponse.json(
-      { ok: false, error: error instanceof Error ? error.message : "Analysis failed" },
-      { status: 500 },
-    );
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Analysis failed" }, { status: 500 });
   }
 }

--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -1,46 +1,40 @@
 "use client";
 
 import { useState } from "react";
+import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
 function num(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary }: { latestPlan?: Record<string, unknown> | null; fallbackSummary?: Record<string, unknown> | null }) {
+export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary, agentPlan }: { latestPlan?: Record<string, unknown> | null; fallbackSummary?: Record<string, unknown> | null; agentPlan?: OnboardingAgentPlan | null }) {
   const [showDevDetails, setShowDevDetails] = useState(false);
   const summary = (latestPlan?.summary ?? latestPlan ?? fallbackSummary ?? {}) as Record<string, any>;
+  const preview = agentPlan?.activationPreview;
 
   return (
     <div className="rounded-2xl border border-amber-500/30 bg-amber-950/20 p-4">
-      <h3 className="text-sm font-semibold text-amber-100">Dry-run activation plan</h3>
-      <p className="mt-2 text-xs text-amber-200/80">Activation remains disabled in this phase.</p>
-      <p className="text-xs text-amber-200/80">No live records have been created.</p>
-      <p className="text-xs text-amber-200/80">This plan is a preview only.</p>
+      <h3 className="text-sm font-semibold text-amber-100">Dry-run activation preview</h3>
+      <p className="mt-2 text-xs text-amber-200/80">No live records have been created. This is dry-run only.</p>
 
       <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
-        <div>Customers ready: <span className="font-semibold text-white">{num(summary.customersReady)}</span></div>
-        <div>Vehicles ready: <span className="font-semibold text-white">{num(summary.vehiclesReady)}</span></div>
-        <div>Historical work orders ready: <span className="font-semibold text-white">{num(summary.historicalWorkOrdersReady)}</span></div>
-        <div>Historical invoices ready: <span className="font-semibold text-white">{num(summary.historicalInvoicesReady)}</span></div>
-        <div>Parts ready: <span className="font-semibold text-white">{num(summary.partsReady)}</span></div>
-        <div>Vendors ready: <span className="font-semibold text-white">{num(summary.vendorsReady)}</span></div>
-        <div>Staff candidates ready: <span className="font-semibold text-white">{num(summary.staffCandidatesReady)}</span></div>
-        <div>Menu suggestions ready: <span className="font-semibold text-white">{num(summary.menuSuggestionsReady)}</span></div>
-        <div>Inspection suggestions ready: <span className="font-semibold text-white">{num(summary.inspectionSuggestionsReady)}</span></div>
-        <div>Links ready: <span className="font-semibold text-white">{num(summary.linksReady)}</span></div>
-        <div>Blocking issues: <span className="font-semibold text-white">{num(summary.blockingIssues)}</span></div>
-        <div>Review needed: <span className="font-semibold text-white">{num(summary.reviewNeeded)}</span></div>
+        <div>Customers: <span className="font-semibold text-white">{num(preview?.creates.customers ?? summary.customersReady)}</span></div>
+        <div>Vehicles: <span className="font-semibold text-white">{num(preview?.creates.vehicles ?? summary.vehiclesReady)}</span></div>
+        <div>Historical work orders: <span className="font-semibold text-white">{num(preview?.creates.historicalWorkOrders ?? summary.historicalWorkOrdersReady)}</span></div>
+        <div>Historical invoices: <span className="font-semibold text-white">{num(preview?.creates.historicalInvoices ?? summary.historicalInvoicesReady)}</span></div>
+        <div>Parts: <span className="font-semibold text-white">{num(preview?.creates.parts ?? summary.partsReady)}</span></div>
+        <div>Vendors: <span className="font-semibold text-white">{num(preview?.creates.vendors ?? summary.vendorsReady)}</span></div>
+        <div>Staff candidates: <span className="font-semibold text-white">{num(preview?.creates.staffCandidates ?? summary.staffCandidatesReady)}</span></div>
+        <div>Menu suggestions: <span className="font-semibold text-white">{num(preview?.creates.menuSuggestions ?? summary.menuSuggestionsReady)}</span></div>
+        <div>Inspection suggestions: <span className="font-semibold text-white">{num(preview?.creates.inspectionSuggestions ?? summary.inspectionSuggestionsReady)}</span></div>
+        <div>Blocking issues: <span className="font-semibold text-white">{num(preview?.blockingIssues ?? summary.blockingIssues)}</span></div>
+        <div>Requires review: <span className="font-semibold text-white">{num(preview?.requiresReview ?? summary.reviewNeeded)}</span></div>
       </div>
 
-      <button
-        onClick={() => setShowDevDetails((v) => !v)}
-        className="mt-3 rounded border border-white/20 px-2 py-1 text-xs text-slate-200"
-      >
-        {showDevDetails ? "Hide" : "Show"} developer details
-      </button>
-      {showDevDetails ? (
-        <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify(latestPlan ?? summary ?? { status: "not_prepared" }, null, 2)}</pre>
-      ) : null}
+      {preview?.risks?.length ? <ul className="mt-3 list-disc pl-5 text-xs text-amber-100/90">{preview.risks.slice(0, 5).map((risk, idx) => <li key={`${risk}-${idx}`}>{risk}</li>)}</ul> : null}
+
+      <button onClick={() => setShowDevDetails((v) => !v)} className="mt-3 rounded border border-white/20 px-2 py-1 text-xs text-slate-200">{showDevDetails ? "Hide" : "Show"} developer details</button>
+      {showDevDetails ? <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify({ latestPlan, agentPlan }, null, 2)}</pre> : null}
     </div>
   );
 }

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -1,123 +1,52 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import type { OnboardingAgentReport } from "@/features/onboarding-agent/lib/agentTypes";
-
-function readinessTone(status: OnboardingAgentReport["activationReadiness"]["status"] | string | undefined) {
-  if (status === "ready_for_dry_run") return "border-emerald-400/40 text-emerald-200";
-  if (status === "review_required") return "border-amber-400/40 text-amber-200";
-  return "border-rose-400/40 text-rose-200";
-}
+import { useState } from "react";
+import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
 export function OnboardingAgentInsightsPanel({
-  sessionId,
   report,
-  onRefresh,
   fallbackReadiness,
 }: {
   sessionId: string;
-  report?: OnboardingAgentReport | null;
+  report?: { mode?: string; summary?: string; model?: string | null; activationReadiness?: { status?: string } } | null;
+  plan?: OnboardingAgentPlan | null;
   fallbackReadiness?: string;
   onRefresh: () => Promise<void>;
 }) {
-  const [running, setRunning] = useState(false);
-  const findings = report?.findings ?? [];
+  const [showDev, setShowDev] = useState(false);
   const displayedReadiness = report?.activationReadiness?.status ?? fallbackReadiness ?? "not_ready";
-  const recommendations = report?.recommendations ?? [];
-
-  const groupedFindings = useMemo(() => {
-    const buckets: Record<string, typeof findings> = {};
-    for (const finding of findings) {
-      buckets[finding.severity] = [...(buckets[finding.severity] ?? []), finding];
-    }
-    return buckets;
-  }, [findings]);
-
-  const groupedRecommendations = useMemo(() => {
-    const buckets: Record<string, typeof recommendations> = {};
-    for (const rec of recommendations) {
-      const key = `${rec.actionType} • ${rec.domain}`;
-      buckets[key] = [...(buckets[key] ?? []), rec];
-    }
-    return buckets;
-  }, [recommendations]);
-
-  const runAnalysis = async () => {
-    setRunning(true);
-    try {
-      await fetch(`/api/onboarding-agent/sessions/${sessionId}/agent-analysis`, { method: "POST" });
-      await onRefresh();
-    } finally {
-      setRunning(false);
-    }
-  };
 
   return (
     <div className="rounded-2xl border border-cyan-500/30 bg-cyan-950/10 p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold text-cyan-100">Agent insights</h3>
-          <p className="mt-1 text-xs text-cyan-100/70">No live records have been created. This is a staged analysis.</p>
+          <p className="mt-1 text-xs text-cyan-100/70">No live records have been created. This is a staged analysis only.</p>
         </div>
-        <button onClick={runAnalysis} disabled={running} className="rounded border border-cyan-400/40 px-3 py-2 text-xs text-cyan-100 disabled:opacity-60">
-          {running ? "Running..." : "Run AI analysis"}
-        </button>
       </div>
 
-      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
         <div className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
           <p className="text-[11px] uppercase tracking-wide text-slate-400">Mode</p>
-          <p className="text-sm text-white">
-            {!report ? "Not run yet" : report.mode === "ai" ? "AI analysis" : "Deterministic fallback"}
-          </p>
-          {report?.mode === "deterministic_fallback" ? (
-            <p className="mt-1 text-xs text-amber-200/90">AI reasoning unavailable; deterministic staging still completed.</p>
-          ) : null}
+          <p className="text-sm text-white">{report?.mode === "ai_planned" ? "AI planned" : report?.mode === "deterministic_fallback" ? "Deterministic fallback" : "AI unavailable"}</p>
         </div>
-        <div className={`rounded-lg border bg-slate-900/50 p-3 ${readinessTone(displayedReadiness)}`}>
+        <div className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Model</p>
+          <p className="text-sm text-white">{report?.model ?? "n/a"}</p>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
           <p className="text-[11px] uppercase tracking-wide text-slate-400">Activation readiness</p>
-          <p className="text-sm">{displayedReadiness}</p>
+          <p className="text-sm text-white">{displayedReadiness}</p>
         </div>
       </div>
 
-      <p className="mt-3 text-sm text-slate-200">{report?.summary ?? "Run analysis to get explainable onboarding insights."}</p>
+      <p className="mt-3 text-sm text-slate-200">{report?.summary ?? "Run analysis to get onboarding understanding."}</p>
 
-      {(report?.findings?.length ?? 0) > 0 ? (
-        <div className="mt-3 space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-300">Findings</p>
-          {Object.entries(groupedFindings).map(([severity, findings]) => (
-            <div key={severity} className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-400">{severity}</p>
-              <ul className="mt-2 space-y-2 text-sm text-slate-200">
-                {findings.map((finding, idx) => (
-                  <li key={`${finding.title}-${idx}`}>
-                    <p className="font-medium text-white">{finding.title}</p>
-                    <p>{finding.explanation}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      ) : null}
-
-      {(report?.recommendations?.length ?? 0) > 0 ? (
-        <div className="mt-3 space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-300">Recommendations</p>
-          {Object.entries(groupedRecommendations).map(([key, recs]) => (
-            <div key={key} className="rounded-lg border border-white/10 bg-slate-900/50 p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-400">{key}</p>
-              <ul className="mt-2 space-y-2 text-sm text-slate-200">
-                {recs.map((rec, idx) => (
-                  <li key={`${rec.title}-${idx}`}>
-                    <p className="font-medium text-white">{rec.title}</p>
-                    <p>{rec.explanation}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
+      <button onClick={() => setShowDev((v) => !v)} className="mt-3 text-xs text-cyan-200 underline">
+        {showDev ? "Hide" : "Show"} developer details
+      </button>
+      {showDev ? (
+        <pre className="mt-2 max-h-72 overflow-auto rounded bg-slate-900/70 p-3 text-[11px] text-slate-200">{JSON.stringify({ report }, null, 2)}</pre>
       ) : null}
     </div>
   );

--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -1,42 +1,38 @@
-const ENTITY_ROWS: Array<{ key: string; label: string }> = [
-  { key: "customer", label: "Customers" },
-  { key: "vehicle", label: "Vehicles" },
-  { key: "historical_work_order", label: "Historical work orders" },
-  { key: "historical_invoice", label: "Historical invoices" },
-  { key: "part", label: "Parts" },
-  { key: "vendor", label: "Vendors" },
-  { key: "staff_candidate", label: "Staff candidates" },
-  { key: "menu_suggestion", label: "Menu suggestions" },
-  { key: "inspection_suggestion", label: "Inspection suggestions" },
-];
+import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
-const LINK_ROWS: Array<{ key: string; label: string }> = [
-  { key: "customer_vehicle", label: "Customer ↔ Vehicle" },
-  { key: "customer_work_order", label: "Customer ↔ Work order" },
-  { key: "vehicle_work_order", label: "Vehicle ↔ Work order" },
-  { key: "work_order_invoice", label: "Work order ↔ Invoice" },
-  { key: "vendor_part", label: "Vendor ↔ Part" },
-  { key: "service_menu_suggestion", label: "Service ↔ Menu suggestion" },
+const ENTITY_ROWS: Array<{ key: string; label: string; planKey: keyof OnboardingAgentPlan["entityPlan"] }> = [
+  { key: "customer", label: "Customers", planKey: "customers" },
+  { key: "vehicle", label: "Vehicles", planKey: "vehicles" },
+  { key: "historical_work_order", label: "Historical work orders", planKey: "historicalWorkOrders" },
+  { key: "historical_invoice", label: "Historical invoices", planKey: "historicalInvoices" },
+  { key: "part", label: "Parts", planKey: "parts" },
+  { key: "vendor", label: "Vendors", planKey: "vendors" },
+  { key: "staff_candidate", label: "Staff candidates", planKey: "staffCandidates" },
+  { key: "menu_suggestion", label: "Menu suggestions", planKey: "menuSuggestions" },
+  { key: "inspection_suggestion", label: "Inspection suggestions", planKey: "inspectionSuggestions" },
 ];
 
 export function OnboardingEntitiesPanel({
   entityCounts,
   entityStatusCounts,
   linkCounts,
+  agentPlan,
 }: {
   entityCounts: Record<string, number>;
   entityStatusCounts: Record<string, Record<string, number>>;
   linkCounts: Record<string, number>;
+  agentPlan?: OnboardingAgentPlan | null;
 }) {
   return (
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <h3 className="text-sm font-semibold text-white">Staged entities & links</h3>
       <div className="mt-3 grid gap-3 lg:grid-cols-2">
         <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-          <p className="text-xs uppercase tracking-wide text-slate-400">Entities discovered</p>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Entity plan (AI + staged)</p>
           <ul className="mt-2 space-y-1 text-sm text-slate-200">
             {ENTITY_ROWS.map((item) => {
               const status = entityStatusCounts[item.key] ?? {};
+              const planned = agentPlan?.entityPlan?.[item.planKey];
               return (
                 <li key={item.key} className="rounded border border-white/5 px-2 py-1">
                   <div className="flex items-center justify-between gap-2">
@@ -44,6 +40,7 @@ export function OnboardingEntitiesPanel({
                     <span className="font-semibold text-white">{entityCounts[item.key] ?? 0}</span>
                   </div>
                   <p className="text-[11px] text-slate-400">ready: {status.ready ?? 0} • review: {(status.needs_review ?? 0) + (status.duplicate_candidate ?? 0)}</p>
+                  {planned ? <p className="text-[11px] text-cyan-200">ai staged: {planned.staged} • ai ready: {planned.ready} • ai review: {planned.review}</p> : null}
                 </li>
               );
             })}
@@ -51,14 +48,15 @@ export function OnboardingEntitiesPanel({
         </div>
 
         <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-          <p className="text-xs uppercase tracking-wide text-slate-400">Links found</p>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Relationship plan</p>
           <ul className="mt-2 space-y-1 text-sm text-slate-200">
-            {LINK_ROWS.map((item) => (
-              <li key={item.key} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1">
-                <span>{item.label}</span>
-                <span className="font-semibold text-white">{linkCounts[item.key] ?? 0}</span>
+            {(agentPlan?.relationshipPlan ?? []).slice(0, 8).map((rel, idx) => (
+              <li key={`${rel.relationshipType}-${idx}`} className="rounded border border-white/5 px-2 py-1">
+                <div className="flex items-center justify-between gap-2"><span>{rel.fromDomain} ↔ {rel.toDomain}</span><span className="text-cyan-200">{Math.round(rel.confidence * 100)}%</span></div>
+                <p className="text-[11px] text-slate-400">{rel.relationshipType} • keys: {rel.matchingKeys.join(", ") || "n/a"}</p>
               </li>
             ))}
+            {!agentPlan?.relationshipPlan?.length ? Object.entries(linkCounts).map(([key, value]) => <li key={key} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1"><span>{key}</span><span className="font-semibold text-white">{value ?? 0}</span></li>) : null}
           </ul>
         </div>
       </div>

--- a/features/onboarding-agent/components/OnboardingReviewPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingReviewPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
 type ReviewItem = {
   id: string;
@@ -14,65 +15,58 @@ type ReviewItem = {
 export function OnboardingReviewPanel({
   reviewCounts,
   reviewItems,
+  agentPlan,
 }: {
   reviewCounts: { blocking?: number; high?: number; medium?: number; low?: number; byDomain?: Record<string, number> };
   reviewItems: ReviewItem[];
+  agentPlan?: OnboardingAgentPlan | null;
 }) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-  const topItems = reviewItems.filter((item) => item).slice(0, 12);
+  const groupedFromPlan = agentPlan?.reviewGroups ?? [];
+  const topItems = groupedFromPlan.length
+    ? groupedFromPlan.slice(0, 12).map((group, index) => ({
+      id: `${group.domain}-${group.issueType}-${index}`,
+      severity: group.severity,
+      domain: group.domain,
+      issue_type: group.issueType,
+      summary: group.summary,
+      details: {
+        count: group.affectedRowCount,
+        sampleRowIndexes: group.sampleRows,
+        recommendedAction: group.recommendedAction,
+        examples: group.sampleRows.map((row) => ({ summary: `Sample row ${row}` })),
+      },
+    }))
+    : reviewItems.filter((item) => item).slice(0, 12);
   const domainCounts = reviewCounts.byDomain ?? {};
 
   return (
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <h3 className="text-sm font-semibold text-white">Review exceptions</h3>
-      <p className="mt-2 text-sm text-slate-300">
-        Blocking: {reviewCounts.blocking ?? 0} • High: {reviewCounts.high ?? 0} • Medium: {reviewCounts.medium ?? 0} • Low: {reviewCounts.low ?? 0}
-      </p>
+      <p className="mt-2 text-sm text-slate-300">Blocking: {reviewCounts.blocking ?? 0} • High: {reviewCounts.high ?? 0} • Medium: {reviewCounts.medium ?? 0} • Low: {reviewCounts.low ?? 0}</p>
 
       <div className="mt-3 rounded-lg border border-white/10 bg-slate-900/60 p-3">
         <p className="text-xs uppercase tracking-wide text-slate-400">By domain</p>
         <ul className="mt-2 grid gap-1 text-xs text-slate-300 sm:grid-cols-2">
-          {Object.entries(domainCounts).map(([domain, count]) => (
-            <li key={domain} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1">
-              <span>{domain}</span>
-              <span className="text-white">{count}</span>
-            </li>
-          ))}
+          {Object.entries(domainCounts).map(([domain, count]) => <li key={domain} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1"><span>{domain}</span><span className="text-white">{count}</span></li>)}
           {Object.keys(domainCounts).length === 0 ? <li className="text-slate-400">No pending exceptions.</li> : null}
         </ul>
       </div>
 
       <div className="mt-3 space-y-2">
-        <p className="text-xs uppercase tracking-wide text-slate-400">Top grouped exceptions</p>
+        <p className="text-xs uppercase tracking-wide text-slate-400">Grouped review issues</p>
         {topItems.map((item) => {
           const details = (item.details ?? {}) as Record<string, any>;
           const examples = Array.isArray(details.examples) ? details.examples : [];
           const key = item.id;
           return (
             <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-400">
-                {item.severity} • {item.domain ?? "unknown"} • {item.issue_type ?? "issue"}
-              </p>
+              <p className="text-xs uppercase tracking-wide text-slate-400">{item.severity} • {item.domain ?? "unknown"} • {item.issue_type ?? "issue"}</p>
               <p className="text-sm text-white">{item.summary}</p>
               {typeof details.count === "number" ? <p className="text-xs text-slate-300">Affected rows: {details.count}</p> : null}
-              {Array.isArray(details.sampleRowIndexes) && details.sampleRowIndexes.length > 0 ? (
-                <p className="text-xs text-slate-400">Sample rows: {details.sampleRowIndexes.slice(0, 5).join(", ")}</p>
-              ) : null}
-              <p className="text-xs text-slate-400">Recommended action: {details.recommendedAction ?? "Review examples and resolve before activation planning."}</p>
-              {examples.length > 0 ? (
-                <>
-                  <button className="mt-2 text-xs text-cyan-200 underline" onClick={() => setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))}>
-                    {expanded[key] ? "Hide examples" : "Show examples"}
-                  </button>
-                  {expanded[key] ? (
-                    <ul className="mt-2 space-y-1 text-xs text-slate-300">
-                      {examples.slice(0, 3).map((example: any, idx: number) => (
-                        <li key={`${key}-${idx}`}>• {example.summary}</li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </>
-              ) : null}
+              {Array.isArray(details.sampleRowIndexes) && details.sampleRowIndexes.length > 0 ? <p className="text-xs text-slate-400">Sample rows: {details.sampleRowIndexes.slice(0, 5).join(", ")}</p> : null}
+              <p className="text-xs text-slate-400">Recommended action: {details.recommendedAction ?? "manual_review"}</p>
+              {examples.length > 0 ? <><button className="mt-2 text-xs text-cyan-200 underline" onClick={() => setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))}>{expanded[key] ? "Hide examples" : "Show examples"}</button>{expanded[key] ? <ul className="mt-2 space-y-1 text-xs text-slate-300">{examples.slice(0, 3).map((example: any, idx: number) => <li key={`${key}-${idx}`}>• {example.summary}</li>)}</ul> : null}</> : null}
             </div>
           );
         })}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -38,11 +38,10 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       if (!res.ok || !json.ok) {
         setError(json?.error || "Analysis failed. Please retry.");
       } else {
-        const mode = json?.agentReport?.mode;
-        if (!json?.agentReport) {
-          setNotice("Analysis complete. Agent insights may be unavailable right now, but deterministic results are staged.");
-        } else if (mode === "deterministic_fallback") {
-          setNotice("Analysis complete. AI is unavailable, so deterministic fallback insights were generated.");
+        const mode = json?.mode;
+        const warnings = Array.isArray(json?.warnings) ? json.warnings : [];
+        if (mode === "deterministic_fallback") {
+          setNotice(warnings[0] ?? "Analysis complete. AI is unavailable, so deterministic fallback staging was used.");
         } else {
           setNotice("Analysis complete.");
         }
@@ -127,12 +126,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       </div>
 
       <OnboardingProgressCard summary={session?.summary ?? null} />
-      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} onRefresh={load} />
+      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} onRefresh={load} />
       <OnboardingFilesPanel files={files} />
-      <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} />
-      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
+      <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} agentPlan={session?.summary?.agentPlan ?? null} />
+      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} agentPlan={session?.summary?.agentPlan ?? null} />
 
-      <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} />
+      <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} agentPlan={session?.summary?.agentPlan ?? null} />
     </div>
   );
 }

--- a/features/onboarding-agent/lib/agentPlanTypes.ts
+++ b/features/onboarding-agent/lib/agentPlanTypes.ts
@@ -1,0 +1,113 @@
+export const ONBOARDING_AGENT_PLAN_VERSION = "onboarding_agent_plan_v1" as const;
+
+export type OnboardingAgentPlanDomain =
+  | "customers"
+  | "vehicles"
+  | "history"
+  | "invoices"
+  | "parts"
+  | "vendors"
+  | "staff"
+  | "menu"
+  | "inspections"
+  | "unknown";
+
+export type OnboardingAgentPlanMode = "ai_planned" | "deterministic_fallback";
+
+export type EntityPlanSummary = {
+  staged: number;
+  ready: number;
+  review: number;
+  confidence: number;
+  notes: string[];
+};
+
+export type OnboardingAgentPlan = {
+  version: typeof ONBOARDING_AGENT_PLAN_VERSION;
+  mode: OnboardingAgentPlanMode;
+  model?: string;
+  liveRecordsCreated: 0;
+  confidence: number;
+  summary: string;
+  files: Array<{
+    fileId: string;
+    filename: string;
+    inferredDomain: OnboardingAgentPlanDomain;
+    confidence: number;
+    reasoning: string;
+    headerMap: Record<string, string>;
+    requiredFieldsPresent: string[];
+    missingImportantFields: string[];
+    rowCountEstimate: number;
+    recommendedParserMode: "stage_entities" | "stage_review_only" | "ignore" | "unsupported";
+  }>;
+  entityPlan: {
+    customers: EntityPlanSummary;
+    vehicles: EntityPlanSummary;
+    historicalWorkOrders: EntityPlanSummary;
+    historicalInvoices: EntityPlanSummary;
+    parts: EntityPlanSummary;
+    vendors: EntityPlanSummary;
+    staffCandidates: EntityPlanSummary;
+    menuSuggestions: EntityPlanSummary;
+    inspectionSuggestions: EntityPlanSummary;
+  };
+  relationshipPlan: Array<{
+    fromDomain: string;
+    toDomain: string;
+    relationshipType: string;
+    confidence: number;
+    matchingKeys: string[];
+    reasoning: string;
+    expectedLinks: number | null;
+    reviewRequired: boolean;
+  }>;
+  reviewGroups: Array<{
+    severity: "low" | "medium" | "high" | "blocking";
+    domain: string;
+    issueType: string;
+    affectedRowCount: number;
+    sampleRows: number[];
+    summary: string;
+    recommendedAction: "accept" | "ignore" | "link_existing" | "edit_mapping" | "upload_better_file" | "manual_review";
+  }>;
+  activationReadiness: "not_ready" | "review_required" | "ready_for_dry_run" | "blocked";
+  activationPreview: {
+    creates: {
+      customers: number;
+      vehicles: number;
+      historicalWorkOrders: number;
+      historicalInvoices: number;
+      parts: number;
+      vendors: number;
+      staffCandidates: number;
+      menuSuggestions: number;
+      inspectionSuggestions: number;
+    };
+    requiresReview: number;
+    blockingIssues: number;
+    risks: string[];
+  };
+};
+
+export type OnboardingAgentInputPayload = {
+  sessionId: string;
+  shopId: string;
+  files: Array<{
+    fileId: string;
+    filename: string;
+    declaredDomain: string | null;
+    detectedDomain: string;
+    parseStatus: string | null;
+    rowCount: number;
+    headers: string[];
+    sampleRows: Record<string, unknown>[];
+    columnExamples: Record<string, unknown[]>;
+    deterministic: {
+      entityCount: number;
+      linkCount: number;
+      reviewCount: number;
+    };
+  }>;
+  targetSchema: Record<string, string[]>;
+};

--- a/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { OnboardingAgentInput, OnboardingAgentReport } from "@/features/onboarding-agent/lib/agentTypes";
-import {
-  buildDeterministicFallbackReport,
-  sanitizeAgentReport,
-} from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
+import { buildDeterministicFallbackReport, sanitizeAgentReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
+import { validateOnboardingAgentPlan } from "@/features/onboarding-agent/server/validateOnboardingAgentPlan";
+import { redactOnboardingSample } from "@/features/onboarding-agent/server/redactOnboardingSample";
 
 function makeInput(reviewSeverity: "blocking" | "high" = "blocking"): OnboardingAgentInput {
   return {
@@ -135,4 +134,33 @@ describe("onboarding agent ai safeguards", () => {
 
     expect(report.liveRecordsCreated).toBe(0);
   });
+
+  it("plan validator clamps confidence and forces liveRecordsCreated=0", () => {
+    const plan = validateOnboardingAgentPlan({
+      validFileIds: new Set(["file-1"]),
+      candidate: {
+        mode: "ai_planned",
+        confidence: 9,
+        liveRecordsCreated: 8,
+        files: [{ fileId: "file-1", filename: "customers.csv", inferredDomain: "customers", confidence: 4, reasoning: "x", headerMap: { Email: "email" }, rowCountEstimate: 10, requiredFieldsPresent: [], missingImportantFields: [], recommendedParserMode: "stage_entities" }],
+        entityPlan: {},
+        relationshipPlan: [],
+        reviewGroups: [],
+        activationReadiness: "ready_for_dry_run",
+        activationPreview: { creates: {}, requiresReview: 0, blockingIssues: 0, risks: [] },
+      },
+    });
+
+    expect(plan.confidence).toBe(1);
+    expect(plan.files[0].confidence).toBe(1);
+    expect(plan.liveRecordsCreated).toBe(0);
+  });
+
+  it("redaction masks email and phone", () => {
+    const row = redactOnboardingSample({ Email: "jane@example.com", Phone: "555-321-1234", Note: "x".repeat(180) });
+    expect(String(row.Email)).toContain("***@");
+    expect(String(row.Phone)).toContain("***-***-");
+    expect(String(row.Note).length).toBeLessThanOrEqual(120);
+  });
+
 });

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -1,13 +1,10 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { parseCsvText } from "@/features/onboarding-agent/lib/csvParsing";
 import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
-import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprints";
-import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
-import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
-import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
-import { markDuplicateEntities, stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
-import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import { applyOnboardingAgentPlan } from "@/features/onboarding-agent/server/applyOnboardingAgentPlan";
+import { buildOnboardingAgentInput } from "@/features/onboarding-agent/server/buildOnboardingAgentInput";
+import { runOpenAIOnboardingPlan } from "@/features/onboarding-agent/server/runOpenAIOnboardingPlan";
 
 const INSERT_CHUNK_SIZE = 1000;
 
@@ -44,24 +41,10 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
   await sb.from("onboarding_sessions").update({ status: "analyzing" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
 
   await sb.from("onboarding_raw_rows").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
-  await sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
-  await sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
-  await sb.from("onboarding_review_items").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
-
-  const stagedEntities: any[] = [];
-  const reviewItems: any[] = [];
-  let totalRows = 0;
 
   for (const file of files ?? []) {
     const dl = await sb.storage.from(file.storage_bucket).download(file.storage_path);
     if (dl.error || !dl.data) {
-      reviewItems.push({
-        severity: "blocking",
-        domain: "unknown",
-        issue_type: "parse_error",
-        summary: `Failed to read ${file.original_filename ?? file.storage_path}`,
-        details: {},
-      });
       const { error: updateError } = await sb
         .from("onboarding_files")
         .update({ parse_status: "failed", parse_error: dl.error?.message ?? "download failed" })
@@ -78,7 +61,6 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       headers: parsed.headers,
       declaredDomain: file.declared_domain,
     });
-    totalRows += parsed.rows.length;
 
     const rawRowsPayload = parsed.rows.map((row, index) => ({
       shop_id: params.shopId,
@@ -92,27 +74,7 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       parse_status: "parsed",
     }));
 
-    const rawRows = await insertInChunks(sb, "onboarding_raw_rows", rawRowsPayload, "id, source_row_index");
-    const rawRowsByIndex = new Map<number, string>((rawRows ?? []).map((row: any) => [Number(row.source_row_index), row.id]));
-
-    parsed.rows.forEach((row, index) => {
-      const normalized = normalizeRow(detectedDomain as any, row);
-      const fingerprint = fingerprintForDomain(detectedDomain as any, normalized.normalized);
-      const staged = stageEntityFromNormalized({
-        domain: detectedDomain as any,
-        normalized: normalized.normalized,
-        displayName: normalized.displayName,
-        sourceFileId: file.id,
-        sourceRowId: rawRowsByIndex.get(index) ?? null,
-        sourceRowIndex: index,
-        shopId: params.shopId,
-        sessionId: params.sessionId,
-        canonicalFingerprint: fingerprint,
-      });
-
-      if (staged.entity) stagedEntities.push(staged.entity);
-      reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
-    });
+    await insertInChunks(sb, "onboarding_raw_rows", rawRowsPayload);
 
     const { error: fileUpdateError } = await sb
       .from("onboarding_files")
@@ -122,66 +84,32 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
     if (fileUpdateError) throw new Error(fileUpdateError.message);
   }
 
-  reviewItems.push(...markDuplicateEntities(stagedEntities, { shopId: params.shopId, sessionId: params.sessionId }).map((item) => ({
-    severity: item.severity,
-    domain: item.domain,
-    issue_type: item.issue_type,
-    summary: item.summary,
-    details: item.details,
-  })));
-
-  const entities = await insertInChunks(sb, "onboarding_entities", stagedEntities, "id, entity_type, status, normalized, display_name, source_external_id");
-
-  const graph = buildStagedLinks({ entities: entities.map((e: any) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
-  reviewItems.push(...graph.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
-
-  const linksToInsert = graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId }));
-  const insertedLinks = await insertInChunks(sb, "onboarding_entity_links", linksToInsert, "id, link_type, status");
-
-  const groupedReviewItems = groupReviewItems(reviewItems as any).map((item) => ({
-    shop_id: params.shopId,
-    session_id: params.sessionId,
-    entity_id: null,
-    severity: item.severity,
-    domain: item.domain,
-    issue_type: item.issue_type,
-    summary: item.summary,
-    details: {
-      count: item.count,
-      sampleRowIndexes: item.sampleRowIndexes,
-      sampleNormalizedValues: item.sampleNormalizedValues,
-      recommendedAction: item.recommended_action,
-      ...item.details,
-    },
-    status: "pending",
-  }));
-  await insertInChunks(sb, "onboarding_review_items", groupedReviewItems);
-
-  const canonical = buildOnboardingSummary({
-    filesCount: (files ?? []).length,
-    rowsParsed: totalRows,
-    entityRows: (entities ?? []).map((e: any) => ({ entity_type: e.entity_type, status: e.status })),
-    linkRows: (insertedLinks ?? []).map((l: any) => ({ link_type: l.link_type, status: l.status })),
-    reviewRows: groupedReviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details, status: item.status })),
-    groupedExceptionCount: groupedReviewItems.length,
-    analysisCompleted: true,
+  const input = await buildOnboardingAgentInput({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
   });
 
-  const blockingCount = (canonical.review_counts_by_severity.blocking ?? 0) + (canonical.review_counts_by_severity.high ?? 0);
-  const status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
+  const requireAi = process.env.ONBOARDING_AGENT_REQUIRE_AI === "true";
+  const { plan, warning } = await runOpenAIOnboardingPlan({ input, requireAi });
+  const applied = await applyOnboardingAgentPlan({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+    plan,
+  });
 
-  const summary = {
-    ...canonical.summaryCounts,
-    activationReadiness: canonical.activation_readiness,
-    activationPlanSummary: canonical.activation_plan_summary,
+  return {
+    mode: plan.mode,
+    warning,
+    planSummary: {
+      summary: plan.summary,
+      confidence: plan.confidence,
+      activationReadiness: plan.activationReadiness,
+      model: plan.model ?? null,
+      files: plan.files.length,
+    },
+    sessionSummary: applied.summary,
     liveRecordsCreated: 0 as const,
   };
-
-  await sb
-    .from("onboarding_sessions")
-    .update({ status, analyzed_at: new Date().toISOString(), summary, stats: canonical })
-    .eq("id", params.sessionId)
-    .eq("shop_id", params.shopId);
-
-  return summary;
 }

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -1,0 +1,184 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprints";
+import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
+import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
+import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
+import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-agent/lib/summaries";
+import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
+
+const INSERT_CHUNK_SIZE = 1000;
+
+async function insertInChunks(sb: any, table: string, rows: any[], returning?: string) {
+  if (!rows.length) return [];
+  const output: any[] = [];
+  for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
+    let query = sb.from(table).insert(chunk);
+    if (returning) query = query.select(returning);
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+    if (Array.isArray(data)) output.push(...data);
+  }
+  return output;
+}
+
+const DOMAIN_TO_ENTITY: Record<string, OnboardingDomain> = {
+  customers: "customers",
+  vehicles: "vehicles",
+  history: "history",
+  invoices: "invoices",
+  parts: "parts",
+  vendors: "vendors",
+  staff: "staff",
+  menu: "menu",
+  inspections: "inspections",
+  unknown: "unknown",
+};
+
+function remapHeaders(raw: Record<string, unknown>, map: Record<string, string>) {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    const key = map[k] ?? map[k.toLowerCase()] ?? k;
+    out[key] = typeof v === "string" ? v : String(v ?? "");
+  }
+  return out;
+}
+
+export async function applyOnboardingAgentPlan(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  plan: OnboardingAgentPlan;
+}) {
+  const sb = params.supabase as any;
+  await sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  await sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  await sb.from("onboarding_review_items").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+
+  const fileMap = new Map(params.plan.files.map((file) => [file.fileId, file]));
+  const rawRowsByFile = new Map<string, any[]>();
+  const { data: rows } = await sb
+    .from("onboarding_raw_rows")
+    .select("id, file_id, source_row_index, raw")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .order("source_row_index", { ascending: true });
+
+  for (const row of rows ?? []) {
+    const list = rawRowsByFile.get(row.file_id) ?? [];
+    list.push(row);
+    rawRowsByFile.set(row.file_id, list);
+  }
+
+  const stagedEntities: any[] = [];
+  const reviewItems: any[] = [];
+
+  for (const [fileId, fileRows] of rawRowsByFile.entries()) {
+    const planFile = fileMap.get(fileId);
+    const domain = DOMAIN_TO_ENTITY[planFile?.inferredDomain ?? "unknown"] ?? "unknown";
+    const headerMap = planFile?.headerMap ?? {};
+    const parserMode = planFile?.recommendedParserMode ?? "stage_review_only";
+
+    if (parserMode === "ignore" || parserMode === "unsupported") {
+      reviewItems.push({ severity: "medium", domain, issue_type: "ignored_file", summary: `File ${planFile?.filename ?? fileId} ignored by plan`, details: { fileId } });
+      continue;
+    }
+
+    for (const row of fileRows) {
+      const mappedRow = remapHeaders((row.raw ?? {}) as Record<string, unknown>, headerMap);
+      const normalized = normalizeRow(domain, mappedRow);
+      const fingerprint = fingerprintForDomain(domain, normalized.normalized);
+      const staged = stageEntityFromNormalized({
+        domain,
+        normalized: normalized.normalized,
+        displayName: normalized.displayName,
+        sourceFileId: fileId,
+        sourceRowId: row.id,
+        sourceRowIndex: Number(row.source_row_index ?? 0),
+        shopId: params.shopId,
+        sessionId: params.sessionId,
+        canonicalFingerprint: fingerprint,
+      });
+      if (staged.entity && parserMode === "stage_entities") stagedEntities.push(staged.entity);
+      if (staged.reviewItems.length) reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
+    }
+
+    await sb.from("onboarding_files").update({
+      detected_domain: domain,
+      parse_status: "parsed",
+    }).eq("shop_id", params.shopId).eq("id", fileId);
+  }
+
+  for (const group of params.plan.reviewGroups) {
+    reviewItems.push({
+      severity: group.severity,
+      domain: group.domain,
+      issue_type: group.issueType,
+      summary: group.summary,
+      details: { sampleRows: group.sampleRows, affectedRowCount: group.affectedRowCount, recommendedAction: group.recommendedAction },
+    });
+  }
+
+  const entities = await insertInChunks(sb, "onboarding_entities", stagedEntities, "id, entity_type, status, normalized");
+  const graph = buildStagedLinks({ entities: (entities ?? []).map((e: any) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
+  const linksToInsert = graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId }));
+  const insertedLinks = await insertInChunks(sb, "onboarding_entity_links", linksToInsert, "id, link_type, status");
+
+  const groupedReviewItems = groupReviewItems(reviewItems as any).map((item) => ({
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+    entity_id: null,
+    severity: item.severity,
+    domain: item.domain,
+    issue_type: item.issue_type,
+    summary: item.summary,
+    details: item.details,
+    status: "pending",
+  }));
+  await insertInChunks(sb, "onboarding_review_items", groupedReviewItems);
+
+  const { data: files } = await sb.from("onboarding_files").select("id").eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  const canonical = buildOnboardingSummary({
+    filesCount: (files ?? []).length,
+    rowsParsed: (rows ?? []).length,
+    entityRows: (entities ?? []).map((e: any) => ({ entity_type: e.entity_type, status: e.status })),
+    linkRows: (insertedLinks ?? []).map((l: any) => ({ link_type: l.link_type, status: l.status })),
+    reviewRows: groupedReviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details, status: item.status })),
+    groupedExceptionCount: groupedReviewItems.length,
+    analysisCompleted: true,
+  });
+
+  const blockingCount = (canonical.review_counts_by_severity.blocking ?? 0) + (canonical.review_counts_by_severity.high ?? 0);
+  let status = nextStatusFromCounts({ fileCount: (files ?? []).length, blockingReviewCount: blockingCount });
+  if (params.plan.activationReadiness === "blocked") status = "blocked";
+  if (params.plan.reviewGroups.length > 0 && status === "analysis_ready") status = "review_required";
+
+  const { data: session } = await sb.from("onboarding_sessions").select("summary").eq("id", params.sessionId).eq("shop_id", params.shopId).maybeSingle();
+  const existingSummary = (session?.summary && typeof session.summary === "object") ? session.summary : {};
+  const summary = {
+    ...existingSummary,
+    ...canonical.summaryCounts,
+    activationReadiness: canonical.activation_readiness,
+    activationPlanSummary: canonical.activation_plan_summary,
+    liveRecordsCreated: 0,
+    agentPlan: params.plan,
+    agentReport: {
+      mode: params.plan.mode,
+      model: params.plan.model ?? null,
+      summary: params.plan.summary,
+      activationReadiness: { status: params.plan.activationReadiness },
+      liveRecordsCreated: 0,
+    },
+  };
+
+  await sb.from("onboarding_sessions").update({
+    status,
+    analyzed_at: new Date().toISOString(),
+    stats: canonical,
+    summary,
+  }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+
+  return { canonical, status, summary };
+}

--- a/features/onboarding-agent/server/buildOnboardingAgentInput.ts
+++ b/features/onboarding-agent/server/buildOnboardingAgentInput.ts
@@ -1,0 +1,119 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { parseCsvText } from "@/features/onboarding-agent/lib/csvParsing";
+import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
+import type { OnboardingAgentInputPayload } from "@/features/onboarding-agent/lib/agentPlanTypes";
+import { redactOnboardingSample } from "@/features/onboarding-agent/server/redactOnboardingSample";
+
+const DEFAULT_SAMPLES = 25;
+
+function targetSchema() {
+  return {
+    customer: ["sourceCustomerId", "name", "businessName", "email", "phone"],
+    vehicle: ["sourceVehicleId", "sourceCustomerId", "vin", "plate", "year", "make", "model"],
+    historical_work_order: ["sourceWorkOrderId", "sourceCustomerId", "sourceVehicleId", "openedDate", "complaint", "correction", "total"],
+    historical_invoice: ["invoiceNumber", "sourceWorkOrderId", "sourceCustomerId", "invoiceDate", "total", "paymentStatus"],
+    part: ["sku", "partNumber", "description", "vendorName", "cost", "price"],
+    vendor: ["name", "email", "phone", "accountNumber"],
+    staff_candidate: ["name", "email", "phone", "role"],
+    menu_suggestion: ["serviceName", "description", "category", "laborHours", "laborPrice", "opCode"],
+    inspection_suggestion: ["name", "description", "category"],
+  };
+}
+
+function pickSamples(rows: Record<string, unknown>[], max: number) {
+  if (rows.length <= max) return rows;
+  const first = rows.slice(0, Math.ceil(max * 0.7));
+  const stride = Math.max(1, Math.floor(rows.length / Math.max(1, max - first.length)));
+  const later: Record<string, unknown>[] = [];
+  for (let i = Math.ceil(max * 0.7); i < rows.length && first.length + later.length < max; i += stride) {
+    later.push(rows[i]);
+  }
+  return [...first, ...later];
+}
+
+export async function buildOnboardingAgentInput(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  sampleRowsPerFile?: number;
+}): Promise<OnboardingAgentInputPayload> {
+  const sb = params.supabase as any;
+  const sampleLimit = Math.max(5, Math.min(50, params.sampleRowsPerFile ?? DEFAULT_SAMPLES));
+
+  const { data: files, error } = await sb
+    .from("onboarding_files")
+    .select("id, original_filename, storage_bucket, storage_path, declared_domain, detected_domain, parse_status, row_count, header_row")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+
+  const fileIds = (files ?? []).map((f: any) => f.id);
+  const rowsByFile = new Map<string, Record<string, unknown>[]>();
+  if (fileIds.length) {
+    const { data: rows } = await sb
+      .from("onboarding_raw_rows")
+      .select("file_id, source_row_index, raw")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .in("file_id", fileIds)
+      .order("source_row_index", { ascending: true });
+
+    for (const row of rows ?? []) {
+      const list = rowsByFile.get(row.file_id) ?? [];
+      list.push((row.raw ?? {}) as Record<string, unknown>);
+      rowsByFile.set(row.file_id, list);
+    }
+  }
+
+  const filesPayload = [];
+  for (const file of files ?? []) {
+    let rows = rowsByFile.get(file.id) ?? [];
+    let headers = Array.isArray(file.header_row) ? file.header_row : [];
+    let rowCount = Number(file.row_count ?? rows.length ?? 0);
+
+    if (!rows.length) {
+      const dl = await sb.storage.from(file.storage_bucket).download(file.storage_path);
+      if (!dl.error && dl.data) {
+        const parsed = parseCsvText(await dl.data.text());
+        rows = parsed.rows;
+        headers = parsed.headers;
+        rowCount = parsed.rows.length;
+      }
+    }
+
+    const sampled = pickSamples(rows, sampleLimit).map(redactOnboardingSample);
+    const columnExamples: Record<string, unknown[]> = {};
+    for (const row of sampled) {
+      for (const [key, val] of Object.entries(row)) {
+        const arr = columnExamples[key] ?? [];
+        if (val && arr.length < 3) arr.push(val);
+        columnExamples[key] = arr;
+      }
+    }
+
+    filesPayload.push({
+      fileId: file.id,
+      filename: file.original_filename ?? file.storage_path,
+      declaredDomain: file.declared_domain,
+      detectedDomain: file.detected_domain ?? detectFileDomain({ filename: file.original_filename ?? file.storage_path, headers, declaredDomain: file.declared_domain }),
+      parseStatus: file.parse_status,
+      rowCount,
+      headers,
+      sampleRows: sampled,
+      columnExamples,
+      deterministic: {
+        entityCount: 0,
+        linkCount: 0,
+        reviewCount: 0,
+      },
+    });
+  }
+
+  return {
+    sessionId: params.sessionId,
+    shopId: params.shopId,
+    files: filesPayload,
+    targetSchema: targetSchema(),
+  };
+}

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -66,6 +66,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     activationPlanSummary: canonical.activation_plan_summary,
     liveRecordsCreated: 0 as const,
     agentReport: (session?.summary ?? {})?.agentReport ?? null,
+    agentPlan: (session?.summary ?? {})?.agentPlan ?? null,
   };
 
   return {

--- a/features/onboarding-agent/server/redactOnboardingSample.ts
+++ b/features/onboarding-agent/server/redactOnboardingSample.ts
@@ -1,0 +1,48 @@
+function maskEmail(value: string) {
+  const [local, domain] = value.split("@");
+  if (!domain) return value;
+  const head = local.slice(0, 2);
+  return `${head}***@${domain}`;
+}
+
+function maskPhone(value: string) {
+  const digits = value.replace(/\D/g, "");
+  if (digits.length < 4) return "***";
+  return `***-***-${digits.slice(-4)}`;
+}
+
+const SAFE_ID_KEYS = ["id", "vin", "invoice", "work order", "ro", "unit", "plate", "license", "stock", "sku", "part number"];
+
+function shouldKeepRaw(key: string) {
+  const normalized = key.toLowerCase();
+  return SAFE_ID_KEYS.some((token) => normalized.includes(token));
+}
+
+export function redactOnboardingSample(row: Record<string, unknown>) {
+  const output: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(row)) {
+    const value = typeof raw === "string" ? raw.trim() : raw;
+    if (typeof value !== "string") {
+      output[key] = value;
+      continue;
+    }
+
+    if (shouldKeepRaw(key)) {
+      output[key] = value.slice(0, 80);
+      continue;
+    }
+
+    if (/@/.test(value)) {
+      output[key] = maskEmail(value);
+      continue;
+    }
+
+    if (/\d{3}[^\d]?\d{3}[^\d]?\d{4}/.test(value)) {
+      output[key] = maskPhone(value);
+      continue;
+    }
+
+    output[key] = value.length > 120 ? `${value.slice(0, 117)}...` : value;
+  }
+  return output;
+}

--- a/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
+++ b/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
@@ -1,0 +1,103 @@
+import type { OnboardingAgentInputPayload, OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
+import { getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
+import { validateOnboardingAgentPlan } from "@/features/onboarding-agent/server/validateOnboardingAgentPlan";
+
+function buildFallbackPlan(input: OnboardingAgentInputPayload, model: string): OnboardingAgentPlan {
+  return validateOnboardingAgentPlan({
+    modeFallback: "deterministic_fallback",
+    model,
+    validFileIds: new Set(input.files.map((f) => f.fileId)),
+    candidate: {
+      version: "onboarding_agent_plan_v1",
+      mode: "deterministic_fallback",
+      confidence: 0.4,
+      summary: "AI reasoning unavailable; deterministic staging was used.",
+      files: input.files.map((f) => ({
+        fileId: f.fileId,
+        filename: f.filename,
+        inferredDomain: f.detectedDomain,
+        confidence: 0.65,
+        reasoning: "Fallback domain detection from deterministic parser.",
+        headerMap: {},
+        requiredFieldsPresent: [],
+        missingImportantFields: [],
+        rowCountEstimate: f.rowCount,
+        recommendedParserMode: "stage_entities",
+      })),
+      entityPlan: {},
+      relationshipPlan: [],
+      reviewGroups: [],
+      activationReadiness: "review_required",
+      activationPreview: { creates: {}, requiresReview: 0, blockingIssues: 0, risks: ["AI unavailable"] },
+      liveRecordsCreated: 0,
+    },
+  });
+}
+
+export async function runOpenAIOnboardingPlan(params: {
+  input: OnboardingAgentInputPayload;
+  requireAi?: boolean;
+}): Promise<{ plan: OnboardingAgentPlan; warning?: string }> {
+  const model = getOnboardingAgentModel();
+  const validFileIds = new Set(params.input.files.map((file) => file.fileId));
+
+  if (!process.env.OPENAI_API_KEY?.trim()) {
+    if (params.requireAi) throw new Error("AI is required but OPENAI_API_KEY is not configured.");
+    return { plan: buildFallbackPlan(params.input, model), warning: "AI reasoning unavailable; deterministic staging was used." };
+  }
+
+  const { openai } = await import("../../../lib/server/openai");
+  const started = Date.now();
+
+  try {
+    const completion = await openai.chat.completions.create({
+      model,
+      temperature: 0.1,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content: "You are the ProFixIQ onboarding migration planner. You produce JSON only. Never claim live record creation. Staged-only semantics: historical work orders are not active jobs; historical invoices are not active invoice workflow; staff rows are candidates/invites, not auth users; menu/inspection rows are suggestions only.",
+        },
+        {
+          role: "user",
+          content: JSON.stringify({
+            instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Return strict OnboardingAgentPlan JSON.",
+            knownFilesHint: ["customers.csv", "vehicles.csv", "work_orders_history.csv", "invoices.csv", "parts_inventory.csv", "vendors.csv", "staff_users.csv", "service_catalog.csv"],
+            input: params.input,
+          }),
+        },
+      ],
+    });
+
+    const content = completion.choices?.[0]?.message?.content;
+    if (!content) throw new Error("No response content returned by model");
+    const parsed = JSON.parse(content);
+    const plan = validateOnboardingAgentPlan({ candidate: parsed, validFileIds, model, modeFallback: "ai_planned" });
+
+    console.info("[onboarding-agent] openai plan", {
+      sessionId: params.input.sessionId,
+      shopId: params.input.shopId,
+      files: params.input.files.length,
+      rowsSampled: params.input.files.reduce((sum, f) => sum + f.sampleRows.length, 0),
+      mode: plan.mode,
+      model,
+      confidence: plan.confidence,
+      durationMs: Date.now() - started,
+      liveRecordsCreated: 0,
+    });
+
+    return { plan };
+  } catch (error) {
+    console.warn("[onboarding-agent] openai planning fallback", {
+      sessionId: params.input.sessionId,
+      shopId: params.input.shopId,
+      model,
+      error: error instanceof Error ? error.message : "unknown",
+      durationMs: Date.now() - started,
+      liveRecordsCreated: 0,
+    });
+    if (params.requireAi) throw new Error("AI planning is required but unavailable.");
+    return { plan: buildFallbackPlan(params.input, model), warning: "AI reasoning unavailable; deterministic staging was used." };
+  }
+}

--- a/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
@@ -1,0 +1,139 @@
+import {
+  ONBOARDING_AGENT_PLAN_VERSION,
+  type EntityPlanSummary,
+  type OnboardingAgentPlan,
+  type OnboardingAgentPlanDomain,
+} from "@/features/onboarding-agent/lib/agentPlanTypes";
+
+const DOMAINS = new Set<OnboardingAgentPlanDomain>(["customers", "vehicles", "history", "invoices", "parts", "vendors", "staff", "menu", "inspections", "unknown"]);
+
+function asObj(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+function asArr(value: unknown) {
+  return Array.isArray(value) ? value : [];
+}
+function asString(v: unknown, fallback = "") {
+  return typeof v === "string" ? v : fallback;
+}
+function asNum(v: unknown, fallback = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+function clamp01(v: unknown, fb = 0.5) {
+  return Math.max(0, Math.min(1, asNum(v, fb)));
+}
+
+function sanitizeEntityPlan(value: unknown): EntityPlanSummary {
+  const o = asObj(value);
+  return {
+    staged: Math.max(0, Math.floor(asNum(o.staged))),
+    ready: Math.max(0, Math.floor(asNum(o.ready))),
+    review: Math.max(0, Math.floor(asNum(o.review))),
+    confidence: clamp01(o.confidence, 0.5),
+    notes: asArr(o.notes).slice(0, 10).map((x) => asString(x)).filter(Boolean),
+  };
+}
+
+export function validateOnboardingAgentPlan(params: {
+  candidate: unknown;
+  validFileIds: Set<string>;
+  modeFallback?: OnboardingAgentPlan["mode"];
+  model?: string;
+}): OnboardingAgentPlan {
+  const root = asObj(params.candidate);
+
+  const files = asArr(root.files).slice(0, 50).map((raw) => {
+    const o = asObj(raw);
+    const fileId = asString(o.fileId);
+    if (!params.validFileIds.has(fileId)) return null;
+    const inferred = asString(o.inferredDomain, "unknown") as OnboardingAgentPlanDomain;
+    return {
+      fileId,
+      filename: asString(o.filename) || fileId,
+      inferredDomain: DOMAINS.has(inferred) ? inferred : "unknown",
+      confidence: clamp01(o.confidence, 0.5),
+      reasoning: asString(o.reasoning).slice(0, 500),
+      headerMap: Object.fromEntries(
+        Object.entries(asObj(o.headerMap)).slice(0, 80).map(([k, v]) => [k, asString(v).slice(0, 80)]),
+      ),
+      requiredFieldsPresent: asArr(o.requiredFieldsPresent).slice(0, 30).map((x) => asString(x)),
+      missingImportantFields: asArr(o.missingImportantFields).slice(0, 30).map((x) => asString(x)),
+      rowCountEstimate: Math.max(0, Math.floor(asNum(o.rowCountEstimate))),
+      recommendedParserMode: (["stage_entities", "stage_review_only", "ignore", "unsupported"].includes(asString(o.recommendedParserMode))
+        ? asString(o.recommendedParserMode)
+        : "stage_review_only") as "stage_entities" | "stage_review_only" | "ignore" | "unsupported",
+    };
+  }).filter(Boolean) as OnboardingAgentPlan["files"];
+
+  const ep = asObj(root.entityPlan);
+  const reviewGroups = asArr(root.reviewGroups).slice(0, 200).map((raw) => {
+    const o = asObj(raw);
+    const severity = asString(o.severity);
+    return {
+      severity: (["low", "medium", "high", "blocking"].includes(severity) ? severity : "medium") as "low" | "medium" | "high" | "blocking",
+      domain: asString(o.domain, "unknown"),
+      issueType: asString(o.issueType, "needs_review"),
+      affectedRowCount: Math.max(0, Math.floor(asNum(o.affectedRowCount))),
+      sampleRows: asArr(o.sampleRows).slice(0, 10).map((x) => Math.max(0, Math.floor(asNum(x)))),
+      summary: asString(o.summary).slice(0, 280),
+      recommendedAction: (["accept", "ignore", "link_existing", "edit_mapping", "upload_better_file", "manual_review"].includes(asString(o.recommendedAction))
+        ? asString(o.recommendedAction)
+        : "manual_review") as "accept" | "ignore" | "link_existing" | "edit_mapping" | "upload_better_file" | "manual_review",
+    };
+  });
+
+  return {
+    version: ONBOARDING_AGENT_PLAN_VERSION,
+    mode: root.mode === "ai_planned" || root.mode === "deterministic_fallback" ? root.mode : (params.modeFallback ?? "deterministic_fallback"),
+    model: params.model,
+    liveRecordsCreated: 0,
+    confidence: clamp01(root.confidence, 0.5),
+    summary: asString(root.summary, "Onboarding plan ready.").slice(0, 1200),
+    files,
+    entityPlan: {
+      customers: sanitizeEntityPlan(ep.customers),
+      vehicles: sanitizeEntityPlan(ep.vehicles),
+      historicalWorkOrders: sanitizeEntityPlan(ep.historicalWorkOrders),
+      historicalInvoices: sanitizeEntityPlan(ep.historicalInvoices),
+      parts: sanitizeEntityPlan(ep.parts),
+      vendors: sanitizeEntityPlan(ep.vendors),
+      staffCandidates: sanitizeEntityPlan(ep.staffCandidates),
+      menuSuggestions: sanitizeEntityPlan(ep.menuSuggestions),
+      inspectionSuggestions: sanitizeEntityPlan(ep.inspectionSuggestions),
+    },
+    relationshipPlan: asArr(root.relationshipPlan).slice(0, 100).map((raw) => {
+      const o = asObj(raw);
+      return {
+        fromDomain: asString(o.fromDomain, "unknown"),
+        toDomain: asString(o.toDomain, "unknown"),
+        relationshipType: asString(o.relationshipType, "unknown"),
+        confidence: clamp01(o.confidence, 0.5),
+        matchingKeys: asArr(o.matchingKeys).slice(0, 10).map((x) => asString(x)),
+        reasoning: asString(o.reasoning).slice(0, 280),
+        expectedLinks: o.expectedLinks == null ? null : Math.max(0, Math.floor(asNum(o.expectedLinks))),
+        reviewRequired: Boolean(o.reviewRequired),
+      };
+    }),
+    reviewGroups,
+    activationReadiness: (["not_ready", "review_required", "ready_for_dry_run", "blocked"].includes(asString(root.activationReadiness))
+      ? asString(root.activationReadiness)
+      : "review_required") as OnboardingAgentPlan["activationReadiness"],
+    activationPreview: {
+      creates: {
+        customers: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).customers))),
+        vehicles: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).vehicles))),
+        historicalWorkOrders: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).historicalWorkOrders))),
+        historicalInvoices: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).historicalInvoices))),
+        parts: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).parts))),
+        vendors: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).vendors))),
+        staffCandidates: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).staffCandidates))),
+        menuSuggestions: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).menuSuggestions))),
+        inspectionSuggestions: Math.max(0, Math.floor(asNum(asObj(asObj(root.activationPreview).creates).inspectionSuggestions))),
+      },
+      requiresReview: Math.max(0, Math.floor(asNum(asObj(root.activationPreview).requiresReview))),
+      blockingIssues: Math.max(0, Math.floor(asNum(asObj(root.activationPreview).blockingIssues))),
+      risks: asArr(asObj(root.activationPreview).risks).slice(0, 20).map((x) => asString(x)),
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Shift the onboarding agent from a brittle parser with commentary to a true AI planning layer that informs deterministic staging decisions. 
- Preserve safety by keeping AI as a planner (no live record creation) and enforcing tenant scoping and owner/admin-only operations. 
- Reduce PII exposure and payload size when sending samples to the model while keeping enough context for mapping and relationship inference. 

### Description
- Add a strict plan contract and input payload types with `features/onboarding-agent/lib/agentPlanTypes.ts` to define `OnboardingAgentPlan` and the compact input shape. 
- Implement a compact, privacy-aware input builder and redaction helper in `features/onboarding-agent/server/buildOnboardingAgentInput.ts` and `features/onboarding-agent/server/redactOnboardingSample.ts` that samples rows, masks emails/phones, preserves matching IDs, and caps payload sizes. 
- Add server-only OpenAI planner `features/onboarding-agent/server/runOpenAIOnboardingPlan.ts` with JSON-only prompts, model resolution, deterministic fallback, and structured logging, plus plan sanitizer `features/onboarding-agent/server/validateOnboardingAgentPlan.ts` that clamps confidences and forces `liveRecordsCreated = 0`. 
- Implement deterministic executor `features/onboarding-agent/server/applyOnboardingAgentPlan.ts` that uses validated `headerMap` and `recommendedParserMode` to stage entities, create links, group review items, persist the agent plan/report in the session, and update file/session stats without creating any live operational records, and wire the new flow into `analyzeOnboardingSession` and the analyze API route. 
- Surface AI-driven insights and plan previews in the owner UI via updated panels (`OnboardingAgentInsightsPanel`, `OnboardingEntitiesPanel`, `OnboardingReviewPanel`, `OnboardingActivationPlanPanel`, `OnboardingSessionPage`) while keeping developer details collapsed. 
- Files added/changed include planner, validator, executor, input builder, redaction, plan types, analyze orchestration, API route changes, UI panel updates, and test extensions under `features/onboarding-agent/*`.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it passed. 
- Lint: ran `npx eslint ...` for the modified onboarding files and it returned only warnings for `any` usage (no blocking errors). 
- Unit tests: ran `npx vitest run` for onboarding tests and all targeted test suites passed (`onboarding-agent.test.ts`, `onboarding-agent-ai.test.ts`, `uploadOnboardingFiles.test.ts`, `onboarding-agent-staging.test.ts`). 
- Build: ran `pnpm build` which failed in this environment due to network issues fetching Google Fonts (`Inter` / `Black Ops One`) during `next build`; this is an environment/network limitation and not a type or runtime error in the new onboarding flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6b2b4c148328a425bb35d298d2a7)