### PR TITLE
Fix onboarding session rows parsed totals to use persisted raw row counts

### DIFF
--- a/app/api/onboarding-agent/sessions/route.ts
+++ b/app/api/onboarding-agent/sessions/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { createOnboardingSession } from "@/features/onboarding-agent/server/createOnboardingSession";
+import { countOnboardingRawRowsBySession } from "@/features/onboarding-agent/server/rawRowCounts";
+import { buildOnboardingSessionListPayload } from "@/features/onboarding-agent/server/sessionListSummary";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
@@ -63,10 +65,17 @@ export async function GET() {
     }
   }
 
-  const sessions = (data ?? []).map((session: any) => ({
-    ...session,
-    file_count: fileCounts.get(String(session.id)) ?? 0,
-  }));
+  const rawRowsBySession = await countOnboardingRawRowsBySession({
+    supabase: admin,
+    shopId,
+    sessionIds,
+  });
+
+  const sessions = buildOnboardingSessionListPayload({
+    sessions: (data ?? []) as Array<{ id: string; summary?: Record<string, unknown> | null }>,
+    fileCounts,
+    rawRowsBySession,
+  });
 
   return NextResponse.json({ ok: true, sessions });
 }

--- a/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
@@ -83,7 +83,7 @@ export function OnboardingAgentDashboard() {
                 </div>
                 <div className="mt-2 grid gap-2 text-xs text-slate-300 sm:grid-cols-3 lg:grid-cols-4">
                   <p>Files: {asCount(session.file_count)}</p>
-                  <p>Rows parsed: {asCount(summary.rowsParsed)}</p>
+                  <p>Rows parsed: {asCount(summary.rowsParsedTotal ?? summary.rowsParsed)}</p>
                   <p>Review exceptions: {asCount(summary.reviewExceptions)}</p>
                   <p>Source: {session.source || "manual"}</p>
                 </div>

--- a/features/onboarding-agent/components/OnboardingProgressCard.tsx
+++ b/features/onboarding-agent/components/OnboardingProgressCard.tsx
@@ -1,7 +1,7 @@
 export function OnboardingProgressCard({ summary }: { summary?: Record<string, unknown> | null }) {
   const rows = [
     ["Uploaded files", String((summary?.uploadedFiles as number) ?? (summary?.fileCount as number) ?? 0)],
-    ["Rows parsed", String((summary?.rowsParsed as number) ?? 0)],
+    ["Rows parsed", String((summary?.rowsParsedTotal as number) ?? (summary?.rowsParsed as number) ?? 0)],
     ["Entities discovered", String((summary?.entitiesDiscovered as number) ?? 0)],
     ["Links found", String((summary?.linksFound as number) ?? 0)],
     ["Review exceptions", String((summary?.reviewExceptions as number) ?? 0)],

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -80,7 +80,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     if (!session) return false;
     if (session.analyzed_at) return true;
     if (session.summary && typeof session.summary === "object") {
-      return Number((session.summary as Record<string, unknown>).rowsParsed ?? 0) > 0;
+      return Number((session.summary as Record<string, unknown>).rowsParsedTotal ?? (session.summary as Record<string, unknown>).rowsParsed ?? 0) > 0;
     }
     return false;
   }, [session]);

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -207,4 +207,23 @@ describe("onboarding staging", () => {
     expect(summary.liveRecordsCreated).toBe(0);
   });
 
+  it("keeps persisted rowsParsedTotal separate from aiRowsSampled", () => {
+    const summary = buildOnboardingSummary({
+      filesCount: 8,
+      rowsParsed: 19717,
+      aiRowsSampled: 1000,
+      aiFilesSampled: 8,
+      entityRows: [],
+      linkRows: [],
+      reviewRows: [],
+      analysisCompleted: true,
+    });
+
+    expect(summary.summaryCounts.rowsParsed).toBe(19717);
+    expect(summary.summaryCounts.rowsParsedTotal).toBe(19717);
+    expect(summary.summaryCounts.aiRowsSampled).toBe(1000);
+    expect(summary.summaryCounts.aiFilesSampled).toBe(8);
+    expect(summary.liveRecordsCreated).toBe(0);
+  });
+
 });

