### PR TITLE
Fix onboarding vendor activation into live suppliers with idempotent matching

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts
@@ -26,7 +26,7 @@ export async function POST(_: Request, context: RouteContext) {
       actorId,
     });
 
-    return NextResponse.json({ ok: true, result });
+    return NextResponse.json(result);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to activate vendors";
     const status = message.includes("Session not found") ? 404 : 500;

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -112,9 +112,9 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       if (!res.ok || !json.ok) {
         setError(json?.error || "Failed to activate staged vendors.");
       } else {
-        const result = json?.result ?? {};
+        const warnings = Array.isArray(json?.warnings) ? json.warnings.length : 0;
         setVendorActivationSummary(
-          `Vendor activation complete. Inserted: ${Number(result.inserted ?? 0)}. Updated: ${Number(result.updated ?? 0)}. Skipped: ${Number(result.skipped ?? 0)}.`,
+          `Vendor activation complete. Staged vendors: ${Number(json?.stagedVendorsFound ?? 0)}. Inserted: ${Number(json?.inserted ?? 0)}. Updated: ${Number(json?.updated ?? 0)}. Skipped: ${Number(json?.skipped ?? 0)}. Suppliers before/after: ${Number(json?.suppliersBefore ?? 0)}/${Number(json?.suppliersAfter ?? 0)}.${warnings > 0 ? ` Warnings: ${warnings}.` : ""}`,
         );
       }
       await load();

--- a/features/onboarding-agent/server/activateOnboardingVendors.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { computeVendorActivationResult } from "@/features/onboarding-agent/server/activateOnboardingVendors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { activateOnboardingVendors, computeVendorActivationResult } from "@/features/onboarding-agent/server/activateOnboardingVendors";
+
+vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
+  assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
+}));
 
 type Entity = Parameters<typeof computeVendorActivationResult>[0]["entities"][number];
 type Supplier = Parameters<typeof computeVendorActivationResult>[0]["supplierRows"][number];
@@ -30,6 +34,102 @@ function supplier(overrides: Partial<Supplier>): Supplier {
     created_at: new Date().toISOString(),
     created_by: null,
     ...overrides,
+  };
+}
+
+function createFakeSupabase(params?: { entities?: Entity[]; suppliers?: Supplier[] }) {
+  const state = {
+    entities: [...(params?.entities ?? [])],
+    suppliers: [...(params?.suppliers ?? [])],
+    nextSupplierId: 100,
+    insertCalls: 0,
+    updateCalls: 0,
+    writes: [] as string[],
+  };
+
+  return {
+    state,
+    from(table: string) {
+      const query: any = {
+        table,
+        filters: [] as Array<{ k: string; v: any }>,
+        payload: null as any,
+        selectColumns: "",
+        update(payload: any) {
+          this.payload = payload;
+          this.op = "update";
+          return this;
+        },
+        insert(payload: any) {
+          this.payload = payload;
+          this.op = "insert";
+          return this;
+        },
+        select(columns: string) {
+          this.selectColumns = columns;
+          this.op = this.op ?? "select";
+          return this;
+        },
+        order() {
+          return this;
+        },
+        eq(k: string, v: any) {
+          this.filters.push({ k, v });
+          return this;
+        },
+        single() {
+          return this.execSingle();
+        },
+        then(resolve: any, reject: any) {
+          return this.exec().then(resolve, reject);
+        },
+        async execSingle() {
+          const result = await this.exec();
+          const first = Array.isArray(result.data) ? result.data[0] ?? null : result.data ?? null;
+          return { ...result, data: first };
+        },
+        async exec() {
+          if (this.table === "onboarding_entities" && this.op === "select") {
+            let rows = [...state.entities];
+            for (const filter of this.filters) rows = rows.filter((row: any) => row[filter.k] === filter.v);
+            return { data: rows, error: null };
+          }
+
+          if (this.table === "suppliers" && this.op === "select") {
+            let rows = [...state.suppliers];
+            for (const filter of this.filters) rows = rows.filter((row: any) => row[filter.k] === filter.v);
+            return { data: rows, error: null };
+          }
+
+          if (this.table === "suppliers" && this.op === "insert") {
+            state.insertCalls += 1;
+            state.writes.push("suppliers:insert");
+            const created = {
+              id: `supplier-${state.nextSupplierId++}`,
+              created_at: new Date().toISOString(),
+              created_by: this.payload.created_by ?? null,
+              is_active: this.payload.is_active ?? true,
+              notes: this.payload.notes ?? null,
+              ...this.payload,
+            };
+            state.suppliers.push(created);
+            return { data: [{ id: created.id }], error: null };
+          }
+
+          if (this.table === "suppliers" && this.op === "update") {
+            state.updateCalls += 1;
+            state.writes.push("suppliers:update");
+            const target = state.suppliers.find((row: any) => this.filters.every((f: any) => row[f.k] === f.v));
+            if (target) Object.assign(target, this.payload);
+            return { data: [], error: null };
+          }
+
+          return { data: [], error: null };
+        },
+      };
+
+      return query;
+    },
   };
 }
 
