### PR TITLE
Add runtime diagnostics and full developer-details visibility for history activation

### DIFF
--- a/features/onboarding-agent/components/OnboardingSessionPage.test.ts
+++ b/features/onboarding-agent/components/OnboardingSessionPage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, historyActivationState, linkIssueReasonLabel, partsVendorGuidance, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
+import { getCustomerDisplayLabel, getVehicleDisplayLabel, groupReviewItemsByDomain, historyActivationState, historyDiagnosticsExtra, linkIssueReasonLabel, partsVendorGuidance, unresolvedReviewPrimaryCopy } from "@/features/onboarding-agent/components/OnboardingSessionPage";
 import { agentInsightsStateCopy } from "@/features/onboarding-agent/components/OnboardingAgentInsightsPanel";
 import { activationPreviewCopy } from "@/features/onboarding-agent/components/OnboardingActivationPlanPanel";
 import { groupReviewIssuesForDisplay } from "@/features/onboarding-agent/components/OnboardingReviewPanel";
@@ -83,5 +83,18 @@ describe("OnboardingSessionPage warning label helpers", () => {
   it("marks history as activated when rows are created or matched", () => {
     expect(historyActivationState({ stagedProcessed: 6076, created: 12, matched: 0, skipped: 6064 })).toBe("activated");
     expect(historyActivationState({ stagedProcessed: 6076, created: 0, matched: 12, skipped: 6064 })).toBe("activated");
+  });
+
+  it("keeps unknown history diagnostics keys for developer-details JSON fallback", () => {
+    const extras = historyDiagnosticsExtra({
+      stagedHistoryRows: 10,
+      runtime: { diagnosticVersion: "history-endpoint-first-v3" },
+      customFutureCounter: 42,
+      nestedFutureShape: { foo: "bar" },
+    });
+    expect(extras).toEqual({
+      customFutureCounter: 42,
+      nestedFutureShape: { foo: "bar" },
+    });
   });
 });

