### PR TITLE
Add safe staged session rerun/delete controls for Onboarding Agent

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { analyzeOnboardingSession } from "@/features/onboarding-agent/server/analyzeOnboardingSession";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
@@ -17,14 +18,7 @@ export async function POST(_: Request, context: RouteContext) {
   const { sessionId } = await context.params;
 
   try {
-    const { data: session, error: sessionError } = await (admin as any)
-      .from("onboarding_sessions")
-      .select("id")
-      .eq("id", sessionId)
-      .eq("shop_id", shopId)
-      .maybeSingle();
-    if (sessionError) throw new Error(sessionError.message);
-    if (!session) return NextResponse.json({ ok: false, error: "Session not found for this shop" }, { status: 404 });
+    await assertOnboardingSessionOwnership({ supabase: admin, shopId, sessionId });
 
     const { count, error: countError } = await (admin as any)
       .from("onboarding_files")
@@ -40,12 +34,14 @@ export async function POST(_: Request, context: RouteContext) {
     return NextResponse.json({
       ok: true,
       mode: result.mode,
+      warning: result.warning ?? null,
       liveRecordsCreated: 0,
       planSummary: result.planSummary,
       sessionSummary: result.sessionSummary,
-      warnings: result.warning ? [result.warning] : [],
     });
   } catch (error) {
-    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Analysis failed" }, { status: 500 });
+    const message = error instanceof Error ? error.message : "Analysis failed";
+    const status = message.includes("not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
   }
 }

--- a/app/api/onboarding-agent/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { deleteOnboardingSession } from "@/features/onboarding-agent/server/deleteOnboardingSession";
 import { getOnboardingSession } from "@/features/onboarding-agent/server/getOnboardingSession";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
@@ -36,5 +37,33 @@ export async function GET(_: Request, context: RouteContext) {
       { ok: false, error: error instanceof Error ? error.message : "Failed to load session" },
       { status: 500 },
     );
+  }
+}
+
+export async function DELETE(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id as string;
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    const result = await deleteOnboardingSession({
+      supabase: admin,
+      shopId,
+      sessionId,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      deletedSessionId: result.deletedSessionId,
+      deletedFiles: result.deletedFiles,
+      storageWarnings: result.storageWarnings,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to delete onboarding session";
+    const status = message.includes("not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
   }
 }

--- a/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentDashboard.tsx
@@ -21,6 +21,8 @@ function asCount(value: unknown) {
 export function OnboardingAgentDashboard() {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [busy, setBusy] = useState(false);
+  const [runningActions, setRunningActions] = useState<Record<string, "rerun" | "delete" | undefined>>({});
+  const [actionErrors, setActionErrors] = useState<Record<string, string | undefined>>({});
 
   const load = async () => {
     const res = await fetch("/api/onboarding-agent/sessions", { cache: "no-store" });
@@ -31,6 +33,51 @@ export function OnboardingAgentDashboard() {
   useEffect(() => {
     void load();
   }, []);
+
+  const setSessionAction = (sessionId: string, action: "rerun" | "delete" | null) => {
+    setRunningActions((prev) => ({ ...prev, [sessionId]: action ?? undefined }));
+  };
+
+  const rerunSession = async (sessionId: string) => {
+    setSessionAction(sessionId, "rerun");
+    setActionErrors((prev) => ({ ...prev, [sessionId]: undefined }));
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/analyze`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setActionErrors((prev) => ({ ...prev, [sessionId]: json?.error || "Rerun failed. Please retry." }));
+      } else {
+        await load();
+      }
+    } catch {
+      setActionErrors((prev) => ({ ...prev, [sessionId]: "Rerun failed. Please retry." }));
+    } finally {
+      setSessionAction(sessionId, null);
+    }
+  };
+
+  const deleteSession = async (sessionId: string) => {
+    const confirmed = window.confirm(
+      "Delete this staged onboarding session? This removes uploaded staged files, analysis rows, staged entities, links, and review items. It does not delete live shop records.",
+    );
+    if (!confirmed) return;
+
+    setSessionAction(sessionId, "delete");
+    setActionErrors((prev) => ({ ...prev, [sessionId]: undefined }));
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { method: "DELETE" });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setActionErrors((prev) => ({ ...prev, [sessionId]: json?.error || "Delete failed. Please retry." }));
+      } else {
+        setSessions((prev) => prev.filter((session) => session.id !== sessionId));
+      }
+    } catch {
+      setActionErrors((prev) => ({ ...prev, [sessionId]: "Delete failed. Please retry." }));
+    } finally {
+      setSessionAction(sessionId, null);
+    }
+  };
 
   const createSession = async () => {
     setBusy(true);
@@ -74,12 +121,28 @@ export function OnboardingAgentDashboard() {
                       Status: {session.status} • Last updated {new Date(session.updated_at).toLocaleString()}
                     </p>
                   </div>
-                  <Link
-                    href={`/dashboard/onboarding/${session.id}`}
-                    className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs text-cyan-100 hover:bg-cyan-500/10"
-                  >
-                    Open
-                  </Link>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      href={`/dashboard/onboarding/${session.id}`}
+                      className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs text-cyan-100 hover:bg-cyan-500/10"
+                    >
+                      Open
+                    </Link>
+                    <button
+                      onClick={() => rerunSession(session.id)}
+                      disabled={Boolean(runningActions[session.id])}
+                      className="rounded-md border border-white/20 px-3 py-1.5 text-xs text-slate-100 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {runningActions[session.id] === "rerun" ? "Rerunning…" : "Rerun"}
+                    </button>
+                    <button
+                      onClick={() => deleteSession(session.id)}
+                      disabled={Boolean(runningActions[session.id])}
+                      className="rounded-md border border-rose-400/40 px-3 py-1.5 text-xs text-rose-200 hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {runningActions[session.id] === "delete" ? "Deleting…" : "Delete"}
+                    </button>
+                  </div>
                 </div>
                 <div className="mt-2 grid gap-2 text-xs text-slate-300 sm:grid-cols-3 lg:grid-cols-4">
                   <p>Files: {asCount(session.file_count)}</p>
@@ -87,6 +150,7 @@ export function OnboardingAgentDashboard() {
                   <p>Review exceptions: {asCount(summary.reviewExceptions)}</p>
                   <p>Source: {session.source || "manual"}</p>
                 </div>
+                {actionErrors[session.id] ? <p className="mt-2 text-xs text-rose-300">{actionErrors[session.id]}</p> : null}
               </div>
             );
           })}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { OnboardingActivationPlanPanel } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
 import { OnboardingAgentInsightsPanel } from "@/features/onboarding-agent/components/OnboardingAgentInsightsPanel";
 import { OnboardingEntitiesPanel } from "@/features/onboarding-agent/components/OnboardingEntitiesPanel";
@@ -10,9 +11,11 @@ import { OnboardingProgressCard } from "@/features/onboarding-agent/components/O
 import { OnboardingReviewPanel } from "@/features/onboarding-agent/components/OnboardingReviewPanel";
 
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
+  const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [planning, setPlanning] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -39,9 +42,9 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         setError(json?.error || "Analysis failed. Please retry.");
       } else {
         const mode = json?.mode;
-        const warnings = Array.isArray(json?.warnings) ? json.warnings : [];
+        const warning = typeof json?.warning === "string" ? json.warning : null;
         if (mode === "deterministic_fallback") {
-          setNotice(warnings[0] ?? "Analysis complete. AI is unavailable, so deterministic fallback staging was used.");
+          setNotice(warning ?? "Analysis complete. AI is unavailable, so deterministic fallback staging was used.");
         } else {
           setNotice("Analysis complete.");
         }
@@ -52,6 +55,33 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       setError("Analysis failed. Please retry.");
     } finally {
       setAnalyzing(false);
+    }
+  };
+
+  const deleteSession = async () => {
+    const confirmed = window.confirm(
+      "Delete this staged onboarding session? This removes uploaded staged files, analysis rows, staged entities, links, and review items. It does not delete live shop records.",
+    );
+    if (!confirmed) return;
+
+    setDeleting(true);
+    setError(null);
+    setNotice(null);
+
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { method: "DELETE" });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setError(json?.error || "Failed to delete staged session.");
+        return;
+      }
+
+      router.push("/dashboard/onboarding");
+      router.refresh();
+    } catch {
+      setError("Failed to delete staged session.");
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -105,17 +135,33 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         <div className="flex flex-wrap gap-2">
           <button
             onClick={analyze}
-            disabled={!hasFiles || analyzing}
+            disabled={!hasFiles || analyzing || deleting}
             className="rounded border border-cyan-400/40 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {analyzing ? "Analyzing…" : "Analyze staged files"}
           </button>
+          {hasAnalysis ? (
+            <button
+              onClick={analyze}
+              disabled={!hasFiles || analyzing || deleting}
+              className="rounded border border-white/20 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {analyzing ? "Rerunning…" : "Rerun analysis"}
+            </button>
+          ) : null}
           <button
             onClick={plan}
-            disabled={!hasAnalysis || planning}
+            disabled={!hasAnalysis || planning || deleting}
             className="rounded border border-amber-400/40 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {planning ? "Preparing…" : "Prepare activation plan"}
+          </button>
+          <button
+            onClick={deleteSession}
+            disabled={deleting || analyzing || planning}
+            className="rounded border border-rose-400/40 px-3 py-2 text-sm text-rose-200 hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {deleting ? "Deleting…" : "Delete staged session"}
           </button>
         </div>
 

--- a/features/onboarding-agent/server/deleteOnboardingSession.test.ts
+++ b/features/onboarding-agent/server/deleteOnboardingSession.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { deleteOnboardingSession } from "@/features/onboarding-agent/server/deleteOnboardingSession";
+
+function createSupabaseMock() {
+  const deletedTables: string[] = [];
+  const removedStorage: Array<{ bucket: string; paths: string[] }> = [];
+
+  const sessionRows = [{ id: "session-1", shop_id: "shop-1" }];
+  const fileRows = [
+    { id: "file-1", session_id: "session-1", shop_id: "shop-1", storage_bucket: "onboarding", storage_path: "shop-1/session-1/file-1.csv" },
+    { id: "file-2", session_id: "session-1", shop_id: "shop-1", storage_bucket: "onboarding", storage_path: "shop-1/session-1/file-2.csv" },
+  ];
+  const liveTableRows = [{ id: "customer-live-1", shop_id: "shop-1" }];
+
+  const makeQuery = (table: string) => {
+    let mode: "select" | "delete" = "select";
+    let filters: Record<string, string> = {};
+    let selected = "*";
+
+    const runSelect = async () => {
+      if (table === "onboarding_sessions" && selected === "id") {
+        const row = sessionRows.find((item) => item.id === filters.id && item.shop_id === filters.shop_id);
+        return { data: row ?? null, error: null };
+      }
+      if (table === "onboarding_files") {
+        const rows = fileRows.filter((item) => item.shop_id === filters.shop_id && item.session_id === filters.session_id);
+        return { data: rows, error: null };
+      }
+      if (table === "customers") {
+        return { data: liveTableRows, error: null };
+      }
+      return { data: [], error: null };
+    };
+
+    const runDelete = async () => {
+      deletedTables.push(table);
+      return { error: null };
+    };
+
+    return {
+      select(columns: string) {
+        selected = columns;
+        mode = "select";
+        return this;
+      },
+      delete() {
+        mode = "delete";
+        return this;
+      },
+      eq(column: string, value: string) {
+        filters = { ...filters, [column]: value };
+        return this;
+      },
+      maybeSingle() {
+        if (mode === "select") return runSelect();
+        return runDelete();
+      },
+      then(resolve: (value: any) => unknown, reject?: (reason?: unknown) => unknown) {
+        const output = mode === "select" ? runSelect() : runDelete();
+        return output.then(resolve, reject);
+      },
+    };
+  };
+
+  const supabase = {
+    from(table: string) {
+      return makeQuery(table);
+    },
+    storage: {
+      from(bucket: string) {
+        return {
+          remove(paths: string[]) {
+            removedStorage.push({ bucket, paths });
+            return Promise.resolve({ error: null });
+          },
+        };
+      },
+    },
+  };
+
+  return { supabase, deletedTables, removedStorage, liveTableRows };
+}
+
+describe("deleteOnboardingSession", () => {
+  it("deletes only staged onboarding tables for the owned shop session", async () => {
+    const { supabase, deletedTables, removedStorage, liveTableRows } = createSupabaseMock();
+
+    const result = await deleteOnboardingSession({
+      supabase: supabase as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+    });
+
+    expect(result.deletedSessionId).toBe("session-1");
+    expect(result.deletedFiles).toBe(2);
+    expect(result.storageWarnings).toEqual([]);
+    expect(deletedTables).toEqual([
+      "onboarding_entity_links",
+      "onboarding_review_items",
+      "onboarding_entities",
+      "onboarding_raw_rows",
+      "onboarding_files",
+      "onboarding_activation_plans",
+      "onboarding_sessions",
+    ]);
+    expect(removedStorage).toEqual([
+      {
+        bucket: "onboarding",
+        paths: ["shop-1/session-1/file-1.csv", "shop-1/session-1/file-2.csv"],
+      },
+    ]);
+    expect(liveTableRows).toHaveLength(1);
+  });
+});

--- a/features/onboarding-agent/server/deleteOnboardingSession.ts
+++ b/features/onboarding-agent/server/deleteOnboardingSession.ts
@@ -1,0 +1,76 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+
+type OnboardingFileRef = {
+  id: string;
+  storage_bucket: string | null;
+  storage_path: string | null;
+};
+
+export async function deleteOnboardingSession(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+}) {
+  const sb = params.supabase as any;
+
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+
+  const { data: files, error: filesError } = await sb
+    .from("onboarding_files")
+    .select("id, storage_bucket, storage_path")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId);
+
+  if (filesError) throw new Error(filesError.message);
+
+  const safeFiles = (files ?? []) as OnboardingFileRef[];
+
+  const deletionSteps: Array<{ table: string; matchSessionId?: boolean }> = [
+    { table: "onboarding_entity_links", matchSessionId: true },
+    { table: "onboarding_review_items", matchSessionId: true },
+    { table: "onboarding_entities", matchSessionId: true },
+    { table: "onboarding_raw_rows", matchSessionId: true },
+    { table: "onboarding_files", matchSessionId: true },
+    { table: "onboarding_activation_plans", matchSessionId: true },
+    { table: "onboarding_sessions" },
+  ];
+
+  for (const step of deletionSteps) {
+    let query = sb.from(step.table).delete().eq("shop_id", params.shopId);
+    if (step.matchSessionId ?? false) {
+      query = query.eq("session_id", params.sessionId);
+    } else {
+      query = query.eq("id", params.sessionId);
+    }
+
+    const { error } = await query;
+    if (error) throw new Error(error.message);
+  }
+
+  const bucketPaths = safeFiles.reduce<Map<string, string[]>>((acc, file) => {
+    if (!file.storage_bucket || !file.storage_path) return acc;
+    const list = acc.get(file.storage_bucket) ?? [];
+    list.push(file.storage_path);
+    acc.set(file.storage_bucket, list);
+    return acc;
+  }, new Map());
+
+  const storageWarnings: string[] = [];
+  for (const [bucket, paths] of bucketPaths.entries()) {
+    const { error } = await sb.storage.from(bucket).remove(paths);
+    if (error) {
+      storageWarnings.push(`Failed to remove ${paths.length} file(s) from ${bucket}: ${error.message}`);
+    }
+  }
+
+  return {
+    deletedSessionId: params.sessionId,
+    deletedFiles: safeFiles.length,
+    storageWarnings,
+  };
+}


### PR DESCRIPTION
### Motivation
- Recent onboarding sessions list became cluttered with test runs and operators need a safe way to remove or re-run staged-only onboarding sessions from the UI.
- Provide first-class, shop-scoped APIs and UI actions to delete staged onboarding session data and to re-run analysis while preserving staged-only semantics and tenant isolation.
- Ensure deletions do not touch live business records and surface storage cleanup warnings non-blockingly.

### Description
- Added a reusable server helper `deleteOnboardingSession` that asserts session ownership, deletes staged onboarding tables in a safe order, and attempts storage cleanup while returning `storageWarnings` if removals fail (`features/onboarding-agent/server/deleteOnboardingSession.ts`).
- Added `DELETE /api/onboarding-agent/sessions/[sessionId]` which is shop-scoped and calls the helper, returning `{ ok, deletedSessionId, deletedFiles, storageWarnings }` on success (`app/api/onboarding-agent/sessions/[sessionId]/route.ts`).
- Updated the analyze rerun endpoint to assert session ownership and return a stable UI-friendly payload including `warning` and `liveRecordsCreated: 0` (`app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts`).
- Added recent-session card actions (Open / Rerun / Delete) with per-session loading state, confirmation for delete, inline error messages, and optimistic list update on delete (`features/onboarding-agent/components/OnboardingAgentDashboard.tsx`).
- Added session-detail actions for `Rerun analysis` and `Delete staged session` with confirmation, loading/disabled states and redirect back to the onboarding list after successful delete (`features/onboarding-agent/components/OnboardingSessionPage.tsx`).
- Added a focused unit test for the delete helper that validates staged-table deletion order/scope and storage removal behavior (`features/onboarding-agent/server/deleteOnboardingSession.test.ts`).

### Testing
- Ran typecheck: `npx tsc --noEmit` and it completed successfully.
- Ran linter for touched files: `npx eslint app/api/onboarding-agent/sessions/[sessionId]/route.ts app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts features/onboarding-agent/components/OnboardingAgentDashboard.tsx features/onboarding-agent/components/OnboardingSessionPage.tsx features/onboarding-agent/server/analyzeOnboardingSession.ts` which completed with only `@typescript-eslint/no-explicit-any` warnings and no errors.
- Ran unit tests with Vitest and all relevant onboarding tests passed including: `features/onboarding-agent/lib/onboarding-agent-ai.test.ts`, `features/onboarding-agent/lib/onboarding-agent-staging.test.ts`, `features/onboarding-agent/server/sessionListSummary.test.ts`, and the new `features/onboarding-agent/server/deleteOnboardingSession.test.ts` (all passed).
- Summary of validation commands run: `npx tsc --noEmit`, the `npx eslint` command above, and `npx vitest run` for listed tests, all of which succeeded (ESLint produced warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef978382d483288bfb0d6cd861dbcb)