### PR TITLE
Add staged→live customer + vehicle activation endpoint and UI

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { activateOnboardingCustomersVehicles } from "@/features/onboarding-agent/server/activateOnboardingCustomersVehicles";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id as string;
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    const result = await activateOnboardingCustomersVehicles({
+      supabase: admin,
+      shopId,
+      sessionId,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to activate customers and vehicles";
+    const status = message.includes("Session not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -21,7 +21,9 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [planning, setPlanning] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [activatingVendors, setActivatingVendors] = useState(false);
+  const [activatingCustomersVehicles, setActivatingCustomersVehicles] = useState(false);
   const [vendorActivationSummary, setVendorActivationSummary] = useState<string | null>(null);
+  const [customerVehicleActivationResult, setCustomerVehicleActivationResult] = useState<any>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -128,6 +130,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     setError(null);
     setNotice(null);
     setVendorActivationSummary(null);
+    setCustomerVehicleActivationResult(null);
 
     try {
       const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/activate-vendors`, { method: "POST" });
@@ -145,6 +148,33 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       setError("Failed to activate staged vendors.");
     } finally {
       setActivatingVendors(false);
+    }
+  };
+
+  const activateCustomersVehicles = async () => {
+    const confirmed = window.confirm(
+      "This writes staged customer and vehicle records into live customers and vehicles for this shop. It does not activate work orders, invoices, parts, staff, or menu items.",
+    );
+    if (!confirmed) return;
+
+    setActivatingCustomersVehicles(true);
+    setError(null);
+    setNotice(null);
+    setCustomerVehicleActivationResult(null);
+
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/activate-customers-vehicles`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || "Failed to activate staged customers and vehicles.");
+      } else {
+        setCustomerVehicleActivationResult(json);
+      }
+      await load();
+    } catch {
+      setError("Failed to activate staged customers and vehicles.");
+    } finally {
+      setActivatingCustomersVehicles(false);
     }
   };
 
@@ -170,7 +200,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const files = payload?.files ?? [];
   const hasFiles = files.length > 0;
   const vendorReadyCount = Number(payload?.entityStatusCounts?.vendor?.ready ?? 0);
+  const customerReadyCount = Number(payload?.entityStatusCounts?.customer?.ready ?? 0);
+  const vehicleReadyCount = Number(payload?.entityStatusCounts?.vehicle?.ready ?? 0);
+  const hasCustomerVehicleReady = customerReadyCount > 0 || vehicleReadyCount > 0;
+  const actionBusy = analyzing || deleting || planning || activatingVendors || activatingCustomersVehicles;
   const canShowVendorActivation = !loadingSession && !sessionLoadError && vendorReadyCount > 0;
+  const canShowCustomerVehicleActivation = !loadingSession && !sessionLoadError && hasCustomerVehicleReady;
 
   const hasAnalysis = useMemo(() => {
     if (!session) return false;
@@ -219,15 +254,24 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
           ) : null}
           <button
             onClick={plan}
-            disabled={!hasAnalysis || planning || deleting}
+            disabled={!hasAnalysis || planning || deleting || activatingCustomersVehicles}
             className="rounded border border-amber-400/40 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {planning ? "Preparing…" : "Prepare activation plan"}
           </button>
+          {canShowCustomerVehicleActivation ? (
+            <button
+              onClick={activateCustomersVehicles}
+              disabled={actionBusy || !!sessionLoadError || !hasCustomerVehicleReady}
+              className="rounded border border-cyan-300/40 px-3 py-2 text-sm text-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {activatingCustomersVehicles ? "Activating customers + vehicles…" : "Activate customers + vehicles"}
+            </button>
+          ) : null}
           {canShowVendorActivation ? (
             <button
               onClick={activateVendors}
-              disabled={activatingVendors || analyzing || deleting || planning || !!sessionLoadError || vendorReadyCount <= 0}
+              disabled={actionBusy || !!sessionLoadError || vendorReadyCount <= 0}
               className="rounded border border-emerald-400/40 px-3 py-2 text-sm text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {activatingVendors ? "Activating vendors…" : "Activate vendors to live suppliers"}
@@ -250,8 +294,48 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
             Creates/updates suppliers only from staged ready vendor records. No customers, vehicles, parts, work orders, or invoices are activated.
           </p>
         ) : null}
