### PR TITLE
Fix onboarding AI sample/staging split and persisted activation preview

### DIFF
--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -18,20 +18,21 @@ export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary, age
       <p className="mt-2 text-xs text-amber-200/80">No live records have been created. This is dry-run only.</p>
 
       <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
-        <div>Customers: <span className="font-semibold text-white">{num(preview?.creates.customers ?? summary.customersReady)}</span></div>
-        <div>Vehicles: <span className="font-semibold text-white">{num(preview?.creates.vehicles ?? summary.vehiclesReady)}</span></div>
-        <div>Historical work orders: <span className="font-semibold text-white">{num(preview?.creates.historicalWorkOrders ?? summary.historicalWorkOrdersReady)}</span></div>
-        <div>Historical invoices: <span className="font-semibold text-white">{num(preview?.creates.historicalInvoices ?? summary.historicalInvoicesReady)}</span></div>
-        <div>Parts: <span className="font-semibold text-white">{num(preview?.creates.parts ?? summary.partsReady)}</span></div>
-        <div>Vendors: <span className="font-semibold text-white">{num(preview?.creates.vendors ?? summary.vendorsReady)}</span></div>
-        <div>Staff candidates: <span className="font-semibold text-white">{num(preview?.creates.staffCandidates ?? summary.staffCandidatesReady)}</span></div>
-        <div>Menu suggestions: <span className="font-semibold text-white">{num(preview?.creates.menuSuggestions ?? summary.menuSuggestionsReady)}</span></div>
-        <div>Inspection suggestions: <span className="font-semibold text-white">{num(preview?.creates.inspectionSuggestions ?? summary.inspectionSuggestionsReady)}</span></div>
-        <div>Blocking issues: <span className="font-semibold text-white">{num(preview?.blockingIssues ?? summary.blockingIssues)}</span></div>
-        <div>Requires review: <span className="font-semibold text-white">{num(preview?.requiresReview ?? summary.reviewNeeded)}</span></div>
+        <div>Customers: <span className="font-semibold text-white">{num(summary.customersReady)}</span></div>
+        <div>Vehicles: <span className="font-semibold text-white">{num(summary.vehiclesReady)}</span></div>
+        <div>Historical work orders: <span className="font-semibold text-white">{num(summary.historicalWorkOrdersReady)}</span></div>
+        <div>Historical invoices: <span className="font-semibold text-white">{num(summary.historicalInvoicesReady)}</span></div>
+        <div>Parts: <span className="font-semibold text-white">{num(summary.partsReady)}</span></div>
+        <div>Vendors: <span className="font-semibold text-white">{num(summary.vendorsReady)}</span></div>
+        <div>Staff candidates: <span className="font-semibold text-white">{num(summary.staffCandidatesReady)}</span></div>
+        <div>Menu suggestions: <span className="font-semibold text-white">{num(summary.menuSuggestionsReady)}</span></div>
+        <div>Inspection suggestions: <span className="font-semibold text-white">{num(summary.inspectionSuggestionsReady)}</span></div>
+        <div>Blocking issues: <span className="font-semibold text-white">{num(summary.blockingIssues)}</span></div>
+        <div>Requires review: <span className="font-semibold text-white">{num(summary.reviewNeeded)}</span></div>
       </div>
 
       {preview?.risks?.length ? <ul className="mt-3 list-disc pl-5 text-xs text-amber-100/90">{preview.risks.slice(0, 5).map((risk, idx) => <li key={`${risk}-${idx}`}>{risk}</li>)}</ul> : null}
