### PR TITLE
Fix onboarding history activation live resolution from staged links

### DIFF
--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -127,6 +127,28 @@ describe("activateOnboardingHistory", () => {
     expect(result.resolvedViaVehicleWorkOrderLink).toBe(1);
   });
 
+  it("resolves linked staged entities via grouped canonical staged identity when linked rows are sparse", async () => {
+    const sb = fakeSb();
+    sb.state.entities = [
+      { id: "h-1", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01" } },
+      { id: "c-stage-linked", shop_id: "shop-1", session_id: "session-1", entity_type: "customer", status: "activated", source_external_id: null, display_name: "Acme", normalized: { name: "Acme", email: null } },
+      { id: "c-stage-canonical", shop_id: "shop-1", session_id: "session-1", entity_type: "customer", status: "activated", source_external_id: "CUST-1", display_name: "Acme", normalized: { sourceCustomerId: "CUST-1", name: "Acme", email: "acme@example.com" } },
+      { id: "v-stage-linked", shop_id: "shop-1", session_id: "session-1", entity_type: "vehicle", status: "activated", source_external_id: null, normalized: { make: "Ford", model: "F150", year: 2021 } },
+      { id: "v-stage-canonical", shop_id: "shop-1", session_id: "session-1", entity_type: "vehicle", status: "activated", source_external_id: "VEH-1", normalized: { sourceVehicleId: "VEH-1", vin: "VIN1", make: "Ford", model: "F150", year: 2021 } },
+    ] as any[];
+    sb.state.links = [
+      { id: "l-c-1", shop_id: "shop-1", session_id: "session-1", link_type: "customer_work_order", from_entity_id: "c-stage-linked", to_entity_id: "h-1" },
+      { id: "l-v-1", shop_id: "shop-1", session_id: "session-1", link_type: "vehicle_work_order", from_entity_id: "v-stage-linked", to_entity_id: "h-1" },
+    ] as any[];
+    sb.state.customers = [{ id: "c-1", shop_id: "shop-1", external_id: "CUST-1", email: "acme@example.com", name: "Acme", business_name: null }] as any[];
+    sb.state.vehicles = [{ id: "v-1", shop_id: "shop-1", external_id: "VEH-1", vin: "VIN1", license_plate: null, unit_number: null, year: 2021, make: "Ford", model: "F150" }] as any[];
+
+    const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.historicalWorkOrdersCreated).toBe(1);
+    expect(result.skippedUnresolved).toBe(0);
+    expect(result.diagnostics.rowsWithBothLiveCustomerAndVehicle).toBe(1);
+  });
+
   it("resolves live vehicle from staged unit number mapping used by customer/vehicle activation", async () => {
     const sb = fakeSb();
     sb.state.entities = [

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -114,6 +114,23 @@ type NormalizedVehicle = {
   model: string | null;
 };
 
+function customerIdentityKey(input: NormalizedCustomer): string | null {
+  if (input.email) return `email:${normalizeLookup(input.email)}`;
+  if (input.sourceCustomerId) return `external:${normalizeLookup(input.sourceCustomerId)}`;
+  if (input.phone) return `phone:${input.phone}`;
+  if (input.name) return `name:${normalizeLookup(input.name)}`;
+  return null;
+}
+
+function vehicleIdentityKey(input: NormalizedVehicle): string | null {
+  if (input.vin) return `vin:${normalizeVin(input.vin)}`;
+  if (input.sourceVehicleId) return `external:${normalizeLookup(input.sourceVehicleId)}`;
+  if (input.plate) return `plate:${normalizePlate(input.plate)}`;
+  if (input.unitNumber) return `unit:${normalizeLookup(input.unitNumber)}`;
+  const descriptor = vehicleDescriptorKey(input);
+  return descriptor ? `descriptor:${descriptor}` : null;
+}
+
 function normalizeText(value: unknown): string {
   return String(value ?? "").trim();
 }
@@ -231,6 +248,77 @@ function resolveLiveVehicleIdFromStagedEntity(stagedEntity: Pick<OnboardingEntit
     || (descriptor && vehicleDescriptorKey({ year: row.year, make: normalizeLookup(row.make), model: normalizeLookup(row.model) }) === descriptor));
   if (matches.length === 1) return { id: matches[0]!.id, ambiguous: false };
   return { id: null, ambiguous: matches.length > 1 };
+}
+
+function buildGroupedCustomerLiveMap(customerEntities: Array<Pick<OnboardingEntityRow, "id" | "source_external_id" | "display_name" | "normalized">>, customerRows: CustomerRow[]) {
+  const grouped = new Map<string, { entityIds: string[]; normalized: NormalizedCustomer }>();
+  for (const entity of customerEntities) {
+    const normalized = toNormalizedCustomer(entity);
+    const key = customerIdentityKey(normalized) ?? `entity:${entity.id}`;
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, { entityIds: [entity.id], normalized });
+      continue;
+    }
+    existing.entityIds.push(entity.id);
+    existing.normalized = {
+      sourceCustomerId: existing.normalized.sourceCustomerId ?? normalized.sourceCustomerId,
+      email: existing.normalized.email ?? normalized.email,
+      phone: existing.normalized.phone ?? normalized.phone,
+      name: existing.normalized.name ?? normalized.name,
+    };
+  }
+
+  const stagedCustomerEntityIdToLiveCustomerId = new Map<string, string>();
+  for (const group of grouped.values()) {
+    const matches = customerRows.filter((row) =>
+      (group.normalized.sourceCustomerId && normalizeLookup(row.external_id) === normalizeLookup(group.normalized.sourceCustomerId))
+      || (group.normalized.email && normalizeLookup(row.email) === normalizeLookup(group.normalized.email))
+      || (group.normalized.phone && normalizePhone(row.phone ?? row.phone_number) === group.normalized.phone)
+      || (group.normalized.name && normalizeLookup(row.business_name || row.name || `${row.first_name ?? ""} ${row.last_name ?? ""}`) === normalizeLookup(group.normalized.name)));
+    if (matches.length !== 1) continue;
+    const id = matches[0]!.id;
+    for (const entityId of group.entityIds) stagedCustomerEntityIdToLiveCustomerId.set(entityId, id);
+  }
+  return stagedCustomerEntityIdToLiveCustomerId;
+}
+
+function buildGroupedVehicleLiveMap(vehicleEntities: Array<Pick<OnboardingEntityRow, "id" | "source_external_id" | "normalized">>, vehicleRows: VehicleRow[]) {
+  const grouped = new Map<string, { entityIds: string[]; normalized: NormalizedVehicle }>();
+  for (const entity of vehicleEntities) {
+    const normalized = toNormalizedVehicle(entity);
+    const key = vehicleIdentityKey(normalized) ?? `entity:${entity.id}`;
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, { entityIds: [entity.id], normalized });
+      continue;
+    }
+    existing.entityIds.push(entity.id);
+    existing.normalized = {
+      sourceVehicleId: existing.normalized.sourceVehicleId ?? normalized.sourceVehicleId,
+      vin: existing.normalized.vin ?? normalized.vin,
+      plate: existing.normalized.plate ?? normalized.plate,
+      unitNumber: existing.normalized.unitNumber ?? normalized.unitNumber,
+      year: existing.normalized.year ?? normalized.year,
+      make: existing.normalized.make ?? normalized.make,
+      model: existing.normalized.model ?? normalized.model,
+    };
+  }
+
+  const stagedVehicleEntityIdToLiveVehicleId = new Map<string, string>();
+  for (const group of grouped.values()) {
+    const descriptor = vehicleDescriptorKey(group.normalized);
+    const matches = vehicleRows.filter((row) =>
+      (group.normalized.sourceVehicleId && normalizeLookup(row.external_id) === normalizeLookup(group.normalized.sourceVehicleId))
+      || (group.normalized.vin && normalizeVin(row.vin) === group.normalized.vin)
+      || (group.normalized.plate && normalizePlate(row.license_plate) === group.normalized.plate)
+      || (group.normalized.unitNumber && normalizeLookup(row.unit_number) === group.normalized.unitNumber)
+      || (descriptor && vehicleDescriptorKey({ year: row.year, make: normalizeLookup(row.make), model: normalizeLookup(row.model) }) === descriptor));
+    if (matches.length !== 1) continue;
+    const id = matches[0]!.id;
+    for (const entityId of group.entityIds) stagedVehicleEntityIdToLiveVehicleId.set(entityId, id);
+  }
+  return stagedVehicleEntityIdToLiveVehicleId;
 }
 
 function toNormalizedHistory(entity: Pick<OnboardingEntityRow, "normalized">): NormalizedHistory {
@@ -426,33 +514,31 @@ export async function activateOnboardingHistory(params: {
     }
   }
 
-  const stagedCustomerEntityIdToLiveCustomerId = new Map<string, string>();
+  const stagedCustomerEntityIdToLiveCustomerId = buildGroupedCustomerLiveMap([...customerEntityById.values()], customerRows);
   const stagedCustomerSourceRowIdToLiveCustomerId = new Map<string, string>();
   const stagedCustomerExternalIdToLiveCustomerId = new Map<string, string>();
   for (const entity of customerEntityById.values()) {
-    const resolved = resolveLiveCustomerIdFromStagedEntity(entity, customerRows);
-    if (!resolved.id || resolved.ambiguous) continue;
-    stagedCustomerEntityIdToLiveCustomerId.set(entity.id, resolved.id);
+    const resolvedId = stagedCustomerEntityIdToLiveCustomerId.get(entity.id);
+    if (!resolvedId) continue;
     const sourceRowKey = normalizeText(entity.source_row_id);
-    if (sourceRowKey) stagedCustomerSourceRowIdToLiveCustomerId.set(sourceRowKey, resolved.id);
+    if (sourceRowKey) stagedCustomerSourceRowIdToLiveCustomerId.set(sourceRowKey, resolvedId);
     const externalKey = normalizeLookup(entity.source_external_id);
-    if (externalKey) stagedCustomerExternalIdToLiveCustomerId.set(externalKey, resolved.id);
+    if (externalKey) stagedCustomerExternalIdToLiveCustomerId.set(externalKey, resolvedId);
   }
 
-  const stagedVehicleEntityIdToLiveVehicleId = new Map<string, string>();
+  const stagedVehicleEntityIdToLiveVehicleId = buildGroupedVehicleLiveMap([...vehicleEntityById.values()], vehicleRows);
   const stagedVehicleSourceRowIdToLiveVehicleId = new Map<string, string>();
   const stagedVehicleExternalIdToLiveVehicleId = new Map<string, string>();
   const stagedVehicleVinToLiveVehicleId = new Map<string, string>();
   for (const entity of vehicleEntityById.values()) {
-    const resolved = resolveLiveVehicleIdFromStagedEntity(entity, vehicleRows);
-    if (!resolved.id || resolved.ambiguous) continue;
-    stagedVehicleEntityIdToLiveVehicleId.set(entity.id, resolved.id);
+    const resolvedId = stagedVehicleEntityIdToLiveVehicleId.get(entity.id);
+    if (!resolvedId) continue;
     const sourceRowKey = normalizeText(entity.source_row_id);
-    if (sourceRowKey) stagedVehicleSourceRowIdToLiveVehicleId.set(sourceRowKey, resolved.id);
+    if (sourceRowKey) stagedVehicleSourceRowIdToLiveVehicleId.set(sourceRowKey, resolvedId);
     const externalKey = normalizeLookup(entity.source_external_id);
-    if (externalKey) stagedVehicleExternalIdToLiveVehicleId.set(externalKey, resolved.id);
+    if (externalKey) stagedVehicleExternalIdToLiveVehicleId.set(externalKey, resolvedId);
     const vinKey = normalizeVin((entity.normalized ?? ({} as any)).vin);
-    if (vinKey) stagedVehicleVinToLiveVehicleId.set(vinKey, resolved.id);
+    if (vinKey) stagedVehicleVinToLiveVehicleId.set(vinKey, resolvedId);
   }
 
   for (const entity of historyRows) {


### PR DESCRIPTION
### Motivation
- Historical activation was processing staged history rows but skipping all rows because live customer/vehicle IDs were not being deterministically resolved from sparse staged links. 
- The goal is to ensure resolvable history rows create or match historical `work_orders` while preserving `shop_id` scoping, RLS/service-role patterns, idempotency, and the requirement that historical imports remain closed/historical only.

### Description
- Add session-scoped grouped staged identity maps and identity-key helpers (`customerIdentityKey`, `vehicleIdentityKey`) that aggregate staged customer/vehicle entities and deterministically map them to live rows, so sparse linked staged entities inherit canonical resolution used by customer/vehicle activation. 
- Use the grouped maps in the history activation resolution path instead of relying only on single-entity direct resolution, while preserving the existing bidirectional `customer_work_order` / `vehicle_work_order` traversal and the requirement that both live customer and vehicle must be resolved before creating a historical work order. 
- Preserve historical constraints: created work orders still use `type = 'historical_import'` and `status = 'completed'`, invoices remain staged-only, and idempotency is retained via the existing `source_row_id`/custom id matching. 
- Files changed: `features/onboarding-agent/server/activateOnboardingHistory.ts` and `features/onboarding-agent/server/activateOnboardingHistory.test.ts` (added a regression test for sparse-linked staged entities resolving via grouped canonical identity).

### Testing
- Ran `npx tsc --noEmit --pretty false` which succeeded with no new type errors. 
- Ran `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (existing + new tests; test suite passed). 
- Ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which produced only pre-existing warnings and no errors. 
- New regression test verifies a history row linked to sparse staged customer/vehicle rows resolves to live IDs via the grouped identity map and creates a historical work order (passes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12153089083288971d9218fcfb6d2)