### PR TITLE
Onboarding: Activate vendors, parts inventory, and historical work orders

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-history/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-history/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { activateOnboardingHistory } from "@/features/onboarding-agent/server/activateOnboardingHistory";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    const result = await activateOnboardingHistory({
+      supabase: admin,
+      shopId: access.profile.shop_id as string,
+      sessionId,
+      actorId: access.profile.id,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to activate history";
+    const status = message.includes("Session not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-parts/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-parts/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { activateOnboardingParts } from "@/features/onboarding-agent/server/activateOnboardingParts";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const admin = createAdminSupabase();
+  const { sessionId } = await context.params;
+
+  try {
+    const result = await activateOnboardingParts({
+      supabase: admin,
+      shopId: access.profile.shop_id as string,
+      sessionId,
+      actorId: access.profile.id,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to activate parts";
+    const status = message.includes("Session not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/app/api/onboarding-agent/sessions/[sessionId]/activation-routes.test.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activation-routes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requireShopScopedApiAccess = vi.fn();
+const createAdminSupabase = vi.fn();
+const activateOnboardingVendors = vi.fn();
+const activateOnboardingParts = vi.fn();
+const activateOnboardingHistory = vi.fn();
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({ requireShopScopedApiAccess }));
+vi.mock("@/features/shared/lib/supabase/server", () => ({ createAdminSupabase }));
+vi.mock("@/features/onboarding-agent/server/activateOnboardingVendors", () => ({ activateOnboardingVendors }));
+vi.mock("@/features/onboarding-agent/server/activateOnboardingParts", () => ({ activateOnboardingParts }));
+vi.mock("@/features/onboarding-agent/server/activateOnboardingHistory", () => ({ activateOnboardingHistory }));
+
+describe("onboarding activation routes", () => {
+  it("rejects unauthenticated access", async () => {
+    requireShopScopedApiAccess.mockResolvedValue({ ok: false, response: new Response("unauthorized", { status: 401 }) });
+    const { POST } = await import("./activate-parts/route");
+    const res = await POST(new Request("http://localhost", { method: "POST" }), { params: Promise.resolve({ sessionId: "s1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns summary shape for vendor route", async () => {
+    requireShopScopedApiAccess.mockResolvedValue({ ok: true, profile: { shop_id: "shop-1", id: "u1" } });
+    createAdminSupabase.mockReturnValue({});
+    activateOnboardingVendors.mockResolvedValue({ ok: true, stagedVendors: 3, created: 1, matchedExisting: 2, updatedNullOnly: 0, skipped: 0, needsReview: 0, suppliersBefore: 10, suppliersAfter: 11, reviewItemsCreated: 0, warnings: [], records: [] });
+
+    const { POST } = await import("./activate-vendors/route");
+    const res = await POST(new Request("http://localhost", { method: "POST" }), { params: Promise.resolve({ sessionId: "s1" }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json).toHaveProperty("created");
+  });
+
+  it("route uses shop-scoped profile for history activation", async () => {
+    requireShopScopedApiAccess.mockResolvedValue({ ok: true, profile: { shop_id: "shop-2", id: "u2" } });
+    createAdminSupabase.mockReturnValue({});
+    activateOnboardingHistory.mockResolvedValue({ ok: true, stagedHistoryRows: 1, historicalWorkOrdersCreated: 1, existingMatched: 0, linesCreated: 0, customerLinksResolved: 0, vehicleLinksResolved: 0, skipped: 0, needsReview: 0, reviewItemsCreated: 0, warnings: [] });
+
+    const { POST } = await import("./activate-history/route");
+    await POST(new Request("http://localhost", { method: "POST" }), { params: Promise.resolve({ sessionId: "s2" }) });
+
+    expect(activateOnboardingHistory).toHaveBeenCalledWith(expect.objectContaining({ shopId: "shop-2", sessionId: "s2" }));
+  });
+});

--- a/features/onboarding-agent/components/OnboardingSessionPage.test.ts
+++ b/features/onboarding-agent/components/OnboardingSessionPage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getCustomerDisplayLabel, getVehicleDisplayLabel, linkIssueReasonLabel, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, linkIssueReasonLabel, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
 
 describe("OnboardingSessionPage warning label helpers", () => {
   it("builds human-readable customer labels", () => {
@@ -34,5 +34,17 @@ describe("OnboardingSessionPage warning label helpers", () => {
     expect(copy.vehicle).toContain("Ford Transit");
     expect(copy.reason).toContain("ambiguous");
     expect(copy.customer).not.toContain("uuid");
+  });
+
+  it("groups review items by domain for operator panel", () => {
+    const grouped = groupReviewItemsByDomain([
+      { domain: "vendors" },
+      { domain: "parts" },
+      { domain: "vendors" },
+      {},
+    ]);
+    expect(grouped.vendors).toBe(2);
+    expect(grouped.parts).toBe(1);
+    expect(grouped.unknown).toBe(1);
   });
 });

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -109,6 +109,14 @@ export function unresolvedReviewPrimaryCopy(reviewItem: UnresolvedReviewItem): {
   };
 }
 
+export function groupReviewItemsByDomain(reviewItems: Array<{ domain?: string | null }>): Record<string, number> {
+  return reviewItems.reduce<Record<string, number>>((acc, item) => {
+    const key = String(item?.domain ?? "unknown");
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
@@ -118,8 +126,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [planning, setPlanning] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [activatingVendors, setActivatingVendors] = useState(false);
+  const [activatingParts, setActivatingParts] = useState(false);
+  const [activatingHistory, setActivatingHistory] = useState(false);
   const [activatingCustomersVehicles, setActivatingCustomersVehicles] = useState(false);
   const [vendorActivationSummary, setVendorActivationSummary] = useState<string | null>(null);
+  const [partsActivationSummary, setPartsActivationSummary] = useState<string | null>(null);
+  const [historyActivationSummary, setHistoryActivationSummary] = useState<string | null>(null);
   const [customerVehicleActivationResult, setCustomerVehicleActivationResult] = useState<any>(null);
   const [resolvingReviewItemId, setResolvingReviewItemId] = useState<string | null>(null);
   const [selectedCustomerByReviewItemId, setSelectedCustomerByReviewItemId] = useState<Record<string, string>>({});
@@ -239,7 +251,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       } else {
         const warnings = Array.isArray(json?.warnings) ? json.warnings.length : 0;
         setVendorActivationSummary(
-          `Vendor activation complete. Staged vendors: ${Number(json?.stagedVendorsFound ?? 0)}. Inserted: ${Number(json?.inserted ?? 0)}. Updated: ${Number(json?.updated ?? 0)}. Skipped: ${Number(json?.skipped ?? 0)}. Suppliers before/after: ${Number(json?.suppliersBefore ?? 0)}/${Number(json?.suppliersAfter ?? 0)}.${warnings > 0 ? ` Warnings: ${warnings}.` : ""}`,
+          `Vendor activation complete. Staged vendors: ${Number(json?.stagedVendors ?? 0)}. Created: ${Number(json?.created ?? 0)}. Matched existing: ${Number(json?.matchedExisting ?? 0)}. Updated null-only: ${Number(json?.updatedNullOnly ?? 0)}. Skipped: ${Number(json?.skipped ?? 0)}. Needs review: ${Number(json?.needsReview ?? 0)}.${warnings > 0 ? ` Warnings: ${warnings}.` : ""}`,
         );
       }
       await load();
@@ -247,6 +259,54 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       setError("Failed to activate staged vendors.");
     } finally {
       setActivatingVendors(false);
+    }
+  };
+
+  const activateParts = async () => {
+    const confirmed = window.confirm("Activate staged parts inventory into live parts and stock records. Safe to rerun; matching records are updated/null-filled without duplicates.");
+    if (!confirmed) return;
+    setActivatingParts(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/activate-parts`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || "Failed to activate staged parts.");
+      } else {
+        setPartsActivationSummary(
+          `Parts activation complete. Staged: ${Number(json?.stagedParts ?? 0)}. Created: ${Number(json?.partsCreated ?? 0)}. Matched: ${Number(json?.existingPartsMatched ?? 0)}. Stock created: ${Number(json?.stockRecordsCreated ?? 0)}. Needs review: ${Number(json?.needsReview ?? 0)}.`,
+        );
+      }
+      await load();
+    } catch {
+      setError("Failed to activate staged parts.");
+    } finally {
+      setActivatingParts(false);
+    }
+  };
+
+  const activateHistory = async () => {
+    const confirmed = window.confirm("Activate historical work orders as closed historical records only. They will not be added to active technician queues.");
+    if (!confirmed) return;
+    setActivatingHistory(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/onboarding-agent/sessions/${sessionId}/activate-history`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || "Failed to activate historical work orders.");
+      } else {
+        setHistoryActivationSummary(
+          `History activation complete. Staged: ${Number(json?.stagedHistoryRows ?? 0)}. Created: ${Number(json?.historicalWorkOrdersCreated ?? 0)}. Matched: ${Number(json?.existingMatched ?? 0)}. Lines created: ${Number(json?.linesCreated ?? 0)}. Needs review: ${Number(json?.needsReview ?? 0)}.`,
+        );
+      }
+      await load();
+    } catch {
+      setError("Failed to activate historical work orders.");
+    } finally {
+      setActivatingHistory(false);
     }
   };
 
@@ -302,8 +362,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const customerReadyCount = Number(payload?.entityStatusCounts?.customer?.ready ?? 0);
   const vehicleReadyCount = Number(payload?.entityStatusCounts?.vehicle?.ready ?? 0);
   const hasCustomerVehicleReady = customerReadyCount > 0 || vehicleReadyCount > 0;
-  const actionBusy = analyzing || deleting || planning || activatingVendors || activatingCustomersVehicles;
+  const actionBusy = analyzing || deleting || planning || activatingVendors || activatingCustomersVehicles || activatingParts || activatingHistory;
   const canShowVendorActivation = !loadingSession && !sessionLoadError && vendorReadyCount > 0;
+  const partReadyCount = Number(payload?.entityStatusCounts?.part?.ready ?? 0);
+  const historyReadyCount = Number(payload?.entityStatusCounts?.historical_work_order?.ready ?? 0);
+  const canShowPartsActivation = !loadingSession && !sessionLoadError && partReadyCount > 0;
+  const canShowHistoryActivation = !loadingSession && !sessionLoadError && historyReadyCount > 0;
   const canShowCustomerVehicleActivation = !loadingSession && !sessionLoadError && hasCustomerVehicleReady;
   const groupedCustomerVehicleWarnings = useMemo(() => {
     const warnings: string[] = Array.isArray(customerVehicleActivationResult?.warnings)
@@ -460,6 +524,24 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
               {activatingVendors ? "Activating vendors…" : "Activate vendors to live suppliers"}
             </button>
           ) : null}
+          {canShowPartsActivation ? (
+            <button
+              onClick={activateParts}
+              disabled={actionBusy || !!sessionLoadError || partReadyCount <= 0}
+              className="rounded border border-indigo-400/40 px-3 py-2 text-sm text-indigo-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {activatingParts ? "Activating parts…" : "Activate parts inventory"}
+            </button>
+          ) : null}
+          {canShowHistoryActivation ? (
+            <button
+              onClick={activateHistory}
+              disabled={actionBusy || !!sessionLoadError || historyReadyCount <= 0}
+              className="rounded border border-fuchsia-400/40 px-3 py-2 text-sm text-fuchsia-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {activatingHistory ? "Activating history…" : "Activate historical work orders"}
+            </button>
+          ) : null}
           <button
             onClick={deleteSession}
             disabled={deleting || analyzing || planning}
@@ -482,8 +564,12 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
             Creates/updates live customers and vehicles only. No work orders, invoices, parts, staff, or menu items are activated.
           </p>
         ) : null}
+        {canShowPartsActivation ? <p className="mt-1 text-xs text-indigo-100/90">Safe to rerun. Existing imported part records will be matched, not duplicated.</p> : null}
+        {canShowHistoryActivation ? <p className="mt-1 text-xs text-fuchsia-100/90">Historical work orders are imported as closed/historical records and will not appear in active technician queues.</p> : null}
         {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
         {vendorActivationSummary ? <p className="mt-2 text-xs text-emerald-200">{vendorActivationSummary}</p> : null}
+        {partsActivationSummary ? <p className="mt-2 text-xs text-indigo-200">{partsActivationSummary}</p> : null}
+        {historyActivationSummary ? <p className="mt-2 text-xs text-fuchsia-200">{historyActivationSummary}</p> : null}
         {customerVehicleActivationResult ? (
           <div className="mt-2 rounded-lg border border-cyan-400/30 bg-cyan-950/20 p-3 text-xs text-cyan-100">
             <p>

--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { activateOnboardingHistory } from "@/features/onboarding-agent/server/activateOnboardingHistory";
+
+vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
+  assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
+}));
+
+function fakeSb() {
+  const state = {
+    entities: [{ id: "h-1", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" } }] as any[],
+    links: [],
+    customers: [{ id: "c-1", external_id: null, email: null, name: "Acme", business_name: null }],
+    vehicles: [{ id: "v-1", external_id: null, vin: "VIN1", license_plate: null }],
+    work_orders: [] as any[],
+    lines: [] as any[],
+    reviewItems: [] as any[],
+  };
+  return {
+    state,
+    from(table: string) {
+      const q: any = {
+        op: "select",
+        payload: null as any,
+        select() { return this; },
+        eq() { return this; },
+        order() { return this; },
+        insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
+        upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this.exec(); },
+        single() { return this.execSingle(); },
+        then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
+        async execSingle() { const r = await this.exec(); return { ...r, data: Array.isArray(r.data) ? r.data[0] : r.data }; },
+        async exec() {
+          if (table === "onboarding_entities") return { data: state.entities, error: null };
+          if (table === "onboarding_entity_links") return { data: state.links, error: null };
+          if (table === "customers") return { data: state.customers, error: null };
+          if (table === "vehicles") return { data: state.vehicles, error: null };
+          if (table === "work_orders" && this.op === "select") return { data: state.work_orders, error: null };
+          if (table === "work_orders" && this.op === "insert") { const row = { ...this.payload, id: `wo-${state.work_orders.length + 1}` }; state.work_orders.push(row); return { data: [{ id: row.id }], error: null }; }
+          if (table === "work_order_lines" && this.op === "insert") { state.lines.push(this.payload); return { data: [], error: null }; }
+          if (table === "onboarding_review_items") { state.reviewItems.push(...(Array.isArray(this.payload) ? this.payload : [this.payload])); return { data: [], error: null }; }
+          return { data: [], error: null };
+        },
+      };
+      return q;
+    },
+  };
+}
+
+describe("activateOnboardingHistory", () => {
+  it("creates historical work order once and rerun does not duplicate", async () => {
+    const sb = fakeSb();
+    const first = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    const second = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(first.historicalWorkOrdersCreated).toBe(1);
+    expect(second.historicalWorkOrdersCreated).toBe(0);
+    expect(sb.state.work_orders[0].status).toBe("completed");
+  });
+
+  it("creates review item for missing identifier", async () => {
+    const sb = fakeSb();
+    sb.state.entities = [{ id: "h-2", normalized: {} }] as any[];
+    const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.needsReview).toBeGreaterThan(0);
+    expect(sb.state.reviewItems.some((i) => i.issue_type === "missing_required_history_identifier")).toBe(true);
+  });
+});

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -1,0 +1,291 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+type OnboardingEntityRow = Database["public"]["Tables"]["onboarding_entities"]["Row"];
+type OnboardingEntityLinkRow = Database["public"]["Tables"]["onboarding_entity_links"]["Row"];
+type CustomerRow = Database["public"]["Tables"]["customers"]["Row"];
+type VehicleRow = Database["public"]["Tables"]["vehicles"]["Row"];
+type WorkOrderRow = Database["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderInsert = Database["public"]["Tables"]["work_orders"]["Insert"];
+type WorkOrderLineInsert = Database["public"]["Tables"]["work_order_lines"]["Insert"];
+type OnboardingReviewItemInsert = Database["public"]["Tables"]["onboarding_review_items"]["Insert"];
+
+type HistoryActivationResult = {
+  ok: true;
+  stagedHistoryRows: number;
+  historicalWorkOrdersCreated: number;
+  existingMatched: number;
+  linesCreated: number;
+  customerLinksResolved: number;
+  vehicleLinksResolved: number;
+  skipped: number;
+  needsReview: number;
+  reviewItemsCreated: number;
+  warnings: string[];
+};
+
+type NormalizedHistory = {
+  sourceWorkOrderId: string | null;
+  invoiceNumber: string | null;
+  openedDate: string | null;
+  closedDate: string | null;
+  customerName: string | null;
+  customerEmail: string | null;
+  sourceCustomerId: string | null;
+  sourceVehicleId: string | null;
+  vehicleVin: string | null;
+  vehiclePlate: string | null;
+  complaint: string | null;
+  correction: string | null;
+  laborTotal: number | null;
+  total: number | null;
+};
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalizeLookup(value: unknown): string {
+  return normalizeText(value).toLowerCase().replace(/[\s\-_.]+/g, " ").trim();
+}
+
+function parseMoney(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const cleaned = normalizeText(value).replace(/[^0-9.-]/g, "");
+  if (!cleaned) return null;
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseDate(value: unknown): string | null {
+  const raw = normalizeText(value);
+  if (!raw) return null;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+function toNormalizedHistory(entity: Pick<OnboardingEntityRow, "normalized">): NormalizedHistory {
+  const normalized = (entity.normalized ?? {}) as Record<string, unknown>;
+  return {
+    sourceWorkOrderId: normalizeText(normalized.sourceWorkOrderId) || null,
+    invoiceNumber: normalizeText(normalized.invoiceNumber ?? normalized.invoiceId) || null,
+    openedDate: parseDate(normalized.openedDate),
+    closedDate: parseDate(normalized.closedDate),
+    customerName: normalizeText(normalized.customerName) || null,
+    customerEmail: normalizeText(normalized.customerEmail).toLowerCase() || null,
+    sourceCustomerId: normalizeText(normalized.sourceCustomerId) || null,
+    sourceVehicleId: normalizeText(normalized.sourceVehicleId) || null,
+    vehicleVin: normalizeText(normalized.vehicleVin).toUpperCase() || null,
+    vehiclePlate: normalizeText(normalized.vehiclePlate).toUpperCase() || null,
+    complaint: normalizeText(normalized.complaint) || null,
+    correction: normalizeText(normalized.correction) || null,
+    laborTotal: parseMoney(normalized.laborTotal ?? normalized.laborRaw),
+    total: parseMoney(normalized.total ?? normalized.totalRaw),
+  };
+}
+
+function reviewItem(params: {
+  shopId: string;
+  sessionId: string;
+  entityId: string;
+  issueType: string;
+  summary: string;
+  details?: Record<string, unknown>;
+  severity?: "low" | "medium" | "high" | "blocking";
+}): OnboardingReviewItemInsert {
+  return {
+    id: stableUuidFromParts(["onboarding-review", params.shopId, params.sessionId, "history", params.issueType, params.entityId]),
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+    entity_id: params.entityId,
+    issue_type: params.issueType,
+    summary: params.summary,
+    severity: params.severity ?? "medium",
+    status: "pending",
+    domain: "history",
+    details: (params.details ?? {}) as any,
+  };
+}
+
+export async function activateOnboardingHistory(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  actorId: string;
+}): Promise<HistoryActivationResult> {
+  const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
+
+  const [{ data: entities }, { data: links }, { data: customers }, { data: vehicles }, { data: workOrders }] = await Promise.all([
+    sb
+      .from("onboarding_entities")
+      .select("id, normalized")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("entity_type", "historical_work_order")
+      .eq("status", "ready")
+      .order("id", { ascending: true }),
+    sb.from("onboarding_entity_links").select("id, from_entity_id, to_entity_id, link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
+    sb.from("customers").select("id, external_id, email, name, business_name").eq("shop_id", params.shopId),
+    sb.from("vehicles").select("id, external_id, vin, license_plate").eq("shop_id", params.shopId),
+    sb.from("work_orders").select("*").eq("shop_id", params.shopId),
+  ]);
+
+  const historyRows = (entities ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized">>;
+  const linkRows = (links ?? []) as Array<Pick<OnboardingEntityLinkRow, "id" | "from_entity_id" | "to_entity_id" | "link_type">>;
+  const customerRows = (customers ?? []) as CustomerRow[];
+  const vehicleRows = (vehicles ?? []) as VehicleRow[];
+  const woRows = [...((workOrders ?? []) as WorkOrderRow[])];
+
+  const reviewItems: OnboardingReviewItemInsert[] = [];
+  const warnings: string[] = [];
+
+  let historicalWorkOrdersCreated = 0;
+  let existingMatched = 0;
+  let linesCreated = 0;
+  let customerLinksResolved = 0;
+  let vehicleLinksResolved = 0;
+  let skipped = 0;
+  let needsReview = 0;
+
+  for (const entity of historyRows) {
+    const history = toNormalizedHistory(entity);
+    if (!history.sourceWorkOrderId && !history.invoiceNumber && !history.openedDate) {
+      skipped += 1;
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_required_history_identifier", summary: "Historical row skipped: missing identifier.", severity: "high" }));
+      continue;
+    }
+    if (!history.openedDate) {
+      skipped += 1;
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_history_date", summary: "Historical row skipped: invalid opened date." }));
+      continue;
+    }
+    if (history.total !== null && history.total < 0) {
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_history_total", summary: "Historical row has invalid total.", details: { total: history.total } }));
+      needsReview += 1;
+    }
+
+    const link = linkRows.find((row) => row.link_type === "customer_vehicle" && (row.from_entity_id === entity.id || row.to_entity_id === entity.id));
+    if (!link) {
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "unresolved_customer_vehicle_link_for_history", summary: "Historical work order missing staged customer/vehicle link." }));
+      needsReview += 1;
+    }
+
+    const customerMatches = customerRows.filter((row) =>
+      (history.sourceCustomerId && normalizeLookup(row.external_id) === normalizeLookup(history.sourceCustomerId))
+      || (history.customerEmail && normalizeLookup(row.email) === normalizeLookup(history.customerEmail))
+      || (history.customerName && normalizeLookup(row.business_name || row.name) === normalizeLookup(history.customerName)),
+    );
+    const vehicleMatches = vehicleRows.filter((row) =>
+      (history.sourceVehicleId && normalizeLookup(row.external_id) === normalizeLookup(history.sourceVehicleId))
+      || (history.vehicleVin && normalizeLookup(row.vin) === normalizeLookup(history.vehicleVin))
+      || (history.vehiclePlate && normalizeLookup(row.license_plate) === normalizeLookup(history.vehiclePlate)),
+    );
+
+    let customerId: string | null = null;
+    let vehicleId: string | null = null;
+
+    if (customerMatches.length === 1) {
+      customerId = customerMatches[0]!.id;
+      customerLinksResolved += 1;
+    } else if (customerMatches.length > 1) {
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "ambiguous_customer_match_for_history", summary: "Historical work order has ambiguous customer match." }));
+    } else {
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_customer_for_history", summary: "Historical work order customer could not be matched." }));
+    }
+
+    if (vehicleMatches.length === 1) {
+      vehicleId = vehicleMatches[0]!.id;
+      vehicleLinksResolved += 1;
+    } else if (vehicleMatches.length > 1) {
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "ambiguous_vehicle_match_for_history", summary: "Historical work order has ambiguous vehicle match." }));
+    } else {
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_vehicle_for_history", summary: "Historical work order vehicle could not be matched." }));
+    }
+
+    const sourceRowKey = stableUuidFromParts([params.shopId, params.sessionId, "history", entity.id]);
+    const existing = woRows.find((row) => row.source_row_id === sourceRowKey || (history.sourceWorkOrderId && normalizeLookup(row.custom_id) === normalizeLookup(history.sourceWorkOrderId)));
+    if (existing) {
+      existingMatched += 1;
+      continue;
+    }
+
+    const payload: WorkOrderInsert = {
+      shop_id: params.shopId,
+      created_by: params.actorId,
+      created_at: history.openedDate,
+      updated_at: history.closedDate ?? history.openedDate,
+      custom_id: history.sourceWorkOrderId ?? history.invoiceNumber,
+      customer_id: customerId,
+      vehicle_id: vehicleId,
+      customer_name: history.customerName,
+      vehicle_vin: history.vehicleVin,
+      vehicle_license_plate: history.vehiclePlate,
+      status: "completed",
+      type: "historical_import",
+      source_intake_id: params.sessionId,
+      source_row_id: sourceRowKey,
+      invoice_total: history.total,
+      labor_total: history.laborTotal,
+      notes: history.complaint ?? history.correction,
+      is_waiter: false,
+    };
+
+    const { data: created, error } = await sb.from("work_orders").insert(payload).select("id").single();
+    if (error) throw new Error(error.message);
+    historicalWorkOrdersCreated += 1;
+
+    if (history.complaint || history.correction) {
+      const linePayload: WorkOrderLineInsert = {
+        shop_id: params.shopId,
+        work_order_id: created?.id,
+        status: "completed",
+        line_type: "labor",
+        line_status: "closed",
+        description: history.complaint ?? history.correction,
+        complaint: history.complaint,
+        correction: history.correction,
+        labor_time: null,
+        price_estimate: history.total,
+        source_intake_id: params.sessionId,
+        source_row_id: sourceRowKey,
+      };
+      const { error: lineError } = await sb.from("work_order_lines").insert(linePayload);
+      if (lineError) {
+        warnings.push(`Unable to create history line for ${entity.id}`);
+        reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "unsupported_history_line_format", summary: "Historical line could not be created safely." }));
+        needsReview += 1;
+      } else {
+        linesCreated += 1;
+      }
+    }
+  }
+
+  if (reviewItems.length > 0) {
+    const { error } = await sb.from("onboarding_review_items").upsert(reviewItems, { onConflict: "id" });
+    if (error) throw new Error(error.message);
+  }
+
+  return {
+    ok: true,
+    stagedHistoryRows: historyRows.length,
+    historicalWorkOrdersCreated,
+    existingMatched,
+    linesCreated,
+    customerLinksResolved,
+    vehicleLinksResolved,
+    skipped,
+    needsReview,
+    reviewItemsCreated: reviewItems.length,
+    warnings,
+  };
+}

--- a/features/onboarding-agent/server/activateOnboardingParts.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { activateOnboardingParts } from "@/features/onboarding-agent/server/activateOnboardingParts";
+
+vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
+  assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
+}));
+
+function fakeSb() {
+  const state = {
+    entities: [{ id: "part-1", normalized: { description: "Brake Pad", partNumber: "BP-1", quantityOnHandRaw: "5" }, display_name: "Brake Pad", source_external_id: "src-1" }] as any[],
+    parts: [] as any[],
+    suppliers: [{ id: "s1", name: "Vendor A" }],
+    stock_locations: [{ id: "loc-1", shop_id: "shop-1" }],
+    part_stock: [] as any[],
+    stock_moves: [] as any[],
+    reviewItems: [] as any[],
+  };
+  return {
+    state,
+    from(table: string) {
+      const q: any = {
+        table,
+        op: "select",
+        payload: null as any,
+        select() { return this; },
+        eq() { return this; },
+        order() { return this; },
+        limit() { return this; },
+        insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
+        update(payload: any) { this.op = "update"; this.payload = payload; return this; },
+        upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this.exec(); },
+        single() { return this.execSingle(); },
+        then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
+        async execSingle() { const r = await this.exec(); return { ...r, data: Array.isArray(r.data) ? r.data[0] : r.data }; },
+        async exec() {
+          if (table === "onboarding_entities") return { data: state.entities, error: null };
+          if (table === "parts" && this.op === "select") return { data: state.parts, error: null };
+          if (table === "parts" && this.op === "insert") { const row = { ...this.payload, id: `p-${state.parts.length + 1}` }; state.parts.push(row); return { data: [row], error: null }; }
+          if (table === "parts" && this.op === "update") return { data: [], error: null };
+          if (table === "suppliers") return { data: state.suppliers, error: null };
+          if (table === "stock_locations") return { data: state.stock_locations, error: null };
+          if (table === "part_stock" && this.op === "select") return { data: state.part_stock, error: null };
+          if (table === "part_stock" && this.op === "insert") { const row = { ...this.payload, id: `ps-${state.part_stock.length + 1}` }; state.part_stock.push(row); return { data: [row], error: null }; }
+          if (table === "stock_moves") { state.stock_moves.push(this.payload); return { data: [], error: null }; }
+          if (table === "onboarding_review_items") { state.reviewItems.push(...(Array.isArray(this.payload) ? this.payload : [this.payload])); return { data: [], error: null }; }
+          return { data: [], error: null };
+        },
+      };
+      return q;
+    },
+  };
+}
+
+describe("activateOnboardingParts", () => {
+  it("creates part + stock once and rerun does not duplicate part", async () => {
+    const sb = fakeSb();
+    const first = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    const second = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(first.partsCreated).toBe(1);
+    expect(second.partsCreated).toBe(0);
+    expect(sb.state.parts.length).toBe(1);
+  });
+
+  it("invalid quantity creates review item", async () => {
+    const sb = fakeSb();
+    sb.state.entities = [{ id: "part-2", normalized: { description: "Rotor", quantityOnHandRaw: "-5" }, display_name: "Rotor", source_external_id: null }] as any[];
+    const result = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.needsReview).toBeGreaterThan(0);
+    expect(sb.state.reviewItems.some((i) => i.issue_type === "invalid_quantity")).toBe(true);
+  });
+});

