### PR TITLE
Fix server-only OpenAI import leak from inspection summary quote path

### DIFF
--- a/features/ai/lib/ai/generateLaborTimeEstimate.ts
+++ b/features/ai/lib/ai/generateLaborTimeEstimate.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
@@ -9,7 +11,12 @@ export async function generateLaborTimeEstimate(
   jobType: string,
 ): Promise<number | null> {
   try {
-    const prompt = `Estimate labor time in hours (number only) for the following automotive job:\n\nJob Type: ${jobType}\nComplaint: ${complaint}\n\nResponse:`;
+    const prompt = `Estimate labor time in hours (number only) for the following automotive job:
+
+Job Type: ${jobType}
+Complaint: ${complaint}
+
+Response:`;
 
     const response = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("reasoning"),
@@ -23,26 +30,6 @@ export async function generateLaborTimeEstimate(
     return isNaN(parsed) ? null : parsed;
   } catch (err) {
     console.error("Failed to generate labor time:", err);
-    return null;
-  }
-}
-
-// Safe to call from client
-export async function estimateLabor(
-  complaint: string,
-  jobType: string,
-): Promise<number | null> {
-  try {
-    const res = await fetch("/api/ai/estimate-labor", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ complaint, jobType }),
-    });
-
-    const data = await res.json();
-    return data.hours ?? null;
-  } catch (err) {
-    console.error("Error estimating labor (client):", err);
     return null;
   }
 }

--- a/features/quotes/lib/quote/generateQuoteFromInspection.ts
+++ b/features/quotes/lib/quote/generateQuoteFromInspection.ts
@@ -1,6 +1,6 @@
 import type { InspectionItem } from "@inspections/lib/inspection/types";
 import { serviceMenu } from "@shared/lib/menuItems";