--- a/features/onboarding-agent/components/OnboardingSessionPage.tsx
+++ b/features/onboarding-agent/components/OnboardingSessionPage.tsx
@@ -171,6 +171,32 @@ export function partsVendorGuidance(input: { canShowPartsActivation: boolean; ve
   return null;
 }
 
+export function historyDiagnosticsExtra(details: Record<string, unknown> | null | undefined): Record<string, unknown> {
+  if (!details || typeof details !== "object") return {};
+  const knownKeys = new Set([
+    "runtime",
+    "stagedHistoryRows",
+    "customerWorkOrderLinks",
+    "vehicleWorkOrderLinks",
+    "historyRowsWithCustomerLink",
+    "historyRowsWithVehicleLink",
+    "linkedCustomerStagedEntitiesFound",
+    "linkedVehicleStagedEntitiesFound",
+    "linkedCustomerLiveResolved",
+    "linkedVehicleLiveResolved",
+    "rowsWithBothLiveCustomerAndVehicle",
+    "rowsMissingLiveCustomer",
+    "rowsMissingLiveVehicle",
+    "rowsMissingBoth",
+    "rowsInvalidDate",
+    "rowsMissingRequiredIdentifier",
+    "workOrdersCreated",
+    "workOrdersMatchedExisting",
+    "unresolvedSamples",
+  ]);
+  return Object.fromEntries(Object.entries(details).filter(([key]) => !knownKeys.has(key)));
+}
+
 export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
   const router = useRouter();
   const [payload, setPayload] = useState<any>(null);
@@ -713,6 +739,9 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
           <details className="mt-2 rounded border border-fuchsia-400/20 bg-fuchsia-950/20 p-2 text-[11px] text-fuchsia-100/90">
             <summary className="cursor-pointer">History developer details</summary>
             <div className="mt-2 grid gap-1 sm:grid-cols-2">
+              <div>diagnosticVersion: {String(historyActivationResult.diagnostics.runtime?.diagnosticVersion ?? "unknown")}</div>
+              <div>activationModule: {String(historyActivationResult.diagnostics.runtime?.activationModule ?? "unknown")}</div>
+              <div>executedAt: {String(historyActivationResult.diagnostics.runtime?.executedAt ?? "unknown")}</div>
               <div>stagedHistoryRows: {asNumber(historyActivationResult.diagnostics.stagedHistoryRows)}</div>
               <div>customerWorkOrderLinks: {asNumber(historyActivationResult.diagnostics.customerWorkOrderLinks)}</div>
               <div>vehicleWorkOrderLinks: {asNumber(historyActivationResult.diagnostics.vehicleWorkOrderLinks)}</div>
@@ -731,6 +760,21 @@ export function OnboardingSessionPage({ sessionId }: { sessionId: string }) {
               <div>workOrdersCreated: {asNumber(historyActivationResult.diagnostics.workOrdersCreated)}</div>
               <div>workOrdersMatchedExisting: {asNumber(historyActivationResult.diagnostics.workOrdersMatchedExisting)}</div>
             </div>
+            <pre className="mt-2 overflow-x-auto rounded border border-fuchsia-400/20 bg-slate-900/70 p-2 text-[10px] text-fuchsia-100/90">{JSON.stringify({
+              linkEndpointEntityTypesByCount: historyActivationResult.diagnostics.linkEndpointEntityTypesByCount ?? {},
+              customerWorkOrderEndpointTypesByCount: historyActivationResult.diagnostics.customerWorkOrderEndpointTypesByCount ?? {},
+              vehicleWorkOrderEndpointTypesByCount: historyActivationResult.diagnostics.vehicleWorkOrderEndpointTypesByCount ?? {},
+              linksPointingToFetchedHistoryIdsFrom: historyActivationResult.diagnostics.linksPointingToFetchedHistoryIdsFrom ?? 0,
+              linksPointingToFetchedHistoryIdsTo: historyActivationResult.diagnostics.linksPointingToFetchedHistoryIdsTo ?? 0,
+              linksPointingToDiscoveredHistoryLikeEntities: historyActivationResult.diagnostics.linksPointingToDiscoveredHistoryLikeEntities ?? 0,
+              discoveredHistoryLikeEntityCount: historyActivationResult.diagnostics.discoveredHistoryLikeEntityCount ?? 0,
+              discoveredCustomerLikeEntityCount: historyActivationResult.diagnostics.discoveredCustomerLikeEntityCount ?? 0,
+              discoveredVehicleLikeEntityCount: historyActivationResult.diagnostics.discoveredVehicleLikeEntityCount ?? 0,
+              historyLinkedViaSparseDuplicateCount: historyActivationResult.diagnostics.historyLinkedViaSparseDuplicateCount ?? 0,
+              historyLinkedViaCanonicalEntityCount: historyActivationResult.diagnostics.historyLinkedViaCanonicalEntityCount ?? 0,
+              firstFiveLinkEndpointSamples: historyActivationResult.diagnostics.firstFiveLinkEndpointSamples ?? [],
+            }, null, 2)}</pre>
+            <pre className="mt-2 overflow-x-auto rounded border border-fuchsia-400/20 bg-slate-900/70 p-2 text-[10px] text-fuchsia-100/90">{JSON.stringify(historyDiagnosticsExtra(historyActivationResult.diagnostics), null, 2)}</pre>
             {Array.isArray(historyActivationResult.diagnostics.unresolvedSamples) && historyActivationResult.diagnostics.unresolvedSamples.length > 0 ? (
               <div className="mt-2">
                 <div>Unresolved samples (first {historyActivationResult.diagnostics.unresolvedSamples.length}):</div>

--- a/features/onboarding-agent/server/activateOnboardingHistory.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.test.ts
@@ -428,6 +428,24 @@ describe("activateOnboardingHistory", () => {
     expect(result.diagnostics.rowsWithBothLiveCustomerAndVehicle).toBe(rows);
   });
 
+  it("emits runtime diagnostic marker and sparse-history discovery counters", async () => {
+    const sb = fakeSb();
+    sb.state.entities = [
+      { id: "h-canonical", shop_id: "shop-1", session_id: "session-1", entity_type: "historical_work_order", status: "ready", source_row_id: "h-row-1", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01" } },
+      { id: "h-sparse", shop_id: "shop-1", session_id: "session-1", entity_type: "work_order", status: "ready", source_row_id: "h-row-1", normalized: { sourceWorkOrderId: "RO-1", openedDate: "2022-01-01" } },
+      { id: "c-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "customer", status: "activated", source_external_id: "CUST-1", normalized: { sourceCustomerId: "CUST-1", email: "a@b.com" } },
+      { id: "v-stage-1", shop_id: "shop-1", session_id: "session-1", entity_type: "vehicle", status: "activated", source_external_id: "VEH-1", normalized: { sourceVehicleId: "VEH-1", vin: "VIN1" } },
+    ] as any[];
+    sb.state.links = [
+      { id: "l1", shop_id: "shop-1", session_id: "session-1", link_type: "customer_work_order", from_entity_id: "c-stage-1", to_entity_id: "h-sparse" },
+      { id: "l2", shop_id: "shop-1", session_id: "session-1", link_type: "vehicle_work_order", from_entity_id: "v-stage-1", to_entity_id: "h-sparse" },
+    ] as any[];
+    const result = await activateOnboardingHistory({ supabase: sb as any, shopId: "shop-1", sessionId: "session-1", actorId: "u1" });
+    expect(result.diagnostics.runtime.diagnosticVersion).toBe("history-endpoint-first-v3");
+    expect(result.diagnostics.discoveredHistoryLikeEntityCount).toBeGreaterThan(0);
+    expect(result.diagnostics.historyLinkedViaSparseDuplicateCount).toBeGreaterThan(0);
+  });
+
   it("rerun matches existing historical import and does not create duplicates", async () => {
     const sb = fakeSb();
     sb.state.work_orders.push({

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -50,6 +50,11 @@ type HistoryActivationResult = {
   unresolvedDueToMissingLiveCustomer: number;
   unresolvedDueToMissingLiveVehicle: number;
   diagnostics: {
+    runtime: {
+      activationModule: string;
+      diagnosticVersion: string;
+      executedAt: string;
+    };
     stagedHistoryRows: number;
     customerWorkOrderLinks: number;
     vehicleWorkOrderLinks: number;
@@ -461,6 +466,11 @@ export async function activateOnboardingHistory(params: {
   sessionId: string;
   actorId: string;
 }): Promise<HistoryActivationResult> {
+  const runtimeDiagnostics = {
+    activationModule: "features/onboarding-agent/server/activateOnboardingHistory.ts",
+    diagnosticVersion: "history-endpoint-first-v3",
+    executedAt: new Date().toISOString(),
+  };
   const sb = params.supabase as any;
   await assertOnboardingSessionOwnership({ supabase: params.supabase, shopId: params.shopId, sessionId: params.sessionId });
 
@@ -933,7 +943,7 @@ export async function activateOnboardingHistory(params: {
     warnings.push("Most skipped history rows were unresolved because no live customer/vehicle mapping could be resolved from staged links.");
   }
 
-  return {
+  const result: HistoryActivationResult = {
     ok: true,
     stagedHistoryRows: historyRows.length,
     historicalWorkOrdersCreated,
@@ -965,6 +975,7 @@ export async function activateOnboardingHistory(params: {
     unresolvedDueToMissingLiveCustomer,
     unresolvedDueToMissingLiveVehicle,
     diagnostics: {
+      runtime: runtimeDiagnostics,
       stagedHistoryRows: historyRows.length,
       customerWorkOrderLinks,
       vehicleWorkOrderLinks,
@@ -998,4 +1009,25 @@ export async function activateOnboardingHistory(params: {
     },
     warnings,
   };
+  console.info("[onboarding.history.activation]", {
+    diagnosticVersion: runtimeDiagnostics.diagnosticVersion,
+    runtimeModule: runtimeDiagnostics.activationModule,
+    executedAt: runtimeDiagnostics.executedAt,
+    shopSessionScope: `${params.shopId.slice(0, 8)}:${params.sessionId.slice(0, 8)}`,
+    stagedHistoryRows: result.stagedHistoryRows,
+    customerWorkOrderLinks: result.customerWorkOrderLinks,
+    vehicleWorkOrderLinks: result.vehicleWorkOrderLinks,
+    historyRowsWithCustomerLink: result.diagnostics.historyRowsWithCustomerLink,
+    historyRowsWithVehicleLink: result.diagnostics.historyRowsWithVehicleLink,
+    discoveredHistoryLikeEndpointCount: result.diagnostics.discoveredHistoryLikeEntityCount,
+    linkedCustomerStagedEntitiesFound: result.diagnostics.linkedCustomerStagedEntitiesFound,
+    linkedVehicleStagedEntitiesFound: result.diagnostics.linkedVehicleStagedEntitiesFound,
+    linkedCustomerLiveResolved: result.diagnostics.linkedCustomerLiveResolved,
+    linkedVehicleLiveResolved: result.diagnostics.linkedVehicleLiveResolved,
+    rowsWithBothLiveCustomerAndVehicle: result.diagnostics.rowsWithBothLiveCustomerAndVehicle,
+    workOrdersCreated: result.diagnostics.workOrdersCreated,
+    workOrdersMatchedExisting: result.diagnostics.workOrdersMatchedExisting,
+    skippedUnresolved: result.skippedUnresolved,
+  });
+  return result;
 }


### PR DESCRIPTION
### Motivation
- Vercel activations were still showing an old diagnostics shape, so we need an end-to-end runtime proof to verify which activation path executed. 
- The goal is to make the activation response self-identifying and ensure the UI does not drop or sanitize newly-added diagnostic keys. 
- Keep changes additive and non-breaking while preserving historical work order invariants (no invoices, `type='historical_import'`, `status='completed'`).

### Description
- Add a small runtime marker to the activation response under `diagnostics.runtime` with `activationModule`, `diagnosticVersion` (`history-endpoint-first-v3`), and `executedAt`. (changed `features/onboarding-agent/server/activateOnboardingHistory.ts`).
- Add a safe structured `console.info` line in the activation function that emits summary counters and the diagnostic version (no PII) for Vercel logs. (changed `features/onboarding-agent/server/activateOnboardingHistory.ts`).
- Expand History developer details UI to render the runtime marker, new endpoint-first diagnostic groups, and a compact JSON fallback that preserves unknown/new diagnostic keys. (changed `features/onboarding-agent/components/OnboardingSessionPage.tsx`).
- Add a helper `historyDiagnosticsExtra` to keep unknown diagnostics keys and tests that assert the runtime marker and diagnostics fallback are preserved. (changed `features/onboarding-agent/components/OnboardingSessionPage.test.ts` and `features/onboarding-agent/server/activateOnboardingHistory.test.ts`).
- No schema migrations, no invoice activation, and historical work order invariants remain unchanged.

### Testing
- Ran `npx tsc --noEmit --pretty false` and the TypeScript build completed successfully. 
- Ran `npx vitest run features/onboarding-agent` and all onboarding-agent tests passed (`118` tests passed across the suite), including new assertions for `diagnosticVersion` and diagnostics preservation. 
- Ran `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which returned warnings only (no errors) and therefore is acceptable for this scoped change. 
- Unit tests added/updated: UI helper test for unknown diagnostics keys (`historyDiagnosticsExtra`) and server test asserting `diagnostics.runtime.diagnosticVersion` plus sparse-history discovery counters (all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1656934f483289fa271bd881111f5)