### PR TITLE
Fix onboarding parts/history activation pagination caps

### DIFF
--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -287,8 +287,21 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       if (!res.ok || !json?.ok) {
         setError(activationErrorMessage(json?.error, "Failed to activate staged parts."));
       } else {
+        const stagedProcessed = Number(json?.stagedParts ?? 0);
+        const created = Number(json?.partsCreated ?? 0);
+        const matched = Number(json?.existingPartsMatched ?? 0);
+        const reviewItemsCreated = Number(json?.reviewItemsCreated ?? json?.needsReview ?? 0);
+        const skipped = Number(json?.skipped ?? 0);
+        const expectedReady = partReadyCount;
+        const processedLessThanExpected = expectedReady > 0 && stagedProcessed < expectedReady;
+        const reconciliationTotal = created + matched + skipped;
+        const reconciliationUnclear = stagedProcessed > 0 && reconciliationTotal > 0 && reconciliationTotal !== stagedProcessed;
+        const warning = processedLessThanExpected || reconciliationUnclear
+          ? " Activation processed fewer staged rows than expected. This may indicate a pagination or filtering issue."
+          : "";
+        const completionLabel = processedLessThanExpected ? "Parts activation finished with warnings." : "Parts activation complete.";
         setPartsActivationSummary(
-          `Parts activation complete. Staged: ${Number(json?.stagedParts ?? 0)}. Created: ${Number(json?.partsCreated ?? 0)}. Matched: ${Number(json?.existingPartsMatched ?? 0)}. Stock created: ${Number(json?.stockRecordsCreated ?? 0)}. Needs review: ${Number(json?.needsReview ?? 0)}.`,
+          `${completionLabel} Staged rows processed: ${stagedProcessed}. Created live records: ${created}. Matched existing live records: ${matched}. Review items created: ${reviewItemsCreated}. Skipped/unresolved: ${skipped}.${warning}`,
         );
       }
       await load();
@@ -311,8 +324,21 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       if (!res.ok || !json?.ok) {
         setError(activationErrorMessage(json?.error, "Failed to activate historical work orders."));
       } else {
+        const stagedProcessed = Number(json?.stagedHistoryRows ?? 0);
+        const created = Number(json?.historicalWorkOrdersCreated ?? 0);
+        const matched = Number(json?.existingMatched ?? 0);
+        const reviewItemsCreated = Number(json?.reviewItemsCreated ?? json?.needsReview ?? 0);
+        const skipped = Number(json?.skipped ?? 0);
+        const expectedReady = historyReadyCount;
+        const processedLessThanExpected = expectedReady > 0 && stagedProcessed < expectedReady;
+        const reconciliationTotal = created + matched + skipped;
+        const reconciliationUnclear = stagedProcessed > 0 && reconciliationTotal > 0 && reconciliationTotal !== stagedProcessed;
+        const warning = processedLessThanExpected || reconciliationUnclear
+          ? " Activation processed fewer staged rows than expected. This may indicate a pagination or filtering issue."
+          : "";
+        const completionLabel = processedLessThanExpected ? "History activation finished with warnings." : "History activation complete.";
         setHistoryActivationSummary(
-          `History activation complete. Staged: ${Number(json?.stagedHistoryRows ?? 0)}. Created: ${Number(json?.historicalWorkOrdersCreated ?? 0)}. Matched: ${Number(json?.existingMatched ?? 0)}. Lines created: ${Number(json?.linesCreated ?? 0)}. Needs review: ${Number(json?.needsReview ?? 0)}.`,
+          `${completionLabel} Staged rows processed: ${stagedProcessed}. Created live records: ${created}. Matched existing live records: ${matched}. Review items created: ${reviewItemsCreated}. Skipped/unresolved: ${skipped}.${warning}`,
         );
       }
       await load();

