### PR TITLE
Harden onboarding customer/vehicle activation integrity and diagnostics

### DIFF
--- a/features/onboarding-agent/components/OnboardingSessionPage.test.ts
+++ b/features/onboarding-agent/components/OnboardingSessionPage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getCustomerDisplayLabel, getVehicleDisplayLabel, linkIssueReasonLabel } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+
+describe("OnboardingSessionPage warning label helpers", () => {
+  it("builds human-readable customer labels", () => {
+    expect(getCustomerDisplayLabel({ businessName: "Northern Shield Security", email: "accounts@nss.com" })).toBe("Northern Shield Security");
+    expect(getCustomerDisplayLabel({ firstName: "Jane", lastName: "Doe" })).toBe("Jane Doe");
+    expect(getCustomerDisplayLabel({ email: "jane@example.com" })).toBe("jane@example.com");
+  });
+
+  it("builds human-readable vehicle labels", () => {
+    expect(getVehicleDisplayLabel({ year: 2019, make: "Ford", model: "F-550", vin: "1FD123" })).toBe("2019 Ford F-550 — VIN 1FD123");
+    expect(getVehicleDisplayLabel({ licensePlate: "ABC123" })).toBe("Plate ABC123");
+  });
+
+  it("maps unresolved link reasons to plain-English triage labels", () => {
+    expect(linkIssueReasonLabel("vehicle_linked_to_different_customer")).toContain("different customer");
+    expect(linkIssueReasonLabel("ambiguous_customer_match")).toContain("ambiguous");
+  });
+});

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -21,6 +21,62 @@ function warningCategory(warning: string): string {
   return "other";
 }
 
+export function getCustomerDisplayLabel(customer?: {
+  businessName?: string | null;
+  name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+} | null): string {
+  if (!customer) return "Unknown customer";
+  const businessName = customer.businessName?.trim();
+  if (businessName) return businessName;
+  const fullName = `${customer.firstName ?? ""} ${customer.lastName ?? ""}`.trim();
+  if (fullName) return fullName;
+  const name = customer.name?.trim();
+  if (name) return name;
+  const email = customer.email?.trim();
+  if (email) return email;
+  const phone = customer.phone?.trim();
+  if (phone) return phone;
+  return "Unknown customer";
+}
+
+export function getVehicleDisplayLabel(vehicle?: {
+  year?: string | number | null;
+  make?: string | null;
+  model?: string | null;
+  vin?: string | null;
+  licensePlate?: string | null;
+  unitNumber?: string | null;
+} | null): string {
+  if (!vehicle) return "Unknown vehicle";
+  const ymm = [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ").trim();
+  const identifier = vehicle.vin || vehicle.licensePlate || vehicle.unitNumber || null;
+  if (ymm && identifier) return `${ymm} — ${vehicle.vin ? `VIN ${vehicle.vin}` : vehicle.licensePlate ? `Plate ${vehicle.licensePlate}` : `Unit ${vehicle.unitNumber}`}`;
+  if (ymm) return ymm;
+  if (vehicle.vin) return `VIN ${vehicle.vin}`;
+  if (vehicle.licensePlate) return `Plate ${vehicle.licensePlate}`;
+  if (vehicle.unitNumber) return `Unit ${vehicle.unitNumber}`;
+  return "Unknown vehicle";
+}
+
+export function linkIssueReasonLabel(reason: string): string {
+  const labels: Record<string, string> = {
+    missing_staged_customer: "Staged customer entity was missing.",
+    missing_staged_vehicle: "Staged vehicle entity was missing.",
+    customer_not_materialized: "Customer could not be materialized.",
+    vehicle_not_materialized: "Vehicle could not be materialized.",
+    vehicle_linked_to_different_customer: "Vehicle was already linked to a different customer.",
+    ambiguous_customer_match: "Customer match was ambiguous.",
+    ambiguous_vehicle_match: "Vehicle match was ambiguous.",
+    unsupported_link_direction: "Link does not connect a staged customer and vehicle.",
+    unknown: "Unknown link materialization issue.",
+  };
+  return labels[reason] ?? labels.unknown;
+}
+
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
@@ -233,6 +289,20 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       examples: group.examples,
     }));
   }, [customerVehicleActivationResult]);
