### PR TITLE
Fix onboarding payload extraction and history lookup diagnostics

### DIFF
--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts
@@ -497,6 +497,38 @@ describe("activateOnboardingCustomersVehicles", () => {
     expect(sb.state.vehicles[0]?.customer_id).toBe(sb.state.customers[0]?.id);
   });
 
+  it("materializes customer details from normalized.details and normalized.payload", async () => {
+    sb = createFakeSupabase({
+      entities: [stagedCustomer("c1", {
+        display_name: "Pat Jones",
+        normalized: {
+          details: {
+            first_name: "Pat",
+            last_name: "Jones",
+            email_address: "pat@example.com",
+            phone_number: "(555) 123-4567",
+            address_line1: "123 Main St",
+            city: "Austin",
+            state: "TX",
+            postal_code: "78701",
+            country: "US",
+            payload: { company_name: "FleetCo", notes: "VIP customer" },
+          },
+        },
+        source_external_id: "SRC-CUST-1",
+      })],
+    });
+    const result = await runActivation(sb);
+    expect(result.customersInserted).toBe(1);
+    const created = sb.state.customers[0]!;
+    expect(created.first_name).toBe("Pat");
+    expect(created.last_name).toBe("Jones");
+    expect(created.email).toBe("pat@example.com");
+    expect(created.phone).toBe("5551234567");
+    expect(created.business_name).toBe("FleetCo");
+    expect(created.city).toBe("Austin");
+  });
+
   it("returns structured unresolved issue for ambiguous customer link", async () => {
     sb = createFakeSupabase({
       entities: [

--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
@@ -203,6 +203,27 @@ function pickAlias(normalized: JsonObject, ...keys: string[]): string | null {
   return null;
 }
 
+function asObject(value: unknown): JsonObject | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as JsonObject;
+}
+
+function collectPayloadLayers(normalized: JsonObject): JsonObject[] {
+  const details = asObject(normalized.details);
+  const payload = asObject(normalized.payload);
+  const nestedDetails = details ? asObject(details.details) : null;
+  const nestedPayload = details ? asObject(details.payload) : null;
+  return [normalized, details, payload, nestedDetails, nestedPayload].filter(Boolean) as JsonObject[];
+}
+
+function pickFromLayers(layers: JsonObject[], ...keys: string[]): string | null {
+  for (const layer of layers) {
+    const value = pickAlias(layer, ...keys);
+    if (value) return value;
+  }
+  return null;
+}
+
 function buildCustomerDisplayName(parts: { businessName: string | null; contactName: string | null; fullName: string | null; firstName: string | null; lastName: string | null; email: string | null; phone: string | null; externalId: string | null; sourceRowId: string | null; }): string | null {
   if (parts.businessName) return parts.businessName;
   if (parts.fullName) return parts.fullName;
@@ -214,17 +235,18 @@ function buildCustomerDisplayName(parts: { businessName: string | null; contactN
 
 function toNormalizedCustomer(entity: Pick<OnboardingEntityRow, "normalized" | "display_name" | "source_external_id" | "source_row_id">): NormalizedCustomer {
   const normalized = (entity.normalized ?? {}) as JsonObject;
-  const businessName = pickAlias(normalized, "businessName", "company_name", "business_name", "company", "Company", "Company Name", "Business Name");
-  const firstName = pickAlias(normalized, "firstName", "first_name", "First Name");
-  const lastName = pickAlias(normalized, "lastName", "last_name", "Last Name");
-  const contactName = pickAlias(normalized, "contactName", "contact_name", "contact", "Contact", "Contact Name");
-  const fullName = pickAlias(normalized, "name", "displayName", "display_name", "fullName", "full_name", "Name", "Customer", "Customer Name", "Full Name") ?? textOrNull(entity.display_name);
-  const email = normalizeEmail(pickAlias(normalized, "email", "Email", "email_address", "Email Address"));
-  const phone = normalizePhone(pickAlias(normalized, "phone", "Phone", "phone_number", "Phone Number", "telephone", "Telephone"));
-  const mobilePhone = normalizePhone(pickAlias(normalized, "mobile", "Mobile", "cell", "Cell", "mobile_phone"));
+  const layers = collectPayloadLayers(normalized);
+  const businessName = pickFromLayers(layers, "businessName", "company_name", "business_name", "company", "companyName", "Company", "Company Name", "Business Name");
+  const firstName = pickFromLayers(layers, "firstName", "first_name", "First Name");
+  const lastName = pickFromLayers(layers, "lastName", "last_name", "Last Name");
+  const contactName = pickFromLayers(layers, "contactName", "contact_name", "contact", "Contact", "Contact Name");
+  const fullName = pickFromLayers(layers, "name", "displayName", "display_name", "fullName", "full_name", "Name", "Customer", "Customer Name", "Full Name") ?? textOrNull(entity.display_name);
+  const email = normalizeEmail(pickFromLayers(layers, "email", "Email", "email_address", "Email Address", "customer_email", "contact_email"));
+  const phone = normalizePhone(pickFromLayers(layers, "phone", "Phone", "phone_number", "Phone Number", "telephone", "Telephone", "work_phone", "contact_phone"));
+  const mobilePhone = normalizePhone(pickFromLayers(layers, "mobile", "Mobile", "cell", "Cell", "mobile_phone"));
   return {
-    externalId: textOrNull(entity.source_external_id) ?? pickAlias(normalized, "source_external_id", "sourceExternalId", "sourceCustomerId", "source_customer_id"),
-    sourceRowId: textOrNull(entity.source_row_id) ?? pickAlias(normalized, "source_row_id", "sourceRowId"),
+    externalId: textOrNull(entity.source_external_id) ?? pickFromLayers(layers, "source_external_id", "sourceExternalId", "sourceCustomerId", "source_customer_id", "customerExternalId"),
+    sourceRowId: textOrNull(entity.source_row_id) ?? pickFromLayers(layers, "source_row_id", "sourceRowId"),
     name: buildCustomerDisplayName({ businessName, contactName, fullName, firstName, lastName, email, phone: phone ?? mobilePhone, externalId: textOrNull(entity.source_external_id), sourceRowId: textOrNull(entity.source_row_id) }),
     firstName,
     lastName,
@@ -233,13 +255,13 @@ function toNormalizedCustomer(entity: Pick<OnboardingEntityRow, "normalized" | "
     email,
     phone: phone ?? mobilePhone,
     mobilePhone,
-    street: pickAlias(normalized, "street", "address_line1", "address1", "address_1", "Address1", "address", "Address", "Address 1", "Street", "Street Address"),
-    address: pickAlias(normalized, "address", "address_line2", "address2", "address_2", "billing_address", "billingAddress"),
-    city: pickAlias(normalized, "city", "City"),
-    province: pickAlias(normalized, "province", "state", "State", "Province", "region"),
-    postalCode: pickAlias(normalized, "postalCode", "postal_code", "zip", "zipCode", "ZIP", "Zip Code", "Postal", "Postal Code"),
-    country: pickAlias(normalized, "country", "Country"),
-    notes: pickAlias(normalized, "notes", "Notes", "memo", "Memo", "comment", "comments"),
+    street: pickFromLayers(layers, "street", "address_line1", "address1", "address_1", "Address1", "address", "Address", "Address 1", "Street", "Street Address"),
+    address: pickFromLayers(layers, "address", "address_line2", "address2", "address_2", "billing_address", "billingAddress"),
+    city: pickFromLayers(layers, "city", "City"),
+    province: pickFromLayers(layers, "province", "state", "State", "Province", "region"),
+    postalCode: pickFromLayers(layers, "postalCode", "postal_code", "zip", "zipCode", "ZIP", "Zip Code", "Postal", "Postal Code"),
+    country: pickFromLayers(layers, "country", "Country"),
+    notes: pickFromLayers(layers, "notes", "Notes", "memo", "Memo", "comment", "comments"),
   };
 }
 

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -140,6 +140,7 @@ type HistoryActivationResult = {
       dateAliasesChecked?: string[];
       normalizedKeysSample?: string[];
     }>;
+    linkedTripleSamples: Array<Record<string, unknown>>;
   };
   warnings: string[];
 };
@@ -234,10 +235,22 @@ function parseDate(value: unknown): string | null {
   return d.toISOString();
 }
 
-function collectSearchRecords(normalized: Record<string, unknown>): Record<string, unknown>[] {
-  const nestedDetails = (normalized.details && typeof normalized.details === "object") ? (normalized.details as Record<string, unknown>) : null;
-  const nestedPayload = (normalized.payload && typeof normalized.payload === "object") ? (normalized.payload as Record<string, unknown>) : null;
-  return [normalized, nestedDetails, nestedPayload].filter(Boolean) as Record<string, unknown>[];
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function collectSearchRecords(normalized: Record<string, unknown>, entity?: Partial<Pick<OnboardingEntityRow, "source_external_id" | "source_row_id" | "display_name">>): Record<string, unknown>[] {
+  const nestedDetails = asRecord(normalized.details);
+  const nestedPayload = asRecord(normalized.payload);
+  const detailsDetails = nestedDetails ? asRecord(nestedDetails.details) : null;
+  const detailsPayload = nestedDetails ? asRecord(nestedDetails.payload) : null;
+  const entityTop = entity ? {
+    source_external_id: entity.source_external_id,
+    source_row_id: entity.source_row_id,
+    display_name: entity.display_name,
+  } : null;
+  return [normalized, nestedDetails, nestedPayload, detailsDetails, detailsPayload, entityTop].filter(Boolean) as Record<string, unknown>[];
 }
 
 function firstTextAlias(records: Record<string, unknown>[], aliases: string[]): { value: string | null; aliasUsed: string | null } {
@@ -290,23 +303,25 @@ function normalizeNumber(value: unknown): number | null {
 }
 function toNormalizedCustomer(entity: Pick<OnboardingEntityRow, "source_external_id" | "display_name" | "normalized"> | null): NormalizedCustomer {
   const normalized = ((entity?.normalized ?? {}) as Record<string, unknown>);
+  const records = collectSearchRecords(normalized, entity ?? undefined);
   return {
-    sourceCustomerId: normalizeText(entity?.source_external_id ?? normalized.sourceCustomerId) || null,
-    email: normalizeEmail(normalized.email),
-    phone: normalizePhone(normalized.phone),
-    name: normalizeText(normalized.businessName ?? normalized.name ?? entity?.display_name) || null,
+    sourceCustomerId: firstTextAlias(records, ["live_customer_id","customer_id","matched_customer_id","imported_customer_id","source_external_id","sourceExternalId","sourceCustomerId","customerExternalId","account_number","source_row_id","sourceRowId"]).value,
+    email: normalizeEmail(firstTextAlias(records, ["email","email_address","customer_email","contact_email"]).value),
+    phone: normalizePhone(firstTextAlias(records, ["phone","phone_number","mobile","cell","work_phone","contact_phone"]).value),
+    name: normalizeText(firstTextAlias(records, ["display_name","name","full_name","customer_name","company","company_name","businessName"]).value ?? entity?.display_name) || null,
   };
 }
 function toNormalizedVehicle(entity: Pick<OnboardingEntityRow, "source_external_id" | "normalized"> | null): NormalizedVehicle {
   const normalized = ((entity?.normalized ?? {}) as Record<string, unknown>);
+  const records = collectSearchRecords(normalized, entity ? { ...entity, source_row_id: null, display_name: null } as any : undefined);
   return {
-    sourceVehicleId: normalizeText(entity?.source_external_id ?? normalized.sourceVehicleId) || null,
-    vin: normalizeVin(normalized.vin),
-    plate: normalizePlate(normalized.plate ?? normalized.licensePlate ?? normalized.vehiclePlate),
-    unitNumber: normalizeLookup(normalized.unitNumber ?? normalized.vehicleUnitNumber),
-    year: normalizeNumber(normalized.year),
-    make: normalizeLookup(normalized.make),
-    model: normalizeLookup(normalized.model),
+    sourceVehicleId: firstTextAlias(records, ["live_vehicle_id","vehicle_id","matched_vehicle_id","imported_vehicle_id","source_external_id","sourceExternalId","sourceVehicleId","vehicleExternalId","unit_id","source_row_id","sourceRowId"]).value,
+    vin: normalizeVin(firstTextAlias(records, ["vin","VIN","vehicle_vin"]).value),
+    plate: normalizePlate(firstTextAlias(records, ["plate","license_plate","licence_plate","vehiclePlate","licensePlate"]).value),
+    unitNumber: normalizeLookup(firstTextAlias(records, ["unit","unit_number","fleet_number","unitNumber","vehicleUnitNumber"]).value),
+    year: normalizeNumber(firstTextAlias(records, ["year"]).value),
+    make: normalizeLookup(firstTextAlias(records, ["make"]).value),
+    model: normalizeLookup(firstTextAlias(records, ["model"]).value),
   };
 }
 function vehicleDescriptorKey(input: { year: number | null; make: string | null; model: string | null }): string | null {
@@ -428,9 +443,9 @@ function buildGroupedVehicleLiveMap(vehicleEntities: Array<Pick<OnboardingEntity
 
 function toNormalizedHistory(entity: Pick<OnboardingEntityRow, "normalized">): NormalizedHistory {
   const normalized = (entity.normalized ?? {}) as Record<string, unknown>;
-  const records = collectSearchRecords(normalized);
-  const identifier = firstTextAlias(records, ["work_order_number", "workOrderNumber", "ro_number", "roNumber", "repair_order_number", "repairOrderNumber", "invoice_number", "invoiceNumber", "reference", "source_external_id", "sourceExternalId", "source_row_id", "sourceRowId", "sourceWorkOrderId"]);
-  const opened = firstDateAlias(records, ["opened_at", "openedAt", "opened_date", "openedDate", "date_opened", "dateOpened", "service_date", "serviceDate", "repair_date", "repairDate", "invoice_date", "invoiceDate", "closed_at", "closedAt", "completed_at", "completedAt", "created_at", "createdAt", "date", "openedDate"]);
+  const records = collectSearchRecords(normalized, entity as any);
+  const identifier = firstTextAlias(records, ["work_order_number","workOrderNumber","ro_number","roNumber","repair_order_number","repairOrderNumber","order_number","orderNumber","invoice_number","invoiceNumber","reference","reference_number","source_work_order_id","sourceWorkOrderId","source_external_id","sourceExternalId","source_row_id","sourceRowId"]);
+  const opened = firstDateAlias(records, ["opened_at","openedAt","opened_date","openedDate","date_opened","dateOpened","service_date","serviceDate","repair_date","repairDate","order_date","orderDate","invoice_date","invoiceDate","closed_at","closedAt","closed_date","closedDate","completed_at","completedAt","completed_date","completedDate","created_at","createdAt","date"]);
   return {
     sourceWorkOrderId: identifier.value,
     invoiceNumber: firstTextAlias(records, ["invoiceNumber", "invoiceId", "sourceInvoiceId", "sourceExternalId"]).value,
@@ -635,6 +650,7 @@ export async function activateOnboardingHistory(params: {
   let rowsMissingLiveVehicle = 0;
   let rowsMissingBoth = 0;
   const unresolvedSamples: HistoryActivationResult["diagnostics"]["unresolvedSamples"] = [];
+  const linkedTripleSamples: Array<Record<string, unknown>> = [];
 
   const customerWorkOrderLinks = linkRows.filter((row) => row.link_type === "customer_work_order").length;
   const vehicleWorkOrderLinks = linkRows.filter((row) => row.link_type === "vehicle_work_order").length;
@@ -837,6 +853,17 @@ export async function activateOnboardingHistory(params: {
 
     const customerResolvedByLink = resolveLiveCustomerIdFromStagedEntity(linkedStagedCustomer, customerRows);
     const vehicleResolvedByLink = resolveLiveVehicleIdFromStagedEntity(linkedStagedVehicle, vehicleRows);
+    if (linkedTripleSamples.length < 5) {
+      linkedTripleSamples.push({
+        historyEntityId: entity.id, historyEntityType: entity.entity_type, historyStatus: (entityById.get(entity.id)?.status ?? null),
+        historySourceRowId: entity.source_row_id, historySourceExternalId: entity.source_external_id, historyDisplayName: entityById.get(entity.id)?.display_name ?? null,
+        historyNormalizedKeys: Object.keys((entity.normalized ?? {}) as Record<string, unknown>).slice(0, 20),
+        linkedCustomerEntityId: linkedStagedCustomer?.id ?? null, linkedCustomerEntityType: linkedStagedCustomer?.entity_type ?? null, linkedCustomerStatus: linkedStagedCustomer?.status ?? null,
+        linkedVehicleEntityId: linkedStagedVehicle?.id ?? null, linkedVehicleEntityType: linkedStagedVehicle?.entity_type ?? null, linkedVehicleStatus: linkedStagedVehicle?.status ?? null,
+        liveCustomerLookupResult: { method: customerResolvedByLink.id ? "staged_entity_lookup" : "none", matchedId: Boolean(customerResolvedByLink.id) },
+        liveVehicleLookupResult: { method: vehicleResolvedByLink.id ? "staged_entity_lookup" : "none", matchedId: Boolean(vehicleResolvedByLink.id) },
+      });
+    }
 
     let customerId = customerResolvedByLink.id
       ?? (stagedCustomerLink.id ? stagedCustomerEntityIdToLiveCustomerId.get(stagedCustomerLink.id) ?? null : null)
@@ -1146,6 +1173,7 @@ export async function activateOnboardingHistory(params: {
       sampleResolvedHistoryLinks,
       firstFiveLinkEndpointSamples,
       unresolvedSamples,
+      linkedTripleSamples,
     },
     warnings,
   };


### PR DESCRIPTION
### Motivation
- Historical activation was skipping all rows because staged→live customer/vehicle lookup and history identifier/date extraction missed the actual nested `normalized.details` / `normalized.payload` shape. 
- Add safer, layered payload extraction and more actionable diagnostics so history activation can resolve live customers/vehicles and produce non-empty identifier/date counters. 
- Preserve existing activation invariants (historical-only work orders, shop/session scoping, RLS) and avoid schema changes. 

### Description
- Read nested payload layers by adding `collectPayloadLayers`/`pickFromLayers` helpers and use them in customer activation so normalized `details`/`payload` keys materialize into live customer fields instead of thin records. (modified `features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts`).
- Expand history extraction to search nested `normalized`/`details`/`payload` and `entity` top-level candidates, extend identifier/date alias lists and date parsing aliases, and prefer stable IDs/VINs before fuzzy name matching. (modified `features/onboarding-agent/server/activateOnboardingHistory.ts`).
- Add compact linked history/customer/vehicle triple diagnostics (`linkedTripleSamples`) that include key keys and whether live lookup matched, without dumping raw sensitive payloads. (modified `features/onboarding-agent/server/activateOnboardingHistory.ts`).
- Add a unit test proving nested `normalized.details`/`normalized.payload` fields materialize into live customer details. (added test in `features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts`).

### Testing
- Ran TypeScript checks with `npx tsc --noEmit --pretty false` and it completed successfully after fixes. 
- Ran unit tests with `npx vitest run features/onboarding-agent` and all tests passed: 123 tests across the onboarding-agent suite (16 test files) succeeded, including the new nested-payload customer materialization test. 
- Ran lint with `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which returned warnings only (no errors) and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17417c028832881ac9bcd21d58f81)