+        {canShowCustomerVehicleActivation ? (
+          <p className="mt-1 text-xs text-cyan-100/90">
+            Creates/updates live customers and vehicles only. No work orders, invoices, parts, staff, or menu items are activated.
+          </p>
+        ) : null}
         {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
         {vendorActivationSummary ? <p className="mt-2 text-xs text-emerald-200">{vendorActivationSummary}</p> : null}
+        {customerVehicleActivationResult ? (
+          <div className="mt-2 rounded-lg border border-cyan-400/30 bg-cyan-950/20 p-3 text-xs text-cyan-100">
+            <p>
+              Staged customers/vehicles: {Number(customerVehicleActivationResult.stagedCustomersFound ?? 0)}/
+              {Number(customerVehicleActivationResult.stagedVehiclesFound ?? 0)}. Links: {Number(customerVehicleActivationResult.stagedCustomerVehicleLinksFound ?? 0)}.
+            </p>
+            <p>
+              Customers inserted/updated/skipped: {Number(customerVehicleActivationResult.customersInserted ?? 0)}/
+              {Number(customerVehicleActivationResult.customersUpdated ?? 0)}/{Number(customerVehicleActivationResult.customersSkipped ?? 0)}.
+            </p>
+            <p>
+              Vehicles inserted/updated/skipped: {Number(customerVehicleActivationResult.vehiclesInserted ?? 0)}/
+              {Number(customerVehicleActivationResult.vehiclesUpdated ?? 0)}/{Number(customerVehicleActivationResult.vehiclesSkipped ?? 0)}.
+            </p>
+            <p>
+              Customer/vehicle links created/updated/skipped: {Number(customerVehicleActivationResult.customerVehicleLinksCreated ?? 0)}/
+              {Number(customerVehicleActivationResult.customerVehicleLinksUpdated ?? 0)}/{Number(customerVehicleActivationResult.customerVehicleLinksSkipped ?? 0)}.
+            </p>
+            <p>
+              Live customers before/after: {Number(customerVehicleActivationResult.customersBefore ?? 0)}/
+              {Number(customerVehicleActivationResult.customersAfter ?? 0)}. Live vehicles before/after: {Number(customerVehicleActivationResult.vehiclesBefore ?? 0)}/
+              {Number(customerVehicleActivationResult.vehiclesAfter ?? 0)}.
+            </p>
+            {Array.isArray(customerVehicleActivationResult.warnings) && customerVehicleActivationResult.warnings.length > 0 ? (
+              <div className="mt-1">
+                <p>Warnings: {customerVehicleActivationResult.warnings.length}</p>
+                <ul className="list-disc pl-5">
+                  {customerVehicleActivationResult.warnings.map((warning: string, index: number) => (
+                    <li key={`${warning}-${index}`}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
         {sessionLoadError ? (
           <div className="mt-3 rounded-lg border border-rose-400/40 bg-rose-950/40 p-3 text-xs text-rose-200">

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { activateOnboardingCustomersVehicles } from "@/features/onboarding-agent/server/activateOnboardingCustomersVehicles";
+
+vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
+  assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
+}));
+
+type ActivationParams = Parameters<typeof activateOnboardingCustomersVehicles>[0];
+type Entity = {
+  id: string;
+  shop_id: string;
+  session_id: string;
+  entity_type: string;
+  status: string;
+  display_name: string | null;
+  normalized: Record<string, unknown>;
+  source_external_id: string | null;
+};
+
+type Link = {
+  id: string;
+  shop_id: string;
+  session_id: string;
+  from_entity_id: string;
+  to_entity_id: string;
+  link_type: string;
+};
+
+type Customer = {
+  id: string;
+  shop_id: string | null;
+  external_id: string | null;
+  email: string | null;
+  phone: string | null;
+  phone_number: string | null;
+  name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  business_name: string | null;
+};
+
+type Vehicle = {
+  id: string;
+  shop_id: string | null;
+  external_id: string | null;
+  vin: string | null;
+  license_plate: string | null;
+  unit_number: string | null;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  customer_id: string | null;
+};
+
+function createFakeSupabase(seed?: {
+  entities?: Entity[];
+  links?: Link[];
+  customers?: Customer[];
+  vehicles?: Vehicle[];
+}) {
+  const state = {
+    entities: [...(seed?.entities ?? [])],
+    links: [...(seed?.links ?? [])],
+    customers: [...(seed?.customers ?? [])],
+    vehicles: [...(seed?.vehicles ?? [])],
+    nextCustomerId: 1,
+    nextVehicleId: 1,
+    writes: [] as string[],
+  };
+
+  return {
+    state,
+    from(table: string) {
+      const query: any = {
+        table,
+        op: "select",
+        payload: null as any,
+        filters: [] as Array<{ k: string; v: any; op: "eq" | "in" }>,
+        selectOpts: null as any,
+        select(_columns: string, options?: any) {
+          this.selectOpts = options ?? null;
+          if (!this.op) this.op = "select";
+          return this;
+        },
+        order() { return this; },
+        eq(k: string, v: any) { this.filters.push({ k, v, op: "eq" }); return this; },
+        in(k: string, v: any[]) { this.filters.push({ k, v, op: "in" }); return this; },
+        update(payload: any) { this.op = "update"; this.payload = payload; return this; },
+        insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
+        single() { return this.execSingle(); },
+        then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
+        async execSingle() {
+          const result = await this.exec();
+          const first = Array.isArray(result.data) ? result.data[0] ?? null : result.data ?? null;
+          return { ...result, data: first };
+        },
+        async exec() {
+          const applyFilters = (rows: any[]) => {
+            let filtered = [...rows];
+            for (const filter of this.filters) {
+              filtered = filtered.filter((row) => {
+                if (filter.op === "eq") return row[filter.k] === filter.v;
+                return Array.isArray(filter.v) && filter.v.includes(row[filter.k]);
+              });
+            }
+            return filtered;
+          };
+
+          if (this.table === "onboarding_entities" && this.op === "select") return { data: applyFilters(state.entities), error: null };
+          if (this.table === "onboarding_entity_links" && this.op === "select") return { data: applyFilters(state.links), error: null };
+
+          if (this.table === "customers" && this.op === "select") {
+            const rows = applyFilters(state.customers);
+            if (this.selectOpts?.head) return { data: null, count: rows.length, error: null };
+            return { data: rows, error: null };
+          }
+
+          if (this.table === "vehicles" && this.op === "select") {
+            const rows = applyFilters(state.vehicles);
+            if (this.selectOpts?.head) return { data: null, count: rows.length, error: null };
+            return { data: rows, error: null };
+          }
+
+          if (this.table === "customers" && this.op === "insert") {
+            const created = { id: `customer-${state.nextCustomerId++}`, ...this.payload };
+            state.customers.push(created);
+            state.writes.push("customers:insert");
+            return { data: [{ id: created.id }], error: null };
+          }
+
+          if (this.table === "customers" && this.op === "update") {
+            const target = applyFilters(state.customers)[0];
+            if (target) Object.assign(target, this.payload);
+            state.writes.push("customers:update");
+            return { data: [], error: null };
+          }
+
+          if (this.table === "vehicles" && this.op === "insert") {
+            const created = { id: `vehicle-${state.nextVehicleId++}`, ...this.payload };
+            state.vehicles.push(created);
+            state.writes.push("vehicles:insert");
+            return { data: [{ id: created.id }], error: null };
+          }
+
+          if (this.table === "vehicles" && this.op === "update") {
+            const target = applyFilters(state.vehicles)[0];
+            if (target) Object.assign(target, this.payload);
+            state.writes.push("vehicles:update");
+            return { data: [], error: null };
+          }
+
+          return { data: [], error: null };
+        },
+      };
+
+      return query;
+    },
+  };
+}
+
+function stagedCustomer(id: string, overrides?: Partial<Entity>): Entity {
+  return {
+    id,
+    shop_id: "shop-1",
+    session_id: "session-1",
+    entity_type: "customer",
+    status: "ready",
+    display_name: "Jane Doe",
+    normalized: { sourceCustomerId: `C-${id}`, name: "Jane Doe", email: `jane${id}@example.com`, phone: "555-111-2222" },
+    source_external_id: `C-${id}`,
+    ...overrides,
+  };
+}
+
+function stagedVehicle(id: string, overrides?: Partial<Entity>): Entity {
+  return {
+    id,
+    shop_id: "shop-1",
+    session_id: "session-1",
+    entity_type: "vehicle",
+    status: "ready",
+    display_name: "2020 Ford F150",
+    normalized: { sourceVehicleId: `V-${id}`, sourceCustomerId: "C-c1", vin: `VIN${id}`, plate: `ABC${id}`, year: "2020", make: "Ford", model: "F150" },
+    source_external_id: `V-${id}`,
+    ...overrides,
+  };
+}
+
+async function runActivation(sb: ReturnType<typeof createFakeSupabase>, overrides?: Partial<ActivationParams>) {
+  return activateOnboardingCustomersVehicles({
+    supabase: sb as any,
+    shopId: "shop-1",
+    sessionId: "session-1",
+    ...overrides,
+  });
+}
+
+describe("activateOnboardingCustomersVehicles", () => {
+  let sb: ReturnType<typeof createFakeSupabase>;
+
+  beforeEach(() => {
+    sb = createFakeSupabase();
+  });
+
+  it("inserts staged ready customers and vehicles and applies customer_vehicle links", async () => {
+    sb = createFakeSupabase({
+      entities: [
+        stagedCustomer("c1", { normalized: { sourceCustomerId: "C-c1", name: "Jane Doe", email: "jane@example.com", phone: "555-111-2222" } }),
+        stagedVehicle("v1", { normalized: { sourceVehicleId: "V-v1", vin: "VIN111", plate: "ABC111", year: "2020", make: "Ford", model: "F150" } }),
+      ],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "c1", to_entity_id: "v1", link_type: "customer_vehicle" }],
+    });
+
+    const result = await runActivation(sb);
+
+    expect(result.customersInserted).toBe(1);
+    expect(result.vehiclesInserted).toBe(1);
+    expect(result.customerVehicleLinksCreated).toBe(1);
+    expect(sb.state.customers).toHaveLength(1);
+    expect(sb.state.vehicles).toHaveLength(1);
+    expect(sb.state.vehicles[0]?.customer_id).toBe(sb.state.customers[0]?.id);
+  });
+
+  it("is idempotent on second run with no duplicates", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1"), stagedVehicle("v1")],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "c1", to_entity_id: "v1", link_type: "customer_vehicle" }],
+    });
+
+    const first = await runActivation(sb);
+    const second = await runActivation(sb);
+
+    expect(first.customersInserted).toBe(1);
+    expect(first.vehiclesInserted).toBe(1);
+    expect(second.customersInserted).toBe(0);
+    expect(second.vehiclesInserted).toBe(0);
+    expect(second.customerVehicleLinksCreated).toBe(0);
+    expect(sb.state.customers).toHaveLength(1);
+    expect(sb.state.vehicles).toHaveLength(1);
+  });
+
+  it("does not overwrite populated live fields but fills null-safe fields", async () => {
+    sb = createFakeSupabase({
+      entities: [
+        stagedCustomer("c1", { normalized: { sourceCustomerId: "SRC-1", name: "Ignored Name", email: "new@example.com", phone: "5559990000" }, source_external_id: "SRC-1" }),
+        stagedVehicle("v1", { normalized: { sourceVehicleId: "VEH-1", vin: "VIN-1", plate: "XYZ-1", year: "2024", make: "Toyota", model: "Camry" }, source_external_id: "VEH-1" }),
+      ],
+      customers: [{ id: "customer-live", shop_id: "shop-1", external_id: "SRC-1", email: "existing@example.com", phone: null, phone_number: null, name: "Existing Name", first_name: null, last_name: null, business_name: null }],
+      vehicles: [{ id: "vehicle-live", shop_id: "shop-1", external_id: "VEH-1", vin: "VIN-1", license_plate: null, unit_number: null, year: null, make: "Ford", model: "F150", customer_id: null }],
+    });
+
+    const result = await runActivation(sb);
+
+    expect(result.customersUpdated).toBe(1);
+    expect(result.vehiclesUpdated).toBe(1);
+    expect(sb.state.customers[0]?.email).toBe("existing@example.com");
+    expect(sb.state.customers[0]?.phone).toBe("5559990000");
+    expect(sb.state.customers[0]?.name).toBe("Existing Name");
+    expect(sb.state.vehicles[0]?.make).toBe("Ford");
+    expect(sb.state.vehicles[0]?.license_plate).toBe("XYZ-1");
+    expect(sb.state.vehicles[0]?.year).toBe(2024);
+  });
+
+  it("ignores cross-shop/session, non-ready, and non-customer/non-vehicle entities", async () => {
+    sb = createFakeSupabase({
+      entities: [
+        stagedCustomer("c1"),
+        stagedCustomer("c2", { shop_id: "shop-2" }),
+        stagedVehicle("v1", { session_id: "session-2" }),
+        stagedVehicle("v2", { status: "needs_review" }),
+        stagedCustomer("c3", { entity_type: "vendor" }),
+      ],
+    });
+
+    const result = await runActivation(sb);
+    expect(result.stagedCustomersFound).toBe(1);
+    expect(result.stagedVehiclesFound).toBe(0);
+    expect(result.customersInserted).toBe(1);
+    expect(result.vehiclesInserted).toBe(0);
+  });
+
+  it("skips ambiguous matches with warnings", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1", { normalized: { name: "Acme", businessName: "Acme" }, source_external_id: null })],
+      customers: [
+        { id: "customer-1", shop_id: "shop-1", external_id: null, email: null, phone: null, phone_number: null, name: "Acme", first_name: null, last_name: null, business_name: null },
+        { id: "customer-2", shop_id: "shop-1", external_id: null, email: null, phone: null, phone_number: null, name: "Acme", first_name: null, last_name: null, business_name: null },
+      ],
+    });
+
+    const result = await runActivation(sb);
+    expect(result.customersSkipped).toBe(1);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("only writes to customers/vehicles tables", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1"), stagedVehicle("v1")],
+    });
+
+    await runActivation(sb);
+    expect(sb.state.writes.every((write) => write.startsWith("customers:") || write.startsWith("vehicles:"))).toBe(true);
+  });
+});

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
@@ -1,0 +1,482 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { normalizePhone } from "@/features/onboarding-agent/lib/fingerprints";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+type JsonObject = Record<string, unknown>;
+type OnboardingEntityRow = Database["public"]["Tables"]["onboarding_entities"]["Row"];
+type OnboardingEntityLinkRow = Database["public"]["Tables"]["onboarding_entity_links"]["Row"];
+type CustomerRow = Database["public"]["Tables"]["customers"]["Row"];
+type CustomerInsert = Database["public"]["Tables"]["customers"]["Insert"];
+type CustomerUpdate = Database["public"]["Tables"]["customers"]["Update"];
+type VehicleRow = Database["public"]["Tables"]["vehicles"]["Row"];
+type VehicleInsert = Database["public"]["Tables"]["vehicles"]["Insert"];
+type VehicleUpdate = Database["public"]["Tables"]["vehicles"]["Update"];
+
+export type CustomerVehicleActivationResult = {
+  ok: true;
+  stagedCustomersFound: number;
+  stagedVehiclesFound: number;
+  stagedCustomerVehicleLinksFound: number;
+  customersInserted: number;
+  customersUpdated: number;
+  customersSkipped: number;
+  vehiclesInserted: number;
+  vehiclesUpdated: number;
+  vehiclesSkipped: number;
+  customerVehicleLinksCreated: number;
+  customerVehicleLinksUpdated: number;
+  customerVehicleLinksSkipped: number;
+  customersBefore: number;
+  customersAfter: number;
+  vehiclesBefore: number;
+  vehiclesAfter: number;
+  warnings: string[];
+};
+
+type NormalizedCustomer = {
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  businessName: string | null;
+  email: string | null;
+  phone: string | null;
+  externalId: string | null;
+};
+
+type NormalizedVehicle = {
+  vin: string | null;
+  plate: string | null;
+  unitNumber: string | null;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  externalId: string | null;
+};
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function textOrNull(value: unknown): string | null {
+  const text = normalizeText(value);
+  return text ? text : null;
+}
+
+function normalizeLookupKey(value: unknown): string {
+  return normalizeText(value).toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function normalizeEmail(value: unknown): string | null {
+  const normalized = normalizeText(value).toLowerCase();
+  return normalized || null;
+}
+
+function normalizeVin(value: unknown): string | null {
+  const normalized = normalizeText(value).toUpperCase().replace(/\s+/g, "");
+  return normalized || null;
+}
+
+function normalizePlate(value: unknown): string | null {
+  const normalized = normalizeText(value).toUpperCase().replace(/\s+/g, "");
+  return normalized || null;
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const numeric = Number(String(value ?? "").replace(/[^0-9]/g, ""));
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function isBlank(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.trim().length === 0;
+  return false;
+}
+
+function toNormalizedCustomer(entity: Pick<OnboardingEntityRow, "normalized" | "display_name" | "source_external_id">): NormalizedCustomer {
+  const normalized = (entity.normalized ?? {}) as JsonObject;
+  const name = textOrNull(normalized.name) ?? textOrNull(entity.display_name);
+
+  return {
+    externalId: textOrNull(entity.source_external_id) ?? textOrNull(normalized.sourceCustomerId),
+    name,
+    firstName: textOrNull(normalized.firstName),
+    lastName: textOrNull(normalized.lastName),
+    businessName: textOrNull(normalized.businessName),
+    email: normalizeEmail(normalized.email),
+    phone: normalizePhone(textOrNull(normalized.phone)),
+  };
+}
+
+function toNormalizedVehicle(entity: Pick<OnboardingEntityRow, "normalized" | "source_external_id">): NormalizedVehicle {
+  const normalized = (entity.normalized ?? {}) as JsonObject;
+  return {
+    externalId: textOrNull(entity.source_external_id) ?? textOrNull(normalized.sourceVehicleId),
+    vin: normalizeVin(normalized.vin),
+    plate: normalizePlate(normalized.plate),
+    unitNumber: textOrNull(normalized.unitNumber),
+    year: normalizeNumber(normalized.year),
+    make: textOrNull(normalized.make),
+    model: textOrNull(normalized.model),
+  };
+}
+
+function buildCustomerUpdate(current: CustomerRow, next: NormalizedCustomer): CustomerUpdate | null {
+  const update: CustomerUpdate = {};
+  if (isBlank(current.external_id) && next.externalId) update.external_id = next.externalId;
+  if (isBlank(current.name) && next.name) update.name = next.name;
+  if (isBlank(current.first_name) && next.firstName) update.first_name = next.firstName;
+  if (isBlank(current.last_name) && next.lastName) update.last_name = next.lastName;
+  if (isBlank(current.business_name) && next.businessName) update.business_name = next.businessName;
+  if (isBlank(current.email) && next.email) update.email = next.email;
+  if (isBlank(current.phone) && next.phone) update.phone = next.phone;
+  if (isBlank(current.phone_number) && next.phone) update.phone_number = next.phone;
+
+  return Object.keys(update).length > 0 ? update : null;
+}
+
+function buildVehicleUpdate(current: VehicleRow, next: NormalizedVehicle): VehicleUpdate | null {
+  const update: VehicleUpdate = {};
+  if (isBlank(current.external_id) && next.externalId) update.external_id = next.externalId;
+  if (isBlank(current.vin) && next.vin) update.vin = next.vin;
+  if (isBlank(current.license_plate) && next.plate) update.license_plate = next.plate;
+  if (isBlank(current.unit_number) && next.unitNumber) update.unit_number = next.unitNumber;
+  if (current.year === null && next.year !== null) update.year = next.year;
+  if (isBlank(current.make) && next.make) update.make = next.make;
+  if (isBlank(current.model) && next.model) update.model = next.model;
+
+  return Object.keys(update).length > 0 ? update : null;
+}
+
+function customerMatchesInPriority(customer: NormalizedCustomer, pool: CustomerRow[]) {
+  if (customer.externalId) {
+    const matches = pool.filter((row) => normalizeLookupKey(row.external_id) === normalizeLookupKey(customer.externalId));
+    return { matches, strategy: "external_id" };
+  }
+
+  if (customer.email) {
+    const matches = pool.filter((row) => normalizeEmail(row.email) === customer.email);
+    return { matches, strategy: "email" };
+  }
+
+  if (customer.phone) {
+    const matches = pool.filter((row) => normalizePhone(row.phone ?? row.phone_number) === customer.phone);
+    return { matches, strategy: "phone" };
+  }
+
+  const nameKey = normalizeLookupKey(customer.businessName ?? customer.name);
+  if (nameKey) {
+    const matches = pool.filter((row) => {
+      const rowBusiness = normalizeLookupKey(row.business_name);
+      const rowName = normalizeLookupKey(row.name || `${row.first_name ?? ""} ${row.last_name ?? ""}`);
+      return rowBusiness === nameKey || rowName === nameKey;
+    });
+    return { matches, strategy: "name" };
+  }
+
+  return { matches: [], strategy: "none" };
+}
+
+function vehicleMatchesInPriority(args: {
+  vehicle: NormalizedVehicle;
+  pool: VehicleRow[];
+  linkedCustomerId: string | null;
+}) {
+  const { vehicle, pool, linkedCustomerId } = args;
+  if (vehicle.vin) {
+    return { matches: pool.filter((row) => normalizeVin(row.vin) === vehicle.vin), strategy: "vin" };
+  }
+
+  if (vehicle.plate) {
+    return { matches: pool.filter((row) => normalizePlate(row.license_plate) === vehicle.plate), strategy: "license_plate" };
+  }
+
+  if (vehicle.externalId) {
+    return { matches: pool.filter((row) => normalizeLookupKey(row.external_id) === normalizeLookupKey(vehicle.externalId)), strategy: "external_id" };
+  }
+
+  if (linkedCustomerId && vehicle.year !== null && vehicle.make && vehicle.model) {
+    const makeKey = normalizeLookupKey(vehicle.make);
+    const modelKey = normalizeLookupKey(vehicle.model);
+    return {
+      matches: pool.filter((row) =>
+        row.customer_id === linkedCustomerId
+        && row.year === vehicle.year
+        && normalizeLookupKey(row.make) === makeKey
+        && normalizeLookupKey(row.model) === modelKey),
+      strategy: "ymm_customer",
+    };
+  }
+
+  return { matches: [], strategy: "none" };
+}
+
+export async function activateOnboardingCustomersVehicles(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+}): Promise<CustomerVehicleActivationResult> {
+  const sb = params.supabase as any;
+
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+
+  const [
+    entitiesResult,
+    linksResult,
+    customersResult,
+    vehiclesResult,
+  ] = await Promise.all([
+    sb
+      .from("onboarding_entities")
+      .select("id, shop_id, session_id, entity_type, status, normalized, display_name, source_external_id")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .in("entity_type", ["customer", "vehicle"])
+      .eq("status", "ready")
+      .order("id", { ascending: true }),
+    sb
+      .from("onboarding_entity_links")
+      .select("id, shop_id, session_id, from_entity_id, to_entity_id, link_type")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("link_type", "customer_vehicle")
+      .order("id", { ascending: true }),
+    sb
+      .from("customers")
+      .select("id, shop_id, external_id, email, phone, phone_number, name, first_name, last_name, business_name")
+      .eq("shop_id", params.shopId)
+      .order("id", { ascending: true }),
+    sb
+      .from("vehicles")
+      .select("id, shop_id, external_id, vin, license_plate, unit_number, year, make, model, customer_id")
+      .eq("shop_id", params.shopId)
+      .order("id", { ascending: true }),
+  ]);
+
+  if (entitiesResult.error) throw new Error(entitiesResult.error.message);
+  if (linksResult.error) throw new Error(linksResult.error.message);
+  if (customersResult.error) throw new Error(customersResult.error.message);
+  if (vehiclesResult.error) throw new Error(vehiclesResult.error.message);
+
+  const entities = (entitiesResult.data ?? []) as Array<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name" | "source_external_id">>;
+  const links = (linksResult.data ?? []) as Array<Pick<OnboardingEntityLinkRow, "id" | "shop_id" | "session_id" | "from_entity_id" | "to_entity_id" | "link_type">>;
+  const customerPool = (customersResult.data ?? []) as CustomerRow[];
+  const vehiclePool = (vehiclesResult.data ?? []) as VehicleRow[];
+
+  const customerEntities = entities.filter((entity) => entity.entity_type === "customer" && entity.status === "ready");
+  const vehicleEntities = entities.filter((entity) => entity.entity_type === "vehicle" && entity.status === "ready");
+  const entityById = new Map(entities.map((entity) => [entity.id, entity]));
+
+  const warnings: string[] = [];
+  const customerEntityToLiveId = new Map<string, string>();
+  const vehicleEntityToLiveId = new Map<string, string>();
+
+  let customersInserted = 0;
+  let customersUpdated = 0;
+  let customersSkipped = 0;
+  for (const entity of customerEntities) {
+    const normalized = toNormalizedCustomer(entity);
+    const { matches, strategy } = customerMatchesInPriority(normalized, customerPool);
+
+    if (matches.length > 1) {
+      customersSkipped += 1;
+      warnings.push(`Customer entity ${entity.id} skipped: ambiguous ${strategy} match (${matches.length} rows).`);
+      continue;
+    }
+
+    if (matches.length === 1) {
+      const current = matches[0];
+      const update = buildCustomerUpdate(current, normalized);
+      customerEntityToLiveId.set(entity.id, current.id);
+      if (!update) {
+        customersSkipped += 1;
+        continue;
+      }
+      const { error } = await sb.from("customers").update(update).eq("shop_id", params.shopId).eq("id", current.id);
+      if (error) throw new Error(error.message);
+      Object.assign(current, update);
+      customersUpdated += 1;
+      continue;
+    }
+
+    const payload: CustomerInsert = {
+      shop_id: params.shopId,
+      external_id: normalized.externalId,
+      name: normalized.name,
+      first_name: normalized.firstName,
+      last_name: normalized.lastName,
+      business_name: normalized.businessName,
+      email: normalized.email,
+      phone: normalized.phone,
+      phone_number: normalized.phone,
+    };
+
+    const { data, error } = await sb.from("customers").insert(payload).select("id").single();
+    if (error) throw new Error(error.message);
+    const newId = String(data?.id);
+    customerEntityToLiveId.set(entity.id, newId);
+    customerPool.push({
+      id: newId,
+      shop_id: params.shopId,
+      external_id: payload.external_id ?? null,
+      email: payload.email ?? null,
+      phone: payload.phone ?? null,
+      phone_number: payload.phone_number ?? null,
+      name: payload.name ?? null,
+      first_name: payload.first_name ?? null,
+      last_name: payload.last_name ?? null,
+      business_name: payload.business_name ?? null,
+    } as CustomerRow);
+    customersInserted += 1;
+  }
+
+  const customerByExternal = new Map<string, string>();
+  for (const entity of customerEntities) {
+    const normalized = toNormalizedCustomer(entity);
+    if (!normalized.externalId) continue;
+    const liveId = customerEntityToLiveId.get(entity.id);
+    if (liveId) customerByExternal.set(normalizeLookupKey(normalized.externalId), liveId);
+  }
+
+  let vehiclesInserted = 0;
+  let vehiclesUpdated = 0;
+  let vehiclesSkipped = 0;
+  for (const entity of vehicleEntities) {
+    const normalized = toNormalizedVehicle(entity);
+    const raw = (entity.normalized ?? {}) as JsonObject;
+    const linkedCustomerId = customerByExternal.get(normalizeLookupKey(raw.sourceCustomerId));
+    const { matches, strategy } = vehicleMatchesInPriority({ vehicle: normalized, pool: vehiclePool, linkedCustomerId: linkedCustomerId ?? null });
+
+    if (matches.length > 1) {
+      vehiclesSkipped += 1;
+      warnings.push(`Vehicle entity ${entity.id} skipped: ambiguous ${strategy} match (${matches.length} rows).`);
+      continue;
+    }
+
+    if (matches.length === 1) {
+      const current = matches[0];
+      const update = buildVehicleUpdate(current, normalized);
+      vehicleEntityToLiveId.set(entity.id, current.id);
+      if (!update) {
+        vehiclesSkipped += 1;
+        continue;
+      }
+      const { error } = await sb.from("vehicles").update(update).eq("shop_id", params.shopId).eq("id", current.id);
+      if (error) throw new Error(error.message);
+      Object.assign(current, update);
+      vehiclesUpdated += 1;
+      continue;
+    }
+
+    const payload: VehicleInsert = {
+      shop_id: params.shopId,
+      external_id: normalized.externalId,
+      customer_id: linkedCustomerId ?? null,
+      vin: normalized.vin,
+      license_plate: normalized.plate,
+      unit_number: normalized.unitNumber,
+      year: normalized.year,
+      make: normalized.make,
+      model: normalized.model,
+    };
+
+    const { data, error } = await sb.from("vehicles").insert(payload).select("id").single();
+    if (error) throw new Error(error.message);
+    const newId = String(data?.id);
+    vehicleEntityToLiveId.set(entity.id, newId);
+    vehiclePool.push({
+      id: newId,
+      shop_id: params.shopId,
+      external_id: payload.external_id ?? null,
+      customer_id: payload.customer_id ?? null,
+      vin: payload.vin ?? null,
+      license_plate: payload.license_plate ?? null,
+      unit_number: payload.unit_number ?? null,
+      year: payload.year ?? null,
+      make: payload.make ?? null,
+      model: payload.model ?? null,
+    } as VehicleRow);
+    vehiclesInserted += 1;
+  }
+
+  let customerVehicleLinksCreated = 0;
+  const customerVehicleLinksUpdated = 0;
+  let customerVehicleLinksSkipped = 0;
+
+  for (const link of links) {
+    const from = entityById.get(link.from_entity_id);
+    const to = entityById.get(link.to_entity_id);
+    const customerEntityId = from?.entity_type === "customer" ? from.id : to?.entity_type === "customer" ? to.id : null;
+    const vehicleEntityId = from?.entity_type === "vehicle" ? from.id : to?.entity_type === "vehicle" ? to.id : null;
+
+    if (!customerEntityId || !vehicleEntityId) {
+      customerVehicleLinksSkipped += 1;
+      warnings.push(`Link ${link.id} skipped: does not connect staged customer+vehicle entities.`);
+      continue;
+    }
+
+    const customerId = customerEntityToLiveId.get(customerEntityId);
+    const vehicleId = vehicleEntityToLiveId.get(vehicleEntityId);
+    if (!customerId || !vehicleId) {
+      customerVehicleLinksSkipped += 1;
+      warnings.push(`Link ${link.id} skipped: customer or vehicle was not materialized.`);
+      continue;
+    }
+
+    const vehicle = vehiclePool.find((row) => row.id === vehicleId);
+    if (!vehicle) {
+      customerVehicleLinksSkipped += 1;
+      continue;
+    }
+
+    if (vehicle.customer_id === customerId) {
+      customerVehicleLinksSkipped += 1;
+      continue;
+    }
+
+    if (vehicle.customer_id) {
+      customerVehicleLinksSkipped += 1;
+      warnings.push(`Link ${link.id} skipped: vehicle ${vehicleId} already belongs to another customer.`);
+      continue;
+    }
+
+    const { error } = await sb.from("vehicles").update({ customer_id: customerId }).eq("shop_id", params.shopId).eq("id", vehicleId);
+    if (error) throw new Error(error.message);
+    vehicle.customer_id = customerId;
+    customerVehicleLinksCreated += 1;
+  }
+
+  const [{ count: customersAfter, error: customersAfterError }, { count: vehiclesAfter, error: vehiclesAfterError }] = await Promise.all([
+    sb.from("customers").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId),
+    sb.from("vehicles").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId),
+  ]);
+
+  if (customersAfterError) throw new Error(customersAfterError.message);
+  if (vehiclesAfterError) throw new Error(vehiclesAfterError.message);
+
+  return {
+    ok: true,
+    stagedCustomersFound: customerEntities.length,
+    stagedVehiclesFound: vehicleEntities.length,
+    stagedCustomerVehicleLinksFound: links.length,
+    customersInserted,
+    customersUpdated,
+    customersSkipped,
+    vehiclesInserted,
+    vehiclesUpdated,
+    vehiclesSkipped,
+    customerVehicleLinksCreated,
+    customerVehicleLinksUpdated,
+    customerVehicleLinksSkipped,
+    customersBefore: customerPool.length - customersInserted,
+    customersAfter: Number(customersAfter ?? customerPool.length),
+    vehiclesBefore: vehiclePool.length - vehiclesInserted,
+    vehiclesAfter: Number(vehiclesAfter ?? vehiclePool.length),
+    warnings,
+  };
+}