@@ -66,13 +166,13 @@ describe("computeVendorActivationResult", () => {
     const result = computeVendorActivationResult({
       shopId: "shop-1",
       sessionId: "session-1",
-      entities: [entity({ normalized: { name: "North Supply", accountNumber: "ACCT-44", email: "new@north.test", phone: "111-222-3333" } })],
-      supplierRows: [supplier({ id: "supplier-1", name: "North Supply", email: "existing@north.test", phone: null, account_no: null })],
+      entities: [entity({ normalized: { name: "North Supply", accountNumber: "ACCT-44", email: "new@north.test", phone: "111-222-3333", notes: "Preferred" } })],
+      supplierRows: [supplier({ id: "supplier-1", name: "North Supply", email: "existing@north.test", phone: null, account_no: "ACCT-44", notes: null })],
     });
 
     expect(result.updated).toBe(1);
     expect(result.preparedUpdates).toHaveLength(1);
-    expect(result.preparedUpdates[0]?.payload).toEqual({ account_no: "ACCT-44", phone: "111-222-3333" });
+    expect(result.preparedUpdates[0]?.payload).toEqual({ phone: "111-222-3333", notes: "Preferred" });
   });
 
   it("ignores cross-shop entities and non-ready/non-vendor rows", () => {
@@ -104,7 +204,7 @@ describe("computeVendorActivationResult", () => {
     expect(result.inserted).toBe(0);
     expect(result.updated).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(result.warnings).toBe(1);
+    expect(result.warnings).toHaveLength(1);
     expect(result.records[0]?.reason).toContain("Ambiguous");
   });
 
@@ -120,5 +220,73 @@ describe("computeVendorActivationResult", () => {
     expect(result.updated).toBe(0);
     expect(result.skipped).toBe(0);
     expect(result.records).toHaveLength(0);
+  });
+});
+
+describe("activateOnboardingVendors", () => {
+  let sb: ReturnType<typeof createFakeSupabase>;
+
+  beforeEach(() => {
+    const stagedVendors = Array.from({ length: 10 }).map((_, index) =>
+      entity({
+        id: `entity-${index + 1}`,
+        normalized: { name: `Vendor ${index + 1}`, email: `vendor${index + 1}@test.com`, account_no: `ACCT-${index + 1}` },
+      }),
+    );
+    sb = createFakeSupabase({ entities: stagedVendors, suppliers: [] });
+  });
+
+  it("creates suppliers from 10 ready staged vendors and is idempotent on rerun", async () => {
+    const first = await activateOnboardingVendors({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "user-1",
+    });
+
+    expect(first.ok).toBe(true);
+    expect(first.stagedVendorsFound).toBe(10);
+    expect(first.suppliersBefore).toBe(0);
+    expect(first.suppliersAfter).toBe(10);
+    expect(first.inserted).toBe(10);
+    expect(first.updated).toBe(0);
+    expect(first.skipped).toBe(0);
+
+    const second = await activateOnboardingVendors({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "user-1",
+    });
+
+    expect(second.inserted).toBe(0);
+    expect(second.updated).toBe(0);
+    expect(second.skipped).toBe(10);
+    expect(second.suppliersBefore).toBe(10);
+    expect(second.suppliersAfter).toBe(10);
+  });
+
+  it("only writes to suppliers table and ignores non-ready/non-vendor/cross-shop rows", async () => {
+    sb = createFakeSupabase({
+      suppliers: [],
+      entities: [
+        entity({ id: "vendor-ready", normalized: { name: "Vendor A" } }),
+        entity({ id: "wrong-shop", shop_id: "shop-2", normalized: { name: "Vendor B" } }),
+        entity({ id: "wrong-session", session_id: "session-2", normalized: { name: "Vendor C" } }),
+        entity({ id: "not-ready", status: "needs_review", normalized: { name: "Vendor D" } }),
+        entity({ id: "not-vendor", entity_type: "vehicle", normalized: { name: "Truck" } }),
+      ],
+    });
+
+    const result = await activateOnboardingVendors({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "user-1",
+    });
+
+    expect(result.stagedVendorsFound).toBe(1);
+    expect(result.inserted).toBe(1);
+    expect(sb.state.writes.every((entry) => entry.startsWith("suppliers:"))).toBe(true);
   });
 });