--- a/features/onboarding-agent/server/activateOnboardingParts.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.ts
@@ -1,0 +1,324 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
+import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+type OnboardingEntityRow = Database["public"]["Tables"]["onboarding_entities"]["Row"];
+type PartRow = Database["public"]["Tables"]["parts"]["Row"];
+type PartInsert = Database["public"]["Tables"]["parts"]["Insert"];
+type PartUpdate = Database["public"]["Tables"]["parts"]["Update"];
+type StockLocationRow = Database["public"]["Tables"]["stock_locations"]["Row"];
+type PartStockRow = Database["public"]["Tables"]["part_stock"]["Row"];
+type OnboardingReviewItemInsert = Database["public"]["Tables"]["onboarding_review_items"]["Insert"];
+
+type NormalizedPart = {
+  name: string | null;
+  partNumber: string | null;
+  sku: string | null;
+  vendorName: string | null;
+  quantity: number | null;
+  cost: number | null;
+  price: number | null;
+  sourceExternalId: string | null;
+};
+
+export type PartsActivationResult = {
+  ok: true;
+  stagedParts: number;
+  partsCreated: number;
+  existingPartsMatched: number;
+  partsNullOnlyUpdated: number;
+  stockRecordsCreated: number;
+  stockQuantitiesInitialized: number;
+  vendorLinksCreated: number;
+  skipped: number;
+  needsReview: number;
+  reviewItemsCreated: number;
+  warnings: string[];
+};
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalizeLookupKey(value: unknown): string {
+  return normalizeText(value).toLowerCase().replace(/[\s\-_.]+/g, " ").replace(/[^a-z0-9]/g, "").trim();
+}
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const cleaned = normalizeText(value).replace(/[^0-9.-]/g, "");
+  if (!cleaned) return null;
+  const parsed = Number(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toNormalizedPart(entity: Pick<OnboardingEntityRow, "normalized" | "display_name" | "source_external_id">): NormalizedPart {
+  const normalized = (entity.normalized ?? {}) as Record<string, unknown>;
+  return {
+    name: normalizeText(normalized.description ?? entity.display_name) || null,
+    partNumber: normalizeText(normalized.partNumber) || null,
+    sku: normalizeText(normalized.sku) || null,
+    vendorName: normalizeText(normalized.vendorName) || null,
+    quantity: parseNumber(normalized.quantityOnHandRaw),
+    cost: parseNumber(normalized.cost),
+    price: parseNumber(normalized.price),
+    sourceExternalId: normalizeText(entity.source_external_id) || null,
+  };
+}
+
+function reviewItem(params: {
+  shopId: string;
+  sessionId: string;
+  entityId: string;
+  issueType: string;
+  summary: string;
+  severity?: "low" | "medium" | "high" | "blocking";
+  details?: Record<string, unknown>;
+}): OnboardingReviewItemInsert {
+  return {
+    id: stableUuidFromParts(["onboarding-review", params.shopId, params.sessionId, "parts", params.issueType, params.entityId]),
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+    entity_id: params.entityId,
+    issue_type: params.issueType,
+    domain: "parts",
+    summary: params.summary,
+    severity: params.severity ?? "medium",
+    status: "pending",
+    details: (params.details ?? {}) as any,
+  };
+}
+
+function getPartMatchCandidates(partRows: PartRow[], part: NormalizedPart): PartRow[] {
+  const partNumberKey = normalizeLookupKey(part.partNumber);
+  if (partNumberKey) {
+    const exact = partRows.filter((row) => normalizeLookupKey(row.part_number) === partNumberKey);
+    if (exact.length > 0) return exact;
+  }
+
+  const skuKey = normalizeLookupKey(part.sku);
+  if (skuKey) {
+    const exact = partRows.filter((row) => normalizeLookupKey(row.sku) === skuKey);
+    if (exact.length > 0) return exact;
+  }
+
+  const nameKey = normalizeLookupKey(part.name);
+  if (nameKey) return partRows.filter((row) => normalizeLookupKey(row.name) === nameKey);
+  return [];
+}
+
+function buildNullOnlyPartUpdate(current: PartRow, incoming: NormalizedPart, supplierName: string | null): PartUpdate | null {
+  const update: PartUpdate = {};
+  if (!normalizeText(current.part_number) && incoming.partNumber) update.part_number = incoming.partNumber;
+  if (!normalizeText(current.sku) && incoming.sku) update.sku = incoming.sku;
+  if (!normalizeText(current.description) && incoming.name) update.description = incoming.name;
+  if (current.cost === null && incoming.cost !== null) update.cost = incoming.cost;
+  if (current.default_cost === null && incoming.cost !== null) update.default_cost = incoming.cost;
+  if (current.price === null && incoming.price !== null) update.price = incoming.price;
+  if (current.default_price === null && incoming.price !== null) update.default_price = incoming.price;
+  if (!normalizeText(current.supplier) && supplierName) update.supplier = supplierName;
+  return Object.keys(update).length > 0 ? update : null;
+}
+
+export async function activateOnboardingParts(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  sessionId: string;
+  actorId: string;
+}): Promise<PartsActivationResult> {
+  const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
+
+  const [{ data: staged }, { data: parts }, { data: suppliers }, { data: stockLocations }, { data: partStockRows }] = await Promise.all([
+    sb
+      .from("onboarding_entities")
+      .select("id, normalized, display_name, source_external_id")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("entity_type", "part")
+      .eq("status", "ready")
+      .order("id", { ascending: true }),
+    sb.from("parts").select("*").eq("shop_id", params.shopId),
+    sb.from("suppliers").select("id, name").eq("shop_id", params.shopId),
+    sb.from("stock_locations").select("*").eq("shop_id", params.shopId).order("created_at", { ascending: true }).limit(1),
+    sb.from("part_stock").select("id, part_id, location_id, qty_on_hand, qty_reserved, reorder_point, reorder_qty"),
+  ]);
+
+  const stagedRows = (staged ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">>;
+  const partRows = [...((parts ?? []) as PartRow[])];
+  const supplierRows = suppliers ?? [];
+  const defaultLocation = (stockLocations?.[0] ?? null) as StockLocationRow | null;
+  const stockRows = [...((partStockRows ?? []) as PartStockRow[])];
+
+  const reviewItems: OnboardingReviewItemInsert[] = [];
+  const warnings: string[] = [];
+
+  let partsCreated = 0;
+  let existingPartsMatched = 0;
+  let partsNullOnlyUpdated = 0;
+  let stockRecordsCreated = 0;
+  let stockQuantitiesInitialized = 0;
+  let vendorLinksCreated = 0;
+  let skipped = 0;
+  let needsReview = 0;
+
+  for (const entity of stagedRows) {
+    const normalized = toNormalizedPart(entity);
+    if (!normalized.name) {
+      skipped += 1;
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_part_name", summary: "Part row skipped: missing part name.", severity: "high" }));
+      continue;
+    }
+
+    if (normalized.quantity !== null && normalized.quantity < 0) {
+      skipped += 1;
+      needsReview += 1;
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_quantity", summary: `Part ${normalized.name} has invalid quantity.`, details: { quantity: normalized.quantity } }));
+      continue;
+    }
+    if (normalized.cost !== null && normalized.cost < 0) {
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_cost", summary: `Part ${normalized.name} has invalid cost.`, details: { cost: normalized.cost } }));
+      needsReview += 1;
+    }
+    if (normalized.price !== null && normalized.price < 0) {
+      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_sale_price", summary: `Part ${normalized.name} has invalid sale price.`, details: { price: normalized.price } }));
+      needsReview += 1;
+    }
+
+    const candidates = getPartMatchCandidates(partRows, normalized);
+    if (candidates.length > 1) {
+      skipped += 1;
+      needsReview += 1;
+      reviewItems.push(reviewItem({
+        shopId: params.shopId,
+        sessionId: params.sessionId,
+        entityId: entity.id,
+        issueType: "ambiguous_part_match",
+        summary: `Part ${normalized.name} matched multiple parts and requires review.`,
+        details: { candidates: candidates.slice(0, 3).map((row) => ({ id: row.id, name: row.name, partNumber: row.part_number, sku: row.sku })) },
+      }));
+      continue;
+    }
+
+    const supplierMatch = normalized.vendorName
+      ? supplierRows.filter((row: any) => normalizeLookupKey(row.name) === normalizeLookupKey(normalized.vendorName))
+      : [];
+    let supplierNameToWrite: string | null = null;
+    if (supplierMatch.length === 1) {
+      supplierNameToWrite = supplierMatch[0].name;
+      vendorLinksCreated += 1;
+    } else if (supplierMatch.length > 1) {
+      reviewItems.push(reviewItem({
+        shopId: params.shopId,
+        sessionId: params.sessionId,
+        entityId: entity.id,
+        issueType: "ambiguous_vendor_for_part",
+        summary: `Vendor for part ${normalized.name} is ambiguous.`,
+        details: { vendorName: normalized.vendorName },
+      }));
+      needsReview += 1;
+    } else if (normalized.vendorName) {
+      reviewItems.push(reviewItem({
+        shopId: params.shopId,
+        sessionId: params.sessionId,
+        entityId: entity.id,
+        issueType: "ambiguous_vendor_for_part",
+        summary: `Vendor for part ${normalized.name} was not found.`,
+        details: { vendorName: normalized.vendorName },
+      }));
+      needsReview += 1;
+    }
+
+    let targetPart: PartRow;
+    if (candidates.length === 1) {
+      targetPart = candidates[0]!;
+      const update = buildNullOnlyPartUpdate(targetPart, normalized, supplierNameToWrite);
+      if (update) {
+        const { error } = await sb.from("parts").update(update).eq("id", targetPart.id).eq("shop_id", params.shopId);
+        if (error) throw new Error(error.message);
+        Object.assign(targetPart, update);
+        partsNullOnlyUpdated += 1;
+      } else {
+        existingPartsMatched += 1;
+      }
+    } else {
+      const payload: PartInsert = {
+        shop_id: params.shopId,
+        name: normalized.name,
+        description: normalized.name,
+        part_number: normalized.partNumber,
+        sku: normalized.sku,
+        supplier: supplierNameToWrite,
+        cost: normalized.cost,
+        default_cost: normalized.cost,
+        price: normalized.price,
+        default_price: normalized.price,
+        external_id: normalized.sourceExternalId,
+        source_intake_id: params.sessionId,
+      };
+      const { data, error } = await sb.from("parts").insert(payload).select("*").single();
+      if (error) throw new Error(error.message);
+      targetPart = data as PartRow;
+      partRows.push(targetPart);
+      partsCreated += 1;
+    }
+
+    if (!defaultLocation) {
+      warnings.push("No stock location found; quantity seed skipped.");
+      continue;
+    }
+
+    const sourceKey = stableUuidFromParts([params.shopId, params.sessionId, entity.id, "stock-seed"]);
+    const stock = stockRows.find((row) => row.part_id === targetPart.id && row.location_id === defaultLocation.id);
+
+    if (!stock) {
+      const initialQty = Math.max(0, normalized.quantity ?? 0);
+      const { data, error } = await sb.from("part_stock").insert({
+        part_id: targetPart.id,
+        location_id: defaultLocation.id,
+        qty_on_hand: initialQty,
+        qty_reserved: 0,
+      }).select("*").single();
+      if (error) throw new Error(error.message);
+      stockRows.push(data as PartStockRow);
+      stockRecordsCreated += 1;
+      stockQuantitiesInitialized += 1;
+
+      if (initialQty > 0) {
+        await sb.from("stock_moves").upsert({
+          id: sourceKey,
+          shop_id: params.shopId,
+          part_id: targetPart.id,
+          location_id: defaultLocation.id,
+          qty_change: initialQty,
+          reason: "seed",
+          created_by: params.actorId,
+          reference_kind: "onboarding_parts_seed",
+          reference_id: entity.id,
+        }, { onConflict: "id" });
+      }
+    }
+  }
+
+  if (reviewItems.length > 0) {
+    const { error } = await sb.from("onboarding_review_items").upsert(reviewItems, { onConflict: "id" });
+    if (error) throw new Error(error.message);
+  }
+
+  return {
+    ok: true,
+    stagedParts: stagedRows.length,
+    partsCreated,
+    existingPartsMatched,
+    partsNullOnlyUpdated,
+    stockRecordsCreated,
+    stockQuantitiesInitialized,
+    vendorLinksCreated,
+    skipped,
+    needsReview,
+    reviewItemsCreated: reviewItems.length,
+    warnings,
+  };
+}

--- a/features/onboarding-agent/server/activateOnboardingVendors.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { activateOnboardingVendors, computeVendorActivationResult } from "@/features/onboarding-agent/server/activateOnboardingVendors";
+import { activateOnboardingVendors } from "@/features/onboarding-agent/server/activateOnboardingVendors";
 
 vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
   assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
 }));
 
