### PR TITLE
Fix onboarding agent mapping fallback, diagnostics, and full-row staging safeguards

### DIFF
--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -11,11 +11,14 @@ export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary, age
   const [showDevDetails, setShowDevDetails] = useState(false);
   const summary = (fallbackSummary ?? latestPlan?.summary ?? latestPlan ?? {}) as Record<string, any>;
   const preview = agentPlan?.activationPreview;
+  const readyTotal = num(summary.customersReady) + num(summary.vehiclesReady) + num(summary.historicalWorkOrdersReady) + num(summary.historicalInvoicesReady) + num(summary.partsReady) + num(summary.vendorsReady) + num(summary.staffCandidatesReady) + num(summary.menuSuggestionsReady) + num(summary.inspectionSuggestionsReady);
+  const reviewTotal = num(summary.reviewNeeded);
 
   return (
     <div className="rounded-2xl border border-amber-500/30 bg-amber-950/20 p-4">
       <h3 className="text-sm font-semibold text-amber-100">Dry-run activation preview</h3>
-      <p className="mt-2 text-xs text-amber-200/80">No live records have been created. This is dry-run only.</p>
+      <p className="mt-2 text-xs text-amber-200/80">No live records have been created. These are activation candidates from persisted staged entities only.</p>
+      <p className="mt-1 text-xs text-amber-100/90">{readyTotal.toLocaleString()} ready, {reviewTotal.toLocaleString()} require review.</p>
 
       <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
         <div>Customers: <span className="font-semibold text-white">{num(summary.customersReady)}</span></div>

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -64,7 +64,7 @@ export function OnboardingAgentInsightsPanel({
                 <li key={file.fileId} className="rounded border border-white/10 px-2 py-1">
                   <p className="text-white">{file.filename}</p>
                   <p>{file.inferredDomain} • {file.recommendedParserMode} • {Math.round(file.confidence * 100)}%</p>
-                  <p className="text-slate-400">mapped: {mappedEntries.length} columns</p>
+                  <p className="text-slate-400">mapped: {mappedEntries.length} columns • source: {file.mappingSource ?? "none"}</p>
                   {file.missingImportantFields.length ? <p className="text-amber-200/90">missing: {file.missingImportantFields.slice(0, 4).join(", ")}</p> : null}
                   {mappedEntries.length ? (
                     <details className="mt-1 text-slate-400">

--- a/features/onboarding-agent/lib/agentPlanTypes.ts
+++ b/features/onboarding-agent/lib/agentPlanTypes.ts
@@ -36,6 +36,7 @@ export type OnboardingAgentPlan = {
     confidence: number;
     reasoning: string;
     headerMap: Record<string, string>;
+    mappingSource?: "ai" | "deterministic_alias" | "mixed" | "none";
     requiredFieldsPresent: string[];
     missingImportantFields: string[];
     rowCountEstimate: number;

--- a/features/onboarding-agent/lib/graph.ts
+++ b/features/onboarding-agent/lib/graph.ts
@@ -3,6 +3,7 @@ import { makeReviewItem } from "@/features/onboarding-agent/lib/staging";
 type Entity = {
   id: string;
   entity_type: string;
+  status?: string | null;
   display_name?: string | null;
   normalized: Record<string, unknown>;
   source_external_id?: string | null;
@@ -23,7 +24,8 @@ type BuildLinksParams = {
 };
 
 export function buildStagedLinks(params: BuildLinksParams) {
-  const { entities, shopId, sessionId } = params;
+  const { shopId, sessionId } = params;
+  const entities = params.entities.filter((entity) => (entity.status ?? "ready") === "ready");
   const links: Array<{ from_entity_id: string; to_entity_id: string; link_type: string; confidence: number; evidence: Record<string, unknown>; status: string }> = [];
   const reviewItems: ReturnType<typeof makeReviewItem>[] = [];
 
@@ -35,21 +37,31 @@ export function buildStagedLinks(params: BuildLinksParams) {
   const vendors = entities.filter((entity) => entity.entity_type === "vendor");
   const menus = entities.filter((entity) => entity.entity_type === "menu_suggestion");
 
-  const customersBySourceId = new Map(customers.map((c) => [text(c.normalized.sourceCustomerId), c]));
-  const customersByEmail = new Map(customers.map((c) => [text(c.normalized.email).toLowerCase(), c]));
-  const customersByPhone = new Map(customers.map((c) => [text(c.normalized.phone), c]));
-  const customersByName = new Map(customers.map((c) => [normalizeName(c.normalized.name || c.normalized.businessName), c]));
+  const mapByNonEmpty = (items: Entity[], getKey: (entity: Entity) => string) => {
+    const map = new Map<string, Entity>();
+    for (const item of items) {
+      const key = getKey(item);
+      if (!key) continue;
+      map.set(key, item);
+    }
+    return map;
+  };
 
-  const vehiclesBySourceId = new Map(vehicles.map((v) => [text(v.normalized.sourceVehicleId), v]));
-  const vehiclesByVin = new Map(vehicles.map((v) => [text(v.normalized.vin).toUpperCase(), v]));
-  const vehiclesByPlate = new Map(vehicles.map((v) => [text(v.normalized.plate).toUpperCase(), v]));
-  const vehiclesByUnit = new Map(vehicles.map((v) => [text(v.normalized.unitNumber).toUpperCase(), v]));
+  const customersBySourceId = mapByNonEmpty(customers, (c) => text(c.normalized.sourceCustomerId));
+  const customersByEmail = mapByNonEmpty(customers, (c) => text(c.normalized.email).toLowerCase());
+  const customersByPhone = mapByNonEmpty(customers, (c) => text(c.normalized.phone));
+  const customersByName = mapByNonEmpty(customers, (c) => normalizeName(c.normalized.name || c.normalized.businessName));
 
-  const workOrdersBySourceId = new Map(workOrders.map((wo) => [text(wo.normalized.sourceWorkOrderId), wo]));
-  const workOrdersByInvoiceId = new Map(workOrders.map((wo) => [text(wo.normalized.invoiceId), wo]));
+  const vehiclesBySourceId = mapByNonEmpty(vehicles, (v) => text(v.normalized.sourceVehicleId));
+  const vehiclesByVin = mapByNonEmpty(vehicles, (v) => text(v.normalized.vin).toUpperCase());
+  const vehiclesByPlate = mapByNonEmpty(vehicles, (v) => text(v.normalized.plate).toUpperCase());
+  const vehiclesByUnit = mapByNonEmpty(vehicles, (v) => text(v.normalized.unitNumber).toUpperCase());
+
+  const workOrdersBySourceId = mapByNonEmpty(workOrders, (wo) => text(wo.normalized.sourceWorkOrderId));
+  const workOrdersByInvoiceId = mapByNonEmpty(workOrders, (wo) => text(wo.normalized.invoiceId));
 
   const pushLink = (from: string, to: string, linkType: string, confidence: number, evidence: Record<string, unknown>) => {
-    if (confidence < 0.6) return;
+    if (confidence < 0.6 || !from || !to) return;
 
     links.push({
       from_entity_id: from,

--- a/features/onboarding-agent/lib/headerMapping.ts
+++ b/features/onboarding-agent/lib/headerMapping.ts
@@ -3,71 +3,93 @@ import { normalizeHeader } from "@/features/onboarding-agent/lib/domains";
 
 const DOMAIN_FIELD_ALIASES: Record<OnboardingDomain, Record<string, string[]>> = {
   customers: {
-    sourceCustomerId: ["customer id", "id", "external customer id"],
-    name: ["customer name", "full name", "name"],
+    sourceCustomerId: ["customer id", "id", "external customer id", "customer_number"],
+    name: ["customer name", "full name", "name", "customer"],
+    firstName: ["first name", "firstname"],
+    lastName: ["last name", "lastname"],
     businessName: ["company", "company name", "business"],
     email: ["email", "email address"],
-    phone: ["phone", "phone number", "mobile"],
+    phone: ["phone", "phone number", "mobile", "phone_number"],
+    address: ["address", "street", "street address"],
   },
   vehicles: {
-    sourceVehicleId: ["vehicle id", "id", "external vehicle id"],
-    sourceCustomerId: ["customer id"],
-    vin: ["vin"],
-    plate: ["plate", "license", "license plate"],
+    sourceVehicleId: ["vehicle id", "id", "external vehicle id", "vehicle_number"],
+    sourceCustomerId: ["customer id", "customer_number"],
+    vin: ["vin", "vehicle vin", "vehicle_vin"],
+    plate: ["plate", "license", "license plate", "license_plate"],
     unitNumber: ["unit", "unit number", "truck number"],
+    customerEmail: ["customer email", "customer_email"],
+    customerPhone: ["customer phone", "customer_phone"],
     year: ["year"],
     make: ["make"],
     model: ["model"],
   },
   history: {
-    sourceWorkOrderId: ["work order", "ro id", "repair order", "ro number", "work order number"],
-    invoiceId: ["invoice id", "invoice number", "invoice"],
-    sourceCustomerId: ["customer id"],
-    sourceVehicleId: ["vehicle id"],
+    sourceWorkOrderId: ["work order", "ro id", "repair order", "ro number", "work order number", "work_order_number"],
+    invoiceId: ["invoice id", "invoice number", "invoice", "invoice_number"],
+    sourceCustomerId: ["customer id", "customer_number"],
+    sourceVehicleId: ["vehicle id", "vehicle_number"],
+    vehicleVin: ["vin", "vehicle vin", "vehicle_vin"],
     openedDate: ["opened", "opened date", "open date", "date", "service date"],
     complaint: ["complaint", "description", "concern", "service text", "service performed"],
+    cause: ["cause"],
     correction: ["correction", "resolution"],
+    serviceDescription: ["service", "service name", "line description", "service description"],
+    laborRaw: ["labor", "labor total"],
     total: ["total", "amount"],
+    odometer: ["odometer"],
   },
   invoices: {
-    invoiceNumber: ["invoice", "invoice number", "invoice id"],
-    sourceWorkOrderId: ["work order", "ro", "ro id", "repair order", "work order number"],
-    sourceCustomerId: ["customer id"],
+    invoiceNumber: ["invoice", "invoice number", "invoice id", "invoice_number"],
+    sourceWorkOrderId: ["work order", "ro", "ro id", "repair order", "work order number", "work_order_number"],
+    sourceCustomerId: ["customer id", "customer_number"],
+    sourceVehicleId: ["vehicle id", "vehicle_number"],
+    vehicleVin: ["vin", "vehicle vin", "vehicle_vin"],
     customerName: ["customer", "customer name", "name"],
     customerEmail: ["customer email", "email"],
-    invoiceDate: ["issue date", "invoice date", "date"],
+    invoiceDate: ["issue date", "invoice date", "date", "invoice_date"],
+    subtotal: ["subtotal"],
+    tax: ["tax"],
     paymentStatus: ["status", "payment status"],
     total: ["total", "amount", "invoice total"],
   },
   parts: {
     sku: ["sku", "part sku"],
-    partNumber: ["part number", "part #", "number"],
+    partNumber: ["part number", "part #", "number", "part_number"],
     description: ["description", "name", "part"],
-    vendorName: ["vendor", "supplier", "vendor name", "supplier name"],
+    vendorName: ["vendor", "supplier", "vendor name", "supplier name", "vendor_id"],
     cost: ["cost", "unit cost"],
     price: ["price", "list price", "sale price"],
+    quantityOnHandRaw: ["qty", "quantity", "on hand", "quantity on hand", "on_hand"],
   },
   vendors: {
     name: ["vendor", "supplier", "company", "vendor name", "supplier name"],
     email: ["email", "vendor email"],
     phone: ["phone", "vendor phone"],
-    accountNumber: ["account", "account number", "vendor account"],
+    accountNumber: ["account", "account number", "vendor account", "account_number"],
   },
   staff: {
     name: ["name", "full name", "employee"],
+    firstName: ["first name", "firstname"],
+    lastName: ["last name", "lastname"],
     email: ["email", "email address"],
     phone: ["phone", "mobile"],
-    role: ["role", "job title", "position", "technician", "advisor"],
+    role: ["role", "job title", "position", "technician", "advisor", "username"],
   },
   menu: {
     serviceName: ["service", "service name", "name"],
     description: ["description", "service description"],
-    category: ["category", "service category"],
+    category: ["category", "service category", "service_type"],
     laborHours: ["labor hours", "hours"],
     laborPrice: ["labor price", "price", "labor rate"],
     opCode: ["operation code", "op code", "labor operation", "canned job"],
+    interval: ["interval", "frequency"],
   },
-  inspections: {},
+  inspections: {
+    name: ["name", "inspection", "inspection name"],
+    description: ["description", "inspection description"],
+    category: ["category", "group"],
+  },
   unknown: {},
 };
 
@@ -94,23 +116,40 @@ export function buildEffectiveHeaderMap(params: {
   domain: OnboardingDomain;
   headers: string[];
   aiHeaderMap?: Record<string, string> | null;
-}): Record<string, string> {
-  const output = buildDeterministicHeaderMap(params.domain, params.headers);
+}): { headerMap: Record<string, string>; mappingSource: "ai" | "deterministic_alias" | "mixed" | "none" } {
+  const deterministicMap = buildDeterministicHeaderMap(params.domain, params.headers);
+  const output: Record<string, string> = { ...deterministicMap };
   const ai = params.aiHeaderMap ?? {};
+  let aiApplied = 0;
 
   for (const [left, right] of Object.entries(ai)) {
     if (!left || !right) continue;
     const canonicalFromRight = resolveCanonicalField(params.domain, right);
     if (canonicalFromRight) {
       output[left] = canonicalFromRight;
+      aiApplied += 1;
       continue;
     }
 
     const canonicalFromLeft = resolveCanonicalField(params.domain, left);
     if (canonicalFromLeft) {
       output[right] = canonicalFromLeft;
+      aiApplied += 1;
     }
   }
 
-  return output;
+  const deterministicCount = Object.keys(deterministicMap).length;
+  const totalCount = Object.keys(output).length;
+  const mappingSource = aiApplied > 0 && deterministicCount > 0
+    ? "mixed"
+    : aiApplied > 0
+      ? "ai"
+      : deterministicCount > 0
+        ? "deterministic_alias"
+        : "none";
+
+  return {
+    headerMap: output,
+    mappingSource: totalCount > 0 ? mappingSource : "none",
+  };
 }

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -6,6 +6,8 @@ import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/stagi
 import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { buildEffectiveHeaderMap } from "@/features/onboarding-agent/lib/headerMapping";
 import { buildDeterministicFallbackReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
+import { detectDomain } from "@/features/onboarding-agent/lib/domains";
+import { fetchOnboardingRawRows } from "@/features/onboarding-agent/server/fetchOnboardingRawRows";
 
 function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
   const normalized = normalizeRow(domain, row);
@@ -25,15 +27,48 @@ function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
 describe("onboarding staging", () => {
 
   it("deterministic header mapping provides canonical fields when AI map is empty", () => {
-    const map = buildEffectiveHeaderMap({
+    const effective = buildEffectiveHeaderMap({
       domain: "customers",
       headers: ["Customer ID", "Full Name", "Email Address"],
       aiHeaderMap: {},
     });
 
-    expect(map["Customer ID"]).toBe("sourceCustomerId");
-    expect(map["Full Name"]).toBe("name");
-    expect(map["Email Address"]).toBe("email");
+    expect(effective.mappingSource).toBe("deterministic_alias");
+    expect(effective.headerMap["Customer ID"]).toBe("sourceCustomerId");
+    expect(effective.headerMap["Full Name"]).toBe("name");
+    expect(effective.headerMap["Email Address"]).toBe("email");
+  });
+
+  it("preserves AI headerMap shape sourceHeader -> canonicalField", () => {
+    const effective = buildEffectiveHeaderMap({
+      domain: "invoices",
+      headers: ["Inv #", "Date Issued"],
+      aiHeaderMap: { "Inv #": "invoiceNumber", "Date Issued": "invoiceDate" },
+    });
+
+    expect(effective.headerMap["Inv #"]).toBe("invoiceNumber");
+    expect(effective.headerMap["Date Issued"]).toBe("invoiceDate");
+    expect(effective.mappingSource).toBe("ai");
+  });
+
+  it("known 8-file scenario yields mapped columns > 0 for each known domain", () => {
+    const fixtures: Array<{ filename: string; headers: string[] }> = [
+      { filename: "customers.csv", headers: ["Customer ID", "Customer Name", "Email"] },
+      { filename: "vehicles.csv", headers: ["Vehicle ID", "VIN", "Customer ID"] },
+      { filename: "work_orders_history.csv", headers: ["RO Number", "Service Date", "Complaint"] },
+      { filename: "invoices.csv", headers: ["Invoice Number", "Invoice Date", "Total"] },
+      { filename: "parts_inventory.csv", headers: ["SKU", "Part Number", "Description"] },
+      { filename: "vendors.csv", headers: ["Vendor Name", "Email", "Account Number"] },
+      { filename: "staff_users.csv", headers: ["Full Name", "Email", "Role"] },
+      { filename: "service_catalog.csv", headers: ["Service Name", "Category", "Price"] },
+    ];
+
+    for (const fixture of fixtures) {
+      const domain = detectDomain({ filename: fixture.filename, headers: fixture.headers });
+      expect(domain).not.toBe("unknown");
+      const effective = buildEffectiveHeaderMap({ domain, headers: fixture.headers, aiHeaderMap: {} });
+      expect(Object.keys(effective.headerMap).length).toBeGreaterThan(0);
+    }
   });
   it("analyze creates staged entities from customer rows", () => {
     const staged = stage("customers", { "Customer ID": "C-1", "Full Name": "Jane Doe", Email: "jane@example.com" });
@@ -205,6 +240,22 @@ describe("onboarding staging", () => {
     expect(graph.reviewItems.some((item) => item.issue_type === "missing_customer_link")).toBe(true);
   });
 
+  it("does not create links when endpoints are not ready", () => {
+    const customer = stage("customers", { Name: "No Identity" }).entity;
+    const vehicle = stage("vehicles", { VIN: "1HGCM82633A111111", "Customer ID": "C-1" }).entity;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [
+        { id: "customer-review", entity_type: "customer", status: "needs_review", normalized: customer?.normalized ?? {} },
+        { id: "vehicle-ready", entity_type: "vehicle", status: vehicle?.status ?? "ready", normalized: vehicle?.normalized ?? {} },
+      ],
+    });
+
+    expect(graph.links.length).toBe(0);
+    expect(graph.reviewItems.some((item) => item.issue_type === "missing_customer_link")).toBe(true);
+  });
+
   it("summary is derived from persisted staged rows and keeps liveRecordsCreated at 0", () => {
     const summary = buildOnboardingSummary({
       filesCount: 2,
@@ -273,6 +324,36 @@ describe("onboarding staging", () => {
     expect(summary.activation_plan_summary.customersReady).toBe(1);
     expect(summary.activation_plan_summary.vehiclesReady).toBe(1);
     expect(summary.activation_plan_summary.historicalInvoicesReady).toBe(1);
+  });
+
+  it("fetchOnboardingRawRows paginates beyond 1000 rows", async () => {
+    const allRows = Array.from({ length: 1501 }, (_, idx) => ({ id: idx + 1, file_id: "file-1", source_row_index: idx, raw: { row: idx } }));
+    const sb = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              order: () => ({
+                order: () => ({
+                  order: () => ({
+                    range: (from: number, to: number) => Promise.resolve({ data: allRows.slice(from, to + 1), error: null }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const rows = await fetchOnboardingRawRows({
+      sb,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      select: "id, file_id, source_row_index, raw",
+    });
+
+    expect(rows).toHaveLength(1501);
   });
 
 });

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -43,10 +43,11 @@ const DOMAIN_TO_ENTITY: Record<string, OnboardingDomain> = {
 
 function remapHeaders(raw: Record<string, unknown>, map: Record<string, string>) {
   const out: Record<string, string> = {};
-  const normalizedMap = Object.fromEntries(Object.entries(map).map(([source, target]) => [source.toLowerCase(), target]));
+  const normalizeKey = (value: string) => value.toLowerCase().replace(/[_-\s]+/g, " ").trim();
+  const normalizedMap = Object.fromEntries(Object.entries(map).map(([source, target]) => [normalizeKey(source), target]));
 
   for (const [k, v] of Object.entries(raw)) {
-    const key = map[k] ?? map[k.toLowerCase()] ?? normalizedMap[k.toLowerCase()] ?? k;
+    const key = map[k] ?? map[k.toLowerCase()] ?? normalizedMap[normalizeKey(k)] ?? k;
     out[key] = typeof v === "string" ? v : String(v ?? "");
   }
   return out;
@@ -104,8 +105,11 @@ export async function applyOnboardingAgentPlan(params: {
               : deterministicDomain));
     const domain = DOMAIN_TO_ENTITY[effectiveDomain] ?? "unknown";
     const fileHeaders = Array.isArray(fileMeta?.header_row) ? fileMeta.header_row : [];
-    const headerMap = buildEffectiveHeaderMap({ domain, headers: fileHeaders, aiHeaderMap: planFile?.headerMap ?? {} });
+    const { headerMap, mappingSource } = buildEffectiveHeaderMap({ domain, headers: fileHeaders, aiHeaderMap: planFile?.headerMap ?? {} });
     const parserMode = planFile?.recommendedParserMode ?? (domain === "unknown" ? "stage_review_only" : "stage_entities");
+    let stagedForFile = 0;
+    let reviewForFile = 0;
+    let missingIdentity = 0;
 
     if (parserMode === "ignore" || parserMode === "unsupported") {
       reviewItems.push({ severity: "medium", domain, issue_type: "ignored_file", summary: `File ${planFile?.filename ?? fileId} ignored by plan`, details: { fileId } });
@@ -127,9 +131,30 @@ export async function applyOnboardingAgentPlan(params: {
         sessionId: params.sessionId,
         canonicalFingerprint: fingerprint,
       });
-      if (staged.entity && parserMode === "stage_entities") stagedEntities.push(staged.entity);
-      if (staged.reviewItems.length) reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
+      if (staged.entity && parserMode === "stage_entities") {
+        stagedEntities.push(staged.entity);
+        stagedForFile += 1;
+      }
+      if (staged.reviewItems.length) {
+        missingIdentity += staged.reviewItems.filter((item) => item.issue_type === "missing_identity").length;
+        reviewForFile += staged.reviewItems.length;
+        reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
+      }
     }
+    console.info("[onboarding-agent] file staging details", {
+      sessionId: params.sessionId,
+      shopId: params.shopId,
+      fileId,
+      filename: planFile?.filename ?? fileMeta?.original_filename ?? fileId,
+      domain,
+      parserMode,
+      rawRowsProcessed: fileRows.length,
+      rowsStaged: stagedForFile,
+      rowsReview: reviewForFile,
+      mappedColumns: Object.keys(headerMap).length,
+      mappingSource,
+      missingIdentity,
+    });
 
     await sb.from("onboarding_files").update({
       detected_domain: effectiveDomain,

--- a/features/onboarding-agent/server/buildOnboardingAgentInput.ts
+++ b/features/onboarding-agent/server/buildOnboardingAgentInput.ts
@@ -143,6 +143,19 @@ export async function buildOnboardingAgentInput(params: {
     });
   }
 
+  console.info("[onboarding-agent] build input", {
+    sessionId: params.sessionId,
+    shopId: params.shopId,
+    mode: "ai_planned",
+    files: filesPayload.map((file) => ({
+      fileId: file.fileId,
+      filename: file.filename,
+      headers: file.headers.length,
+      sampleRows: file.sampleRows.length,
+      detectedDomain: file.detectedDomain,
+    })),
+  });
+
   return {
     sessionId: params.sessionId,
     shopId: params.shopId,

--- a/features/onboarding-agent/server/fetchOnboardingRawRows.ts
+++ b/features/onboarding-agent/server/fetchOnboardingRawRows.ts
@@ -18,6 +18,7 @@ export async function fetchOnboardingRawRows(params: {
       .eq("session_id", params.sessionId)
       .order("file_id", { ascending: true })
       .order("source_row_index", { ascending: true })
+      .order("id", { ascending: true })
       .range(from, from + PAGE_SIZE - 1);
 
     if (params.fileIds?.length) {

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -62,6 +62,8 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
 
   const canonicalSummary = {
     ...canonical.summaryCounts,
+    aiRowsSampled: Number((session?.summary ?? {})?.aiRowsSampled ?? canonical.summaryCounts.aiRowsSampled ?? 0),
+    aiFilesSampled: Number((session?.summary ?? {})?.aiFilesSampled ?? canonical.summaryCounts.aiFilesSampled ?? 0),
     activationReadiness: canonical.activation_readiness,
     activationPlanSummary: canonical.activation_plan_summary,
     liveRecordsCreated: 0 as const,

--- a/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
+++ b/features/onboarding-agent/server/runOpenAIOnboardingPlan.ts
@@ -54,7 +54,7 @@ export async function runOpenAIOnboardingPlan(params: {
     schemaName: "OnboardingAgentPlan",
     system: "You are the ProFixIQ onboarding migration planner. You produce JSON only. Never claim live record creation. Staged-only semantics: historical work orders are not active jobs; historical invoices are not active invoice workflow; staff rows are candidates/invites, not auth users; menu/inspection rows are suggestions only.",
     user: {
-      instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Use filename heavily, then headers/samples to refine. For known exports, do not return unknown. Use stage_entities for recognized domains. Missing links should create review groups rather than unsupported file outputs. Historical work orders/invoices may stage without resolved links. Staff rows are candidates only. Service catalog rows are menu suggestions only. Return strict OnboardingAgentPlan JSON.",
+      instruction: "Infer per-file domains, header mappings, review groups, relationships, and a dry-run activation preview. Header map contract is required: headerMap keys MUST be source/raw headers and values MUST be canonical fields. Use filename heavily, then headers/samples to refine. For known exports, do not return unknown. Use stage_entities for recognized domains. Missing links should create review groups rather than unsupported file outputs. Historical work orders/invoices may stage without resolved links. Staff rows are candidates only. Service catalog rows are menu suggestions only. Return strict OnboardingAgentPlan JSON.",
       knownFilesHint: ["customers.csv", "vehicles.csv", "work_orders_history.csv", "invoices.csv", "parts_inventory.csv", "vendors.csv", "staff_users.csv", "service_catalog.csv"],
       input: params.input,
     },
@@ -79,6 +79,13 @@ export async function runOpenAIOnboardingPlan(params: {
     mode: result.mode,
     liveRecordsCreated: 0,
   });
+  console.info("[onboarding-agent] ai input files", params.input.files.map((file) => ({
+    fileId: file.fileId,
+    filename: file.filename,
+    headers: file.headers.length,
+    sampleRows: file.sampleRows.length,
+    detectedDomain: file.detectedDomain,
+  })));
 
   return {
     plan: result.output,

--- a/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/validateOnboardingAgentPlan.ts
@@ -63,15 +63,18 @@ export function validateOnboardingAgentPlan(params: {
     const fileId = asString(o.fileId);
     if (!params.validFileIds.has(fileId)) return null;
     const inferred = normalizePlanDomain(o.inferredDomain);
+    const headerMap = Object.fromEntries(
+      Object.entries(asObj(o.headerMap)).slice(0, 80).map(([k, v]) => [k, asString(v).slice(0, 80)]).filter(([k, v]) => Boolean(k) && Boolean(v)),
+    );
+    const mappingSource = (["ai", "deterministic_alias", "mixed", "none"].includes(asString(o.mappingSource)) ? asString(o.mappingSource) : "none") as "ai" | "deterministic_alias" | "mixed" | "none";
     return {
       fileId,
       filename: asString(o.filename) || fileId,
       inferredDomain: inferred,
       confidence: clamp01(o.confidence, 0.5),
       reasoning: asString(o.reasoning).slice(0, 500),
-      headerMap: Object.fromEntries(
-        Object.entries(asObj(o.headerMap)).slice(0, 80).map(([k, v]) => [k, asString(v).slice(0, 80)]),
-      ),
+      headerMap,
+      mappingSource: Object.keys(headerMap).length > 0 && mappingSource === "none" ? "ai" : mappingSource,
       requiredFieldsPresent: asArr(o.requiredFieldsPresent).slice(0, 30).map((x) => asString(x)),
       missingImportantFields: asArr(o.missingImportantFields).slice(0, 30).map((x) => asString(x)),
       rowCountEstimate: Math.max(0, Math.floor(asNum(o.rowCountEstimate))),
@@ -104,6 +107,7 @@ export function validateOnboardingAgentPlan(params: {
       confidence: 0.5,
       reasoning: "AI omitted this file; deterministic fallback applied.",
       headerMap: {},
+      mappingSource: "none",
       requiredFieldsPresent: [],
       missingImportantFields: [],
       rowCountEstimate: deterministic?.rowCount ?? 0,


### PR DESCRIPTION
### Motivation
- The AI-planned onboarding run lost per-file sampling diagnostics and header mappings, causing UI to show `AI sampled rows: 0` and `mapped: 0` for known files despite samples being sent. 
- Deterministic header aliases were not reliably used when the AI `headerMap` was empty, leading to zero staged customers/vehicles while relationships were nevertheless created. 
- Raw-row processing was being capped by an implicit 1000-row limit in paginated selects, and link building could produce links that referenced non-ready/missing entities. 
- Activation preview and insights needed clearer, persisted diagnostics derived from staged-only data while preserving `liveRecordsCreated = 0` semantics.

### Description
- Enforced a single `headerMap` contract (`sourceHeader -> canonicalField`) and added `mappingSource` to plan files, updated `runOpenAIOnboardingPlan` prompt, and hardened `validateOnboardingAgentPlan` to sanitize mappings.  (files: `runOpenAIOnboardingPlan.ts`, `validateOnboardingAgentPlan.ts`, `agentPlanTypes.ts`)
- Expanded deterministic domain alias coverage and implemented `buildEffectiveHeaderMap` to merge deterministic aliases and validated AI mappings and return `{ headerMap, mappingSource }` so deterministic fallback is used when AI map is empty.  (file: `headerMapping.ts`)
- Made header remapping case/whitespace/underscore/hyphen insensitive, applied effective header map before normalization, added per-file staging diagnostics/logging (rows processed, rows staged/review, mapped columns, mapping source, missing identity counts), and preserved AI sample counts when building session summaries.  (files: `applyOnboardingAgentPlan.ts`, `buildOnboardingAgentInput.ts`, `getOnboardingSession.ts`)
- Fixed full-row paging by adding deterministic `id` ordering in `fetchOnboardingRawRows`, and hardened `buildStagedLinks` to only build links from `ready` entities and require both non-empty endpoint IDs before inserting links.  (files: `fetchOnboardingRawRows.ts`, `graph.ts`)
- UI adjustments to surface mapping source and activation-candidate semantics and developer-facing per-file mapping counts.  (files: `OnboardingAgentInsightsPanel.tsx`, `OnboardingActivationPlanPanel.tsx`)

### Testing
- Typecheck: ran `npx tsc --noEmit` and it completed successfully. 
- Lint: ran `npx eslint` on the touched onboarding files and it completed with existing `@typescript-eslint/no-explicit-any` warnings but no new lint errors. 
- Unit tests: ran `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts`, `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts`, and `npx vitest run features/onboarding-agent/server/sessionListSummary.test.ts`, and all tests passed. 
- Added tests that verify deterministic header fallback, AI `headerMap` shape preservation, known 8-file mapping expectations, pagination beyond 1000 rows, and link safety when endpoints are not ready, and these tests passed as part of the above test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa1e9ed80832890966840efc76591)