### PR TITLE
Centralize OpenAI client & model resolver; add structured Responses helper, embeddings, and modernize onboarding AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# OpenAI API key enables server-side AI calls.
+OPENAI_API_KEY=
+
+# Repo-wide model controls.
+# Prefer purpose-specific vars; OPENAI_MODEL is the global fallback.
+OPENAI_MODEL=
+OPENAI_REASONING_MODEL=
+OPENAI_FAST_MODEL=
+OPENAI_EXTRACTION_MODEL=
+OPENAI_EMBEDDING_MODEL=
+
+# Feature-specific model controls.
+# Onboarding model precedence:
+# ONBOARDING_AGENT_MODEL -> OPENAI_EXTRACTION_MODEL -> OPENAI_REASONING_MODEL -> OPENAI_MODEL -> code default.
+ONBOARDING_AGENT_MODEL=
+
+# If true, onboarding analysis fails when OpenAI is unavailable.
+# If false (default), deterministic fallback is used and surfaced in UI/reporting.
+ONBOARDING_AGENT_REQUIRE_AI=false

--- a/app/api/ai/interpret/route.ts
+++ b/app/api/ai/interpret/route.ts
@@ -1,12 +1,11 @@
 // /app/api/ai/interpret/route.ts (FULL FILE REPLACEMENT)
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
 export const runtime = "nodejs";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+const openai = getOpenAIClient();
 
 type CommandStatus = "ok" | "fail" | "na" | "recommend";
 type InterpretMode = "open" | "strict_context";
@@ -373,7 +372,7 @@ Optional section hint (may be empty): ${norm(ctx?.sectionTitle ?? "")}
       .join("\n\n");
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: getOpenAIModelForPurpose("extraction"),
       temperature: 0.2,
       messages: [
         { role: "system", content: systemPrompt },

--- a/app/api/ai/parts/suggest/route.ts
+++ b/app/api/ai/parts/suggest/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildPartSuggestions } from "@/features/parts/server/buildPartSuggestions";
 import type { CanonicalPartSuggestion } from "@/features/parts/types/partSuggestions";
@@ -19,7 +20,7 @@ type SuggestRequestBody = {
   topK?: number;
 };
 
