### PR TITLE
Add vendor-only onboarding activation to live suppliers

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { activateOnboardingVendors } from "@/features/onboarding-agent/server/activateOnboardingVendors";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    const result = await activateOnboardingVendors({
+      supabase: admin,
+      shopId,
+      sessionId,
+      actorId,
+    });
+
+    return NextResponse.json({ ok: true, result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to activate vendors";
+    const status = message.includes("Session not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -18,6 +18,8 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [analyzing, setAnalyzing] = useState(false);
   const [planning, setPlanning] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [activatingVendors, setActivatingVendors] = useState(false);
+  const [vendorActivationSummary, setVendorActivationSummary] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -91,6 +93,38 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     }
   };
 
+
+
+  const activateVendors = async () => {
+    const confirmed = window.confirm(
+      "This writes staged vendor records into live supplier records for this shop. It does not activate customers, vehicles, parts, invoices, or work orders.",
+    );
+    if (!confirmed) return;
+
+    setActivatingVendors(true);
+    setError(null);
+    setNotice(null);
+    setVendorActivationSummary(null);
+
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/activate-vendors`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setError(json?.error || "Failed to activate staged vendors.");
+      } else {
+        const result = json?.result ?? {};
+        setVendorActivationSummary(
+          `Vendor activation complete. Inserted: ${Number(result.inserted ?? 0)}. Updated: ${Number(result.updated ?? 0)}. Skipped: ${Number(result.skipped ?? 0)}.`,
+        );
+      }
+      await load();
+    } catch {
+      setError("Failed to activate staged vendors.");
+    } finally {
+      setActivatingVendors(false);
+    }
+  };
+
   const plan = async () => {
     setPlanning(true);
     setError(null);
@@ -112,6 +146,8 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const session = payload?.session;
   const files = payload?.files ?? [];
   const hasFiles = files.length > 0;
+  const vendorReadyCount = Number(payload?.entityStatusCounts?.vendor?.ready ?? 0);
+
   const hasAnalysis = useMemo(() => {
     if (!session) return false;
     if (session.analyzed_at) return true;
@@ -162,6 +198,15 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
           >
             {planning ? "Preparing…" : "Prepare activation plan"}
           </button>
+          {vendorReadyCount > 0 ? (
+            <button
+              onClick={activateVendors}
+              disabled={!hasAnalysis || activatingVendors || analyzing || deleting || planning}
+              className="rounded border border-emerald-400/40 px-3 py-2 text-sm text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {activatingVendors ? "Activating vendors…" : "Activate vendors to live suppliers"}
+            </button>
+          ) : null}
           <button
             onClick={deleteSession}
             disabled={deleting || analyzing || planning}
@@ -174,7 +219,13 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         {!hasFiles ? <p className="mt-2 text-xs text-slate-400">Upload at least one file before analysis.</p> : null}
         {hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analysis already exists; use Rerun analysis to safely clear and rebuild staged artifacts.</p> : null}
         {!hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analyze staged files before preparing an activation plan.</p> : null}
+        {vendorReadyCount > 0 ? (
+          <p className="mt-1 text-xs text-amber-200/90">
+            This writes staged vendor records into live supplier records for this shop. It does not activate customers, vehicles, parts, invoices, or work orders.
+          </p>
+        ) : null}
         {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
+        {vendorActivationSummary ? <p className="mt-2 text-xs text-emerald-200">{vendorActivationSummary}</p> : null}
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
       </div>
 

--- a/features/onboarding-agent/server/activateOnboardingVendors.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { computeVendorActivationResult } from "@/features/onboarding-agent/server/activateOnboardingVendors";
+
+type Entity = Parameters<typeof computeVendorActivationResult>[0]["entities"][number];
+type Supplier = Parameters<typeof computeVendorActivationResult>[0]["supplierRows"][number];
+
+function entity(overrides: Partial<Entity>): Entity {
+  return {
+    id: "entity-1",
+    shop_id: "shop-1",
+    session_id: "session-1",
+    entity_type: "vendor",
+    status: "ready",
+    display_name: null,
+    normalized: {},
+    ...overrides,
+  } as Entity;
+}
+
+function supplier(overrides: Partial<Supplier>): Supplier {
+  return {
+    id: "supplier-1",
+    shop_id: "shop-1",
+    name: "North Supply",
+    account_no: null,
+    email: null,
+    phone: null,
+    notes: null,
+    is_active: true,
+    created_at: new Date().toISOString(),
+    created_by: null,
+    ...overrides,
+  };
+}
+
+describe("computeVendorActivationResult", () => {
+  it("inserts suppliers for ready staged vendor entities", () => {
+    const result = computeVendorActivationResult({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [entity({ normalized: { name: "North Supply", email: "orders@north.test" } })],
+      supplierRows: [],
+    });
+
+    expect(result.inserted).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.preparedInserts).toHaveLength(1);
+  });
+
+  it("rerun does not duplicate suppliers because name match resolves to existing", () => {
+    const result = computeVendorActivationResult({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [entity({ normalized: { name: "North Supply" } })],
+      supplierRows: [supplier({ id: "supplier-1", name: "North Supply" })],
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.records[0]?.reason).toContain("already has mapped fields");
+  });
+
+  it("updates only null-safe fields on existing supplier matches", () => {
+    const result = computeVendorActivationResult({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [entity({ normalized: { name: "North Supply", accountNumber: "ACCT-44", email: "new@north.test", phone: "111-222-3333" } })],
+      supplierRows: [supplier({ id: "supplier-1", name: "North Supply", email: "existing@north.test", phone: null, account_no: null })],
+    });
+
+    expect(result.updated).toBe(1);
+    expect(result.preparedUpdates).toHaveLength(1);
+    expect(result.preparedUpdates[0]?.payload).toEqual({ account_no: "ACCT-44", phone: "111-222-3333" });
+  });
+
+  it("ignores cross-shop entities and non-ready/non-vendor rows", () => {
+    const result = computeVendorActivationResult({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [
+        entity({ id: "entity-cross-shop", shop_id: "shop-2", normalized: { name: "Wrong Shop" } }),
+        entity({ id: "entity-wrong-session", session_id: "session-2", normalized: { name: "Wrong Session" } }),
+        entity({ id: "entity-not-ready", status: "needs_review", normalized: { name: "Needs Review" } }),
+        entity({ id: "entity-not-vendor", entity_type: "customer", normalized: { name: "Customer Co" } }),
+      ],
+      supplierRows: [],
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("skips ambiguous matches and returns warnings", () => {
+    const result = computeVendorActivationResult({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [entity({ normalized: { name: "North Supply" } })],
+      supplierRows: [supplier({ id: "supplier-1", name: "North Supply" }), supplier({ id: "supplier-2", name: "North Supply" })],
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.warnings).toBe(1);
+    expect(result.records[0]?.reason).toContain("Ambiguous");
+  });
+
+  it("analyze/rerun guarantee: activation result is empty when no ready vendor entities are present", () => {
+    const result = computeVendorActivationResult({
+      shopId: "shop-1",
+      sessionId: "session-1",
+      entities: [entity({ entity_type: "part", status: "ready", normalized: { name: "Brake Pad" } })],
+      supplierRows: [],
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.records).toHaveLength(0);
+  });
+});

--- a/features/onboarding-agent/server/activateOnboardingVendors.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.ts
@@ -1,0 +1,250 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+type JsonObject = Record<string, unknown>;
+type OnboardingEntityRow = Database["public"]["Tables"]["onboarding_entities"]["Row"];
+type SupplierRow = Database["public"]["Tables"]["suppliers"]["Row"];
+type SupplierInsert = Database["public"]["Tables"]["suppliers"]["Insert"];
+type SupplierUpdate = Database["public"]["Tables"]["suppliers"]["Update"];
+
+export type VendorActivationRecordResult = {
+  entityId: string;
+  supplierId: string | null;
+  action: "inserted" | "updated" | "skipped";
+  reason: string;
+};
+
+export type VendorActivationResult = {
+  inserted: number;
+  updated: number;
+  skipped: number;
+  warnings: number;
+  records: VendorActivationRecordResult[];
+};
+
+type NormalizedVendor = {
+  name: string;
+  accountNo: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalizeLookupKey(value: unknown): string {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[\s\-_.]+/g, " ")
+    .replace(/[^a-z0-9 @+]/g, "")
+    .trim();
+}
+
+function normalizeEmail(value: unknown): string | null {
+  const text = normalizeText(value).toLowerCase();
+  return text ? text : null;
+}
+
+function firstText(values: unknown[]): string | null {
+  for (const value of values) {
+    const text = normalizeText(value);
+    if (text) return text;
+  }
+  return null;
+}
+
+function toNormalizedVendor(entity: Pick<OnboardingEntityRow, "normalized" | "display_name">): NormalizedVendor | null {
+  const normalized = (entity.normalized ?? {}) as JsonObject;
+  const name = firstText([normalized.name, entity.display_name]);
+  if (!name) return null;
+
+  const accountNo = firstText([
+    normalized.account_no,
+    normalized.accountNo,
+    normalized.accountNumber,
+    normalized.vendorCode,
+    normalized.sourceVendorId,
+  ]);
+
+  return {
+    name,
+    accountNo,
+    email: normalizeEmail(normalized.email),
+    phone: firstText([normalized.phone]),
+  };
+}
+
+function collectMatchCandidates(params: { supplierRows: SupplierRow[]; vendor: NormalizedVendor }) {
+  const nameKey = normalizeLookupKey(params.vendor.name);
+  const accountKey = params.vendor.accountNo ? normalizeLookupKey(params.vendor.accountNo) : "";
+  const emailKey = params.vendor.email ? normalizeLookupKey(params.vendor.email) : "";
+
+  const matches = params.supplierRows.filter((row) => {
+    if (accountKey && normalizeLookupKey(row.account_no) === accountKey) return true;
+    if (emailKey && normalizeLookupKey(row.email) === emailKey) return true;
+    if (nameKey && normalizeLookupKey(row.name) === nameKey) return true;
+    return false;
+  });
+
+  return matches;
+}
+
+function buildNullSafeUpdate(params: { current: SupplierRow; vendor: NormalizedVendor }): SupplierUpdate | null {
+  const update: SupplierUpdate = {};
+  if (!normalizeText(params.current.name)) update.name = params.vendor.name;
+  if (!normalizeText(params.current.account_no) && params.vendor.accountNo) update.account_no = params.vendor.accountNo;
+  if (!normalizeText(params.current.email) && params.vendor.email) update.email = params.vendor.email;
+  if (!normalizeText(params.current.phone) && params.vendor.phone) update.phone = params.vendor.phone;
+
+  return Object.keys(update).length ? update : null;
+}
+
+export function computeVendorActivationResult(params: {
+  shopId: string;
+  sessionId: string;
+  entities: Array<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name">>;
+  supplierRows: SupplierRow[];
+}) {
+  const records: VendorActivationRecordResult[] = [];
+  const preparedInserts: Array<{ entityId: string; payload: SupplierInsert }> = [];
+  const preparedUpdates: Array<{ entityId: string; supplierId: string; payload: SupplierUpdate }> = [];
+  const supplierPool = [...params.supplierRows];
+
+  for (const entity of params.entities) {
+    if (entity.shop_id !== params.shopId || entity.session_id !== params.sessionId) continue;
+    if (entity.entity_type !== "vendor" || entity.status !== "ready") continue;
+
+    const normalizedVendor = toNormalizedVendor(entity);
+    if (!normalizedVendor) {
+      records.push({ entityId: entity.id, supplierId: null, action: "skipped", reason: "Missing vendor name in staged normalized payload" });
+      continue;
+    }
+
+    const matches = collectMatchCandidates({ supplierRows: supplierPool, vendor: normalizedVendor });
+    if (matches.length > 1) {
+      records.push({ entityId: entity.id, supplierId: null, action: "skipped", reason: "Ambiguous supplier match; manual review required" });
+      continue;
+    }
+
+    if (matches.length === 1) {
+      const current = matches[0];
+      const update = buildNullSafeUpdate({ current, vendor: normalizedVendor });
+      if (!update) {
+        records.push({ entityId: entity.id, supplierId: current.id, action: "skipped", reason: "Existing supplier already has mapped fields" });
+        continue;
+      }
+
+      preparedUpdates.push({ entityId: entity.id, supplierId: current.id, payload: update });
+      Object.assign(current, update);
+      records.push({ entityId: entity.id, supplierId: current.id, action: "updated", reason: "Matched existing supplier and filled null-only fields" });
+      continue;
+    }
+
+    const insertPayload: SupplierInsert = {
+      shop_id: params.shopId,
+      name: normalizedVendor.name,
+      account_no: normalizedVendor.accountNo,
+      email: normalizedVendor.email,
+      phone: normalizedVendor.phone,
+    };
+
+    preparedInserts.push({ entityId: entity.id, payload: insertPayload });
+    supplierPool.push({
+      id: `pending:${entity.id}`,
+      created_at: new Date(0).toISOString(),
+      created_by: null,
+      is_active: true,
+      notes: null,
+      ...insertPayload,
+    } as SupplierRow);
+    records.push({ entityId: entity.id, supplierId: null, action: "inserted", reason: "Inserted new supplier from staged vendor" });
+  }
+
+  const inserted = records.filter((item) => item.action === "inserted").length;
+  const updated = records.filter((item) => item.action === "updated").length;
+  const skipped = records.filter((item) => item.action === "skipped").length;
+  const warnings = records.filter((item) => item.reason.toLowerCase().includes("ambiguous")).length;
+
+  return {
+    inserted,
+    updated,
+    skipped,
+    warnings,
+    records,
+    preparedInserts,
+    preparedUpdates,
+  };
+}
+
+export async function activateOnboardingVendors(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  actorId: string;
+}): Promise<VendorActivationResult> {
+  const sb = params.supabase as any;
+
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+
+  const { data: entities, error: entityError } = await sb
+    .from("onboarding_entities")
+    .select("id, shop_id, session_id, entity_type, status, normalized, display_name")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .eq("entity_type", "vendor")
+    .eq("status", "ready")
+    .order("id", { ascending: true });
+
+  if (entityError) throw new Error(entityError.message);
+
+  const { data: suppliers, error: supplierError } = await sb
+    .from("suppliers")
+    .select("id, shop_id, name, account_no, email, phone, notes, is_active, created_at, created_by")
+    .eq("shop_id", params.shopId)
+    .order("name", { ascending: true });
+
+  if (supplierError) throw new Error(supplierError.message);
+
+  const computed = computeVendorActivationResult({
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+    entities: (entities ?? []) as Array<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name">>,
+    supplierRows: (suppliers ?? []) as SupplierRow[],
+  });
+
+  for (const pendingInsert of computed.preparedInserts) {
+    const payload = {
+      ...pendingInsert.payload,
+      created_by: params.actorId,
+    };
+    const { data, error } = await sb.from("suppliers").insert(payload).select("id").single();
+    if (error) throw new Error(error.message);
+
+    const target = computed.records.find((record) => record.entityId === pendingInsert.entityId && record.action === "inserted");
+    if (target) target.supplierId = data?.id ?? null;
+  }
+
+  for (const pendingUpdate of computed.preparedUpdates) {
+    const { error } = await sb
+      .from("suppliers")
+      .update(pendingUpdate.payload)
+      .eq("shop_id", params.shopId)
+      .eq("id", pendingUpdate.supplierId);
+
+    if (error) throw new Error(error.message);
+  }
+
+  return {
+    inserted: computed.inserted,
+    updated: computed.updated,
+    skipped: computed.skipped,
+    warnings: computed.warnings,
+    records: computed.records,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, explicit first activation path to materialize staged onboarding vendors into live supplier records for a single shop and session. 
- Keep activation owner/admin-scoped, idempotent, shop-scoped, and conservative to prove the pattern before expanding to other domains. 
- Avoid any changes to the staging/analysis pipeline, global schema, or produce destructive writes. 

### Description
- Added a vendor activation server helper `activateOnboardingVendors` with a deterministic compute step (`computeVendorActivationResult`) that only reads `onboarding_entities` where `entity_type='vendor'` and `status='ready'` for the exact `shop_id` + `session_id`, and then inserts or null-only-updates `suppliers` as appropriate. 
- New API route `POST /api/onboarding-agent/sessions/[sessionId]/activate-vendors` enforces owner/admin shop-scoped access and passes `actorId` to inserts. 
- Onboarding session UI now includes a scoped action button “Activate vendors to live suppliers” with confirmation copy and a post-run summary showing inserted/updated/skipped counts (only visible when ready vendor entities exist). 
- Conservative matching/idempotency: match by normalized account number, normalized email, or normalized name; update only null/missing fields; insert when no match; skip with a warning on ambiguous multi-match cases. 
- Inspected `suppliers` columns and mapped only supported fields: `name`, `account_no`, `email`, `phone` (and `created_by` on insert); no schema changes or new tables were introduced. 

### Testing
- Ran typecheck: `npx tsc --noEmit --pretty false` — success (no type errors). 
- Ran unit tests for onboarding agent: `npx vitest run features/onboarding-agent` — all onboarding-agent tests (including the new `activateOnboardingVendors.test.ts`) passed. 
- Linted the touched areas: `npx eslint app/api/onboarding-agent app/dashboard/onboarding app/parts/vendors features/onboarding-agent` — completed with warnings only and 0 errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01bf6e4f08328a5f6cae1cc6791e3)