### PR TITLE
Fix onboarding staging to use executable mappings and safe per-file tracing

### DIFF
--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -21,6 +21,8 @@ export function OnboardingAgentInsightsPanel({
   const usingFallback = report?.mode === "deterministic_fallback";
   const aiRowsSampled = Number(summary?.aiRowsSampled ?? 0);
   const rowsParsed = Number(summary?.rowsParsedTotal ?? summary?.rowsParsed ?? 0);
+  const effectiveFileMappings = Array.isArray(summary?.effectiveFileMappings) ? summary.effectiveFileMappings as Array<Record<string, unknown>> : [];
+  const effectiveByFileId = new Map(effectiveFileMappings.map((item) => [String(item.fileId ?? ""), item]));
 
   return (
     <div className="rounded-2xl border border-cyan-500/30 bg-cyan-950/10 p-4">
@@ -56,15 +58,21 @@ export function OnboardingAgentInsightsPanel({
 
       {plan?.files?.length ? (
         <div className="mt-3 rounded-lg border border-white/10 bg-slate-900/50 p-3">
-          <p className="text-[11px] uppercase tracking-wide text-slate-400">Per-file AI plan</p>
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Per-file AI plan & effective mapping</p>
           <ul className="mt-2 space-y-1 text-xs text-slate-200">
             {plan.files.slice(0, 12).map((file) => {
               const mappedEntries = Object.entries(file.headerMap ?? {});
+              const effective = effectiveByFileId.get(file.fileId);
               return (
                 <li key={file.fileId} className="rounded border border-white/10 px-2 py-1">
                   <p className="text-white">{file.filename}</p>
                   <p>{file.inferredDomain} • {file.recommendedParserMode} • {Math.round(file.confidence * 100)}%</p>
-                  <p className="text-slate-400">mapped: {mappedEntries.length} columns • source: {file.mappingSource ?? "none"}</p>
+                  <p className="text-slate-400">AI map: {mappedEntries.length} columns • source: {file.mappingSource ?? "none"}</p>
+                  {effective ? (
+                    <p className="text-cyan-200/90">
+                      Effective map: {Number(effective.mappedColumnCount ?? 0)} columns • source: {String(effective.mappingSource ?? "none")} • staged rows: {Number(effective.stagedRows ?? 0)}
+                    </p>
+                  ) : null}
                   {file.missingImportantFields.length ? <p className="text-amber-200/90">missing: {file.missingImportantFields.slice(0, 4).join(", ")}</p> : null}
                   {mappedEntries.length ? (
                     <details className="mt-1 text-slate-400">

--- a/features/onboarding-agent/lib/fileDetection.ts
+++ b/features/onboarding-agent/lib/fileDetection.ts
@@ -1,6 +1,11 @@
 import { detectDomain } from "./domains";
+import { ONBOARDING_DOMAINS, type OnboardingDomain } from "./domains";
+
+const VALID_DECLARED_DOMAINS = new Set<OnboardingDomain>(ONBOARDING_DOMAINS);
 
 export function detectFileDomain(params: { filename?: string | null; headers?: string[]; declaredDomain?: string | null }) {
-  if (params.declaredDomain && params.declaredDomain !== "unknown") return params.declaredDomain;
+  if (params.declaredDomain && VALID_DECLARED_DOMAINS.has(params.declaredDomain as OnboardingDomain) && params.declaredDomain !== "unknown") {
+    return params.declaredDomain;
+  }
   return detectDomain({ filename: params.filename, headers: params.headers });
 }

--- a/features/onboarding-agent/lib/headerMapping.ts
+++ b/features/onboarding-agent/lib/headerMapping.ts
@@ -194,7 +194,16 @@ export function buildEffectiveHeaderMap(params: {
   domain: OnboardingDomain;
   headers: string[];
   aiHeaderMap?: Record<string, string> | null;
-}): { headerMap: Record<string, string>; mappingSource: "ai" | "deterministic_alias" | "mixed" | "none" } {
+}): {
+  headerMap: Record<string, string>;
+  mappingSource: "ai" | "deterministic_alias" | "mixed" | "none";
+  mappedColumnCount: number;
+  diagnostics: {
+    aiMappedColumns: number;
+    deterministicMappedColumns: number;
+    canonicalPassthroughColumns: number;
+  };
+} {
   const deterministicMap = buildDeterministicHeaderMap(params.domain, params.headers);
   const aiMap = normalizeAiHeaderMap({
     domain: params.domain,
@@ -203,6 +212,7 @@ export function buildEffectiveHeaderMap(params: {
   });
   const output: Record<string, string> = { ...aiMap };
   const aiApplied = Object.keys(aiMap).length;
+  let passthroughCount = 0;
 
   for (const [header, canonical] of Object.entries(deterministicMap)) {
     if (!output[header]) output[header] = canonical;
@@ -210,7 +220,10 @@ export function buildEffectiveHeaderMap(params: {
 
   for (const header of params.headers) {
     const canonical = resolveCanonicalField(params.domain, header);
-    if (canonical && !output[header]) output[header] = canonical;
+    if (canonical && !output[header]) {
+      output[header] = canonical;
+      passthroughCount += 1;
+    }
   }
 
   const deterministicCount = Object.keys(deterministicMap).length;
@@ -226,5 +239,11 @@ export function buildEffectiveHeaderMap(params: {
   return {
     headerMap: output,
     mappingSource: totalCount > 0 ? mappingSource : "none",
+    mappedColumnCount: totalCount,
+    diagnostics: {
+      aiMappedColumns: aiApplied,
+      deterministicMappedColumns: deterministicCount,
+      canonicalPassthroughColumns: passthroughCount,
+    },
   };
 }

--- a/features/onboarding-agent/lib/normalization.ts
+++ b/features/onboarding-agent/lib/normalization.ts
@@ -1,13 +1,18 @@
 import type { OnboardingDomain } from "./domains";
 import { normalizePhone } from "./fingerprints";
 
-const normalizeKey = (value: string) => value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+const normalizeKey = (value: string) => value
+  .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, " ")
+  .replace(/\s+/g, " ")
+  .trim();
 
-const value = (row: Record<string, string>, keys: string[]): string => {
-  const normalizedKeys = keys.map(normalizeKey);
+const value = (row: Record<string, string>, canonicalKey: string, keys: string[]): string => {
+  const normalizedKeys = new Set([canonicalKey, ...keys].map(normalizeKey));
   for (const [header, rawValue] of Object.entries(row)) {
     const key = normalizeKey(header);
-    if (normalizedKeys.includes(key) && rawValue) return rawValue.trim();
+    if (normalizedKeys.has(key) && rawValue) return rawValue.trim();
   }
   return "";
 };
@@ -21,40 +26,40 @@ function parseMoney(raw: string): number | null {
 
 export function normalizeRow(domain: OnboardingDomain, row: Record<string, string>) {
   if (domain === "customers") {
-    const name = value(row, ["customer name", "full name", "name"]);
+    const name = value(row, "name", ["customer name", "full name", "name"]);
     const [firstName = "", ...rest] = name.split(" ");
     return {
       entityType: "customer",
-      displayName: name || value(row, ["company name", "company", "business"]),
+      displayName: name || value(row, "businessName", ["company name", "company", "business"]),
       normalized: {
-        sourceCustomerId: value(row, ["customer id", "id", "external customer id"]),
+        sourceCustomerId: value(row, "sourceCustomerId", ["customer id", "id", "external customer id"]),
         name,
         firstName,
-        lastName: rest.join(" "),
-        businessName: value(row, ["company", "company name", "business"]),
-        email: value(row, ["email", "email address", "e mail", "e-mail"]).toLowerCase(),
-        phone: normalizePhone(value(row, ["phone", "phone number", "mobile"])),
+        lastName: value(row, "lastName", ["last name"]) || rest.join(" "),
+        businessName: value(row, "businessName", ["company", "company name", "business"]),
+        email: value(row, "email", ["email", "email address", "e mail", "e-mail"]).toLowerCase(),
+        phone: normalizePhone(value(row, "phone", ["phone", "phone number", "mobile"])),
       },
     };
   }
 
   if (domain === "vehicles") {
-    const year = value(row, ["year"]);
-    const make = value(row, ["make"]);
-    const model = value(row, ["model"]);
-    const vin = value(row, ["vin"]).toUpperCase().replace(/\s+/g, "");
-    const plate = value(row, ["plate", "license", "license plate"]).toUpperCase().replace(/\s+/g, "");
-    const unitNumber = value(row, ["unit", "unit number", "truck number"]);
+    const year = value(row, "year", ["year"]);
+    const make = value(row, "make", ["make"]);
+    const model = value(row, "model", ["model"]);
+    const vin = value(row, "vin", ["vin"]).toUpperCase().replace(/\s+/g, "");
+    const plate = value(row, "plate", ["plate", "license", "license plate"]).toUpperCase().replace(/\s+/g, "");
+    const unitNumber = value(row, "unitNumber", ["unit", "unit number", "truck number"]);
 
     return {
       entityType: "vehicle",
       displayName: `${year} ${make} ${model}`.trim() || vin || plate || unitNumber,
       normalized: {
-        sourceVehicleId: value(row, ["vehicle id", "id", "external vehicle id"]),
-        sourceCustomerId: value(row, ["customer id"]),
-        customerName: value(row, ["customer name", "name"]),
-        customerEmail: value(row, ["customer email", "email", "customer e-mail", "customer e mail"]),
-        customerPhone: normalizePhone(value(row, ["customer phone", "phone"])),
+        sourceVehicleId: value(row, "sourceVehicleId", ["vehicle id", "id", "external vehicle id"]),
+        sourceCustomerId: value(row, "sourceCustomerId", ["customer id"]),
+        customerName: value(row, "customerName", ["customer name", "name"]),
+        customerEmail: value(row, "customerEmail", ["customer email", "email", "customer e-mail", "customer e mail"]),
+        customerPhone: normalizePhone(value(row, "customerPhone", ["customer phone", "phone"])),
         vin,
         plate,
         unitNumber,
@@ -66,11 +71,11 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "history") {
-    const sourceWorkOrderId = value(row, ["work order", "ro id", "repair order", "ro number", "work order number"]);
-    const invoiceId = value(row, ["invoice id", "invoice number", "invoice"]);
-    const openedDate = value(row, ["opened", "opened date", "open date", "date", "service date"]);
-    const complaint = value(row, ["complaint", "description", "concern", "service text", "service performed"]);
-    const correction = value(row, ["correction", "resolution"]);
+    const sourceWorkOrderId = value(row, "sourceWorkOrderId", ["work order", "ro id", "repair order", "ro number", "work order number"]);
+    const invoiceId = value(row, "invoiceId", ["invoice id", "invoice number", "invoice"]);
+    const openedDate = value(row, "openedDate", ["opened", "opened date", "open date", "date", "service date"]);
+    const complaint = value(row, "complaint", ["complaint", "description", "concern", "service text", "service performed"]);
+    const correction = value(row, "correction", ["correction", "resolution"]);
 
     return {
       entityType: "historical_work_order",
@@ -78,33 +83,34 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       normalized: {
         sourceWorkOrderId,
         invoiceId,
-        sourceCustomerId: value(row, ["customer id"]),
-        customerEmail: value(row, ["customer email", "email", "customer e-mail", "customer e mail"]).toLowerCase(),
-        customerName: value(row, ["customer name", "name"]),
-        sourceVehicleId: value(row, ["vehicle id"]),
-        vehicleVin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
-        vehiclePlate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
-        vehicleUnitNumber: value(row, ["unit", "unit number"]),
-        invoiceNumber: value(row, ["invoice number", "invoice", "invoice id"]),
+        sourceCustomerId: value(row, "sourceCustomerId", ["customer id"]),
+        customerEmail: value(row, "customerEmail", ["customer email", "email", "customer e-mail", "customer e mail"]).toLowerCase(),
+        customerName: value(row, "customerName", ["customer name", "name"]),
+        sourceVehicleId: value(row, "sourceVehicleId", ["vehicle id"]),
+        vehicleVin: value(row, "vehicleVin", ["vin"]).toUpperCase().replace(/\s+/g, ""),
+        vehiclePlate: value(row, "vehiclePlate", ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
+        vehicleUnitNumber: value(row, "vehicleUnitNumber", ["unit", "unit number"]),
+        invoiceNumber: value(row, "invoiceNumber", ["invoice number", "invoice", "invoice id"]),
         complaint,
-        cause: value(row, ["cause"]),
+        cause: value(row, "cause", ["cause"]),
         correction,
-        serviceDescription: value(row, ["service", "service name", "line description", "service description"]),
+        serviceDescription: value(row, "serviceDescription", ["service", "service name", "line description", "service description"]),
         openedDate,
-        closedDate: value(row, ["closed", "completed date", "closed date"]),
-        laborRaw: value(row, ["labor", "labor total"]),
-        laborTotal: parseMoney(value(row, ["labor", "labor total"])),
-        totalRaw: value(row, ["total", "amount"]),
-        total: parseMoney(value(row, ["total", "amount"])),
+        closedDate: value(row, "closedDate", ["closed", "completed date", "closed date"]),
+        laborRaw: value(row, "laborRaw", ["labor", "labor total"]),
+        laborTotal: parseMoney(value(row, "laborRaw", ["labor", "labor total"])),
+        totalRaw: value(row, "totalRaw", ["total", "amount"]),
+        total: parseMoney(value(row, "totalRaw", ["total", "amount"])),
+        odometer: value(row, "odometer", ["odometer"]),
       },
     };
   }
 
   if (domain === "invoices") {
-    const totalRaw = value(row, ["total", "amount", "invoice total"]);
-    const sourceWorkOrderId = value(row, ["work order", "ro", "ro id", "repair order", "work order number"]);
-    const invoiceNumber = value(row, ["invoice", "invoice number", "invoice id"]);
-    const invoiceDate = value(row, ["issue date", "invoice date", "date"]);
+    const totalRaw = value(row, "totalRaw", ["total", "amount", "invoice total"]);
+    const sourceWorkOrderId = value(row, "sourceWorkOrderId", ["work order", "ro", "ro id", "repair order", "work order number"]);
+    const invoiceNumber = value(row, "invoiceNumber", ["invoice", "invoice number", "invoice id"]);
+    const invoiceDate = value(row, "invoiceDate", ["issue date", "invoice date", "date"]);
 
     return {
       entityType: "historical_invoice",
@@ -112,14 +118,14 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       normalized: {
         invoiceNumber,
         sourceWorkOrderId,
-        sourceCustomerId: value(row, ["customer id"]),
-        customerName: value(row, ["customer", "customer name", "name"]),
-        customerEmail: value(row, ["customer email", "email", "customer e-mail", "customer e mail"]).toLowerCase(),
-        sourceVehicleId: value(row, ["vehicle id"]),
-        vehicleVin: value(row, ["vin"]).toUpperCase().replace(/\s+/g, ""),
-        vehiclePlate: value(row, ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
+        sourceCustomerId: value(row, "sourceCustomerId", ["customer id"]),
+        customerName: value(row, "customerName", ["customer", "customer name", "name"]),
+        customerEmail: value(row, "customerEmail", ["customer email", "email", "customer e-mail", "customer e mail"]).toLowerCase(),
+        sourceVehicleId: value(row, "sourceVehicleId", ["vehicle id"]),
+        vehicleVin: value(row, "vehicleVin", ["vin"]).toUpperCase().replace(/\s+/g, ""),
+        vehiclePlate: value(row, "vehiclePlate", ["plate", "license"]).toUpperCase().replace(/\s+/g, ""),
         invoiceDate,
-        paymentStatus: value(row, ["status", "payment status"]),
+        paymentStatus: value(row, "paymentStatus", ["status", "payment status"]),
         totalRaw,
         total: parseMoney(totalRaw),
       },
@@ -127,9 +133,9 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
   }
 
   if (domain === "parts") {
-    const description = value(row, ["description", "name", "part"]);
-    const partNumber = value(row, ["part number", "part #", "number"]);
-    const sku = value(row, ["sku", "part sku"]);
+    const description = value(row, "description", ["description", "name", "part"]);
+    const partNumber = value(row, "partNumber", ["part number", "part #", "number"]);
+    const sku = value(row, "sku", ["sku", "part sku"]);
     return {
       entityType: "part",
       displayName: description || partNumber || sku,
@@ -137,35 +143,35 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         sku,
         partNumber,
         description,
-        vendorName: value(row, ["vendor", "supplier", "vendor name", "supplier name"]),
-        quantityOnHandRaw: value(row, ["qty", "quantity", "on hand", "quantity on hand"]),
-        costRaw: value(row, ["cost", "unit cost"]),
-        cost: parseMoney(value(row, ["cost", "unit cost"])),
-        priceRaw: value(row, ["price", "list price", "sale price"]),
-        price: parseMoney(value(row, ["price", "list price", "sale price"])),
+        vendorName: value(row, "vendorName", ["vendor", "supplier", "vendor name", "supplier name"]),
+        quantityOnHandRaw: value(row, "quantityOnHandRaw", ["qty", "quantity", "on hand", "quantity on hand"]),
+        costRaw: value(row, "costRaw", ["cost", "unit cost"]),
+        cost: parseMoney(value(row, "costRaw", ["cost", "unit cost"])),
+        priceRaw: value(row, "priceRaw", ["price", "list price", "sale price"]),
+        price: parseMoney(value(row, "priceRaw", ["price", "list price", "sale price"])),
       },
     };
   }
 
   if (domain === "vendors") {
-    const name = value(row, ["vendor", "supplier", "company", "vendor name", "supplier name"]);
+    const name = value(row, "name", ["vendor", "supplier", "company", "vendor name", "supplier name"]);
     return {
       entityType: "vendor",
       displayName: name,
       normalized: {
-        sourceVendorId: value(row, ["vendor id", "external vendor id", "vendor_number"]),
+        sourceVendorId: value(row, "sourceVendorId", ["vendor id", "external vendor id", "vendor_number"]),
         name,
-        email: value(row, ["email", "vendor email", "e mail", "e-mail"]).toLowerCase(),
-        phone: normalizePhone(value(row, ["phone", "vendor phone"])),
-        accountNumber: value(row, ["account", "account number", "vendor account"]),
+        email: value(row, "email", ["email", "vendor email", "e mail", "e-mail"]).toLowerCase(),
+        phone: normalizePhone(value(row, "phone", ["phone", "vendor phone"])),
+        accountNumber: value(row, "accountNumber", ["account", "account number", "vendor account"]),
       },
     };
   }
 
   if (domain === "staff") {
-    const name = value(row, ["name", "full name", "employee"]);
-    const email = value(row, ["email", "email address", "e mail", "e-mail"]).toLowerCase();
-    const username = value(row, ["username", "user name", "login"]);
+    const name = value(row, "name", ["name", "full name", "employee"]);
+    const email = value(row, "email", ["email", "email address", "e mail", "e-mail"]).toLowerCase();
+    const username = value(row, "username", ["username", "user name", "login"]);
     return {
       entityType: "staff_candidate",
       displayName: name || email || username,
@@ -173,16 +179,16 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
         name,
         email,
         username,
-        phone: normalizePhone(value(row, ["phone", "mobile"])),
-        role: value(row, ["role", "job title", "position", "technician", "advisor"]),
+        phone: normalizePhone(value(row, "phone", ["phone", "mobile"])),
+        role: value(row, "role", ["role", "job title", "position", "technician", "advisor"]),
       },
     };
   }
 
   if (domain === "menu") {
-    const serviceName = value(row, ["service", "service name", "name"]);
-    const description = value(row, ["description", "service description", "service_description"]);
-    const laborPriceRaw = value(row, ["labor price", "price", "labor rate"]);
+    const serviceName = value(row, "serviceName", ["service", "service name", "name"]);
+    const description = value(row, "description", ["description", "service description", "service_description"]);
+    const laborPriceRaw = value(row, "laborPriceRaw", ["labor price", "price", "labor rate"]);
 
     return {
       entityType: "menu_suggestion",
@@ -190,12 +196,12 @@ export function normalizeRow(domain: OnboardingDomain, row: Record<string, strin
       normalized: {
         serviceName,
         description,
-        category: value(row, ["category", "service category"]),
-        laborHours: value(row, ["labor hours", "hours"]),
+        category: value(row, "category", ["category", "service category"]),
+        laborHours: value(row, "laborHours", ["labor hours", "hours"]),
         laborPriceRaw,
         laborPrice: parseMoney(laborPriceRaw),
-        opCode: value(row, ["operation code", "op code", "labor operation", "canned job"]),
-        inspectionHint: value(row, ["inspection", "inspection hint", "recommended inspection"]),
+        opCode: value(row, "opCode", ["operation code", "op code", "labor operation", "canned job"]),
+        inspectionHint: value(row, "inspectionHint", ["inspection", "inspection hint", "recommended inspection"]),
       },
     };
   }

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -8,6 +8,7 @@ import { buildEffectiveHeaderMap } from "@/features/onboarding-agent/lib/headerM
 import { buildDeterministicFallbackReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
 import { detectDomain } from "@/features/onboarding-agent/lib/domains";
 import { fetchOnboardingRawRows } from "@/features/onboarding-agent/server/fetchOnboardingRawRows";
+import { detectFileDomain } from "@/features/onboarding-agent/lib/fileDetection";
 
 function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
   const normalized = normalizeRow(domain, row);
@@ -34,6 +35,7 @@ describe("onboarding staging", () => {
     });
 
     expect(effective.mappingSource).toBe("deterministic_alias");
+    expect(effective.mappedColumnCount).toBe(3);
     expect(effective.headerMap["Customer ID"]).toBe("sourceCustomerId");
     expect(effective.headerMap["Full Name"]).toBe("name");
     expect(effective.headerMap["Email Address"]).toBe("email");
@@ -91,8 +93,17 @@ describe("onboarding staging", () => {
       const domain = detectDomain({ filename: fixture.filename, headers: fixture.headers });
       expect(domain).not.toBe("unknown");
       const effective = buildEffectiveHeaderMap({ domain, headers: fixture.headers, aiHeaderMap: {} });
-      expect(Object.keys(effective.headerMap).length).toBeGreaterThan(0);
+      expect(effective.mappedColumnCount).toBeGreaterThan(0);
     }
+  });
+
+  it("detectFileDomain ignores invalid declared domain and keeps deterministic match", () => {
+    const domain = detectFileDomain({
+      filename: "work_orders_history.csv",
+      headers: ["RO Number", "Complaint", "Service Date"],
+      declaredDomain: "not-a-domain",
+    });
+    expect(domain).toBe("history");
   });
   it("analyze creates staged entities from customer rows", () => {
     const staged = stage("customers", { "Customer ID": "C-1", "Full Name": "Jane Doe", Email: "jane@example.com" });
@@ -113,6 +124,17 @@ describe("onboarding staging", () => {
     });
 
     expect(graph.links.some((link) => link.link_type === "customer_vehicle")).toBe(true);
+  });
+
+  it("does not create customer_vehicle links when there are no vehicles", () => {
+    const customer = stage("customers", { "Customer ID": "C-1", Name: "Jane" }).entity!;
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [{ id: "customer-1", entity_type: customer.entity_type, normalized: customer.normalized }],
+    });
+
+    expect(graph.links.some((link) => link.link_type === "customer_vehicle")).toBe(false);
   });
 
   it("creates historical_work_order and historical_invoice entities", () => {
@@ -298,6 +320,45 @@ describe("onboarding staging", () => {
 
     expect(graph.links.length).toBe(0);
     expect(graph.reviewItems.some((item) => item.issue_type === "missing_customer_link")).toBe(true);
+  });
+
+  it("golden 8-file pipeline stages all domains from mapped canonical rows", () => {
+    const fixtures = [
+      { domain: "customers", row: { "Customer ID": "C-100", "Customer Name": "Dana Driver", Email: "dana@example.test" } },
+      { domain: "vehicles", row: { "Vehicle ID": "V-100", "Customer ID": "C-100", VIN: "1HGCM82633A777777", Make: "Ford", Model: "Transit", Year: "2021" } },
+      { domain: "history", row: { "RO Number": "RO-100", "Customer ID": "C-100", "Vehicle ID": "V-100", "Service Date": "2026-03-20", Complaint: "Brake pulsation" } },
+      { domain: "invoices", row: { "Invoice Number": "INV-100", "Work Order": "RO-100", "Invoice Date": "2026-03-21", Total: "899.12" } },
+      { domain: "parts", row: { SKU: "BRK-10", "Part Number": "P-100", Description: "Brake Kit", Vendor: "Metro Supply" } },
+      { domain: "vendors", row: { "Vendor Name": "Metro Supply", Email: "orders@metro.test" } },
+      { domain: "staff", row: { "Full Name": "Alex Tech", Email: "alex@shop.test", Role: "Technician" } },
+      { domain: "menu", row: { "Service Name": "Brake Service", Description: "Pad and rotor replacement", Price: "350" } },
+    ] as const;
+
+    const staged = fixtures.map((fixture, index) => stage(fixture.domain, fixture.row as Record<string, string>, index).entity).filter(Boolean);
+    const counts = staged.reduce<Record<string, number>>((acc, entity) => {
+      acc[entity!.entity_type] = (acc[entity!.entity_type] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    expect(counts.customer ?? 0).toBeGreaterThan(0);
+    expect(counts.vehicle ?? 0).toBeGreaterThan(0);
+    expect(counts.historical_work_order ?? 0).toBeGreaterThan(0);
+    expect(counts.historical_invoice ?? 0).toBeGreaterThan(0);
+    expect(counts.part ?? 0).toBeGreaterThan(0);
+    expect(counts.vendor ?? 0).toBeGreaterThan(0);
+    expect(counts.staff_candidate ?? 0).toBeGreaterThan(0);
+    expect(counts.menu_suggestion ?? 0).toBeGreaterThan(0);
+
+    const graph = buildStagedLinks({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: staged.map((entity, index) => ({ id: `entity-${index}`, entity_type: entity!.entity_type, normalized: entity!.normalized, status: entity!.status })),
+    });
+    expect(graph.links.some((link) => link.link_type === "customer_vehicle")).toBe(true);
+    expect(graph.links.some((link) => link.link_type === "customer_work_order")).toBe(true);
+    expect(graph.links.some((link) => link.link_type === "vehicle_work_order")).toBe(true);
+    expect(graph.links.some((link) => link.link_type === "work_order_invoice")).toBe(true);
+    expect(graph.links.some((link) => link.link_type === "vendor_part")).toBe(true);
   });
 
   it("does not create missing-link reviews when no lookup identity exists", () => {

--- a/features/onboarding-agent/lib/staging.ts
+++ b/features/onboarding-agent/lib/staging.ts
@@ -106,11 +106,10 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
 
   if (domain === "history") {
     const hasPrimary = has(n.sourceWorkOrderId) || has(n.invoiceId);
-    const hasContext = has(n.sourceCustomerId) || has(n.customerEmail) || has(n.customerName)
-      || has(n.sourceVehicleId) || has(n.vehicleVin) || has(n.vehiclePlate) || has(n.vehicleUnitNumber);
-    const hasNarrative = has(n.complaint) || has(n.cause) || has(n.correction) || has(n.serviceDescription) || has(n.invoiceNumber);
+    const hasNarrative = has(n.complaint) || has(n.cause) || has(n.correction) || has(n.serviceDescription);
     const hasDate = has(n.openedDate) || has(n.closedDate);
-    if (hasPrimary || ((hasNarrative || hasContext) && hasDate)) {
+    const hasOdometerNarrative = has(n.odometer) && hasNarrative;
+    if (hasPrimary || (hasDate && hasNarrative) || hasOdometerNarrative) {
       status = "ready";
       confidence = 0.86;
       reviewReason = null;
@@ -132,7 +131,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "parts") {
-    if (has(n.sku) || has(n.partNumber) || has(n.description)) {
+    if (has(n.sku) || has(n.partNumber) || has(n.description) || has(n.vendorPartNumber)) {
       status = "ready";
       confidence = 0.82;
       reviewReason = null;
@@ -140,7 +139,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "vendors") {
-    if (has(n.name) || has(n.sourceVendorId) || has(n.accountNumber)) {
+    if (has(n.name) || has(n.sourceVendorId) || has(n.accountNumber) || has(n.email) || has(n.phone)) {
       status = "ready";
       confidence = 0.84;
       reviewReason = null;
@@ -148,7 +147,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "staff") {
-    if (has(n.name) || has(n.email) || has(n.username)) {
+    if (has(n.name) || has(n.email) || has(n.username) || has(n.role)) {
       status = "ready";
       confidence = 0.82;
       reviewReason = null;
@@ -156,7 +155,7 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
   }
 
   if (domain === "menu") {
-    if (has(n.serviceName) || has(n.description)) {
+    if (has(n.serviceName) || has(n.description) || has(n.laborHours) || hasNumber(n.laborPrice)) {
       status = "ready";
       confidence = 0.8;
       reviewReason = null;

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -50,7 +50,6 @@ function remapHeaders(raw: Record<string, unknown>, map: Record<string, string>)
     const key = map[k] ?? map[k.toLowerCase()] ?? normalizedMap[normalizeKey(k)] ?? k;
     const stringValue = typeof v === "string" ? v : String(v ?? "");
     if (!(key in out) || !out[key]) out[key] = stringValue;
-    if (!(k in out)) out[k] = stringValue;
   }
   return out;
 }
@@ -91,6 +90,19 @@ export async function applyOnboardingAgentPlan(params: {
   const reviewItems: any[] = [];
   const stagedByDomain: Record<string, number> = {};
   const reviewByDomain: Record<string, number> = {};
+  const effectiveFileMappings: Array<{
+    fileId: string;
+    filename: string;
+    domain: OnboardingDomain;
+    mappedColumnCount: number;
+    mappingSource: "ai" | "deterministic_alias" | "mixed" | "none";
+    aiMappedColumnCount: number;
+    deterministicMappedColumnCount: number;
+    canonicalPassthroughColumnCount: number;
+    rawRowsProcessed: number;
+    stagedRows: number;
+    reviewRows: number;
+  }> = [];
 
   for (const [fileId, fileRows] of rawRowsByFile.entries()) {
     const planFile = fileMap.get(fileId);
@@ -109,7 +121,11 @@ export async function applyOnboardingAgentPlan(params: {
               : deterministicDomain));
     const domain = DOMAIN_TO_ENTITY[effectiveDomain] ?? "unknown";
     const fileHeaders = Array.isArray(fileMeta?.header_row) ? fileMeta.header_row : [];
-    const { headerMap, mappingSource } = buildEffectiveHeaderMap({ domain, headers: fileHeaders, aiHeaderMap: planFile?.headerMap ?? {} });
+    const { headerMap, mappingSource, mappedColumnCount, diagnostics } = buildEffectiveHeaderMap({
+      domain,
+      headers: fileHeaders,
+      aiHeaderMap: planFile?.headerMap ?? {},
+    });
     const parserMode = planFile?.recommendedParserMode ?? (domain === "unknown" ? "stage_review_only" : "stage_entities");
     let stagedForFile = 0;
     let reviewForFile = 0;
@@ -155,9 +171,16 @@ export async function applyOnboardingAgentPlan(params: {
           shopId: params.shopId,
           fileId,
           filename: planFile?.filename ?? fileMeta?.original_filename ?? fileId,
+          declaredDomain: fileMeta?.declared_domain ?? null,
+          detectedDomain: fileMeta?.detected_domain ?? null,
           inferredDomain: effectiveDomain,
+          mappingSource,
+          mappedColumnCount,
+          effectiveHeaderMapKeys: Object.keys(headerMap),
           rowIndex: Number(row.source_row_index ?? 0),
           rawHeaderKeys: Object.keys((row.raw ?? {}) as Record<string, unknown>),
+          rawRowSampleKeysOnly: Object.keys((row.raw ?? {}) as Record<string, unknown>),
+          remappedRowKeys: Object.keys(mappedRow),
           effectiveMappedKeys: Object.keys(mappedRow).filter((key) => key in normalized.normalized),
           normalizedKeysPresent: Object.entries(normalized.normalized).filter(([, value]) => {
             if (typeof value === "string") return value.trim().length > 0;
@@ -165,6 +188,12 @@ export async function applyOnboardingAgentPlan(params: {
             return Boolean(value);
           }).map(([key]) => key),
           entityStaged: Boolean(staged.entity && parserMode === "stage_entities"),
+          stageResult: {
+            entityCreated: Boolean(staged.entity && parserMode === "stage_entities"),
+            entityType: staged.entity?.entity_type ?? normalized.entityType,
+            status: staged.entity?.status ?? null,
+            reviewItemsGenerated: staged.reviewItems.map((item) => item.issue_type),
+          },
           reviewIssueTypes: staged.reviewItems.map((item) => item.issue_type),
           fingerprint: fingerprint ?? null,
         });
@@ -180,9 +209,22 @@ export async function applyOnboardingAgentPlan(params: {
       rawRowsProcessed: fileRows.length,
       rowsStaged: stagedForFile,
       rowsReview: reviewForFile,
-      mappedColumns: Object.keys(headerMap).length,
+      mappedColumns: mappedColumnCount,
       mappingSource,
       missingIdentity,
+    });
+    effectiveFileMappings.push({
+      fileId,
+      filename: planFile?.filename ?? fileMeta?.original_filename ?? fileId,
+      domain,
+      mappedColumnCount,
+      mappingSource,
+      aiMappedColumnCount: diagnostics.aiMappedColumns,
+      deterministicMappedColumnCount: diagnostics.deterministicMappedColumns,
+      canonicalPassthroughColumnCount: diagnostics.canonicalPassthroughColumns,
+      rawRowsProcessed: fileRows.length,
+      stagedRows: stagedForFile,
+      reviewRows: reviewForFile,
     });
 
     await sb.from("onboarding_files").update({
@@ -251,6 +293,7 @@ export async function applyOnboardingAgentPlan(params: {
     ...canonical.summaryCounts,
     aiRowsSampled: Number(existingSummary.aiRowsSampled ?? 0),
     aiFilesSampled: Number(existingSummary.aiFilesSampled ?? 0),
+    effectiveFileMappings,
     activationReadiness: canonical.activation_readiness,
     activationPlanSummary: canonical.activation_plan_summary,
     liveRecordsCreated: 0,


### PR DESCRIPTION
### Motivation
- The onboarding staging pipeline was producing incorrect/missing staged entities because execution relied too heavily on AI plan header maps and declared domains that could be invalid. 
- Deterministic filename/header mapping must be an executable fallback so known CSVs stage correctly even when AI maps are empty or reversed. 
- Add safe, non-sensitive per-file/per-row tracing to diagnose mapping/normalization/linking without exposing PII.

### Description
- Hardened file domain detection to ignore invalid `declared_domain` values and prefer deterministic filename/header detection via `detectFileDomain`.
- Improved header mapping with `buildEffectiveHeaderMap` to enforce a source-header -> canonical-field contract, added `mappedColumnCount` and diagnostics, and normalized AI-provided maps that were reversed.
- Rewrote normalization to prefer canonical mapped keys (supporting camelCase/punctuation variants) and added odometer extraction, plus adjusted normalization helpers to consult canonical keys when resolving values.
- Relaxed and clarified domain identity rules in `stageEntityFromNormalized` so history/parts/vendors/staff/menu rows with realistic identity cues stage as `ready` rather than being rejected.
- Ensured `applyOnboardingAgentPlan` processes the full persisted `onboarding_raw_rows` set (paginated), uses the effective header map at execution time, prevents adding duplicate raw keys, and records a safe `row trace` (keys/counts only) for one representative row per file.
- Persisted per-file `effectiveFileMappings` into the session `summary` and surfaced Effective vs AI mapping metrics in the Insights UI (`OnboardingAgentInsightsPanel`) to avoid misleading “mapped: 0” displays.
- Added and updated targeted unit tests including header-mapping counts, `detectFileDomain` fallback, a no-vehicle-link guard, and a golden 8-file pipeline test that asserts each expected domain stages and only creates links when endpoints exist.

### Testing
- Ran `npx tsc --noEmit` successfully with no new type errors introduced. 
- Ran the linter with `npx eslint ...` on the touched onboarding files; the run completed with existing `@typescript-eslint/no-explicit-any` warnings (23 warnings) and no new lint errors. 
- Ran unit tests with Vitest: `npx vitest run features/onboarding-agent/lib/onboarding-agent-ai.test.ts` (11 tests passed), `npx vitest run features/onboarding-agent/lib/onboarding-agent-staging.test.ts` (29 tests passed), and `npx vitest run features/onboarding-agent/server/sessionListSummary.test.ts` (1 test passed). 
- Summary: type checking and tests passed; linter reported existing warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb0061e8c8328ab48028266e8ff58)