### PR TITLE
Stabilize onboarding-agent analyze/rerun with safe reset and idempotent staging

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/rerun/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/rerun/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { analyzeOnboardingSession } from "@/features/onboarding-agent/server/analyzeOnboardingSession";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id as string;
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    await assertOnboardingSessionOwnership({ supabase: admin, shopId, sessionId });
+    const result = await analyzeOnboardingSession({ supabase: admin, shopId, sessionId });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Rerun failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/db/sql/2026-04-27_onboarding_agent_analysis_statuses_and_idempotency.sql
+++ b/db/sql/2026-04-27_onboarding_agent_analysis_statuses_and_idempotency.sql
@@ -1,0 +1,25 @@
+-- Expand onboarding session analysis statuses for explicit staged analysis phases.
+-- Add deterministic-id uniqueness helpers for rerunnable staged artifacts.
+
+begin;
+
+alter table public.onboarding_sessions
+  drop constraint if exists onboarding_sessions_status_check;
+
+alter table public.onboarding_sessions
+  add constraint onboarding_sessions_status_check
+  check (status in (
+    'draft','files_uploaded','analyzing_started','clearing_previous_analysis','applying_analysis','analyzing','analysis_failed','analysis_ready','review_required','activation_ready','activating','activated','blocked','cancelled'
+  ));
+
+create unique index if not exists onboarding_entities_shop_session_source_row_entity_type_uidx
+  on public.onboarding_entities(shop_id, session_id, source_file_id, source_row_index, entity_type)
+  where source_file_id is not null and source_row_index is not null;
+
+create unique index if not exists onboarding_entity_links_shop_session_edge_type_uidx
+  on public.onboarding_entity_links(shop_id, session_id, link_type, from_entity_id, to_entity_id);
+
+create unique index if not exists onboarding_review_items_shop_session_issue_scope_uidx
+  on public.onboarding_review_items(shop_id, session_id, domain, issue_type, severity, md5(coalesce(details::text, '')));
+
+commit;

--- a/features/onboarding-agent/components/OnboardingProgressCard.tsx
+++ b/features/onboarding-agent/components/OnboardingProgressCard.tsx
@@ -3,8 +3,8 @@ export function OnboardingProgressCard({ summary }: { summary?: Record<string, u
     ["Uploaded files", String((summary?.uploadedFiles as number) ?? (summary?.fileCount as number) ?? 0)],
     ["Rows parsed", String((summary?.rowsParsedTotal as number) ?? (summary?.rowsParsed as number) ?? 0)],
     ["AI sampled rows", String((summary?.aiRowsSampled as number) ?? 0)],
-    ["Unique staged entities", String((summary?.entitiesDiscovered as number) ?? 0)],
-    ["Links found", String((summary?.linksFound as number) ?? 0)],
+    ["Persisted staged entities", String((summary?.entitiesDiscovered as number) ?? 0)],
+    ["Relationship links", String((summary?.linksFound as number) ?? 0)],
     ["Review exceptions", String((summary?.reviewExceptions as number) ?? 0)],
   ];
 

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -29,13 +29,14 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     void load();
   }, [load]);
 
