### PR TITLE
Fix onboarding session detail error handling and vendor activation visibility

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/route.ts
@@ -33,8 +33,22 @@ export async function GET(_: Request, context: RouteContext) {
 
     return NextResponse.json({ ok: true, ...payload });
   } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load session";
+    console.error("[onboarding-agent][session:get] failed", {
+      shopId,
+      sessionId,
+      actorId,
+      message,
+      error,
+    });
     return NextResponse.json(
-      { ok: false, error: error instanceof Error ? error.message : "Failed to load session" },
+      {
+        ok: false,
+        error: {
+          code: "SESSION_LOAD_FAILED",
+          message,
+        },
+      },
       { status: 500 },
     );
   }

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -15,6 +15,8 @@ import { formatOnboardingSessionStatusLabel } from "@/features/onboarding-agent/
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
+  const [loadingSession, setLoadingSession] = useState(true);
+  const [sessionLoadError, setSessionLoadError] = useState<string | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [planning, setPlanning] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -24,9 +26,30 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
-    const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { cache: "no-store" });
-    const json = await res.json();
-    setPayload(json);
+    setLoadingSession(true);
+    setSessionLoadError(null);
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) {
+        const message = typeof json?.error?.message === "string"
+          ? json.error.message
+          : typeof json?.error === "string"
+            ? json.error
+            : "Failed to load onboarding session.";
+        setPayload(null);
+        setNotice(null);
+        setSessionLoadError(message);
+        return;
+      }
+      setPayload(json);
+    } catch {
+      setPayload(null);
+      setNotice(null);
+      setSessionLoadError("Failed to load onboarding session.");
+    } finally {
+      setLoadingSession(false);
+    }
   }, [sessionId]);
 
   useEffect(() => {
@@ -147,6 +170,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const files = payload?.files ?? [];
   const hasFiles = files.length > 0;
   const vendorReadyCount = Number(payload?.entityStatusCounts?.vendor?.ready ?? 0);
+  const canShowVendorActivation = !loadingSession && !sessionLoadError && vendorReadyCount > 0;
 
   const hasAnalysis = useMemo(() => {
     if (!session) return false;
@@ -161,7 +185,9 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     <div className="space-y-4 p-6 text-white">
       <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
         <h1 className="text-xl font-semibold">Onboarding session</h1>
-        <p className="text-sm text-slate-300">Status: {session?.status ? formatOnboardingSessionStatusLabel(session.status) : "loading"}</p>
+        <p className="text-sm text-slate-300">
+          Status: {loadingSession ? "loading" : session?.status ? formatOnboardingSessionStatusLabel(session.status) : "unavailable"}
+        </p>
         <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
           <span className="rounded-full border border-cyan-400/50 px-2 py-1 text-cyan-200">Staged-only</span>
           <span className="rounded-full border border-emerald-400/40 px-2 py-1 text-emerald-200">No live records created</span>
@@ -198,10 +224,10 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
           >
             {planning ? "Preparing…" : "Prepare activation plan"}
           </button>
-          {vendorReadyCount > 0 ? (
+          {canShowVendorActivation ? (
             <button
               onClick={activateVendors}
-              disabled={!hasAnalysis || activatingVendors || analyzing || deleting || planning}
+              disabled={activatingVendors || analyzing || deleting || planning || !!sessionLoadError || vendorReadyCount <= 0}
               className="rounded border border-emerald-400/40 px-3 py-2 text-sm text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {activatingVendors ? "Activating vendors…" : "Activate vendors to live suppliers"}
@@ -219,23 +245,31 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         {!hasFiles ? <p className="mt-2 text-xs text-slate-400">Upload at least one file before analysis.</p> : null}
         {hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analysis already exists; use Rerun analysis to safely clear and rebuild staged artifacts.</p> : null}
         {!hasAnalysis ? <p className="mt-1 text-xs text-slate-400">Analyze staged files before preparing an activation plan.</p> : null}
-        {vendorReadyCount > 0 ? (
+        {canShowVendorActivation ? (
           <p className="mt-1 text-xs text-amber-200/90">
-            This writes staged vendor records into live supplier records for this shop. It does not activate customers, vehicles, parts, invoices, or work orders.
+            Creates/updates suppliers only from staged ready vendor records. No customers, vehicles, parts, work orders, or invoices are activated.
           </p>
         ) : null}
         {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
         {vendorActivationSummary ? <p className="mt-2 text-xs text-emerald-200">{vendorActivationSummary}</p> : null}
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
+        {sessionLoadError ? (
+          <div className="mt-3 rounded-lg border border-rose-400/40 bg-rose-950/40 p-3 text-xs text-rose-200">
+            Failed to load session details: {sessionLoadError}
+          </div>
+        ) : null}
       </div>
 
-      <OnboardingProgressCard summary={session?.summary ?? null} />
-      <OnboardingAgentInsightsPanel report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} summary={session?.summary ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} />
-      <OnboardingFilesPanel files={files} />
-      <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} agentPlan={session?.summary?.agentPlan ?? null} />
-      <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
-
-      <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} agentPlan={session?.summary?.agentPlan ?? null} />
+      {!sessionLoadError ? (
+        <>
+          <OnboardingProgressCard summary={session?.summary ?? null} />
+          <OnboardingAgentInsightsPanel report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} summary={session?.summary ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} />
+          <OnboardingFilesPanel files={files} />
+          <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} agentPlan={session?.summary?.agentPlan ?? null} />
+          <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
+          <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} agentPlan={session?.summary?.agentPlan ?? null} />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/features/onboarding-agent/server/activateOnboardingVendors.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.ts
@@ -256,6 +256,12 @@ export async function activateOnboardingVendors(params: {
     if (error) throw new Error(error.message);
   }
 
+  const { count: finalSupplierCount, error: finalCountError } = await sb
+    .from("suppliers")
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", params.shopId);
+  if (finalCountError) throw new Error(finalCountError.message);
+
   return {
     ok: true,
     inserted: computed.inserted,
@@ -263,7 +269,7 @@ export async function activateOnboardingVendors(params: {
     skipped: computed.skipped,
     warnings: computed.warnings,
     suppliersBefore,
-    suppliersAfter: suppliersBefore + computed.inserted,
+    suppliersAfter: Number(finalSupplierCount ?? (suppliersBefore + computed.inserted)),
     stagedVendorsFound,
     records: computed.records,
   };

--- a/features/onboarding-agent/server/getOnboardingSession.ts
+++ b/features/onboarding-agent/server/getOnboardingSession.ts
@@ -17,7 +17,27 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
     sessionId: params.sessionId,
   });
 
-  const [{ data: session }, { data: files }, entities, links, reviews, { data: latestPlan }, rowsParsedTotal, totalEntitiesCount, totalLinksCount, totalPendingReviewCount] = await Promise.all([
+  const latestPlanPromise = sb
+    .from("onboarding_activation_plans")
+    .select("id, status, summary, created_at")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+    .then(({ data, error }: { data: any; error: any }) => {
+      if (error) {
+        console.warn("[onboarding-agent][session:get] activation plan lookup skipped", {
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          message: error.message,
+        });
+        return null;
+      }
+      return data ?? null;
+    });
+
+  const [{ data: session }, { data: files }, entities, links, reviews, latestPlan, rowsParsedTotal, totalEntitiesCount, totalLinksCount, totalPendingReviewCount] = await Promise.all([
     sb.from("onboarding_sessions").select("*").eq("shop_id", params.shopId).eq("id", params.sessionId).maybeSingle(),
     sb.from("onboarding_files").select("*").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }),
     fetchPaginatedOnboardingRows<{ entity_type: string; status?: string | null }>({
@@ -47,7 +67,7 @@ export async function getOnboardingSession(params: { supabase: SupabaseClient; s
       orderBy: "created_at",
       ascending: false,
     }),
-    sb.from("onboarding_activation_plans").select("id, status, summary, created_at").eq("shop_id", params.shopId).eq("session_id", params.sessionId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    latestPlanPromise,
     countOnboardingRawRows({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
     countOnboardingEntities({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),
     countOnboardingEntityLinks({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId }),


### PR DESCRIPTION
### Motivation
- Prevent 500s when loading onboarding session details and ensure the UI surfaces real backend errors instead of rendering fake zero-state data.
- Make activation-plan lookup non-fatal so persisted staged session data still loads when optional activation rows are missing or the activation query errors.
- Ensure the vendor activation CTA is visible when staged ready vendors exist and that activation returns accurate before/after supplier counts.

### Description
- Hardened `GET /api/onboarding-agent/sessions/[sessionId]` to log contextual failure details and return a structured error payload `{ ok: false, error: { code, message } }` for safe UI handling (`app/api/onboarding-agent/sessions/[sessionId]/route.ts`).
- Made activation-plan lookup optional (warn and continue) inside `getOnboardingSession` so other session reads (files, entities, links, counts) succeed even if activation-plan query fails (`features/onboarding-agent/server/getOnboardingSession.ts`).
- Updated `OnboardingSessionPage` to track load state and load errors, stop rendering progress/entity/review panels when session load fails, show an explicit error panel, clear stale notices on failed refreshes, and make vendor activation visibility/disable logic depend on a successful load plus staged ready vendor count (`features/onboarding-agent/components/OnboardingSessionPage.tsx`).
- Adjusted vendor activation flow to return an accurate `suppliersAfter` by re-counting suppliers after writes (with a safe fallback for test/mocked DBs) so the UI can display inserted/updated/skipped/warnings/suppliersBefore/suppliersAfter/stagedVendorsFound (`features/onboarding-agent/server/activateOnboardingVendors.ts`).
- Files changed: `app/api/onboarding-agent/sessions/[sessionId]/route.ts`, `features/onboarding-agent/server/getOnboardingSession.ts`, `features/onboarding-agent/components/OnboardingSessionPage.tsx`, `features/onboarding-agent/server/activateOnboardingVendors.ts`.
- No schema changes, migrations, or new onboarding/activation domains were added.

### Testing
- Ran type check with `npx tsc --noEmit --pretty false` and it succeeded (no new type errors introduced).
- Ran unit tests with `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (final run: 11 files, 64 tests, all ✓); ran the targeted `activateOnboardingVendors` test (`npx vitest run features/onboarding-agent/server/activateOnboardingVendors.test.ts`) and it passed after the fix.
- Ran linter with `npx eslint app/api/onboarding-agent app/dashboard/onboarding app/parts/vendors features/onboarding-agent` which completed with warnings only and no errors.
- No automated DB integration tests were run because no DB env was available; logic verified by unit tests and by ensuring `suppliersAfter` is computed from a fresh DB count when available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0241ff0908328ad75a1b60200c910)