### PR TITLE
Fix history activation live-link resolution and blocked status messaging

### DIFF
--- a/features/onboarding-agent/components/OnboardingSessionPage.test.ts
+++ b/features/onboarding-agent/components/OnboardingSessionPage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, linkIssueReasonLabel, partsVendorGuidance, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, historyActivationState, linkIssueReasonLabel, partsVendorGuidance, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
 import { agentInsightsStateCopy } from "@/features/onboarding-agent/components/OnboardingAgentInsightsPanel";
 import { activationPreviewCopy } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
 import { groupReviewIssuesForDisplay } from "@/features/onboarding-agent/components/OnboardingReviewPanel";
@@ -74,5 +74,14 @@ describe("OnboardingSessionPage warning label helpers", () => {
     ]);
     expect(grouped).toHaveLength(1);
     expect(grouped[0]?.count).toBe(2);
+  });
+
+  it("does not mark history as activated when all processed rows were skipped", () => {
+    expect(historyActivationState({ stagedProcessed: 6076, created: 0, matched: 0, skipped: 6076 })).toBe("blocked");
+  });
+
+  it("marks history as activated when rows are created or matched", () => {
+    expect(historyActivationState({ stagedProcessed: 6076, created: 12, matched: 0, skipped: 6064 })).toBe("activated");
+    expect(historyActivationState({ stagedProcessed: 6076, created: 0, matched: 12, skipped: 6064 })).toBe("activated");
   });
 });

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -150,6 +150,12 @@ function formatActivationPhaseSummary(input: {
   return `${input.phaseLabel} activation: Processed: ${input.stagedProcessed.toLocaleString()} staged rows. Created: ${input.created.toLocaleString()} live records. Matched existing: ${input.matched.toLocaleString()} live records. Skipped/unresolved: ${input.skipped.toLocaleString()}. Review items persisted: ${input.reviewItemsPersisted.toLocaleString()}${reviewSuffix}. Review exceptions now open for ${input.phaseLabel.toLowerCase()}: ${input.openReviewForDomain.toLocaleString()}.${input.warning ?? ""}`;
 }
 
+export function historyActivationState(input: { stagedProcessed: number; created: number; matched: number; skipped: number }): "activated" | "blocked" | "not_run" {
+  if (input.created > 0 || input.matched > 0) return "activated";
+  if (input.stagedProcessed > 0 && input.skipped >= input.stagedProcessed) return "blocked";
+  return "not_run";
+}
+
 export function partsVendorGuidance(input: { canShowPartsActivation: boolean; vendorsActivated: boolean; vendorPartLinkCount: number }): string | null {
   if (!input.canShowPartsActivation) return null;
   if (!input.vendorsActivated) {
@@ -176,6 +182,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const [vendorActivationSummary, setVendorActivationSummary] = useState<string | null>(null);
   const [partsActivationSummary, setPartsActivationSummary] = useState<string | null>(null);
   const [historyActivationSummary, setHistoryActivationSummary] = useState<string | null>(null);
+  const [historyActivationOutcome, setHistoryActivationOutcome] = useState<"activated" | "blocked" | "not_run">("not_run");
   const [customerVehicleActivationResult, setCustomerVehicleActivationResult] = useState<any>(null);
   const [resolvingReviewItemId, setResolvingReviewItemId] = useState<string | null>(null);
   const [selectedCustomerByReviewItemId, setSelectedCustomerByReviewItemId] = useState<Record<string, string>>({});
@@ -386,12 +393,20 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
         const reviewItemsReused = asNumber(json?.reviewItemsReused);
         const skipped = asNumber(json?.skipped);
         const openReviewForDomain = asNumber(json?.reviewItemsOpenForDomain ?? byDomainCounts.history);
+        const skippedMissingCustomer = asNumber(json?.skippedMissingCustomer);
+        const skippedMissingVehicle = asNumber(json?.skippedMissingVehicle);
         const expectedReady = historyReadyCount;
         const processedLessThanExpected = expectedReady > 0 && stagedProcessed < expectedReady;
         const reconciliationTotal = created + matched + skipped;
         const reconciliationUnclear = stagedProcessed > 0 && reconciliationTotal > 0 && reconciliationTotal !== stagedProcessed;
         const warning = processedLessThanExpected || reconciliationUnclear
           ? " Activation processed fewer staged rows than expected. This may indicate a pagination or filtering issue."
+          : "";
+        const mappingBlocked = stagedProcessed > 0 && created === 0 && matched === 0 && skipped >= stagedProcessed;
+        const mappingReason = mappingBlocked
+          ? (skippedMissingCustomer > 0 || skippedMissingVehicle > 0
+            ? " Most rows were skipped because no live customer/vehicle mapping could be resolved."
+            : " History attempted: no historical work orders created.")
           : "";
         setHistoryActivationSummary(
           formatActivationPhaseSummary({
@@ -403,9 +418,10 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
             reviewItemsPersisted,
             reviewItemsReused,
             openReviewForDomain,
-            warning,
+            warning: `${warning}${mappingReason}`,
           }),
         );
+        setHistoryActivationOutcome(historyActivationState({ stagedProcessed, created, matched, skipped }));
       }
       await load();
     } catch {
@@ -880,7 +896,7 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
               customersVehicles: customerVehicleActivationResult ? "activated" : "not_run",
               vendors: vendorActivationSummary ? "activated" : "not_run",
               parts: partsActivationSummary ? "activated" : "not_run",
-              history: historyActivationSummary ? "activated" : "not_run",
+              history: historyActivationSummary ? historyActivationOutcome === "blocked" ? "not_run" : "activated" : "not_run",
             }}
           />
           <OnboardingFilesPanel files={files} />