--- a/features/onboarding-agent/server/activateOnboardingVendors.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.ts
@@ -16,10 +16,14 @@ export type VendorActivationRecordResult = {
 };
 
 export type VendorActivationResult = {
+  ok: true;
   inserted: number;
   updated: number;
   skipped: number;
-  warnings: number;
+  warnings: string[];
+  suppliersBefore: number;
+  suppliersAfter: number;
+  stagedVendorsFound: number;
   records: VendorActivationRecordResult[];
 };
 
@@ -28,6 +32,8 @@ type NormalizedVendor = {
   accountNo: string | null;
   email: string | null;
   phone: string | null;
+  notes: string | null;
+  isActive: boolean | null;
 };
 
 function normalizeText(value: unknown): string {
@@ -73,22 +79,25 @@ function toNormalizedVendor(entity: Pick<OnboardingEntityRow, "normalized" | "di
     accountNo,
     email: normalizeEmail(normalized.email),
     phone: firstText([normalized.phone]),
+    notes: firstText([normalized.notes, normalized.note]),
+    isActive: typeof normalized.is_active === "boolean" ? normalized.is_active : typeof normalized.active === "boolean" ? normalized.active : null,
   };
 }
 
 function collectMatchCandidates(params: { supplierRows: SupplierRow[]; vendor: NormalizedVendor }) {
-  const nameKey = normalizeLookupKey(params.vendor.name);
   const accountKey = params.vendor.accountNo ? normalizeLookupKey(params.vendor.accountNo) : "";
+  if (accountKey) {
+    return params.supplierRows.filter((row) => normalizeLookupKey(row.account_no) === accountKey);
+  }
+
   const emailKey = params.vendor.email ? normalizeLookupKey(params.vendor.email) : "";
+  if (emailKey) {
+    return params.supplierRows.filter((row) => normalizeLookupKey(row.email) === emailKey);
+  }
 
-  const matches = params.supplierRows.filter((row) => {
-    if (accountKey && normalizeLookupKey(row.account_no) === accountKey) return true;
-    if (emailKey && normalizeLookupKey(row.email) === emailKey) return true;
-    if (nameKey && normalizeLookupKey(row.name) === nameKey) return true;
-    return false;
-  });
-
-  return matches;
+  const nameKey = normalizeLookupKey(params.vendor.name);
+  if (!nameKey) return [];
+  return params.supplierRows.filter((row) => normalizeLookupKey(row.name) === nameKey);
 }
 
 function buildNullSafeUpdate(params: { current: SupplierRow; vendor: NormalizedVendor }): SupplierUpdate | null {
@@ -97,6 +106,7 @@ function buildNullSafeUpdate(params: { current: SupplierRow; vendor: NormalizedV
   if (!normalizeText(params.current.account_no) && params.vendor.accountNo) update.account_no = params.vendor.accountNo;
   if (!normalizeText(params.current.email) && params.vendor.email) update.email = params.vendor.email;
   if (!normalizeText(params.current.phone) && params.vendor.phone) update.phone = params.vendor.phone;
+  if (!normalizeText(params.current.notes) && params.vendor.notes) update.notes = params.vendor.notes;
 
   return Object.keys(update).length ? update : null;
 }
@@ -108,6 +118,7 @@ export function computeVendorActivationResult(params: {
   supplierRows: SupplierRow[];
 }) {
   const records: VendorActivationRecordResult[] = [];
+  const warnings: string[] = [];
   const preparedInserts: Array<{ entityId: string; payload: SupplierInsert }> = [];
   const preparedUpdates: Array<{ entityId: string; supplierId: string; payload: SupplierUpdate }> = [];
   const supplierPool = [...params.supplierRows];
@@ -124,6 +135,8 @@ export function computeVendorActivationResult(params: {
 
     const matches = collectMatchCandidates({ supplierRows: supplierPool, vendor: normalizedVendor });
     if (matches.length > 1) {
+      const warning = `Entity ${entity.id} skipped: multiple supplier matches found in shop for staged vendor "${normalizedVendor.name}".`;
+      warnings.push(warning);
       records.push({ entityId: entity.id, supplierId: null, action: "skipped", reason: "Ambiguous supplier match; manual review required" });
       continue;
     }
@@ -148,6 +161,8 @@ export function computeVendorActivationResult(params: {
       account_no: normalizedVendor.accountNo,
       email: normalizedVendor.email,
       phone: normalizedVendor.phone,
+      notes: normalizedVendor.notes,
+      is_active: normalizedVendor.isActive ?? true,
     };
 
     preparedInserts.push({ entityId: entity.id, payload: insertPayload });
@@ -165,7 +180,6 @@ export function computeVendorActivationResult(params: {
   const inserted = records.filter((item) => item.action === "inserted").length;
   const updated = records.filter((item) => item.action === "updated").length;
   const skipped = records.filter((item) => item.action === "skipped").length;
-  const warnings = records.filter((item) => item.reason.toLowerCase().includes("ambiguous")).length;
 
   return {
     inserted,
@@ -210,6 +224,8 @@ export async function activateOnboardingVendors(params: {
     .order("name", { ascending: true });
 
   if (supplierError) throw new Error(supplierError.message);
+  const suppliersBefore = (suppliers ?? []).length;
+  const stagedVendorsFound = (entities ?? []).length;
 
   const computed = computeVendorActivationResult({
     shopId: params.shopId,
@@ -241,10 +257,14 @@ export async function activateOnboardingVendors(params: {
   }
 
   return {
+    ok: true,
     inserted: computed.inserted,
     updated: computed.updated,
     skipped: computed.skipped,
     warnings: computed.warnings,
+    suppliersBefore,
+    suppliersAfter: suppliersBefore + computed.inserted,
+    stagedVendorsFound,
     records: computed.records,
   };
 }

--- a/features/onboarding-agent/server/analyzeOnboardingSession.test.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.test.ts
@@ -41,6 +41,7 @@ function createFakeSupabase() {
       },
     ],
     upsertCalls: [] as Array<{ rows: any[]; onConflict: string }>,
+    touchedTables: [] as string[],
   };
 
   return {
@@ -53,6 +54,7 @@ function createFakeSupabase() {
     rawRows: state.rawRows,
     files: state.files,
     upsertCalls: state.upsertCalls,
+    touchedTables: state.touchedTables,
     storage: {
       from: () => ({
         download: async () => ({
@@ -64,6 +66,7 @@ function createFakeSupabase() {
       }),
     },
     from(table: string) {
+      state.touchedTables.push(table);
       const query: any = {
       table,
       op: null,
@@ -163,6 +166,7 @@ describe("analyzeOnboardingSession idempotent raw-row rebuild", () => {
     expect(secondRunCount).toBe(firstRunCount);
     expect(sb.upsertCalls.every((call) => call.onConflict === "shop_id,file_id,source_row_index")).toBe(true);
     expect(sb.upsertCalls.flatMap((call) => call.rows).every((row) => row.session_id === "session-1" && row.error_reason === null)).toBe(true);
+    expect(sb.touchedTables.includes("suppliers")).toBe(false);
   });
 
   it("throws 409 conflict when a run is already in progress", async () => {


### PR DESCRIPTION
### Motivation
- The vendor activation path was not reliably creating live `suppliers` from staged `onboarding_entities` and lacked clear API output for the UI to surface results.  
- Activation needed to be shop-scoped, idempotent, and only map safe supplier columns without overwriting existing supplier data.  
- Tests were required to prove correct inserts, updates, skips, idempotency, and to ensure analysis flows remain read-only with respect to `suppliers`.

### Description
- Return the activation result directly from the route by changing `app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts` to return the result payload consumed by the UI.  
- Harden `activateOnboardingVendors` in `features/onboarding-agent/server/activateOnboardingVendors.ts` to enforce shop/session ownership, restrict reads to staged rows where `entity_type='vendor'` and `status='ready'`, map only supported `suppliers` columns (`shop_id`, `name`, `account_no`, `email`, `phone`, `notes`, `is_active`, `created_by`), and return a richer response (`ok`, `inserted`, `updated`, `skipped`, `warnings`, `suppliersBefore`, `suppliersAfter`, `stagedVendorsFound`).  
- Implement deterministic match priority and idempotency by matching on normalized `account_no` first, then `email`, then `name`, inserting when no match, updating only null/blank fields when exactly one match, and skipping with a warning on multiple matches.  
- Update the onboarding UI `features/onboarding-agent/components/OnboardingSessionPage.tsx` to display the returned staged/inserted/updated/skipped counts and before/after supplier totals, and add/adjust tests in `features/onboarding-agent/server/activateOnboardingVendors.test.ts` and `features/onboarding-agent/server/analyzeOnboardingSession.test.ts` to validate the requested behaviors.

### Testing
- Ran type-checking with `npx tsc --noEmit --pretty false` which completed successfully.  
- Ran unit tests with `npx vitest run features/onboarding-agent` and all tests in that suite passed (`64 tests` across the onboarding-agent tests in this run passed).  
- Ran linting `npx eslint app/api/onboarding-agent app/dashboard/onboarding app/parts/vendors features/onboarding-agent` which completed with warnings only and no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01f9efec08328bc36a0ee2bb218e6)