### PR TITLE
Add operator review + resolution flow for unresolved customer↔vehicle activation links

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/resolve-customer-vehicle-link/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/resolve-customer-vehicle-link/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { resolveCustomerVehicleLink } from "@/features/onboarding-agent/server/resolveCustomerVehicleLink";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id as string;
+  const actorId = access.profile.id;
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const action = body?.action === "link" || body?.action === "skip" ? body.action : null;
+    if (!action) {
+      return NextResponse.json({ ok: false, error: "action is required: link | skip" }, { status: 400 });
+    }
+    const result = await resolveCustomerVehicleLink({
+      supabase: admin,
+      shopId,
+      sessionId,
+      actorId,
+      reviewItemId: typeof body?.reviewItemId === "string" ? body.reviewItemId : undefined,
+      stagedLinkId: typeof body?.stagedLinkId === "string" ? body.stagedLinkId : undefined,
+      action,
+      selectedCustomerId: typeof body?.selectedCustomerId === "string" ? body.selectedCustomerId : undefined,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to resolve customer/vehicle link";
+    const status = message.includes("not found") ? 404 : message.includes("required") || message.includes("different customer") ? 400 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/features/onboarding-agent/components/OnboardingSessionPage.test.ts
+++ b/features/onboarding-agent/components/OnboardingSessionPage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getCustomerDisplayLabel, getVehicleDisplayLabel, linkIssueReasonLabel } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+import { getCustomerDisplayLabel, getVehicleDisplayLabel, linkIssueReasonLabel, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
 
 describe("OnboardingSessionPage warning label helpers", () => {
   it("builds human-readable customer labels", () => {
@@ -16,5 +16,23 @@ describe("OnboardingSessionPage warning label helpers", () => {
   it("maps unresolved link reasons to plain-English triage labels", () => {
     expect(linkIssueReasonLabel("vehicle_linked_to_different_customer")).toContain("different customer");
     expect(linkIssueReasonLabel("ambiguous_customer_match")).toContain("ambiguous");
+  });
+
+  it("keeps UUIDs out of unresolved-link primary copy", () => {
+    const copy = unresolvedReviewPrimaryCopy({
+      id: "review-uuid-1",
+      status: "pending",
+      details: {
+        proposedCustomerLabel: "Canyon Civil 4",
+        proposedVehicleLabel: "2012 Ford Transit — VIN EMDZE5XJXPNM2Z9M9",
+        reasonLabel: "Customer match was ambiguous.",
+        stagedCustomerEntityId: "uuid-customer-123",
+      },
+    });
+
+    expect(copy.customer).toBe("Canyon Civil 4");
+    expect(copy.vehicle).toContain("Ford Transit");
+    expect(copy.reason).toContain("ambiguous");
+    expect(copy.customer).not.toContain("uuid");
   });
 });

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -77,6 +77,38 @@ export function linkIssueReasonLabel(reason: string): string {
   return labels[reason] ?? labels.unknown;
 }
 
+type UnresolvedReviewItem = {
+  id: string;
+  status: string;
+  details?: Record<string, any> | null;
+};
+
+function unresolvedReviewDetails(reviewItem: UnresolvedReviewItem) {
+  const details = reviewItem?.details && typeof reviewItem.details === "object" ? reviewItem.details : {};
+  return {
+    stagedLinkId: typeof details.stagedLinkId === "string" ? details.stagedLinkId : null,
+    proposedCustomerLabel: typeof details.proposedCustomerLabel === "string" ? details.proposedCustomerLabel : "Unknown customer",
+    proposedVehicleLabel: typeof details.proposedVehicleLabel === "string" ? details.proposedVehicleLabel : "Unknown vehicle",
+    reasonCode: typeof details.reasonCode === "string" ? details.reasonCode : "unknown",
+    reasonLabel: typeof details.reasonLabel === "string" ? details.reasonLabel : linkIssueReasonLabel(String(details.reasonCode ?? "unknown")),
+    liveVehicleId: typeof details.liveVehicleId === "string" ? details.liveVehicleId : null,
+    candidateLiveCustomers: Array.isArray(details.candidateLiveCustomers) ? details.candidateLiveCustomers : [],
+    stagedCustomerEntityId: typeof details.stagedCustomerEntityId === "string" ? details.stagedCustomerEntityId : null,
+    stagedVehicleEntityId: typeof details.stagedVehicleEntityId === "string" ? details.stagedVehicleEntityId : null,
+    liveCustomerId: typeof details.liveCustomerId === "string" ? details.liveCustomerId : null,
+    currentVehicleCustomerId: typeof details.currentVehicleCustomerId === "string" ? details.currentVehicleCustomerId : null,
+  };
+}
+
+export function unresolvedReviewPrimaryCopy(reviewItem: UnresolvedReviewItem): { customer: string; vehicle: string; reason: string } {
+  const details = unresolvedReviewDetails(reviewItem);
+  return {
+    customer: details.proposedCustomerLabel,
+    vehicle: details.proposedVehicleLabel,
+    reason: details.reasonLabel,
+  };
+}
+
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
@@ -89,6 +121,8 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [activatingCustomersVehicles, setActivatingCustomersVehicles] = useState(false);
   const [vendorActivationSummary, setVendorActivationSummary] = useState<string | null>(null);
   const [customerVehicleActivationResult, setCustomerVehicleActivationResult] = useState<any>(null);
+  const [resolvingReviewItemId, setResolvingReviewItemId] = useState<string | null>(null);
+  const [selectedCustomerByReviewItemId, setSelectedCustomerByReviewItemId] = useState<Record<string, string>>({});
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -303,6 +337,58 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
     }
     return [...groups.entries()].map(([reason, group]) => ({ reason, ...group }));
   }, [customerVehicleActivationResult]);
+  const unresolvedCustomerVehicleReviewItems = useMemo(() => {
+    const items = Array.isArray(payload?.reviewItems) ? payload.reviewItems : [];
+    return items.filter((item: any) => item?.issue_type === "unresolved_customer_vehicle_link");
+  }, [payload?.reviewItems]);
+  const unresolvedPendingItems = useMemo(
+    () => unresolvedCustomerVehicleReviewItems.filter((item: any) => String(item?.status ?? "pending") === "pending"),
+    [unresolvedCustomerVehicleReviewItems],
+  );
+  const unresolvedManuallyResolvedCount = useMemo(
+    () => unresolvedCustomerVehicleReviewItems.filter((item: any) => ["resolved", "skipped"].includes(String(item?.status ?? ""))).length,
+    [unresolvedCustomerVehicleReviewItems],
+  );
+  const groupedUnresolvedPendingByReason = useMemo(() => {
+    const groups = new Map<string, { reasonLabel: string; count: number }>();
+    for (const item of unresolvedPendingItems) {
+      const details = unresolvedReviewDetails(item);
+      const key = details.reasonCode;
+      const group = groups.get(key) ?? { reasonLabel: details.reasonLabel, count: 0 };
+      group.count += 1;
+      groups.set(key, group);
+    }
+    return [...groups.entries()].map(([reasonCode, group]) => ({ reasonCode, ...group }));
+  }, [unresolvedPendingItems]);
+
+  const resolveUnresolvedLink = useCallback(async (args: { reviewItemId: string; action: "link" | "skip"; selectedCustomerId?: string }) => {
+    setResolvingReviewItemId(args.reviewItemId);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/resolve-customer-vehicle-link`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          reviewItemId: args.reviewItemId,
+          action: args.action,
+          selectedCustomerId: args.selectedCustomerId,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || "Failed to resolve unresolved customer/vehicle link.");
+      } else {
+        const warning = typeof json?.warning === "string" && json.warning ? ` Warning: ${json.warning}` : "";
+        setNotice(`${args.action === "skip" ? "Skipped" : "Linked"} ${json?.vehicleLabel ?? "vehicle"}${json?.customerLabel ? ` to ${json.customerLabel}` : ""}.${warning}`);
+      }
+      await load();
+    } catch {
+      setError("Failed to resolve unresolved customer/vehicle link.");
+    } finally {
+      setResolvingReviewItemId(null);
+    }
+  }, [load, sessionId]);
 
   const hasAnalysis = useMemo(() => {
     if (!session) return false;
@@ -426,6 +512,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
             <p>
               Links materialized: {Number(customerVehicleActivationResult.vehicleCustomerLinksMaterialized ?? 0)} / {Number(customerVehicleActivationResult.stagedCustomerVehicleLinksFound ?? 0)}.
               Unresolved links: {Number(customerVehicleActivationResult.vehicleCustomerLinksUnresolved ?? 0)}.
+              Resolved manually: {unresolvedManuallyResolvedCount}.
               Live vehicle/customer links after: {Number(customerVehicleActivationResult.liveVehicleCustomerLinksAfter ?? 0)}.
             </p>
             <p>
@@ -486,6 +573,89 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
                 </ul>
               </div>
             ) : null}
+          </div>
+        ) : null}
+        {unresolvedCustomerVehicleReviewItems.length > 0 ? (
+          <div className="mt-3 rounded-lg border border-cyan-400/25 bg-slate-950/50 p-3 text-xs text-cyan-100">
+            <p className="font-medium">Unresolved customer/vehicle links</p>
+            <p className="mt-1 text-cyan-100/90">
+              Pending: {unresolvedPendingItems.length}. Manually resolved/skipped: {unresolvedManuallyResolvedCount}.
+            </p>
+            {groupedUnresolvedPendingByReason.length > 0 ? (
+              <ul className="mt-1 list-disc pl-5 text-[11px] text-cyan-100/90">
+                {groupedUnresolvedPendingByReason.map((group) => (
+                  <li key={`pending-group-${group.reasonCode}`}>{group.reasonLabel}: {group.count}</li>
+                ))}
+              </ul>
+            ) : null}
+            <div className="mt-2 space-y-2">
+              {unresolvedPendingItems.slice(0, 25).map((item: any) => {
+                const details = unresolvedReviewDetails(item);
+                const selectedCustomerId = selectedCustomerByReviewItemId[item.id] ?? "";
+                const canLink = details.liveVehicleId && details.candidateLiveCustomers.length > 0;
+                return (
+                  <div key={item.id} className="rounded border border-cyan-400/20 bg-cyan-950/10 p-2">
+                    <div>Customer: {details.proposedCustomerLabel}</div>
+                    <div>Vehicle: {details.proposedVehicleLabel}</div>
+                    <div>Reason: {details.reasonLabel}</div>
+                    {canLink ? (
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <select
+                          value={selectedCustomerId}
+                          onChange={(event) => setSelectedCustomerByReviewItemId((prev) => ({ ...prev, [item.id]: event.target.value }))}
+                          className="rounded border border-cyan-300/30 bg-slate-900 px-2 py-1 text-xs text-cyan-50"
+                        >
+                          <option value="">Select live customer…</option>
+                          {details.candidateLiveCustomers.map((customer: any) => (
+                            <option key={`${item.id}-${customer.id}`} value={customer.id}>
+                              {getCustomerDisplayLabel(customer)}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          type="button"
+                          onClick={() => resolveUnresolvedLink({ reviewItemId: item.id, action: "link", selectedCustomerId })}
+                          disabled={!selectedCustomerId || resolvingReviewItemId === item.id}
+                          className="rounded border border-emerald-300/40 px-2 py-1 text-xs text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Link to selected customer
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => resolveUnresolvedLink({ reviewItemId: item.id, action: "skip" })}
+                          disabled={resolvingReviewItemId === item.id}
+                          className="rounded border border-amber-300/40 px-2 py-1 text-xs text-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Do not link
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="mt-2 text-[11px] text-cyan-200/85">
+                        Manual link requires exactly one materialized vehicle and candidate live customer matches.
+                        <button
+                          type="button"
+                          onClick={() => resolveUnresolvedLink({ reviewItemId: item.id, action: "skip" })}
+                          disabled={resolvingReviewItemId === item.id}
+                          className="ml-2 rounded border border-amber-300/40 px-2 py-1 text-xs text-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Do not link
+                        </button>
+                      </div>
+                    )}
+                    <details className="mt-2 text-[11px] text-cyan-200/85">
+                      <summary className="cursor-pointer">Developer details</summary>
+                      <div>review_item_id: {item.id}</div>
+                      <div>staged_link_id: {details.stagedLinkId ?? "n/a"}</div>
+                      <div>staged_customer_entity_id: {details.stagedCustomerEntityId ?? "n/a"}</div>
+                      <div>staged_vehicle_entity_id: {details.stagedVehicleEntityId ?? "n/a"}</div>
+                      <div>live_customer_id: {details.liveCustomerId ?? "n/a"}</div>
+                      <div>live_vehicle_id: {details.liveVehicleId ?? "n/a"}</div>
+                      <div>current_vehicle_customer_id: {details.currentVehicleCustomerId ?? "n/a"}</div>
+                    </details>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         ) : null}
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
@@ -51,12 +51,27 @@ type Vehicle = {
   model: string | null;
   customer_id: string | null;
 };
+type ReviewItem = {
+  id: string;
+  shop_id: string;
+  session_id: string;
+  issue_type: string;
+  link_id: string | null;
+  status: string;
+  summary: string;
+  details: Record<string, unknown>;
+  severity: string;
+  domain: string | null;
+  entity_id: string | null;
+  resolved_at?: string | null;
+};
 
 function createFakeSupabase(seed?: {
   entities?: Entity[];
   links?: Link[];
   customers?: Customer[];
   vehicles?: Vehicle[];
+  reviewItems?: ReviewItem[];
   failCustomerInsertForEmails?: string[];
   conflictRecoveryCustomerByEmail?: Record<string, Customer>;
 }) {
@@ -69,6 +84,7 @@ function createFakeSupabase(seed?: {
     links: [...(seed?.links ?? [])],
     customers: [...(seed?.customers ?? [])],
     vehicles: [...(seed?.vehicles ?? [])],
+    reviewItems: [...(seed?.reviewItems ?? [])],
     nextCustomerId: 1,
     nextVehicleId: 1,
     writes: [] as string[],
@@ -99,6 +115,7 @@ function createFakeSupabase(seed?: {
         not(k: string, op: string, v: any) { this.notFilters.push({ k, op, v }); return this; },
         update(payload: any) { this.op = "update"; this.payload = payload; return this; },
         insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
+        upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this; },
         single() { return this.execSingle(); },
         then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
         async execSingle() {
@@ -123,7 +140,7 @@ function createFakeSupabase(seed?: {
             if (typeof this.rangeFrom === "number" && typeof this.rangeTo === "number") {
               return filtered.slice(this.rangeFrom, this.rangeTo + 1);
             }
-            if (!this.selectOpts?.head && this.op === "select" && (this.table === "onboarding_entities" || this.table === "onboarding_entity_links" || this.table === "customers" || this.table === "vehicles")) {
+            if (!this.selectOpts?.head && this.op === "select" && (this.table === "onboarding_entities" || this.table === "onboarding_entity_links" || this.table === "customers" || this.table === "vehicles" || this.table === "onboarding_review_items")) {
               return filtered.slice(0, 1000);
             }
             return filtered;
@@ -131,6 +148,7 @@ function createFakeSupabase(seed?: {
 
           if (this.table === "onboarding_entities" && this.op === "select") return { data: applyFilters(state.entities), error: null };
           if (this.table === "onboarding_entity_links" && this.op === "select") return { data: applyFilters(state.links), error: null };
+          if (this.table === "onboarding_review_items" && this.op === "select") return { data: applyFilters(state.reviewItems), error: null };
 
           if (this.table === "customers" && this.op === "select") {
             const rows = applyFilters(state.customers);
@@ -180,6 +198,24 @@ function createFakeSupabase(seed?: {
             const target = applyFilters(state.vehicles)[0];
             if (target) Object.assign(target, this.payload);
             state.writes.push("vehicles:update");
+            return { data: [], error: null };
+          }
+
+          if (this.table === "onboarding_review_items" && this.op === "upsert") {
+            const rows = Array.isArray(this.payload) ? this.payload : [this.payload];
+            for (const row of rows) {
+              const existingIndex = state.reviewItems.findIndex((item) => item.id === row.id);
+              if (existingIndex >= 0) state.reviewItems[existingIndex] = { ...state.reviewItems[existingIndex], ...row };
+              else state.reviewItems.push(row);
+            }
+            state.writes.push("onboarding_review_items:upsert");
+            return { data: rows, error: null };
+          }
+
+          if (this.table === "onboarding_review_items" && this.op === "update") {
+            const target = applyFilters(state.reviewItems)[0];
+            if (target) Object.assign(target, this.payload);
+            state.writes.push("onboarding_review_items:update");
             return { data: [], error: null };
           }
 
@@ -504,5 +540,26 @@ describe("activateOnboardingCustomersVehicles", () => {
     expect(result.vehicleCustomerLinksSkipped).toBe(1);
     expect(result.vehicleCustomerLinksUnresolved).toBe(1);
     expect(result.customerVehicleLinkIssues[0]?.reason).toBe("vehicle_linked_to_different_customer");
+  });
+
+  it("persists unresolved review items idempotently across reruns", async () => {
+    sb = createFakeSupabase({
+      entities: [
+        stagedCustomer("c1", { normalized: { sourceCustomerId: null, email: null, phone: "5551112222", businessName: null, name: "Ambig" }, source_external_id: null }),
+        stagedVehicle("v1", { normalized: { sourceVehicleId: "V-1", vin: "VIN-1", plate: "P-1", year: "2020", make: "Ford", model: "F150" } }),
+      ],
+      links: [{ id: "l1", shop_id: "shop-1", session_id: "session-1", from_entity_id: "c1", to_entity_id: "v1", link_type: "customer_vehicle" }],
+      customers: [
+        { id: "customer-1", shop_id: "shop-1", external_id: null, email: "a1@example.com", phone: "5551112222", phone_number: "5551112222", name: "One", first_name: null, last_name: null, business_name: null },
+        { id: "customer-2", shop_id: "shop-1", external_id: null, email: "a2@example.com", phone: "5551112222", phone_number: "5551112222", name: "Two", first_name: null, last_name: null, business_name: null },
+      ],
+    });
+
+    await runActivation(sb);
+    await runActivation(sb);
+
+    const unresolved = sb.state.reviewItems.filter((item) => item.issue_type === "unresolved_customer_vehicle_link");
+    expect(unresolved).toHaveLength(1);
+    expect(unresolved[0]?.details?.reasonCode).toBe("ambiguous_customer_match");
   });
 });

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { normalizePhone } from "@/features/onboarding-agent/lib/fingerprints";
+import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 import type { Database } from "@/features/shared/types/types/supabase";
 
@@ -12,6 +13,8 @@ type CustomerUpdate = Database["public"]["Tables"]["customers"]["Update"];
 type VehicleRow = Database["public"]["Tables"]["vehicles"]["Row"];
 type VehicleInsert = Database["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = Database["public"]["Tables"]["vehicles"]["Update"];
+type OnboardingReviewItemRow = Database["public"]["Tables"]["onboarding_review_items"]["Row"];
+type OnboardingReviewItemInsert = Database["public"]["Tables"]["onboarding_review_items"]["Insert"];
 const PAGE_SIZE = 1000;
 
 export type CustomerVehicleActivationResult = {
@@ -82,6 +85,26 @@ export type CustomerVehicleLinkIssue = {
   liveCustomerId?: string | null;
   liveVehicleId?: string | null;
   currentVehicleCustomerId?: string | null;
+  candidateLiveCustomers?: Array<{
+    id: string;
+    name: string | null;
+    businessName: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    phone: string | null;
+  }>;
+  candidateLiveVehicles?: Array<{
+    id: string;
+    externalId: string | null;
+    vin: string | null;
+    licensePlate: string | null;
+    unitNumber: string | null;
+    year: number | null;
+    make: string | null;
+    model: string | null;
+    customerId: string | null;
+  }>;
 };
 
 type NormalizedCustomer = {
@@ -352,6 +375,136 @@ function pickLiveCustomerMatch(candidate: NormalizedCustomer, indexes: ReturnTyp
 
   const [single] = [...matchedRowsById.values()];
   return { row: single ?? null, ambiguous: false, strategy: "single_key" as const };
+}
+
+function customerLabel(candidate?: {
+  businessName?: string | null;
+  name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+} | null) {
+  if (!candidate) return "Unknown customer";
+  const business = textOrNull(candidate.businessName);
+  if (business) return business;
+  const fullName = textOrNull(`${candidate.firstName ?? ""} ${candidate.lastName ?? ""}`);
+  if (fullName) return fullName;
+  const name = textOrNull(candidate.name);
+  if (name) return name;
+  return textOrNull(candidate.email) ?? textOrNull(candidate.phone) ?? "Unknown customer";
+}
+
+function vehicleLabel(candidate?: {
+  year?: string | number | null;
+  make?: string | null;
+  model?: string | null;
+  vin?: string | null;
+  licensePlate?: string | null;
+  unitNumber?: string | null;
+} | null) {
+  if (!candidate) return "Unknown vehicle";
+  const ymm = [candidate.year, candidate.make, candidate.model].filter(Boolean).join(" ").trim();
+  if (candidate.vin) return ymm ? `${ymm} — VIN ${candidate.vin}` : `VIN ${candidate.vin}`;
+  if (candidate.licensePlate) return ymm ? `${ymm} — Plate ${candidate.licensePlate}` : `Plate ${candidate.licensePlate}`;
+  if (candidate.unitNumber) return ymm ? `${ymm} — Unit ${candidate.unitNumber}` : `Unit ${candidate.unitNumber}`;
+  return ymm || "Unknown vehicle";
+}
+
+function issueReasonLabel(reason: CustomerVehicleLinkIssue["reason"]): string {
+  const labels: Record<CustomerVehicleLinkIssue["reason"], string> = {
+    missing_staged_customer: "Staged customer entity was missing",
+    missing_staged_vehicle: "Staged vehicle entity was missing",
+    customer_not_materialized: "Customer was not materialized",
+    vehicle_not_materialized: "Vehicle was not materialized",
+    vehicle_linked_to_different_customer: "Vehicle already linked to a different customer",
+    ambiguous_customer_match: "Customer match was ambiguous",
+    ambiguous_vehicle_match: "Vehicle match was ambiguous",
+    unsupported_link_direction: "Link direction is unsupported",
+    unknown: "Unknown materialization issue",
+  };
+  return labels[reason] ?? labels.unknown;
+}
+
+async function persistUnresolvedLinkReviewItems(args: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  issues: CustomerVehicleLinkIssue[];
+}) {
+  const sb = args.supabase as any;
+  const issueType = "unresolved_customer_vehicle_link";
+  const unresolved = args.issues.filter((issue) => issue.reason !== "unknown");
+  const unresolvedLinkIds = new Set(unresolved.map((issue) => issue.linkId));
+
+  const { data: existingRows, error: existingError } = await sb
+    .from("onboarding_review_items")
+    .select("id, link_id, status")
+    .eq("shop_id", args.shopId)
+    .eq("session_id", args.sessionId)
+    .eq("issue_type", issueType);
+  if (existingError) throw new Error(existingError.message);
+
+  const existingById = new Map<string, Pick<OnboardingReviewItemRow, "id" | "status" | "link_id">>(
+    ((existingRows ?? []) as Array<Pick<OnboardingReviewItemRow, "id" | "status" | "link_id">>).map((row) => [row.id, row]),
+  );
+
+  const upserts: OnboardingReviewItemInsert[] = unresolved.map((issue) => {
+    const reviewItemId = stableUuidFromParts(["onboarding_review", args.shopId, args.sessionId, issueType, issue.linkId]);
+    const existing = existingById.get(reviewItemId);
+    const status = existing?.status === "skipped" ? "skipped" : "pending";
+    return {
+      id: reviewItemId,
+      shop_id: args.shopId,
+      session_id: args.sessionId,
+      link_id: issue.linkId,
+      entity_id: issue.stagedVehicleSummary?.entityId ?? issue.stagedCustomerSummary?.entityId ?? null,
+      domain: "vehicles",
+      issue_type: issueType,
+      severity: "medium",
+      status,
+      summary: `${customerLabel(issue.stagedCustomerSummary)} ↔ ${vehicleLabel(issue.stagedVehicleSummary)}: ${issueReasonLabel(issue.reason)}.`,
+      details: {
+        stagedLinkId: issue.linkId,
+        stagedCustomerEntityId: issue.stagedCustomerSummary?.entityId ?? null,
+        stagedVehicleEntityId: issue.stagedVehicleSummary?.entityId ?? null,
+        proposedCustomerLabel: customerLabel(issue.stagedCustomerSummary),
+        proposedVehicleLabel: vehicleLabel(issue.stagedVehicleSummary),
+        reasonCode: issue.reason,
+        reasonLabel: issueReasonLabel(issue.reason),
+        stagedCustomerSummary: issue.stagedCustomerSummary ?? null,
+        stagedVehicleSummary: issue.stagedVehicleSummary ?? null,
+        liveCustomerId: issue.liveCustomerId ?? null,
+        liveVehicleId: issue.liveVehicleId ?? null,
+        currentVehicleCustomerId: issue.currentVehicleCustomerId ?? null,
+        candidateLiveCustomers: issue.candidateLiveCustomers ?? [],
+        candidateLiveVehicles: issue.candidateLiveVehicles ?? [],
+      },
+    };
+  });
+
+  if (upserts.length > 0) {
+    const { error: upsertError } = await sb.from("onboarding_review_items").upsert(upserts, { onConflict: "id" });
+    if (upsertError) throw new Error(upsertError.message);
+  }
+
+  const stalePendingIds = ((existingRows ?? []) as Array<Pick<OnboardingReviewItemRow, "id" | "status" | "link_id">>)
+    .filter((row) => row.status === "pending" && !unresolvedLinkIds.has(String(row.link_id ?? "")))
+    .map((row) => row.id);
+
+  for (const id of stalePendingIds) {
+    const { error } = await sb
+      .from("onboarding_review_items")
+      .update({
+        status: "resolved",
+        resolved_at: new Date().toISOString(),
+        summary: "Unresolved customer/vehicle link no longer requires manual review.",
+      })
+      .eq("shop_id", args.shopId)
+      .eq("session_id", args.sessionId)
+      .eq("id", id);
+    if (error) throw new Error(error.message);
+  }
 }
 
 function isCustomerEmailUniqueViolation(error: { message?: string; code?: string; details?: string } | null): boolean {
@@ -681,6 +834,8 @@ export async function activateOnboardingCustomersVehicles(params: {
 
     const customerId = customerEntityToLiveId.get(customerEntityId);
     const vehicleId = vehicleEntityToLiveId.get(vehicleEntityId);
+    const customerEntityRow = customerEntity!;
+    const vehicleEntityRow = vehicleEntity!;
     if (!customerId || !vehicleId) {
       vehicleCustomerLinksSkipped += 1;
       warnings.push(`Link ${link.id} skipped: customer or vehicle was not materialized.`);
@@ -692,10 +847,54 @@ export async function activateOnboardingCustomersVehicles(params: {
         fromEntityId: link.from_entity_id,
         toEntityId: link.to_entity_id,
         reason,
-        stagedCustomerSummary: customerEntity ? toStagedCustomerSummary(customerEntity) : undefined,
-        stagedVehicleSummary: vehicleEntity ? toStagedVehicleSummary(vehicleEntity) : undefined,
+        stagedCustomerSummary: toStagedCustomerSummary(customerEntityRow),
+        stagedVehicleSummary: toStagedVehicleSummary(vehicleEntityRow),
         liveCustomerId: customerId ?? null,
         liveVehicleId: vehicleId ?? null,
+        candidateLiveCustomers: customerEntitySkippedReason.get(customerEntityId) === "ambiguous_customer_match"
+          ? customerPool
+            .filter((row) => {
+              const normalized = toNormalizedCustomer(customerEntityRow);
+              return (
+                (normalized.email && normalizeEmail(row.email) === normalized.email)
+                || (normalized.phone && normalizePhone(row.phone ?? row.phone_number) === normalized.phone)
+                || (normalized.externalId && normalizeLookupKey(row.external_id) === normalizeLookupKey(normalized.externalId))
+              );
+            })
+            .slice(0, 10)
+            .map((row) => ({
+              id: row.id,
+              name: row.name,
+              businessName: row.business_name,
+              firstName: row.first_name,
+              lastName: row.last_name,
+              email: row.email,
+              phone: row.phone ?? row.phone_number,
+            }))
+          : [],
+        candidateLiveVehicles: vehicleEntitySkippedReason.get(vehicleEntityId) === "ambiguous_vehicle_match"
+          ? vehiclePool
+            .filter((row) => {
+              const normalizedVehicle = toNormalizedVehicle(vehicleEntityRow);
+              return (
+                (normalizedVehicle.vin && normalizeVin(row.vin) === normalizedVehicle.vin)
+                || (normalizedVehicle.plate && normalizePlate(row.license_plate) === normalizedVehicle.plate)
+                || (normalizedVehicle.externalId && normalizeLookupKey(row.external_id) === normalizeLookupKey(normalizedVehicle.externalId))
+              );
+            })
+            .slice(0, 10)
+            .map((row) => ({
+              id: row.id,
+              externalId: row.external_id,
+              vin: row.vin,
+              licensePlate: row.license_plate,
+              unitNumber: row.unit_number,
+              year: row.year,
+              make: row.make,
+              model: row.model,
+              customerId: row.customer_id,
+            }))
+          : [],
       });
       continue;
     }
@@ -747,6 +946,13 @@ export async function activateOnboardingCustomersVehicles(params: {
     }
     vehicle.customer_id = customerId;
   }
+
+  await persistUnresolvedLinkReviewItems({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+    issues: customerVehicleLinkIssues,
+  });
 
   const [{ count: customersAfter, error: customersAfterError }, { count: vehiclesAfter, error: vehiclesAfterError }, { count: liveVehicleCustomerLinksAfter, error: liveVehicleCustomerLinksAfterError }] = await Promise.all([
     sb.from("customers").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId),

--- a/features/onboarding-agent/server/resolveCustomerVehicleLink.test.ts
+++ b/features/onboarding-agent/server/resolveCustomerVehicleLink.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCustomerVehicleLink } from "@/features/onboarding-agent/server/resolveCustomerVehicleLink";
+
+vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
+  assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
+}));
+
+type ReviewItem = {
+  id: string;
+  shop_id: string;
+  session_id: string;
+  issue_type: string;
+  link_id: string;
+  status: string;
+  summary: string;
+  details: Record<string, unknown>;
+  resolved_at?: string | null;
+  resolved_by?: string | null;
+};
+
+type Customer = {
+  id: string;
+  shop_id: string | null;
+  business_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  phone_number: string | null;
+};
+
+type Vehicle = {
+  id: string;
+  shop_id: string | null;
+  customer_id: string | null;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  vin: string | null;
+  license_plate: string | null;
+  unit_number: string | null;
+};
+
+function createFakeSupabase(seed?: { reviewItems?: ReviewItem[]; customers?: Customer[]; vehicles?: Vehicle[] }) {
+  const state = {
+    reviewItems: [...(seed?.reviewItems ?? [])],
+    customers: [...(seed?.customers ?? [])],
+    vehicles: [...(seed?.vehicles ?? [])],
+  };
+
+  return {
+    state,
+    from(table: string) {
+      const query: any = {
+        table,
+        op: "select",
+        payload: null as any,
+        filters: [] as Array<{ k: string; v: any; op: "eq" | "is" }>,
+        select() { return this; },
+        eq(k: string, v: any) { this.filters.push({ k, v, op: "eq" }); return this; },
+        is(k: string, v: any) { this.filters.push({ k, v, op: "is" }); return this; },
+        update(payload: any) { this.op = "update"; this.payload = payload; return this; },
+        maybeSingle() { return this.execSingle(); },
+        then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
+        async execSingle() {
+          const result = await this.exec();
+          const first = Array.isArray(result.data) ? result.data[0] ?? null : result.data ?? null;
+          return { ...result, data: first };
+        },
+        async exec() {
+          const source = this.table === "onboarding_review_items"
+            ? state.reviewItems
+            : this.table === "customers"
+              ? state.customers
+              : this.table === "vehicles"
+                ? state.vehicles
+                : [];
+          const filtered = source.filter((row: any) => this.filters.every((f: any) => {
+            if (f.op === "eq") return row[f.k] === f.v;
+            return f.v === null ? (row[f.k] === null || row[f.k] === undefined) : row[f.k] === f.v;
+          }));
+
+          if (this.op === "select") return { data: filtered, error: null };
+
+          if (this.op === "update") {
+            for (const row of filtered) Object.assign(row, this.payload);
+            return { data: filtered, error: null };
+          }
+
+          return { data: [], error: null };
+        },
+      };
+      return query;
+    },
+  };
+}
+
+function baseReviewItem(): ReviewItem {
+  return {
+    id: "review-1",
+    shop_id: "shop-1",
+    session_id: "session-1",
+    issue_type: "unresolved_customer_vehicle_link",
+    link_id: "link-1",
+    status: "pending",
+    summary: "pending",
+    details: {
+      liveVehicleId: "vehicle-1",
+      proposedVehicleLabel: "2012 Ford Transit — VIN VIN123",
+      candidateLiveCustomers: [{ id: "customer-1", name: "Target Customer" }],
+    },
+  };
+}
+
+describe("resolveCustomerVehicleLink", () => {
+  let sb: ReturnType<typeof createFakeSupabase>;
+
+  beforeEach(() => {
+    sb = createFakeSupabase({
+      reviewItems: [baseReviewItem()],
+      customers: [
+        { id: "customer-1", shop_id: "shop-1", business_name: null, first_name: null, last_name: null, name: "Target Customer", email: "target@example.com", phone: null, phone_number: null },
+        { id: "customer-2", shop_id: "shop-2", business_name: null, first_name: null, last_name: null, name: "Other Shop", email: "other@example.com", phone: null, phone_number: null },
+      ],
+      vehicles: [
+        { id: "vehicle-1", shop_id: "shop-1", customer_id: null, year: 2012, make: "Ford", model: "Transit", vin: "VIN123", license_plate: null, unit_number: null },
+        { id: "vehicle-2", shop_id: "shop-2", customer_id: null, year: 2014, make: "Ford", model: "Transit", vin: "VIN222", license_plate: null, unit_number: null },
+      ],
+    });
+  });
+
+  it("links vehicle to selected customer", async () => {
+    const result = await resolveCustomerVehicleLink({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "operator-1",
+      reviewItemId: "review-1",
+      action: "link",
+      selectedCustomerId: "customer-1",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sb.state.vehicles[0]?.customer_id).toBe("customer-1");
+    expect(sb.state.reviewItems[0]?.status).toBe("resolved");
+  });
+
+  it("rejects cross-shop customer", async () => {
+    await expect(resolveCustomerVehicleLink({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "operator-1",
+      reviewItemId: "review-1",
+      action: "link",
+      selectedCustomerId: "customer-2",
+    })).rejects.toThrow("Selected customer not found in shop");
+  });
+
+  it("rejects cross-shop vehicle/session via review lookup", async () => {
+    await expect(resolveCustomerVehicleLink({
+      supabase: sb as any,
+      shopId: "shop-2",
+      sessionId: "session-1",
+      actorId: "operator-1",
+      reviewItemId: "review-1",
+      action: "link",
+      selectedCustomerId: "customer-1",
+    })).rejects.toThrow("Review item not found");
+  });
+
+  it("does not overwrite existing link to different customer", async () => {
+    sb.state.vehicles[0]!.customer_id = "customer-other";
+
+    await expect(resolveCustomerVehicleLink({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "operator-1",
+      reviewItemId: "review-1",
+      action: "link",
+      selectedCustomerId: "customer-1",
+    })).rejects.toThrow("replace is not supported");
+  });
+
+  it("skip action marks review item as skipped", async () => {
+    const result = await resolveCustomerVehicleLink({
+      supabase: sb as any,
+      shopId: "shop-1",
+      sessionId: "session-1",
+      actorId: "operator-1",
+      reviewItemId: "review-1",
+      action: "skip",
+    });
+
+    expect(result.action).toBe("skip");
+    expect(sb.state.reviewItems[0]?.status).toBe("skipped");
+  });
+});

--- a/features/onboarding-agent/server/resolveCustomerVehicleLink.ts
+++ b/features/onboarding-agent/server/resolveCustomerVehicleLink.ts
@@ -1,0 +1,184 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+type VehicleRow = Database["public"]["Tables"]["vehicles"]["Row"];
+type CustomerRow = Database["public"]["Tables"]["customers"]["Row"];
+
+type ResolveAction = "link" | "skip";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function text(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized ? normalized : null;
+}
+
+function customerLabel(row: Pick<CustomerRow, "business_name" | "first_name" | "last_name" | "name" | "email" | "phone" | "phone_number"> | null): string {
+  if (!row) return "Unknown customer";
+  return text(row.business_name)
+    ?? text(`${row.first_name ?? ""} ${row.last_name ?? ""}`)
+    ?? text(row.name)
+    ?? text(row.email)
+    ?? text(row.phone ?? row.phone_number)
+    ?? "Unknown customer";
+}
+
+function vehicleLabel(row: Pick<VehicleRow, "year" | "make" | "model" | "vin" | "license_plate" | "unit_number"> | null): string {
+  if (!row) return "Unknown vehicle";
+  const ymm = [row.year, row.make, row.model].filter(Boolean).join(" ").trim();
+  if (row.vin) return ymm ? `${ymm} — VIN ${row.vin}` : `VIN ${row.vin}`;
+  if (row.license_plate) return ymm ? `${ymm} — Plate ${row.license_plate}` : `Plate ${row.license_plate}`;
+  if (row.unit_number) return ymm ? `${ymm} — Unit ${row.unit_number}` : `Unit ${row.unit_number}`;
+  return ymm || "Unknown vehicle";
+}
+
+export async function resolveCustomerVehicleLink(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  actorId: string;
+  reviewItemId?: string;
+  stagedLinkId?: string;
+  action: ResolveAction;
+  selectedCustomerId?: string;
+}) {
+  const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({
+    supabase: params.supabase,
+    shopId: params.shopId,
+    sessionId: params.sessionId,
+  });
+
+  if (!params.reviewItemId && !params.stagedLinkId) {
+    throw new Error("reviewItemId or stagedLinkId is required");
+  }
+  if (params.action === "link" && !params.selectedCustomerId) {
+    throw new Error("selectedCustomerId is required when action='link'");
+  }
+
+  let reviewQuery = sb
+    .from("onboarding_review_items")
+    .select("id, shop_id, session_id, status, details, link_id, issue_type")
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .eq("issue_type", "unresolved_customer_vehicle_link");
+  if (params.reviewItemId) reviewQuery = reviewQuery.eq("id", params.reviewItemId);
+  if (params.stagedLinkId) reviewQuery = reviewQuery.eq("link_id", params.stagedLinkId);
+
+  const { data: reviewItem, error: reviewError } = await reviewQuery.maybeSingle();
+  if (reviewError) throw new Error(reviewError.message);
+  if (!reviewItem) throw new Error("Review item not found");
+
+  const details = asRecord(reviewItem.details);
+  const liveVehicleId = text(details.liveVehicleId);
+  if (!liveVehicleId) {
+    throw new Error("Review item is missing a materialized live vehicle target");
+  }
+
+  const { data: vehicle, error: vehicleError } = await sb
+    .from("vehicles")
+    .select("id, shop_id, customer_id, year, make, model, vin, license_plate, unit_number")
+    .eq("shop_id", params.shopId)
+    .eq("id", liveVehicleId)
+    .maybeSingle();
+  if (vehicleError) throw new Error(vehicleError.message);
+  if (!vehicle) throw new Error("Vehicle not found in shop");
+
+  if (params.action === "skip") {
+    const { error: updateError } = await sb
+      .from("onboarding_review_items")
+      .update({
+        status: "skipped",
+        resolved_at: new Date().toISOString(),
+        resolved_by: params.actorId,
+        summary: "Operator marked unresolved customer/vehicle link as do not link.",
+        details: {
+          ...details,
+          resolution: {
+            action: "skip",
+            resolvedBy: params.actorId,
+            resolvedAt: new Date().toISOString(),
+          },
+        },
+      })
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("id", reviewItem.id);
+    if (updateError) throw new Error(updateError.message);
+
+    return {
+      ok: true as const,
+      action: "skip" as const,
+      vehicleId: vehicle.id,
+      customerId: vehicle.customer_id,
+      customerLabel: null,
+      vehicleLabel: vehicleLabel(vehicle),
+      reviewItemStatus: "skipped",
+      warning: "Link was skipped by operator.",
+    };
+  }
+
+  const selectedCustomerId = String(params.selectedCustomerId);
+  const { data: customer, error: customerError } = await sb
+    .from("customers")
+    .select("id, shop_id, business_name, first_name, last_name, name, email, phone, phone_number")
+    .eq("shop_id", params.shopId)
+    .eq("id", selectedCustomerId)
+    .maybeSingle();
+  if (customerError) throw new Error(customerError.message);
+  if (!customer) throw new Error("Selected customer not found in shop");
+
+  if (vehicle.customer_id && vehicle.customer_id !== selectedCustomerId) {
+    throw new Error("Vehicle is already linked to a different customer; replace is not supported");
+  }
+
+  let warning: string | null = null;
+  if (!vehicle.customer_id) {
+    const { error: linkError } = await sb
+      .from("vehicles")
+      .update({ customer_id: selectedCustomerId })
+      .eq("shop_id", params.shopId)
+      .eq("id", vehicle.id)
+      .is("customer_id", null);
+    if (linkError) throw new Error(linkError.message);
+  } else {
+    warning = "Vehicle was already linked to this customer. No change applied.";
+  }
+
+  const { error: reviewUpdateError } = await sb
+    .from("onboarding_review_items")
+    .update({
+      status: "resolved",
+      resolved_at: new Date().toISOString(),
+      resolved_by: params.actorId,
+      summary: `Operator linked vehicle to ${customerLabel(customer)}.`,
+      details: {
+        ...details,
+        resolution: {
+          action: "link",
+          selectedCustomerId,
+          selectedCustomerLabel: customerLabel(customer),
+          resolvedBy: params.actorId,
+          resolvedAt: new Date().toISOString(),
+        },
+      },
+    })
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .eq("id", reviewItem.id);
+  if (reviewUpdateError) throw new Error(reviewUpdateError.message);
+
+  return {
+    ok: true as const,
+    action: "link" as const,
+    vehicleId: vehicle.id,
+    customerId: customer.id,
+    customerLabel: customerLabel(customer),
+    vehicleLabel: vehicleLabel(vehicle),
+    reviewItemStatus: "resolved",
+    warning,
+  };
+}


### PR DESCRIPTION
### Motivation
- Activation now processes the full dataset but leaves a few ambiguous customer↔vehicle links unresolved, so operators need a safe, auditable workflow to resolve them without guessing or breaking activation behavior.
- Persisting unresolved cases as review items enables an explicit, idempotent operator workflow scoped to shop + session that preserves RLS/tenant boundaries and avoids automatic guessing.

### Description
- Persist unresolved activation link issues as idempotent `onboarding_review_items` rows using `issue_type = 'unresolved_customer_vehicle_link'`, deterministic IDs (`stableUuidFromParts` keyed by shop/session/link), and a rich `details` payload containing staged IDs, readable labels, reason code/label, live IDs and candidate matches; no DB schema changes were made. (files: `features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts`) 
- Add a shop-scoped resolver API and server logic that enforces session ownership and owner/admin access, validates in-shop vehicle/customer, supports `action: 'link' | 'skip'`, prevents replacing an existing vehicle customer link, and marks review items resolved/skipped with metadata. (files: `features/onboarding-agent/server/resolveCustomerVehicleLink.ts`, `app/api/onboarding-agent/sessions/[sessionId]/resolve-customer-vehicle-link/route.ts`)
- Extend onboarding UI with an operational "Unresolved customer/vehicle links" panel showing counts, reason grouping, readable customer/vehicle labels, candidate live-customer picker when safe, and a "Do not link" option; UUIDs are only shown in collapsed Developer details. (file: `features/onboarding-agent/components/OnboardingSessionPage.tsx`)
- Add/extend tests for persistence/idempotency of review items, resolver safety guards (cross-shop rejects, no overwrite), skip action, and UI primary copy that hides UUIDs. (files: `features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts`, `features/onboarding-agent/server/resolveCustomerVehicleLink.test.ts`, `features/onboarding-agent/components/OnboardingSessionPage.test.ts`)

### Testing
- Type check: `npx tsc --noEmit --pretty false` completed successfully with no errors. 
- Unit tests: `npx vitest run features/onboarding-agent` completed successfully and reported all tests passed (features/onboarding-agent test suite passed). 
- Lint: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` ran and produced existing warnings only (no new errors).
- Tests added/updated include activation unresolved-review persistence idempotency, resolver success and guard cases (cross-shop checks and prevention of overwrite), skip action marking, and UI label tests for UUID-free primary copy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ddbab038832885bae7435d1fe044)