-type Entity = Parameters<typeof computeVendorActivationResult>[0]["entities"][number];
-type Supplier = Parameters<typeof computeVendorActivationResult>[0]["supplierRows"][number];
+type Entity = any;
+type Supplier = any;
 
 function entity(overrides: Partial<Entity>): Entity {
   return {
@@ -16,9 +16,10 @@ function entity(overrides: Partial<Entity>): Entity {
     entity_type: "vendor",
     status: "ready",
     display_name: null,
+    source_external_id: null,
     normalized: {},
     ...overrides,
-  } as Entity;
+  };
 }
 
 function supplier(overrides: Partial<Supplier>): Supplier {
@@ -37,14 +38,11 @@ function supplier(overrides: Partial<Supplier>): Supplier {
   };
 }
 
-function createFakeSupabase(params?: { entities?: Entity[]; suppliers?: Supplier[] }) {
+function fakeSb(params?: { entities?: Entity[]; suppliers?: Supplier[] }) {
   const state = {
     entities: [...(params?.entities ?? [])],
     suppliers: [...(params?.suppliers ?? [])],
-    nextSupplierId: 100,
-    insertCalls: 0,
-    updateCalls: 0,
-    writes: [] as string[],
+    reviewItems: [] as any[],
   };
 
   return {
@@ -52,241 +50,88 @@ function createFakeSupabase(params?: { entities?: Entity[]; suppliers?: Supplier
     from(table: string) {
       const query: any = {
         table,
-        filters: [] as Array<{ k: string; v: any }>,
+        filters: [] as Array<{ key: string; value: any }>,
         payload: null as any,
-        selectColumns: "",
-        update(payload: any) {
-          this.payload = payload;
-          this.op = "update";
-          return this;
-        },
-        insert(payload: any) {
-          this.payload = payload;
-          this.op = "insert";
-          return this;
-        },
-        select(columns: string) {
-          this.selectColumns = columns;
-          this.op = this.op ?? "select";
-          return this;
-        },
-        order() {
-          return this;
-        },
-        eq(k: string, v: any) {
-          this.filters.push({ k, v });
-          return this;
-        },
-        single() {
-          return this.execSingle();
-        },
-        then(resolve: any, reject: any) {
-          return this.exec().then(resolve, reject);
-        },
+        op: "select",
+        select() { return this; },
+        order() { return this; },
+        eq(key: string, value: any) { this.filters.push({ key, value }); return this; },
+        insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
+        update(payload: any) { this.op = "update"; this.payload = payload; return this; },
+        upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this.exec(); },
+        single() { return this.execSingle(); },
+        then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
         async execSingle() {
           const result = await this.exec();
-          const first = Array.isArray(result.data) ? result.data[0] ?? null : result.data ?? null;
-          return { ...result, data: first };
+          const data = Array.isArray(result.data) ? (result.data[0] ?? null) : result.data;
+          return { ...result, data };
         },
         async exec() {
-          if (this.table === "onboarding_entities" && this.op === "select") {
+          if (table === "onboarding_entities") {
             let rows = [...state.entities];
-            for (const filter of this.filters) rows = rows.filter((row: any) => row[filter.k] === filter.v);
+            for (const f of this.filters) rows = rows.filter((row) => row[f.key] === f.value);
             return { data: rows, error: null };
           }
-
-          if (this.table === "suppliers" && this.op === "select") {
+          if (table === "suppliers" && this.op === "select") {
             let rows = [...state.suppliers];
-            for (const filter of this.filters) rows = rows.filter((row: any) => row[filter.k] === filter.v);
+            for (const f of this.filters) rows = rows.filter((row) => row[f.key] === f.value);
             return { data: rows, error: null };
           }
-
-          if (this.table === "suppliers" && this.op === "insert") {
-            state.insertCalls += 1;
-            state.writes.push("suppliers:insert");
-            const created = {
-              id: `supplier-${state.nextSupplierId++}`,
-              created_at: new Date().toISOString(),
-              created_by: this.payload.created_by ?? null,
-              is_active: this.payload.is_active ?? true,
-              notes: this.payload.notes ?? null,
-              ...this.payload,
-            };
+          if (table === "suppliers" && this.op === "insert") {
+            const created = { ...this.payload, id: `supplier-${state.suppliers.length + 1}`, created_at: new Date().toISOString() };
             state.suppliers.push(created);
             return { data: [{ id: created.id }], error: null };
           }
-
-          if (this.table === "suppliers" && this.op === "update") {
-            state.updateCalls += 1;
-            state.writes.push("suppliers:update");
-            const target = state.suppliers.find((row: any) => this.filters.every((f: any) => row[f.k] === f.v));
+          if (table === "suppliers" && this.op === "update") {
+            const target = state.suppliers.find((row) => this.filters.every((f: any) => row[f.key] === f.value));
             if (target) Object.assign(target, this.payload);
             return { data: [], error: null };
           }
-
+          if (table === "suppliers" && this.filters.length === 1 && this.filters[0]?.key === "shop_id" && this.payload === null) {
+            return { count: state.suppliers.length, error: null };
+          }
+          if (table === "onboarding_review_items") {
+            state.reviewItems.push(...(Array.isArray(this.payload) ? this.payload : [this.payload]));
+            return { data: [], error: null };
+          }
           return { data: [], error: null };
         },
       };
-
       return query;
     },
   };
 }
 
-describe("computeVendorActivationResult", () => {
-  it("inserts suppliers for ready staged vendor entities", () => {
-    const result = computeVendorActivationResult({
-      shopId: "shop-1",
-      sessionId: "session-1",
-      entities: [entity({ normalized: { name: "North Supply", email: "orders@north.test" } })],
-      supplierRows: [],
-    });
-
-    expect(result.inserted).toBe(1);
-    expect(result.updated).toBe(0);
-    expect(result.skipped).toBe(0);
-    expect(result.preparedInserts).toHaveLength(1);
-  });
-
-  it("rerun does not duplicate suppliers because name match resolves to existing", () => {
-    const result = computeVendorActivationResult({
-      shopId: "shop-1",
-      sessionId: "session-1",
-      entities: [entity({ normalized: { name: "North Supply" } })],
-      supplierRows: [supplier({ id: "supplier-1", name: "North Supply" })],
-    });
-
-    expect(result.inserted).toBe(0);
-    expect(result.updated).toBe(0);
-    expect(result.skipped).toBe(1);
-    expect(result.records[0]?.reason).toContain("already has mapped fields");
-  });
-
-  it("updates only null-safe fields on existing supplier matches", () => {
-    const result = computeVendorActivationResult({
-      shopId: "shop-1",
-      sessionId: "session-1",
-      entities: [entity({ normalized: { name: "North Supply", accountNumber: "ACCT-44", email: "new@north.test", phone: "111-222-3333", notes: "Preferred" } })],
-      supplierRows: [supplier({ id: "supplier-1", name: "North Supply", email: "existing@north.test", phone: null, account_no: "ACCT-44", notes: null })],
-    });
-
-    expect(result.updated).toBe(1);
-    expect(result.preparedUpdates).toHaveLength(1);
-    expect(result.preparedUpdates[0]?.payload).toEqual({ phone: "111-222-3333", notes: "Preferred" });
-  });
-
-  it("ignores cross-shop entities and non-ready/non-vendor rows", () => {
-    const result = computeVendorActivationResult({
-      shopId: "shop-1",
-      sessionId: "session-1",
-      entities: [
-        entity({ id: "entity-cross-shop", shop_id: "shop-2", normalized: { name: "Wrong Shop" } }),
-        entity({ id: "entity-wrong-session", session_id: "session-2", normalized: { name: "Wrong Session" } }),
-        entity({ id: "entity-not-ready", status: "needs_review", normalized: { name: "Needs Review" } }),
-        entity({ id: "entity-not-vendor", entity_type: "customer", normalized: { name: "Customer Co" } }),
-      ],
-      supplierRows: [],
-    });
-
-    expect(result.inserted).toBe(0);
-    expect(result.updated).toBe(0);
-    expect(result.skipped).toBe(0);
-  });
-
-  it("skips ambiguous matches and returns warnings", () => {
-    const result = computeVendorActivationResult({
-      shopId: "shop-1",
-      sessionId: "session-1",
-      entities: [entity({ normalized: { name: "North Supply" } })],
-      supplierRows: [supplier({ id: "supplier-1", name: "North Supply" }), supplier({ id: "supplier-2", name: "North Supply" })],
-    });
-
-    expect(result.inserted).toBe(0);
-    expect(result.updated).toBe(0);
-    expect(result.skipped).toBe(1);
-    expect(result.warnings).toHaveLength(1);
-    expect(result.records[0]?.reason).toContain("Ambiguous");
-  });
-
-  it("analyze/rerun guarantee: activation result is empty when no ready vendor entities are present", () => {
-    const result = computeVendorActivationResult({
-      shopId: "shop-1",
-      sessionId: "session-1",
-      entities: [entity({ entity_type: "part", status: "ready", normalized: { name: "Brake Pad" } })],
-      supplierRows: [],
-    });
-
-    expect(result.inserted).toBe(0);
-    expect(result.updated).toBe(0);
-    expect(result.skipped).toBe(0);
-    expect(result.records).toHaveLength(0);
-  });
-});
-
 describe("activateOnboardingVendors", () => {
-  let sb: ReturnType<typeof createFakeSupabase>;
+  let sb: ReturnType<typeof fakeSb>;
 
   beforeEach(() => {
-    const stagedVendors = Array.from({ length: 10 }).map((_, index) =>
-      entity({
-        id: `entity-${index + 1}`,
-        normalized: { name: `Vendor ${index + 1}`, email: `vendor${index + 1}@test.com`, account_no: `ACCT-${index + 1}` },
-      }),
-    );
-    sb = createFakeSupabase({ entities: stagedVendors, suppliers: [] });
+    sb = fakeSb({ entities: [entity({ normalized: { name: "Vendor A" } })] });
   });
 
-  it("creates suppliers from 10 ready staged vendors and is idempotent on rerun", async () => {
-    const first = await activateOnboardingVendors({
-      supabase: sb as any,
-      shopId: "shop-1",
-      sessionId: "session-1",
-      actorId: "user-1",
-    });
+  it("creates vendor once then rerun matches existing", async () => {
+    const first = await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
+    const second = await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
 
-    expect(first.ok).toBe(true);
-    expect(first.stagedVendorsFound).toBe(10);
-    expect(first.suppliersBefore).toBe(0);
-    expect(first.suppliersAfter).toBe(10);
-    expect(first.inserted).toBe(10);
-    expect(first.updated).toBe(0);
-    expect(first.skipped).toBe(0);
-
-    const second = await activateOnboardingVendors({
-      supabase: sb as any,
-      shopId: "shop-1",
-      sessionId: "session-1",
-      actorId: "user-1",
-    });
-
-    expect(second.inserted).toBe(0);
-    expect(second.updated).toBe(0);
-    expect(second.skipped).toBe(10);
-    expect(second.suppliersBefore).toBe(10);
-    expect(second.suppliersAfter).toBe(10);
+    expect(first.created).toBe(1);
+    expect(second.created).toBe(0);
+    expect(second.matchedExisting + second.updatedNullOnly).toBe(1);
   });
 
-  it("only writes to suppliers table and ignores non-ready/non-vendor/cross-shop rows", async () => {
-    sb = createFakeSupabase({
-      suppliers: [],
-      entities: [
-        entity({ id: "vendor-ready", normalized: { name: "Vendor A" } }),
-        entity({ id: "wrong-shop", shop_id: "shop-2", normalized: { name: "Vendor B" } }),
-        entity({ id: "wrong-session", session_id: "session-2", normalized: { name: "Vendor C" } }),
-        entity({ id: "not-ready", status: "needs_review", normalized: { name: "Vendor D" } }),
-        entity({ id: "not-vendor", entity_type: "vehicle", normalized: { name: "Truck" } }),
-      ],
-    });
+  it("writes review item for missing vendor name", async () => {
+    sb = fakeSb({ entities: [entity({ id: "entity-missing", normalized: {} })] });
+    const result = await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
+    expect(result.needsReview).toBeGreaterThan(0);
+    expect(sb.state.reviewItems.some((item) => item.issue_type === "missing_vendor_name")).toBe(true);
+  });
 
-    const result = await activateOnboardingVendors({
-      supabase: sb as any,
-      shopId: "shop-1",
-      sessionId: "session-1",
-      actorId: "user-1",
+  it("null-only updates existing matched supplier", async () => {
+    sb = fakeSb({
+      entities: [entity({ normalized: { name: "North Supply", phone: "555-1234" } })],
+      suppliers: [supplier({ name: "North Supply", phone: null })],
     });
-
-    expect(result.stagedVendorsFound).toBe(1);
-    expect(result.inserted).toBe(1);
-    expect(sb.state.writes.every((entry) => entry.startsWith("suppliers:"))).toBe(true);
+    const result = await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
+    expect(result.updatedNullOnly).toBe(1);
+    expect(sb.state.suppliers[0].phone).toBe("555-1234");
   });
 });

--- a/features/onboarding-agent/server/activateOnboardingVendors.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
 import type { Database } from "@/features/shared/types/types/supabase";
 
@@ -7,33 +8,35 @@ type OnboardingEntityRow = Database["public"]["Tables"]["onboarding_entities"]["
 type SupplierRow = Database["public"]["Tables"]["suppliers"]["Row"];
 type SupplierInsert = Database["public"]["Tables"]["suppliers"]["Insert"];
 type SupplierUpdate = Database["public"]["Tables"]["suppliers"]["Update"];
-
-export type VendorActivationRecordResult = {
-  entityId: string;
-  supplierId: string | null;
-  action: "inserted" | "updated" | "skipped";
-  reason: string;
-};
+type OnboardingReviewItemInsert = Database["public"]["Tables"]["onboarding_review_items"]["Insert"];
 
 export type VendorActivationResult = {
   ok: true;
-  inserted: number;
-  updated: number;
+  stagedVendors: number;
+  created: number;
+  matchedExisting: number;
+  updatedNullOnly: number;
   skipped: number;
-  warnings: string[];
+  needsReview: number;
   suppliersBefore: number;
   suppliersAfter: number;
-  stagedVendorsFound: number;
-  records: VendorActivationRecordResult[];
+  reviewItemsCreated: number;
+  warnings: string[];
+  records: Array<{
+    entityId: string;
+    supplierId: string | null;
+    action: "created" | "matched_existing" | "updated_null_only" | "skipped" | "needs_review";
+    reason: string;
+  }>;
 };
 
 type NormalizedVendor = {
-  name: string;
+  name: string | null;
   accountNo: string | null;
   email: string | null;
   phone: string | null;
   notes: string | null;
-  isActive: boolean | null;
+  sourceExternalId: string | null;
 };
 
 function normalizeText(value: unknown): string {
@@ -61,134 +64,57 @@ function firstText(values: unknown[]): string | null {
   return null;
 }
 
-function toNormalizedVendor(entity: Pick<OnboardingEntityRow, "normalized" | "display_name">): NormalizedVendor | null {
+function toNormalizedVendor(entity: Pick<OnboardingEntityRow, "normalized" | "display_name" | "source_external_id">): NormalizedVendor {
   const normalized = (entity.normalized ?? {}) as JsonObject;
-  const name = firstText([normalized.name, entity.display_name]);
-  if (!name) return null;
-
-  const accountNo = firstText([
-    normalized.account_no,
-    normalized.accountNo,
-    normalized.accountNumber,
-    normalized.vendorCode,
-    normalized.sourceVendorId,
-  ]);
-
   return {
-    name,
-    accountNo,
+    name: firstText([normalized.name, entity.display_name]),
+    accountNo: firstText([normalized.account_no, normalized.accountNo, normalized.accountNumber]),
     email: normalizeEmail(normalized.email),
     phone: firstText([normalized.phone]),
     notes: firstText([normalized.notes, normalized.note]),
-    isActive: typeof normalized.is_active === "boolean" ? normalized.is_active : typeof normalized.active === "boolean" ? normalized.active : null,
+    sourceExternalId: firstText([entity.source_external_id, normalized.sourceVendorId]),
   };
 }
 
-function collectMatchCandidates(params: { supplierRows: SupplierRow[]; vendor: NormalizedVendor }) {
-  const accountKey = params.vendor.accountNo ? normalizeLookupKey(params.vendor.accountNo) : "";
-  if (accountKey) {
-    return params.supplierRows.filter((row) => normalizeLookupKey(row.account_no) === accountKey);
-  }
-
-  const emailKey = params.vendor.email ? normalizeLookupKey(params.vendor.email) : "";
-  if (emailKey) {
-    return params.supplierRows.filter((row) => normalizeLookupKey(row.email) === emailKey);
-  }
-
-  const nameKey = normalizeLookupKey(params.vendor.name);
-  if (!nameKey) return [];
-  return params.supplierRows.filter((row) => normalizeLookupKey(row.name) === nameKey);
-}
-
-function buildNullSafeUpdate(params: { current: SupplierRow; vendor: NormalizedVendor }): SupplierUpdate | null {
+function buildNullOnlySupplierUpdate(current: SupplierRow, vendor: NormalizedVendor): SupplierUpdate | null {
   const update: SupplierUpdate = {};
-  if (!normalizeText(params.current.name)) update.name = params.vendor.name;
-  if (!normalizeText(params.current.account_no) && params.vendor.accountNo) update.account_no = params.vendor.accountNo;
-  if (!normalizeText(params.current.email) && params.vendor.email) update.email = params.vendor.email;
-  if (!normalizeText(params.current.phone) && params.vendor.phone) update.phone = params.vendor.phone;
-  if (!normalizeText(params.current.notes) && params.vendor.notes) update.notes = params.vendor.notes;
-
-  return Object.keys(update).length ? update : null;
+  if (!normalizeText(current.account_no) && vendor.accountNo) update.account_no = vendor.accountNo;
+  if (!normalizeText(current.email) && vendor.email) update.email = vendor.email;
+  if (!normalizeText(current.phone) && vendor.phone) update.phone = vendor.phone;
+  if (!normalizeText(current.notes) && vendor.notes) update.notes = vendor.notes;
+  return Object.keys(update).length > 0 ? update : null;
 }
 
-export function computeVendorActivationResult(params: {
+function vendorMatchScore(row: SupplierRow, vendor: NormalizedVendor): number {
+  let score = 0;
+  if (vendor.sourceExternalId && normalizeLookupKey(vendor.sourceExternalId) === normalizeLookupKey(row.account_no)) score += 100;
+  if (vendor.accountNo && normalizeLookupKey(vendor.accountNo) === normalizeLookupKey(row.account_no)) score += 90;
+  if (vendor.email && normalizeLookupKey(vendor.email) === normalizeLookupKey(row.email)) score += 80;
+  if (vendor.phone && normalizeLookupKey(vendor.phone) === normalizeLookupKey(row.phone)) score += 70;
+  if (vendor.name && normalizeLookupKey(vendor.name) === normalizeLookupKey(row.name)) score += 60;
+  return score;
+}
+
+function makeReviewItem(params: {
   shopId: string;
   sessionId: string;
-  entities: Array<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name">>;
-  supplierRows: SupplierRow[];
-}) {
-  const records: VendorActivationRecordResult[] = [];
-  const warnings: string[] = [];
-  const preparedInserts: Array<{ entityId: string; payload: SupplierInsert }> = [];
-  const preparedUpdates: Array<{ entityId: string; supplierId: string; payload: SupplierUpdate }> = [];
-  const supplierPool = [...params.supplierRows];
-
-  for (const entity of params.entities) {
-    if (entity.shop_id !== params.shopId || entity.session_id !== params.sessionId) continue;
-    if (entity.entity_type !== "vendor" || entity.status !== "ready") continue;
-
-    const normalizedVendor = toNormalizedVendor(entity);
-    if (!normalizedVendor) {
-      records.push({ entityId: entity.id, supplierId: null, action: "skipped", reason: "Missing vendor name in staged normalized payload" });
-      continue;
-    }
-
-    const matches = collectMatchCandidates({ supplierRows: supplierPool, vendor: normalizedVendor });
-    if (matches.length > 1) {
-      const warning = `Entity ${entity.id} skipped: multiple supplier matches found in shop for staged vendor "${normalizedVendor.name}".`;
-      warnings.push(warning);
-      records.push({ entityId: entity.id, supplierId: null, action: "skipped", reason: "Ambiguous supplier match; manual review required" });
-      continue;
-    }
-
-    if (matches.length === 1) {
-      const current = matches[0];
-      const update = buildNullSafeUpdate({ current, vendor: normalizedVendor });
-      if (!update) {
-        records.push({ entityId: entity.id, supplierId: current.id, action: "skipped", reason: "Existing supplier already has mapped fields" });
-        continue;
-      }
-
-      preparedUpdates.push({ entityId: entity.id, supplierId: current.id, payload: update });
-      Object.assign(current, update);
-      records.push({ entityId: entity.id, supplierId: current.id, action: "updated", reason: "Matched existing supplier and filled null-only fields" });
-      continue;
-    }
-
-    const insertPayload: SupplierInsert = {
-      shop_id: params.shopId,
-      name: normalizedVendor.name,
-      account_no: normalizedVendor.accountNo,
-      email: normalizedVendor.email,
-      phone: normalizedVendor.phone,
-      notes: normalizedVendor.notes,
-      is_active: normalizedVendor.isActive ?? true,
-    };
-
-    preparedInserts.push({ entityId: entity.id, payload: insertPayload });
-    supplierPool.push({
-      id: `pending:${entity.id}`,
-      created_at: new Date(0).toISOString(),
-      created_by: null,
-      is_active: true,
-      notes: null,
-      ...insertPayload,
-    } as SupplierRow);
-    records.push({ entityId: entity.id, supplierId: null, action: "inserted", reason: "Inserted new supplier from staged vendor" });
-  }
-
-  const inserted = records.filter((item) => item.action === "inserted").length;
-  const updated = records.filter((item) => item.action === "updated").length;
-  const skipped = records.filter((item) => item.action === "skipped").length;
-
+  entityId: string;
+  issueType: string;
+  summary: string;
+  details: Record<string, unknown>;
+  severity?: "low" | "medium" | "high" | "blocking";
+}): OnboardingReviewItemInsert {
   return {
-    inserted,
-    updated,
-    skipped,
-    warnings,
-    records,
-    preparedInserts,
-    preparedUpdates,
+    id: stableUuidFromParts(["onboarding-review", params.shopId, params.sessionId, "vendor", params.issueType, params.entityId]),
+    shop_id: params.shopId,
+    session_id: params.sessionId,
+    entity_id: params.entityId,
+    domain: "vendors",
+    issue_type: params.issueType,
+    summary: params.summary,
+    severity: params.severity ?? "medium",
+    status: "pending",
+    details: params.details as any,
   };
 }
 
@@ -199,78 +125,148 @@ export async function activateOnboardingVendors(params: {
   actorId: string;
 }): Promise<VendorActivationResult> {
   const sb = params.supabase as any;
+  await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
 
-  await assertOnboardingSessionOwnership({
-    supabase: params.supabase,
-    shopId: params.shopId,
-    sessionId: params.sessionId,
-  });
-
-  const { data: entities, error: entityError } = await sb
-    .from("onboarding_entities")
-    .select("id, shop_id, session_id, entity_type, status, normalized, display_name")
-    .eq("shop_id", params.shopId)
-    .eq("session_id", params.sessionId)
-    .eq("entity_type", "vendor")
-    .eq("status", "ready")
-    .order("id", { ascending: true });
-
+  const [{ data: entities, error: entityError }, { data: suppliers, error: supplierError }] = await Promise.all([
+    sb
+      .from("onboarding_entities")
+      .select("id, shop_id, session_id, entity_type, status, normalized, display_name, source_external_id")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("entity_type", "vendor")
+      .eq("status", "ready")
+      .order("id", { ascending: true }),
+    sb.from("suppliers").select("id, shop_id, name, account_no, email, phone, notes, is_active, created_at, created_by").eq("shop_id", params.shopId),
+  ]);
   if (entityError) throw new Error(entityError.message);
-
-  const { data: suppliers, error: supplierError } = await sb
-    .from("suppliers")
-    .select("id, shop_id, name, account_no, email, phone, notes, is_active, created_at, created_by")
-    .eq("shop_id", params.shopId)
-    .order("name", { ascending: true });
-
   if (supplierError) throw new Error(supplierError.message);
-  const suppliersBefore = (suppliers ?? []).length;
-  const stagedVendorsFound = (entities ?? []).length;
 
-  const computed = computeVendorActivationResult({
-    shopId: params.shopId,
-    sessionId: params.sessionId,
-    entities: (entities ?? []) as Array<Pick<OnboardingEntityRow, "id" | "shop_id" | "session_id" | "entity_type" | "status" | "normalized" | "display_name">>,
-    supplierRows: (suppliers ?? []) as SupplierRow[],
-  });
+  const staged = (entities ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">>;
+  const supplierPool = [...((suppliers ?? []) as SupplierRow[])];
+  const suppliersBefore = supplierPool.length;
+  const reviewItems: OnboardingReviewItemInsert[] = [];
+  const warnings: string[] = [];
+  const records: VendorActivationResult["records"] = [];
 
-  for (const pendingInsert of computed.preparedInserts) {
-    const payload = {
-      ...pendingInsert.payload,
+  let created = 0;
+  let matchedExisting = 0;
+  let updatedNullOnly = 0;
+  let skipped = 0;
+  let needsReview = 0;
+
+  for (const entity of staged) {
+    const vendor = toNormalizedVendor(entity);
+    if (!vendor.name) {
+      skipped += 1;
+      needsReview += 1;
+      records.push({ entityId: entity.id, supplierId: null, action: "needs_review", reason: "Missing vendor name" });
+      reviewItems.push(
+        makeReviewItem({
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          entityId: entity.id,
+          issueType: "missing_vendor_name",
+          summary: "Vendor row skipped: name is required.",
+          details: { sourceExternalId: vendor.sourceExternalId },
+          severity: "high",
+        }),
+      );
+      continue;
+    }
+
+    const scored = supplierPool
+      .map((row) => ({ row, score: vendorMatchScore(row, vendor) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    if (scored.length > 1 && scored[0]?.score === scored[1]?.score) {
+      skipped += 1;
+      needsReview += 1;
+      warnings.push(`Ambiguous vendor match for entity ${entity.id}`);
+      records.push({ entityId: entity.id, supplierId: null, action: "needs_review", reason: "Ambiguous vendor match" });
+      reviewItems.push(
+        makeReviewItem({
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          entityId: entity.id,
+          issueType: "ambiguous_vendor_match",
+          summary: `Vendor "${vendor.name}" matched multiple suppliers and requires review.`,
+          details: {
+            sourceExternalId: vendor.sourceExternalId,
+            vendorName: vendor.name,
+            candidates: scored.slice(0, 3).map((entry) => ({ id: entry.row.id, name: entry.row.name, email: entry.row.email, phone: entry.row.phone })),
+          },
+          severity: "high",
+        }),
+      );
+      continue;
+    }
+
+    if (scored.length > 0) {
+      const target = scored[0]!.row;
+      const update = buildNullOnlySupplierUpdate(target, vendor);
+      if (update) {
+        const { error } = await sb.from("suppliers").update(update).eq("shop_id", params.shopId).eq("id", target.id);
+        if (error) throw new Error(error.message);
+        Object.assign(target, update);
+        updatedNullOnly += 1;
+        records.push({ entityId: entity.id, supplierId: target.id, action: "updated_null_only", reason: "Matched existing supplier and applied null-only updates" });
+      } else {
+        matchedExisting += 1;
+        records.push({ entityId: entity.id, supplierId: target.id, action: "matched_existing", reason: "Matched existing supplier" });
+      }
+      continue;
+    }
+
+    const insertPayload: SupplierInsert = {
+      shop_id: params.shopId,
+      name: vendor.name,
+      account_no: vendor.accountNo,
+      email: vendor.email,
+      phone: vendor.phone,
+      notes: vendor.notes,
+      is_active: true,
       created_by: params.actorId,
     };
-    const { data, error } = await sb.from("suppliers").insert(payload).select("id").single();
+    const { data, error } = await sb.from("suppliers").insert(insertPayload).select("id").single();
     if (error) throw new Error(error.message);
 
-    const target = computed.records.find((record) => record.entityId === pendingInsert.entityId && record.action === "inserted");
-    if (target) target.supplierId = data?.id ?? null;
+    created += 1;
+    supplierPool.push({
+      id: data?.id,
+      shop_id: params.shopId,
+      name: vendor.name,
+      account_no: vendor.accountNo,
+      email: vendor.email,
+      phone: vendor.phone,
+      notes: vendor.notes,
+      is_active: true,
+      created_at: new Date().toISOString(),
+      created_by: params.actorId,
+    } as SupplierRow);
+    records.push({ entityId: entity.id, supplierId: data?.id ?? null, action: "created", reason: "Created supplier" });
   }
 
-  for (const pendingUpdate of computed.preparedUpdates) {
-    const { error } = await sb
-      .from("suppliers")
-      .update(pendingUpdate.payload)
-      .eq("shop_id", params.shopId)
-      .eq("id", pendingUpdate.supplierId);
-
+  if (reviewItems.length > 0) {
+    const { error } = await sb.from("onboarding_review_items").upsert(reviewItems, { onConflict: "id" });
     if (error) throw new Error(error.message);
   }
 
-  const { count: finalSupplierCount, error: finalCountError } = await sb
-    .from("suppliers")
-    .select("id", { head: true, count: "exact" })
-    .eq("shop_id", params.shopId);
-  if (finalCountError) throw new Error(finalCountError.message);
+  const { count: suppliersAfterCount, error: suppliersAfterError } = await sb.from("suppliers").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId);
+  if (suppliersAfterError) throw new Error(suppliersAfterError.message);
 
   return {
     ok: true,
-    inserted: computed.inserted,
-    updated: computed.updated,
-    skipped: computed.skipped,
-    warnings: computed.warnings,
+    stagedVendors: staged.length,
+    created,
+    matchedExisting,
+    updatedNullOnly,
+    skipped,
+    needsReview,
     suppliersBefore,
-    suppliersAfter: Number(finalSupplierCount ?? (suppliersBefore + computed.inserted)),
-    stagedVendorsFound,
-    records: computed.records,
+    suppliersAfter: Number(suppliersAfterCount ?? supplierPool.length),
+    reviewItemsCreated: reviewItems.length,
+    warnings,
+    records,
   };
 }


### PR DESCRIPTION
### Motivation
- Continue the onboarding-agent activation pipeline by adding Parts and Historical Work Orders activation while improving Vendor activation, preserving tenant scoping, RBAC, and review-first semantics. 
- Ensure activation is safe to rerun (idempotent), does not create duplicate live records, and surfaces unresolved/conflicting rows to `onboarding_review_items` for operator review.

### Description
- Key code added/changed: `features/onboarding-agent/server/activateOnboardingVendors.ts`, `features/onboarding-agent/server/activateOnboardingParts.ts`, `features/onboarding-agent/server/activateOnboardingHistory.ts`, API routes `app/api/onboarding-agent/sessions/[sessionId]/activate-parts/route.ts`, `app/api/onboarding-agent/sessions/[sessionId]/activate-history/route.ts`, UI updates `features/onboarding-agent/components/OnboardingSessionPage.tsx`, and new/updated tests under `features/onboarding-agent/server/*` and `app/api/onboarding-agent/sessions/[sessionId]/activation-routes.test.ts`.
- Activation target tables (Phase A audit): vendors -> `suppliers`; parts -> `parts`; stock/inventory -> `part_stock` with audit `stock_moves`; historical work orders -> `work_orders`; historical work order lines -> `work_order_lines`; historical invoices are intentionally left for a later phase.
- API routes added/updated (owner/admin, shop-scoped): `POST /api/onboarding-agent/sessions/[sessionId]/activate-vendors`, `POST /api/onboarding-agent/sessions/[sessionId]/activate-parts`, and `POST /api/onboarding-agent/sessions/[sessionId]/activate-history` (each uses shop-scoped admin supabase client and returns a flat summary + review counts).
- Idempotency strategy: vendors use deterministic matching by external/account/email/phone/name plus null-only updates and deterministic review IDs; parts use deterministic match order (part_number → sku → normalized name), create-once semantics, and seed stock only when `part_stock` for `(part_id,location_id)` is absent with deterministic `stock_moves` upsert ids to avoid duplicate movements; history uses a stable `source_row_id` key and checks existing `source_row_id` / `custom_id` before insert and marks imported WOs as closed/historical so they do not enter active queues.
- Review items persisted instead of silent drops (examples added): vendors: `missing_vendor_name`, `ambiguous_vendor_match`; parts: `missing_part_name`, `ambiguous_part_match`, `ambiguous_vendor_for_part`, `invalid_quantity`, `invalid_cost`, `invalid_sale_price`; history: `unresolved_customer_vehicle_link_for_history`, `missing_required_history_identifier`, `invalid_history_date`, `invalid_history_total`, `ambiguous_customer_match_for_history`, `missing_customer_for_history`, `ambiguous_vehicle_match_for_history`, `missing_vehicle_for_history`, `unsupported_history_line_format`.
- UI changes: onboarding session page shows new activation cards (Parts, Historical work orders) in the activation order, displays counts/status (Ready / Needs review / Activated / Partial), rerun-safe copy, last-run-style summaries, and explicit copy that historical work orders remain closed and won’t appear in active technician queues.

### Testing
- Commands run: `npx tsc --noEmit --pretty false` (TypeScript check) which completed successfully with no errors. 
- Unit/integration tests: `npx vitest run features/onboarding-agent` ran and passed (16 test files, 87 tests passed for `features/onboarding-agent`); newly added tests cover vendor create/rerun/null-only updates, parts create/stock seeding/idempotency and invalid-quantity review, history create-once and missing-identifier review, and route auth/summary shapes. 
- Lint: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` completed; existing warnings remain but no new lint errors were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e268be50832886f7d2ac9861f7ee)