--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -16,10 +16,17 @@ function fakeSb() {
   ].join("|");
 
   const state = {
-    entities: [{ id: "h-1", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" } }] as any[],
-    links: [] as any[],
-    customers: [{ id: "c-1", shop_id: "shop-1", external_id: null, email: null, name: "Acme", business_name: null }],
-    vehicles: [{ id: "v-1", shop_id: "shop-1", external_id: null, vin: "VIN1", license_plate: null }],
+    entities: [
+      { id: "h-1", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" } },
+      { id: "c-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "customer", status: "ready", source_external_id: "CUST-1", display_name: "Acme", normalized: { sourceCustomerId: "CUST-1", name: "Acme" } },
+      { id: "v-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "vehicle", status: "ready", source_external_id: "VEH-1", normalized: { sourceVehicleId: "VEH-1", vin: "VIN1" } },
+    ] as any[],
+    links: [
+      { id: "l-c-1", shop_id: "shop-1", session_id: "session-1", link_type: "customer_work_order", from_entity_id: "c-stage-1", to_entity_id: "h-1" },
+      { id: "l-v-1", shop_id: "shop-1", session_id: "session-1", link_type: "vehicle_work_order", from_entity_id: "v-stage-1", to_entity_id: "h-1" },
+    ] as any[],
+    customers: [{ id: "c-1", shop_id: "shop-1", external_id: "CUST-1", email: null, name: "Acme", business_name: null }],
+    vehicles: [{ id: "v-1", shop_id: "shop-1", external_id: "VEH-1", vin: "VIN1", license_plate: null }],
     work_orders: [] as any[],
     lines: [] as any[],
     reviewItems: [] as any[],
@@ -95,6 +102,18 @@ describe("activateOnboardingHistory", () => {
     expect(sb.state.work_orders[0].status).toBe("completed");
   });
 
+  it("resolves customer_work_order and vehicle_work_order links in either direction", async () => {
+    const sb = fakeSb();
+    sb.state.links = [
+      { id: "l-c-1", shop_id: "shop-1", session_id: "session-1", link_type: "customer_work_order", from_entity_id: "h-1", to_entity_id: "c-stage-1" },
+      { id: "l-v-1", shop_id: "shop-1", session_id: "session-1", link_type: "vehicle_work_order", from_entity_id: "v-stage-1", to_entity_id: "h-1" },
+    ];
+    const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.historicalWorkOrdersCreated).toBe(1);
+    expect(sb.state.work_orders[0].customer_id).toBe("c-1");
+    expect(sb.state.work_orders[0].vehicle_id).toBe("v-1");
+  });
+
   it("creates review item for missing identifier", async () => {
     const sb = fakeSb();
     sb.state.entities = [{ id: "h-2", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: {} }] as any[];
@@ -123,7 +142,7 @@ describe("activateOnboardingHistory", () => {
 
   it("paginates staged history rows over 1000 and keeps historical queue behavior", async () => {
     const sb = fakeSb();
-    sb.state.entities = Array.from({ length: 6076 }, (_, index) => ({
+    sb.state.entities = (Array.from({ length: 6076 }, (_, index) => ({
       id: `h-${index + 1}`,
       shop_id: "shop-1",
       session_id: "session-1",
@@ -132,7 +151,14 @@ describe("activateOnboardingHistory", () => {
       normalized: index === 6075
         ? { sourceWorkOrderId: `RO-${index + 1}`, openedDate: "2022-01-01", customerName: "Acme", vehicleVin: "VIN1", complaint: "Noise" }
         : { sourceWorkOrderId: `RO-${index + 1}` },
-    }));
+    })) as any[]).concat([
+      { id: "c-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "customer", status: "ready", source_external_id: "CUST-1", display_name: "Acme", normalized: { sourceCustomerId: "CUST-1", name: "Acme" } },
+      { id: "v-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "vehicle", status: "ready", source_external_id: "VEH-1", normalized: { sourceVehicleId: "VEH-1", vin: "VIN1" } },
+    ]);
+    sb.state.links = [
+      { id: "l-c-1", shop_id: "shop-1", session_id: "session-1", link_type: "customer_work_order", from_entity_id: "c-stage-1", to_entity_id: "h-6076" },
+      { id: "l-v-1", shop_id: "shop-1", session_id: "session-1", link_type: "vehicle_work_order", from_entity_id: "v-stage-1", to_entity_id: "h-6076" },
+    ];
 
     const first = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
     const second = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
@@ -146,6 +172,37 @@ describe("activateOnboardingHistory", () => {
     expect(second.historicalWorkOrdersCreated).toBe(0);
     expect(second.reviewItemsCreated).toBe(0);
     expect(second.reviewItemsReused).toBeGreaterThan(0);
+  });
+
+  it("skips unresolved mapping rows and does not create orphan work orders", async () => {
+    const sb = fakeSb();
+    sb.state.links = [];
+    sb.state.entities = [
+      { id: "h-1", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01" } },
+      { id: "c-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "customer", status: "ready", source_external_id: "CUST-1", display_name: "Acme", normalized: { sourceCustomerId: "CUST-1", name: "Acme" } },
+      { id: "v-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "vehicle", status: "ready", source_external_id: "VEH-1", normalized: { sourceVehicleId: "VEH-1", vin: "VIN1" } },
+    ] as any[];
+    const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.historicalWorkOrdersCreated).toBe(0);
+    expect(result.skippedUnresolved).toBe(1);
+    expect(result.skippedMissingCustomer).toBe(1);
+    expect(result.skippedMissingVehicle).toBe(1);
+    expect(sb.state.work_orders).toHaveLength(0);
+  });
+
+  it("rerun matches existing historical import and does not create duplicates", async () => {
+    const sb = fakeSb();
+    sb.state.work_orders.push({
+      id: "wo-existing",
+      shop_id: "shop-1",
+      custom_id: "RO-1",
+      source_row_id: "not-used",
+      type: "historical_import",
+      status: "completed",
+    });
+    const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.existingMatched).toBe(1);
+    expect(result.historicalWorkOrdersCreated).toBe(0);
   });
 
 });

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -26,6 +26,12 @@ type HistoryActivationResult = {
   customerLinksResolved: number;
   vehicleLinksResolved: number;
   skipped: number;
+  skippedUnresolved: number;
+  skippedMissingCustomer: number;
+  skippedMissingVehicle: number;
+  skippedMissingIdentifier: number;
+  skippedInvalidDate: number;
+  skippedInvalidTotal: number;
   needsReview: number;
   reviewItemsAttempted: number;
   reviewItemsPersisted: number;
@@ -74,6 +80,70 @@ function parseDate(value: unknown): string | null {
   const d = new Date(raw);
   if (Number.isNaN(d.getTime())) return null;
   return d.toISOString();
+}
+
+type ResolveLiveIdResult = { id: string | null; ambiguous: boolean };
+
+function normalizeEmail(value: unknown): string | null {
+  const normalized = normalizeText(value).toLowerCase();
+  return normalized || null;
+}
+
+function normalizeVin(value: unknown): string | null {
+  const normalized = normalizeText(value).toUpperCase().replace(/\s+/g, "");
+  return normalized || null;
+}
+
+function normalizePlate(value: unknown): string | null {
+  const normalized = normalizeText(value).toUpperCase().replace(/\s+/g, "");
+  return normalized || null;
+}
+
+function resolveStagedLinkEntityId(params: {
+  historyEntityId: string;
+  linkType: string;
+  targetEntityType: "customer" | "vehicle";
+  linkRows: Array<Pick<OnboardingEntityLinkRow, "from_entity_id" | "to_entity_id" | "link_type">>;
+  entityById: Map<string, Pick<OnboardingEntityRow, "id" | "entity_type">>;
+}): { id: string | null; ambiguous: boolean } {
+  const matches = params.linkRows.filter((row) => row.link_type === params.linkType && (row.from_entity_id === params.historyEntityId || row.to_entity_id === params.historyEntityId));
+  const candidateEntityIds = new Set<string>();
+  for (const row of matches) {
+    const candidateId = row.from_entity_id === params.historyEntityId ? row.to_entity_id : row.from_entity_id;
+    const candidate = params.entityById.get(candidateId);
+    if (candidate?.entity_type === params.targetEntityType) candidateEntityIds.add(candidateId);
+  }
+  if (candidateEntityIds.size === 1) return { id: [...candidateEntityIds][0] ?? null, ambiguous: false };
+  if (candidateEntityIds.size > 1) return { id: null, ambiguous: true };
+  return { id: null, ambiguous: false };
+}
+
+function resolveLiveCustomerIdFromStagedEntity(stagedEntity: Pick<OnboardingEntityRow, "source_external_id" | "display_name" | "normalized"> | null, customerRows: CustomerRow[]): ResolveLiveIdResult {
+  if (!stagedEntity) return { id: null, ambiguous: false };
+  const normalized = (stagedEntity.normalized ?? {}) as Record<string, unknown>;
+  const sourceCustomerId = normalizeText(stagedEntity.source_external_id ?? normalized.sourceCustomerId) || null;
+  const customerEmail = normalizeEmail(normalized.email);
+  const customerName = normalizeText(normalized.businessName ?? normalized.name ?? stagedEntity.display_name) || null;
+  const matches = customerRows.filter((row) =>
+    (sourceCustomerId && normalizeLookup(row.external_id) === normalizeLookup(sourceCustomerId))
+    || (customerEmail && normalizeLookup(row.email) === normalizeLookup(customerEmail))
+    || (customerName && normalizeLookup(row.business_name || row.name || `${row.first_name ?? ""} ${row.last_name ?? ""}`) === normalizeLookup(customerName)));
+  if (matches.length === 1) return { id: matches[0]!.id, ambiguous: false };
+  return { id: null, ambiguous: matches.length > 1 };
+}
+
+function resolveLiveVehicleIdFromStagedEntity(stagedEntity: Pick<OnboardingEntityRow, "source_external_id" | "normalized"> | null, vehicleRows: VehicleRow[]): ResolveLiveIdResult {
+  if (!stagedEntity) return { id: null, ambiguous: false };
+  const normalized = (stagedEntity.normalized ?? {}) as Record<string, unknown>;
+  const sourceVehicleId = normalizeText(stagedEntity.source_external_id ?? normalized.sourceVehicleId) || null;
+  const vehicleVin = normalizeVin(normalized.vin);
+  const vehiclePlate = normalizePlate(normalized.plate);
+  const matches = vehicleRows.filter((row) =>
+    (sourceVehicleId && normalizeLookup(row.external_id) === normalizeLookup(sourceVehicleId))
+    || (vehicleVin && normalizeVin(row.vin) === vehicleVin)
+    || (vehiclePlate && normalizePlate(row.license_plate) === vehiclePlate));
+  if (matches.length === 1) return { id: matches[0]!.id, ambiguous: false };
+  return { id: null, ambiguous: matches.length > 1 };
 }
 
 function toNormalizedHistory(entity: Pick<OnboardingEntityRow, "normalized">): NormalizedHistory {
@@ -128,14 +198,24 @@ export async function activateOnboardingHistory(params: {
   const sb = params.supabase as any;
   await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
 
-  const [historyRows, linkRows, customerRows, vehicleRows, workOrders] = await Promise.all([
-    fetchAllPaginatedRows<Pick<OnboardingEntityRow, "id" | "normalized">>((from, to) =>
+  const [historyRows, entityRows, linkRows, customerRows, vehicleRows, workOrders] = await Promise.all([
+    fetchAllPaginatedRows<Pick<OnboardingEntityRow, "id" | "normalized" | "entity_type">>((from, to) =>
       sb
         .from("onboarding_entities")
-        .select("id, normalized")
+        .select("id, normalized, entity_type")
         .eq("shop_id", params.shopId)
         .eq("session_id", params.sessionId)
         .eq("entity_type", "historical_work_order")
+        .eq("status", "ready")
+        .order("id", { ascending: true })
+        .range(from, to)),
+    fetchAllPaginatedRows<Pick<OnboardingEntityRow, "id" | "normalized" | "entity_type" | "source_external_id" | "display_name">>((from, to) =>
+      sb
+        .from("onboarding_entities")
+        .select("id, normalized, entity_type, source_external_id, display_name")
+        .eq("shop_id", params.shopId)
+        .eq("session_id", params.sessionId)
+        .in("entity_type", ["customer", "vehicle"])
         .eq("status", "ready")
         .order("id", { ascending: true })
         .range(from, to)),
@@ -150,7 +230,7 @@ export async function activateOnboardingHistory(params: {
     fetchAllPaginatedRows<CustomerRow>((from, to) =>
       sb
         .from("customers")
-        .select("id, external_id, email, name, business_name")
+        .select("id, external_id, email, name, business_name, first_name, last_name")
         .eq("shop_id", params.shopId)
         .order("id", { ascending: true })
         .range(from, to)),
@@ -181,67 +261,111 @@ export async function activateOnboardingHistory(params: {
   let customerLinksResolved = 0;
   let vehicleLinksResolved = 0;
   let skipped = 0;
+  let skippedUnresolved = 0;
+  let skippedMissingCustomer = 0;
+  let skippedMissingVehicle = 0;
+  let skippedMissingIdentifier = 0;
+  let skippedInvalidDate = 0;
+  let skippedInvalidTotal = 0;
   let needsReview = 0;
+  const entityById = new Map<string, Pick<OnboardingEntityRow, "id" | "entity_type">>([
+    ...historyRows.map((row) => [row.id, { id: row.id, entity_type: row.entity_type }] as const),
+    ...entityRows.map((row) => [row.id, { id: row.id, entity_type: row.entity_type }] as const),
+  ]);
+  const customerEntityById = new Map(entityRows.filter((row) => row.entity_type === "customer").map((row) => [row.id, row]));
+  const vehicleEntityById = new Map(entityRows.filter((row) => row.entity_type === "vehicle").map((row) => [row.id, row]));
 
   for (const entity of historyRows) {
     const history = toNormalizedHistory(entity);
     if (!history.sourceWorkOrderId && !history.invoiceNumber && !history.openedDate) {
       skipped += 1;
+      skippedMissingIdentifier += 1;
       needsReview += 1;
       reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_required_history_identifier", summary: "Historical row skipped: missing identifier.", severity: "high" }));
       continue;
     }
     if (!history.openedDate) {
       skipped += 1;
+      skippedInvalidDate += 1;
       needsReview += 1;
       reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_history_date", summary: "Historical row skipped: invalid opened date." }));
       continue;
     }
     if (history.total !== null && history.total < 0) {
+      skippedInvalidTotal += 1;
       reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "invalid_history_total", summary: "Historical row has invalid total.", details: { total: history.total } }));
       needsReview += 1;
     }
 
-    const link = linkRows.find((row) => row.link_type === "customer_vehicle" && (row.from_entity_id === entity.id || row.to_entity_id === entity.id));
-    if (!link) {
-      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "unresolved_customer_vehicle_link_for_history", summary: "Historical work order missing staged customer/vehicle link." }));
-      needsReview += 1;
+    const stagedCustomerLink = resolveStagedLinkEntityId({ historyEntityId: entity.id, linkType: "customer_work_order", targetEntityType: "customer", linkRows, entityById });
+    const stagedVehicleLink = resolveStagedLinkEntityId({ historyEntityId: entity.id, linkType: "vehicle_work_order", targetEntityType: "vehicle", linkRows, entityById });
+    const linkedStagedCustomer = stagedCustomerLink.id ? customerEntityById.get(stagedCustomerLink.id) ?? null : null;
+    const linkedStagedVehicle = stagedVehicleLink.id ? vehicleEntityById.get(stagedVehicleLink.id) ?? null : null;
+
+    const customerResolvedByLink = resolveLiveCustomerIdFromStagedEntity(linkedStagedCustomer, customerRows);
+    const vehicleResolvedByLink = resolveLiveVehicleIdFromStagedEntity(linkedStagedVehicle, vehicleRows);
+
+    let customerId = customerResolvedByLink.id;
+    let vehicleId = vehicleResolvedByLink.id;
+
+    if (!customerId) {
+      const fallbackCustomerMatches = customerRows.filter((row) =>
+        (history.sourceCustomerId && normalizeLookup(row.external_id) === normalizeLookup(history.sourceCustomerId))
+        || (history.customerEmail && normalizeLookup(row.email) === normalizeLookup(history.customerEmail))
+        || (history.customerName && normalizeLookup(row.business_name || row.name || `${row.first_name ?? ""} ${row.last_name ?? ""}`) === normalizeLookup(history.customerName)));
+      if (fallbackCustomerMatches.length === 1) customerId = fallbackCustomerMatches[0]!.id;
+      else if (fallbackCustomerMatches.length > 1 && !customerResolvedByLink.ambiguous) customerResolvedByLink.ambiguous = true;
+    }
+    if (!vehicleId) {
+      const fallbackVehicleMatches = vehicleRows.filter((row) =>
+        (history.sourceVehicleId && normalizeLookup(row.external_id) === normalizeLookup(history.sourceVehicleId))
+        || (history.vehicleVin && normalizeVin(row.vin) === normalizeVin(history.vehicleVin))
+        || (history.vehiclePlate && normalizePlate(row.license_plate) === normalizePlate(history.vehiclePlate)));
+      if (fallbackVehicleMatches.length === 1) vehicleId = fallbackVehicleMatches[0]!.id;
+      else if (fallbackVehicleMatches.length > 1 && !vehicleResolvedByLink.ambiguous) vehicleResolvedByLink.ambiguous = true;
     }
 
-    const customerMatches = customerRows.filter((row) =>
-      (history.sourceCustomerId && normalizeLookup(row.external_id) === normalizeLookup(history.sourceCustomerId))
-      || (history.customerEmail && normalizeLookup(row.email) === normalizeLookup(history.customerEmail))
-      || (history.customerName && normalizeLookup(row.business_name || row.name) === normalizeLookup(history.customerName)),
-    );
-    const vehicleMatches = vehicleRows.filter((row) =>
-      (history.sourceVehicleId && normalizeLookup(row.external_id) === normalizeLookup(history.sourceVehicleId))
-      || (history.vehicleVin && normalizeLookup(row.vin) === normalizeLookup(history.vehicleVin))
-      || (history.vehiclePlate && normalizeLookup(row.license_plate) === normalizeLookup(history.vehiclePlate)),
-    );
+    if (customerId) customerLinksResolved += 1;
+    if (vehicleId) vehicleLinksResolved += 1;
 
-    let customerId: string | null = null;
-    let vehicleId: string | null = null;
-
-    if (customerMatches.length === 1) {
-      customerId = customerMatches[0]!.id;
-      customerLinksResolved += 1;
-    } else if (customerMatches.length > 1) {
-      needsReview += 1;
-      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "ambiguous_customer_match_for_history", summary: "Historical work order has ambiguous customer match." }));
-    } else {
-      needsReview += 1;
-      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_customer_for_history", summary: "Historical work order customer could not be matched." }));
-    }
-
-    if (vehicleMatches.length === 1) {
-      vehicleId = vehicleMatches[0]!.id;
-      vehicleLinksResolved += 1;
-    } else if (vehicleMatches.length > 1) {
-      needsReview += 1;
-      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "ambiguous_vehicle_match_for_history", summary: "Historical work order has ambiguous vehicle match." }));
-    } else {
-      needsReview += 1;
-      reviewItems.push(reviewItem({ shopId: params.shopId, sessionId: params.sessionId, entityId: entity.id, issueType: "missing_vehicle_for_history", summary: "Historical work order vehicle could not be matched." }));
+    if (!customerId || !vehicleId) {
+      skipped += 1;
+      skippedUnresolved += 1;
+      if (!customerId) {
+        skippedMissingCustomer += 1;
+        needsReview += 1;
+        reviewItems.push(reviewItem({
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          entityId: entity.id,
+          issueType: customerResolvedByLink.ambiguous || stagedCustomerLink.ambiguous ? "ambiguous_customer_match_for_history" : "missing_customer_for_history",
+          summary: customerResolvedByLink.ambiguous || stagedCustomerLink.ambiguous
+            ? "Historical work order has ambiguous customer mapping."
+            : "Historical work order customer could not be matched.",
+          details: {
+            stagedCustomerEntityId: stagedCustomerLink.id,
+            hasCustomerWorkOrderLink: Boolean(stagedCustomerLink.id),
+          },
+        }));
+      }
+      if (!vehicleId) {
+        skippedMissingVehicle += 1;
+        needsReview += 1;
+        reviewItems.push(reviewItem({
+          shopId: params.shopId,
+          sessionId: params.sessionId,
+          entityId: entity.id,
+          issueType: vehicleResolvedByLink.ambiguous || stagedVehicleLink.ambiguous ? "ambiguous_vehicle_match_for_history" : "missing_vehicle_for_history",
+          summary: vehicleResolvedByLink.ambiguous || stagedVehicleLink.ambiguous
+            ? "Historical work order has ambiguous vehicle mapping."
+            : "Historical work order vehicle could not be matched.",
+          details: {
+            stagedVehicleEntityId: stagedVehicleLink.id,
+            hasVehicleWorkOrderLink: Boolean(stagedVehicleLink.id),
+          },
+        }));
+      }
+      continue;
     }
 
     const sourceRowKey = stableUuidFromParts([params.shopId, params.sessionId, "history", entity.id]);
@@ -323,6 +447,9 @@ export async function activateOnboardingHistory(params: {
     .eq("domain", "history")
     .eq("status", "pending");
   if (reviewItemsOpenError) throw new Error(reviewItemsOpenError.message);
+  if (skippedUnresolved > 0) {
+    warnings.push("Most skipped history rows were unresolved because no live customer/vehicle mapping could be resolved from staged links.");
+  }
 
   return {
     ok: true,
@@ -333,6 +460,12 @@ export async function activateOnboardingHistory(params: {
     customerLinksResolved,
     vehicleLinksResolved,
     skipped,
+    skippedUnresolved,
+    skippedMissingCustomer,
+    skippedMissingVehicle,
+    skippedMissingIdentifier,
+    skippedInvalidDate,
+    skippedInvalidTotal,
     needsReview,
     reviewItemsAttempted: reviewItems.length,
     reviewItemsPersisted,


### PR DESCRIPTION
### Motivation

- History activation was skipping all staged rows because it did not reliably resolve staged `customer_work_order` / `vehicle_work_order` links into staged customer/vehicle entities and then live IDs, producing misleading “activated” UI state when nothing was materialized.
- The intent is to create historical work orders only when both live `customer_id` and `vehicle_id` can be deterministically resolved (via staged links → staged entity → live lookup) while preserving existing review/skip behavior for genuinely unresolved rows.

### Description

- Added staged-link traversal and live-ID resolution helpers to `activateOnboardingHistory.ts` so history rows resolve: history entity → `customer_work_order`/`vehicle_work_order` link → staged customer/vehicle entity → live customer/vehicle lookup, with bidirectional link handling and safe fallback matching. (file: `features/onboarding-agent/server/activateOnboardingHistory.ts`)
- Introduced explicit skip counters and diagnostics in the history activation response (`skippedUnresolved`, `skippedMissingCustomer`, `skippedMissingVehicle`, `skippedMissingIdentifier`, `skippedInvalidDate`, `skippedInvalidTotal`) and an explanatory warning when link-to-live resolution is the dominant skip reason. (file: `features/onboarding-agent/server/activateOnboardingHistory.ts`)
- Prevented creation of orphan historical work orders when either live `customer_id` or `vehicle_id` cannot be resolved, and preserved idempotent rerun behavior and existing `type=historical_import` / `status=completed` semantics. (file: `features/onboarding-agent/server/activateOnboardingHistory.ts`)
- Updated onboarding UI to avoid showing “History: activated” when a history run processed rows but created=0 and matched=0 and skipped == processed, instead showing a blocked/blocked-with-reason state and operator-readable summary text; added `historyActivationState` helper and updated summary wording. (files: `features/onboarding-agent/components/OnboardingSessionPage.tsx`, `features/onboarding-agent/components/OnboardingSessionPage.test.ts`)
- Added and updated focused tests to cover bidirectional link resolution, unresolved-row skipping (no orphan work orders), idempotent reruns, and UI blocked-vs-activated logic. (file: `features/onboarding-agent/server/activateOnboardingHistory.test.ts`)
- No database migrations were added and invoice activation behavior was left unchanged (invoices remain staged only).

### Testing

- Type-check: ran `npx tsc --noEmit --pretty false` and it completed successfully.
- Unit tests: ran `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (105 tests passed across the suite after changes).  Also ran targeted tests `npx vitest run features/onboarding-agent/server/activateOnboardingHistory.test.ts features/onboarding-agent/components/OnboardingSessionPage.test.ts` and they passed.
- Lint: ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which completed with warnings only and no blocking errors.

Files changed: `features/onboarding-agent/server/activateOnboardingHistory.ts`, `features/onboarding-agent/server/activateOnboardingHistory.test.ts`, `features/onboarding-agent/components/OnboardingSessionPage.tsx`, and `features/onboarding-agent/components/OnboardingSessionPage.test.ts`.

Expected effect: history activation will now materialize historical work orders for rows that have staged customer/vehicle links to already-activated live customers/vehicles, skip only genuinely unresolved or invalid rows, and present an accurate operator-facing activation state and summary message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10b9f5fb483288ed3176ed1ad40cf)