+  const groupedLinkIssues = useMemo(() => {
+    const issues = Array.isArray(customerVehicleActivationResult?.customerVehicleLinkIssues)
+      ? customerVehicleActivationResult.customerVehicleLinkIssues
+      : [];
+    const groups = new Map<string, { count: number; examples: any[] }>();
+    for (const issue of issues) {
+      const key = issue.reason ?? "unknown";
+      const group = groups.get(key) ?? { count: 0, examples: [] };
+      group.count += 1;
+      if (group.examples.length < 5) group.examples.push(issue);
+      groups.set(key, group);
+    }
+    return [...groups.entries()].map(([reason, group]) => ({ reason, ...group }));
+  }, [customerVehicleActivationResult]);
 
   const hasAnalysis = useMemo(() => {
     if (!session) return false;
@@ -354,10 +424,48 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
               {Number(customerVehicleActivationResult.vehicleCustomerLinksUpdated ?? 0)}/{Number(customerVehicleActivationResult.vehicleCustomerLinksAlreadyCorrect ?? 0)}/{Number(customerVehicleActivationResult.vehicleCustomerLinksSkipped ?? 0)}.
             </p>
             <p>
+              Links materialized: {Number(customerVehicleActivationResult.vehicleCustomerLinksMaterialized ?? 0)} / {Number(customerVehicleActivationResult.stagedCustomerVehicleLinksFound ?? 0)}.
+              Unresolved links: {Number(customerVehicleActivationResult.vehicleCustomerLinksUnresolved ?? 0)}.
+              Live vehicle/customer links after: {Number(customerVehicleActivationResult.liveVehicleCustomerLinksAfter ?? 0)}.
+            </p>
+            <p>
               Live customers before/after: {Number(customerVehicleActivationResult.customersBefore ?? 0)}/
               {Number(customerVehicleActivationResult.customersAfter ?? 0)}. Live vehicles before/after: {Number(customerVehicleActivationResult.vehiclesBefore ?? 0)}/
               {Number(customerVehicleActivationResult.vehiclesAfter ?? 0)}.
             </p>
+            {groupedLinkIssues.length > 0 ? (
+              <div className="mt-2">
+                <p>Unresolved customer/vehicle links: {Number(customerVehicleActivationResult.vehicleCustomerLinksUnresolved ?? 0)}</p>
+                <ul className="list-disc pl-5">
+                  {groupedLinkIssues.map((group) => (
+                    <li key={`issue-${group.reason}`}>
+                      {group.reason}: {group.count}
+                      <details className="mt-1 pl-2">
+                        <summary className="cursor-pointer text-[11px] text-cyan-200/90">Show first {group.examples.length} examples</summary>
+                        <ul className="list-disc pl-5 pt-1 text-[11px] text-cyan-100/90">
+                          {group.examples.map((issue: any, index: number) => (
+                            <li key={`${group.reason}-${index}`}>
+                              <div>Customer: {getCustomerDisplayLabel(issue?.stagedCustomerSummary)}</div>
+                              <div>Vehicle: {getVehicleDisplayLabel(issue?.stagedVehicleSummary)}</div>
+                              <div>Reason: {linkIssueReasonLabel(issue?.reason ?? "unknown")}</div>
+                              <details className="pl-2 text-cyan-200/80">
+                                <summary className="cursor-pointer">Developer details</summary>
+                                <div>link_id: {issue?.linkId ?? "n/a"}</div>
+                                <div>staged_customer_entity_id: {issue?.stagedCustomerSummary?.entityId ?? "n/a"}</div>
+                                <div>staged_vehicle_entity_id: {issue?.stagedVehicleSummary?.entityId ?? "n/a"}</div>
+                                <div>live_customer_id: {issue?.liveCustomerId ?? "n/a"}</div>
+                                <div>live_vehicle_id: {issue?.liveVehicleId ?? "n/a"}</div>
+                                <div>current_vehicle_customer_id: {issue?.currentVehicleCustomerId ?? "n/a"}</div>
+                              </details>
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
             {Array.isArray(customerVehicleActivationResult.warnings) && customerVehicleActivationResult.warnings.length > 0 ? (
               <div className="mt-1">
                 <p>Warnings: {customerVehicleActivationResult.warnings.length}</p>

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
@@ -83,6 +83,7 @@ function createFakeSupabase(seed?: {
         op: "select",
         payload: null as any,
         filters: [] as Array<{ k: string; v: any; op: "eq" | "in" }>,
+        notFilters: [] as Array<{ k: string; op: string; v: any }>,
         selectOpts: null as any,
         rangeFrom: null as number | null,
         rangeTo: null as number | null,
@@ -95,6 +96,7 @@ function createFakeSupabase(seed?: {
         range(from: number, to: number) { this.rangeFrom = from; this.rangeTo = to; return this; },
         eq(k: string, v: any) { this.filters.push({ k, v, op: "eq" }); return this; },
         in(k: string, v: any[]) { this.filters.push({ k, v, op: "in" }); return this; },
+        not(k: string, op: string, v: any) { this.notFilters.push({ k, op, v }); return this; },
         update(payload: any) { this.op = "update"; this.payload = payload; return this; },
         insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
         single() { return this.execSingle(); },
@@ -112,6 +114,11 @@ function createFakeSupabase(seed?: {
                 if (filter.op === "eq") return row[filter.k] === filter.v;
                 return Array.isArray(filter.v) && filter.v.includes(row[filter.k]);
               });
+            }
+            for (const filter of this.notFilters) {
+              if (filter.op === "is" && filter.v === null) {
+                filtered = filtered.filter((row) => row[filter.k] !== null && row[filter.k] !== undefined);
+              }
             }
             if (typeof this.rangeFrom === "number" && typeof this.rangeTo === "number") {
               return filtered.slice(this.rangeFrom, this.rangeTo + 1);
@@ -311,7 +318,7 @@ describe("activateOnboardingCustomersVehicles", () => {
 
     expect(result.customersInserted).toBe(1);
     expect(result.customersSkippedDuplicateStaged).toBe(1);
-    expect(result.vehicleCustomerLinksCreated + result.vehicleCustomerLinksSkipped).toBeGreaterThan(0);
+    expect(result.vehicleCustomerLinksMaterialized + result.vehicleCustomerLinksSkipped).toBeGreaterThan(0);
     expect(sb.state.vehicles[0]?.customer_id).toBe(sb.state.customers[0]?.id);
   });
 
@@ -381,6 +388,10 @@ describe("activateOnboardingCustomersVehicles", () => {
     expect(result.stagedVehiclesFound).not.toBe(595);
     expect(result.stagedCustomerVehicleLinksFound).not.toBe(1000);
     expect(result.vehiclesAfter).toBe(2600);
+    expect(result.vehicleCustomerLinksAttempted).toBe(2600);
+    expect(result.vehicleCustomerLinksMaterialized).toBe(2600);
+    expect(result.vehicleCustomerLinksUnresolved).toBe(0);
+    expect(result.liveVehicleCustomerLinksAfter).toBe(2600);
     expect(sb.state.vehicles[1500]?.customer_id).toBeTruthy();
   });
 
@@ -428,5 +439,70 @@ describe("activateOnboardingCustomersVehicles", () => {
     expect(first.vehicleCustomerLinksCreated).toBeGreaterThan(1000);
     expect(second.vehicleCustomerLinksCreated).toBe(0);
     expect(second.vehicleCustomerLinksAlreadyCorrect).toBe(2600);
+  });
+
+  it("materializes reversed customer_vehicle link direction", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1"), stagedVehicle("v1")],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "v1", to_entity_id: "c1", link_type: "customer_vehicle" }],
+    });
+
+    const result = await runActivation(sb);
+
+    expect(result.vehicleCustomerLinksMaterialized).toBe(1);
+    expect(result.vehicleCustomerLinksUnresolved).toBe(0);
+    expect(sb.state.vehicles[0]?.customer_id).toBe(sb.state.customers[0]?.id);
+  });
+
+  it("returns structured unresolved issue for ambiguous customer link", async () => {
+    sb = createFakeSupabase({
+      entities: [
+        stagedCustomer("c1", { normalized: { sourceCustomerId: null, email: null, phone: "5551112222", businessName: null, name: "Ambig" }, source_external_id: null }),
+        stagedVehicle("v1", { normalized: { sourceVehicleId: "V-1", vin: "VIN-1", plate: "P-1", year: "2020", make: "Ford", model: "F150" } }),
+      ],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "c1", to_entity_id: "v1", link_type: "customer_vehicle" }],
+      customers: [
+        { id: "customer-1", shop_id: "shop-1", external_id: null, email: "a1@example.com", phone: "5551112222", phone_number: "5551112222", name: "One", first_name: null, last_name: null, business_name: null },
+        { id: "customer-2", shop_id: "shop-1", external_id: null, email: "a2@example.com", phone: "5551112222", phone_number: "5551112222", name: "Two", first_name: null, last_name: null, business_name: null },
+      ],
+    });
+
+    const result = await runActivation(sb);
+
+    expect(result.vehicleCustomerLinksUnresolved).toBe(1);
+    expect(result.customerVehicleLinkIssues).toHaveLength(1);
+    expect(result.customerVehicleLinkIssues[0]?.reason).toBe("ambiguous_customer_match");
+    expect(result.customerVehicleLinkIssues[0]?.stagedCustomerSummary?.name).toBe("Ambig");
+  });
+
+  it("marks already-linked vehicles as alreadyCorrect and counts live links after from db", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1"), stagedVehicle("v1")],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "c1", to_entity_id: "v1", link_type: "customer_vehicle" }],
+      customers: [{ id: "customer-live", shop_id: "shop-1", external_id: "C-c1", email: null, phone: null, phone_number: null, name: "Existing", first_name: null, last_name: null, business_name: null }],
+      vehicles: [{ id: "vehicle-live", shop_id: "shop-1", external_id: "V-v1", vin: "VINv1", license_plate: "ABCv1", unit_number: null, year: 2020, make: "Ford", model: "F150", customer_id: "customer-live" }],
+    });
+
+    const result = await runActivation(sb);
+    expect(result.vehicleCustomerLinksAlreadyCorrect).toBe(1);
+    expect(result.liveVehicleCustomerLinksAfter).toBe(1);
+  });
+
+  it("returns unresolved issue when vehicle is linked to different customer", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1"), stagedVehicle("v1")],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "c1", to_entity_id: "v1", link_type: "customer_vehicle" }],
+      customers: [
+        { id: "customer-live", shop_id: "shop-1", external_id: "C-c1", email: "a@example.com", phone: null, phone_number: null, name: "Target", first_name: null, last_name: null, business_name: null },
+        { id: "customer-other", shop_id: "shop-1", external_id: "other", email: "other@example.com", phone: null, phone_number: null, name: "Other", first_name: null, last_name: null, business_name: null },
+      ],
+      vehicles: [{ id: "vehicle-live", shop_id: "shop-1", external_id: "V-v1", vin: "VINv1", license_plate: "ABCv1", unit_number: null, year: 2020, make: "Ford", model: "F150", customer_id: "customer-other" }],
+    });
+
+    const result = await runActivation(sb);
+
+    expect(result.vehicleCustomerLinksSkipped).toBe(1);
+    expect(result.vehicleCustomerLinksUnresolved).toBe(1);
+    expect(result.customerVehicleLinkIssues[0]?.reason).toBe("vehicle_linked_to_different_customer");
   });
 });

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
@@ -34,12 +34,54 @@ export type CustomerVehicleActivationResult = {
   vehicleCustomerLinksCreated: number;
   vehicleCustomerLinksUpdated: number;
   vehicleCustomerLinksAlreadyCorrect: number;
+  vehicleCustomerLinksAttempted: number;
+  vehicleCustomerLinksMaterialized: number;
   vehicleCustomerLinksSkipped: number;
+  vehicleCustomerLinksUnresolved: number;
   customersBefore: number;
   customersAfter: number;
   vehiclesBefore: number;
   vehiclesAfter: number;
+  liveVehicleCustomerLinksAfter: number;
+  customerVehicleLinkIssues: CustomerVehicleLinkIssue[];
   warnings: string[];
+};
+
+export type CustomerVehicleLinkIssue = {
+  linkId: string;
+  fromEntityId: string | null;
+  toEntityId: string | null;
+  reason:
+    | "missing_staged_customer"
+    | "missing_staged_vehicle"
+    | "customer_not_materialized"
+    | "vehicle_not_materialized"
+    | "vehicle_linked_to_different_customer"
+    | "ambiguous_customer_match"
+    | "ambiguous_vehicle_match"
+    | "unsupported_link_direction"
+    | "unknown";
+  stagedCustomerSummary?: {
+    entityId: string;
+    sourceExternalId?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    name?: string | null;
+    businessName?: string | null;
+  };
+  stagedVehicleSummary?: {
+    entityId: string;
+    sourceExternalId?: string | null;
+    vin?: string | null;
+    licensePlate?: string | null;
+    unitNumber?: string | null;
+    year?: string | number | null;
+    make?: string | null;
+    model?: string | null;
+  };
+  liveCustomerId?: string | null;
+  liveVehicleId?: string | null;
+  currentVehicleCustomerId?: string | null;
 };
 
 type NormalizedCustomer = {
@@ -68,6 +110,12 @@ type StagedCustomerCandidate = {
   entityIds: string[];
   normalized: NormalizedCustomer;
 };
+
+type LinkSideIssueReason =
+  | "customer_not_materialized"
+  | "ambiguous_customer_match"
+  | "vehicle_not_materialized"
+  | "ambiguous_vehicle_match";
 
 function normalizeText(value: unknown): string {
   return String(value ?? "").trim();
@@ -134,6 +182,32 @@ function toNormalizedVehicle(entity: Pick<OnboardingEntityRow, "normalized" | "s
     year: normalizeNumber(normalized.year),
     make: textOrNull(normalized.make),
     model: textOrNull(normalized.model),
+  };
+}
+
+function toStagedCustomerSummary(entity: Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">) {
+  const normalized = toNormalizedCustomer(entity);
+  return {
+    entityId: entity.id,
+    sourceExternalId: normalized.externalId,
+    email: normalized.email,
+    phone: normalized.phone,
+    name: normalized.name ?? null,
+    businessName: normalized.businessName,
+  };
+}
+
+function toStagedVehicleSummary(entity: Pick<OnboardingEntityRow, "id" | "normalized" | "source_external_id">) {
+  const normalized = toNormalizedVehicle(entity);
+  return {
+    entityId: entity.id,
+    sourceExternalId: normalized.externalId,
+    vin: normalized.vin,
+    licensePlate: normalized.plate,
+    unitNumber: normalized.unitNumber,
+    year: normalized.year,
+    make: normalized.make,
+    model: normalized.model,
   };
 }
 
@@ -392,7 +466,10 @@ export async function activateOnboardingCustomersVehicles(params: {
 
   const warnings: string[] = [];
   const customerEntityToLiveId = new Map<string, string>();
+  const customerEntitySkippedReason = new Map<string, LinkSideIssueReason>();
   const vehicleEntityToLiveId = new Map<string, string>();
+  const vehicleEntitySkippedReason = new Map<string, LinkSideIssueReason>();
+  const customerVehicleLinkIssues: CustomerVehicleLinkIssue[] = [];
 
   const { candidates: customerCandidates, customersSkippedDuplicateStaged } = buildCustomerCandidates(customerEntities);
   const indexes = buildLiveCustomerIndexes(customerPool);
@@ -408,6 +485,10 @@ export async function activateOnboardingCustomersVehicles(params: {
 
     if (match.ambiguous) {
       customersSkippedAmbiguous += 1;
+      customerEntitySkippedReason.set(candidate.canonicalEntityId, "ambiguous_customer_match");
+      for (const duplicateEntityId of candidate.entityIds) {
+        customerEntitySkippedReason.set(duplicateEntityId, "ambiguous_customer_match");
+      }
       warnings.push(`Customer candidate ${candidate.canonicalEntityId} skipped: ambiguous ${match.strategy} live match.`);
       continue;
     }
@@ -469,6 +550,9 @@ export async function activateOnboardingCustomersVehicles(params: {
 
       warnings.push(`Customer candidate ${candidate.canonicalEntityId} skipped: unique conflict recovery failed for email ${normalized.email}.`);
       customersSkippedAmbiguous += 1;
+      for (const duplicateEntityId of candidate.entityIds) {
+        customerEntitySkippedReason.set(duplicateEntityId, "ambiguous_customer_match");
+      }
       continue;
     }
 
@@ -514,6 +598,7 @@ export async function activateOnboardingCustomersVehicles(params: {
 
     if (matches.length > 1) {
       vehiclesSkipped += 1;
+      vehicleEntitySkippedReason.set(entity.id, "ambiguous_vehicle_match");
       warnings.push(`Vehicle entity ${entity.id} skipped: ambiguous ${strategy} match (${matches.length} rows).`);
       continue;
     }
@@ -568,17 +653,29 @@ export async function activateOnboardingCustomersVehicles(params: {
   let vehicleCustomerLinksUpdated = 0;
   let vehicleCustomerLinksAlreadyCorrect = 0;
   let vehicleCustomerLinksSkipped = 0;
+  let vehicleCustomerLinksAttempted = 0;
   const vehicleById = new Map(vehiclePool.map((row) => [row.id, row]));
 
   for (const link of links) {
+    vehicleCustomerLinksAttempted += 1;
     const from = entityById.get(link.from_entity_id);
     const to = entityById.get(link.to_entity_id);
-    const customerEntityId = from?.entity_type === "customer" ? from.id : to?.entity_type === "customer" ? to.id : null;
-    const vehicleEntityId = from?.entity_type === "vehicle" ? from.id : to?.entity_type === "vehicle" ? to.id : null;
+    const customerEntity = from?.entity_type === "customer" ? from : to?.entity_type === "customer" ? to : null;
+    const vehicleEntity = from?.entity_type === "vehicle" ? from : to?.entity_type === "vehicle" ? to : null;
+    const customerEntityId = customerEntity?.id ?? null;
+    const vehicleEntityId = vehicleEntity?.id ?? null;
 
     if (!customerEntityId || !vehicleEntityId) {
       vehicleCustomerLinksSkipped += 1;
       warnings.push(`Link ${link.id} skipped: does not connect staged customer+vehicle entities.`);
+      customerVehicleLinkIssues.push({
+        linkId: link.id,
+        fromEntityId: link.from_entity_id,
+        toEntityId: link.to_entity_id,
+        reason: !customerEntityId && !vehicleEntityId ? "unsupported_link_direction" : !customerEntityId ? "missing_staged_customer" : "missing_staged_vehicle",
+        stagedCustomerSummary: customerEntity ? toStagedCustomerSummary(customerEntity) : undefined,
+        stagedVehicleSummary: vehicleEntity ? toStagedVehicleSummary(vehicleEntity) : undefined,
+      });
       continue;
     }
 
@@ -587,12 +684,35 @@ export async function activateOnboardingCustomersVehicles(params: {
     if (!customerId || !vehicleId) {
       vehicleCustomerLinksSkipped += 1;
       warnings.push(`Link ${link.id} skipped: customer or vehicle was not materialized.`);
+      const reason = !customerId
+        ? (customerEntitySkippedReason.get(customerEntityId) ?? "customer_not_materialized")
+        : (vehicleEntitySkippedReason.get(vehicleEntityId) ?? "vehicle_not_materialized");
+      customerVehicleLinkIssues.push({
+        linkId: link.id,
+        fromEntityId: link.from_entity_id,
+        toEntityId: link.to_entity_id,
+        reason,
+        stagedCustomerSummary: customerEntity ? toStagedCustomerSummary(customerEntity) : undefined,
+        stagedVehicleSummary: vehicleEntity ? toStagedVehicleSummary(vehicleEntity) : undefined,
+        liveCustomerId: customerId ?? null,
+        liveVehicleId: vehicleId ?? null,
+      });
       continue;
     }
 
     const vehicle = vehicleById.get(vehicleId);
     if (!vehicle) {
       vehicleCustomerLinksSkipped += 1;
+      customerVehicleLinkIssues.push({
+        linkId: link.id,
+        fromEntityId: link.from_entity_id,
+        toEntityId: link.to_entity_id,
+        reason: "unknown",
+        stagedCustomerSummary: customerEntity ? toStagedCustomerSummary(customerEntity) : undefined,
+        stagedVehicleSummary: vehicleEntity ? toStagedVehicleSummary(vehicleEntity) : undefined,
+        liveCustomerId: customerId,
+        liveVehicleId: vehicleId,
+      });
       continue;
     }
 
@@ -604,6 +724,17 @@ export async function activateOnboardingCustomersVehicles(params: {
     if (vehicle.customer_id) {
       vehicleCustomerLinksSkipped += 1;
       warnings.push(`Link ${link.id} skipped: vehicle ${vehicleId} already belongs to another customer.`);
+      customerVehicleLinkIssues.push({
+        linkId: link.id,
+        fromEntityId: link.from_entity_id,
+        toEntityId: link.to_entity_id,
+        reason: "vehicle_linked_to_different_customer",
+        stagedCustomerSummary: customerEntity ? toStagedCustomerSummary(customerEntity) : undefined,
+        stagedVehicleSummary: vehicleEntity ? toStagedVehicleSummary(vehicleEntity) : undefined,
+        liveCustomerId: customerId,
+        liveVehicleId: vehicleId,
+        currentVehicleCustomerId: vehicle.customer_id,
+      });
       continue;
     }
 
@@ -617,15 +748,19 @@ export async function activateOnboardingCustomersVehicles(params: {
     vehicle.customer_id = customerId;
   }
 
-  const [{ count: customersAfter, error: customersAfterError }, { count: vehiclesAfter, error: vehiclesAfterError }] = await Promise.all([
+  const [{ count: customersAfter, error: customersAfterError }, { count: vehiclesAfter, error: vehiclesAfterError }, { count: liveVehicleCustomerLinksAfter, error: liveVehicleCustomerLinksAfterError }] = await Promise.all([
     sb.from("customers").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId),
     sb.from("vehicles").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId),
+    sb.from("vehicles").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId).not("customer_id", "is", null),
   ]);
 
   if (customersAfterError) throw new Error(customersAfterError.message);
   if (vehiclesAfterError) throw new Error(vehiclesAfterError.message);
+  if (liveVehicleCustomerLinksAfterError) throw new Error(liveVehicleCustomerLinksAfterError.message);
 
   const customersSkipped = customersSkippedDuplicateStaged + customersSkippedAmbiguous;
+  const vehicleCustomerLinksMaterialized = vehicleCustomerLinksCreated + vehicleCustomerLinksUpdated + vehicleCustomerLinksAlreadyCorrect;
+  const vehicleCustomerLinksUnresolved = links.length - vehicleCustomerLinksMaterialized;
 
   return {
     ok: true,
@@ -647,11 +782,16 @@ export async function activateOnboardingCustomersVehicles(params: {
     vehicleCustomerLinksCreated,
     vehicleCustomerLinksUpdated,
     vehicleCustomerLinksAlreadyCorrect,
+    vehicleCustomerLinksAttempted,
+    vehicleCustomerLinksMaterialized,
     vehicleCustomerLinksSkipped,
+    vehicleCustomerLinksUnresolved,
     customersBefore,
     customersAfter: Number(customersAfter ?? customerPool.length),
     vehiclesBefore,
     vehiclesAfter: Number(vehiclesAfter ?? vehiclePool.length),
+    liveVehicleCustomerLinksAfter: Number(liveVehicleCustomerLinksAfter ?? vehiclePool.filter((row) => row.customer_id !== null).length),
+    customerVehicleLinkIssues,
     warnings,
   };
 }


### PR DESCRIPTION
### Motivation
- Improve determinism and operator diagnosability for staged customer→vehicle activations by making link materialization fully paginated, idempotent, shop/session scoped, and explainable.
- Surface precise, structured reasons for every unresolved staged customer_vehicle link so operators can triage which staged rows failed and why instead of opaque string warnings.
- Support either link direction (`customer -> vehicle` or `vehicle -> customer`) reliably and ensure duplicate staged customers map to a single canonical live customer when safely resolvable.
- Provide operator-friendly human-readable labels for customers and vehicles in the UI while keeping developer IDs in expandable details.

### Description
- Server: extended `activateOnboardingCustomersVehicles` result with explicit counters and diagnostics by adding `vehicleCustomerLinksAttempted`, `vehicleCustomerLinksMaterialized`, `vehicleCustomerLinksUnresolved`, `liveVehicleCustomerLinksAfter`, and `customerVehicleLinkIssues[]`, and added deterministic issue reason codes and staged/live summaries; preserved shop/session scoping and idempotence (`features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts`).
- Link processing: type-resolve each link side (customer vs vehicle) so reversed link direction materializes correctly, propagate per-entity skip reasons (e.g. `ambiguous_customer_match`) into link diagnostics, and compute `materialized = created + updated + alreadyCorrect` and `unresolved = staged_links - materialized`.
- UI: added `getCustomerDisplayLabel`, `getVehicleDisplayLabel`, and `linkIssueReasonLabel` helpers and a grouped, truncated “Unresolved customer/vehicle links” triage panel that shows counts by reason, up to 5 examples per reason with developer-only details hidden behind `details` (`features/onboarding-agent/components/OnboardingSessionPage.tsx`).
- Tests: extended activation tests and added helper tests to cover full pagination past 1000 rows, duplicate staged customer mapping, reversed link direction, structured unresolved diagnostics for ambiguous matches, unresolved/materialized math, DB-backed `liveVehicleCustomerLinksAfter`, idempotence, already-correct links, and vehicle-linked-to-different-customer behavior (`features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts` and new `features/onboarding-agent/components/OnboardingSessionPage.test.ts`).

### Testing
- Typecheck: ran `npx tsc --noEmit --pretty false` and it succeeded without type errors.
- Unit tests: ran `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (13 test files, 80 tests passed).
- Lint: ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which returned only pre-existing warnings and no errors.
- Changes covered by tests include pagination beyond 1000 rows, dedupe mapping, reversed link direction materialization, structured unresolved issue creation, unresolved count correctness, DB live-linked-vehicle count, and idempotent re-run behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d0bfed188328a398dc15a9640344)