### PR TITLE
Harden onboarding activation scoping and historical queue exclusions

### DIFF
--- a/app/api/scheduling/assigned-work-order-lines/route.ts
+++ b/app/api/scheduling/assigned-work-order-lines/route.ts
@@ -67,6 +67,18 @@ export async function GET(req: NextRequest) {
   const effectiveUserId = a.isAdmin ? userId : a.me.id;
   const admin = createAdminSupabase();
 
+  const { data: parentWorkOrder, error: parentErr } = await admin
+    .from("work_orders")
+    .select("id, type")
+    .eq("shop_id", shopId)
+    .eq("id", workOrderId)
+    .maybeSingle<{ id: string; type: string | null }>();
+
+  if (parentErr) return NextResponse.json({ error: parentErr.message }, { status: 500 });
+  if (!parentWorkOrder || parentWorkOrder.type === "historical_import") {
+    return NextResponse.json({ lines: [] });
+  }
+
   // 1) Lines directly assigned via assigned_tech_id
   const { data: directLines, error: dErr } = await admin
     .from("work_order_lines")

--- a/app/api/scheduling/assigned-work-orders/route.ts
+++ b/app/api/scheduling/assigned-work-orders/route.ts
@@ -74,6 +74,7 @@ export async function GET(req: NextRequest) {
     .select("id, custom_id, status, vehicle_id")
     .eq("shop_id", shopId)
     .eq("assigned_tech", effectiveUserId)
+    .neq("type", "historical_import")
     .order("created_at", { ascending: false })
     .limit(200);
 

--- a/app/mobile/tech/queue/page.tsx
+++ b/app/mobile/tech/queue/page.tsx
@@ -19,7 +19,7 @@ type Line = DB["public"]["Tables"]["work_order_lines"]["Row"];
 
 type WorkOrderPick = Pick<
   DB["public"]["Tables"]["work_orders"]["Row"],
-  "id" | "custom_id" | "vehicle_id"
+  "id" | "custom_id" | "vehicle_id" | "type"
 >;
 
 type VehiclePick = Pick<
@@ -198,7 +198,6 @@ export default function MobileTechQueuePage() {
       }
 
       const assignedLines = (techLines ?? []) as Line[];
-      setLines(assignedLines);
 
       // 4) fetch WOs + all lines for those WOs, to compute “client” line numbers
       const woIds = Array.from(
@@ -213,8 +212,9 @@ export default function MobileTechQueuePage() {
         const [wosRes, allLinesRes] = await Promise.all([
           supabase
             .from("work_orders")
-            .select("id, custom_id, vehicle_id")
-            .in("id", woIds),
+            .select("id, custom_id, vehicle_id, type")
+            .in("id", woIds)
+            .neq("type", "historical_import"),
           supabase
             .from("work_order_lines")
             .select("id, work_order_id, created_at, job_type, approval_state, line_type")
@@ -223,6 +223,8 @@ export default function MobileTechQueuePage() {
         ]);
 
         const wos = (wosRes.data ?? []) as WorkOrderPick[];
+        const allowedWorkOrderIds = new Set(wos.map((wo) => wo.id));
+        setLines(assignedLines.filter((line) => line.work_order_id && allowedWorkOrderIds.has(line.work_order_id)));
 
         // vehicles lookup (batch)
         const vehicleIds = Array.from(
@@ -307,6 +309,7 @@ export default function MobileTechQueuePage() {
 
         setLineNumberMap(lnMap);
       } else {
+        setLines([]);
         setWorkOrderMap({});
         setLineNumberMap({});
       }

--- a/app/portal/history/types.ts
+++ b/app/portal/history/types.ts
@@ -5,8 +5,9 @@ export type WorkOrder = Database["public"]["Tables"]["work_orders"]["Row"];
 export type HistoryRow = Database["public"]["Tables"]["history"]["Row"];
 
 /**
- * Small shapes the UI needs. These keep us compatible even if your
- * work_orders table doesn’t actually have `status` or `type` right now.
+ * Small shapes the UI needs.
+ * `work_orders.status` and `work_orders.type` exist in generated DB types,
+ * but these remain optional for defensive UI compatibility.
  */
 type VehicleMini = {
   id: Vehicle["id"];

--- a/app/tech/queue/page.tsx
+++ b/app/tech/queue/page.tsx
@@ -14,7 +14,7 @@ type DB = Database;
 type Line = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type WorkOrderSlim = Pick<
   DB["public"]["Tables"]["work_orders"]["Row"],
-  "id" | "custom_id"
+  "id" | "custom_id" | "type"
 >;
 type PartRequest = DB["public"]["Tables"]["part_requests"]["Row"];
 type PartRequestMini = Pick<PartRequest, "job_id" | "work_order_id">;
@@ -246,7 +246,29 @@ export default function TechQueuePage() {
       }
 
       const raw = (techLines ?? []) as Line[];
-      const activeQueue = raw.filter((l) => !isCompletedLike(l.status));
+      const woIds = Array.from(
+        new Set(
+          raw
+            .map((l) => l.work_order_id)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      );
+
+      let woTypeMap: Record<string, string | null> = {};
+      if (woIds.length > 0) {
+        const { data: wos } = await supabase
+          .from("work_orders")
+          .select("id, custom_id, type")
+          .in("id", woIds);
+
+        woTypeMap = {};
+        (wos ?? []).forEach((wo) => {
+          const row = wo as WorkOrderSlim;
+          woTypeMap[row.id] = row.type ?? null;
+        });
+      }
+
+      const activeQueue = raw.filter((l) => !isCompletedLike(l.status) && woTypeMap[l.work_order_id ?? ""] !== "historical_import");
       setLines(activeQueue);
 
       // 4) determine active punched-in line (strong highlight)
@@ -262,19 +284,12 @@ export default function TechQueuePage() {
       setActiveWorkOrderId(punched?.work_order_id ?? null);
 
       // 5) fetch work orders for display labels
-      const woIds = Array.from(
-        new Set(
-          activeQueue
-            .map((l) => l.work_order_id)
-            .filter((id): id is string => Boolean(id)),
-        ),
-      );
-
       if (woIds.length > 0) {
         const { data: wos } = await supabase
           .from("work_orders")
-          .select("id, custom_id")
-          .in("id", woIds);
+          .select("id, custom_id, type")
+          .in("id", woIds)
+          .neq("type", "historical_import");
 
         const map: Record<string, { id: string; custom_id: string | null }> =
           {};

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -12,6 +12,9 @@ type WorkOrderInsert = Database["public"]["Tables"]["work_orders"]["Insert"];
 type WorkOrderLineInsert = Database["public"]["Tables"]["work_order_lines"]["Insert"];
 type OnboardingReviewItemInsert = Database["public"]["Tables"]["onboarding_review_items"]["Insert"];
 
+const HISTORICAL_WORK_ORDER_STATUS: WorkOrderInsert["status"] = "completed";
+const HISTORICAL_WORK_ORDER_TYPE: NonNullable<WorkOrderInsert["type"]> = "historical_import";
+
 type HistoryActivationResult = {
   ok: true;
   stagedHistoryRows: number;
@@ -230,8 +233,8 @@ export async function activateOnboardingHistory(params: {
       customer_name: history.customerName,
       vehicle_vin: history.vehicleVin,
       vehicle_license_plate: history.vehiclePlate,
-      status: "completed",
-      type: "historical_import",
+      status: HISTORICAL_WORK_ORDER_STATUS,
+      type: HISTORICAL_WORK_ORDER_TYPE,
       source_intake_id: params.sessionId,
       source_row_id: sourceRowKey,
       invoice_total: history.total,

--- a/features/onboarding-agent/server/activateOnboardingParts.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.test.ts
@@ -1,48 +1,87 @@
 import { describe, expect, it, vi } from "vitest";
+import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
 import { activateOnboardingParts } from "@/features/onboarding-agent/server/activateOnboardingParts";
 
 vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", () => ({
   assertOnboardingSessionOwnership: vi.fn().mockResolvedValue(undefined),
 }));
 
+type Op = "eq" | "in";
+
 function fakeSb() {
   const state = {
-    entities: [{ id: "part-1", normalized: { description: "Brake Pad", partNumber: "BP-1", quantityOnHandRaw: "5" }, display_name: "Brake Pad", source_external_id: "src-1" }] as any[],
+    entities: [
+      {
+        id: "part-1",
+        shop_id: "shop-1",
+        session_id: "session-1",
+        entity_type: "part",
+        status: "ready",
+        normalized: { description: "Brake Pad", partNumber: "BP-1", quantityOnHandRaw: "5" },
+        display_name: "Brake Pad",
+        source_external_id: "src-1",
+      },
+    ] as any[],
     parts: [] as any[],
-    suppliers: [{ id: "s1", name: "Vendor A" }],
+    suppliers: [{ id: "s1", name: "Vendor A", shop_id: "shop-1" }],
     stock_locations: [{ id: "loc-1", shop_id: "shop-1" }],
     part_stock: [] as any[],
     stock_moves: [] as any[],
     reviewItems: [] as any[],
   };
+
   return {
     state,
     from(table: string) {
+      const filters: Array<{ op: Op; col: string; value: any }> = [];
       const q: any = {
         table,
         op: "select",
         payload: null as any,
+        options: null as any,
         select() { return this; },
-        eq() { return this; },
+        eq(col: string, value: any) { filters.push({ op: "eq", col, value }); return this; },
+        in(col: string, value: any[]) { filters.push({ op: "in", col, value }); return this; },
         order() { return this; },
         limit() { return this; },
         insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
         update(payload: any) { this.op = "update"; this.payload = payload; return this; },
-        upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this.exec(); },
+        upsert(payload: any, options?: any) { this.op = "upsert"; this.payload = payload; this.options = options; return this.exec(); },
         single() { return this.execSingle(); },
         then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
         async execSingle() { const r = await this.exec(); return { ...r, data: Array.isArray(r.data) ? r.data[0] : r.data }; },
         async exec() {
-          if (table === "onboarding_entities") return { data: state.entities, error: null };
-          if (table === "parts" && this.op === "select") return { data: state.parts, error: null };
-          if (table === "parts" && this.op === "insert") { const row = { ...this.payload, id: `p-${state.parts.length + 1}` }; state.parts.push(row); return { data: [row], error: null }; }
+          const applyFilters = (rows: any[]) => rows.filter((row) => filters.every((f) => (f.op === "eq" ? row?.[f.col] === f.value : (f.value ?? []).includes(row?.[f.col]))));
+
+          if (table === "onboarding_entities") return { data: applyFilters(state.entities), error: null };
+          if (table === "parts" && this.op === "select") return { data: applyFilters(state.parts), error: null };
+          if (table === "parts" && this.op === "insert") {
+            const row = { ...this.payload, id: `p-${state.parts.length + 1}` };
+            state.parts.push(row);
+            return { data: [row], error: null };
+          }
           if (table === "parts" && this.op === "update") return { data: [], error: null };
-          if (table === "suppliers") return { data: state.suppliers, error: null };
-          if (table === "stock_locations") return { data: state.stock_locations, error: null };
-          if (table === "part_stock" && this.op === "select") return { data: state.part_stock, error: null };
-          if (table === "part_stock" && this.op === "insert") { const row = { ...this.payload, id: `ps-${state.part_stock.length + 1}` }; state.part_stock.push(row); return { data: [row], error: null }; }
-          if (table === "stock_moves") { state.stock_moves.push(this.payload); return { data: [], error: null }; }
-          if (table === "onboarding_review_items") { state.reviewItems.push(...(Array.isArray(this.payload) ? this.payload : [this.payload])); return { data: [], error: null }; }
+          if (table === "suppliers") return { data: applyFilters(state.suppliers), error: null };
+          if (table === "stock_locations") return { data: applyFilters(state.stock_locations), error: null };
+          if (table === "part_stock" && this.op === "select") return { data: applyFilters(state.part_stock), error: null };
+          if (table === "part_stock" && this.op === "insert") {
+            const row = { ...this.payload, id: `ps-${state.part_stock.length + 1}` };
+            state.part_stock.push(row);
+            return { data: [row], error: null };
+          }
+          if (table === "stock_moves") {
+            if (this.op === "upsert" && this.options?.onConflict === "id") {
+              const row = this.payload;
+              const i = state.stock_moves.findIndex((m) => m.id === row.id);
+              if (i >= 0) state.stock_moves[i] = { ...state.stock_moves[i], ...row };
+              else state.stock_moves.push(row);
+            }
+            return { data: [], error: null };
+          }
+          if (table === "onboarding_review_items") {
+            state.reviewItems.push(...(Array.isArray(this.payload) ? this.payload : [this.payload]));
+            return { data: [], error: null };
+          }
           return { data: [], error: null };
         },
       };
@@ -52,20 +91,83 @@ function fakeSb() {
 }
 
 describe("activateOnboardingParts", () => {
-  it("creates part + stock once and rerun does not duplicate part", async () => {
+  it("creates deterministic stock seed move once and rerun does not duplicate", async () => {
     const sb = fakeSb();
+
     const first = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     const second = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+
+    const expectedMoveId = stableUuidFromParts(["shop-1", "session-1", "part-1", "stock-seed"]);
     expect(first.partsCreated).toBe(1);
     expect(second.partsCreated).toBe(0);
     expect(sb.state.parts.length).toBe(1);
+    expect(sb.state.stock_moves).toHaveLength(1);
+    expect(sb.state.stock_moves[0]).toMatchObject({
+      id: expectedMoveId,
+      shop_id: "shop-1",
+      reference_id: "part-1",
+      reference_kind: "onboarding_parts_seed",
+      reason: "seed",
+    });
   });
 
-  it("invalid quantity creates review item", async () => {
+  it("stock move id is stable for same shop/session/source row/part/location tuple", async () => {
+    const a = stableUuidFromParts(["shop-1", "session-1", "part-1", "stock-seed"]);
+    const b = stableUuidFromParts(["shop-1", "session-1", "part-1", "stock-seed"]);
+    expect(a).toBe(b);
+  });
+
+  it("writes stock_moves only for active shop/session entities and skips invalid rows", async () => {
     const sb = fakeSb();
-    sb.state.entities = [{ id: "part-2", normalized: { description: "Rotor", quantityOnHandRaw: "-5" }, display_name: "Rotor", source_external_id: null }] as any[];
-    const result = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
-    expect(result.needsReview).toBeGreaterThan(0);
-    expect(sb.state.reviewItems.some((i) => i.issue_type === "invalid_quantity")).toBe(true);
+    sb.state.entities = [
+      {
+        id: "part-valid",
+        shop_id: "shop-1",
+        session_id: "session-1",
+        entity_type: "part",
+        status: "ready",
+        normalized: { description: "Rotor", quantityOnHandRaw: "3" },
+        display_name: "Rotor",
+        source_external_id: null,
+      },
+      {
+        id: "part-invalid",
+        shop_id: "shop-1",
+        session_id: "session-1",
+        entity_type: "part",
+        status: "ready",
+        normalized: { description: "Bad Qty", quantityOnHandRaw: "-2" },
+        display_name: "Bad Qty",
+        source_external_id: null,
+      },
+      {
+        id: "part-other-session",
+        shop_id: "shop-1",
+        session_id: "session-2",
+        entity_type: "part",
+        status: "ready",
+        normalized: { description: "Other Session", quantityOnHandRaw: "4" },
+        display_name: "Other Session",
+        source_external_id: null,
+      },
+      {
+        id: "part-other-shop",
+        shop_id: "shop-2",
+        session_id: "session-1",
+        entity_type: "part",
+        status: "ready",
+        normalized: { description: "Other Shop", quantityOnHandRaw: "4" },
+        display_name: "Other Shop",
+        source_external_id: null,
+      },
+    ];
+
+    await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+
+    expect(sb.state.stock_moves).toHaveLength(1);
+    expect(sb.state.stock_moves[0]?.reference_id).toBe("part-valid");
+    expect(sb.state.stock_moves[0]?.shop_id).toBe("shop-1");
+    expect(sb.state.reviewItems.some((i) => i.issue_type === "invalid_quantity" && i.entity_id === "part-invalid")).toBe(true);
+    expect(sb.state.stock_moves.some((m) => m.reference_id === "part-other-session" || m.reference_id === "part-other-shop")).toBe(false);
   });
 });

--- a/features/onboarding-agent/server/activateOnboardingParts.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.ts
@@ -130,7 +130,7 @@ export async function activateOnboardingParts(params: {
   const sb = params.supabase as any;
   await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
 
-  const [{ data: staged }, { data: parts }, { data: suppliers }, { data: stockLocations }, { data: partStockRows }] = await Promise.all([
+  const [{ data: staged }, { data: parts }, { data: suppliers }, { data: stockLocations }] = await Promise.all([
     sb
       .from("onboarding_entities")
       .select("id, normalized, display_name, source_external_id")
@@ -142,14 +142,24 @@ export async function activateOnboardingParts(params: {
     sb.from("parts").select("*").eq("shop_id", params.shopId),
     sb.from("suppliers").select("id, name").eq("shop_id", params.shopId),
     sb.from("stock_locations").select("*").eq("shop_id", params.shopId).order("created_at", { ascending: true }).limit(1),
-    sb.from("part_stock").select("id, part_id, location_id, qty_on_hand, qty_reserved, reorder_point, reorder_qty"),
   ]);
 
   const stagedRows = (staged ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">>;
   const partRows = [...((parts ?? []) as PartRow[])];
   const supplierRows = suppliers ?? [];
   const defaultLocation = (stockLocations?.[0] ?? null) as StockLocationRow | null;
-  const stockRows = [...((partStockRows ?? []) as PartStockRow[])];
+  const shopPartIds = partRows.map((row) => row.id).filter((id): id is string => Boolean(id));
+
+  let stockRows: PartStockRow[] = [];
+  if (defaultLocation && shopPartIds.length > 0) {
+    const { data: partStockRows, error: partStockError } = await sb
+      .from("part_stock")
+      .select("id, part_id, location_id, qty_on_hand, qty_reserved, reorder_point, reorder_qty")
+      .eq("location_id", defaultLocation.id)
+      .in("part_id", shopPartIds);
+    if (partStockError) throw new Error(partStockError.message);
+    stockRows = [...((partStockRows ?? []) as PartStockRow[])];
+  }
 
   const reviewItems: OnboardingReviewItemInsert[] = [];
   const warnings: string[] = [];


### PR DESCRIPTION
### Motivation
- Prevent accidental cross-shop reads/writes during parts activation by removing a global `part_stock` preload and ensuring all activation I/O is shop-scoped.  
- Make onboarding parts activation reruns idempotent and prove deterministic `stock_moves` behavior so activation can be safely re-run in tests and staging.  
- Ensure imported historical work orders cannot surface in live operational queues by adding explicit policy-level exclusions.  
- Avoid assuming unsafe schema shapes for history activation by using typed markers/fallbacks so history rows remain isolated from active flows.

### Description
- Scoped `part_stock` preload in `activateOnboardingParts` to the activation shop by loading only `part_stock` rows for the shop's parts and the shop's default `stock_locations` (`location_id = defaultLocation.id` and `part_id IN shopPartIds`), using indirect shop scoping through `parts.shop_id` (because `part_stock` rows do not include `shop_id` in generated types). (`features/onboarding-agent/server/activateOnboardingParts.ts`)  
- Kept stock-seed writes idempotent and deterministic by generating stable seed `id` with `stableUuidFromParts([shopId, sessionId, entity.id, "stock-seed"])` and using `stock_moves.upsert(..., { onConflict: 'id' })`. (`features/onboarding-agent/server/activateOnboardingParts.ts`)  
- Added focused tests to assert `stock_moves` idempotency, deterministic id stability, shop/session scoping, and skip behavior for invalid rows: `creates deterministic stock seed move once and rerun does not duplicate`, `stock move id is stable for same shop/session/source row/part/location tuple`, and `writes stock_moves only for active shop/session entities and skips invalid rows`. (`features/onboarding-agent/server/activateOnboardingParts.test.ts`)  
- Explicitly excluded `historical_import` work orders from active queues by applying the guard `work_orders.type != 'historical_import'` (or returning an empty set when a parent WO has `type === 'historical_import'`) in the affected helpers and routes: `app/tech/queue/page.tsx`, `app/mobile/tech/queue/page.tsx`, `app/api/scheduling/assigned-work-orders/route.ts`, and `app/api/scheduling/assigned-work-order-lines/route.ts`.  
- Hardened history activation assumptions by introducing typed constants for the historical markers and using the generated DB Insert types (`HISTORICAL_WORK_ORDER_STATUS = 'completed'` and `HISTORICAL_WORK_ORDER_TYPE = 'historical_import'`) so history rows are written with safe, canonical markers and the same marker is used by the queue exclusions. (`features/onboarding-agent/server/activateOnboardingHistory.ts`)  
- Minor defensive doc update to `app/portal/history/types.ts` to reflect that `work_orders.status` and `work_orders.type` exist in the generated types while keeping UI code defensive.

### Testing
- Ran TypeScript compile check: `npx tsc --noEmit --pretty false` (exit 0).  
- Ran onboarding-agent unit tests: `npx vitest run features/onboarding-agent` and observed all onboarding-agent tests pass (Test files: 16, Tests: 88 passed).  
- Ran linting: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which produced only existing `@typescript-eslint/no-explicit-any` warnings and no new errors (0 errors).  
- Verified no invoice tables were modified and no invoice writes were added by this patch.  
- Summary of changed files: `features/onboarding-agent/server/activateOnboardingParts.ts`, `features/onboarding-agent/server/activateOnboardingParts.test.ts`, `features/onboarding-agent/server/activateOnboardingHistory.ts`, `app/tech/queue/page.tsx`, `app/mobile/tech/queue/page.tsx`, `app/api/scheduling/assigned-work-orders/route.ts`, `app/api/scheduling/assigned-work-order-lines/route.ts`, and `app/portal/history/types.ts`.

If you want, I can open a follow-up PR to centralize the `historical_import` exclusion into a shared helper used by queue fetchers, but this patch keeps changes narrow and focused per requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0edf635048328afeb6244877d7688)