### PR TITLE
Fix onboarding activation review-item idempotency and stock location lookup

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-history/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-history/route.ts
@@ -29,10 +29,16 @@ export async function POST(_: Request, context: RouteContext) {
           code: "activation_review_item_write_failed",
           message: "Activation review item write failed",
           phase: error.phase,
+          domain: error.domain,
           issueType: error.issueType,
+          severity: error.severity,
+          scope: error.scope,
           scopeKey: error.scopeKey,
-          reason: error.causeMessage,
-          details: error.message,
+          reason: "review_item_persist_failed",
+          developer: {
+            code: error.causeCode,
+            message: error.causeMessage,
+          },
         },
       }, { status: 500 });
     }

--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-parts/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-parts/route.ts
@@ -29,10 +29,16 @@ export async function POST(_: Request, context: RouteContext) {
           code: "activation_review_item_write_failed",
           message: "Activation review item write failed",
           phase: error.phase,
+          domain: error.domain,
           issueType: error.issueType,
+          severity: error.severity,
+          scope: error.scope,
           scopeKey: error.scopeKey,
-          reason: error.causeMessage,
-          details: error.message,
+          reason: "review_item_persist_failed",
+          developer: {
+            code: error.causeCode,
+            message: error.causeMessage,
+          },
         },
       }, { status: 500 });
     }