-  const analyze = async () => {
+  const analyze = async (mode: "analyze" | "rerun" = "analyze") => {
     setAnalyzing(true);
     setError(null);
     setNotice(null);
 
     try {
-      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/analyze`, { method: "POST" });
+      const endpoint = mode === "rerun" ? "rerun" : "analyze";
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/${endpoint}`, { method: "POST" });
       const json = await res.json();
 
       if (!res.ok || !json.ok) {
@@ -134,15 +135,15 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
         <div className="flex flex-wrap gap-2">
           <button
-            onClick={analyze}
-            disabled={!hasFiles || analyzing || deleting}
+            onClick={() => analyze("analyze")}
+            disabled={!hasFiles || hasAnalysis || analyzing || deleting}
             className="rounded border border-cyan-400/40 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {analyzing ? "Analyzing…" : "Analyze staged files"}
           </button>
           {hasAnalysis ? (
             <button
-              onClick={analyze}
+              onClick={() => analyze("rerun")}
               disabled={!hasFiles || analyzing || deleting}
               className="rounded border border-white/20 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             >
@@ -166,6 +167,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         </div>
 
         {!hasFiles ? <p className="mt-2 text-xs text-slate-400">Upload at least one file before analysis.</p> : null}
+        {hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analysis already exists; use Rerun analysis to safely clear and rebuild staged artifacts.</p> : null}
         {!hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analyze staged files before preparing an activation plan.</p> : null}
         {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}

--- a/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
+++ b/features/onboarding-agent/lib/onboarding-agent-staging.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprints";
 import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
-import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { stableUuidFromParts, stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
 import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { buildEffectiveHeaderMap } from "@/features/onboarding-agent/lib/headerMapping";
 import { buildDeterministicFallbackReport } from "@/features/onboarding-agent/server/runOnboardingAgentAnalysis";
@@ -26,6 +26,20 @@ function stage(domain: any, row: Record<string, string>, sourceRowIndex = 0) {
 }
 
 describe("onboarding staging", () => {
+  it("stableUuidFromParts is deterministic", () => {
+    const a = stableUuidFromParts(["shop-1", "session-1", "file-1", 10, "vehicle"]);
+    const b = stableUuidFromParts(["shop-1", "session-1", "file-1", 10, "vehicle"]);
+    const c = stableUuidFromParts(["shop-1", "session-1", "file-1", 11, "vehicle"]);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it("staged entity id is deterministic across reruns for same source row", () => {
+    const one = stage("customers", { "Customer ID": "C-1", "Full Name": "Jane Doe", Email: "jane@example.com" }, 7);
+    const two = stage("customers", { "Customer ID": "C-1", "Full Name": "Jane Doe", Email: "jane@example.com" }, 7);
+    expect(one.entity?.id).toBeTruthy();
+    expect(one.entity?.id).toBe(two.entity?.id);
+  });
 
   it("deterministic header mapping provides canonical fields when AI map is empty", () => {
     const effective = buildEffectiveHeaderMap({
@@ -256,6 +270,44 @@ describe("onboarding staging", () => {
       activationPlanSummary: null,
     });
     expect(report.liveRecordsCreated).toBe(0);
+  });
+
+  it("fetchOnboardingRawRows paginates beyond 1000 rows", async () => {
+    const PAGE = 1000;
+    const rows = Array.from({ length: 1450 }).map((_, i) => ({
+      id: `row-${i}`,
+      file_id: "file-1",
+      source_row_index: i,
+      raw: { i },
+      shop_id: "shop-1",
+      session_id: "session-1",
+    }));
+    const ranges: Array<{ from: number; to: number }> = [];
+
+    const sb = {
+      from() {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          order() { return this; },
+          range(from: number, to: number) {
+            ranges.push({ from, to });
+            return Promise.resolve({ data: rows.slice(from, to + 1), error: null });
+          },
+        };
+      },
+    };
+
+    const output = await fetchOnboardingRawRows({
+      sb,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      select: "id,file_id,source_row_index,raw",
+    });
+
+    expect(output).toHaveLength(1450);
+    expect(ranges.length).toBeGreaterThan(1);
+    expect(ranges[0]).toEqual({ from: 0, to: PAGE - 1 });
   });
 
   it("deterministic report carries non-empty entity/link count input", () => {

--- a/features/onboarding-agent/lib/sessionStatus.ts
+++ b/features/onboarding-agent/lib/sessionStatus.ts
@@ -1,7 +1,11 @@
 export type OnboardingSessionStatus =
   | "draft"
   | "files_uploaded"
+  | "analyzing_started"
+  | "clearing_previous_analysis"
+  | "applying_analysis"
   | "analyzing"
+  | "analysis_failed"
   | "analysis_ready"
   | "review_required"
   | "activation_ready"

--- a/features/onboarding-agent/lib/staging.ts
+++ b/features/onboarding-agent/lib/staging.ts
@@ -1,4 +1,5 @@
 import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
+import { createHash } from "node:crypto";
 
 export type EntityStatus = "ready" | "needs_review" | "duplicate_candidate";
 
@@ -12,6 +13,12 @@ export type StageEntityInput = {
   shopId: string;
   sessionId: string;
 };
+
+export function stableUuidFromParts(parts: Array<string | number | null | undefined>): string {
+  const seed = parts.map((part) => String(part ?? "")).join("|");
+  const hex = createHash("sha1").update(seed).digest("hex").slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
 
 function text(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -207,6 +214,14 @@ export function stageEntityFromNormalized(input: StageEntityInput & { canonicalF
 
   return {
     entity: {
+      id: stableUuidFromParts([
+        "onboarding_entity",
+        input.shopId,
+        input.sessionId,
+        input.sourceFileId,
+        input.sourceRowIndex,
+        entityTypeByDomain[domain] ?? "unknown",
+      ]),
       shop_id: input.shopId,
       session_id: input.sessionId,
       entity_type: entityTypeByDomain[domain] ?? "unknown",

--- a/features/onboarding-agent/server/analyzeOnboardingSession.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.ts
@@ -5,6 +5,7 @@ import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/se
 import { applyOnboardingAgentPlan } from "@/features/onboarding-agent/server/applyOnboardingAgentPlan";
 import { buildOnboardingAgentInput } from "@/features/onboarding-agent/server/buildOnboardingAgentInput";
 import { runOpenAIOnboardingPlan } from "@/features/onboarding-agent/server/runOpenAIOnboardingPlan";
+import { resetOnboardingAnalysisArtifacts } from "@/features/onboarding-agent/server/resetOnboardingAnalysisArtifacts";
 
 const INSERT_CHUNK_SIZE = 1000;
 
@@ -38,11 +39,19 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
     .order("created_at", { ascending: true });
   if (filesError) throw new Error(filesError.message);
 
-  await sb.from("onboarding_sessions").update({ status: "analyzing" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+  await sb.from("onboarding_sessions").update({ status: "analyzing_started" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
 
-  await sb.from("onboarding_raw_rows").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+  try {
+    await resetOnboardingAnalysisArtifacts({
+      supabase: params.supabase,
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+    });
+    await sb.from("onboarding_sessions").update({ status: "applying_analysis" }).eq("id", params.sessionId).eq("shop_id", params.shopId);
 
-  for (const file of files ?? []) {
+    await sb.from("onboarding_raw_rows").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
+
+    for (const file of files ?? []) {
     const dl = await sb.storage.from(file.storage_bucket).download(file.storage_path);
     if (dl.error || !dl.data) {
       const { error: updateError } = await sb
@@ -82,53 +91,68 @@ export async function analyzeOnboardingSession(params: { supabase: SupabaseClien
       .eq("id", file.id)
       .eq("shop_id", params.shopId);
     if (fileUpdateError) throw new Error(fileUpdateError.message);
-  }
+    }
 
-  const input = await buildOnboardingAgentInput({
+    const input = await buildOnboardingAgentInput({
     supabase: params.supabase,
     shopId: params.shopId,
     sessionId: params.sessionId,
   });
 
-  const aiRowsSampled = input.files.reduce((sum, file) => sum + (Array.isArray(file.sampleRows) ? file.sampleRows.length : 0), 0);
-  const aiFilesSampled = input.files.filter((file) => Array.isArray(file.sampleRows) && file.sampleRows.length > 0).length;
+    const aiRowsSampled = input.files.reduce((sum, file) => sum + (Array.isArray(file.sampleRows) ? file.sampleRows.length : 0), 0);
+    const aiFilesSampled = input.files.filter((file) => Array.isArray(file.sampleRows) && file.sampleRows.length > 0).length;
 
-  const { data: sessionForAiSummary } = await sb
+    const { data: sessionForAiSummary } = await sb
     .from("onboarding_sessions")
     .select("summary")
     .eq("id", params.sessionId)
     .eq("shop_id", params.shopId)
     .maybeSingle();
-  const existingAiSummary = (sessionForAiSummary?.summary && typeof sessionForAiSummary.summary === "object") ? sessionForAiSummary.summary : {};
-  await sb.from("onboarding_sessions").update({
-    summary: {
-      ...existingAiSummary,
-      aiRowsSampled,
-      aiFilesSampled,
-      liveRecordsCreated: 0,
-    },
-  }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+    const existingAiSummary = (sessionForAiSummary?.summary && typeof sessionForAiSummary.summary === "object") ? sessionForAiSummary.summary : {};
+    await sb.from("onboarding_sessions").update({
+      summary: {
+        ...existingAiSummary,
+        aiRowsSampled,
+        aiFilesSampled,
+        liveRecordsCreated: 0,
+      },
+    }).eq("id", params.sessionId).eq("shop_id", params.shopId);
 
-  const requireAi = process.env.ONBOARDING_AGENT_REQUIRE_AI === "true";
-  const { plan, warning } = await runOpenAIOnboardingPlan({ input, requireAi });
-  const applied = await applyOnboardingAgentPlan({
-    supabase: params.supabase,
-    shopId: params.shopId,
-    sessionId: params.sessionId,
-    plan,
-  });
+    const requireAi = process.env.ONBOARDING_AGENT_REQUIRE_AI === "true";
+    const { plan, warning } = await runOpenAIOnboardingPlan({ input, requireAi });
+    const applied = await applyOnboardingAgentPlan({
+      supabase: params.supabase,
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      plan,
+    });
 
-  return {
-    mode: plan.mode,
-    warning,
-    planSummary: {
-      summary: plan.summary,
-      confidence: plan.confidence,
-      activationReadiness: plan.activationReadiness,
-      model: plan.model ?? null,
-      files: plan.files.length,
-    },
-    sessionSummary: applied.summary,
-    liveRecordsCreated: 0 as const,
-  };
+    return {
+      mode: plan.mode,
+      warning,
+      planSummary: {
+        summary: plan.summary,
+        confidence: plan.confidence,
+        activationReadiness: plan.activationReadiness,
+        model: plan.model ?? null,
+        files: plan.files.length,
+      },
+      sessionSummary: applied.summary,
+      liveRecordsCreated: 0 as const,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Analysis failed";
+    const { data: failedSession } = await sb.from("onboarding_sessions").select("summary").eq("id", params.sessionId).eq("shop_id", params.shopId).maybeSingle();
+    const failedSummary = (failedSession?.summary && typeof failedSession.summary === "object") ? failedSession.summary : {};
+    await sb.from("onboarding_sessions").update({
+      status: "analysis_failed",
+      summary: {
+        ...failedSummary,
+        analysisError: message,
+        analysisFailedAt: new Date().toISOString(),
+        liveRecordsCreated: 0,
+      },
+    }).eq("id", params.sessionId).eq("shop_id", params.shopId);
+    throw error;
+  }
 }

--- a/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
+++ b/features/onboarding-agent/server/applyOnboardingAgentPlan.ts
@@ -3,7 +3,7 @@ import { fingerprintForDomain } from "@/features/onboarding-agent/lib/fingerprin
 import { buildStagedLinks } from "@/features/onboarding-agent/lib/graph";
 import { normalizeRow } from "@/features/onboarding-agent/lib/normalization";
 import { nextStatusFromCounts } from "@/features/onboarding-agent/lib/sessionStatus";
-import { stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
+import { stableUuidFromParts, stageEntityFromNormalized } from "@/features/onboarding-agent/lib/staging";
 import { buildOnboardingSummary, groupReviewItems } from "@/features/onboarding-agent/lib/summaries";
 import type { OnboardingDomain } from "@/features/onboarding-agent/lib/domains";
 import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
@@ -20,7 +20,7 @@ async function insertInChunks(sb: any, table: string, rows: any[], returning?: s
   const output: any[] = [];
   for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
     const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
-    let query = sb.from(table).insert(chunk);
+    let query = sb.from(table).upsert(chunk, { onConflict: "id" });
     if (returning) query = query.select(returning);
     const { data, error } = await query;
     if (error) throw new Error(error.message);
@@ -97,9 +97,6 @@ export async function applyOnboardingAgentPlan(params: {
   plan: OnboardingAgentPlan;
 }) {
   const sb = params.supabase as any;
-  await sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
-  await sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
-  await sb.from("onboarding_review_items").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId);
 
   const fileMap = new Map(params.plan.files.map((file) => [file.fileId, file]));
   const { data: filesData } = await sb
@@ -205,7 +202,7 @@ export async function applyOnboardingAgentPlan(params: {
         reviewItemsByFile[fileId] = byFile;
         reviewForFile += staged.reviewItems.length;
         reviewByDomain[domain] = (reviewByDomain[domain] ?? 0) + staged.reviewItems.length;
-        reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: item.details })));
+        reviewItems.push(...staged.reviewItems.map((item) => ({ severity: item.severity, domain: item.domain, issue_type: item.issue_type, summary: item.summary, details: { ...(item.details ?? {}), fileId } })));
       }
 
       if (!didTraceRow) {
@@ -324,12 +321,18 @@ export async function applyOnboardingAgentPlan(params: {
 
   const entities = await insertInChunks(sb, "onboarding_entities", stagedEntities, "id, entity_type, status, normalized");
   const graph = buildStagedLinks({ entities: (entities ?? []).map((e: any) => ({ ...e, normalized: e.normalized ?? {} })), shopId: params.shopId, sessionId: params.sessionId });
-  const linksToInsert = graph.links.map((link) => ({ ...link, shop_id: params.shopId, session_id: params.sessionId }));
+  const linksToInsert = graph.links.map((link) => ({
+    ...link,
+    id: stableUuidFromParts(["onboarding_link", params.shopId, params.sessionId, link.link_type, link.from_entity_id, link.to_entity_id]),
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+  }));
   const insertedLinks = await insertInChunks(sb, "onboarding_entity_links", linksToInsert, "id, link_type, status");
 
-  reviewItems.push(...graph.reviewItems);
+  reviewItems.push(...graph.reviewItems.map((item) => ({ ...item, details: item.details ?? {} })));
 
   const groupedReviewItems = groupReviewItems(reviewItems as any).map((item) => ({
+    id: stableUuidFromParts(["onboarding_review", params.shopId, params.sessionId, item.domain, item.issue_type, item.severity, JSON.stringify(item.details ?? {})]),
     shop_id: params.shopId,
     session_id: params.sessionId,
     entity_id: null,
@@ -352,12 +355,6 @@ export async function applyOnboardingAgentPlan(params: {
     linksByEntityId.set(link.to_entity_id, to);
   }
 
-  const reviewCountsByIssueCode = groupedReviewItems.reduce<Record<string, number>>((acc, item) => {
-    const issueCode = String(item.issue_type ?? "issue");
-    acc[issueCode] = (acc[issueCode] ?? 0) + 1;
-    return acc;
-  }, {});
-
   for (const trace of pipelineTraces) {
     const stagedForFile = stagedEntitiesByFile[trace.fileId] ?? [];
     const linkCounts = stagedForFile.reduce<Record<string, number>>((acc, entity) => {
@@ -368,10 +365,13 @@ export async function applyOnboardingAgentPlan(params: {
     trace.persistedLinkCountsByType = linkCounts;
     trace.rowsSampledForAI = Math.min(trace.rowCountTotal, 25);
     trace.readyCount = stagedForFile.filter((entity) => String(entity.status ?? "ready") === "ready").length;
-    trace.reviewCount = stagedForFile.filter((entity) => String(entity.status ?? "ready") !== "ready").length;
-    trace.reviewIssueCountsByCode = Object.keys(trace.reviewIssueCountsByCode).length
-      ? trace.reviewIssueCountsByCode
-      : reviewCountsByIssueCode;
+    const fileReviewItems = groupedReviewItems.filter((item) => String((item.details as Record<string, unknown> | undefined)?.fileId ?? "") === trace.fileId);
+    trace.reviewCount = fileReviewItems.length;
+    trace.reviewIssueCountsByCode = fileReviewItems.reduce<Record<string, number>>((acc, item) => {
+      const issueCode = String(item.issue_type ?? "issue");
+      acc[issueCode] = (acc[issueCode] ?? 0) + 1;
+      return acc;
+    }, {});
   }
 
   const { data: files } = await sb.from("onboarding_files").select("id").eq("shop_id", params.shopId).eq("session_id", params.sessionId);

--- a/features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.test.ts
+++ b/features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { resetOnboardingAnalysisArtifacts } from "@/features/onboarding-agent/server/resetOnboardingAnalysisArtifacts";
+
+describe("resetOnboardingAnalysisArtifacts", () => {
+  it("clears staged artifacts in dependency order scoped by shop+session", async () => {
+    const calls: string[] = [];
+
+    const sb = {
+      from(table: string) {
+        return {
+          update() { calls.push(`update:${table}`); return this; },
+          delete() { calls.push(`delete:${table}`); return this; },
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle() { return Promise.resolve({ data: { summary: { aiRowsSampled: 50 } }, error: null }); },
+          then(resolve: (v: any) => unknown, reject?: (r?: unknown) => unknown) {
+            return Promise.resolve({ error: null }).then(resolve, reject);
+          },
+        };
+      },
+    };
+
+    await resetOnboardingAnalysisArtifacts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1" });
+
+    expect(calls).toEqual([
+      "update:onboarding_sessions",
+      "delete:onboarding_entity_links",
+      "delete:onboarding_review_items",
+      "delete:onboarding_entities",
+      "update:onboarding_sessions",
+    ]);
+  });
+});

--- a/features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.ts
+++ b/features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const SUMMARY_RESET = {
+  uploadedFiles: 0,
+  rowsParsed: 0,
+  rowsParsedTotal: 0,
+  aiRowsSampled: 0,
+  aiFilesSampled: 0,
+  entitiesDiscovered: 0,
+  linksFound: 0,
+  reviewExceptions: 0,
+  groupedExceptionCount: 0,
+  effectiveFileMappings: [],
+  filePipelineTraces: [],
+  activationReadiness: "not_ready",
+  activationPlanSummary: null,
+  agentPlan: null,
+  agentReport: null,
+  analysisError: null,
+  analysisFailedAt: null,
+  liveRecordsCreated: 0,
+};
+
+export async function resetOnboardingAnalysisArtifacts(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+}) {
+  const sb = params.supabase as any;
+
+  const run = async (promise: Promise<{ error?: { message?: string } | null }>) => {
+    const { error } = await promise;
+    if (error) throw new Error(error.message ?? "Failed onboarding analysis reset step");
+  };
+
+  await run(sb.from("onboarding_sessions").update({ status: "clearing_previous_analysis" }).eq("shop_id", params.shopId).eq("id", params.sessionId));
+
+  await run(sb.from("onboarding_entity_links").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId));
+  await run(sb.from("onboarding_review_items").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId));
+  await run(sb.from("onboarding_entities").delete().eq("shop_id", params.shopId).eq("session_id", params.sessionId));
+
+  const { data: session } = await sb.from("onboarding_sessions").select("summary").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle();
+  const existingSummary = (session?.summary && typeof session.summary === "object") ? session.summary : {};
+
+  await run(sb.from("onboarding_sessions").update({
+    analyzed_at: null,
+    stats: {},
+    summary: {
+      ...existingSummary,
+      ...SUMMARY_RESET,
+    },
+  }).eq("shop_id", params.shopId).eq("id", params.sessionId));
+}


### PR DESCRIPTION
### Motivation

- Previous analyze runs could time out and leave partial persisted staged rows/links/reviews that blocked safe reruns due to duplicate-key conflicts and misleading UI counts.  
- Rerun must be resumable, idempotent, and scoped to `shop_id + session_id` without creating any live records.  
- Per-file traces and top review codes must reflect persisted, file-scoped review items (not global or capped samples).

### Description

- Added a scoped reset helper `resetOnboardingAnalysisArtifacts` that clears staged artifacts in dependency-safe order (`onboarding_entity_links` → `onboarding_review_items` → `onboarding_entities`) and resets session summary/stats while preserving uploaded files/raw rows; file: `features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.ts`.  
- Updated analyze flow to explicit phase states and safe failure handling: `analyzing_started`, `clearing_previous_analysis`, `applying_analysis`, `analysis_failed`; analyze now calls the reset helper before rebuilding; file: `features/onboarding-agent/server/analyzeOnboardingSession.ts`.  
- Made staged artifacts idempotent/deterministic by generating stable UUIDs (`stableUuidFromParts`) for staged entities/links/review groups and switching to chunked upserts (`upsert` by `id`) to avoid duplicate-key aborts on rerun; files: `features/onboarding-agent/lib/staging.ts`, `features/onboarding-agent/server/applyOnboardingAgentPlan.ts`.  
- Built a dedicated rerun API route `POST /api/onboarding-agent/sessions/[sessionId]/rerun` that reuses the same safe analyze path; file: `app/api/onboarding-agent/sessions/[sessionId]/rerun/route.ts`.  
- UI: changed analyze button semantics so initial `Analyze staged files` is disabled once analysis exists and the user is guided to use `Rerun analysis` for safe rebuilds; file: `features/onboarding-agent/components/OnboardingSessionPage.tsx`.  
- Fixed per-file trace aggregation so top review codes/counts are derived from persisted review items scoped to each file trace instead of falling back to a global set; file: `features/onboarding-agent/server/applyOnboardingAgentPlan.ts`.  
- Clarified progress card labels to emphasize persisted-truth counts (`Persisted staged entities`, `Relationship links`); file: `features/onboarding-agent/components/OnboardingProgressCard.tsx`.  
- Added SQL hardening migration to expand allowed session statuses and add scoped uniqueness indexes to support deterministic reruns (`db/sql/2026-04-27_onboarding_agent_analysis_statuses_and_idempotency.sql`).  
- Tests added/updated: deterministic UUID behavior, pagination for `fetchOnboardingRawRows` (>1000 rows), and reset ordering/scope; files: `features/onboarding-agent/lib/onboarding-agent-staging.test.ts`, `features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.test.ts`.

### Testing

- Type check: ran `npx tsc --noEmit` and it succeeded.  
- Unit tests: ran `npx vitest` for onboarding-agent test groups including `features/onboarding-agent/lib/onboarding-agent-ai.test.ts`, `features/onboarding-agent/lib/onboarding-agent-staging.test.ts`, `features/onboarding-agent/lib/onboarding-agent-golden-files.test.ts`, `features/onboarding-agent/server/sessionListSummary.test.ts`, `features/onboarding-agent/server/deleteOnboardingSession.test.ts`, and the new `features/onboarding-agent/server/resetOnboardingAnalysisArtifacts.test.ts`; all test files and tests passed.  
- Lint: ran `npx eslint` on modified files; there are warnings (pre-existing `no-explicit-any` uses) but no new lint errors.  

If you want, I can split the SQL migration into a separate PR or add a short rollout checklist for applying the DB migration in staging before running large analyzes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc2d4f7708328913ad7c7a3dc9983)