-const MODEL = process.env.OPENAI_MODEL?.trim() || "gpt-5.1-mini";
+const MODEL = getOpenAIModelForPurpose("reasoning");
 
 async function inferAiOnlySuggestions(args: {
   description?: string | null;

--- a/app/api/ai/suggestions/route.ts
+++ b/app/api/ai/suggestions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { createOpenAIEmbedding } from "@/features/shared/lib/server/openai-embeddings";
 
 type DB = Database;
 
@@ -83,33 +84,11 @@ function normalizeIntelligenceText(input: {
 }
 
 async function createEmbedding(text: string): Promise<number[] | null> {
-  const apiKey = process.env.OPENAI_API_KEY;
   const cleaned = text.trim();
+  if (!cleaned) return null;
 
-  if (!apiKey || !cleaned) return null;
-
-  const res = await fetch("https://api.openai.com/v1/embeddings", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: "text-embedding-3-small",
-      input: cleaned,
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Embedding request failed: ${res.status} ${body}`);
-  }
-
-  const json = (await res.json()) as {
-    data?: Array<{ embedding?: number[] }>;
-  };
-
-  return json.data?.[0]?.embedding ?? null;
+  const embedding = await createOpenAIEmbedding(cleaned);
+  return embedding?.embedding ?? null;
 }
 
 function toPgVectorLiteral(values: number[] | null): string | null {

--- a/app/api/ai/summarize-stats/route.ts
+++ b/app/api/ai/summarize-stats/route.ts
@@ -1,11 +1,10 @@
 // app/api/ai/summarize-stats/route.ts
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-const apiKey = process.env.OPENAI_API_KEY ?? "";
-
-const openai = new OpenAI({ apiKey });
+const openai = isOpenAIConfigured() ? getOpenAIClient() : null;
 
 export async function POST(req: Request) {
   const supabase = createServerSupabaseRoute();
@@ -17,7 +16,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!apiKey) {
+  if (!openai) {
     return NextResponse.json(
       { error: "OPENAI_API_KEY is not set" },
       { status: 500 }
@@ -39,7 +38,7 @@ ${JSON.stringify(body.stats, null, 2)}
 `;
 
   const res = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
+    model: getOpenAIModelForPurpose("fast"),
     messages: [{ role: "user", content: prompt }],
   });
 

--- a/app/api/ai/summarize-tech-performance/route.ts
+++ b/app/api/ai/summarize-tech-performance/route.ts
@@ -1,6 +1,7 @@
 // app/api/ai/summarize-tech-performance/route.ts
 import { NextResponse } from "next/server";
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type Range = "weekly" | "monthly" | "quarterly" | "yearly";
@@ -92,7 +93,7 @@ export async function POST(req: Request) {
     ].join("\n");
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("fast"),
       temperature: 0.4,
       max_tokens: 260,
       messages: [

--- a/app/api/assistant/export/route.ts
+++ b/app/api/assistant/export/route.ts
@@ -3,11 +3,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = getOpenAIClient();
 
 type Vehicle = {
   year?: string | null;
@@ -63,7 +64,7 @@ export async function POST(req: Request) {
     ].join("\n");
 
     const completion = await openai.chat.completions.create({
-      model: process.env.OPENAI_MODEL?.trim() || "gpt-4o",
+      model: getOpenAIModelForPurpose("reasoning"),
       temperature: 0.3,
       stream: false,
       messages: [{ role: "user", content: prompt }],

--- a/app/api/dtc-suggest/route.ts
+++ b/app/api/dtc-suggest/route.ts
@@ -1,6 +1,7 @@
 // app/api/work-orders/dtc-suggest/route.ts
 import { NextResponse } from "next/server";
-import { openai } from "lib/server/openai"; // adjust path if needed
+import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models"; // adjust path if needed
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type DtcSuggestion = {
@@ -75,7 +76,7 @@ export async function POST(req: Request) {
     let completion;
     try {
       completion = await openai.chat.completions.create({
-        model: process.env.OPENAI_MODEL?.trim() || "gpt-5.1",
+        model: getOpenAIModelForPurpose("reasoning"),
         response_format: { type: "json_object" },
         messages: [
           {

--- a/app/api/fleet/forms/upload/route.ts
+++ b/app/api/fleet/forms/upload/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import OpenAI from "openai";
 
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
@@ -19,7 +20,7 @@ type FleetParseResult = {
   sections?: FleetParseSection[];
 };
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = getOpenAIClient();
 
 function guessMimeFromName(name: string): string {
   const lower = name.toLowerCase();
@@ -190,7 +191,7 @@ export async function POST(req: NextRequest) {
       ].join("\n");
 
       const completion = await openai.chat.completions.create({
-        model: "gpt-4.1-mini",
+        model: getOpenAIModelForPurpose("vision"),
         response_format: { type: "json_object" },
         messages: [
           { role: "system", content: systemPrompt },

--- a/app/api/generate-inspection/route.ts
+++ b/app/api/generate-inspection/route.ts
@@ -1,9 +1,10 @@
 // app/api/generate-inspection/route.ts
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { toInspectionCategories } from "@/features/inspections/lib/inspection/normalize";
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = getOpenAIClient();
 
 type GenerateBody = {
   prompt?: string;
@@ -24,7 +25,7 @@ export async function POST(req: Request) {
       "The list should be practical and shop-usable. No extra keys, no markdown.";
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o",
+      model: getOpenAIModelForPurpose("extraction"),
       temperature: 0.2,
       response_format: { type: "json_object" },
       messages: [

--- a/app/api/inspections/build-from-prompt/route.ts
+++ b/app/api/inspections/build-from-prompt/route.ts
@@ -1,7 +1,8 @@
 // app/api/inspections/build-from-prompt/route.ts (FULL FILE REPLACEMENT)
 import "server-only";
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import {
   buildFromMaster,
   type VehicleType,
@@ -425,7 +426,7 @@ export async function POST(req: Request) {
     // 7) try to augment with OpenAI
     let aiSections: SectionOut[] = [];
     try {
-      const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+      const openai = getOpenAIClient();
 
       const lightDutyMode = dutyClass === "light" || brakeSystem === "hyd_brake";
 
@@ -452,7 +453,7 @@ export async function POST(req: Request) {
         .join("\n");
 
       const resp = await openai.responses.create({
-        model: "gpt-4o-mini",
+        model: getOpenAIModelForPurpose("extraction"),
         input: [
           { role: "system", content: system },
           { role: "user", content: user },

--- a/app/api/inspections/generate/route.ts
+++ b/app/api/inspections/generate/route.ts
@@ -1,7 +1,8 @@
 // app/api/inspections/generate/route.ts
 import "server-only";
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import {
   buildFromMaster,
   type VehicleType,
@@ -171,7 +172,7 @@ export async function POST(req: Request) {
     });
 
     // 4) call OpenAI — same pattern as your build-from-prompt route
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+    const openai = getOpenAIClient();
 
     const system = [
       "You are an AI assistant for generating vehicle inspection templates.",
@@ -189,7 +190,7 @@ export async function POST(req: Request) {
     ].join("\n");
 
     const resp = await openai.responses.create({
-      model: "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("extraction"),
       input: [
         { role: "system", content: system },
         { role: "user", content: user },

--- a/app/api/ocr/registration/route.ts
+++ b/app/api/ocr/registration/route.ts
@@ -1,10 +1,12 @@
 // app/api/ocr/registration/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import type { ChatCompletionMessageParam } from "openai/resources/chat";
 
 export const runtime = "nodejs";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const client = getOpenAIClient();
 
 /* ----------------------------- helpers ----------------------------- */
 function normalizeVin(raw?: string | null): string | null {
@@ -102,7 +104,7 @@ export async function POST(req: NextRequest) {
     }
 
     // ---- Chat Completions (vision) + JSON mode (no casts, fully typed) ----
-    const messages: OpenAI.ChatCompletionMessageParam[] = [
+    const messages: ChatCompletionMessageParam[] = [
       {
         role: "user",
         content: [
@@ -122,7 +124,7 @@ export async function POST(req: NextRequest) {
     ];
 
     const completion = await client.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("extraction"),
       messages,
       temperature: 0,
       // Ensures a valid JSON object string

--- a/app/api/stats/summarize/route.ts
+++ b/app/api/stats/summarize/route.ts
@@ -1,15 +1,15 @@
 // features/ai/api/stats/summarize/route.ts
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const apiKey = process.env.OPENAI_API_KEY ?? "";
-if (!apiKey) {
+if (!isOpenAIConfigured()) {
   // Don’t throw at import-time in Next; return a clean error on request.
   // eslint-disable-next-line no-console
   console.warn("[summarize-stats] OPENAI_API_KEY is not set");
 }
 
-const openai = new OpenAI({ apiKey });
+const openai = isOpenAIConfigured() ? getOpenAIClient() : null;
 
 type SummarizeBody = {
   timeRange?: string;
@@ -18,7 +18,7 @@ type SummarizeBody = {
 
 export async function POST(req: Request) {
   try {
-    if (!apiKey) {
+    if (!openai) {
       return NextResponse.json(
         { error: "OPENAI_API_KEY is not set" },
         { status: 500 },
@@ -48,7 +48,7 @@ Output in paragraph form.
 `.trim();
 
     const response = await openai.chat.completions.create({
-      model: process.env.OPENAI_MODEL ?? "gpt-5",
+      model: getOpenAIModelForPurpose("reasoning"),
       temperature: 0.7,
       messages: [{ role: "user", content: prompt }],
     });

--- a/app/api/vin/extract-from-image/route.ts
+++ b/app/api/vin/extract-from-image/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY!,
-});
+const openai = getOpenAIClient();
 
 function findVinLike(text: string): string | null {
   const match = text.toUpperCase().match(/[A-HJ-NPR-Z0-9]{17}/);
@@ -24,7 +23,7 @@ export async function POST(req: NextRequest) {
     const dataUrl = "data:" + file.type + ";base64," + base64;
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: getOpenAIModelForPurpose("vision"),
       max_tokens: 50,
       messages: [
         {

--- a/app/api/work-orders/dtc-suggest/route.ts
+++ b/app/api/work-orders/dtc-suggest/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { Database, Json } from "@shared/types/types/supabase";
 
@@ -330,7 +331,7 @@ async function generateDtcResponse(args: {
   messages: PersistedMessage[];
 }): Promise<DtcSuggestResponse> {
   const completion = await openai.chat.completions.create({
-    model: process.env.OPENAI_MODEL?.trim() || "gpt-5-mini",
+    model: getOpenAIModelForPurpose("reasoning"),
     response_format: { type: "json_object" },
     messages: [
       {

--- a/app/api/work-orders/suggest-lines/route.ts
+++ b/app/api/work-orders/suggest-lines/route.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
 export const runtime = "nodejs";
 
@@ -235,7 +236,7 @@ export async function POST(req: Request) {
     ].join(" ");
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("fast"),
       temperature: 0.4,
       messages: [
         { role: "system", content: system },

--- a/features/agent/lib/plannerOpenAI.ts
+++ b/features/agent/lib/plannerOpenAI.ts
@@ -2,6 +2,7 @@
 import type { ToolContext } from "./toolTypes";
 import { getServerSupabase } from "../server/supabase";
 import { buildPartSuggestions } from "@/features/parts/server/buildPartSuggestions";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import {
   buildInspectionTemplateEfficiencyRecommendations,
   buildMenuItemEfficiencyRecommendations,
@@ -226,7 +227,7 @@ async function llmParseGoal(
       "content-type": "application/json",
     },
     body: JSON.stringify({
-      model: process.env.OPENAI_AGENT_MODEL || "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("reasoning"),
       response_format: { type: "json_object" },
       messages: [
         { role: "system", content: system },

--- a/features/ai/api/ai/generateInspectionList/route.ts
+++ b/features/ai/api/ai/generateInspectionList/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+const openai = getOpenAIClient();
 
 export async function POST(req: Request) {
   const { prompt } = await req.json();
 
   const response = await openai.chat.completions.create({
-    model: "gpt-4o",
+    model: getOpenAIModelForPurpose("extraction"),
     messages: [
       {
         role: "system",

--- a/features/ai/api/chatbot/route.ts
+++ b/features/ai/api/chatbot/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 // IMPORTANT: use your alias-based import so Vercel resolves it consistently.
 // If your project uses a different alias, adjust this one line.
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
 type Variant = "marketing" | "full";
 type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
@@ -62,7 +63,7 @@ export async function POST(req: Request) {
     ];
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("fast"),
       messages: safeMsgs,
       temperature: 0.4,
       max_tokens: 600,

--- a/features/ai/lib/ai/generateLaborTimeEstimate.ts
+++ b/features/ai/lib/ai/generateLaborTimeEstimate.ts
@@ -1,8 +1,7 @@
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY!,
-});
+const openai = getOpenAIClient();
 
 // Runs only on the server
 export async function generateLaborTimeEstimate(
@@ -13,7 +12,7 @@ export async function generateLaborTimeEstimate(
     const prompt = `Estimate labor time in hours (number only) for the following automotive job:\n\nJob Type: ${jobType}\nComplaint: ${complaint}\n\nResponse:`;
 
     const response = await openai.chat.completions.create({
-      model: "gpt-4o",
+      model: getOpenAIModelForPurpose("reasoning"),
       messages: [{ role: "user", content: prompt }],
       max_tokens: 10,
       temperature: 0.3,

--- a/features/ai/lib/ai/inferPartName.ts
+++ b/features/ai/lib/ai/inferPartName.ts
@@ -1,8 +1,7 @@
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+const openai = getOpenAIClient();
 
 /**
  * Infer part name from a job description using GPT.
@@ -11,7 +10,7 @@ export async function inferPartName(description: string): Promise<string> {
   const prompt = `Given the job description "${description}", suggest the most likely part name involved. Respond with only the part name.`;
 
   const chat = await openai.chat.completions.create({
-    model: "gpt-4o",
+    model: getOpenAIModelForPurpose("reasoning"),
     messages: [
       {
         role: "system",

--- a/features/ai/lib/ai/mapColumns.ts
+++ b/features/ai/lib/ai/mapColumns.ts
@@ -1,8 +1,7 @@
-import OpenAI from "openai";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+const openai = getOpenAIClient();
 
 export async function mapCsvColumns(
   headers: string[],
@@ -22,7 +21,7 @@ JSON:
 `;
 
   const response = await openai.chat.completions.create({
-    model: "gpt-4o",
+    model: getOpenAIModelForPurpose("extraction"),
     messages: [{ role: "user", content: prompt }],
     temperature: 0.1,
   });

--- a/features/ai/lib/chatgptHandler.ts
+++ b/features/ai/lib/chatgptHandler.ts
@@ -1,16 +1,14 @@
-import OpenAI from "openai";
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+
+const openai = getOpenAIClient();
 
 export default async function chatgptHandler(
   messages: ChatCompletionMessageParam[],
 ) {
   const response = await openai.chat.completions.create({
-    model: "gpt-4o",
+    model: getOpenAIModelForPurpose("reasoning"),
     messages,
   });
 

--- a/features/assistant/server/runAssistant.ts
+++ b/features/assistant/server/runAssistant.ts
@@ -1,7 +1,5 @@
 // features/assistant/server/runAssistant.ts
 
-import OpenAI from "openai";
-
 import type {
   AssistantAction,
   AssistantContext,
@@ -10,6 +8,8 @@ import type {
   PlannerPayload,
 } from "../types/assistant";
 import { getRoleDailySummary } from "@/features/agent/server/getRoleDailySummary";
+import { getOpenAIClient as getCanonicalOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
 type RunAssistantParams = {
   shopId: string;
@@ -37,11 +37,11 @@ type LlmAssistantResponse = {
   actions?: LlmAssistantAction[];
 };
 
-function getOpenAIClient(): OpenAI | null {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) return null;
-  return new OpenAI({ apiKey });
+function getOpenAIClient() {
+  if (!isOpenAIConfigured()) return null;
+  return getCanonicalOpenAIClient();
 }
+
 
 function extractPlannerPayloadFromNotification(
   item: AssistantNotification,
@@ -286,7 +286,7 @@ export async function runAssistant(
 
   try {
     const response = await client.chat.completions.create({
-      model: process.env.OPENAI_ASSISTANT_MODEL || "gpt-4.1-mini",
+      model: getOpenAIModelForPurpose("reasoning"),
       temperature: 0.2,
       response_format: { type: "json_object" },
       messages: [

--- a/features/integrations/ai/index.ts
+++ b/features/integrations/ai/index.ts
@@ -1,6 +1,7 @@
 //features/integrations/ai/index.ts
 
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 /* ========================================================================== */
@@ -54,7 +55,7 @@ export const ProFixAI = {
     ].join("\n");
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: getOpenAIModelForPurpose("fast"),
       temperature: 0.4,
       max_tokens: 600,
       messages: [

--- a/features/integrations/ai/shopBoost.ts
+++ b/features/integrations/ai/shopBoost.ts
@@ -2,6 +2,7 @@
 import { randomUUID, createHash } from "crypto";
 
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import type {
@@ -1641,7 +1642,7 @@ async function generateSnapshotWithAI(
 
   try {
     const completion = await openai.chat.completions.create({
-      model: process.env.OPENAI_MODEL || "gpt-4.1-mini",
+      model: getOpenAIModelForPurpose("fast"),
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },

--- a/features/maintenance/server/generateMaintenanceRules.ts
+++ b/features/maintenance/server/generateMaintenanceRules.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { openai } from "lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
 type DB = Database;
 
@@ -224,7 +225,7 @@ export async function generateMaintenanceRulesForVehicle(opts: {
   ].join("\n");
 
   const completion = await openai.chat.completions.create({
-    model: "gpt-4o-mini",
+    model: getOpenAIModelForPurpose("fast"),
     temperature: 0.4,
     max_tokens: 900,
     messages: [

--- a/features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { detectDomain } from "@/features/onboarding-agent/lib/domains";
+
+const fixtures: Array<{ filename: string; expected: string }> = [
+  { filename: "customers.csv", expected: "customers" },
+  { filename: "vehicles.csv", expected: "vehicles" },
+  { filename: "work_orders_history.csv", expected: "history" },
+  { filename: "invoices.csv", expected: "invoices" },
+  { filename: "parts_inventory.csv", expected: "parts" },
+  { filename: "vendors.csv", expected: "vendors" },
+  { filename: "staff_users.csv", expected: "staff" },
+  { filename: "service_catalog.csv", expected: "menu" },
+];
+
+describe("onboarding known file domain mapping", () => {
+  it("maps known fixture filenames to expected domains", () => {
+    for (const fixture of fixtures) {
+      expect(detectDomain({ filename: fixture.filename, headers: [] })).toBe(fixture.expected);
+    }
+  });
+});

--- a/features/onboarding-agent/server/model.ts
+++ b/features/onboarding-agent/server/model.ts
@@ -1,13 +1,10 @@
-const DEFAULT_ONBOARDING_MODEL = "gpt-5-mini";
+import { getOnboardingAgentModel as getCanonicalOnboardingModel } from "@/features/shared/lib/server/openai-models";
+import { isOpenAIConfigured } from "@/features/shared/lib/server/openai";
 
 export function getOnboardingAgentModel() {
-  return (
-    process.env.ONBOARDING_AGENT_MODEL?.trim() ||
-    process.env.OPENAI_MODEL?.trim() ||
-    DEFAULT_ONBOARDING_MODEL
-  );
+  return getCanonicalOnboardingModel();
 }
 
 export function getOnboardingAgentEnabled() {
-  return Boolean(process.env.OPENAI_API_KEY?.trim());
+  return isOpenAIConfigured();
 }

--- a/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
+++ b/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
@@ -1,5 +1,5 @@
 import type { OnboardingAgentInputPayload, OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
-import { getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
+import { runOpenAIStructuredJson } from "@/features/shared/lib/server/openai-structured";
 import { validateOnboardingAgentPlan } from "@/features/onboarding-agent/server/validateOnboardingAgentPlan";
 
 function buildFallbackPlan(input: OnboardingAgentInputPayload, model: string): OnboardingAgentPlan {
@@ -38,66 +38,42 @@ export async function runOpenAIOnboardingPlan(params: {
   input: OnboardingAgentInputPayload;
   requireAi?: boolean;
 }): Promise<{ plan: OnboardingAgentPlan; warning?: string }> {
-  const model = getOnboardingAgentModel();
   const validFileIds = new Set(params.input.files.map((file) => file.fileId));
+  const rowsSampled = params.input.files.reduce((sum, file) => sum + file.sampleRows.length, 0);
 
-  if (!process.env.OPENAI_API_KEY?.trim()) {
-    if (params.requireAi) throw new Error("AI is required but OPENAI_API_KEY is not configured.");
-    return { plan: buildFallbackPlan(params.input, model), warning: "AI reasoning unavailable; deterministic staging was used." };
-  }
-
-  const { openai } = await import("../../../lib/server/openai");
-  const started = Date.now();
-
-  try {
-    const completion = await openai.chat.completions.create({
+  const result = await runOpenAIStructuredJson<OnboardingAgentPlan>({
+    purpose: "onboarding",
+    feature: "onboarding-agent-plan",
+    schemaName: "OnboardingAgentPlan",
+    system: "You are the ProFixIQ onboarding migration planner. You produce JSON only. Never claim live record creation. Staged-only semantics: historical work orders are not active jobs; historical invoices are not active invoice workflow; staff rows are candidates/invites, not auth users; menu/inspection rows are suggestions only.",
+    user: {
+      instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Return strict OnboardingAgentPlan JSON.",
+      knownFilesHint: ["customers.csv", "vehicles.csv", "work_orders_history.csv", "invoices.csv", "parts_inventory.csv", "vendors.csv", "staff_users.csv", "service_catalog.csv"],
+      input: params.input,
+    },
+    requireAI: params.requireAi,
+    temperature: 0.1,
+    fallback: (model) => buildFallbackPlan(params.input, model),
+    validate: (candidate, model) => validateOnboardingAgentPlan({
+      candidate,
+      validFileIds,
       model,
-      temperature: 0.1,
-      response_format: { type: "json_object" },
-      messages: [
-        {
-          role: "system",
-          content: "You are the ProFixIQ onboarding migration planner. You produce JSON only. Never claim live record creation. Staged-only semantics: historical work orders are not active jobs; historical invoices are not active invoice workflow; staff rows are candidates/invites, not auth users; menu/inspection rows are suggestions only.",
-        },
-        {
-          role: "user",
-          content: JSON.stringify({
-            instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Return strict OnboardingAgentPlan JSON.",
-            knownFilesHint: ["customers.csv", "vehicles.csv", "work_orders_history.csv", "invoices.csv", "parts_inventory.csv", "vendors.csv", "staff_users.csv", "service_catalog.csv"],
-            input: params.input,
-          }),
-        },
-      ],
-    });
+      modeFallback: "ai_planned",
+    }),
+  });
 
-    const content = completion.choices?.[0]?.message?.content;
-    if (!content) throw new Error("No response content returned by model");
-    const parsed = JSON.parse(content);
-    const plan = validateOnboardingAgentPlan({ candidate: parsed, validFileIds, model, modeFallback: "ai_planned" });
+  console.info("[onboarding-agent] plan summary", {
+    sessionId: params.input.sessionId,
+    shopId: params.input.shopId,
+    files: params.input.files.length,
+    rowsSampled,
+    model: result.model,
+    mode: result.mode,
+    liveRecordsCreated: 0,
+  });
 
-    console.info("[onboarding-agent] openai plan", {
-      sessionId: params.input.sessionId,
-      shopId: params.input.shopId,
-      files: params.input.files.length,
-      rowsSampled: params.input.files.reduce((sum, f) => sum + f.sampleRows.length, 0),
-      mode: plan.mode,
-      model,
-      confidence: plan.confidence,
-      durationMs: Date.now() - started,
-      liveRecordsCreated: 0,
-    });
-
-    return { plan };
-  } catch (error) {
-    console.warn("[onboarding-agent] openai planning fallback", {
-      sessionId: params.input.sessionId,
-      shopId: params.input.shopId,
-      model,
-      error: error instanceof Error ? error.message : "unknown",
-      durationMs: Date.now() - started,
-      liveRecordsCreated: 0,
-    });
-    if (params.requireAi) throw new Error("AI planning is required but unavailable.");
-    return { plan: buildFallbackPlan(params.input, model), warning: "AI reasoning unavailable; deterministic staging was used." };
-  }
+  return {
+    plan: result.output,
+    warning: result.warning,
+  };
 }

--- a/features/shared/lib/server/openai-embeddings.ts
+++ b/features/shared/lib/server/openai-embeddings.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+import { getOpenAIEmbeddingModel } from "@/features/shared/lib/server/openai-models";
+
+export async function createOpenAIEmbedding(input: string): Promise<{ model: string; embedding: number[] } | null> {
+  if (!isOpenAIConfigured()) return null;
+
+  const model = getOpenAIEmbeddingModel();
+  const client = getOpenAIClient();
+  const response = await client.embeddings.create({
+    model,
+    input,
+  });
+
+  return {
+    model,
+    embedding: response.data[0]?.embedding ?? [],
+  };
+}

--- a/features/shared/lib/server/openai-models.test.ts
+++ b/features/shared/lib/server/openai-models.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getOnboardingAgentModel,
+  getOpenAIEmbeddingModel,
+  getOpenAIExtractionModel,
+  getOpenAIFastModel,
+  getOpenAIReasoningModel,
+} from "@/features/shared/lib/server/openai-models";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("openai-models precedence", () => {
+  it("prefers purpose-specific env before OPENAI_MODEL", () => {
+    process.env.OPENAI_MODEL = "gpt-global";
+    process.env.OPENAI_REASONING_MODEL = "gpt-reasoning";
+    process.env.OPENAI_FAST_MODEL = "gpt-fast";
+    process.env.OPENAI_EXTRACTION_MODEL = "gpt-extract";
+    process.env.OPENAI_EMBEDDING_MODEL = "text-embedding-custom";
+    process.env.ONBOARDING_AGENT_MODEL = "gpt-onboarding";
+
+    expect(getOpenAIReasoningModel()).toBe("gpt-reasoning");
+    expect(getOpenAIFastModel()).toBe("gpt-fast");
+    expect(getOpenAIExtractionModel()).toBe("gpt-extract");
+    expect(getOpenAIEmbeddingModel()).toBe("text-embedding-custom");
+    expect(getOnboardingAgentModel()).toBe("gpt-onboarding");
+  });
+
+  it("falls back through global model and defaults", () => {
+    delete process.env.OPENAI_REASONING_MODEL;
+    delete process.env.OPENAI_FAST_MODEL;
+    delete process.env.OPENAI_EXTRACTION_MODEL;
+    delete process.env.OPENAI_EMBEDDING_MODEL;
+    delete process.env.ONBOARDING_AGENT_MODEL;
+    process.env.OPENAI_MODEL = "gpt-global";
+
+    expect(getOpenAIReasoningModel()).toBe("gpt-global");
+    expect(getOpenAIFastModel()).toBe("gpt-global");
+    expect(getOpenAIExtractionModel()).toBe("gpt-global");
+    expect(getOpenAIEmbeddingModel()).toBe("text-embedding-3-small");
+    expect(getOnboardingAgentModel()).toBe("gpt-global");
+  });
+});

--- a/features/shared/lib/server/openai-models.ts
+++ b/features/shared/lib/server/openai-models.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+
+export type OpenAIModelPurpose =
+  | "reasoning"
+  | "fast"
+  | "extraction"
+  | "embedding"
+  | "vision"
+  | "onboarding";
+
+const DEFAULT_REASONING_MODEL = "gpt-5-mini";
+const DEFAULT_FAST_MODEL = "gpt-4.1-mini";
+const DEFAULT_EXTRACTION_MODEL = "gpt-4.1-mini";
+const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+const DEFAULT_VISION_MODEL = "gpt-4.1-mini";
+
+function env(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+export function getOpenAIReasoningModel(): string {
+  return env("OPENAI_REASONING_MODEL") ?? env("OPENAI_MODEL") ?? DEFAULT_REASONING_MODEL;
+}
+
+export function getOpenAIFastModel(): string {
+  return env("OPENAI_FAST_MODEL") ?? env("OPENAI_MODEL") ?? DEFAULT_FAST_MODEL;
+}
+
+export function getOpenAIExtractionModel(): string {
+  return env("OPENAI_EXTRACTION_MODEL") ?? getOpenAIReasoningModel() ?? env("OPENAI_MODEL") ?? DEFAULT_EXTRACTION_MODEL;
+}
+
+export function getOpenAIEmbeddingModel(): string {
+  return env("OPENAI_EMBEDDING_MODEL") ?? DEFAULT_EMBEDDING_MODEL;
+}
+
+export function getOnboardingAgentModel(): string {
+  return env("ONBOARDING_AGENT_MODEL") ?? getOpenAIExtractionModel() ?? getOpenAIReasoningModel() ?? env("OPENAI_MODEL") ?? DEFAULT_REASONING_MODEL;
+}
+
+export function getOpenAIModelForPurpose(purpose: OpenAIModelPurpose): string {
+  switch (purpose) {
+    case "reasoning":
+      return getOpenAIReasoningModel();
+    case "fast":
+      return getOpenAIFastModel();
+    case "extraction":
+      return getOpenAIExtractionModel();
+    case "embedding":
+      return getOpenAIEmbeddingModel();
+    case "vision":
+      return env("OPENAI_VISION_MODEL") ?? getOpenAIExtractionModel() ?? DEFAULT_VISION_MODEL;
+    case "onboarding":
+      return getOnboardingAgentModel();
+    default:
+      return getOpenAIReasoningModel();
+  }
+}
+
+export function getOpenAIModelDiagnostics() {
+  return {
+    reasoningModel: getOpenAIReasoningModel(),
+    fastModel: getOpenAIFastModel(),
+    extractionModel: getOpenAIExtractionModel(),
+    embeddingModel: getOpenAIEmbeddingModel(),
+    onboardingModel: getOnboardingAgentModel(),
+    openAIConfigured: isOpenAIConfigured(),
+  };
+}

--- a/features/shared/lib/server/openai-structured.test.ts
+++ b/features/shared/lib/server/openai-structured.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/shared/lib/server/openai", () => ({
+  isOpenAIConfigured: vi.fn(() => false),
+  getOpenAIClient: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/openai-models", () => ({
+  getOpenAIModelForPurpose: vi.fn(() => "gpt-test"),
+}));
+
+import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+import { runOpenAIStructuredJson } from "@/features/shared/lib/server/openai-structured";
+
+describe("runOpenAIStructuredJson", () => {
+  it("returns fallback when OpenAI is disabled and requireAI=false", async () => {
+    vi.mocked(isOpenAIConfigured).mockReturnValue(false);
+
+    const result = await runOpenAIStructuredJson({
+      purpose: "extraction",
+      feature: "test",
+      system: "system",
+      user: { ok: true },
+      schemaName: "Test",
+      fallback: () => ({ ok: false }),
+      requireAI: false,
+    });
+
+    expect(result.mode).toBe("fallback");
+    expect(result.output).toEqual({ ok: false });
+  });
+
+  it("throws when OpenAI is disabled and requireAI=true", async () => {
+    vi.mocked(isOpenAIConfigured).mockReturnValue(false);
+
+    await expect(
+      runOpenAIStructuredJson({
+        purpose: "extraction",
+        feature: "test",
+        system: "system",
+        user: { ok: true },
+        schemaName: "Test",
+        fallback: () => ({ ok: false }),
+        requireAI: true,
+      }),
+    ).rejects.toThrow(/AI is required/);
+  });
+
+  it("parses valid JSON", async () => {
+    vi.mocked(isOpenAIConfigured).mockReturnValue(true);
+    vi.mocked(getOpenAIClient).mockReturnValue({
+      responses: {
+        create: vi.fn(async () => ({ output_text: '{"value":123}' })),
+      },
+    } as never);
+
+    const result = await runOpenAIStructuredJson({
+      purpose: "extraction",
+      feature: "test",
+      system: "system",
+      user: { ok: true },
+      schemaName: "Test",
+      fallback: () => ({ value: 0 }),
+    });
+
+    expect(result.mode).toBe("ai");
+    expect(result.output).toEqual({ value: 123 });
+  });
+
+  it("falls back on invalid JSON", async () => {
+    vi.mocked(isOpenAIConfigured).mockReturnValue(true);
+    vi.mocked(getOpenAIClient).mockReturnValue({
+      responses: {
+        create: vi.fn(async () => ({ output_text: "not-json" })),
+      },
+    } as never);
+
+    const result = await runOpenAIStructuredJson({
+      purpose: "extraction",
+      feature: "test",
+      system: "system",
+      user: { ok: true },
+      schemaName: "Test",
+      fallback: () => ({ value: 0 }),
+      requireAI: false,
+    });
+
+    expect(result.mode).toBe("fallback");
+    expect(result.output).toEqual({ value: 0 });
+  });
+});

--- a/features/shared/lib/server/openai-structured.ts
+++ b/features/shared/lib/server/openai-structured.ts
@@ -1,0 +1,86 @@
+import "server-only";
+
+import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose, type OpenAIModelPurpose } from "@/features/shared/lib/server/openai-models";
+
+export async function runOpenAIStructuredJson<T>(params: {
+  purpose: OpenAIModelPurpose;
+  feature: string;
+  system: string;
+  user: unknown;
+  schemaName: string;
+  schema?: unknown;
+  validate?: (candidate: unknown, model: string) => T;
+  fallback: (model: string) => T;
+  requireAI?: boolean;
+  temperature?: number;
+  maxOutputTokens?: number;
+}): Promise<{ mode: "ai" | "fallback"; model: string; output: T; warning?: string }> {
+  const started = Date.now();
+  const model = getOpenAIModelForPurpose(params.purpose);
+
+  if (!isOpenAIConfigured()) {
+    if (params.requireAI) {
+      throw new Error(`[${params.feature}] AI is required but OPENAI_API_KEY is not configured.`);
+    }
+    return { mode: "fallback", model, output: params.fallback(model), warning: "OPENAI_API_KEY is not configured." };
+  }
+
+  try {
+    const client = getOpenAIClient();
+
+    const response = await client.responses.create({
+      model,
+      temperature: params.temperature,
+      max_output_tokens: params.maxOutputTokens,
+      text: {
+        format: {
+          type: "json_object",
+        },
+      },
+      input: [
+        { role: "system", content: [{ type: "input_text", text: params.system }] },
+        { role: "user", content: [{ type: "input_text", text: JSON.stringify(params.user) }] },
+      ],
+    });
+
+    const outputText = response.output_text?.trim();
+    if (!outputText) throw new Error("No structured response text returned.");
+
+    const parsed = JSON.parse(outputText);
+    const output = params.validate ? params.validate(parsed, model) : (parsed as T);
+
+    console.info("[openai-structured] success", {
+      feature: params.feature,
+      purpose: params.purpose,
+      model,
+      mode: "ai",
+      durationMs: Date.now() - started,
+    });
+
+    return { mode: "ai", model, output };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown_error";
+
+    console.warn("[openai-structured] fallback", {
+      feature: params.feature,
+      purpose: params.purpose,
+      model,
+      mode: "fallback",
+      durationMs: Date.now() - started,
+      errorClass: error instanceof Error ? error.name : "UnknownError",
+      error: message.slice(0, 160),
+    });
+
+    if (params.requireAI) {
+      throw new Error(`[${params.feature}] AI call failed: ${message}`);
+    }
+
+    return {
+      mode: "fallback",
+      model,
+      output: params.fallback(model),
+      warning: "AI call failed; deterministic fallback was used.",
+    };
+  }
+}

--- a/features/shared/lib/server/openai.ts
+++ b/features/shared/lib/server/openai.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import OpenAI from "openai";
+
+let cachedClient: OpenAI | null = null;
+
+export function isOpenAIConfigured(): boolean {
+  return Boolean(process.env.OPENAI_API_KEY?.trim());
+}
+
+export function getOpenAIClient(): OpenAI {
+  if (!isOpenAIConfigured()) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+
+  if (!cachedClient) {
+    cachedClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+
+  return cachedClient;
+}
+
+export const openai = new Proxy(
+  {},
+  {
+    get(_target, prop, receiver) {
+      const client = getOpenAIClient() as unknown as Record<string | symbol, unknown>;
+      const value = Reflect.get(client, prop, receiver);
+      return typeof value === "function" ? value.bind(client) : value;
+    },
+  },
+) as OpenAI;

--- a/lib/server/openai.ts
+++ b/lib/server/openai.ts
@@ -1,11 +1,3 @@
-// lib/server/openai.ts
-import OpenAI from "openai";
+import "server-only";
 
-if (!process.env.OPENAI_API_KEY) {
-  // fail fast on the server if misconfigured
-  console.warn("[openai] OPENAI_API_KEY is not set");
-}
-
-export const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+export { getOpenAIClient, isOpenAIConfigured, openai } from "@/features/shared/lib/server/openai";


### PR DESCRIPTION
### Motivation
- Consolidate scattered OpenAI usage into one server-only client and one model resolver so model selection and API plumbing are controlled centrally. 
- Provide a safe, reusable structured-output helper (Responses API) and an embeddings helper to avoid repeated, ad-hoc parsing and raw embedding fetches across features. 
- Make the Onboarding Agent rely on the canonical OpenAI layer so model precedence, require-AI behaviour, and deterministic fallbacks are consistent and testable. 

### Description
- Added a canonical server-only OpenAI client at `features/shared/lib/server/openai.ts` exposing `getOpenAIClient()` and `isOpenAIConfigured()` and a compatibility `openai` export; re-exported these from `lib/server/openai.ts` for backwards compatibility. 
- Implemented a purpose-based model resolver at `features/shared/lib/server/openai-models.ts` with functions `getOpenAIModelForPurpose()`, `getOpenAIReasoningModel()`, `getOpenAIFastModel()`, `getOpenAIExtractionModel()`, `getOpenAIEmbeddingModel()`, `getOnboardingAgentModel()` and diagnostics; env precedence follows the requested rules. 
- Added a structured-output helper using the Responses API at `features/shared/lib/server/openai-structured.ts` (`runOpenAIStructuredJson`) that: uses canonical client, resolves models by purpose, requests JSON/structured output, validates/parses safely, enforces `requireAI` semantics and falls back deterministically. 
- Added an embeddings helper at `features/shared/lib/server/openai-embeddings.ts` and switched embedding creation in `app/api/ai/suggestions/route.ts` to use it. 
- Refactored Onboarding Agent plumbing to use the canonical model resolver and `runOpenAIStructuredJson` (files: `features/onboarding-agent/server/model.ts`, `features/onboarding-agent/server/runOpenAIOnboardingPlan.ts`), preserving deterministic fallback behavior and making `ONBOARDING_AGENT_REQUIRE_AI` enforceable. 
- Incrementally migrated many server-side call sites to use `getOpenAIClient()` and `getOpenAIModelForPurpose(...)` instead of ad-hoc `new OpenAI(...)` and hardcoded `gpt-*` literals (examples include inspection generators, VIN/photo extraction, assistant export, summaries, parts/DT C suggestions, agent/planner, etc.). 
- Added `.env.example` documenting the new env vars: `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_REASONING_MODEL`, `OPENAI_FAST_MODEL`, `OPENAI_EXTRACTION_MODEL`, `OPENAI_EMBEDDING_MODEL`, `ONBOARDING_AGENT_MODEL`, and `ONBOARDING_AGENT_REQUIRE_AI`. 
- Added focused tests: `features/shared/lib/server/openai-models.test.ts`, `features/shared/lib/server/openai-structured.test.ts`, and `features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts`. 

### Testing
- Repo audit/grep run: `grep -RIn "gpt-\|text-embedding\|chat.completions.create\|responses.create\|OPENAI_API_KEY\|OPENAI_MODEL" app features lib src` (used to locate call sites and guide migration). 
- Typecheck: `npx tsc --noEmit` — passed. 
- Lint: `npx eslint ...` (targeted files) — ran and produced warnings only (no new errors). 
- Unit tests (Vitest): `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts` — passed; `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts` — passed; `npx vitest run features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts` — passed; `npx vitest run features/shared/lib/server/openai-models.test.ts features/shared/lib/server/openai-structured.test.ts` — passed. 
- Build: `pnpm build` — attempted; Next build fails in this environment due to external network/font fetch errors (Google Fonts `Inter` / `Black Ops One`) and not due to TypeScript or the OpenAI changes. This is an environment network limitation and not a code regression. 

If you want I can follow up to: finish migrating remaining specialized realtime/transcribe/image hardcoded literals to the canonical resolver, and centralize the small set of remaining model literals used for real-time/transcribe flows in purpose-specific config.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7837e348832895bf2c4014e9b74a)