### PR TITLE
Fix onboarding activation summary reconciliation and activation guidance

### DIFF
--- a/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingActivationPlanPanel.tsx
@@ -7,17 +7,30 @@ function num(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary, agentPlan }: { latestPlan?: Record<string, unknown> | null; fallbackSummary?: Record<string, unknown> | null; agentPlan?: OnboardingAgentPlan | null }) {
+export function activationPreviewCopy(activationStarted: boolean): { title: string; description: string } {
+  return activationStarted
+    ? {
+      title: "Activation readiness snapshot",
+      description: "This snapshot is based on staged rows and review items. Some live records may already be created or matched.",
+    }
+    : {
+      title: "Dry-run activation preview",
+      description: "No live records have been created yet. These are activation candidates from persisted staged entities only.",
+    };
+}
+
+export function OnboardingActivationPlanPanel({ latestPlan, fallbackSummary, agentPlan, activationStarted = false }: { latestPlan?: Record<string, unknown> | null; fallbackSummary?: Record<string, unknown> | null; agentPlan?: OnboardingAgentPlan | null; activationStarted?: boolean }) {
   const [showDevDetails, setShowDevDetails] = useState(false);
   const summary = (fallbackSummary ?? latestPlan?.summary ?? latestPlan ?? {}) as Record<string, any>;
   const preview = agentPlan?.activationPreview;
+  const copy = activationPreviewCopy(activationStarted);
   const readyTotal = num(summary.customersReady) + num(summary.vehiclesReady) + num(summary.historicalWorkOrdersReady) + num(summary.historicalInvoicesReady) + num(summary.partsReady) + num(summary.vendorsReady) + num(summary.staffCandidatesReady) + num(summary.menuSuggestionsReady) + num(summary.inspectionSuggestionsReady);
   const reviewTotal = num(summary.reviewNeeded);
 
   return (
     <div className="rounded-2xl border border-amber-500/30 bg-amber-950/20 p-4">
-      <h3 className="text-sm font-semibold text-amber-100">Dry-run activation preview</h3>
-      <p className="mt-2 text-xs text-amber-200/80">No live records have been created. These are activation candidates from persisted staged entities only.</p>
+      <h3 className="text-sm font-semibold text-amber-100">{copy.title}</h3>
+      <p className="mt-2 text-xs text-amber-200/80">{copy.description}</p>
       <p className="mt-1 text-xs text-amber-100/90">{readyTotal.toLocaleString()} ready, {reviewTotal.toLocaleString()} require review.</p>
 
       <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">

--- a/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingAgentInsightsPanel.tsx
@@ -3,16 +3,30 @@
 import { useState } from "react";
 import type { OnboardingAgentPlan } from "@/features/onboarding-agent/lib/agentPlanTypes";
 
+export function agentInsightsStateCopy(started: boolean): string {
+  return started
+    ? "Activation has started. Some records may have been created or matched. Historical work orders remain closed/historical and invoices remain staged."
+    : "No live records have been created yet. This is staged analysis only.";
+}
+
 export function OnboardingAgentInsightsPanel({
   report,
   plan,
   fallbackReadiness,
   summary,
+  activationState,
 }: {
   report?: { mode?: string; summary?: string; model?: string | null; activationReadiness?: { status?: string } } | null;
   plan?: OnboardingAgentPlan | null;
   fallbackReadiness?: string;
   summary?: Record<string, unknown> | null;
+  activationState?: {
+    started: boolean;
+    customersVehicles: "activated" | "matched" | "not_run";
+    vendors: "activated" | "matched" | "not_run";
+    parts: "activated" | "matched" | "not_run";
+    history: "activated" | "matched" | "not_run";
+  };
 }) {
   const [showDev, setShowDev] = useState(false);
   const displayedReadiness = report?.activationReadiness?.status ?? fallbackReadiness ?? "not_ready";
@@ -29,7 +43,16 @@ export function OnboardingAgentInsightsPanel({
       <div className="flex items-center justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold text-cyan-100">Agent insights</h3>
-          <p className="mt-1 text-xs text-cyan-100/70">No live records have been created. This is a staged analysis only.</p>
+          <p className="mt-1 text-xs text-cyan-100/70">
+            {agentInsightsStateCopy(Boolean(activationState?.started))}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1 text-[10px] text-cyan-100/85">
+            <span className="rounded border border-cyan-500/30 px-2 py-0.5">Customers/vehicles: {activationState?.customersVehicles ?? "not_run"}</span>
+            <span className="rounded border border-cyan-500/30 px-2 py-0.5">Vendors: {activationState?.vendors ?? "not_run"}</span>
+            <span className="rounded border border-cyan-500/30 px-2 py-0.5">Parts: {activationState?.parts ?? "not_run"}</span>
+            <span className="rounded border border-cyan-500/30 px-2 py-0.5">History: {activationState?.history ?? "not_run"}</span>
+            <span className="rounded border border-amber-500/40 px-2 py-0.5 text-amber-100">Invoices: staged only</span>
+          </div>
         </div>
       </div>
 

--- a/features/onboarding-agent/components/OnboardingReviewPanel.tsx
+++ b/features/onboarding-agent/components/OnboardingReviewPanel.tsx
@@ -11,6 +11,36 @@ type ReviewItem = {
   details?: Record<string, unknown>;
 };
 
+export function groupReviewIssuesForDisplay(reviewItems: ReviewItem[]) {
+  return Object.values(
+    reviewItems.reduce<Record<string, {
+      id: string;
+      severity: string;
+      domain: string;
+      issueType: string;
+      summary: string;
+      count: number;
+      examples: string[];
+      detailExamples: Record<string, unknown>[];
+    }>>((acc, item) => {
+      if (!item) return acc;
+      const domain = String(item.domain ?? "unknown");
+      const issueType = String(item.issue_type ?? "issue");
+      const summary = String(item.summary ?? "Review required");
+      const severity = String(item.severity ?? "medium");
+      const key = `${domain}|${severity}|${issueType}|${summary}`;
+      if (!acc[key]) {
+        acc[key] = { id: key, severity, domain, issueType, summary, count: 0, examples: [], detailExamples: [] };
+      }
+      const bucket = acc[key]!;
+      bucket.count += 1;
+      if (bucket.examples.length < 3) bucket.examples.push(summary);
+      if (bucket.detailExamples.length < 3 && item.details && typeof item.details === "object") bucket.detailExamples.push(item.details);
+      return acc;
+    }, {}),
+  ).sort((a, b) => b.count - a.count).slice(0, 12);
+}
+
 export function OnboardingReviewPanel({
   reviewCounts,
   reviewItems,
@@ -19,7 +49,7 @@ export function OnboardingReviewPanel({
   reviewItems: ReviewItem[];
 }) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-  const topItems = reviewItems.filter((item) => item).slice(0, 12);
+  const groupedItems = groupReviewIssuesForDisplay(reviewItems);
   const domainCounts = reviewCounts.byDomain ?? {};
 
   return (
@@ -37,22 +67,25 @@ export function OnboardingReviewPanel({
 
       <div className="mt-3 space-y-2">
         <p className="text-xs uppercase tracking-wide text-slate-400">Grouped review issues</p>
-        {topItems.map((item) => {
-          const details = (item.details ?? {}) as Record<string, any>;
-          const examples = Array.isArray(details.examples) ? details.examples : [];
+        {groupedItems.map((item) => {
           const key = item.id;
           return (
             <div key={item.id} className="rounded-lg border border-white/10 bg-slate-900/60 p-3">
-              <p className="text-xs uppercase tracking-wide text-slate-400">{item.severity} • {item.domain ?? "unknown"} • {item.issue_type ?? "issue"}</p>
+              <p className="text-xs uppercase tracking-wide text-slate-400">{item.severity} • {item.domain} • {item.issueType}</p>
               <p className="text-sm text-white">{item.summary}</p>
-              {typeof details.count === "number" ? <p className="text-xs text-slate-300">Affected rows: {details.count}</p> : null}
-              {Array.isArray(details.sampleRowIndexes) && details.sampleRowIndexes.length > 0 ? <p className="text-xs text-slate-400">Sample rows: {details.sampleRowIndexes.slice(0, 5).join(", ")}</p> : null}
-              <p className="text-xs text-slate-400">Recommended action: {details.recommendedAction ?? "manual_review"}</p>
-              {examples.length > 0 ? <><button className="mt-2 text-xs text-cyan-200 underline" onClick={() => setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))}>{expanded[key] ? "Hide examples" : "Show examples"}</button>{expanded[key] ? <ul className="mt-2 space-y-1 text-xs text-slate-300">{examples.slice(0, 3).map((example: any, idx: number) => <li key={`${key}-${idx}`}>• {example.summary}</li>)}</ul> : null}</> : null}
+              <p className="text-xs text-slate-300">Count: {item.count}</p>
+              <p className="text-xs text-slate-400">Recommended action: manual_review</p>
+              {item.examples.length > 0 ? <><button className="mt-2 text-xs text-cyan-200 underline" onClick={() => setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))}>{expanded[key] ? "Hide examples" : "Show examples"}</button>{expanded[key] ? <ul className="mt-2 space-y-1 text-xs text-slate-300">{item.examples.slice(0, 3).map((example: string, idx: number) => <li key={`${key}-${idx}`}>• {example}</li>)}</ul> : null}</> : null}
+              {expanded[key] && item.detailExamples.length > 0 ? (
+                <details className="mt-2 text-[11px] text-slate-400">
+                  <summary className="cursor-pointer">Developer details</summary>
+                  <pre className="mt-1 overflow-auto rounded bg-slate-950/60 p-2">{JSON.stringify(item.detailExamples, null, 2)}</pre>
+                </details>
+              ) : null}
             </div>
           );
         })}
-        {topItems.length === 0 ? <p className="text-xs text-slate-400">No pending review exceptions.</p> : null}
+        {groupedItems.length === 0 ? <p className="text-xs text-slate-400">No pending review exceptions.</p> : null}
       </div>
     </div>
   );

--- a/features/onboarding-agent/components/OnboardingSessionPage.test.ts
+++ b/features/onboarding-agent/components/OnboardingSessionPage.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, linkIssueReasonLabel, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, linkIssueReasonLabel, partsVendorGuidance, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+import { agentInsightsStateCopy } from "@/features/onboarding-agent/components/OnboardingAgentInsightsPanel";
+import { activationPreviewCopy } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
+import { groupReviewIssuesForDisplay } from "@/features/onboarding-agent/components/OnboardingReviewPanel";
 
 describe("OnboardingSessionPage warning label helpers", () => {
   it("builds human-readable customer labels", () => {
@@ -46,5 +49,30 @@ describe("OnboardingSessionPage warning label helpers", () => {
     expect(grouped.vendors).toBe(2);
     expect(grouped.parts).toBe(1);
     expect(grouped.unknown).toBe(1);
+  });
+
+  it("switches agent insights copy after activation starts", () => {
+    expect(agentInsightsStateCopy(false)).toContain("No live records have been created yet");
+    expect(agentInsightsStateCopy(true)).toContain("Activation has started");
+    expect(agentInsightsStateCopy(true)).toContain("invoices remain staged");
+  });
+
+  it("switches dry-run label after activation starts", () => {
+    expect(activationPreviewCopy(false).title).toBe("Dry-run activation preview");
+    expect(activationPreviewCopy(true).title).toBe("Activation readiness snapshot");
+  });
+
+  it("renders vendor-before-parts guidance when vendor links are unavailable", () => {
+    expect(partsVendorGuidance({ canShowPartsActivation: true, vendorsActivated: false, vendorPartLinkCount: 0 })).toContain("vendor links may require review");
+    expect(partsVendorGuidance({ canShowPartsActivation: true, vendorsActivated: true, vendorPartLinkCount: 0 })).toContain("No vendor-part relationships");
+  });
+
+  it("groups repeated review summaries into a single display bucket", () => {
+    const grouped = groupReviewIssuesForDisplay([
+      { id: "1", severity: "medium", domain: "parts", issue_type: "missing_vendor", summary: "Vendor not found", details: { a: 1 } },
+      { id: "2", severity: "medium", domain: "parts", issue_type: "missing_vendor", summary: "Vendor not found", details: { a: 2 } },
+    ]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.count).toBe(2);
   });
 });

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -130,6 +130,37 @@ export function groupReviewItemsByDomain(reviewItems: Array<{ domain?: string | 
   }, {});
 }
 
+function asNumber(value: unknown): number {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function formatActivationPhaseSummary(input: {
+  phaseLabel: string;
+  stagedProcessed: number;
+  created: number;
+  matched: number;
+  skipped: number;
+  reviewItemsPersisted: number;
+  reviewItemsReused: number;
+  openReviewForDomain: number;
+  warning?: string;
+}) {
+  const reviewSuffix = input.reviewItemsReused > 0 ? `, reused ${input.reviewItemsReused}` : "";
+  return `${input.phaseLabel} activation: Processed: ${input.stagedProcessed.toLocaleString()} staged rows. Created: ${input.created.toLocaleString()} live records. Matched existing: ${input.matched.toLocaleString()} live records. Skipped/unresolved: ${input.skipped.toLocaleString()}. Review items persisted: ${input.reviewItemsPersisted.toLocaleString()}${reviewSuffix}. Review exceptions now open for ${input.phaseLabel.toLowerCase()}: ${input.openReviewForDomain.toLocaleString()}.${input.warning ?? ""}`;
+}
+
+export function partsVendorGuidance(input: { canShowPartsActivation: boolean; vendorsActivated: boolean; vendorPartLinkCount: number }): string | null {
+  if (!input.canShowPartsActivation) return null;
+  if (!input.vendorsActivated) {
+    return "Parts can still be activated, but vendor links may require review until suppliers are activated/matched.";
+  }
+  if (input.vendorPartLinkCount <= 0) {
+    return "No vendor-part relationships were found in staged links. Parts were matched/created without supplier linkage.";
+  }
+  return null;
+}
+
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
@@ -263,8 +294,21 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         setError(json?.error || "Failed to activate staged vendors.");
       } else {
         const warnings = Array.isArray(json?.warnings) ? json.warnings.length : 0;
+        const reviewItemsPersisted = asNumber(json?.reviewItemsPersisted ?? json?.reviewItemsCreated);
+        const reviewItemsReused = asNumber(json?.reviewItemsReused);
+        const openReviewForDomain = asNumber(json?.reviewItemsOpenForDomain ?? byDomainCounts.vendors);
         setVendorActivationSummary(
-          `Vendor activation complete. Staged vendors: ${Number(json?.stagedVendors ?? 0)}. Created: ${Number(json?.created ?? 0)}. Matched existing: ${Number(json?.matchedExisting ?? 0)}. Updated null-only: ${Number(json?.updatedNullOnly ?? 0)}. Skipped: ${Number(json?.skipped ?? 0)}. Needs review: ${Number(json?.needsReview ?? 0)}.${warnings > 0 ? ` Warnings: ${warnings}.` : ""}`,
+          formatActivationPhaseSummary({
+            phaseLabel: "Vendors",
+            stagedProcessed: asNumber(json?.stagedVendors),
+            created: asNumber(json?.created),
+            matched: asNumber(json?.matchedExisting) + asNumber(json?.updatedNullOnly),
+            skipped: asNumber(json?.skipped),
+            reviewItemsPersisted,
+            reviewItemsReused,
+            openReviewForDomain,
+            warning: warnings > 0 ? ` Warnings: ${warnings}.` : "",
+          }),
         );
       }
       await load();
@@ -287,11 +331,13 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       if (!res.ok || !json?.ok) {
         setError(activationErrorMessage(json?.error, "Failed to activate staged parts."));
       } else {
-        const stagedProcessed = Number(json?.stagedParts ?? 0);
-        const created = Number(json?.partsCreated ?? 0);
-        const matched = Number(json?.existingPartsMatched ?? 0);
-        const reviewItemsCreated = Number(json?.reviewItemsCreated ?? json?.needsReview ?? 0);
-        const skipped = Number(json?.skipped ?? 0);
+        const stagedProcessed = asNumber(json?.stagedParts);
+        const created = asNumber(json?.partsCreated);
+        const matched = asNumber(json?.existingPartsMatched) + asNumber(json?.partsNullOnlyUpdated);
+        const reviewItemsPersisted = asNumber(json?.reviewItemsPersisted ?? json?.reviewItemsCreated);
+        const reviewItemsReused = asNumber(json?.reviewItemsReused);
+        const skipped = asNumber(json?.skipped);
+        const openReviewForDomain = asNumber(json?.reviewItemsOpenForDomain ?? byDomainCounts.parts);
         const expectedReady = partReadyCount;
         const processedLessThanExpected = expectedReady > 0 && stagedProcessed < expectedReady;
         const reconciliationTotal = created + matched + skipped;
@@ -299,9 +345,18 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         const warning = processedLessThanExpected || reconciliationUnclear
           ? " Activation processed fewer staged rows than expected. This may indicate a pagination or filtering issue."
           : "";
-        const completionLabel = processedLessThanExpected ? "Parts activation finished with warnings." : "Parts activation complete.";
         setPartsActivationSummary(
-          `${completionLabel} Staged rows processed: ${stagedProcessed}. Created live records: ${created}. Matched existing live records: ${matched}. Review items created: ${reviewItemsCreated}. Skipped/unresolved: ${skipped}.${warning}`,
+          formatActivationPhaseSummary({
+            phaseLabel: "Parts",
+            stagedProcessed,
+            created,
+            matched,
+            skipped,
+            reviewItemsPersisted,
+            reviewItemsReused,
+            openReviewForDomain,
+            warning,
+          }),
         );
       }
       await load();
@@ -324,11 +379,13 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       if (!res.ok || !json?.ok) {
         setError(activationErrorMessage(json?.error, "Failed to activate historical work orders."));
       } else {
-        const stagedProcessed = Number(json?.stagedHistoryRows ?? 0);
-        const created = Number(json?.historicalWorkOrdersCreated ?? 0);
-        const matched = Number(json?.existingMatched ?? 0);
-        const reviewItemsCreated = Number(json?.reviewItemsCreated ?? json?.needsReview ?? 0);
-        const skipped = Number(json?.skipped ?? 0);
+        const stagedProcessed = asNumber(json?.stagedHistoryRows);
+        const created = asNumber(json?.historicalWorkOrdersCreated);
+        const matched = asNumber(json?.existingMatched);
+        const reviewItemsPersisted = asNumber(json?.reviewItemsPersisted ?? json?.reviewItemsCreated);
+        const reviewItemsReused = asNumber(json?.reviewItemsReused);
+        const skipped = asNumber(json?.skipped);
+        const openReviewForDomain = asNumber(json?.reviewItemsOpenForDomain ?? byDomainCounts.history);
         const expectedReady = historyReadyCount;
         const processedLessThanExpected = expectedReady > 0 && stagedProcessed < expectedReady;
         const reconciliationTotal = created + matched + skipped;
@@ -336,9 +393,18 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         const warning = processedLessThanExpected || reconciliationUnclear
           ? " Activation processed fewer staged rows than expected. This may indicate a pagination or filtering issue."
           : "";
-        const completionLabel = processedLessThanExpected ? "History activation finished with warnings." : "History activation complete.";
         setHistoryActivationSummary(
-          `${completionLabel} Staged rows processed: ${stagedProcessed}. Created live records: ${created}. Matched existing live records: ${matched}. Review items created: ${reviewItemsCreated}. Skipped/unresolved: ${skipped}.${warning}`,
+          formatActivationPhaseSummary({
+            phaseLabel: "History",
+            stagedProcessed,
+            created,
+            matched,
+            skipped,
+            reviewItemsPersisted,
+            reviewItemsReused,
+            openReviewForDomain,
+            warning,
+          }),
         );
       }
       await load();
@@ -408,6 +474,10 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const canShowPartsActivation = !loadingSession && !sessionLoadError && partReadyCount > 0;
   const canShowHistoryActivation = !loadingSession && !sessionLoadError && historyReadyCount > 0;
   const canShowCustomerVehicleActivation = !loadingSession && !sessionLoadError && hasCustomerVehicleReady;
+  const byDomainCounts = useMemo(() => groupReviewItemsByDomain(Array.isArray(payload?.reviewItems) ? payload.reviewItems : []), [payload?.reviewItems]);
+  const vendorPartLinkCount = asNumber(payload?.linkCounts?.vendor_part);
+  const vendorsActivated = Boolean(vendorActivationSummary);
+  const anyActivationStarted = Boolean(vendorActivationSummary || partsActivationSummary || historyActivationSummary || customerVehicleActivationResult);
   const groupedCustomerVehicleWarnings = useMemo(() => {
     const warnings: string[] = Array.isArray(customerVehicleActivationResult?.warnings)
       ? customerVehicleActivationResult.warnings
@@ -511,7 +581,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         </p>
         <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
           <span className="rounded-full border border-cyan-400/50 px-2 py-1 text-cyan-200">Staged-only</span>
-          <span className="rounded-full border border-emerald-400/40 px-2 py-1 text-emerald-200">No live records created</span>
+          <span className="rounded-full border border-emerald-400/40 px-2 py-1 text-emerald-200">{anyActivationStarted ? "Activation started" : "No live records created yet"}</span>
         </div>
         <p className="mt-2 text-xs text-cyan-100/80">
           Historical work orders remain historical (not active jobs). Historical invoices remain imported historical billing records.
@@ -604,7 +674,13 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
           </p>
         ) : null}
         {canShowPartsActivation ? <p className="mt-1 text-xs text-indigo-100/90">Safe to rerun. Existing imported part records will be matched, not duplicated.</p> : null}
+        {partsVendorGuidance({ canShowPartsActivation, vendorsActivated, vendorPartLinkCount }) ? (
+          <p className="mt-1 text-xs text-amber-100/90">{partsVendorGuidance({ canShowPartsActivation, vendorsActivated, vendorPartLinkCount })}</p>
+        ) : null}
         {canShowHistoryActivation ? <p className="mt-1 text-xs text-fuchsia-100/90">Historical work orders are imported as closed/historical records and will not appear in active technician queues.</p> : null}
+        <div className="mt-2 rounded-md border border-slate-700/80 bg-slate-900/60 px-3 py-2 text-[11px] text-slate-300">
+          Recommended order: 1) Activate vendors to live suppliers 2) Activate customers + vehicles 3) Activate parts inventory 4) Activate historical work orders.
+        </div>
         {notice ? <p className="mt-2 text-xs text-emerald-200">{notice}</p> : null}
         {vendorActivationSummary ? <p className="mt-2 text-xs text-emerald-200">{vendorActivationSummary}</p> : null}
         {partsActivationSummary ? <p className="mt-2 text-xs text-indigo-200">{partsActivationSummary}</p> : null}
@@ -794,11 +870,23 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
       {!sessionLoadError ? (
         <>
           <OnboardingProgressCard summary={session?.summary ?? null} />
-          <OnboardingAgentInsightsPanel report={session?.summary?.agentReport ?? null} plan={session?.summary?.agentPlan ?? null} summary={session?.summary ?? null} fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness} />
+          <OnboardingAgentInsightsPanel
+            report={session?.summary?.agentReport ?? null}
+            plan={session?.summary?.agentPlan ?? null}
+            summary={session?.summary ?? null}
+            fallbackReadiness={payload?.readiness ?? session?.summary?.activationReadiness}
+            activationState={{
+              started: anyActivationStarted,
+              customersVehicles: customerVehicleActivationResult ? "activated" : "not_run",
+              vendors: vendorActivationSummary ? "activated" : "not_run",
+              parts: partsActivationSummary ? "activated" : "not_run",
+              history: historyActivationSummary ? "activated" : "not_run",
+            }}
+          />
           <OnboardingFilesPanel files={files} />
           <OnboardingEntitiesPanel entityCounts={payload?.entityCounts ?? {}} entityStatusCounts={payload?.entityStatusCounts ?? {}} linkCounts={payload?.linkCounts ?? {}} agentPlan={session?.summary?.agentPlan ?? null} />
           <OnboardingReviewPanel reviewCounts={payload?.reviewCounts ?? {}} reviewItems={payload?.reviewItems ?? []} />
-          <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} agentPlan={session?.summary?.agentPlan ?? null} />
+          <OnboardingActivationPlanPanel latestPlan={payload?.latestPlan ?? null} fallbackSummary={payload?.activationPlanSummary ?? session?.summary?.activationPlanSummary ?? null} agentPlan={session?.summary?.agentPlan ?? null} activationStarted={anyActivationStarted} />
         </>
       ) : null}
     </div>

--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -144,6 +144,8 @@ describe("activateOnboardingHistory", () => {
     expect(sb.state.work_orders.some((row) => row.custom_id === "RO-6076")).toBe(true);
     expect(sb.state.work_orders.every((row) => row.type === "historical_import" && row.status === "completed")).toBe(true);
     expect(second.historicalWorkOrdersCreated).toBe(0);
+    expect(second.reviewItemsCreated).toBe(0);
+    expect(second.reviewItemsReused).toBeGreaterThan(0);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -27,7 +27,11 @@ type HistoryActivationResult = {
   vehicleLinksResolved: number;
   skipped: number;
   needsReview: number;
+  reviewItemsAttempted: number;
+  reviewItemsPersisted: number;
+  reviewItemsReused: number;
   reviewItemsCreated: number;
+  reviewItemsOpenForDomain: number;
   warnings: string[];
 };
 
@@ -298,15 +302,27 @@ export async function activateOnboardingHistory(params: {
     }
   }
 
+  let reviewItemsPersisted = 0;
+  let reviewItemsReused = 0;
   if (reviewItems.length > 0) {
-    await upsertOnboardingReviewItems({
+    const writeResult = await upsertOnboardingReviewItems({
       supabase: params.supabase,
       phase: "history",
       shopId: params.shopId,
       sessionId: params.sessionId,
       reviewItems,
     });
+    reviewItemsPersisted = writeResult.persisted;
+    reviewItemsReused = writeResult.reused;
   }
+  const { count: reviewItemsOpenCount, error: reviewItemsOpenError } = await sb
+    .from("onboarding_review_items")
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .eq("domain", "history")
+    .eq("status", "pending");
+  if (reviewItemsOpenError) throw new Error(reviewItemsOpenError.message);
 
   return {
     ok: true,
@@ -318,7 +334,11 @@ export async function activateOnboardingHistory(params: {
     vehicleLinksResolved,
     skipped,
     needsReview,
-    reviewItemsCreated: reviewItems.length,
+    reviewItemsAttempted: reviewItems.length,
+    reviewItemsPersisted,
+    reviewItemsReused,
+    reviewItemsCreated: Math.max(0, reviewItemsPersisted - reviewItemsReused),
+    reviewItemsOpenForDomain: Number(reviewItemsOpenCount ?? 0),
     warnings,
   };
 }

--- a/features/onboarding-agent/server/activateOnboardingParts.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.test.ts
@@ -268,7 +268,9 @@ describe("activateOnboardingParts", () => {
     expect(first.skipped).toBeGreaterThan(0);
     expect(first.reviewItemsCreated).toBeGreaterThan(0);
     expect(second.partsCreated).toBe(0);
-    expect(second.reviewItemsCreated).toBe(first.reviewItemsCreated);
+    expect(second.reviewItemsCreated).toBe(0);
+    expect(second.reviewItemsReused).toBeGreaterThan(0);
+    expect(second.reviewItemsPersisted).toBeGreaterThan(0);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingParts.ts
+++ b/features/onboarding-agent/server/activateOnboardingParts.ts
@@ -35,7 +35,11 @@ export type PartsActivationResult = {
   vendorLinksCreated: number;
   skipped: number;
   needsReview: number;
+  reviewItemsAttempted: number;
+  reviewItemsPersisted: number;
+  reviewItemsReused: number;
   reviewItemsCreated: number;
+  reviewItemsOpenForDomain: number;
   warnings: string[];
 };
 
@@ -322,15 +326,27 @@ export async function activateOnboardingParts(params: {
     }
   }
 
+  let reviewItemsPersisted = 0;
+  let reviewItemsReused = 0;
   if (reviewItems.length > 0) {
-    await upsertOnboardingReviewItems({
+    const writeResult = await upsertOnboardingReviewItems({
       supabase: params.supabase,
       phase: "parts",
       shopId: params.shopId,
       sessionId: params.sessionId,
       reviewItems,
     });
+    reviewItemsPersisted = writeResult.persisted;
+    reviewItemsReused = writeResult.reused;
   }
+  const { count: reviewItemsOpenCount, error: reviewItemsOpenError } = await sb
+    .from("onboarding_review_items")
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .eq("domain", "parts")
+    .eq("status", "pending");
+  if (reviewItemsOpenError) throw new Error(reviewItemsOpenError.message);
 
   return {
     ok: true,
@@ -343,7 +359,11 @@ export async function activateOnboardingParts(params: {
     vendorLinksCreated,
     skipped,
     needsReview,
-    reviewItemsCreated: reviewItems.length,
+    reviewItemsAttempted: reviewItems.length,
+    reviewItemsPersisted,
+    reviewItemsReused,
+    reviewItemsCreated: Math.max(0, reviewItemsPersisted - reviewItemsReused),
+    reviewItemsOpenForDomain: Number(reviewItemsOpenCount ?? 0),
     warnings,
   };
 }

--- a/features/onboarding-agent/server/activateOnboardingVendors.ts
+++ b/features/onboarding-agent/server/activateOnboardingVendors.ts
@@ -21,7 +21,11 @@ export type VendorActivationResult = {
   needsReview: number;
   suppliersBefore: number;
   suppliersAfter: number;
+  reviewItemsAttempted: number;
+  reviewItemsPersisted: number;
+  reviewItemsReused: number;
   reviewItemsCreated: number;
+  reviewItemsOpenForDomain: number;
   warnings: string[];
   records: Array<{
     entityId: string;
@@ -248,15 +252,27 @@ export async function activateOnboardingVendors(params: {
     records.push({ entityId: entity.id, supplierId: data?.id ?? null, action: "created", reason: "Created supplier" });
   }
 
+  let reviewItemsPersisted = 0;
+  let reviewItemsReused = 0;
   if (reviewItems.length > 0) {
-    await upsertOnboardingReviewItems({
+    const writeResult = await upsertOnboardingReviewItems({
       supabase: params.supabase,
       phase: "vendors",
       shopId: params.shopId,
       sessionId: params.sessionId,
       reviewItems,
     });
+    reviewItemsPersisted = writeResult.persisted;
+    reviewItemsReused = writeResult.reused;
   }
+  const { count: reviewItemsOpenCount, error: reviewItemsOpenError } = await sb
+    .from("onboarding_review_items")
+    .select("id", { head: true, count: "exact" })
+    .eq("shop_id", params.shopId)
+    .eq("session_id", params.sessionId)
+    .eq("domain", "vendors")
+    .eq("status", "pending");
+  if (reviewItemsOpenError) throw new Error(reviewItemsOpenError.message);
 
   const { count: suppliersAfterCount, error: suppliersAfterError } = await sb.from("suppliers").select("id", { head: true, count: "exact" }).eq("shop_id", params.shopId);
   if (suppliersAfterError) throw new Error(suppliersAfterError.message);
@@ -271,7 +287,11 @@ export async function activateOnboardingVendors(params: {
     needsReview,
     suppliersBefore,
     suppliersAfter: Number(suppliersAfterCount ?? supplierPool.length),
-    reviewItemsCreated: reviewItems.length,
+    reviewItemsAttempted: reviewItems.length,
+    reviewItemsPersisted,
+    reviewItemsReused,
+    reviewItemsCreated: Math.max(0, reviewItemsPersisted - reviewItemsReused),
+    reviewItemsOpenForDomain: Number(reviewItemsOpenCount ?? 0),
     warnings,
     records,
   };


### PR DESCRIPTION
### Motivation
- The activation UI showed misleading counts (e.g. “Review items created: 3200”) because attempted review-item generation was presented as persisted creations, causing operator confusion. 
- Activation copy remained staged-only even after real matches/writes ran, and the dry-run preview persisted in a way that suggested nothing live had occurred. 
- Operators needed clearer guidance about activation ordering (vendors → customers/vehicles → parts → history) and better grouping of repeated review exceptions for readability.

### Description
- Server-side: split activation result semantics for parts/history/vendors to return `reviewItemsAttempted`, `reviewItemsPersisted`, `reviewItemsReused`, `reviewItemsCreated` (new only) and `reviewItemsOpenForDomain` (pending persisted count) and use `upsertOnboardingReviewItems`’s returned metrics when writing review items. (files: `activateOnboardingParts.ts`, `activateOnboardingHistory.ts`, `activateOnboardingVendors.ts`).
- UI / presentation: changed activation summaries to a reconciled, operator-safe format that shows processed staged rows, created live records, matched existing records, skipped/unresolved, persisted/reused review items, and persisted open review exceptions; added per-phase formatted summaries. (file: `OnboardingSessionPage.tsx`).
- Copy and UX: made Agent Insights state-aware and added phase badges, relabeled the dry-run panel to an “Activation readiness snapshot” after activation runs, and explicitly preserved invoices as staged-only. (files: `OnboardingAgentInsightsPanel.tsx`, `OnboardingActivationPlanPanel.tsx`).
- Guidance and grouping: added activation-order guidance and non-blocking vendor/parts guidance near activation actions, and improved review exceptions display by grouping repeated issues (domain/severity/issue_type/summary) with counts and expandable examples. (files: `OnboardingSessionPage.tsx`, `OnboardingReviewPanel.tsx`).
- Tests: added and updated focused tests to assert new counter semantics, idempotency on reruns, activation-aware copy and dry-run relabeling, vendor-before-parts guidance, and grouping of repeated review issues. (files: `activateOnboardingParts.test.ts`, `activateOnboardingHistory.test.ts`, `OnboardingSessionPage.test.ts`).
- No DB migrations were added and invoice activation behavior was not changed.

### Testing
- Type-check: `npx tsc --noEmit --pretty false` completed successfully with no type errors. 
- Unit tests: `npx vitest run features/onboarding-agent` passed (Test Files: 16 passed, Tests: 100 passed). 
- Lint: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` ran and produced warnings but no errors. 
- All changes are scoped to onboarding activation summaries, copy, and review-display UX with tests updated to cover the new semantics and idempotency behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1009b912483289df73a109ae7a8da)