--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -16,10 +16,10 @@ function fakeSb() {
   ].join("|");
 
   const state = {
-    entities: [{ id: "h-1", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" } }] as any[],
-    links: [],
-    customers: [{ id: "c-1", external_id: null, email: null, name: "Acme", business_name: null }],
-    vehicles: [{ id: "v-1", external_id: null, vin: "VIN1", license_plate: null }],
+    entities: [{ id: "h-1", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" } }] as any[],
+    links: [] as any[],
+    customers: [{ id: "c-1", shop_id: "shop-1", external_id: null, email: null, name: "Acme", business_name: null }],
+    vehicles: [{ id: "v-1", shop_id: "shop-1", external_id: null, vin: "VIN1", license_plate: null }],
     work_orders: [] as any[],
     lines: [] as any[],
     reviewItems: [] as any[],
@@ -31,10 +31,13 @@ function fakeSb() {
         filters: [] as Array<{ key: string; value: any }>,
         op: "select",
         payload: null as any,
+        rangeFrom: 0,
+        rangeTo: Number.MAX_SAFE_INTEGER,
         select() { return this; },
         eq(key: string, value: any) { this.filters.push({ key, value }); return this; },
         in() { return this; },
         order() { return this; },
+        range(from: number, to: number) { this.rangeFrom = from; this.rangeTo = to; return this; },
         insert(payload: any) { this.op = "insert"; this.payload = payload; return this; },
         update(payload: any) { this.op = "update"; this.payload = payload; return this; },
         upsert(payload: any) { this.op = "upsert"; this.payload = payload; return this.exec(); },
@@ -42,11 +45,14 @@ function fakeSb() {
         then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
         async execSingle() { const r = await this.exec(); return { ...r, data: Array.isArray(r.data) ? r.data[0] : r.data }; },
         async exec() {
-          if (table === "onboarding_entities") return { data: state.entities, error: null };
-          if (table === "onboarding_entity_links") return { data: state.links, error: null };
-          if (table === "customers") return { data: state.customers, error: null };
-          if (table === "vehicles") return { data: state.vehicles, error: null };
-          if (table === "work_orders" && this.op === "select") return { data: state.work_orders, error: null };
+          const applyFilters = (rows: any[]) => rows
+            .filter((row) => this.filters.every((f: any) => row?.[f.key] === f.value))
+            .slice(this.rangeFrom, this.rangeTo + 1);
+          if (table === "onboarding_entities") return { data: applyFilters(state.entities), error: null };
+          if (table === "onboarding_entity_links") return { data: applyFilters(state.links), error: null };
+          if (table === "customers") return { data: applyFilters(state.customers), error: null };
+          if (table === "vehicles") return { data: applyFilters(state.vehicles), error: null };
+          if (table === "work_orders" && this.op === "select") return { data: applyFilters(state.work_orders), error: null };
           if (table === "work_orders" && this.op === "insert") { const row = { ...this.payload, id: `wo-${state.work_orders.length + 1}` }; state.work_orders.push(row); return { data: [{ id: row.id }], error: null }; }
           if (table === "work_order_lines" && this.op === "insert") { state.lines.push(this.payload); return { data: [], error: null }; }
           if (table === "onboarding_review_items" && this.op === "select") return { data: [...state.reviewItems], error: null };
@@ -91,7 +97,7 @@ describe("activateOnboardingHistory", () => {
 
   it("creates review item for missing identifier", async () => {
     const sb = fakeSb();
-    sb.state.entities = [{ id: "h-2", normalized: {} }] as any[];
+    sb.state.entities = [{ id: "h-2", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: {} }] as any[];
     const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     expect(result.needsReview).toBeGreaterThan(0);
     expect(sb.state.reviewItems.some((i) => i.issue_type === "missing_required_history_identifier")).toBe(true);
@@ -99,7 +105,7 @@ describe("activateOnboardingHistory", () => {
 
   it("rerun is idempotent for missing_required_history_identifier", async () => {
     const sb = fakeSb();
-    sb.state.entities = [{ id: "h-dup", normalized: {} }] as any[];
+    sb.state.entities = [{ id: "h-dup", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: {} }] as any[];
     await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     const before = sb.state.reviewItems.length;
     await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
@@ -109,10 +115,35 @@ describe("activateOnboardingHistory", () => {
 
   it("rerun does not duplicate invalid_history_date review items", async () => {
     const sb = fakeSb();
-    sb.state.entities = [{ id: "h-invalid-date", normalized: { sourceWorkOrderId: "RO-404", openedDate: "not-a-date" } }] as any[];
+    sb.state.entities = [{ id: "h-invalid-date", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: { sourceWorkOrderId: "RO-404", openedDate: "not-a-date" } }] as any[];
     await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "invalid_history_date")).toHaveLength(1);
+  });
+
+  it("paginates staged history rows over 1000 and keeps historical queue behavior", async () => {
+    const sb = fakeSb();
+    sb.state.entities = Array.from({ length: 6076 }, (_, index) => ({
+      id: `h-${index + 1}`,
+      shop_id: "shop-1",
+      session_id: "session-1",
+      entity_type: "historical_work_order",
+      status: "ready",
+      normalized: index === 6075
+        ? { sourceWorkOrderId: `RO-${index + 1}`, openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" }
+        : { sourceWorkOrderId: `RO-${index + 1}` },
+    }));
+
+    const first = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    const second = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+
+    expect(first.stagedHistoryRows).toBe(6076);
+    expect(first.historicalWorkOrdersCreated).toBe(1);
+    expect(first.skipped).toBeGreaterThan(0);
+    expect(first.reviewItemsCreated).toBeGreaterThan(0);
+    expect(sb.state.work_orders.some((row) => row.custom_id === "RO-6076")).toBe(true);
+    expect(sb.state.work_orders.every((row) => row.type === "historical_import" && row.status === "completed")).toBe(true);
+    expect(second.historicalWorkOrdersCreated).toBe(0);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import { fetchAllPaginatedRows } from "@/features/onboarding-agent/server/fetchAllPaginatedRows";
 import { upsertOnboardingReviewItems } from "@/features/onboarding-agent/server/upsertOnboardingReviewItems";
 import type { Database } from "@/features/shared/types/types/supabase";
 
@@ -123,26 +124,49 @@ export async function activateOnboardingHistory(params: {
   const sb = params.supabase as any;
   await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
 
-  const [{ data: entities }, { data: links }, { data: customers }, { data: vehicles }, { data: workOrders }] = await Promise.all([
-    sb
-      .from("onboarding_entities")
-      .select("id, normalized")
-      .eq("shop_id", params.shopId)
-      .eq("session_id", params.sessionId)
-      .eq("entity_type", "historical_work_order")
-      .eq("status", "ready")
-      .order("id", { ascending: true }),
-    sb.from("onboarding_entity_links").select("id, from_entity_id, to_entity_id, link_type").eq("shop_id", params.shopId).eq("session_id", params.sessionId),
-    sb.from("customers").select("id, external_id, email, name, business_name").eq("shop_id", params.shopId),
-    sb.from("vehicles").select("id, external_id, vin, license_plate").eq("shop_id", params.shopId),
-    sb.from("work_orders").select("*").eq("shop_id", params.shopId),
+  const [historyRows, linkRows, customerRows, vehicleRows, workOrders] = await Promise.all([
+    fetchAllPaginatedRows<Pick<OnboardingEntityRow, "id" | "normalized">>((from, to) =>
+      sb
+        .from("onboarding_entities")
+        .select("id, normalized")
+        .eq("shop_id", params.shopId)
+        .eq("session_id", params.sessionId)
+        .eq("entity_type", "historical_work_order")
+        .eq("status", "ready")
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllPaginatedRows<Pick<OnboardingEntityLinkRow, "id" | "from_entity_id" | "to_entity_id" | "link_type">>((from, to) =>
+      sb
+        .from("onboarding_entity_links")
+        .select("id, from_entity_id, to_entity_id, link_type")
+        .eq("shop_id", params.shopId)
+        .eq("session_id", params.sessionId)
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllPaginatedRows<CustomerRow>((from, to) =>
+      sb
+        .from("customers")
+        .select("id, external_id, email, name, business_name")
+        .eq("shop_id", params.shopId)
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllPaginatedRows<VehicleRow>((from, to) =>
+      sb
+        .from("vehicles")
+        .select("id, external_id, vin, license_plate")
+        .eq("shop_id", params.shopId)
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllPaginatedRows<WorkOrderRow>((from, to) =>
+      sb
+        .from("work_orders")
+        .select("*")
+        .eq("shop_id", params.shopId)
+        .order("id", { ascending: true })
+        .range(from, to)),
   ]);
 
-  const historyRows = (entities ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized">>;
-  const linkRows = (links ?? []) as Array<Pick<OnboardingEntityLinkRow, "id" | "from_entity_id" | "to_entity_id" | "link_type">>;
-  const customerRows = (customers ?? []) as CustomerRow[];
-  const vehicleRows = (vehicles ?? []) as VehicleRow[];
-  const woRows = [...((workOrders ?? []) as WorkOrderRow[])];
+  const woRows = [...workOrders];
 
   const reviewItems: OnboardingReviewItemInsert[] = [];
   const warnings: string[] = [];

--- a/features/onboarding-agent/server/activateOnboardingParts.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.test.ts
@@ -48,9 +48,12 @@ function fakeSb() {
         op: "select",
         payload: null as any,
         options: null as any,
+        rangeFrom: 0,
+        rangeTo: Number.MAX_SAFE_INTEGER,
         select() { return this; },
         eq(col: string, value: any) { filters.push({ op: "eq", col, value }); return this; },
         in(col: string, value: any[]) { filters.push({ op: "in", col, value }); return this; },
+        range(from: number, to: number) { this.rangeFrom = from; this.rangeTo = to; return this; },
         order(col: string) {
           if (table === "stock_locations" && col === "created_at") throw new Error("stock_locations.created_at should not be queried");
           return this;
@@ -63,7 +66,9 @@ function fakeSb() {
         then(resolve: any, reject: any) { return this.exec().then(resolve, reject); },
         async execSingle() { const r = await this.exec(); return { ...r, data: Array.isArray(r.data) ? r.data[0] : r.data }; },
         async exec() {
-          const applyFilters = (rows: any[]) => rows.filter((row) => filters.every((f) => (f.op === "eq" ? row?.[f.col] === f.value : (f.value ?? []).includes(row?.[f.col]))));
+          const applyFilters = (rows: any[]) => rows
+            .filter((row) => filters.every((f) => (f.op === "eq" ? row?.[f.col] === f.value : (f.value ?? []).includes(row?.[f.col]))))
+            .slice(this.rangeFrom, this.rangeTo + 1);
 
           if (table === "onboarding_entities") return { data: applyFilters(state.entities), error: null };
           if (table === "parts" && this.op === "select") return { data: applyFilters(state.parts), error: null };
@@ -236,6 +241,34 @@ describe("activateOnboardingParts", () => {
     await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     expect(sb.state.reviewItems.filter((i: any) => i.issue_type === "ambiguous_vendor_for_part")).toHaveLength(1);
+  });
+
+  it("paginates staged parts over 1000 rows and preserves idempotency across reruns", async () => {
+    const sb = fakeSb();
+    sb.state.entities = Array.from({ length: 3200 }, (_, index) => ({
+      id: `part-${index + 1}`,
+      shop_id: "shop-1",
+      session_id: "session-1",
+      entity_type: "part",
+      status: "ready",
+      normalized: {
+        description: index === 3199 ? "Part 3200" : "",
+        quantityOnHandRaw: index === 1500 ? "-1" : "1",
+      },
+      display_name: `Part ${index + 1}`,
+      source_external_id: `src-${index + 1}`,
+    }));
+
+    const first = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    const second = await activateOnboardingParts({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+
+    expect(first.stagedParts).toBe(3200);
+    expect(first.partsCreated).toBe(1);
+    expect(sb.state.parts.some((row) => row.source_intake_id === "session-1" && row.name === "Part 3200")).toBe(true);
+    expect(first.skipped).toBeGreaterThan(0);
+    expect(first.reviewItemsCreated).toBeGreaterThan(0);
+    expect(second.partsCreated).toBe(0);
+    expect(second.reviewItemsCreated).toBe(first.reviewItemsCreated);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingParts.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { stableUuidFromParts } from "@/features/onboarding-agent/lib/staging";
 import { assertOnboardingSessionOwnership } from "@/features/onboarding-agent/server/assertOnboardingSessionOwnership";
+import { fetchAllPaginatedRows } from "@/features/onboarding-agent/server/fetchAllPaginatedRows";
 import { upsertOnboardingReviewItems } from "@/features/onboarding-agent/server/upsertOnboardingReviewItems";
 import type { Database } from "@/features/shared/types/types/supabase";
 
@@ -131,35 +132,43 @@ export async function activateOnboardingParts(params: {
   const sb = params.supabase as any;
   await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
 
-  const [{ data: staged }, { data: parts }, { data: suppliers }, { data: stockLocations }] = await Promise.all([
-    sb
-      .from("onboarding_entities")
-      .select("id, normalized, display_name, source_external_id")
-      .eq("shop_id", params.shopId)
-      .eq("session_id", params.sessionId)
-      .eq("entity_type", "part")
-      .eq("status", "ready")
-      .order("id", { ascending: true }),
-    sb.from("parts").select("*").eq("shop_id", params.shopId),
+  const [{ data: suppliers }, { data: stockLocations }, stagedRows, partRows] = await Promise.all([
     sb.from("suppliers").select("id, name").eq("shop_id", params.shopId),
     sb.from("stock_locations").select("*").eq("shop_id", params.shopId).order("code", { ascending: true }).order("name", { ascending: true }).order("id", { ascending: true }).limit(1),
+    fetchAllPaginatedRows<Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">>((from, to) =>
+      sb
+        .from("onboarding_entities")
+        .select("id, normalized, display_name, source_external_id")
+        .eq("shop_id", params.shopId)
+        .eq("session_id", params.sessionId)
+        .eq("entity_type", "part")
+        .eq("status", "ready")
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllPaginatedRows<PartRow>((from, to) =>
+      sb
+        .from("parts")
+        .select("*")
+        .eq("shop_id", params.shopId)
+        .order("id", { ascending: true })
+        .range(from, to)),
   ]);
 
-  const stagedRows = (staged ?? []) as Array<Pick<OnboardingEntityRow, "id" | "normalized" | "display_name" | "source_external_id">>;
-  const partRows = [...((parts ?? []) as PartRow[])];
+  const materializedParts = [...partRows];
   const supplierRows = suppliers ?? [];
   const defaultLocation = (stockLocations?.[0] ?? null) as StockLocationRow | null;
-  const shopPartIds = partRows.map((row) => row.id).filter((id): id is string => Boolean(id));
+  const shopPartIds = materializedParts.map((row) => row.id).filter((id): id is string => Boolean(id));
 
   let stockRows: PartStockRow[] = [];
   if (defaultLocation && shopPartIds.length > 0) {
-    const { data: partStockRows, error: partStockError } = await sb
-      .from("part_stock")
-      .select("id, part_id, location_id, qty_on_hand, qty_reserved, reorder_point, reorder_qty")
-      .eq("location_id", defaultLocation.id)
-      .in("part_id", shopPartIds);
-    if (partStockError) throw new Error(partStockError.message);
-    stockRows = [...((partStockRows ?? []) as PartStockRow[])];
+    stockRows = await fetchAllPaginatedRows<PartStockRow>((from, to) =>
+      sb
+        .from("part_stock")
+        .select("id, part_id, location_id, qty_on_hand, qty_reserved, reorder_point, reorder_qty")
+        .eq("location_id", defaultLocation.id)
+        .in("part_id", shopPartIds)
+        .order("id", { ascending: true })
+        .range(from, to));
   }
 
   const reviewItems: OnboardingReviewItemInsert[] = [];
@@ -198,7 +207,7 @@ export async function activateOnboardingParts(params: {
       needsReview += 1;
     }
 
-    const candidates = getPartMatchCandidates(partRows, normalized);
+    const candidates = getPartMatchCandidates(materializedParts, normalized);
     if (candidates.length > 1) {
       skipped += 1;
       needsReview += 1;
@@ -272,7 +281,7 @@ export async function activateOnboardingParts(params: {
       const { data, error } = await sb.from("parts").insert(payload).select("*").single();
       if (error) throw new Error(error.message);
       targetPart = data as PartRow;
-      partRows.push(targetPart);
+      materializedParts.push(targetPart);
       partsCreated += 1;
     }
 

--- a/features/onboarding-agent/server/fetchAllPaginatedRows.ts
+++ b/features/onboarding-agent/server/fetchAllPaginatedRows.ts
@@ -1,0 +1,18 @@
+const PAGE_SIZE = 1000;
+
+export async function fetchAllPaginatedRows<T>(buildQuery: (from: number, to: number) => Promise<{ data: T[] | null; error: { message: string } | null }>): Promise<T[]> {
+  const rows: T[] = [];
+  let from = 0;
+
+  while (true) {
+    const to = from + PAGE_SIZE - 1;
+    const { data, error } = await buildQuery(from, to);
+    if (error) throw new Error(error.message);
+    const batch = (data ?? []) as T[];
+    rows.push(...batch);
+    if (batch.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return rows;
+}


### PR DESCRIPTION
### Motivation
- Activation for parts and historical work orders was truncated at Supabase's 1,000-row default because staged/live reads were not paginated, causing incomplete activation runs in Vercel tests.
- The change aims to process the full staged datasets while preserving shop/session scoping, idempotency, and safe review-item writes.

### Description
- Added a small shared helper `fetchAllPaginatedRows` (PAGE_SIZE = 1000) to page `.range(from,to)` queries until a short page is returned, and reused it for onboarding activations.
- Updated `activateOnboardingParts` to paginate staged `onboarding_entities` for `part` plus live `parts` and `part_stock` preloads so all staged parts are considered and deterministic ordering is preserved.
- Updated `activateOnboardingHistory` to paginate staged `onboarding_entities` for `historical_work_order`, `onboarding_entity_links`, and live `customers`, `vehicles`, and `work_orders` preloads so all staged history rows are considered and historical_import behavior is preserved.
- Improved UI activation wording in `OnboardingSessionPage.tsx` to show clearer labels (staged processed / created / matched / review items / skipped) and surface a warning if processed rows are lower than expected or reconciliation is unclear.
- Added regression tests exercising pagination and idempotency for >1000 rows in `activateOnboardingParts.test.ts` and `activateOnboardingHistory.test.ts` and extended test mocks to emulate `.range(from,to)` slicing so regressions will fail if pagination is removed.

### Testing
- Ran TypeScript check: `npx tsc --noEmit --pretty false`, which completed successfully.
- Ran onboarding-agent unit tests: `npx vitest run features/onboarding-agent`, and onboarding-agent suite passed (all tests for the feature suite passed; final test run showed 96 tests passing across the feature files touched).
- Ran linter: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent`, which reported warnings only and no errors.
- Test highlights: parts activation test verifies processing of 3,200 staged part rows and idempotency, and history activation test verifies processing of 6,076 staged history rows plus historical_import invariants; both test files pass in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fc3185808328a5595d6a521e4fab)