--- a/features/onboarding-agent/server/analyzeOnboardingSession.test.ts
+++ b/features/onboarding-agent/server/analyzeOnboardingSession.test.ts
@@ -167,6 +167,8 @@ describe("analyzeOnboardingSession idempotent raw-row rebuild", () => {
     expect(sb.upsertCalls.every((call) => call.onConflict === "shop_id,file_id,source_row_index")).toBe(true);
     expect(sb.upsertCalls.flatMap((call) => call.rows).every((row) => row.session_id === "session-1" && row.error_reason === null)).toBe(true);
     expect(sb.touchedTables.includes("suppliers")).toBe(false);
+    expect(sb.touchedTables.includes("customers")).toBe(false);
+    expect(sb.touchedTables.includes("vehicles")).toBe(false);
   });
 
   it("throws 409 conflict when a run is already in progress", async () => {


### PR DESCRIPTION
### Motivation
- Provide a safe, conservative activation path to materialize staged customers and vehicles into live shop data without touching other domains. 
- Follow the proven vendor activation pattern: session ownership guard, shop/session scoping, idempotent writes, and null-safe updates. 
- This enables the next vertical activation slice (customers + vehicles) while preserving RLS/tenant safety and avoiding activation of parts/invoices/work orders/staff/menu items. 
- Expected staged totals for the known good session: staged customers: **1,800**, staged vehicles: **2,600**, staged customer_vehicle links: **2,600**.

### Description
- New API route `POST /api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles` that requires owner/admin shop-scoped access and returns the required flat JSON activation summary. (file: `app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts`).
- New server helper `activateOnboardingCustomersVehicles` implementing conservative staged→live logic (file: `features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts`).
- Matching and activation behavior implemented as requested:
  - Customer matching priority: `external_id` → normalized email → normalized phone → deterministic business/name key; exact-one match performs null-safe update only, multiple matches are skipped with warnings, no match inserts a new customer scoped to `shop_id`.
  - Vehicle matching priority: VIN → `license_plate` (if present) → `external_id` → year/make/model + linked customer; exact-one match performs null-safe update only, multiple matches are skipped with warnings, no match inserts a new vehicle scoped to `shop_id`.
  - Customer↔vehicle linking uses the canonical `vehicles.customer_id` update only, is idempotent, and skips/warns on unsafe owner relink.
- UI: added clearly labeled button and helper copy to onboarding session page plus a results summary panel and clear error surface (file: `features/onboarding-agent/components/OnboardingSessionPage.tsx`).
- Tests: added focused unit tests covering inserts/updates/links/idempotency/scope/ambiguous-match handling and a guard that analysis/rerun does not write live customers/vehicles (file: `features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts`).
- Inspected live table columns (from generated DB types) and used only those exact columns; no schema changes:
  - customers inspected: `id, shop_id, external_id, email, phone, phone_number, name, first_name, last_name, business_name`.
  - vehicles inspected: `id, shop_id, external_id, vin, license_plate, unit_number, year, make, model, customer_id`.
- No schema/migration changes were added and activation writes are explicitly limited to `customers` and `vehicles` only.

### Testing
- Type-check: `npx tsc --noEmit --pretty false` — succeeded. 
- Unit tests: `npx vitest run features/onboarding-agent` — all tests in the onboarding-agent suite passed (70 tests across the suite passed). 
- Lint: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` — passed (existing repo warnings remain, no new errors introduced).
- The new activation tests validate: staged ready customers/vehicles insert, null-safe updates to existing records, customer_vehicle links applied idempotently, cross-shop/session and non-ready rows ignored, ambiguous matches skipped with warnings, and that analysis/rerun do not write live customer/vehicle records.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02a9a6fe88328a344e72b4572f925)