--- a/features/onboarding-agent/lib/summaries.ts
+++ b/features/onboarding-agent/lib/summaries.ts
@@ -180,6 +180,8 @@ export function buildOnboardingSummary(input: {
   reviewRows: PendingReviewItem[];
   groupedExceptionCount?: number;
   analysisCompleted?: boolean;
+  aiRowsSampled?: number;
+  aiFilesSampled?: number;
 }) {
   const entityCounts = ENTITY_BUCKETS.reduce<Record<string, number>>((acc, key) => {
     acc[key] = 0;
@@ -276,6 +278,9 @@ export function buildOnboardingSummary(input: {
     summaryCounts: {
       uploadedFiles: input.filesCount,
       rowsParsed: input.rowsParsed,
+      rowsParsedTotal: input.rowsParsed,
+      aiRowsSampled: toNumber(input.aiRowsSampled),
+      aiFilesSampled: toNumber(input.aiFilesSampled),
       entitiesDiscovered: totalEntities,
       linksFound: totalLinks,
       reviewExceptions: totalReviewItems,

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -90,6 +90,25 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
     sessionId: params.sessionId,
   });
 
+  const aiRowsSampled = input.files.reduce((sum, file) => sum + (Array.isArray(file.sampleRows) ? file.sampleRows.length : 0), 0);
+  const aiFilesSampled = input.files.filter((file) => Array.isArray(file.sampleRows) && file.sampleRows.length > 0).length;
+
+  const { data: sessionForAiSummary } = await sb
+    .from("onboarding_sessions")
+    .select("summary")
+    .eq("id", params.sessionId)
+    .eq("shop_id", params.shopId)
+    .maybeSingle();
+  const existingAiSummary = (sessionForAiSummary?.summary && typeof sessionForAiSummary.summary === "object") ? sessionForAiSummary.summary : {};
+  await sb.from("onboarding_sessions").update({
+    summary: {
+      ...existingAiSummary,
+      aiRowsSampled,
+      aiFilesSampled,
+      liveRecordsCreated: 0,
+    },
+  }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+
   const requireAi = process.env.ONBOARDING_AGENT_REQUIRE_AI === "true";
   const { plan, warning } = await runOpenAIOnboardingPlan({ input, requireAi });
   const applied = await applyOnboardingAgentPlan({

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -8,6 +8,7 @@ import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-
 import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
 import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
+import { countOnboardingRawRows } from "@/features/onboarding-agent/server/rawRowCounts";
 
 const INSERT_CHUNK_SIZE = 1000;
 
@@ -162,9 +163,15 @@ export async function applyOnboardingAgentPlan(params: {
   await insertInChunks(sb, "onboarding_review_items", groupedReviewItems);
 
   const { data: files } = await sb.from("onboarding_files").select("id").eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  const rowsParsedTotal = await countOnboardingRawRows({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+
   const canonical = buildOnboardingSummary({
     filesCount: (files ?? []).length,
-    rowsParsed: (rows ?? []).length,
+    rowsParsed: rowsParsedTotal,
     entityRows: (entities ?? []).map((e: any) => ({ entity_type: e.entity_type, status: e.status })),
     linkRows: (insertedLinks ?? []).map((l: any) => ({ link_type: l.link_type, status: l.status })),
     reviewRows: groupedReviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details, status: item.status })),

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildOnboardingSummary, ENTITY_BUCKETS, LINK_BUCKETS } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import { countOnboardingRawRows } from "@/features/onboarding-agent/server/rawRowCounts";
 
 export async function getOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
@@ -10,7 +11,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     sessionId: params.sessionId,
   });
 
-  const [{ data: session }, { data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }] = await Promise.all([
+  const [{ data: session }, { data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }, rowsParsedTotal] = await Promise.all([
     sb.from("onboarding_sessions").select("*").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
     sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
     sb.from("onboarding_entities").select("entity_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
@@ -22,12 +23,11 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
       .eq("session_id", params.sessionId)
       .order("created_at", { ascending: false }),
     sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    countOnboardingRawRows({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
   ]);
-
-  const rowsParsedFromFiles = (files ?? []).reduce((sum: number, file: any) => sum + Number(file.row_count ?? 0), 0);
   const canonical = buildOnboardingSummary({
     filesCount: (files ?? []).length,
-    rowsParsed: rowsParsedFromFiles,
+    rowsParsed: rowsParsedTotal,
     entityRows: (entities ?? []).map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
     linkRows: (links ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
     reviewRows: (reviews ?? []).map((row: any) => ({

--- a/features/onboarding-agent/server/rawRowCounts.ts
+++ b/features/onboarding-agent/server/rawRowCounts.ts
@@ -1,0 +1,35 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function countOnboardingRawRows(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+}): Promise<number> {
+  const sb = params.supabase as any;
+  const { count, error } = await sb
+    .from("onboarding_raw_rows")
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId);
+
+  if (error) throw new Error(error.message);
+  return Number(count ?? 0);
+}
+
+export async function countOnboardingRawRowsBySession(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionIds: string[];
+}): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  const uniqueSessionIds = Array.from(new Set(params.sessionIds.filter(Boolean)));
+  await Promise.all(uniqueSessionIds.map(async (sessionId) => {
+    const count = await countOnboardingRawRows({
+      supabase: params.supabase,
+      shopId: params.shopId,
+      sessionId,
+    });
+    counts.set(sessionId, count);
+  }));
+  return counts;
+}

--- a/features/onboarding-agent/server/sessionListSummary.test.ts
+++ b/features/onboarding-agent/server/sessionListSummary.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildOnboardingSessionListPayload } from "@/features/onboarding-agent/server/sessionListSummary";
+
+describe("onboarding session list summary", () => {
+  it("uses persisted raw row totals instead of ai sampled row caps", () => {
+    const sessions = buildOnboardingSessionListPayload({
+      sessions: [
+        {
+          id: "session-1",
+          status: "analysis_ready",
+          summary: {
+            rowsParsed: 1000,
+            aiRowsSampled: 1000,
+          },
+        },
+      ],
+      fileCounts: new Map([["session-1", 8]]),
+      rawRowsBySession: new Map([["session-1", 19717]]),
+    });
+
+    expect(sessions[0].file_count).toBe(8);
+    expect((sessions[0].summary as Record<string, unknown>).rowsParsed).toBe(19717);
+    expect((sessions[0].summary as Record<string, unknown>).rowsParsedTotal).toBe(19717);
+    expect((sessions[0].summary as Record<string, unknown>).aiRowsSampled).toBe(1000);
+    expect((sessions[0].summary as Record<string, unknown>).liveRecordsCreated).toBe(0);
+  });
+});

--- a/features/onboarding-agent/server/sessionListSummary.ts
+++ b/features/onboarding-agent/server/sessionListSummary.ts
@@ -1,0 +1,32 @@
+type SessionListInputRow = {
+  id: string;
+  summary?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+export function buildOnboardingSessionListPayload(params: {
+  sessions: SessionListInputRow[];
+  fileCounts: Map<string, number>;
+  rawRowsBySession: Map<string, number>;
+}) {
+  return params.sessions.map((session) => {
+    const sessionId = String(session.id);
+    const rowsParsedTotal = Number(params.rawRowsBySession.get(sessionId) ?? 0);
+    const summarySource = (session.summary && typeof session.summary === "object") ? session.summary : {};
+    const aiRowsSampled = Number(summarySource.aiRowsSampled ?? 0);
+    const aiFilesSampled = Number(summarySource.aiFilesSampled ?? 0);
+
+    return {
+      ...session,
+      file_count: params.fileCounts.get(sessionId) ?? 0,
+      summary: {
+        ...summarySource,
+        rowsParsed: rowsParsedTotal,
+        rowsParsedTotal,
+        aiRowsSampled,
+        aiFilesSampled,
+        liveRecordsCreated: 0,
+      },
+    };
+  });
+}


### PR DESCRIPTION
### Motivation
- Recent sessions list showed `Rows parsed: 1000` because the persisted summary used a capped in-memory fetch instead of the canonical persisted raw-row total. 
- The UI needs `rowsParsed` to represent the total persisted raw rows (`onboarding_raw_rows`) while AI sampling/capping remains a separate diagnostic. 

### Description
- Add canonical raw-row count helpers `countOnboardingRawRows` and `countOnboardingRawRowsBySession` and use them where totals must reflect persisted rows. 
- Normalize recent sessions payload via `buildOnboardingSessionListPayload` so list and detail cannot drift and expose `rowsParsedTotal`, `aiRowsSampled`, and `aiFilesSampled` explicitly. 
- Update server flows to use persisted totals: `getOnboardingSession` and `applyOnboardingAgentPlan` now derive `rowsParsed` from `COUNT(*)` on `onboarding_raw_rows`, and `analyzeOnboardingSession` persists AI sampling diagnostics (`aiRowsSampled`, `aiFilesSampled`) without changing sampling behavior. 
- UI consumers were updated to prefer `rowsParsedTotal` with a fallback to `rowsParsed` so the recent sessions list, session detail, and progress card consistently display the real parsed total while `liveRecordsCreated` remains `0`. 

### Testing
- Type-checking: ran `npx tsc --noEmit` and it completed successfully. 
- Unit tests: ran `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts`, `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts`, and `npx vitest run features/onboarding-agent/server/sessionListSummary.test.ts`, and all tests passed. 
- Lint: ran `npx eslint` on touched files; it completed with warnings (legacy `any` usages) and no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef939c41888328808ed62d0eea5225)