--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { activateOnboardingVendors } from "@/features/onboarding-agent/server/activateOnboardingVendors";
+import { ActivationReviewItemWriteError } from "@/features/onboarding-agent/server/upsertOnboardingReviewItems";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
@@ -28,6 +29,26 @@ export async function POST(_: Request, context: RouteContext) {
 
     return NextResponse.json(result);
   } catch (error) {
+    if (error instanceof ActivationReviewItemWriteError) {
+      return NextResponse.json({
+        ok: false,
+        error: {
+          code: "activation_review_item_write_failed",
+          message: "Activation review item write failed",
+          phase: error.phase,
+          domain: error.domain,
+          issueType: error.issueType,
+          severity: error.severity,
+          scope: error.scope,
+          scopeKey: error.scopeKey,
+          reason: "review_item_persist_failed",
+          developer: {
+            code: error.causeCode,
+            message: error.causeMessage,
+          },
+        },
+      }, { status: 500 });
+    }
     const message = error instanceof Error ? error.message : "Failed to activate vendors";
     const status = message.includes("Session not found") ? 404 : 500;
     return NextResponse.json({ ok: false, error: message }, { status });

--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -6,6 +6,15 @@ vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", (
 }));
 
 function fakeSb() {
+  const reviewScopeKey = (row: any) => [
+    row.shop_id ?? "",
+    row.session_id ?? "",
+    row.domain ?? "",
+    row.issue_type ?? "",
+    row.severity ?? "",
+    JSON.stringify(row.details ?? {}),
+  ].join("|");
+
   const state = {
     entities: [{ id: "h-1", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" } }] as any[],
     links: [],
@@ -19,13 +28,15 @@ function fakeSb() {
     state,
     from(table: string) {
       const q: any = {
+        filters: [] as Array<{ key: string; value: any }>,
         op: "select",
         payload: null as any,
         select() { return this; },
-        eq() { return this; },
+        eq(key: string, value: any) { this.filters.push({ key, value }); return this; },
         in() { return this; },
         order() { return this; },
         insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
+        update(payload: any) { this.op = "update"; this.payload = payload; return this; },
         upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this.exec(); },
         single() { return this.execSingle(); },
         then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
@@ -39,7 +50,18 @@ function fakeSb() {
           if (table === "work_orders" && this.op === "insert") { const row = { ...this.payload, id: `wo-${state.work_orders.length + 1}` }; state.work_orders.push(row); return { data: [{ id: row.id }], error: null }; }
           if (table === "work_order_lines" && this.op === "insert") { state.lines.push(this.payload); return { data: [], error: null }; }
           if (table === "onboarding_review_items" && this.op === "select") return { data: [...state.reviewItems], error: null };
-          if (table === "onboarding_review_items" && this.op === "insert") return { data: null, error: { message: "duplicate key value violates unique constraint \"onboarding_review_items_shop_session_issue_scope_uidx\"" } };
+          if (table === "onboarding_review_items" && this.op === "insert") {
+            const row = this.payload;
+            const existing = state.reviewItems.find((item) => reviewScopeKey(item) === reviewScopeKey(row));
+            if (existing) return { data: null, error: { code: "23505", message: "duplicate key value violates unique constraint \"onboarding_review_items_shop_session_issue_scope_uidx\"" } };
+            state.reviewItems.push(row);
+            return { data: [row], error: null };
+          }
+          if (table === "onboarding_review_items" && this.op === "update") {
+            const target = state.reviewItems.find((item) => this.filters.every((f: any) => item[f.key] === f.value));
+            if (target) Object.assign(target, this.payload);
+            return { data: [], error: null };
+          }
           if (table === "onboarding_review_items" && this.op === "upsert") {
             const rows = Array.isArray(this.payload) ? this.payload : [this.payload];
             for (const row of rows) {
@@ -83,6 +105,14 @@ describe("activateOnboardingHistory", () => {
     await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     expect(sb.state.reviewItems.length).toBe(before);
     expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "missing_required_history_identifier")).toHaveLength(1);
+  });
+
+  it("rerun does not duplicate invalid_history_date review items", async () => {
+    const sb = fakeSb();
+    sb.state.entities = [{ id: "h-invalid-date", normalized: { sourceWorkOrderId: "RO-404", openedDate: "not-a-date" } }] as any[];
+    await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "invalid_history_date")).toHaveLength(1);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingParts.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.test.ts
@@ -9,6 +9,15 @@ vi.mock("@/features/onboarding-agent/server/assertOnboardingSessionOwnership", (
 type Op = "eq" | "in";
 
 function fakeSb() {
+  const reviewScopeKey = (row: any) => [
+    row.shop_id ?? "",
+    row.session_id ?? "",
+    row.domain ?? "",
+    row.issue_type ?? "",
+    row.severity ?? "",
+    JSON.stringify(row.details ?? {}),
+  ].join("|");
+
   const state = {
     entities: [
       {
@@ -42,7 +51,10 @@ function fakeSb() {
         select() { return this; },
         eq(col: string, value: any) { filters.push({ op: "eq", col, value }); return this; },
         in(col: string, value: any[]) { filters.push({ op: "in", col, value }); return this; },
-        order() { return this; },
+        order(col: string) {
+          if (table === "stock_locations" && col === "created_at") throw new Error("stock_locations.created_at should not be queried");
+          return this;
+        },
         limit() { return this; },
         insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
         update(payload: any) { this.op = "update"; this.payload = payload; return this; },
@@ -79,7 +91,18 @@ function fakeSb() {
             return { data: [], error: null };
           }
           if (table === "onboarding_review_items" && this.op === "select") return { data: [...state.reviewItems], error: null };
-          if (table === "onboarding_review_items" && this.op === "insert") return { data: null, error: { message: 'duplicate key value violates unique constraint "onboarding_review_items_shop_session_issue_scope_uidx"' } };
+          if (table === "onboarding_review_items" && this.op === "insert") {
+            const row = this.payload;
+            const existing = state.reviewItems.find((item) => reviewScopeKey(item) === reviewScopeKey(row));
+            if (existing) return { data: null, error: { code: "23505", message: 'duplicate key value violates unique constraint "onboarding_review_items_shop_session_issue_scope_uidx"' } };
+            state.reviewItems.push(row);
+            return { data: [row], error: null };
+          }
+          if (table === "onboarding_review_items" && this.op === "update") {
+            const target = state.reviewItems.find((item) => filters.every((f) => (f.op === "eq" ? item?.[f.col] === f.value : (f.value ?? []).includes(item?.[f.col]))));
+            if (target) Object.assign(target, this.payload);
+            return { data: [], error: null };
+          }
           if (table === "onboarding_review_items" && this.op === "upsert") {
             const rows = Array.isArray(this.payload) ? this.payload : [this.payload];
             for (const row of rows) {
@@ -195,6 +218,24 @@ describe("activateOnboardingParts", () => {
     await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     expect(sb.state.reviewItems.length).toBe(before);
     expect(sb.state.reviewItems.filter((i) => i.issue_type === "invalid_quantity")).toHaveLength(1);
+  });
+
+  it("rerun does not duplicate ambiguous_vendor_for_part review items", async () => {
+    const sb = fakeSb();
+    sb.state.entities = [{
+      id: "part-ambiguous-vendor",
+      shop_id: "shop-1",
+      session_id: "session-1",
+      entity_type: "part",
+      status: "ready",
+      normalized: { description: "Pad", vendorName: "Missing Vendor" },
+      display_name: "Pad",
+      source_external_id: null,
+    }];
+
+    await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "ambiguous_vendor_for_part")).toHaveLength(1);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingParts.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.ts
@@ -142,7 +142,7 @@ export async function activateOnboardingParts(params: {
       .order("id", { ascending: true }),
     sb.from("parts").select("*").eq("shop_id", params.shopId),
     sb.from("suppliers").select("id, name").eq("shop_id", params.shopId),
-    sb.from("stock_locations").select("*").eq("shop_id", params.shopId).order("created_at", { ascending: true }).limit(1),
+    sb.from("stock_locations").select("*").eq("shop_id", params.shopId).order("code", { ascending: true }).order("name", { ascending: true }).order("id", { ascending: true }).limit(1),
   ]);
 
   const stagedRows = (staged ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">>;

--- a/features/onboarding-agent/server/activateOnboardingVendors.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.test.ts
@@ -39,6 +39,15 @@ function supplier(overrides: Partial<Supplier>): Supplier {
 }
 
 function fakeSb(params?: { entities?: Entity[]; suppliers?: Supplier[] }) {
+  const reviewScopeKey = (row: any) => [
+    row.shop_id ?? "",
+    row.session_id ?? "",
+    row.domain ?? "",
+    row.issue_type ?? "",
+    row.severity ?? "",
+    JSON.stringify(row.details ?? {}),
+  ].join("|");
+
   const state = {
     entities: [...(params?.entities ?? [])],
     suppliers: [...(params?.suppliers ?? [])],
@@ -92,7 +101,18 @@ function fakeSb(params?: { entities?: Entity[]; suppliers?: Supplier[] }) {
             return { count: state.suppliers.length, error: null };
           }
           if (table === "onboarding_review_items" && this.op === "select") return { data: [...state.reviewItems], error: null };
-          if (table === "onboarding_review_items" && this.op === "insert") return { data: null, error: { message: "duplicate key value violates unique constraint \"onboarding_review_items_shop_session_issue_scope_uidx\"" } };
+          if (table === "onboarding_review_items" && this.op === "insert") {
+            const row = this.payload;
+            const existing = state.reviewItems.find((item) => reviewScopeKey(item) === reviewScopeKey(row));
+            if (existing) return { data: null, error: { code: "23505", message: "duplicate key value violates unique constraint \"onboarding_review_items_shop_session_issue_scope_uidx\"" } };
+            state.reviewItems.push(row);
+            return { data: [row], error: null };
+          }
+          if (table === "onboarding_review_items" && this.op === "update") {
+            const target = state.reviewItems.find((item) => this.filters.every((f: any) => item[f.key] === f.value));
+            if (target) Object.assign(target, this.payload);
+            return { data: [], error: null };
+          }
           if (table === "onboarding_review_items" && this.op === "upsert") {
             const rows = Array.isArray(this.payload) ? this.payload : [this.payload];
             for (const row of rows) {
@@ -151,6 +171,20 @@ describe("activateOnboardingVendors", () => {
     await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
     expect(sb.state.reviewItems.length).toBe(before);
     expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "missing_vendor_name")).toHaveLength(1);
+  });
+
+  it("rerun does not duplicate ambiguous_vendor_match review items", async () => {
+    const sb = fakeSb({
+      entities: [entity({ id: "entity-ambiguous", normalized: { name: "North Supply" } })],
+      suppliers: [
+        supplier({ id: "supplier-a", name: "North Supply", email: "n@example.com", phone: "111" }),
+        supplier({ id: "supplier-b", name: "North Supply", email: "n@example.com", phone: "111" }),
+      ],
+    });
+
+    await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
+    await activateOnboardingVendors({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "user-1" });
+    expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "ambiguous_vendor_match")).toHaveLength(1);
   });
 
 });

--- a/features/onboarding-agent/server/upsertOnboardingReviewItems.ts
+++ b/features/onboarding-agent/server/upsertOnboardingReviewItems.ts
@@ -9,16 +9,33 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
 
 export class ActivationReviewItemWriteError extends Error {
   phase: string;
+  domain: string;
   issueType: string;
+  severity: string;
+  scope: { shopId: string; sessionId: string; domain: string; issueType: string; severity: string };
   scopeKey: string;
+  causeCode: string | null;
   causeMessage: string;
 
-  constructor(params: { phase: string; issueType: string; scopeKey: string; causeMessage: string }) {
-    super(`Activation review item write failed (${params.phase}:${params.issueType}:${params.scopeKey}) - ${params.causeMessage}`);
+  constructor(params: {
+    phase: string;
+    domain: string;
+    issueType: string;
+    severity: string;
+    scope: { shopId: string; sessionId: string; domain: string; issueType: string; severity: string };
+    scopeKey: string;
+    causeCode?: string | null;
+    causeMessage: string;
+  }) {
+    super(`Activation review item write failed (${params.phase}:${params.domain}:${params.issueType}:${params.severity}:${params.scopeKey}) - ${params.causeMessage}`);
     this.name = "ActivationReviewItemWriteError";
     this.phase = params.phase;
+    this.domain = params.domain;
     this.issueType = params.issueType;
+    this.severity = params.severity;
+    this.scope = params.scope;
     this.scopeKey = params.scopeKey;
+    this.causeCode = params.causeCode ?? null;
     this.causeMessage = params.causeMessage;
   }
 }
@@ -114,7 +131,7 @@ export async function upsertOnboardingReviewItems(params: {
       ? mergeDetails(canonicalDetails(existing.details ?? {}), normalizedDetails)
       : normalizedDetails;
 
-    payload.push({
+    const normalizedItem: OnboardingReviewItemInsert = {
       ...item,
       id: existing?.id ?? item.id,
       shop_id: params.shopId,
@@ -127,28 +144,134 @@ export async function upsertOnboardingReviewItems(params: {
       entity_id: existing?.entity_id ?? item.entity_id ?? null,
       link_id: existing?.link_id ?? item.link_id ?? null,
       details: mergedDetails as any,
-    });
+    };
+    payload.push(normalizedItem);
 
     if (existing) reused += 1;
   }
 
-  const { error } = await sb.from("onboarding_review_items").upsert(payload, { onConflict: "id" });
-  if (error) {
-    const failedItem = payload[0];
-    throw new ActivationReviewItemWriteError({
-      phase: params.phase,
-      issueType: String(failedItem?.issue_type ?? "unknown"),
-      scopeKey: scopeKey({
-        shop_id: params.shopId,
-        session_id: params.sessionId,
-        domain: failedItem?.domain,
-        issue_type: failedItem?.issue_type ?? "unknown",
-        severity: failedItem?.severity ?? "medium",
-        details: failedItem?.details ?? {},
-      }),
-      causeMessage: error.message,
+  const writtenKeys = new Set<string>();
+  let persisted = 0;
+
+  for (const item of payload) {
+    const key = scopeKey({
+      shop_id: params.shopId,
+      session_id: params.sessionId,
+      domain: item.domain,
+      issue_type: item.issue_type,
+      severity: item.severity,
+      details: item.details ?? {},
     });
+    if (writtenKeys.has(key)) continue;
+    writtenKeys.add(key);
+
+    const current = existingByScope.get(key);
+    if (current) {
+      const updatePayload = {
+        summary: current.summary || item.summary,
+        details: mergeDetails(canonicalDetails(current.details ?? {}), canonicalDetails(item.details ?? {})) as any,
+        entity_id: current.entity_id ?? item.entity_id ?? null,
+        link_id: current.link_id ?? item.link_id ?? null,
+      };
+      const { error: updateError } = await sb.from("onboarding_review_items").update(updatePayload).eq("id", current.id);
+      if (updateError) {
+        throw new ActivationReviewItemWriteError({
+          phase: params.phase,
+          domain: String(item.domain ?? "unknown"),
+          issueType: String(item.issue_type ?? "unknown"),
+          severity: String(item.severity ?? "medium"),
+          scope: {
+            shopId: params.shopId,
+            sessionId: params.sessionId,
+            domain: String(item.domain ?? ""),
+            issueType: String(item.issue_type ?? "unknown"),
+            severity: String(item.severity ?? "medium"),
+          },
+          scopeKey: key,
+          causeCode: String((updateError as { code?: string } | null)?.code ?? ""),
+          causeMessage: updateError.message,
+        });
+      }
+      persisted += 1;
+      continue;
+    }
+
+    const { error: insertError } = await sb.from("onboarding_review_items").insert(item);
+    if (!insertError) {
+      persisted += 1;
+      continue;
+    }
+
+    const conflict = String((insertError as { code?: string } | null)?.code ?? "") === "23505"
+      || String(insertError.message ?? "").includes("onboarding_review_items_shop_session_issue_scope_uidx");
+    if (!conflict) {
+      throw new ActivationReviewItemWriteError({
+        phase: params.phase,
+        domain: String(item.domain ?? "unknown"),
+        issueType: String(item.issue_type ?? "unknown"),
+        severity: String(item.severity ?? "medium"),
+        scope: {
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          domain: String(item.domain ?? ""),
+          issueType: String(item.issue_type ?? "unknown"),
+          severity: String(item.severity ?? "medium"),
+        },
+        scopeKey: key,
+        causeCode: String((insertError as { code?: string } | null)?.code ?? ""),
+        causeMessage: insertError.message,
+      });
+    }
+
+    const { data: conflictRows, error: conflictLookupError } = await sb
+      .from("onboarding_review_items")
+      .select("id, shop_id, session_id, domain, issue_type, severity, details, status, summary, entity_id, link_id")
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("domain", item.domain ?? "")
+      .eq("issue_type", item.issue_type)
+      .eq("severity", item.severity);
+    if (conflictLookupError) {
+      throw new ActivationReviewItemWriteError({
+        phase: params.phase,
+        domain: String(item.domain ?? "unknown"),
+        issueType: String(item.issue_type ?? "unknown"),
+        severity: String(item.severity ?? "medium"),
+        scope: {
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          domain: String(item.domain ?? ""),
+          issueType: String(item.issue_type ?? "unknown"),
+          severity: String(item.severity ?? "medium"),
+        },
+        scopeKey: key,
+        causeCode: String((conflictLookupError as { code?: string } | null)?.code ?? ""),
+        causeMessage: conflictLookupError.message,
+      });
+    }
+
+    const resolved = ((conflictRows ?? []) as OnboardingReviewItemRow[]).find((row) => scopeKey(row) === key);
+    if (!resolved) {
+      throw new ActivationReviewItemWriteError({
+        phase: params.phase,
+        domain: String(item.domain ?? "unknown"),
+        issueType: String(item.issue_type ?? "unknown"),
+        severity: String(item.severity ?? "medium"),
+        scope: {
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          domain: String(item.domain ?? ""),
+          issueType: String(item.issue_type ?? "unknown"),
+          severity: String(item.severity ?? "medium"),
+        },
+        scopeKey: key,
+        causeCode: String((insertError as { code?: string } | null)?.code ?? ""),
+        causeMessage: "Conflict detected but scoped row was not found after retry",
+      });
+    }
+    existingByScope.set(key, resolved);
+    reused += 1;
   }
 
-  return { persisted: payload.length, reused };
+  return { persisted, reused };
 }


### PR DESCRIPTION
### Motivation
- Activation was failing because `activateOnboardingParts` assumed `stock_locations.created_at` exists and ordered by it, causing Supabase 400 errors for shops without that column.  
- Activation also raised 409s when inserting `onboarding_review_items` because activation paths used upsert-by-`id` while the DB enforces a scoped unique index (shop/session/domain/issue_type/severity/md5(details::text)).  
- The intent is to make parts/history/vendors activation idempotent and deterministic without broad refactors or DB migrations.

### Description
- Fixed `stock_locations` lookup in `features/onboarding-agent/server/activateOnboardingParts.ts` by removing `.order('created_at')` (column does not exist) and using a deterministic fallback ordering of existing columns: `.order('code').order('name').order('id').limit(1)`; inspected `stock_locations` columns are `code`, `id`, `name`, `shop_id`.  
- Rewrote review-item persistence in `features/onboarding-agent/server/upsertOnboardingReviewItems.ts` to stop using `upsert(..., { onConflict: 'id' })` and instead: preload existing rows for the `shop_id/session_id` (and domains), canonicalize `details` (stable key order), compute scope keys, update existing scoped rows (safe fields only), insert missing rows, detect duplicate-scope conflicts (`23505` / constraint message), re-query the scoped candidates and reuse/update the resolved row; this prevents onConflict:id collisions during activation.  
- Canonicalized and merged `details` via a stable sorted JSON function to ensure scope matching is stable across analyze/activation/reruns.  
- Improved activation route error payloads (`app/api/onboarding-agent/.../activate-*.ts`) to surface structured metadata (`phase`, `domain`, `issueType`, `severity`, `scope`) and developer-safe Supabase error details (`code` and message) when review-item persistence fails.  
- Added and adjusted unit tests and fake-supabase harness behavior in `features/onboarding-agent/server/*.{test.ts}` to emulate scoped unique-index collisions and verify idempotency for `ambiguous_vendor_for_part` (parts), `invalid_history_date` (history), and `ambiguous_vendor_match` (vendors).

### Testing
- Ran `npx tsc --noEmit --pretty false` which completed successfully.  
- Ran `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (`Test Files 16 passed`, `Tests 94 passed`).  
- Ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent`, which produced existing warnings but no errors (lint passed).  
- Added targeted unit tests for rerun idempotency and simulated `23505` insert conflicts; those tests passed as part of the `vitest` run.  

Notes: no DB migration was required; `onConflict: 'id'` still remains where intentionally used for `stock_moves` idempotency, but review-item upserts for activation paths no longer emit `on_conflict=id`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f79219c083288a29a6fd36549ee6)