### PR TITLE
Centralize OpenAI model resolution and enforce GPT-5.5 onboarding defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,25 @@
 # OpenAI API key enables server-side AI calls.
+# Never expose this key in browser/client code.
 OPENAI_API_KEY=
 
 # Repo-wide model controls.
 # Prefer purpose-specific vars; OPENAI_MODEL is the global fallback.
-OPENAI_MODEL=
-OPENAI_REASONING_MODEL=
-OPENAI_FAST_MODEL=
-OPENAI_EXTRACTION_MODEL=
-OPENAI_EMBEDDING_MODEL=
+OPENAI_MODEL=gpt-5.5
+OPENAI_REASONING_MODEL=gpt-5.5
+OPENAI_FAST_MODEL=gpt-5.4-mini
+OPENAI_EXTRACTION_MODEL=gpt-5.5
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+OPENAI_REALTIME_TRANSCRIBE_MODEL=gpt-4o-mini-transcribe
 
 # Feature-specific model controls.
 # Onboarding model precedence:
 # ONBOARDING_AGENT_MODEL -> OPENAI_EXTRACTION_MODEL -> OPENAI_REASONING_MODEL -> OPENAI_MODEL -> code default.
-ONBOARDING_AGENT_MODEL=
+ONBOARDING_AGENT_MODEL=gpt-5.5
 
 # If true, onboarding analysis fails when OpenAI is unavailable.
 # If false (default), deterministic fallback is used and surfaced in UI/reporting.
+# ONBOARDING_AGENT_REQUIRE_AI=true is useful for testing real AI calls and
+# should be used carefully because it disables deterministic fallback.
 ONBOARDING_AGENT_REQUIRE_AI=false
+
+# Do not add NEXT_PUBLIC_OPENAI_API_KEY.

