### PR TITLE
Fix full-session customer/vehicle activation pagination and compact warnings

### DIFF
--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -12,6 +12,15 @@ import { OnboardingReviewPanel } from "@/features/onboarding-agent/components/On
 import { onboardingSessionActionPath } from "@/features/onboarding-agent/lib/routes";
 import { formatOnboardingSessionStatusLabel } from "@/features/onboarding-agent/lib/sessionStatus";
 
+function warningCategory(warning: string): string {
+  if (warning.includes("unique conflict recovery failed")) return "unique conflict recovery failed";
+  if (warning.includes("does not connect staged customer+vehicle entities")) return "invalid customer_vehicle link";
+  if (warning.includes("customer or vehicle was not materialized")) return "unmaterialized customer/vehicle";
+  if (warning.includes("already belongs to another customer")) return "vehicle already linked to other customer";
+  if (warning.includes("ambiguous")) return "ambiguous match";
+  return "other";
+}
+
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
@@ -206,6 +215,24 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const actionBusy = analyzing || deleting || planning || activatingVendors || activatingCustomersVehicles;
   const canShowVendorActivation = !loadingSession && !sessionLoadError && vendorReadyCount > 0;
   const canShowCustomerVehicleActivation = !loadingSession && !sessionLoadError && hasCustomerVehicleReady;
