### PR TITLE
Fix onboarding agent AI plan contract to drive staged entities, links, and summaries

### DIFF
--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -9,7 +9,7 @@ function num(value: unknown) {
 
 export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary, agentPlan }: { latestPlan?: Record<string, unknown> | null; fallbackSummary?: Record<string, unknown> | null; agentPlan?: OnboardingAgentPlan | null }) {
   const [showDevDetails, setShowDevDetails] = useState(false);
-  const summary = (latestPlan?.summary ?? latestPlan ?? fallbackSummary ?? {}) as Record<string, any>;
+  const summary = (fallbackSummary ?? latestPlan?.summary ?? latestPlan ?? {}) as Record<string, any>;
   const preview = agentPlan?.activationPreview;
 
   return (

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -5,6 +5,7 @@ import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentP
 
 export function OnboardingAgentInsightsPanel({
   report,
+  plan,
   fallbackReadiness,
 }: {
   sessionId: string;
@@ -15,6 +16,7 @@ export function OnboardingAgentInsightsPanel({
 }) {
   const [showDev, setShowDev] = useState(false);
   const displayedReadiness = report?.activationReadiness?.status ?? fallbackReadiness ?? "not_ready";
+  const usingFallback = report?.mode === "deterministic_fallback";
 
   return (
     <div className="rounded-2xl border border-cyan-500/30 bg-cyan-950/10 p-4">
@@ -41,12 +43,28 @@ export function OnboardingAgentInsightsPanel({
       </div>
 
       <p className="mt-3 text-sm text-slate-200">{report?.summary ?? "Run analysis to get onboarding understanding."}</p>
+      {usingFallback ? <p className="mt-2 text-xs text-amber-200">Warning: AI output fell back to deterministic planning for one or more files.</p> : null}
+
+      {plan?.files?.length ? (
+        <div className="mt-3 rounded-lg border border-white/10 bg-slate-900/50 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Per-file AI plan</p>
+          <ul className="mt-2 space-y-1 text-xs text-slate-200">
+            {plan.files.slice(0, 12).map((file) => (
+              <li key={file.fileId} className="rounded border border-white/10 px-2 py-1">
+                <p className="text-white">{file.filename}</p>
+                <p>{file.inferredDomain} • {file.recommendedParserMode} • {Math.round(file.confidence * 100)}%</p>
+                <p className="text-slate-400">mapped: {Object.values(file.headerMap).slice(0, 6).join(", ") || "none"}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       <button onClick={() => setShowDev((v) => !v)} className="mt-3 text-xs text-cyan-200 underline">
         {showDev ? "Hide" : "Show"} developer details
       </button>
       {showDev ? (
-        <pre className="mt-2 max-h-72 overflow-auto rounded bg-slate-900/70 p-3 text-[11px] text-slate-200">{JSON.stringify({ report }, null, 2)}</pre>
+        <pre className="mt-2 max-h-72 overflow-auto rounded bg-slate-900/70 p-3 text-[11px] text-slate-200">{JSON.stringify({ report, plan }, null, 2)}</pre>
       ) : null}
     </div>
   );

--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -33,6 +33,7 @@ export function OnboardingEntitiesPanel({
             {ENTITY_ROWS.map((item) => {
               const status = entityStatusCounts[item.key] ?? {};
               const planned = agentPlan?.entityPlan?.[item.planKey];
+              const hasMeaningfulPlan = Boolean(planned && (planned.staged > 0 || planned.ready > 0 || planned.review > 0));
               return (
                 <li key={item.key} className="rounded border border-white/5 px-2 py-1">
                   <div className="flex items-center justify-between gap-2">
@@ -40,7 +41,7 @@ export function OnboardingEntitiesPanel({
                     <span className="font-semibold text-white">{entityCounts[item.key] ?? 0}</span>
                   </div>
                   <p className="text-[11px] text-slate-400">ready: {status.ready ?? 0} • review: {(status.needs_review ?? 0) + (status.duplicate_candidate ?? 0)}</p>
-                  {planned ? <p className="text-[11px] text-cyan-200">ai staged: {planned.staged} • ai ready: {planned.ready} • ai review: {planned.review}</p> : null}
+                  {hasMeaningfulPlan ? <p className="text-[11px] text-cyan-200">ai staged: {planned!.staged} • ai ready: {planned!.ready} • ai review: {planned!.review}</p> : null}
                 </li>
               );
             })}

--- a/features/onboarding-agent/components/OnboardingReviewPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingReviewPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
 type ReviewItem = {
   id: string;
@@ -15,29 +14,12 @@ type ReviewItem = {
 export function OnboardingReviewPanel({
   reviewCounts,
   reviewItems,
-  agentPlan,
 }: {
   reviewCounts: { blocking?: number; high?: number; medium?: number; low?: number; byDomain?: Record<string, number> };
   reviewItems: ReviewItem[];
-  agentPlan?: OnboardingAgentPlan | null;
 }) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-  const groupedFromPlan = agentPlan?.reviewGroups ?? [];
-  const topItems = groupedFromPlan.length
-    ? groupedFromPlan.slice(0, 12).map((group, index) => ({
-      id: `${group.domain}-${group.issueType}-${index}`,
-      severity: group.severity,
-      domain: group.domain,
-      issue_type: group.issueType,
-      summary: group.summary,
-      details: {
-        count: group.affectedRowCount,
-        sampleRowIndexes: group.sampleRows,
-        recommendedAction: group.recommendedAction,
-        examples: group.sampleRows.map((row) => ({ summary: `Sample row ${row}` })),
-      },
-    }))
-    : reviewItems.filter((item) => item).slice(0, 12);
+  const topItems = reviewItems.filter((item) => item).slice(0, 12);
   const domainCounts = reviewCounts.byDomain ?? {};
 
   return (

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -129,7 +129,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} onRefresh={load} />
       <OnboardingFilesPanel files={files} />
       <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} agentPlan={session?.summary?.agentPlan ?? null} />
-      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} agentPlan={session?.summary?.agentPlan ?? null} />
+      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
 
       <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} agentPlan={session?.summary?.agentPlan ?? null} />
     </div>

--- a/features/onboarding-agent/lib/agentPlanTypes.ts
+++ b/features/onboarding-agent/lib/agentPlanTypes.ts
@@ -97,11 +97,16 @@ export type OnboardingAgentInputPayload = {
     fileId: string;
     filename: string;
     declaredDomain: string | null;
+    deterministicDetectedDomain: string;
     detectedDomain: string;
     parseStatus: string | null;
     rowCount: number;
     headers: string[];
+    normalizedHeaders: string[];
+    sampleRowIndexes: number[];
     sampleRows: Record<string, unknown>[];
+    idReferenceColumns: string[];
+    relationshipColumns: string[];
     columnExamples: Record<string, unknown[]>;
     deterministic: {
       entityCount: number;

--- a/features/onboarding-agent/lib/domains.ts
+++ b/features/onboarding-agent/lib/domains.ts
@@ -86,6 +86,28 @@ export function detectDomain(input: { filename?: string | null; headers?: string
     }
   }
 
+  const hasToken = (token: string) => filename.includes(token) || filenameTokens.includes(token);
+  if (hasToken("service catalog") || hasToken("service menu") || hasToken("catalog") || hasToken("menu")) {
+    scores.menu += 20;
+    scores.parts = Math.max(0, scores.parts - 10);
+  }
+  if (hasToken("vendor") || hasToken("supplier")) {
+    scores.vendors += 20;
+    scores.customers = Math.max(0, scores.customers - 10);
+  }
+  if (hasToken("staff") || hasToken("users") || hasToken("employees")) {
+    scores.staff += 20;
+    scores.customers = Math.max(0, scores.customers - 10);
+  }
+  if (hasToken("invoice")) {
+    scores.invoices += 20;
+    scores.history = Math.max(0, scores.history - 8);
+  }
+  if (hasToken("work orders history") || hasToken("work order history") || hasToken("repair order history") || hasToken("history")) {
+    scores.history += 20;
+    scores.invoices = Math.max(0, scores.invoices - 8);
+  }
+
   if (scores.menu > 0 && scores.parts > 0 && scores.menu >= scores.parts) {
     scores.parts = Math.max(0, scores.parts - 4);
   }

--- a/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
@@ -156,6 +156,38 @@ describe("onboarding agent ai safeguards", () => {
     expect(plan.liveRecordsCreated).toBe(0);
   });
 
+  it("plan validator preserves valid file mapping and falls back missing files per-file", () => {
+    const plan = validateOnboardingAgentPlan({
+      validFileIds: new Set(["file-1", "file-2"]),
+      deterministicByFileId: new Map([
+        ["file-1", { filename: "customers.csv", inferredDomain: "customers", rowCount: 22 }],
+        ["file-2", { filename: "vehicles.csv", inferredDomain: "vehicles", rowCount: 14 }],
+      ]),
+      candidate: {
+        mode: "ai_planned",
+        files: [{
+          fileId: "file-1",
+          filename: "customers.csv",
+          inferredDomain: "customers",
+          confidence: 0.87,
+          reasoning: "name/email columns",
+          headerMap: { "Customer Name": "name", Email: "email" },
+          rowCountEstimate: 22,
+          requiredFieldsPresent: ["name"],
+          missingImportantFields: [],
+          recommendedParserMode: "stage_entities",
+        }],
+      },
+    });
+
+    expect(plan.files).toHaveLength(2);
+    expect(plan.files.find((file) => file.fileId === "file-1")?.inferredDomain).toBe("customers");
+    expect(plan.files.find((file) => file.fileId === "file-1")?.recommendedParserMode).toBe("stage_entities");
+    expect(plan.files.find((file) => file.fileId === "file-1")?.headerMap?.Email).toBe("email");
+    expect(plan.files.find((file) => file.fileId === "file-2")?.inferredDomain).toBe("vehicles");
+    expect(plan.files.find((file) => file.fileId === "file-2")?.reasoning).toContain("deterministic fallback");
+  });
+
   it("redaction masks email and phone", () => {
     const row = redactOnboardingSample({ Email: "jane@example.com", Phone: "555-321-1234", Note: "x".repeat(180) });
     expect(String(row.Email)).toContain("***@");

--- a/features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts
@@ -18,4 +18,16 @@ describe("onboarding known file domain mapping", () => {
       expect(detectDomain({ filename: fixture.filename, headers: [] })).toBe(fixture.expected);
     }
   });
+
+  it("keeps service catalog in menu domain even with price columns", () => {
+    expect(detectDomain({ filename: "service_catalog.csv", headers: ["Service Name", "Price", "Labor Hours"] })).toBe("menu");
+  });
+
+  it("keeps vendors in vendors domain even with email/phone", () => {
+    expect(detectDomain({ filename: "vendors.csv", headers: ["Company", "Email", "Phone"] })).toBe("vendors");
+  });
+
+  it("keeps staff files in staff domain even with email/phone", () => {
+    expect(detectDomain({ filename: "staff_users.csv", headers: ["Full Name", "Email", "Phone"] })).toBe("staff");
+  });
 });

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -3,6 +3,7 @@ import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprin
 import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
 import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { buildDeterministicFallbackReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 
 function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
@@ -179,6 +180,31 @@ describe("onboarding staging", () => {
     expect(invoice?.entity_type).toBe("historical_invoice");
     expect(invoice?.status).toBe("ready");
     expect(graph.reviewItems.some((item) => item.issue_type === "missing_work_order_link")).toBe(true);
+  });
+
+  it("creates review when vehicle has unresolved customer link", () => {
+    const vehicle = stage("vehicles", { "Vehicle ID": "V-404", VIN: "1HGCM82633A999999", "Customer ID": "C-missing" }).entity;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [{ id: "vehicle-404", entity_type: vehicle!.entity_type, normalized: vehicle!.normalized }],
+    });
+    expect(graph.reviewItems.some((item) => item.issue_type === "missing_customer_link")).toBe(true);
+  });
+
+  it("summary is derived from persisted staged rows and keeps liveRecordsCreated at 0", () => {
+    const summary = buildOnboardingSummary({
+      filesCount: 2,
+      rowsParsed: 4,
+      entityRows: [{ entity_type: "customer", status: "ready" }, { entity_type: "vehicle", status: "needs_review" }],
+      linkRows: [{ link_type: "customer_vehicle", status: "staged" }],
+      reviewRows: [{ severity: "medium", domain: "vehicles", issue_type: "missing_customer_link", summary: "x", status: "pending" }],
+      analysisCompleted: true,
+    });
+    expect(summary.total_entities).toBe(2);
+    expect(summary.total_links).toBe(1);
+    expect(summary.total_review_items).toBe(1);
+    expect(summary.liveRecordsCreated).toBe(0);
   });
 
 });

--- a/features/onboarding-agent/lib/summaries.ts
+++ b/features/onboarding-agent/lib/summaries.ts
@@ -203,7 +203,12 @@ export function buildOnboardingSummary(input: {
     acc[key] = 0;
     return acc;
   }, {});
+  const linkCountsByStatus: Record<string, number> = {};
   for (const row of input.linkRows) linkCounts[row.link_type] = (linkCounts[row.link_type] ?? 0) + 1;
+  for (const row of input.linkRows) {
+    const status = row.status ?? "staged";
+    linkCountsByStatus[status] = (linkCountsByStatus[status] ?? 0) + 1;
+  }
 
   const pending = input.reviewRows.filter((row) => !row.status || row.status === "pending");
   const reviewCountsByDomain: Record<string, number> = {};
@@ -215,8 +220,13 @@ export function buildOnboardingSummary(input: {
   }
 
   const totalEntities = Object.values(entityCounts).reduce((sum, count) => sum + count, 0);
+  const entityCountsByStatus = Object.values(entityStatusCountsByType).reduce<Record<string, number>>((acc, counts) => {
+    for (const [status, count] of Object.entries(counts)) acc[status] = (acc[status] ?? 0) + toNumber(count);
+    return acc;
+  }, {});
   const totalLinks = Object.values(linkCounts).reduce((sum, count) => sum + count, 0);
   const totalReviewItems = Object.values(reviewCountsBySeverity).reduce((sum, count) => sum + count, 0);
+  const groupedReviewItems = groupReviewItems(pending);
   const readyEntityTotal = Object.values(entityStatusCountsByType).reduce((sum, counts) => sum + toNumber(counts.ready), 0);
 
   const activationPlanSummary = buildActivationPlanSummary({
@@ -247,9 +257,11 @@ export function buildOnboardingSummary(input: {
     rows_parsed: input.rowsParsed,
     total_entities: totalEntities,
     entity_counts_by_type: entityCounts,
+    entity_counts_by_status: entityCountsByStatus,
     entity_status_counts_by_type: entityStatusCountsByType,
     total_links: totalLinks,
     link_counts_by_type: linkCounts,
+    link_counts_by_status: linkCountsByStatus,
     total_review_items: totalReviewItems,
     review_counts_by_domain: {
       ...reviewCountsByDomain,
@@ -257,6 +269,7 @@ export function buildOnboardingSummary(input: {
     },
     review_counts_by_severity: reviewCountsBySeverity,
     grouped_exception_count: input.groupedExceptionCount ?? 0,
+    grouped_review_items: groupedReviewItems,
     activation_readiness: activationReadiness,
     activation_plan_summary: activationPlanSummary,
     liveRecordsCreated: 0 as const,

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -7,6 +7,7 @@ import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/stagi
 import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-agent/lib/summaries";
 import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
 import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
+import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
 
 const INSERT_CHUNK_SIZE = 1000;
 
@@ -58,6 +59,12 @@ export async function applyOnboardingAgentPlan(params: {
   await sb.from("onboarding_review_items").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
 
   const fileMap = new Map(params.plan.files.map((file) => [file.fileId, file]));
+  const { data: filesData } = await sb
+    .from("onboarding_files")
+    .select("id, original_filename, declared_domain, detected_domain, header_row")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId);
+  const fileMetadataById = new Map((filesData ?? []).map((file: any) => [file.id, file]));
   const rawRowsByFile = new Map<string, any[]>();
   const { data: rows } = await sb
     .from("onboarding_raw_rows")
@@ -77,9 +84,22 @@ export async function applyOnboardingAgentPlan(params: {
 
   for (const [fileId, fileRows] of rawRowsByFile.entries()) {
     const planFile = fileMap.get(fileId);
-    const domain = DOMAIN_TO_ENTITY[planFile?.inferredDomain ?? "unknown"] ?? "unknown";
+    const fileMeta = (fileMetadataById.get(fileId) ?? null) as any;
+    const deterministicDomain = detectFileDomain({
+      filename: fileMeta?.original_filename,
+      headers: Array.isArray(fileMeta?.header_row) ? fileMeta.header_row : [],
+      declaredDomain: fileMeta?.declared_domain ?? null,
+    });
+    const effectiveDomain = planFile?.inferredDomain && planFile.inferredDomain !== "unknown"
+      ? planFile.inferredDomain
+      : (fileMeta?.detected_domain && fileMeta.detected_domain !== "unknown"
+          ? fileMeta.detected_domain
+          : (fileMeta?.declared_domain && fileMeta.declared_domain !== "unknown"
+              ? fileMeta.declared_domain
+              : deterministicDomain));
+    const domain = DOMAIN_TO_ENTITY[effectiveDomain] ?? "unknown";
     const headerMap = planFile?.headerMap ?? {};
-    const parserMode = planFile?.recommendedParserMode ?? "stage_review_only";
+    const parserMode = planFile?.recommendedParserMode ?? (domain === "unknown" ? "stage_review_only" : "stage_entities");
 
     if (parserMode === "ignore" || parserMode === "unsupported") {
       reviewItems.push({ severity: "medium", domain, issue_type: "ignored_file", summary: `File ${planFile?.filename ?? fileId} ignored by plan`, details: { fileId } });
@@ -106,7 +126,7 @@ export async function applyOnboardingAgentPlan(params: {
     }
 
     await sb.from("onboarding_files").update({
-      detected_domain: domain,
+      detected_domain: effectiveDomain,
       parse_status: "parsed",
     }).eq("shop_id", params.shopId).eq("id", fileId);
   }
@@ -125,6 +145,8 @@ export async function applyOnboardingAgentPlan(params: {
   const graph = buildStagedLinks({ entities: (entities ?? []).map((e: any) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
   const linksToInsert = graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId }));
   const insertedLinks = await insertInChunks(sb, "onboarding_entity_links", linksToInsert, "id, link_type, status");
+
+  reviewItems.push(...graph.reviewItems);
 
   const groupedReviewItems = groupReviewItems(reviewItems as any).map((item) => ({
     shop_id: params.shopId,

--- a/features/onboarding-agent/server/buildOnboardingAgentInput.ts
+++ b/features/onboarding-agent/server/buildOnboardingAgentInput.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { parseCsvText } from "@/features/onboarding-agent/lib/csvParsing";
 import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
+import { normalizeHeader } from "@/features/onboarding-agent/lib/domains";
 import type { OnboardingAgentInputPayload } from "@/features/onboarding-agent/lib/agentPlanTypes";
 import { redactOnboardingSample } from "@/features/onboarding-agent/server/redactOnboardingSample";
 
@@ -21,14 +22,31 @@ function targetSchema() {
 }
 
 function pickSamples(rows: Record<string, unknown>[], max: number) {
-  if (rows.length <= max) return rows;
-  const first = rows.slice(0, Math.ceil(max * 0.7));
+  if (rows.length <= max) {
+    return rows.map((row, idx) => ({ row, idx }));
+  }
+  const first = rows.slice(0, Math.ceil(max * 0.7)).map((row, idx) => ({ row, idx }));
   const stride = Math.max(1, Math.floor(rows.length / Math.max(1, max - first.length)));
-  const later: Record<string, unknown>[] = [];
+  const later: Array<{ row: Record<string, unknown>; idx: number }> = [];
   for (let i = Math.ceil(max * 0.7); i < rows.length && first.length + later.length < max; i += stride) {
-    later.push(rows[i]);
+    later.push({ row: rows[i], idx: i });
   }
   return [...first, ...later];
+}
+
+const RELATIONSHIP_HEADER_HINTS = [
+  "customer id", "customer", "vehicle id", "vin", "unit", "plate", "work order", "repair order", "ro number", "invoice",
+  "vendor id", "vendor", "part number", "sku", "service", "menu", "operation code", "op code",
+];
+
+function detectReferenceColumns(headers: string[]) {
+  const normalized = headers.map(normalizeHeader);
+  const idReferenceColumns = normalized.filter((header) => header.includes(" id") || header.endsWith("id") || header.includes("number") || header.includes("vin") || header.includes("sku"));
+  const relationshipColumns = normalized.filter((header) => RELATIONSHIP_HEADER_HINTS.some((hint) => header.includes(hint)));
+  return {
+    idReferenceColumns: Array.from(new Set(idReferenceColumns)).slice(0, 40),
+    relationshipColumns: Array.from(new Set(relationshipColumns)).slice(0, 40),
+  };
 }
 
 export async function buildOnboardingAgentInput(params: {
@@ -82,9 +100,18 @@ export async function buildOnboardingAgentInput(params: {
       }
     }
 
-    const sampled = pickSamples(rows, sampleLimit).map(redactOnboardingSample);
+    const sampled = pickSamples(rows, sampleLimit);
+    const sampleRows = sampled.map((entry) => redactOnboardingSample(entry.row));
+    const sampleRowIndexes = sampled.map((entry) => entry.idx);
+    const normalizedHeaders = headers.map(normalizeHeader);
+    const deterministicDetectedDomain = detectFileDomain({
+      filename: file.original_filename ?? file.storage_path,
+      headers,
+      declaredDomain: file.declared_domain,
+    });
+    const { idReferenceColumns, relationshipColumns } = detectReferenceColumns(headers);
     const columnExamples: Record<string, unknown[]> = {};
-    for (const row of sampled) {
+    for (const row of sampleRows) {
       for (const [key, val] of Object.entries(row)) {
         const arr = columnExamples[key] ?? [];
         if (val && arr.length < 3) arr.push(val);
@@ -96,11 +123,16 @@ export async function buildOnboardingAgentInput(params: {
       fileId: file.id,
       filename: file.original_filename ?? file.storage_path,
       declaredDomain: file.declared_domain,
-      detectedDomain: file.detected_domain ?? detectFileDomain({ filename: file.original_filename ?? file.storage_path, headers, declaredDomain: file.declared_domain }),
+      deterministicDetectedDomain,
+      detectedDomain: file.detected_domain ?? deterministicDetectedDomain,
       parseStatus: file.parse_status,
       rowCount,
       headers,
-      sampleRows: sampled,
+      normalizedHeaders,
+      sampleRowIndexes,
+      sampleRows,
+      idReferenceColumns,
+      relationshipColumns,
       columnExamples,
       deterministic: {
         entityCount: 0,

--- a/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
+++ b/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
@@ -1,11 +1,18 @@
-import type { OnboardingAgentInputPayload, OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
+import type { OnboardingAgentInputPayload, OnboardingAgentPlan, OnboardingAgentPlanDomain } from "@/features/onboarding-agent/lib/agentPlanTypes";
 import { runOpenAIStructuredJson } from "@/features/shared/lib/server/openai-structured";
 import { validateOnboardingAgentPlan } from "@/features/onboarding-agent/server/validateOnboardingAgentPlan";
+
+function domainOrUnknown(value: string): OnboardingAgentPlanDomain {
+  return (["customers", "vehicles", "history", "invoices", "parts", "vendors", "staff", "menu", "inspections", "unknown"].includes(value)
+    ? value
+    : "unknown") as OnboardingAgentPlanDomain;
+}
 
 function buildFallbackPlan(input: OnboardingAgentInputPayload, model: string): OnboardingAgentPlan {
   return validateOnboardingAgentPlan({
     modeFallback: "deterministic_fallback",
     model,
+    deterministicByFileId: new Map(input.files.map((f) => [f.fileId, { filename: f.filename, inferredDomain: domainOrUnknown(f.deterministicDetectedDomain), rowCount: f.rowCount }])),
     validFileIds: new Set(input.files.map((f) => f.fileId)),
     candidate: {
       version: "onboarding_agent_plan_v1",
@@ -47,7 +54,7 @@ export async function runOpenAIOnboardingPlan(params: {
     schemaName: "OnboardingAgentPlan",
     system: "You are the ProFixIQ onboarding migration planner. You produce JSON only. Never claim live record creation. Staged-only semantics: historical work orders are not active jobs; historical invoices are not active invoice workflow; staff rows are candidates/invites, not auth users; menu/inspection rows are suggestions only.",
     user: {
-      instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Return strict OnboardingAgentPlan JSON.",
+      instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Use filename heavily, then headers/samples to refine. For known exports, do not return unknown. Use stage_entities for recognized domains. Missing links should create review groups rather than unsupported file outputs. Historical work orders/invoices may stage without resolved links. Staff rows are candidates only. Service catalog rows are menu suggestions only. Return strict OnboardingAgentPlan JSON.",
       knownFilesHint: ["customers.csv", "vehicles.csv", "work_orders_history.csv", "invoices.csv", "parts_inventory.csv", "vendors.csv", "staff_users.csv", "service_catalog.csv"],
       input: params.input,
     },
@@ -58,6 +65,7 @@ export async function runOpenAIOnboardingPlan(params: {
       candidate,
       validFileIds,
       model,
+      deterministicByFileId: new Map(params.input.files.map((f) => [f.fileId, { filename: f.filename, inferredDomain: domainOrUnknown(f.deterministicDetectedDomain), rowCount: f.rowCount }])),
       modeFallback: "ai_planned",
     }),
   });

--- a/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
@@ -38,12 +38,13 @@ function sanitizeEntityPlan(value: unknown): EntityPlanSummary {
 export function validateOnboardingAgentPlan(params: {
   candidate: unknown;
   validFileIds: Set<string>;
+  deterministicByFileId?: Map<string, { filename: string; inferredDomain: OnboardingAgentPlanDomain; rowCount: number }>;
   modeFallback?: OnboardingAgentPlan["mode"];
   model?: string;
 }): OnboardingAgentPlan {
   const root = asObj(params.candidate);
 
-  const files = asArr(root.files).slice(0, 50).map((raw) => {
+  const parsedFiles = asArr(root.files).slice(0, 50).map((raw) => {
     const o = asObj(raw);
     const fileId = asString(o.fileId);
     if (!params.validFileIds.has(fileId)) return null;
@@ -62,9 +63,39 @@ export function validateOnboardingAgentPlan(params: {
       rowCountEstimate: Math.max(0, Math.floor(asNum(o.rowCountEstimate))),
       recommendedParserMode: (["stage_entities", "stage_review_only", "ignore", "unsupported"].includes(asString(o.recommendedParserMode))
         ? asString(o.recommendedParserMode)
-        : "stage_review_only") as "stage_entities" | "stage_review_only" | "ignore" | "unsupported",
+        : "stage_entities") as "stage_entities" | "stage_review_only" | "ignore" | "unsupported",
     };
   }).filter(Boolean) as OnboardingAgentPlan["files"];
+
+  const filesById = new Map(parsedFiles.map((file) => [file.fileId, file]));
+  const files: OnboardingAgentPlan["files"] = [];
+  for (const fileId of params.validFileIds) {
+    const candidateFile = filesById.get(fileId);
+    const deterministic = params.deterministicByFileId?.get(fileId);
+    if (candidateFile) {
+      if (candidateFile.inferredDomain === "unknown" && deterministic?.inferredDomain && deterministic.inferredDomain !== "unknown") {
+        candidateFile.inferredDomain = deterministic.inferredDomain;
+        candidateFile.reasoning = `${candidateFile.reasoning || "AI response incomplete."} Deterministic domain fallback applied.`;
+      }
+      if (!candidateFile.rowCountEstimate && deterministic?.rowCount) candidateFile.rowCountEstimate = deterministic.rowCount;
+      if (!candidateFile.filename && deterministic?.filename) candidateFile.filename = deterministic.filename;
+      files.push(candidateFile);
+      continue;
+    }
+
+    files.push({
+      fileId,
+      filename: deterministic?.filename ?? fileId,
+      inferredDomain: deterministic?.inferredDomain ?? "unknown",
+      confidence: 0.5,
+      reasoning: "AI omitted this file; deterministic fallback applied.",
+      headerMap: {},
+      requiredFieldsPresent: [],
+      missingImportantFields: [],
+      rowCountEstimate: deterministic?.rowCount ?? 0,
+      recommendedParserMode: deterministic?.inferredDomain && deterministic.inferredDomain !== "unknown" ? "stage_entities" : "stage_review_only",
+    });
+  }
 
   const ep = asObj(root.entityPlan);
   const reviewGroups = asArr(root.reviewGroups).slice(0, 200).map((raw) => {


### PR DESCRIPTION
### Motivation
- The onboarding planner produced weak or empty staged output because AI file plans could be omitted/invalid and the validator/application paths collapsed to unknown or ignored AI hints instead of applying safe per-file fallbacks. 
- Relationship review items inferred by the graph were not being merged into persisted grouped review items, leaving the UI with placeholders and zeroed counts.

### Description
- Strengthened agent input: `buildOnboardingAgentInput` now includes `deterministicDetectedDomain`, `normalizedHeaders`, `sampleRowIndexes`, `idReferenceColumns`, and `relationshipColumns`, with capped/redacted sample rows and examples. (file: `buildOnboardingAgentInput.ts`, `agentPlanTypes.ts`)
- Improved deterministic domain detection heuristics to favor explicit filename hints for the eight known CSV exports and to prefer `menu`/`vendors`/`staff`/`history` when appropriate. (file: `domains.ts`)
- Switched the OpenAI run to use the canonical structured helper and strengthened the system/user prompt to require known-export behavior and staged-only semantics; pass deterministic per-file context to validator/fallback. (file: `runOpenAIOnboardingPlan.ts`)
- Validator changes: `validateOnboardingAgentPlan` now preserves valid AI file entries, clamps confidence, forces `liveRecordsCreated = 0`, and applies deterministic per-file fallback for omitted/bad files instead of collapsing the whole session to unknown. (file: `validateOnboardingAgentPlan.ts`)
- Apply path fixes: `applyOnboardingAgentPlan` resolves an `effectiveDomain` per file by combining AI inferred domain, existing detected/declared domain, and deterministic fallback; it updates `onboarding_files.detected_domain`, stages entities with header maps, inserts links, and includes graph-produced review items into persisted grouped review items. (file: `applyOnboardingAgentPlan.ts`)
- Canonical summary improvements: `summaries.ts` now reports link counts by status, entity counts by status, grouped review items, and other aggregated metrics; `liveRecordsCreated` remains 0. (file: `summaries.ts`)
- UI updates: insights panel shows fallback warnings and per-file AI mapping; entities panel hides meaningless all-zero AI lines; review panel and activation panel prioritize persisted grouped review/staged summary data. (files: `OnboardingAgentInsightsPanel.tsx`, `OnboardingEntitiesPanel.tsx`, `OnboardingReviewPanel.tsx`, `OnboardingActivationPlanPanel.tsx`, `OnboardingSessionPage.tsx`)
- Tests added/updated to cover deterministic domain mapping for the 8 filenames, per-file validator fallback, staging/link/review behaviors, and canonical summary derivation. (tests under `features/onboarding-agent/lib/*`)

### Testing
- Ran TypeScript compile: `npx tsc --noEmit` — succeeded. 
- Linted changed files: `npx eslint ...` — warnings only (no errors). 
- Unit tests run (Vitest):
  - `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts` — 9 tests passed.
  - `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts` — 14 tests passed.
  - `npx vitest run features/onboarding-agent/lib/onboarding-agent-domain-mapping.test.ts` — 4 tests passed.
  - `npx vitest run features/onboarding-agent/lib/uploadOnboardingFiles.test.ts` — 3 tests passed.
  - `npx vitest run features/shared/lib/server/openai-models.test.ts features/shared/lib/server/openai-structured.test.ts` — 6 tests passed.
- `pnpm build` attempted and failed due to environment network inability to fetch Google Fonts (Next/font), which is an unrelated known CI/network issue and not caused by these changes.

All changes preserve shop/session scoping, respect Supabase RLS expectations, keep staged-only semantics, and enforce `liveRecordsCreated = 0` throughout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7e18eff08328bd43937c2f464105)