### PR TITLE
Refactor OWNER sidebar navigation into workflow-based sections

### DIFF
--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -11,6 +11,10 @@ import {
   type Scope,
   type Tile,
 } from "@/features/shared/config/tiles";
+import {
+  OWNER_GROUP_ORDER,
+  getOwnerSidebarTiles,
+} from "@/features/shared/lib/ownerSidebarNav";
 import { cn } from "@/features/shared/utils/cn";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
@@ -25,6 +29,7 @@ const GROUP_ORDER = [
   "Settings",
   "General",
 ];
+
 
 function normalizeRole(raw: string | null | undefined): Role | null {
   const r = String(raw ?? "").toLowerCase().trim();
@@ -81,9 +86,12 @@ export default function RoleSidebar() {
   const tiles = useMemo(() => {
     if (!role) return [] as Tile[];
 
-    return TILES.filter((t) => t.roles.includes(role)).filter(
+    const filteredTiles = TILES.filter((t) => t.roles.includes(role)).filter(
       (t) => t.scopes.includes("all") || t.scopes.includes(scopeFilter),
     );
+
+    if (role === "owner") return getOwnerSidebarTiles(filteredTiles);
+    return filteredTiles;
   }, [role, scopeFilter]);
 
   const canonicalActiveTile = useMemo(
@@ -102,15 +110,14 @@ export default function RoleSidebar() {
     }, {});
   }, [tiles]);
 
-  const sortedGroups = useMemo(
-    () =>
-      Object.entries(groups).sort(([a], [b]) => {
-        const ia = GROUP_ORDER.indexOf(a);
-        const ib = GROUP_ORDER.indexOf(b);
-        return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
-      }),
-    [groups],
-  );
+  const sortedGroups = useMemo(() => {
+    const groupOrder = role === "owner" ? OWNER_GROUP_ORDER : GROUP_ORDER;
+    return Object.entries(groups).sort(([a], [b]) => {
+      const ia = groupOrder.indexOf(a);
+      const ib = groupOrder.indexOf(b);
+      return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+    });
+  }, [groups, role]);
 
   useEffect(() => {
     if (!sortedGroups.length) return;

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -1,0 +1,86 @@
+import type { Tile } from "@/features/shared/config/tiles";
+
+export const OWNER_GROUP_ORDER = [
+  "Dashboard",
+  "Operations",
+  "Parts",
+  "Fleet",
+  "Inspections & Menu",
+  "People & Workforce",
+  "Admin & Oversight",
+  "Growth",
+  "Billing & Plan",
+  "Settings",
+  "Technician Tools",
+  "General",
+];
+
+const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
+  "/dashboard": "Dashboard",
+  "/dashboard/owner/reports": "Dashboard",
+  "/work-orders/create?autostart=1": "Operations",
+  "/work-orders/view": "Operations",
+  "/work-orders/quote-review": "Operations",
+  "/customers/search": "Operations",
+  "/billing": "Operations",
+  "/work-orders/history": "Operations",
+  "/parts": "Parts",
+  "/parts/requests": "Parts",
+  "/parts/receiving": "Parts",
+  "/parts/receive": "Parts",
+  "/parts/inventory": "Parts",
+  "/parts/po": "Parts",
+  "/parts/po/receive": "Parts",
+  "/parts/movements": "Parts",
+  "/parts/allocations": "Parts",
+  "/parts/vendors": "Parts",
+  "/fleet/tower": "Fleet",
+  "/fleet/dispatch": "Operations",
+  "/fleet/units": "Fleet",
+  "/fleet/units/new": "Fleet",
+  "/fleet/programs": "Fleet",
+  "/menu": "Inspections & Menu",
+  "/inspections/custom-inspection": "Inspections & Menu",
+  "/inspections/templates": "Inspections & Menu",
+  "/inspections/fleet-import": "Inspections & Menu",
+  "/inspections/saved": "Inspections & Menu",
+  "/dashboard/admin/people": "People & Workforce",
+  "/dashboard/admin/employees": "People & Workforce",
+  "/dashboard/admin/payroll-time": "People & Workforce",
+  "/dashboard/owner/create-user": "People & Workforce",
+  "/dashboard/admin": "Admin & Oversight",
+  "/dashboard/admin/shops": "Admin & Oversight",
+  "/dashboard/admin/audit": "Admin & Oversight",
+  "/dashboard/onboarding": "Admin & Oversight",
+  "/dashboard/marketing": "Growth",
+  "/dashboard/reviews": "Growth",
+  "/compare-plans": "Billing & Plan",
+  "/dashboard/owner/payments": "Billing & Plan",
+  "/dashboard/owner/settings": "Settings",
+  "/dashboard/tech/settings": "Settings",
+  "/tech/queue": "Technician Tools",
+  "/parts/requests?mine=1": "Technician Tools",
+  "/chat": "Technician Tools",
+};
+
+const OWNER_TITLE_OVERRIDES_BY_HREF: Record<string, string> = {
+  "/work-orders/view": "Work Orders",
+  "/billing": "Customer Billing",
+  "/parts/requests": "Parts Requests",
+  "/dashboard/onboarding": "Data Onboarding",
+};
+
+export function getOwnerTileOverrides(tile: Tile): Pick<Tile, "section" | "title"> {
+  if (tile.href === "/dashboard/appointments" && tile.title === "Scheduling") {
+    return { section: "People & Workforce", title: tile.title };
+  }
+
+  return {
+    section: OWNER_SECTION_OVERRIDES_BY_HREF[tile.href] ?? tile.section,
+    title: OWNER_TITLE_OVERRIDES_BY_HREF[tile.href] ?? tile.title,
+  };
+}
+
+export function getOwnerSidebarTiles(tiles: Tile[]): Tile[] {
+  return tiles.map((tile) => ({ ...tile, ...getOwnerTileOverrides(tile) }));
+}

--- a/tests/owner-sidebar-nav.test.ts
+++ b/tests/owner-sidebar-nav.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { TILES, type Role } from "@/features/shared/config/tiles";
+import {
+  OWNER_GROUP_ORDER,
+  getOwnerSidebarTiles,
+} from "@/features/shared/lib/ownerSidebarNav";
+
+function ownerTiles() {
+  const base = TILES.filter((tile) => tile.roles.includes("owner"));
+  return getOwnerSidebarTiles(base);
+}
+
+describe("owner sidebar IA", () => {
+  it("keeps owner route coverage intact while reorganizing labels/sections", () => {
+    const base = TILES.filter((tile) => tile.roles.includes("owner"));
+    const reorganized = getOwnerSidebarTiles(base);
+
+    expect(new Set(reorganized.map((tile) => tile.href))).toEqual(
+      new Set(base.map((tile) => tile.href)),
+    );
+  });
+
+  it("uses the owner section order with dashboard first and technician tools near the bottom", () => {
+    expect(OWNER_GROUP_ORDER[0]).toBe("Dashboard");
+    expect(OWNER_GROUP_ORDER.at(-2)).toBe("Technician Tools");
+  });
+
+  it("keeps customer billing separate from plan billing", () => {
+    const tiles = ownerTiles();
+    const customerBilling = tiles.find((tile) => tile.href === "/billing");
+    const planBilling = tiles.find((tile) => tile.href === "/compare-plans");
+
+    expect(customerBilling?.title).toBe("Customer Billing");
+    expect(customerBilling?.section).toBe("Operations");
+    expect(planBilling?.title).toBe("Plan & Billing");
+    expect(planBilling?.section).toBe("Billing & Plan");
+  });
+
+  it("groups inspection and menu builder routes together", () => {
+    const tiles = ownerTiles();
+    const groupedHrefs = [
+      "/menu",
+      "/inspections/custom-inspection",
+      "/inspections/templates",
+      "/inspections/fleet-import",
+      "/inspections/saved",
+    ];
+
+    for (const href of groupedHrefs) {
+      expect(tiles.find((tile) => tile.href === href)?.section).toBe(
+        "Inspections & Menu",
+      );
+    }
+  });
+
+  it("does not remove expected primary routes for tech/admin/parts roles", () => {
+    const roleToHrefs: Record<Role, string[]> = {
+      mechanic: ["/dashboard", "/tech/queue"],
+      admin: ["/dashboard/admin", "/compare-plans"],
+      parts: ["/parts", "/parts/requests"],
+      advisor: [],
+      dispatcher: [],
+      driver: [],
+      fleet_manager: [],
+      manager: [],
+      owner: [],
+    };
+
+    for (const [role, hrefs] of Object.entries(roleToHrefs)) {
+      const roleTiles = TILES.filter((tile) => tile.roles.includes(role as Role));
+      for (const href of hrefs) {
+        expect(roleTiles.some((tile) => tile.href === href)).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- The OWNER sidebar mixed technician, admin, and setup surfaces in a flat, confusing order making the owner view feel cluttered instead of a clear operational command center.
- Labels and groupings like `Billing` (customer invoices) vs subscription `Plan & Billing`, `Tools` containing inspections/menu, and tech routes leading the nav caused discoverability and IA issues.
- The change must not remove routes, alter RBAC/capability checks, or change business logic — only reorganize owner-facing navigation and labels.

### Description
- Added an owner-only mapping module `features/shared/lib/ownerSidebarNav.ts` that defines `OWNER_GROUP_ORDER` and safe per-href section/title overrides so hrefs and role eligibility are preserved.
- Updated `RoleSidebar` to apply owner-only transforms (`getOwnerSidebarTiles`) when `role === "owner"` and to use the owner group ordering while non-owner roles keep the existing grouping behavior.
- Renamed owner-facing labels via overrides (label-only): `View Work Orders` → `Work Orders`, `Billing` (operations) → `Customer Billing`, `Requests` → `Parts Requests`, and `Onboarding Agent` → `Data Onboarding`, and moved Dispatch/Shop Health/Reviews/Marketing into owner-appropriate sections per the new IA.
- Added tests `tests/owner-sidebar-nav.test.ts` that assert owner route coverage parity, owner section ordering intent, billing separation, inspection/menu grouping, and that primary routes remain present for other roles.

### Testing
- Ran the owner nav unit tests with `npm run test -- tests/owner-sidebar-nav.test.ts` and they passed: 5 tests, 1 file (all green).
- Ran type-checking with `npx tsc --noEmit` which completed successfully with no new type errors.
- Ran lint `npm run lint`, which reports pre-existing repository lint errors unrelated to these changes and did not fail the targeted tests or typecheck; the navigation changes did not introduce new lint/TS issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efad25282c8328b3b940d182e5305b)