### PR TITLE
Fix onboarding-agent summary and activation counts beyond 1000 rows

### DIFF
--- a/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
+++ b/features/onboarding-agent/server/buildOnboardingActivationPlan.ts
@@ -2,6 +2,12 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildDryRunActivationPlan } from "@/features/onboarding-agent/lib/activationPlan";
 import { buildOnboardingSummary } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import {
+  countOnboardingEntities,
+  countOnboardingEntityLinks,
+  countOnboardingPendingReviewItems,
+  fetchPaginatedOnboardingRows,
+} from "@/features/onboarding-agent/server/rawRowCounts";
 
 export async function buildOnboardingActivationPlan(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
@@ -11,12 +17,39 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
     sessionId: params.sessionId,
   });
 
-  const [{ data: entityRows }, { data: linkRows }, { data: reviewRows }, { data: filesRows }, { data: sessionRow }] = await Promise.all([
-    sb.from("onboarding_entities").select("entity_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_review_items").select("severity, status, domain, issue_type, summary, details").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+  const [entityRows, linkRows, reviewRows, { data: filesRows }, { data: sessionRow }, totalEntitiesCount, totalLinksCount, totalPendingReviewCount] = await Promise.all([
+    fetchPaginatedOnboardingRows<{ entity_type: string; status?: string | null }>({
+      supabase: params.supabase,
+      table: "onboarding_entities",
+      select: "entity_type, status",
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      orderBy: "id",
+      ascending: true,
+    }),
+    fetchPaginatedOnboardingRows<{ link_type: string; status?: string | null }>({
+      supabase: params.supabase,
+      table: "onboarding_entity_links",
+      select: "link_type, status",
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      orderBy: "id",
+      ascending: true,
+    }),
+    fetchPaginatedOnboardingRows<any>({
+      supabase: params.supabase,
+      table: "onboarding_review_items",
+      select: "severity, status, domain, issue_type, summary, details",
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      orderBy: "id",
+      ascending: true,
+    }),
     sb.from("onboarding_files").select("row_count").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
     sb.from("onboarding_sessions").select("summary, analyzed_at").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
+    countOnboardingEntities({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
+    countOnboardingEntityLinks({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
+    countOnboardingPendingReviewItems({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
   ]);
 
   const filesCount = (filesRows ?? []).length;
@@ -25,9 +58,9 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
   const canonical = buildOnboardingSummary({
     filesCount,
     rowsParsed,
-    entityRows: (entityRows ?? []).map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
-    linkRows: (linkRows ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
-    reviewRows: (reviewRows ?? []).map((row: any) => ({
+    entityRows: entityRows.map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
+    linkRows: linkRows.map((row: any) => ({ link_type: row.link_type, status: row.status })),
+    reviewRows: reviewRows.map((row: any) => ({
       severity: row.severity,
       status: row.status,
       domain: row.domain,
@@ -35,14 +68,14 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
       summary: row.summary ?? "",
       details: row.details ?? {},
     })),
-    groupedExceptionCount: (reviewRows ?? []).length,
+    groupedExceptionCount: totalPendingReviewCount,
     analysisCompleted: Boolean(sessionRow?.analyzed_at),
   });
 
   const plan = buildDryRunActivationPlan({
     sessionId: params.sessionId,
     entityStatusCountsByType: canonical.entity_status_counts_by_type,
-    linkRows: (linkRows ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
+    linkRows: linkRows.map((row: any) => ({ link_type: row.link_type, status: row.status })),
     reviewCountsBySeverity: canonical.review_counts_by_severity,
   });
 
@@ -50,6 +83,9 @@ export async function buildOnboardingActivationPlan(params: { supabase: Supabase
   const summaryWithAgent = {
     ...plan,
     readiness: canonical.activation_readiness,
+    entitiesDiscovered: totalEntitiesCount,
+    linksFound: totalLinksCount,
+    reviewExceptions: totalPendingReviewCount,
     agentReport: sessionSummary.agentReport ?? null,
     liveRecordsCreated: 0,
   };

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -1,7 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildOnboardingSummary, ENTITY_BUCKETS, LINK_BUCKETS } from "@/features/onboarding-agent/lib/summaries";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
-import { countOnboardingRawRows } from "@/features/onboarding-agent/server/rawRowCounts";
+import {
+  countOnboardingEntities,
+  countOnboardingEntityLinks,
+  countOnboardingPendingReviewItems,
+  countOnboardingRawRows,
+  fetchPaginatedOnboardingRows,
+} from "@/features/onboarding-agent/server/rawRowCounts";
 
 export async function getOnboardingSession(params: { supabase: SupabaseClient; shopId: string; sessionId: string }) {
   const sb = params.supabase as any;
@@ -11,26 +17,48 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     sessionId: params.sessionId,
   });
 
-  const [{ data: session }, { data: files }, { data: entities }, { data: links }, { data: reviews }, { data: latestPlan }, rowsParsedTotal] = await Promise.all([
+  const [{ data: session }, { data: files }, entities, links, reviews, { data: latestPlan }, rowsParsedTotal, totalEntitiesCount, totalLinksCount, totalPendingReviewCount] = await Promise.all([
     sb.from("onboarding_sessions").select("*").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
     sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
-    sb.from("onboarding_entities").select("entity_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("onboarding_entity_links").select("link_type, status").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb
-      .from("onboarding_review_items")
-      .select("id, severity, status, domain, summary, issue_type, details")
-      .eq("shop_id", params.shopId)
-      .eq("session_id", params.sessionId)
-      .order("created_at", { ascending: false }),
+    fetchPaginatedOnboardingRows<{ entity_type: string; status?: string | null }>({
+      supabase: params.supabase,
+      table: "onboarding_entities",
+      select: "entity_type, status",
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      orderBy: "id",
+      ascending: true,
+    }),
+    fetchPaginatedOnboardingRows<{ link_type: string; status?: string | null }>({
+      supabase: params.supabase,
+      table: "onboarding_entity_links",
+      select: "link_type, status",
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      orderBy: "id",
+      ascending: true,
+    }),
+    fetchPaginatedOnboardingRows<any>({
+      supabase: params.supabase,
+      table: "onboarding_review_items",
+      select: "id, severity, status, domain, summary, issue_type, details",
+      shopId: params.shopId,
+      sessionId: params.sessionId,
+      orderBy: "created_at",
+      ascending: false,
+    }),
     sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
     countOnboardingRawRows({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
+    countOnboardingEntities({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
+    countOnboardingEntityLinks({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
+    countOnboardingPendingReviewItems({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
   ]);
   const canonical = buildOnboardingSummary({
     filesCount: (files ?? []).length,
     rowsParsed: rowsParsedTotal,
-    entityRows: (entities ?? []).map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
-    linkRows: (links ?? []).map((row: any) => ({ link_type: row.link_type, status: row.status })),
-    reviewRows: (reviews ?? []).map((row: any) => ({
+    entityRows: entities.map((row: any) => ({ entity_type: row.entity_type, status: row.status })),
+    linkRows: links.map((row: any) => ({ link_type: row.link_type, status: row.status })),
+    reviewRows: reviews.map((row: any) => ({
       id: row.id,
       severity: row.severity,
       status: row.status,
@@ -39,7 +67,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
       summary: row.summary,
       details: row.details ?? {},
     })),
-    groupedExceptionCount: (reviews ?? []).length,
+    groupedExceptionCount: totalPendingReviewCount,
     analysisCompleted: Boolean(session?.analyzed_at),
   });
 
@@ -66,6 +94,9 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     filePipelineTraces: Array.isArray((session?.summary ?? {})?.filePipelineTraces) ? (session?.summary ?? {}).filePipelineTraces : [],
     aiRowsSampled: Number((session?.summary ?? {})?.aiRowsSampled ?? canonical.summaryCounts.aiRowsSampled ?? 0),
     aiFilesSampled: Number((session?.summary ?? {})?.aiFilesSampled ?? canonical.summaryCounts.aiFilesSampled ?? 0),
+    entitiesDiscovered: totalEntitiesCount,
+    linksFound: totalLinksCount,
+    reviewExceptions: totalPendingReviewCount,
     activationReadiness: canonical.activation_readiness,
     activationPlanSummary: canonical.activation_plan_summary,
     liveRecordsCreated: 0 as const,
@@ -79,7 +110,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     entityCounts,
     entityStatusCounts: canonical.entity_status_counts_by_type,
     reviewCounts,
-    reviewItems: reviews ?? [],
+    reviewItems: reviews,
     linkCounts,
     activationPlanSummary: canonical.activation_plan_summary,
     readiness: canonical.activation_readiness,

--- a/features/onboarding-agent/server/phase1-consolidation.test.ts
+++ b/features/onboarding-agent/server/phase1-consolidation.test.ts
@@ -2,7 +2,142 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { buildOnboardingActivationPlan } from "@/features/onboarding-agent/server/buildOnboardingActivationPlan";
+import { getOnboardingSession } from "@/features/onboarding-agent/server/getOnboardingSession";
 import { ONBOARDING_SESSION_ALLOWED_STATUSES } from "@/features/onboarding-agent/lib/sessionStatus";
+
+function createOnboardingSbMock() {
+  const tables: string[] = [];
+  const entities = Array.from({ length: 1205 }, (_, idx) => ({
+    id: `entity-${idx}`,
+    shop_id: "shop-1",
+    session_id: "session-1",
+    entity_type: idx % 2 === 0 ? "customer" : "vehicle",
+    status: idx % 3 === 0 ? "ready" : "needs_review",
+  }));
+  const links = Array.from({ length: 1301 }, (_, idx) => ({
+    id: `link-${idx}`,
+    shop_id: "shop-1",
+    session_id: "session-1",
+    link_type: idx % 2 === 0 ? "customer_vehicle" : "vehicle_work_order",
+    status: idx % 5 === 0 ? "needs_review" : "staged",
+  }));
+  const reviews = Array.from({ length: 1402 }, (_, idx) => ({
+    id: `review-${idx}`,
+    shop_id: "shop-1",
+    session_id: "session-1",
+    severity: idx % 2 === 0 ? "high" : "low",
+    status: "pending",
+    domain: idx % 2 === 0 ? "customers" : "vehicles",
+    issue_type: idx % 2 === 0 ? "duplicate" : "missing_link",
+    summary: `Issue ${idx}`,
+    details: { sourceRowIndex: idx },
+    created_at: new Date(Date.now() - idx * 1000).toISOString(),
+  }));
+  const files = [{ id: "file-1", shop_id: "shop-1", session_id: "session-1", row_count: 19717 }];
+
+  const rowsByTable: Record<string, any[]> = {
+    onboarding_entities: entities,
+    onboarding_entity_links: links,
+    onboarding_review_items: reviews,
+    onboarding_files: files,
+  };
+
+  const applyFilters = (rows: any[], filters: Record<string, unknown>, orFilter?: string | null) => {
+    let next = rows.filter((row) => Object.entries(filters).every(([key, value]) => row[key] === value));
+    if (orFilter === "status.is.null,status.eq.pending") {
+      next = next.filter((row) => row.status == null || row.status === "pending");
+    }
+    return next;
+  };
+
+  const sb = {
+    from(table: string) {
+      tables.push(table);
+      const state: {
+        filters: Record<string, unknown>;
+        orderBy?: string;
+        ascending: boolean;
+        rangeFrom?: number;
+        rangeTo?: number;
+        orFilter?: string;
+        wantCount: boolean;
+        headOnly: boolean;
+      } = {
+        filters: {},
+        ascending: true,
+        wantCount: false,
+        headOnly: false,
+      };
+
+      const buildResult = () => {
+        if (table === "onboarding_sessions") {
+          return { data: { id: "session-1", summary: {}, analyzed_at: new Date().toISOString() }, error: null, count: null };
+        }
+        if (table === "onboarding_activation_plans") {
+          return { data: { id: "plan-1", status: "ready", summary: {}, created_at: new Date().toISOString() }, error: null, count: null };
+        }
+
+        const rows = applyFilters(rowsByTable[table] ?? [], state.filters, state.orFilter);
+        const count = state.wantCount ? rows.length : null;
+        if (state.headOnly) return { data: null, error: null, count };
+
+        let ordered = [...rows];
+        if (state.orderBy) {
+          ordered.sort((a, b) => {
+            const av = a[state.orderBy!];
+            const bv = b[state.orderBy!];
+            if (av === bv) return 0;
+            if (av == null) return 1;
+            if (bv == null) return -1;
+            return av > bv ? 1 : -1;
+          });
+          if (!state.ascending) ordered.reverse();
+        }
+        if (typeof state.rangeFrom === "number" && typeof state.rangeTo === "number") {
+          ordered = ordered.slice(state.rangeFrom, state.rangeTo + 1);
+        }
+        return { data: ordered, error: null, count };
+      };
+
+      const query: any = {
+        select(_columns?: string, options?: { count?: string; head?: boolean }) {
+          state.wantCount = options?.count === "exact";
+          state.headOnly = options?.head === true;
+          return query;
+        },
+        eq(column: string, value: unknown) {
+          state.filters[column] = value;
+          return query;
+        },
+        or(value: string) {
+          state.orFilter = value;
+          return query;
+        },
+        order(column: string, options?: { ascending?: boolean }) {
+          state.orderBy = column;
+          state.ascending = options?.ascending ?? true;
+          return query;
+        },
+        range(from: number, to: number) {
+          state.rangeFrom = from;
+          state.rangeTo = to;
+          return Promise.resolve(buildResult());
+        },
+        limit() { return query; },
+        maybeSingle() { return Promise.resolve(buildResult()); },
+        single() { return Promise.resolve(buildResult()); },
+        insert() { return query; },
+        update() { return query; },
+        then(resolveFn: (value: any) => unknown, rejectFn?: (reason?: unknown) => unknown) {
+          return Promise.resolve(buildResult()).then(resolveFn, rejectFn);
+        },
+      };
+      return query;
+    },
+  };
+
+  return { sb, tables, entities, links, reviews };
+}
 
 describe("onboarding phase 1 consolidation", () => {
   it("dashboard rerun and session rerun share canonical route helper usage", () => {
@@ -14,35 +149,36 @@ describe("onboarding phase 1 consolidation", () => {
   });
 
   it("activation preview reads staged onboarding artifacts only", async () => {
-    const tables: string[] = [];
-
-    const sb = {
-      from(table: string) {
-        tables.push(table);
-        return {
-          select() { return this; },
-          eq() { return this; },
-          maybeSingle() {
-            if (table === "onboarding_sessions") {
-              return Promise.resolve({ data: { id: "session-1", summary: {}, analyzed_at: new Date().toISOString() }, error: null });
-            }
-            return Promise.resolve({ data: null, error: null });
-          },
-          then(resolveFn: (value: any) => unknown, rejectFn?: (reason?: unknown) => unknown) {
-            const defaultData = table === "onboarding_files" ? [] : [];
-            return Promise.resolve({ data: defaultData, error: null }).then(resolveFn, rejectFn);
-          },
-          insert() { return this; },
-          update() { return this; },
-          single() { return Promise.resolve({ data: { id: "plan-1", status: "ready", summary: {}, created_at: new Date().toISOString() }, error: null }); },
-        };
-      },
-    };
+    const { sb, tables } = createOnboardingSbMock();
 
     await buildOnboardingActivationPlan({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1" });
 
     const nonOnboardingReads = tables.filter((table) => !table.startsWith("onboarding_"));
     expect(nonOnboardingReads).toEqual([]);
+  });
+
+  it("getOnboardingSession counts entities/links/reviews beyond 1000 persisted rows", async () => {
+    const { sb, entities, links, reviews } = createOnboardingSbMock();
+    const session = await getOnboardingSession({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1" });
+
+    expect(session.summaryCounts.entitiesDiscovered).toBe(entities.length);
+    expect(session.summaryCounts.linksFound).toBe(links.length);
+    expect(session.summaryCounts.reviewExceptions).toBe(reviews.length);
+    expect(session.entityCounts.customer + session.entityCounts.vehicle).toBe(entities.length);
+    expect(session.linkCounts.customer_vehicle + session.linkCounts.vehicle_work_order).toBe(links.length);
+    expect(
+      Object.values(session.reviewCounts.byDomain ?? {}).reduce((sum, value) => sum + Number(value ?? 0), 0),
+    ).toBe(reviews.length + session.entityStatusCounts.customer.needs_review + session.entityStatusCounts.vehicle.needs_review);
+  });
+
+  it("activation preview uses full persisted counts beyond first 1000 rows", async () => {
+    const { sb, entities, links, reviews } = createOnboardingSbMock();
+    const result = await buildOnboardingActivationPlan({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1" });
+
+    expect((result.plan as any).entitiesDiscovered).toBe(entities.length);
+    expect((result.plan as any).linksFound).toBe(links.length);
+    expect((result.plan as any).reviewExceptions).toBe(reviews.length);
+    expect(result.plan.reviewNeeded).toBeGreaterThan(1000);
   });
 
   it("status helper and SQL migration stay aligned", () => {

--- a/features/onboarding-agent/server/rawRowCounts.ts
+++ b/features/onboarding-agent/server/rawRowCounts.ts
@@ -1,19 +1,104 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+const ONBOARDING_PAGE_SIZE = 1000;
+
+async function countOnboardingTableRows(params: {
+  supabase: SupabaseClient;
+  table: string;
+  shopId: string;
+  sessionId: string;
+  orFilter?: string;
+}): Promise<number> {
+  const sb = params.supabase as any;
+  let query = sb
+    .from(params.table)
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId);
+
+  if (params.orFilter) query = query.or(params.orFilter);
+
+  const { count, error } = await query;
+  if (error) throw new Error(error.message);
+  return Number(count ?? 0);
+}
+
 export async function countOnboardingRawRows(params: {
   supabase: SupabaseClient;
   shopId: string;
   sessionId: string;
 }): Promise<number> {
-  const sb = params.supabase as any;
-  const { count, error } = await sb
-    .from("onboarding_raw_rows")
-    .select("id", { head: true, count: "exact" })
-    .eq("shop_id", params.shopId)
-    .eq("session_id", params.sessionId);
+  return countOnboardingTableRows({
+    supabase: params.supabase,
+    table: "onboarding_raw_rows",
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+}
 
-  if (error) throw new Error(error.message);
-  return Number(count ?? 0);
+export async function countOnboardingEntities(params: { supabase: SupabaseClient; shopId: string; sessionId: string }): Promise<number> {
+  return countOnboardingTableRows({
+    supabase: params.supabase,
+    table: "onboarding_entities",
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+}
+
+export async function countOnboardingEntityLinks(params: { supabase: SupabaseClient; shopId: string; sessionId: string }): Promise<number> {
+  return countOnboardingTableRows({
+    supabase: params.supabase,
+    table: "onboarding_entity_links",
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+}
+
+export async function countOnboardingPendingReviewItems(params: { supabase: SupabaseClient; shopId: string; sessionId: string }): Promise<number> {
+  return countOnboardingTableRows({
+    supabase: params.supabase,
+    table: "onboarding_review_items",
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+    orFilter: "status.is.null,status.eq.pending",
+  });
+}
+
+export async function fetchPaginatedOnboardingRows<T>(params: {
+  supabase: SupabaseClient;
+  table: string;
+  select: string;
+  shopId: string;
+  sessionId: string;
+  orderBy?: string;
+  ascending?: boolean;
+  orFilter?: string;
+}): Promise<T[]> {
+  const sb = params.supabase as any;
+  const rows: T[] = [];
+  let from = 0;
+
+  while (true) {
+    const to = from + ONBOARDING_PAGE_SIZE - 1;
+    let query = sb
+      .from(params.table)
+      .select(params.select)
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId);
+
+    if (params.orFilter) query = query.or(params.orFilter);
+    if (params.orderBy) query = query.order(params.orderBy, { ascending: params.ascending ?? true });
+    query = query.range(from, to);
+
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+    const batch = (data ?? []) as T[];
+    rows.push(...batch);
+    if (batch.length < ONBOARDING_PAGE_SIZE) break;
+    from += ONBOARDING_PAGE_SIZE;
+  }
+
+  return rows;
 }
 
 export async function countOnboardingRawRowsBySession(params: {


### PR DESCRIPTION
### Motivation
- Onboarding session summaries and dry-run activation previews were under-reporting persisted staged counts because non-paginated Supabase `.select()` reads were being consumed as in-memory arrays (effectively `data.length`) and can be capped at ~1000 rows.
- The goal is to make all session/entity/link/review counters rely on exact persisted totals without adding schema changes, new files, or changing activation/live-table creation.

### Description
- Replaced non-paginated selects used for summary/preview with deterministic paginated reads and exact-count helpers by adding `fetchPaginatedOnboardingRows` and count helpers in `rawRowCounts.ts` (`countOnboardingEntities`, `countOnboardingEntityLinks`, `countOnboardingPendingReviewItems`).
- Wired session summary to use exact persisted totals for key counters (`entitiesDiscovered`, `linksFound`, `reviewExceptions`) and used paginated reads for breakdown/grouping in `getOnboardingSession.ts`.
- Updated activation preview path in `buildOnboardingActivationPlan.ts` to read full paginated entity/link/review rows and fetch exact totals for the dry-run summary output.
- Added/updated tests and a Supabase mock in `phase1-consolidation.test.ts` to verify >1000 persisted rows for entities/links/reviews are counted and reflected in session summaries and activation previews.
- Files changed: `features/onboarding-agent/server/rawRowCounts.ts`, `features/onboarding-agent/server/getOnboardingSession.ts`, `features/onboarding-agent/server/buildOnboardingActivationPlan.ts`, `features/onboarding-agent/server/phase1-consolidation.test.ts`.
- Exact capped-count source found: non-paginated `.select()` reads against `onboarding_entities`, `onboarding_entity_links`, and `onboarding_review_items` where summaries derived counts from returned arrays.
- `PAGE_SIZE = 1000` assessment: existing `fetchOnboardingRawRows` pagination was safe (it loops via `range` until exhausted); the bug was separate non-paginated selects that assumed the returned array contained all rows.
- Before: summary/preview derived counts from selected arrays which could be capped by the DB client; After: totals come from `select(..., { head: true, count: "exact" })` and breakdowns come from `fetchPaginatedOnboardingRows` that iterates pages until exhausted.

### Testing
- Type-check: ran `npx tsc --noEmit --pretty false` and it completed successfully.
- Unit tests: ran `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (10 test files, 56 tests total passed), including new >1000-row assertions in `phase1-consolidation.test.ts` which confirm session summary and activation preview use full persisted counts.
- Lint: ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which completed; existing `no-explicit-any` warnings remain but no new errors were introduced.
- Tests added/updated: `features/onboarding-agent/server/phase1-consolidation.test.ts` now includes tests that create >1000 mocked `onboarding_entities`, `onboarding_entity_links`, and `onboarding_review_items` and assert counts surface correctly in `getOnboardingSession` and `buildOnboardingActivationPlan`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00c1872ec8328a0848c1ac2e196ea)