-import { generateLaborTimeEstimate } from "@ai/lib/ai/generateLaborTimeEstimate";
+import { estimateLabor } from "@ai/lib/ai/estimateLabor";
 
 /** Shape expected by QuoteViewer (summary page) */
 export interface QuoteLine {
@@ -75,7 +75,7 @@ export async function generateQuoteFromInspection(
     }
 
     // 2) Fall back to AI labor estimate
-    const labor = await generateLaborTimeEstimate(term, "repair");
+    const labor = await estimateLabor(term, "repair");
     if (labor && labor > 0) {
       quote.push({
         description: term,

--- a/features/quotes/lib/quote/matchToMenuItem.ts
+++ b/features/quotes/lib/quote/matchToMenuItem.ts
@@ -1,6 +1,6 @@
 import type { InspectionItem } from "@inspections/lib/inspection/types";
 import { serviceMenu } from "@shared/lib/menuItems";
-import { generateLaborTimeEstimate } from "@ai/lib/ai/generateLaborTimeEstimate";
+import { estimateLabor } from "@ai/lib/ai/estimateLabor";
 
 /** Shape expected by QuoteViewer (summary page) */
 export interface QuoteLine {
@@ -78,7 +78,7 @@ export async function generateQuoteFromInspection(
     }
 
     // 2) Fall back to AI labor estimate
-    const labor = await generateLaborTimeEstimate(term, "repair");
+    const labor = await estimateLabor(term, "repair");
     if (typeof labor === "number" && labor > 0) {
       quote.push({
         description: term,

--- a/features/shared/lib/openai-models.ts
+++ b/features/shared/lib/openai-models.ts
@@ -1,0 +1,75 @@
+export type OpenAIModelPurpose =
+  | "reasoning"
+  | "fast"
+  | "extraction"
+  | "embedding"
+  | "vision"
+  | "onboarding";
+
+export const DEFAULT_REASONING_MODEL = "gpt-5.5";
+export const DEFAULT_FAST_MODEL = "gpt-5.4-mini";
+export const DEFAULT_EXTRACTION_MODEL = "gpt-5.5";
+export const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+export const DEFAULT_VISION_MODEL = "gpt-5.5";
+
+export type OpenAIModelEnvReader = (name: string) => string | undefined;
+
+function fromEnv(readEnv: OpenAIModelEnvReader, name: string): string | undefined {
+  const value = readEnv(name)?.trim();
+  return value ? value : undefined;
+}
+
+export function resolveOpenAIReasoningModel(readEnv: OpenAIModelEnvReader): string {
+  return fromEnv(readEnv, "OPENAI_REASONING_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_MODEL")
+    ?? DEFAULT_REASONING_MODEL;
+}
+
+export function resolveOpenAIFastModel(readEnv: OpenAIModelEnvReader): string {
+  return fromEnv(readEnv, "OPENAI_FAST_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_MODEL")
+    ?? DEFAULT_FAST_MODEL;
+}
+
+export function resolveOpenAIExtractionModel(readEnv: OpenAIModelEnvReader): string {
+  return fromEnv(readEnv, "OPENAI_EXTRACTION_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_REASONING_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_MODEL")
+    ?? DEFAULT_EXTRACTION_MODEL;
+}
+
+export function resolveOpenAIEmbeddingModel(readEnv: OpenAIModelEnvReader): string {
+  return fromEnv(readEnv, "OPENAI_EMBEDDING_MODEL") ?? DEFAULT_EMBEDDING_MODEL;
+}
+
+export function resolveOnboardingAgentModel(readEnv: OpenAIModelEnvReader): string {
+  return fromEnv(readEnv, "ONBOARDING_AGENT_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_EXTRACTION_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_REASONING_MODEL")
+    ?? fromEnv(readEnv, "OPENAI_MODEL")
+    ?? DEFAULT_REASONING_MODEL;
+}
+
+export function resolveOpenAIModelForPurpose(
+  purpose: OpenAIModelPurpose,
+  readEnv: OpenAIModelEnvReader,
+): string {
+  switch (purpose) {
+    case "reasoning":
+      return resolveOpenAIReasoningModel(readEnv);
+    case "fast":
+      return resolveOpenAIFastModel(readEnv);
+    case "extraction":
+      return resolveOpenAIExtractionModel(readEnv);
+    case "embedding":
+      return resolveOpenAIEmbeddingModel(readEnv);
+    case "vision":
+      return fromEnv(readEnv, "OPENAI_VISION_MODEL")
+        ?? resolveOpenAIExtractionModel(readEnv)
+        ?? DEFAULT_VISION_MODEL;
+    case "onboarding":
+      return resolveOnboardingAgentModel(readEnv);
+    default:
+      return resolveOpenAIReasoningModel(readEnv);
+  }
+}

--- a/features/shared/lib/server/openai-models.ts
+++ b/features/shared/lib/server/openai-models.ts
@@ -1,67 +1,44 @@
 import "server-only";
 
 import { isOpenAIConfigured } from "@/features/shared/lib/server/openai";
-
-export type OpenAIModelPurpose =
-  | "reasoning"
-  | "fast"
-  | "extraction"
-  | "embedding"
-  | "vision"
-  | "onboarding";
-
-const DEFAULT_REASONING_MODEL = "gpt-5.5";
-const DEFAULT_FAST_MODEL = "gpt-5.4-mini";
-const DEFAULT_EXTRACTION_MODEL = "gpt-5.5";
-const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
-const DEFAULT_VISION_MODEL = "gpt-5.5";
+import {
+  resolveOnboardingAgentModel,
+  resolveOpenAIEmbeddingModel,
+  resolveOpenAIExtractionModel,
+  resolveOpenAIFastModel,
+  resolveOpenAIModelForPurpose,
+  resolveOpenAIReasoningModel,
+  type OpenAIModelPurpose,
+} from "@/features/shared/lib/openai-models";
 
 function env(name: string): string | undefined {
-  const value = process.env[name]?.trim();
-  return value ? value : undefined;
+  return process.env[name];
 }
 
+export type { OpenAIModelPurpose };
+
 export function getOpenAIReasoningModel(): string {
-  return env("OPENAI_REASONING_MODEL") ?? env("OPENAI_MODEL") ?? DEFAULT_REASONING_MODEL;
+  return resolveOpenAIReasoningModel(env);
 }
 
 export function getOpenAIFastModel(): string {
-  return env("OPENAI_FAST_MODEL") ?? env("OPENAI_MODEL") ?? DEFAULT_FAST_MODEL;
+  return resolveOpenAIFastModel(env);
 }
 
 export function getOpenAIExtractionModel(): string {
-  return env("OPENAI_EXTRACTION_MODEL") ?? env("OPENAI_REASONING_MODEL") ?? env("OPENAI_MODEL") ?? DEFAULT_EXTRACTION_MODEL;
+  return resolveOpenAIExtractionModel(env);
 }
 
 export function getOpenAIEmbeddingModel(): string {
-  return env("OPENAI_EMBEDDING_MODEL") ?? DEFAULT_EMBEDDING_MODEL;
+  return resolveOpenAIEmbeddingModel(env);
 }
 
 export function getOnboardingAgentModel(): string {
-  return env("ONBOARDING_AGENT_MODEL")
-    ?? env("OPENAI_EXTRACTION_MODEL")
-    ?? env("OPENAI_REASONING_MODEL")
-    ?? env("OPENAI_MODEL")
-    ?? DEFAULT_REASONING_MODEL;
+  return resolveOnboardingAgentModel(env);
 }
 
 export function getOpenAIModelForPurpose(purpose: OpenAIModelPurpose): string {
-  switch (purpose) {
-    case "reasoning":
-      return getOpenAIReasoningModel();
-    case "fast":
-      return getOpenAIFastModel();
-    case "extraction":
-      return getOpenAIExtractionModel();
-    case "embedding":
-      return getOpenAIEmbeddingModel();
-    case "vision":
-      return env("OPENAI_VISION_MODEL") ?? getOpenAIExtractionModel() ?? DEFAULT_VISION_MODEL;
-    case "onboarding":
-      return getOnboardingAgentModel();
-    default:
-      return getOpenAIReasoningModel();
-  }
+  return resolveOpenAIModelForPurpose(purpose, env);
 }
 
 export function getOpenAIModelDiagnostics() {

--- a/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
+++ b/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
@@ -9,7 +9,7 @@ import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { estimateLabor } from "@ai/lib/ai/generateLaborTimeEstimate";
+import { estimateLabor } from "@ai/lib/ai/estimateLabor";
 
 type DB = Database;
 


### PR DESCRIPTION
### Motivation
- A client/page-reachable path (`inspection/summary`) imported quote generation utilities that transitively imported server-only OpenAI helpers, causing Vercel build errors about `server-only` leaking into client bundles.
- The goal is to preserve server-only OpenAI client and API-key usage while exposing only pure, safe model constants/resolvers to shared code so pages do not pull `server-only` into browser bundles.

### Description
- Split pure model resolution into a new shared module `features/shared/lib/openai-models.ts` that contains model-purpose types, defaults, and resolver functions and does not import `server-only` or read `process.env` directly.
- Kept server-only wrappers in `features/shared/lib/server/openai-models.ts` which import `server-only`, read `process.env`, and call the pure resolvers for server usage only.
- Made `features/ai/lib/ai/generateLaborTimeEstimate.ts` explicitly server-only (`import "server-only"`) and removed its client-safe fetch helper so it only runs on the server.
- Replaced direct imports of the server-only estimator in client-reachable code with a safe fetch helper: updated `features/quotes/lib/quote/generateQuoteFromInspection.ts`, `features/quotes/lib/quote/matchToMenuItem.ts`, and `features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts` to use the client-safe `estimateLabor` path instead of importing server-only helpers.
- Preserved all server-side OpenAI helpers (`features/shared/lib/server/openai.ts`, `openai-structured.ts`, `openai-embeddings.ts`) and onboarding agent flows so their OpenAI API-key usage and RLS/shop_id expectations remain unchanged.

### Testing
- Ran typecheck with `npx tsc --noEmit` and it succeeded.
- Ran lint on targeted files with `npx eslint features/shared/lib/openai-models.ts features/shared/lib/server/openai-models.ts features/shared/lib/server/openai.ts features/ai/lib/ai/generateLaborTimeEstimate.ts features/quotes/lib/quote/generateQuoteFromInspection.ts features/inspections/app/inspection/summary/page.tsx` and it returned only pre-existing warnings (no errors).
- Ran targeted tests with `npx vitest run` for `features/shared/lib/server/openai-models.test.ts`, `features/shared/lib/server/openai-structured.test.ts` and onboarding-agent tests and all passed.
- Attempted full build with `pnpm build` but it was blocked in this environment by external Google Fonts network fetch failures for `Inter` and `Black Ops One`; this is an external network/font issue not related to the OpenAI boundary fix.

Files changed: `features/shared/lib/openai-models.ts` (new), `features/shared/lib/server/openai-models.ts`, `features/ai/lib/ai/generateLaborTimeEstimate.ts`, `features/quotes/lib/quote/generateQuoteFromInspection.ts`, `features/quotes/lib/quote/matchToMenuItem.ts`, and `features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts`.

Security confirmations: the `OPENAI_API_KEY` remains used only by server-only helpers, and onboarding agent still uses the canonical server-side OpenAI helpers and model resolution wrappers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef82016e088328b72c601307e1478e)