--- a/app/api/openai/realtime-token/route.ts
+++ b/app/api/openai/realtime-token/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getOpenAIRealtimeTranscriptionModel } from "@/features/shared/lib/openai-realtime-models";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -79,6 +80,7 @@ export async function GET() {
 
   try {
     const apiKey = process.env.OPENAI_API_KEY;
+    const transcriptionModel = getOpenAIRealtimeTranscriptionModel();
 
     if (!apiKey) {
       console.error("[realtime-token] Missing OPENAI_API_KEY");
@@ -101,7 +103,7 @@ export async function GET() {
               type: "near_field",
             },
             transcription: {
-              model: "gpt-4o-mini-transcribe",
+              model: transcriptionModel,
               language: "en",
             },
             turn_detection: {

--- a/features/inspections/lib/inspection/useRealtimeVoice.ts
+++ b/features/inspections/lib/inspection/useRealtimeVoice.ts
@@ -9,6 +9,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { getOpenAIRealtimeTranscriptionModel } from "@/features/shared/lib/openai-realtime-models";
 
 export type VoiceState = "idle" | "connecting" | "listening" | "error";
 
@@ -92,6 +93,7 @@ export function useRealtimeVoice(
   maybeHandleWakeWord: (text: string) => string | null,
   opts?: RealtimeVoiceOptions,
 ) {
+  const transcriptionModel = getOpenAIRealtimeTranscriptionModel();
   const wsRef = useRef<WebSocket | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
@@ -215,7 +217,7 @@ export function useRealtimeVoice(
                 format: { type: "audio/pcm", rate: 24000 },
                 noise_reduction: { type: "near_field" },
                 transcription: {
-                  model: "gpt-4o-mini-transcribe",
+                  model: transcriptionModel,
                   language: "en",
                 },
                 // Keep these modest; if you had a known-good set before, use it.

--- a/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
+++ b/features/onboarding-agent/server/runOnboardingAgentAnalysis.ts
@@ -10,7 +10,8 @@ import { ONBOARDING_DOMAINS, type OnboardingDomain } from "@/features/onboarding
 import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 import { buildOnboardingAgentSystemPrompt, buildOnboardingAgentUserPrompt } from "@/features/onboarding-agent/server/prompts";
-import { getOnboardingAgentEnabled, getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
+import { getOnboardingAgentModel } from "@/features/onboarding-agent/server/model";
+import { runOpenAIStructuredJson } from "@/features/shared/lib/server/openai-structured";
 
 type RunParams = {
   supabase: SupabaseClient;
@@ -31,14 +32,6 @@ const VALID_ACTION_TYPES = new Set([
 ]);
 const VALID_READINESS = new Set(["not_ready", "empty", "review_required", "ready_for_dry_run", "activation_disabled"]);
 const VALID_DOMAINS = new Set<string>([...ONBOARDING_DOMAINS, "all"]);
-
-function stripJsonFences(raw: string) {
-  return raw.replace(/^```json\s*/i, "").replace(/^```\s*/i, "").replace(/```\s*$/i, "").trim();
-}
-
-function parseModelJson(raw: string): unknown {
-  return JSON.parse(stripJsonFences(raw));
-}
 
 function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
@@ -289,25 +282,22 @@ export function sanitizeAgentReport(params: {
 }
 
 export async function callOnboardingAgentModel(input: OnboardingAgentInput): Promise<OnboardingAgentReport | null> {
-  if (!getOnboardingAgentEnabled()) return null;
-  const { openai } = await import("../../../lib/server/openai");
-
-  const model = getOnboardingAgentModel();
-  const completion = await openai.chat.completions.create({
-    model,
+  const requireAi = process.env.ONBOARDING_AGENT_REQUIRE_AI === "true";
+  const result = await runOpenAIStructuredJson<OnboardingAgentReport | null>({
+    purpose: "onboarding",
+    feature: "onboarding-agent-analysis",
+    schemaName: "OnboardingAgentReport",
+    system: buildOnboardingAgentSystemPrompt(),
+    user: {
+      prompt: buildOnboardingAgentUserPrompt(input),
+      input,
+    },
+    requireAI: requireAi,
     temperature: 0.1,
-    messages: [
-      { role: "system", content: buildOnboardingAgentSystemPrompt() },
-      { role: "user", content: buildOnboardingAgentUserPrompt(input) },
-    ],
-    response_format: { type: "json_object" },
+    fallback: () => null,
+    validate: (candidate) => candidate as OnboardingAgentReport,
   });
-
-  const text = completion.choices?.[0]?.message?.content;
-  if (!text) return null;
-
-  const parsed = parseModelJson(text);
-  return parsed as OnboardingAgentReport;
+  return result.output;
 }
 
 export async function runOnboardingAgentAnalysis(params: RunParams): Promise<OnboardingAgentReport> {
@@ -446,6 +436,9 @@ export async function runOnboardingAgentAnalysis(params: RunParams): Promise<Onb
       report.mode = "ai";
     }
   } catch (error) {
+    if (process.env.ONBOARDING_AGENT_REQUIRE_AI === "true") {
+      throw error;
+    }
     console.warn("[onboarding-agent] AI analysis fallback", {
       sessionId: params.sessionId,
       shopId: params.shopId,

--- a/features/shared/lib/openai-realtime-models.ts
+++ b/features/shared/lib/openai-realtime-models.ts
@@ -1,0 +1,13 @@
+const DEFAULT_REALTIME_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe";
+
+function env(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+export function getOpenAIRealtimeTranscriptionModel(): string {
+  return env("OPENAI_REALTIME_TRANSCRIBE_MODEL")
+    ?? env("OPENAI_FAST_MODEL")
+    ?? env("OPENAI_MODEL")
+    ?? DEFAULT_REALTIME_TRANSCRIPTION_MODEL;
+}

--- a/features/shared/lib/server/openai-models.test.ts
+++ b/features/shared/lib/server/openai-models.test.ts
@@ -43,4 +43,39 @@ describe("openai-models precedence", () => {
     expect(getOpenAIEmbeddingModel()).toBe("text-embedding-3-small");
     expect(getOnboardingAgentModel()).toBe("gpt-global");
   });
+
+  it("uses latest defaults when no env is set", () => {
+    delete process.env.OPENAI_MODEL;
+    delete process.env.OPENAI_REASONING_MODEL;
+    delete process.env.OPENAI_FAST_MODEL;
+    delete process.env.OPENAI_EXTRACTION_MODEL;
+    delete process.env.OPENAI_EMBEDDING_MODEL;
+    delete process.env.ONBOARDING_AGENT_MODEL;
+
+    expect(getOpenAIReasoningModel()).toBe("gpt-5.5");
+    expect(getOpenAIFastModel()).toBe("gpt-5.4-mini");
+    expect(getOpenAIExtractionModel()).toBe("gpt-5.5");
+    expect(getOpenAIEmbeddingModel()).toBe("text-embedding-3-small");
+    expect(getOnboardingAgentModel()).toBe("gpt-5.5");
+  });
+
+  it("onboarding model precedence is ONBOARDING -> EXTRACTION -> REASONING -> OPENAI_MODEL -> default", () => {
+    delete process.env.OPENAI_MODEL;
+    delete process.env.OPENAI_REASONING_MODEL;
+    delete process.env.OPENAI_EXTRACTION_MODEL;
+    delete process.env.ONBOARDING_AGENT_MODEL;
+    expect(getOnboardingAgentModel()).toBe("gpt-5.5");
+
+    process.env.OPENAI_MODEL = "gpt-global";
+    expect(getOnboardingAgentModel()).toBe("gpt-global");
+
+    process.env.OPENAI_REASONING_MODEL = "gpt-reasoning";
+    expect(getOnboardingAgentModel()).toBe("gpt-reasoning");
+
+    process.env.OPENAI_EXTRACTION_MODEL = "gpt-extraction";
+    expect(getOnboardingAgentModel()).toBe("gpt-extraction");
+
+    process.env.ONBOARDING_AGENT_MODEL = "gpt-onboarding";
+    expect(getOnboardingAgentModel()).toBe("gpt-onboarding");
+  });
 });

--- a/features/shared/lib/server/openai-models.ts
+++ b/features/shared/lib/server/openai-models.ts
@@ -10,11 +10,11 @@ export type OpenAIModelPurpose =
   | "vision"
   | "onboarding";
 
-const DEFAULT_REASONING_MODEL = "gpt-5-mini";
-const DEFAULT_FAST_MODEL = "gpt-4.1-mini";
-const DEFAULT_EXTRACTION_MODEL = "gpt-4.1-mini";
+const DEFAULT_REASONING_MODEL = "gpt-5.5";
+const DEFAULT_FAST_MODEL = "gpt-5.4-mini";
+const DEFAULT_EXTRACTION_MODEL = "gpt-5.5";
 const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
-const DEFAULT_VISION_MODEL = "gpt-4.1-mini";
+const DEFAULT_VISION_MODEL = "gpt-5.5";
 
 function env(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -30,7 +30,7 @@ export function getOpenAIFastModel(): string {
 }
 
 export function getOpenAIExtractionModel(): string {
-  return env("OPENAI_EXTRACTION_MODEL") ?? getOpenAIReasoningModel() ?? env("OPENAI_MODEL") ?? DEFAULT_EXTRACTION_MODEL;
+  return env("OPENAI_EXTRACTION_MODEL") ?? env("OPENAI_REASONING_MODEL") ?? env("OPENAI_MODEL") ?? DEFAULT_EXTRACTION_MODEL;
 }
 
 export function getOpenAIEmbeddingModel(): string {
@@ -38,7 +38,11 @@ export function getOpenAIEmbeddingModel(): string {
 }
 
 export function getOnboardingAgentModel(): string {
-  return env("ONBOARDING_AGENT_MODEL") ?? getOpenAIExtractionModel() ?? getOpenAIReasoningModel() ?? env("OPENAI_MODEL") ?? DEFAULT_REASONING_MODEL;
+  return env("ONBOARDING_AGENT_MODEL")
+    ?? env("OPENAI_EXTRACTION_MODEL")
+    ?? env("OPENAI_REASONING_MODEL")
+    ?? env("OPENAI_MODEL")
+    ?? DEFAULT_REASONING_MODEL;
 }
 
 export function getOpenAIModelForPurpose(purpose: OpenAIModelPurpose): string {


### PR DESCRIPTION
### Motivation
- Ensure repo-wide OpenAI model selection goes through a single canonical resolver so the app can consistently use the new recommended models (notably `gpt-5.5` for reasoning/onboarding) and avoid scattered hardcoded model strings. 
- Harden the Onboarding Agent to use server-side structured Responses helper and respect `ONBOARDING_AGENT_REQUIRE_AI` while preserving staged-only semantics and preventing client-side API key exposure.

### Description
- Updated canonical defaults and precedence in `features/shared/lib/server/openai-models.ts` to use `gpt-5.5` for reasoning/extraction/onboarding and `gpt-5.4-mini` for fast flows, and tightened extraction/onboarding env precedence logic. 
- Replaced onboarding direct Chat Completions usage with the shared structured helper by calling `runOpenAIStructuredJson` (purpose: "onboarding") in `features/onboarding-agent/server/runOnboardingAgentAnalysis.ts`, preserving deterministic fallback and honoring `ONBOARDING_AGENT_REQUIRE_AI`. 
- Added a realtime transcription model resolver `features/shared/lib/openai-realtime-models.ts` and replaced literal transcription model strings in `app/api/openai/realtime-token/route.ts` and `features/inspections/lib/inspection/useRealtimeVoice.ts`. 
- Extended tests in `features/shared/lib/server/openai-models.test.ts` to cover new defaults and onboarding precedence; updated `.env.example` with recommended env values and server-only guidance. 

### Testing
- Ran a grep audit (scoped paths) to locate OpenAI usage and model strings; changes limited to resolver, onboarding agent, and realtime transcription paths. (passed; remaining `chat.completions.create` occurrences intentionally left for follow-up to avoid high blast radius). 
- Typecheck: `npx tsc --noEmit` — passed. 
- Lint: `npx eslint ...` on touched files — passed with pre-existing `@typescript-eslint/no-explicit-any` warnings only (no new lint errors). 
- Unit tests: `npx vitest` for model/resolver and onboarding test suites — all targeted tests passed. 
- Build: `pnpm build` attempted but failed in this environment due to external Google Fonts network fetch errors for `Inter` and `Black Ops One` (documented; unrelated to OpenAI changes). 

Files changed (high-level): `features/shared/lib/server/openai-models.ts`, `features/shared/lib/server/openai-models.test.ts`, `features/onboarding-agent/server/runOnboardingAgentAnalysis.ts`, `features/shared/lib/openai-realtime-models.ts` (new), `app/api/openai/realtime-token/route.ts`, `features/inspections/lib/inspection/useRealtimeVoice.ts`, `.env.example`.

If you'd like, I can follow up by migrating other server-side `chat.completions.create` usages to the canonical helpers in a staged pass to complete the migration while keeping changes minimal per module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7f975d8c8328a1b36b103470e8ab)