+  const groupedCustomerVehicleWarnings = useMemo(() => {
+    const warnings: string[] = Array.isArray(customerVehicleActivationResult?.warnings)
+      ? customerVehicleActivationResult.warnings
+      : [];
+    const groups = new Map<string, { count: number; examples: string[] }>();
+    for (const warning of warnings) {
+      const key = warningCategory(warning);
+      const group = groups.get(key) ?? { count: 0, examples: [] };
+      group.count += 1;
+      if (group.examples.length < 10) group.examples.push(warning);
+      groups.set(key, group);
+    }
+    return [...groups.entries()].map(([reason, group]) => ({
+      reason,
+      count: group.count,
+      examples: group.examples,
+    }));
+  }, [customerVehicleActivationResult]);
 
   const hasAnalysis = useMemo(() => {
     if (!session) return false;
@@ -315,16 +342,16 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
               {Number(customerVehicleActivationResult.customersUpdated ?? 0)}/{Number(customerVehicleActivationResult.customersMatchedExisting ?? 0)}/{Number(customerVehicleActivationResult.customersSkipped ?? 0)}.
             </p>
             <p>
-              Vehicles inserted/updated/skipped: {Number(customerVehicleActivationResult.vehiclesInserted ?? 0)}/
-              {Number(customerVehicleActivationResult.vehiclesUpdated ?? 0)}/{Number(customerVehicleActivationResult.vehiclesSkipped ?? 0)}.
+              Vehicles inserted/updated/matched existing/skipped: {Number(customerVehicleActivationResult.vehiclesInserted ?? 0)}/
+              {Number(customerVehicleActivationResult.vehiclesUpdated ?? 0)}/{Number(customerVehicleActivationResult.vehiclesMatchedExisting ?? 0)}/{Number(customerVehicleActivationResult.vehiclesSkipped ?? 0)}.
             </p>
             <p>
               Customer duplicate-staged/ambiguous/recovered from unique conflict: {Number(customerVehicleActivationResult.customersSkippedDuplicateStaged ?? 0)}/
               {Number(customerVehicleActivationResult.customersSkippedAmbiguous ?? 0)}/{Number(customerVehicleActivationResult.customersRecoveredFromUniqueConflict ?? 0)}.
             </p>
             <p>
-              Vehicle/customer links created/updated/skipped: {Number(customerVehicleActivationResult.vehicleCustomerLinksCreated ?? 0)}/
-              {Number(customerVehicleActivationResult.vehicleCustomerLinksUpdated ?? 0)}/{Number(customerVehicleActivationResult.vehicleCustomerLinksSkipped ?? 0)}.
+              Vehicle/customer links created/updated/already-correct/skipped: {Number(customerVehicleActivationResult.vehicleCustomerLinksCreated ?? 0)}/
+              {Number(customerVehicleActivationResult.vehicleCustomerLinksUpdated ?? 0)}/{Number(customerVehicleActivationResult.vehicleCustomerLinksAlreadyCorrect ?? 0)}/{Number(customerVehicleActivationResult.vehicleCustomerLinksSkipped ?? 0)}.
             </p>
             <p>
               Live customers before/after: {Number(customerVehicleActivationResult.customersBefore ?? 0)}/
@@ -335,8 +362,18 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
               <div className="mt-1">
                 <p>Warnings: {customerVehicleActivationResult.warnings.length}</p>
                 <ul className="list-disc pl-5">
-                  {customerVehicleActivationResult.warnings.map((warning: string, index: number) => (
-                    <li key={`${warning}-${index}`}>{warning}</li>
+                  {groupedCustomerVehicleWarnings.map((group) => (
+                    <li key={group.reason}>
+                      {group.reason}: {group.count}
+                      <details className="mt-1 pl-2">
+                        <summary className="cursor-pointer text-[11px] text-cyan-200/90">Show first {group.examples.length} examples</summary>
+                        <ul className="list-disc pl-5 pt-1 text-[11px] text-cyan-100/90">
+                          {group.examples.map((warning: string, index: number) => (
+                            <li key={`${group.reason}-${index}`}>{warning}</li>
+                          ))}
+                        </ul>
+                      </details>
+                    </li>
                   ))}
                 </ul>
               </div>

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
@@ -84,12 +84,15 @@ function createFakeSupabase(seed?: {
         payload: null as any,
         filters: [] as Array<{ k: string; v: any; op: "eq" | "in" }>,
         selectOpts: null as any,
+        rangeFrom: null as number | null,
+        rangeTo: null as number | null,
         select(_columns: string, options?: any) {
           this.selectOpts = options ?? null;
           if (!this.op) this.op = "select";
           return this;
         },
         order() { return this; },
+        range(from: number, to: number) { this.rangeFrom = from; this.rangeTo = to; return this; },
         eq(k: string, v: any) { this.filters.push({ k, v, op: "eq" }); return this; },
         in(k: string, v: any[]) { this.filters.push({ k, v, op: "in" }); return this; },
         update(payload: any) { this.op = "update"; this.payload = payload; return this; },
@@ -109,6 +112,12 @@ function createFakeSupabase(seed?: {
                 if (filter.op === "eq") return row[filter.k] === filter.v;
                 return Array.isArray(filter.v) && filter.v.includes(row[filter.k]);
               });
+            }
+            if (typeof this.rangeFrom === "number" && typeof this.rangeTo === "number") {
+              return filtered.slice(this.rangeFrom, this.rangeTo + 1);
+            }
+            if (!this.selectOpts?.head && this.op === "select" && (this.table === "onboarding_entities" || this.table === "onboarding_entity_links" || this.table === "customers" || this.table === "vehicles")) {
+              return filtered.slice(0, 1000);
             }
             return filtered;
           };
@@ -333,5 +342,91 @@ describe("activateOnboardingCustomersVehicles", () => {
 
     expect(result.customersSkippedAmbiguous).toBe(1);
     expect(result.warnings.some((warning) => warning.includes("ambiguous"))).toBe(true);
+  });
+
+  it("paginates full staged customer/vehicle/link sets and processes links past first 1000", async () => {
+    const customers = Array.from({ length: 1800 }, (_, index) => stagedCustomer(`c${index + 1}`, {
+      normalized: { sourceCustomerId: `C-${index + 1}`, email: `customer${index + 1}@example.com`, name: `Customer ${index + 1}` },
+      source_external_id: `C-${index + 1}`,
+    }));
+    const vehicles = Array.from({ length: 2600 }, (_, index) => stagedVehicle(`v${index + 1}`, {
+      normalized: {
+        sourceVehicleId: `V-${index + 1}`,
+        sourceCustomerId: `C-${(index % 1800) + 1}`,
+        vin: `VIN${String(index + 1).padStart(6, "0")}`,
+        plate: `PLATE${index + 1}`,
+        year: "2022",
+        make: "Ford",
+        model: "Transit",
+      },
+      source_external_id: `V-${index + 1}`,
+    }));
+    const links = Array.from({ length: 2600 }, (_, index) => ({
+      id: `l${index + 1}`,
+      shop_id: "shop-1",
+      session_id: "session-1",
+      from_entity_id: `c${(index % 1800) + 1}`,
+      to_entity_id: `v${index + 1}`,
+      link_type: "customer_vehicle",
+    }));
+
+    sb = createFakeSupabase({ entities: [...customers, ...vehicles], links });
+
+    const result = await runActivation(sb);
+
+    expect(result.stagedCustomersFound).toBe(1800);
+    expect(result.stagedVehiclesFound).toBe(2600);
+    expect(result.stagedCustomerVehicleLinksFound).toBe(2600);
+    expect(result.stagedCustomersFound).not.toBe(405);
+    expect(result.stagedVehiclesFound).not.toBe(595);
+    expect(result.stagedCustomerVehicleLinksFound).not.toBe(1000);
+    expect(result.vehiclesAfter).toBe(2600);
+    expect(sb.state.vehicles[1500]?.customer_id).toBeTruthy();
+  });
+
+  it("maps duplicate staged customer ids to one live customer and links past 1000 stay idempotent", async () => {
+    const entities: Entity[] = [
+      stagedCustomer("c1", { normalized: { sourceCustomerId: "SRC-ONE", email: "one@example.com", name: "One" } }),
+      stagedCustomer("c2", { normalized: { sourceCustomerId: "SRC-TWO", email: "one@example.com", name: "One Duplicate" } }),
+      ...Array.from({ length: 2600 }, (_, index) => stagedVehicle(`v${index + 1}`, {
+        normalized: {
+          sourceVehicleId: `V-${index + 1}`,
+          sourceCustomerId: index >= 1000 ? "SRC-TWO" : "SRC-ONE",
+          vin: `VIN${String(index + 1).padStart(6, "0")}`,
+          plate: `P${index + 1}`,
+          year: "2021",
+          make: "Toyota",
+          model: "Camry",
+        },
+      })),
+    ];
+    const links: Link[] = Array.from({ length: 2600 }, (_, index) => ({
+      id: `l${index + 1}`,
+      shop_id: "shop-1",
+      session_id: "session-1",
+      from_entity_id: index >= 1000 ? "c2" : "c1",
+      to_entity_id: `v${index + 1}`,
+      link_type: "customer_vehicle",
+    }));
+
+    sb = createFakeSupabase({
+      entities,
+      links,
+      customers: [
+        { id: "customer-live", shop_id: "shop-1", external_id: null, email: "one@example.com", phone: null, phone_number: null, name: "Existing One", first_name: null, last_name: null, business_name: null },
+      ],
+    });
+
+    const first = await runActivation(sb);
+    const second = await runActivation(sb);
+
+    expect(first.customersInserted).toBe(0);
+    expect(first.customersMatchedExisting + first.customersUpdated).toBe(1);
+    expect(first.customersSkippedDuplicateStaged).toBe(1);
+    expect(sb.state.customerInsertAttemptsByEmail.get("one@example.com") ?? 0).toBe(0);
+    expect(sb.state.vehicles[1500]?.customer_id).toBe("customer-live");
+    expect(first.vehicleCustomerLinksCreated).toBeGreaterThan(1000);
+    expect(second.vehicleCustomerLinksCreated).toBe(0);
+    expect(second.vehicleCustomerLinksAlreadyCorrect).toBe(2600);
   });
 });

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
@@ -12,6 +12,7 @@ type CustomerUpdate = Database["public"]["Tables"]["customers"]["Update"];
 type VehicleRow = Database["public"]["Tables"]["vehicles"]["Row"];
 type VehicleInsert = Database["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = Database["public"]["Tables"]["vehicles"]["Update"];
+const PAGE_SIZE = 1000;
 
 export type CustomerVehicleActivationResult = {
   ok: true;
@@ -28,9 +29,11 @@ export type CustomerVehicleActivationResult = {
   customersSkipped: number;
   vehiclesInserted: number;
   vehiclesUpdated: number;
+  vehiclesMatchedExisting: number;
   vehiclesSkipped: number;
   vehicleCustomerLinksCreated: number;
   vehicleCustomerLinksUpdated: number;
+  vehicleCustomerLinksAlreadyCorrect: number;
   vehicleCustomerLinksSkipped: number;
   customersBefore: number;
   customersAfter: number;
@@ -323,6 +326,20 @@ export async function activateOnboardingCustomersVehicles(params: {
   sessionId: string;
 }): Promise<CustomerVehicleActivationResult> {
   const sb = params.supabase as any;
+  async function fetchAllRows<T>(buildQuery: (from: number, to: number) => any): Promise<T[]> {
+    const rows: T[] = [];
+    let from = 0;
+    while (true) {
+      const to = from + PAGE_SIZE - 1;
+      const { data, error } = await buildQuery(from, to);
+      if (error) throw new Error(error.message);
+      const batch = (data ?? []) as T[];
+      rows.push(...batch);
+      if (batch.length < PAGE_SIZE) break;
+      from += PAGE_SIZE;
+    }
+    return rows;
+  }
 
   await assertOnboardingSessionOwnership({
     supabase: params.supabase,
@@ -330,48 +347,41 @@ export async function activateOnboardingCustomersVehicles(params: {
     sessionId: params.sessionId,
   });
 
-  const [
-    entitiesResult,
-    linksResult,
-    customersResult,
-    vehiclesResult,
-  ] = await Promise.all([
-    sb
-      .from("onboarding_entities")
-      .select("id, shop_id, session_id, entity_type, status, normalized, display_name, source_external_id")
-      .eq("shop_id", params.shopId)
-      .eq("session_id", params.sessionId)
-      .in("entity_type", ["customer", "vehicle"])
-      .eq("status", "ready")
-      .order("id", { ascending: true }),
-    sb
-      .from("onboarding_entity_links")
-      .select("id, shop_id, session_id, from_entity_id, to_entity_id, link_type")
-      .eq("shop_id", params.shopId)
-      .eq("session_id", params.sessionId)
-      .eq("link_type", "customer_vehicle")
-      .order("id", { ascending: true }),
-    sb
-      .from("customers")
-      .select("id, shop_id, external_id, email, phone, phone_number, name, first_name, last_name, business_name")
-      .eq("shop_id", params.shopId)
-      .order("id", { ascending: true }),
-    sb
-      .from("vehicles")
-      .select("id, shop_id, external_id, vin, license_plate, unit_number, year, make, model, customer_id")
-      .eq("shop_id", params.shopId)
-      .order("id", { ascending: true }),
+  const [entities, links, customerPool, vehiclePool] = await Promise.all([
+    fetchAllRows<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name" | "source_external_id">>((from, to) =>
+      sb
+        .from("onboarding_entities")
+        .select("id, shop_id, session_id, entity_type, status, normalized, display_name, source_external_id")
+        .eq("shop_id", params.shopId)
+        .eq("session_id", params.sessionId)
+        .in("entity_type", ["customer", "vehicle"])
+        .eq("status", "ready")
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllRows<Pick<OnboardingEntityLinkRow, "id" | "shop_id" | "session_id" | "from_entity_id" | "to_entity_id" | "link_type">>((from, to) =>
+      sb
+        .from("onboarding_entity_links")
+        .select("id, shop_id, session_id, from_entity_id, to_entity_id, link_type")
+        .eq("shop_id", params.shopId)
+        .eq("session_id", params.sessionId)
+        .eq("link_type", "customer_vehicle")
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllRows<CustomerRow>((from, to) =>
+      sb
+        .from("customers")
+        .select("id, shop_id, external_id, email, phone, phone_number, name, first_name, last_name, business_name")
+        .eq("shop_id", params.shopId)
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllRows<VehicleRow>((from, to) =>
+      sb
+        .from("vehicles")
+        .select("id, shop_id, external_id, vin, license_plate, unit_number, year, make, model, customer_id")
+        .eq("shop_id", params.shopId)
+        .order("id", { ascending: true })
+        .range(from, to)),
   ]);
-
-  if (entitiesResult.error) throw new Error(entitiesResult.error.message);
-  if (linksResult.error) throw new Error(linksResult.error.message);
-  if (customersResult.error) throw new Error(customersResult.error.message);
-  if (vehiclesResult.error) throw new Error(vehiclesResult.error.message);
-
-  const entities = (entitiesResult.data ?? []) as Array<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name" | "source_external_id">>;
-  const links = (linksResult.data ?? []) as Array<Pick<OnboardingEntityLinkRow, "id" | "shop_id" | "session_id" | "from_entity_id" | "to_entity_id" | "link_type">>;
-  const customerPool = (customersResult.data ?? []) as CustomerRow[];
-  const vehiclePool = (vehiclesResult.data ?? []) as VehicleRow[];
 
   const customersBefore = customerPool.length;
   const vehiclesBefore = vehiclePool.length;
@@ -431,12 +441,14 @@ export async function activateOnboardingCustomersVehicles(params: {
     const { data, error } = await sb.from("customers").insert(payload).select("id").single();
     if (error) {
       if (!normalized.email || !isCustomerEmailUniqueViolation(error)) throw new Error(error.message);
-      const recoveryResult = await sb
-        .from("customers")
-        .select("id, shop_id, external_id, email, phone, phone_number, name, first_name, last_name, business_name")
-        .eq("shop_id", params.shopId);
-      if (recoveryResult.error) throw new Error(recoveryResult.error.message);
-      const recovered = ((recoveryResult.data ?? []) as CustomerRow[])
+      const recovered = (await fetchAllRows<CustomerRow>((from, to) =>
+        sb
+          .from("customers")
+          .select("id, shop_id, external_id, email, phone, phone_number, name, first_name, last_name, business_name")
+          .eq("shop_id", params.shopId)
+          .eq("email", normalized.email)
+          .order("id", { ascending: true })
+          .range(from, to)))
         .filter((row) => normalizeEmail(row.email) === normalized.email);
 
       if (recovered.length === 1) {
@@ -492,6 +504,7 @@ export async function activateOnboardingCustomersVehicles(params: {
 
   let vehiclesInserted = 0;
   let vehiclesUpdated = 0;
+  let vehiclesMatchedExisting = 0;
   let vehiclesSkipped = 0;
   for (const entity of vehicleEntities) {
     const normalized = toNormalizedVehicle(entity);
@@ -510,7 +523,7 @@ export async function activateOnboardingCustomersVehicles(params: {
       const update = buildVehicleUpdate(current, normalized);
       vehicleEntityToLiveId.set(entity.id, current.id);
       if (!update) {
-        vehiclesSkipped += 1;
+        vehiclesMatchedExisting += 1;
         continue;
       }
       const { error } = await sb.from("vehicles").update(update).eq("shop_id", params.shopId).eq("id", current.id);
@@ -552,8 +565,10 @@ export async function activateOnboardingCustomersVehicles(params: {
   }
 
   let vehicleCustomerLinksCreated = 0;
-  const vehicleCustomerLinksUpdated = 0;
+  let vehicleCustomerLinksUpdated = 0;
+  let vehicleCustomerLinksAlreadyCorrect = 0;
   let vehicleCustomerLinksSkipped = 0;
+  const vehicleById = new Map(vehiclePool.map((row) => [row.id, row]));
 
   for (const link of links) {
     const from = entityById.get(link.from_entity_id);
@@ -575,14 +590,14 @@ export async function activateOnboardingCustomersVehicles(params: {
       continue;
     }
 
-    const vehicle = vehiclePool.find((row) => row.id === vehicleId);
+    const vehicle = vehicleById.get(vehicleId);
     if (!vehicle) {
       vehicleCustomerLinksSkipped += 1;
       continue;
     }
 
     if (vehicle.customer_id === customerId) {
-      vehicleCustomerLinksSkipped += 1;
+      vehicleCustomerLinksAlreadyCorrect += 1;
       continue;
     }
 
@@ -594,8 +609,12 @@ export async function activateOnboardingCustomersVehicles(params: {
 
     const { error } = await sb.from("vehicles").update({ customer_id: customerId }).eq("shop_id", params.shopId).eq("id", vehicleId);
     if (error) throw new Error(error.message);
+    if (vehicle.customer_id === null) {
+      vehicleCustomerLinksCreated += 1;
+    } else {
+      vehicleCustomerLinksUpdated += 1;
+    }
     vehicle.customer_id = customerId;
-    vehicleCustomerLinksCreated += 1;
   }
 
   const [{ count: customersAfter, error: customersAfterError }, { count: vehiclesAfter, error: vehiclesAfterError }] = await Promise.all([
@@ -623,9 +642,11 @@ export async function activateOnboardingCustomersVehicles(params: {
     customersSkipped,
     vehiclesInserted,
     vehiclesUpdated,
+    vehiclesMatchedExisting,
     vehiclesSkipped,
     vehicleCustomerLinksCreated,
     vehicleCustomerLinksUpdated,
+    vehicleCustomerLinksAlreadyCorrect,
     vehicleCustomerLinksSkipped,
     customersBefore,
     customersAfter: Number(customersAfter ?? customerPool.length),


### PR DESCRIPTION
### Motivation
- Activation was truncated by Supabase's implicit 1000-row cap on non-paginated selects, causing partial materialization (the 405/595/1000 symptom) and a flood of per-row warnings in the operator UI.  
- The change must process the entire staged session (customers, vehicles, customer_vehicle links) deterministically without schema changes and keep writes limited to live customers and vehicles.  

### Description
- Added a local `PAGE_SIZE=1000` and `fetchAllRows` pager to `activateOnboardingCustomersVehicles.ts` and replaced the non-paginated reads for `onboarding_entities`, `onboarding_entity_links`, `customers`, and `vehicles` with deterministic `.range(from,to)` loops until exhaustion.  
- Made unique-conflict recovery use the same paginated reads scoped by `shop_id` + `email` to avoid hidden truncation during recovery.  
- Preserved and used the canonical staged-to-live mappings for dedupe and linking, added `vehiclesMatchedExisting` and `vehicleCustomerLinksAlreadyCorrect` counters, and switched link resolution to a `vehicleById` map so all staged links are processed idempotently across the full session.  
- UI change: grouped activation warnings by reason in `OnboardingSessionPage.tsx`, showing counts and only the first 10 examples per group behind a `<details>` disclosure to avoid operator panel spam.  
- Tests and harness updates: extended the activation test harness to emulate `.range(from,to)`, added regression tests that mock 1800 customers, 2600 vehicles, and 2600 links to assert full staged counts, link processing beyond index 1000, dedupe mapping, and idempotent reruns; changed files: `features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts`, `features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts`, and `features/onboarding-agent/components/OnboardingSessionPage.tsx`.  

### Testing
- Ran `npx tsc --noEmit --pretty false` and the TypeScript check completed successfully.  
- Ran `npx vitest run features/onboarding-agent` and all tests passed (73 tests across onboarding-agent target, including the new pagination/regression tests).  
- Ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which completed with warnings only (no lint errors), consistent with pre-existing warnings in the area.  
- Regression specifics: the new tests assert `stagedCustomersFound=1800`, `stagedVehiclesFound=2600`, `stagedCustomerVehicleLinksFound=2600`, that links after index 1000 are processed and linked, and that reruns are idempotent; these assertions passed under the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0be77c3548328b8e6f2b2b8b196f0)