+      {preview ? <p className="mt-2 text-[11px] text-amber-200/70">AI activation preview is advisory only; counts above are derived from persisted staged rows.</p> : null}
 
       <button onClick={() => setShowDevDetails((v) => !v)} className="mt-3 rounded border border-white/20 px-2 py-1 text-xs text-slate-200">{showDevDetails ? "Hide" : "Show"} developer details</button>
       {showDevDetails ? <pre className="mt-2 overflow-auto rounded-lg bg-slate-900/60 p-3 text-xs text-slate-200">{JSON.stringify({ latestPlan, agentPlan }, null, 2)}</pre> : null}

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -7,16 +7,20 @@ export function OnboardingAgentInsightsPanel({
   report,
   plan,
   fallbackReadiness,
+  summary,
 }: {
   sessionId: string;
   report?: { mode?: string; summary?: string; model?: string | null; activationReadiness?: { status?: string } } | null;
   plan?: OnboardingAgentPlan | null;
   fallbackReadiness?: string;
+  summary?: Record<string, unknown> | null;
   onRefresh: () => Promise<void>;
 }) {
   const [showDev, setShowDev] = useState(false);
   const displayedReadiness = report?.activationReadiness?.status ?? fallbackReadiness ?? "not_ready";
   const usingFallback = report?.mode === "deterministic_fallback";
+  const aiRowsSampled = Number(summary?.aiRowsSampled ?? 0);
+  const rowsParsed = Number(summary?.rowsParsedTotal ?? summary?.rowsParsed ?? 0);
 
   return (
     <div className="rounded-2xl border border-cyan-500/30 bg-cyan-950/10 p-4">
@@ -42,6 +46,11 @@ export function OnboardingAgentInsightsPanel({
         </div>
       </div>
 
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+        <p className="rounded border border-white/10 bg-slate-900/50 px-3 py-2 text-xs text-slate-200">Rows parsed: <span className="font-semibold text-white">{rowsParsed.toLocaleString()}</span></p>
+        <p className="rounded border border-white/10 bg-slate-900/50 px-3 py-2 text-xs text-slate-200">AI sampled rows: <span className="font-semibold text-white">{aiRowsSampled.toLocaleString()}</span></p>
+      </div>
+
       <p className="mt-3 text-sm text-slate-200">{report?.summary ?? "Run analysis to get onboarding understanding."}</p>
       {usingFallback ? <p className="mt-2 text-xs text-amber-200">Warning: AI output fell back to deterministic planning for one or more files.</p> : null}
 
@@ -49,13 +58,25 @@ export function OnboardingAgentInsightsPanel({
         <div className="mt-3 rounded-lg border border-white/10 bg-slate-900/50 p-3">
           <p className="text-[11px] uppercase tracking-wide text-slate-400">Per-file AI plan</p>
           <ul className="mt-2 space-y-1 text-xs text-slate-200">
-            {plan.files.slice(0, 12).map((file) => (
-              <li key={file.fileId} className="rounded border border-white/10 px-2 py-1">
-                <p className="text-white">{file.filename}</p>
-                <p>{file.inferredDomain} • {file.recommendedParserMode} • {Math.round(file.confidence * 100)}%</p>
-                <p className="text-slate-400">mapped: {Object.values(file.headerMap).slice(0, 6).join(", ") || "none"}</p>
-              </li>
-            ))}
+            {plan.files.slice(0, 12).map((file) => {
+              const mappedEntries = Object.entries(file.headerMap ?? {});
+              return (
+                <li key={file.fileId} className="rounded border border-white/10 px-2 py-1">
+                  <p className="text-white">{file.filename}</p>
+                  <p>{file.inferredDomain} • {file.recommendedParserMode} • {Math.round(file.confidence * 100)}%</p>
+                  <p className="text-slate-400">mapped: {mappedEntries.length} columns</p>
+                  {file.missingImportantFields.length ? <p className="text-amber-200/90">missing: {file.missingImportantFields.slice(0, 4).join(", ")}</p> : null}
+                  {mappedEntries.length ? (
+                    <details className="mt-1 text-slate-400">
+                      <summary className="cursor-pointer">mapping details</summary>
+                      <ul className="mt-1 space-y-0.5 text-[11px]">
+                        {mappedEntries.slice(0, 8).map(([sourceHeader, canonicalField]) => <li key={`${file.fileId}-${sourceHeader}`}>{canonicalField} ← {sourceHeader}</li>)}
+                      </ul>
+                    </details>
+                  ) : null}
+                </li>
+              );
+            })}
           </ul>
         </div>
       ) : null}

--- a/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingEntitiesPanel.tsx
@@ -1,15 +1,15 @@
 import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
-const ENTITY_ROWS: Array<{ key: string; label: string; planKey: keyof OnboardingAgentPlan["entityPlan"] }> = [
-  { key: "customer", label: "Customers", planKey: "customers" },
-  { key: "vehicle", label: "Vehicles", planKey: "vehicles" },
-  { key: "historical_work_order", label: "Historical work orders", planKey: "historicalWorkOrders" },
-  { key: "historical_invoice", label: "Historical invoices", planKey: "historicalInvoices" },
-  { key: "part", label: "Parts", planKey: "parts" },
-  { key: "vendor", label: "Vendors", planKey: "vendors" },
-  { key: "staff_candidate", label: "Staff candidates", planKey: "staffCandidates" },
-  { key: "menu_suggestion", label: "Menu suggestions", planKey: "menuSuggestions" },
-  { key: "inspection_suggestion", label: "Inspection suggestions", planKey: "inspectionSuggestions" },
+const ENTITY_ROWS: Array<{ key: string; label: string }> = [
+  { key: "customer", label: "Customers" },
+  { key: "vehicle", label: "Vehicles" },
+  { key: "historical_work_order", label: "Historical work orders" },
+  { key: "historical_invoice", label: "Historical invoices" },
+  { key: "part", label: "Parts" },
+  { key: "vendor", label: "Vendors" },
+  { key: "staff_candidate", label: "Staff candidates" },
+  { key: "menu_suggestion", label: "Menu suggestions" },
+  { key: "inspection_suggestion", label: "Inspection suggestions" },
 ];
 
 export function OnboardingEntitiesPanel({
@@ -28,12 +28,10 @@ export function OnboardingEntitiesPanel({
       <h3 className="text-sm font-semibold text-white">Staged entities & links</h3>
       <div className="mt-3 grid gap-3 lg:grid-cols-2">
         <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-          <p className="text-xs uppercase tracking-wide text-slate-400">Entity plan (AI + staged)</p>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Persisted staged entities</p>
           <ul className="mt-2 space-y-1 text-sm text-slate-200">
             {ENTITY_ROWS.map((item) => {
               const status = entityStatusCounts[item.key] ?? {};
-              const planned = agentPlan?.entityPlan?.[item.planKey];
-              const hasMeaningfulPlan = Boolean(planned && (planned.staged > 0 || planned.ready > 0 || planned.review > 0));
               return (
                 <li key={item.key} className="rounded border border-white/5 px-2 py-1">
                   <div className="flex items-center justify-between gap-2">
@@ -41,7 +39,6 @@ export function OnboardingEntitiesPanel({
                     <span className="font-semibold text-white">{entityCounts[item.key] ?? 0}</span>
                   </div>
                   <p className="text-[11px] text-slate-400">ready: {status.ready ?? 0} • review: {(status.needs_review ?? 0) + (status.duplicate_candidate ?? 0)}</p>
-                  {hasMeaningfulPlan ? <p className="text-[11px] text-cyan-200">ai staged: {planned!.staged} • ai ready: {planned!.ready} • ai review: {planned!.review}</p> : null}
                 </li>
               );
             })}
@@ -49,16 +46,25 @@ export function OnboardingEntitiesPanel({
         </div>
 
         <div className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-          <p className="text-xs uppercase tracking-wide text-slate-400">Relationship plan</p>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Persisted relationship links</p>
           <ul className="mt-2 space-y-1 text-sm text-slate-200">
-            {(agentPlan?.relationshipPlan ?? []).slice(0, 8).map((rel, idx) => (
-              <li key={`${rel.relationshipType}-${idx}`} className="rounded border border-white/5 px-2 py-1">
-                <div className="flex items-center justify-between gap-2"><span>{rel.fromDomain} ↔ {rel.toDomain}</span><span className="text-cyan-200">{Math.round(rel.confidence * 100)}%</span></div>
-                <p className="text-[11px] text-slate-400">{rel.relationshipType} • keys: {rel.matchingKeys.join(", ") || "n/a"}</p>
+            {Object.entries(linkCounts).map(([key, value]) => (
+              <li key={key} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1">
+                <span>{key}</span>
+                <span className="font-semibold text-white">{value ?? 0}</span>
               </li>
             ))}
-            {!agentPlan?.relationshipPlan?.length ? Object.entries(linkCounts).map(([key, value]) => <li key={key} className="flex items-center justify-between gap-2 rounded border border-white/5 px-2 py-1"><span>{key}</span><span className="font-semibold text-white">{value ?? 0}</span></li>) : null}
           </ul>
+          {agentPlan?.relationshipPlan?.length ? (
+            <div className="mt-3 border-t border-white/10 pt-2">
+              <p className="text-[11px] uppercase tracking-wide text-slate-500">AI relationship hints</p>
+              <ul className="mt-1 space-y-1 text-xs text-slate-400">
+                {agentPlan.relationshipPlan.slice(0, 5).map((rel, idx) => (
+                  <li key={`${rel.relationshipType}-${idx}`}>{rel.fromDomain} → {rel.toDomain} ({rel.relationshipType})</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/features/onboarding-agent/components/OnboardingProgressCard.tsx
+++ b/features/onboarding-agent/components/OnboardingProgressCard.tsx
@@ -2,7 +2,8 @@ export function OnboardingProgressCard({ summary }: { summary?: Record<string, u
   const rows = [
     ["Uploaded files", String((summary?.uploadedFiles as number) ?? (summary?.fileCount as number) ?? 0)],
     ["Rows parsed", String((summary?.rowsParsedTotal as number) ?? (summary?.rowsParsed as number) ?? 0)],
-    ["Entities discovered", String((summary?.entitiesDiscovered as number) ?? 0)],
+    ["AI sampled rows", String((summary?.aiRowsSampled as number) ?? 0)],
+    ["Unique staged entities", String((summary?.entitiesDiscovered as number) ?? 0)],
     ["Links found", String((summary?.linksFound as number) ?? 0)],
     ["Review exceptions", String((summary?.reviewExceptions as number) ?? 0)],
   ];

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -172,7 +172,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       </div>
 
       <OnboardingProgressCard summary={session?.summary ?? null} />
-      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} onRefresh={load} />
+      <OnboardingAgentInsightsPanel sessionId={sessionId} report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} summary={session?.summary ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} onRefresh={load} />
       <OnboardingFilesPanel files={files} />
       <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} agentPlan={session?.summary?.agentPlan ?? null} />
       <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />

--- a/features/onboarding-agent/lib/headerMapping.ts
+++ b/features/onboarding-agent/lib/headerMapping.ts
@@ -1,0 +1,116 @@
+import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+import { normalizeHeader } from "@/features/onboarding-agent/lib/domains";
+
+const DOMAIN_FIELD_ALIASES: Record<OnboardingDomain, Record<string, string[]>> = {
+  customers: {
+    sourceCustomerId: ["customer id", "id", "external customer id"],
+    name: ["customer name", "full name", "name"],
+    businessName: ["company", "company name", "business"],
+    email: ["email", "email address"],
+    phone: ["phone", "phone number", "mobile"],
+  },
+  vehicles: {
+    sourceVehicleId: ["vehicle id", "id", "external vehicle id"],
+    sourceCustomerId: ["customer id"],
+    vin: ["vin"],
+    plate: ["plate", "license", "license plate"],
+    unitNumber: ["unit", "unit number", "truck number"],
+    year: ["year"],
+    make: ["make"],
+    model: ["model"],
+  },
+  history: {
+    sourceWorkOrderId: ["work order", "ro id", "repair order", "ro number", "work order number"],
+    invoiceId: ["invoice id", "invoice number", "invoice"],
+    sourceCustomerId: ["customer id"],
+    sourceVehicleId: ["vehicle id"],
+    openedDate: ["opened", "opened date", "open date", "date", "service date"],
+    complaint: ["complaint", "description", "concern", "service text", "service performed"],
+    correction: ["correction", "resolution"],
+    total: ["total", "amount"],
+  },
+  invoices: {
+    invoiceNumber: ["invoice", "invoice number", "invoice id"],
+    sourceWorkOrderId: ["work order", "ro", "ro id", "repair order", "work order number"],
+    sourceCustomerId: ["customer id"],
+    customerName: ["customer", "customer name", "name"],
+    customerEmail: ["customer email", "email"],
+    invoiceDate: ["issue date", "invoice date", "date"],
+    paymentStatus: ["status", "payment status"],
+    total: ["total", "amount", "invoice total"],
+  },
+  parts: {
+    sku: ["sku", "part sku"],
+    partNumber: ["part number", "part #", "number"],
+    description: ["description", "name", "part"],
+    vendorName: ["vendor", "supplier", "vendor name", "supplier name"],
+    cost: ["cost", "unit cost"],
+    price: ["price", "list price", "sale price"],
+  },
+  vendors: {
+    name: ["vendor", "supplier", "company", "vendor name", "supplier name"],
+    email: ["email", "vendor email"],
+    phone: ["phone", "vendor phone"],
+    accountNumber: ["account", "account number", "vendor account"],
+  },
+  staff: {
+    name: ["name", "full name", "employee"],
+    email: ["email", "email address"],
+    phone: ["phone", "mobile"],
+    role: ["role", "job title", "position", "technician", "advisor"],
+  },
+  menu: {
+    serviceName: ["service", "service name", "name"],
+    description: ["description", "service description"],
+    category: ["category", "service category"],
+    laborHours: ["labor hours", "hours"],
+    laborPrice: ["labor price", "price", "labor rate"],
+    opCode: ["operation code", "op code", "labor operation", "canned job"],
+  },
+  inspections: {},
+  unknown: {},
+};
+
+function resolveCanonicalField(domain: OnboardingDomain, value: string): string | null {
+  const aliases = DOMAIN_FIELD_ALIASES[domain] ?? {};
+  const normalized = normalizeHeader(value);
+  for (const [field, fieldAliases] of Object.entries(aliases)) {
+    if (normalized === normalizeHeader(field)) return field;
+    if (fieldAliases.some((alias) => normalizeHeader(alias) === normalized)) return field;
+  }
+  return null;
+}
+
+export function buildDeterministicHeaderMap(domain: OnboardingDomain, headers: string[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const header of headers) {
+    const canonical = resolveCanonicalField(domain, header);
+    if (canonical) map[header] = canonical;
+  }
+  return map;
+}
+
+export function buildEffectiveHeaderMap(params: {
+  domain: OnboardingDomain;
+  headers: string[];
+  aiHeaderMap?: Record<string, string> | null;
+}): Record<string, string> {
+  const output = buildDeterministicHeaderMap(params.domain, params.headers);
+  const ai = params.aiHeaderMap ?? {};
+
+  for (const [left, right] of Object.entries(ai)) {
+    if (!left || !right) continue;
+    const canonicalFromRight = resolveCanonicalField(params.domain, right);
+    if (canonicalFromRight) {
+      output[left] = canonicalFromRight;
+      continue;
+    }
+
+    const canonicalFromLeft = resolveCanonicalField(params.domain, left);
+    if (canonicalFromLeft) {
+      output[right] = canonicalFromLeft;
+    }
+  }
+
+  return output;
+}

--- a/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-ai.test.ts
@@ -195,4 +195,20 @@ describe("onboarding agent ai safeguards", () => {
     expect(String(row.Note).length).toBeLessThanOrEqual(120);
   });
 
+  it("plan validator normalizes known review and relationship domains", () => {
+    const plan = validateOnboardingAgentPlan({
+      validFileIds: new Set(["file-1"]),
+      candidate: {
+        files: [{ fileId: "file-1", filename: "work_orders_history.csv", inferredDomain: "historical_work_order", confidence: 0.8, reasoning: "x", headerMap: {}, rowCountEstimate: 5, requiredFieldsPresent: [], missingImportantFields: [], recommendedParserMode: "stage_entities" }],
+        relationshipPlan: [{ fromDomain: "historical_work_order", toDomain: "invoice", relationshipType: "work_order_invoice", confidence: 0.7, matchingKeys: ["workOrderId"], reasoning: "x", expectedLinks: 3, reviewRequired: false }],
+        reviewGroups: [{ severity: "medium", domain: "historical_invoice", issueType: "missing_work_order_link", affectedRowCount: 2, sampleRows: [1], summary: "x", recommendedAction: "manual_review" }],
+      },
+    });
+
+    expect(plan.files[0].inferredDomain).toBe("history");
+    expect(plan.relationshipPlan[0].fromDomain).toBe("history");
+    expect(plan.relationshipPlan[0].toDomain).toBe("invoices");
+    expect(plan.reviewGroups[0].domain).toBe("invoices");
+  });
+
 });

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -4,6 +4,7 @@ import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
 import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
 import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
+import { buildEffectiveHeaderMap } from "@/features/onboarding-agent/lib/headerMapping";
 import { buildDeterministicFallbackReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 
 function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
@@ -22,6 +23,18 @@ function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
 }
 
 describe("onboarding staging", () => {
+
+  it("deterministic header mapping provides canonical fields when AI map is empty", () => {
+    const map = buildEffectiveHeaderMap({
+      domain: "customers",
+      headers: ["Customer ID", "Full Name", "Email Address"],
+      aiHeaderMap: {},
+    });
+
+    expect(map["Customer ID"]).toBe("sourceCustomerId");
+    expect(map["Full Name"]).toBe("name");
+    expect(map["Email Address"]).toBe("email");
+  });
   it("analyze creates staged entities from customer rows", () => {
     const staged = stage("customers", { "Customer ID": "C-1", "Full Name": "Jane Doe", Email: "jane@example.com" });
     expect(staged.entity?.entity_type).toBe("customer");
@@ -224,6 +237,42 @@ describe("onboarding staging", () => {
     expect(summary.summaryCounts.aiRowsSampled).toBe(1000);
     expect(summary.summaryCounts.aiFilesSampled).toBe(8);
     expect(summary.liveRecordsCreated).toBe(0);
+  });
+
+  it("entities discovered can exceed AI sampled rows", () => {
+    const summary = buildOnboardingSummary({
+      filesCount: 1,
+      rowsParsed: 1500,
+      aiRowsSampled: 200,
+      aiFilesSampled: 1,
+      entityRows: Array.from({ length: 1500 }, () => ({ entity_type: "customer", status: "ready" as const })),
+      linkRows: [],
+      reviewRows: [],
+      analysisCompleted: true,
+    });
+
+    expect(summary.summaryCounts.rowsParsedTotal).toBe(1500);
+    expect(summary.summaryCounts.aiRowsSampled).toBe(200);
+    expect(summary.summaryCounts.entitiesDiscovered).toBe(1500);
+  });
+
+  it("activation plan summary is derived from persisted staged rows", () => {
+    const summary = buildOnboardingSummary({
+      filesCount: 1,
+      rowsParsed: 3,
+      entityRows: [
+        { entity_type: "customer", status: "ready" },
+        { entity_type: "vehicle", status: "ready" },
+        { entity_type: "historical_invoice", status: "ready" },
+      ],
+      linkRows: [],
+      reviewRows: [],
+      analysisCompleted: true,
+    });
+
+    expect(summary.activation_plan_summary.customersReady).toBe(1);
+    expect(summary.activation_plan_summary.vehiclesReady).toBe(1);
+    expect(summary.activation_plan_summary.historicalInvoicesReady).toBe(1);
   });
 
 });

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -8,6 +8,8 @@ import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-
 import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
 import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
+import { buildEffectiveHeaderMap } from "@/features/onboarding-agent/lib/headerMapping";
+import { fetchOnboardingRawRows } from "@/features/onboarding-agent/server/fetchOnboardingRawRows";
 import { countOnboardingRawRows } from "@/features/onboarding-agent/server/rawRowCounts";
 
 const INSERT_CHUNK_SIZE = 1000;
@@ -41,8 +43,10 @@ const DOMAIN_TO_ENTITY: Record<string, OnboardingDomain> = {
 
 function remapHeaders(raw: Record<string, unknown>, map: Record<string, string>) {
   const out: Record<string, string> = {};
+  const normalizedMap = Object.fromEntries(Object.entries(map).map(([source, target]) => [source.toLowerCase(), target]));
+
   for (const [k, v] of Object.entries(raw)) {
-    const key = map[k] ?? map[k.toLowerCase()] ?? k;
+    const key = map[k] ?? map[k.toLowerCase()] ?? normalizedMap[k.toLowerCase()] ?? k;
     out[key] = typeof v === "string" ? v : String(v ?? "");
   }
   return out;
@@ -67,14 +71,14 @@ export async function applyOnboardingAgentPlan(params: {
     .eq("session_id", params.sessionId);
   const fileMetadataById = new Map((filesData ?? []).map((file: any) => [file.id, file]));
   const rawRowsByFile = new Map<string, any[]>();
-  const { data: rows } = await sb
-    .from("onboarding_raw_rows")
-    .select("id, file_id, source_row_index, raw")
-    .eq("shop_id", params.shopId)
-    .eq("session_id", params.sessionId)
-    .order("source_row_index", { ascending: true });
+  const rows = await fetchOnboardingRawRows({
+    sb,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+    select: "id, file_id, source_row_index, raw",
+  });
 
-  for (const row of rows ?? []) {
+  for (const row of rows) {
     const list = rawRowsByFile.get(row.file_id) ?? [];
     list.push(row);
     rawRowsByFile.set(row.file_id, list);
@@ -99,7 +103,8 @@ export async function applyOnboardingAgentPlan(params: {
               ? fileMeta.declared_domain
               : deterministicDomain));
     const domain = DOMAIN_TO_ENTITY[effectiveDomain] ?? "unknown";
-    const headerMap = planFile?.headerMap ?? {};
+    const fileHeaders = Array.isArray(fileMeta?.header_row) ? fileMeta.header_row : [];
+    const headerMap = buildEffectiveHeaderMap({ domain, headers: fileHeaders, aiHeaderMap: planFile?.headerMap ?? {} });
     const parserMode = planFile?.recommendedParserMode ?? (domain === "unknown" ? "stage_review_only" : "stage_entities");
 
     if (parserMode === "ignore" || parserMode === "unsupported") {
@@ -133,9 +138,10 @@ export async function applyOnboardingAgentPlan(params: {
   }
 
   for (const group of params.plan.reviewGroups) {
+    const normalizedDomain = DOMAIN_TO_ENTITY[group.domain] ? group.domain : "unknown";
     reviewItems.push({
       severity: group.severity,
-      domain: group.domain,
+      domain: normalizedDomain,
       issue_type: group.issueType,
       summary: group.summary,
       details: { sampleRows: group.sampleRows, affectedRowCount: group.affectedRowCount, recommendedAction: group.recommendedAction },
@@ -189,6 +195,8 @@ export async function applyOnboardingAgentPlan(params: {
   const summary = {
     ...existingSummary,
     ...canonical.summaryCounts,
+    aiRowsSampled: Number(existingSummary.aiRowsSampled ?? 0),
+    aiFilesSampled: Number(existingSummary.aiFilesSampled ?? 0),
     activationReadiness: canonical.activation_readiness,
     activationPlanSummary: canonical.activation_plan_summary,
     liveRecordsCreated: 0,

--- a/features/onboarding-agent/server/buildOnboardingAgentInput.ts
+++ b/features/onboarding-agent/server/buildOnboardingAgentInput.ts
@@ -4,6 +4,7 @@ import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection"
 import { normalizeHeader } from "@/features/onboarding-agent/lib/domains";
 import type { OnboardingAgentInputPayload } from "@/features/onboarding-agent/lib/agentPlanTypes";
 import { redactOnboardingSample } from "@/features/onboarding-agent/server/redactOnboardingSample";
+import { fetchOnboardingRawRows } from "@/features/onboarding-agent/server/fetchOnboardingRawRows";
 
 const DEFAULT_SAMPLES = 25;
 
@@ -69,15 +70,15 @@ export async function buildOnboardingAgentInput(params: {
   const fileIds = (files ?? []).map((f: any) => f.id);
   const rowsByFile = new Map<string, Record<string, unknown>[]>();
   if (fileIds.length) {
-    const { data: rows } = await sb
-      .from("onboarding_raw_rows")
-      .select("file_id, source_row_index, raw")
-      .eq("shop_id", params.shopId)
-      .eq("session_id", params.sessionId)
-      .in("file_id", fileIds)
-      .order("source_row_index", { ascending: true });
+    const rows = await fetchOnboardingRawRows({
+      sb,
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      select: "file_id, source_row_index, raw",
+      fileIds,
+    });
 
-    for (const row of rows ?? []) {
+    for (const row of rows) {
       const list = rowsByFile.get(row.file_id) ?? [];
       list.push((row.raw ?? {}) as Record<string, unknown>);
       rowsByFile.set(row.file_id, list);

--- a/features/onboarding-agent/server/fetchOnboardingRawRows.ts
+++ b/features/onboarding-agent/server/fetchOnboardingRawRows.ts
@@ -1,0 +1,36 @@
+const PAGE_SIZE = 1000;
+
+export async function fetchOnboardingRawRows(params: {
+  sb: any;
+  shopId: string;
+  sessionId: string;
+  select: string;
+  fileIds?: string[];
+}) {
+  const rows: any[] = [];
+  let from = 0;
+
+  while (true) {
+    let query = params.sb
+      .from("onboarding_raw_rows")
+      .select(params.select)
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .order("file_id", { ascending: true })
+      .order("source_row_index", { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (params.fileIds?.length) {
+      query = query.in("file_id", params.fileIds);
+    }
+
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+    const batch = data ?? [];
+    rows.push(...batch);
+    if (batch.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return rows;
+}

--- a/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
@@ -24,6 +24,20 @@ function clamp01(v: unknown, fb = 0.5) {
   return Math.max(0, Math.min(1, asNum(v, fb)));
 }
 
+
+function normalizePlanDomain(raw: unknown): OnboardingAgentPlanDomain {
+  const value = asString(raw, "unknown").toLowerCase();
+  if (value === "historical_work_order" || value === "work_orders" || value === "work_order") return "history";
+  if (value === "historical_invoice" || value === "invoice" || value === "billing") return "invoices";
+  if (value === "customer") return "customers";
+  if (value === "vehicle") return "vehicles";
+  if (value === "part") return "parts";
+  if (value === "vendor") return "vendors";
+  if (value === "employee" || value === "users") return "staff";
+  if (value === "service_catalog" || value === "service_menu") return "menu";
+  return (DOMAINS.has(value as OnboardingAgentPlanDomain) ? value : "unknown") as OnboardingAgentPlanDomain;
+}
+
 function sanitizeEntityPlan(value: unknown): EntityPlanSummary {
   const o = asObj(value);
   return {
@@ -48,11 +62,11 @@ export function validateOnboardingAgentPlan(params: {
     const o = asObj(raw);
     const fileId = asString(o.fileId);
     if (!params.validFileIds.has(fileId)) return null;
-    const inferred = asString(o.inferredDomain, "unknown") as OnboardingAgentPlanDomain;
+    const inferred = normalizePlanDomain(o.inferredDomain);
     return {
       fileId,
       filename: asString(o.filename) || fileId,
-      inferredDomain: DOMAINS.has(inferred) ? inferred : "unknown",
+      inferredDomain: inferred,
       confidence: clamp01(o.confidence, 0.5),
       reasoning: asString(o.reasoning).slice(0, 500),
       headerMap: Object.fromEntries(
@@ -103,7 +117,7 @@ export function validateOnboardingAgentPlan(params: {
     const severity = asString(o.severity);
     return {
       severity: (["low", "medium", "high", "blocking"].includes(severity) ? severity : "medium") as "low" | "medium" | "high" | "blocking",
-      domain: asString(o.domain, "unknown"),
+      domain: normalizePlanDomain(o.domain),
       issueType: asString(o.issueType, "needs_review"),
       affectedRowCount: Math.max(0, Math.floor(asNum(o.affectedRowCount))),
       sampleRows: asArr(o.sampleRows).slice(0, 10).map((x) => Math.max(0, Math.floor(asNum(x)))),
@@ -136,8 +150,8 @@ export function validateOnboardingAgentPlan(params: {
     relationshipPlan: asArr(root.relationshipPlan).slice(0, 100).map((raw) => {
       const o = asObj(raw);
       return {
-        fromDomain: asString(o.fromDomain, "unknown"),
-        toDomain: asString(o.toDomain, "unknown"),
+        fromDomain: normalizePlanDomain(o.fromDomain),
+        toDomain: normalizePlanDomain(o.toDomain),
         relationshipType: asString(o.relationshipType, "unknown"),
         confidence: clamp01(o.confidence, 0.5),
         matchingKeys: asArr(o.matchingKeys).slice(0, 10).map((x) => asString(x)),


### PR DESCRIPTION
### Motivation
- The AI sample cap was leaking into staging semantics and dry-run counts, causing staged entity totals and activation previews to reflect only sampled rows instead of all persisted `onboarding_raw_rows`.
- AI must only inspect a compact/redacted sample for planning while the deterministic executor applies the validated plan to all persisted rows and preserves staged-only semantics (`liveRecordsCreated` remains 0).
- The UI needed to clearly separate AI diagnostics (`aiRowsSampled`) from canonical parsed totals (`rowsParsed`/`rowsParsedTotal`) and show deterministic header mapping information when AI mappings are absent.

### Description
- Added paginated raw-row loader `fetchOnboardingRawRows` and wired it into `buildOnboardingAgentInput` and `applyOnboardingAgentPlan` so the full persisted `onboarding_raw_rows` set is read and processed rather than being implicitly limited by sampling or query limits.
- Introduced deterministic header alias mapping in `features/onboarding-agent/lib/headerMapping.ts` and merged AI `headerMap` via `buildEffectiveHeaderMap`, and applied the merged map before `normalizeRow` in `applyOnboardingAgentPlan` to ensure mappings drive normalization even when AI returns sparse maps.
- Sanitized and normalized AI plan domains in `validateOnboardingAgentPlan` (e.g., `historical_work_order` → `history`, `invoice` → `invoices`) and normalized review/relationship domains to reduce spurious `unknown` review groups.
- Updated staging and summary semantics so `buildOnboardingSummary` and the dry-run activation flow derive counts from persisted staged entities/links/review rows, kept AI activation preview advisory only, preserved `aiRowsSampled`/`aiFilesSampled` as diagnostics, and ensured `liveRecordsCreated` remains 0.
- Adjusted UI panels: `OnboardingAgentInsightsPanel` now shows `Rows parsed` and `AI sampled rows` separately and per-file mapped-column counts/details, `OnboardingProgressCard` exposes sampled vs parsed counts and labels unique staged entities, `OnboardingEntitiesPanel` and `OnboardingActivationPlanPanel` use persisted staged/link counts as the source of truth and show AI hints as advisory.
- Added/updated tests to assert that AI sampling is diagnostic-only, header mapping fallback works, `entitiesDiscovered` can exceed the AI sample cap, activation preview derives from persisted staged rows, and domain normalization works for review/relationship plans.

### Testing
- Type-checking was run with `npx tsc --noEmit` and completed successfully.
- Linting was run with `npx eslint features/onboarding-agent/server/buildOnboardingAgentInput.ts features/onboarding-agent/server/applyOnboardingAgentPlan.ts features/onboarding-agent/server/analyzeOnboardingSession.ts features/onboarding-agent/server/validateOnboardingAgentPlan.ts features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx features/onboarding-agent/components/OnboardingEntitiesPanel.tsx features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx features/onboarding-agent/components/OnboardingSessionPage.tsx` and produced existing `no-explicit-any` warnings but no new errors.
- Unit tests were executed with `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts`, `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts`, and `npx vitest run features/onboarding-agent/server/sessionListSummary.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef99426360832887fa6a887754dc69)