### PR TITLE
Persist staged live IDs and improve history date/identifier extraction for onboarding

### DIFF
--- a/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
+++ b/features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts
@@ -165,6 +165,14 @@ type LinkSideIssueReason =
   | "vehicle_not_materialized"
   | "ambiguous_vehicle_match";
 
+function withResolvedLiveId(normalized: unknown, field: "live_customer_id" | "live_vehicle_id", liveId: string): JsonObject {
+  const base = (normalized && typeof normalized === "object" && !Array.isArray(normalized))
+    ? { ...(normalized as JsonObject) }
+    : {};
+  base[field] = liveId;
+  return base;
+}
+
 function normalizeText(value: unknown): string {
   return String(value ?? "").trim();
 }
@@ -848,6 +856,7 @@ export async function activateOnboardingCustomersVehicles(params: {
   }
 
   const customerByExternal = new Map<string, string>();
+  const customerEntityNormalizedById = new Map(customerEntities.map((entity) => [entity.id, entity.normalized]));
   for (const entity of customerEntities) {
     const normalized = toNormalizedCustomer(entity);
     if (!normalized.externalId) continue;
@@ -916,6 +925,31 @@ export async function activateOnboardingCustomersVehicles(params: {
       model: payload.model ?? null,
     } as VehicleRow);
     vehiclesInserted += 1;
+  }
+
+  const customerResolutionWrites = [...customerEntityToLiveId.entries()].map(([entityId, liveId]) => {
+    const priorNormalized = customerEntityNormalizedById.get(entityId);
+    return sb
+      .from("onboarding_entities")
+      .update({ normalized: withResolvedLiveId(priorNormalized, "live_customer_id", liveId) })
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("id", entityId)
+      .eq("entity_type", "customer");
+  });
+  const vehicleResolutionWrites = [...vehicleEntityToLiveId.entries()].map(([entityId, liveId]) => {
+    const priorNormalized = (entityById.get(entityId)?.normalized ?? null);
+    return sb
+      .from("onboarding_entities")
+      .update({ normalized: withResolvedLiveId(priorNormalized, "live_vehicle_id", liveId) })
+      .eq("shop_id", params.shopId)
+      .eq("session_id", params.sessionId)
+      .eq("id", entityId)
+      .eq("entity_type", "vehicle");
+  });
+  for (const write of [...customerResolutionWrites, ...vehicleResolutionWrites]) {
+    const { error } = await write;
+    if (error) throw new Error(error.message);
   }
 
   let vehicleCustomerLinksCreated = 0;

--- a/features/onboarding-agent/server/activateOnboardingHistory.ts
+++ b/features/onboarding-agent/server/activateOnboardingHistory.ts
@@ -140,6 +140,7 @@ type HistoryActivationResult = {
       identifierAliasesChecked?: string[];
       dateAliasesChecked?: string[];
       normalizedKeysSample?: string[];
+      searchLayerKeySamples?: Array<{ layerIndex: number; keys: string[] }>;
     }>;
     linkedTripleSamples: Array<Record<string, unknown>>;
   };
@@ -432,18 +433,18 @@ function toNormalizedHistory(entity: Pick<OnboardingEntityRow, "normalized">): N
   const normalized = (entity.normalized ?? {}) as Record<string, unknown>;
   const records = collectSearchRecords(normalized, entity as any);
   const identifier = firstTextAlias(records, ["work_order_number","workOrderNumber","ro_number","roNumber","repair_order_number","repairOrderNumber","order_number","orderNumber","invoice_number","invoiceNumber","reference","reference_number","source_work_order_id","sourceWorkOrderId","source_external_id","sourceExternalId","source_row_id","sourceRowId"]);
-  const opened = firstDateAlias(records, ["opened_at","openedAt","opened_date","openedDate","date_opened","dateOpened","created_at","createdAt","date","service_date","serviceDate","completed_at","completedAt","completed_date","completedDate","closed_at","closedAt","closed_date","closedDate","invoice_date","invoiceDate","posted_date","postedDate"]);
+  const opened = firstDateAlias(records, ["opened_at","openedAt","opened_date","openedDate","date_opened","dateOpened","created_at","createdAt","date","Date","service_date","serviceDate","serviceDateTime","repair_date","repairDate","work_order_date","workOrderDate","invoice_date","invoiceDate","posted_date","postedDate","completed_at","completedAt","completed_date","completedDate","closed_at","closedAt","closed_date","closedDate"]);
   return {
     sourceWorkOrderId: identifier.value,
-    invoiceNumber: firstTextAlias(records, ["invoiceNumber", "invoiceId", "sourceInvoiceId", "sourceExternalId"]).value,
+    invoiceNumber: firstTextAlias(records, ["invoiceNumber", "invoice_number", "invoiceId", "sourceInvoiceId", "sourceExternalId", "source_external_id"]).value,
     openedDate: opened.value,
-    closedDate: firstDateAlias(records, ["closedDate", "closedAt", "completedAt", "invoiceDate"]).value,
-    customerName: firstTextAlias(records, ["customerName", "name", "businessName"]).value,
+    closedDate: firstDateAlias(records, ["closedDate", "closedAt", "closed_date", "completedAt", "completed_date", "invoiceDate", "invoice_date"]).value,
+    customerName: firstTextAlias(records, ["customerName", "customer_name", "name", "businessName", "business_name", "company", "company_name"]).value,
     customerEmail: firstTextAlias(records, ["customerEmail", "email"]).value?.toLowerCase() ?? null,
-    sourceCustomerId: firstTextAlias(records, ["sourceCustomerId", "customerId", "customerExternalId", "source_external_id"]).value,
-    sourceVehicleId: firstTextAlias(records, ["sourceVehicleId", "vehicleId", "vehicleExternalId", "source_external_id"]).value,
+    sourceCustomerId: firstTextAlias(records, ["sourceCustomerId", "source_customer_id", "customerId", "customer_id", "customerExternalId", "customer_external_id", "source_external_id"]).value,
+    sourceVehicleId: firstTextAlias(records, ["sourceVehicleId", "source_vehicle_id", "vehicleId", "vehicle_id", "vehicleExternalId", "vehicle_external_id", "source_external_id"]).value,
     vehicleVin: firstTextAlias(records, ["vehicleVin", "vin"]).value?.toUpperCase() ?? null,
-    vehiclePlate: firstTextAlias(records, ["vehiclePlate", "plate", "licensePlate"]).value?.toUpperCase() ?? null,
+    vehiclePlate: firstTextAlias(records, ["vehiclePlate", "vehicle_plate", "plate", "licensePlate", "license_plate"]).value?.toUpperCase() ?? null,
     complaint: normalizeText(normalized.complaint) || null,
     correction: normalizeText(normalized.correction) || null,
     laborTotal: parseMoney(normalized.laborTotal ?? normalized.laborRaw),
@@ -774,6 +775,8 @@ export async function activateOnboardingHistory(params: {
   let historyRowsWithBothLinkedEntities = 0;
   for (const entity of combinedHistoryRows.values()) {
     const history = toNormalizedHistory(entity);
+    const layerRecords = collectSearchRecords((entity.normalized ?? {}) as Record<string, unknown>, entity as any);
+    const layerKeySamples = layerRecords.slice(0, 4).map((record, index) => ({ layerIndex: index, keys: Object.keys(record).slice(0, 20) }));
     if (!history.sourceWorkOrderId && !history.invoiceNumber && !history.openedDate) {
       skipped += 1;
       skippedMissingIdentifier += 1;
@@ -793,6 +796,7 @@ export async function activateOnboardingHistory(params: {
           vehicleResolutionAttemptedKeys: [],
           finalSkipReason: "missing_required_history_identifier",
           normalizedKeysSample: Object.keys((entity.normalized ?? {}) as Record<string, unknown>).slice(0, 12),
+          searchLayerKeySamples: layerKeySamples,
         });
       }
       continue;
@@ -816,6 +820,7 @@ export async function activateOnboardingHistory(params: {
           vehicleResolutionAttemptedKeys: [],
           finalSkipReason: "invalid_history_date",
           normalizedKeysSample: Object.keys((entity.normalized ?? {}) as Record<string, unknown>).slice(0, 12),
+          searchLayerKeySamples: layerKeySamples,
         });
       }
       continue;
@@ -970,6 +975,7 @@ export async function activateOnboardingHistory(params: {
           identifierAliasesChecked: ["work_order_number","workOrderNumber","ro_number","roNumber","repair_order_number","repairOrderNumber","invoice_number","invoiceNumber","reference","source_external_id","sourceExternalId","source_row_id","sourceRowId"],
           dateAliasesChecked: ["opened_at","openedAt","opened_date","openedDate","date_opened","dateOpened","service_date","serviceDate","repair_date","repairDate","invoice_date","invoiceDate","closed_at","closedAt","completed_at","completedAt","created_at","createdAt","date"],
           normalizedKeysSample: Object.keys((entity.normalized ?? {}) as Record<string, unknown>).slice(0, 12),
+          searchLayerKeySamples: layerKeySamples,
         });
       }
       continue;


### PR DESCRIPTION
### Motivation
- Fix the final bridge between staged activation and history activation so staged customers/vehicles can deterministically resolve to live rows and history rows can extract usable dates, without creating invoices or orphan historical work orders.
- Vercel diagnostics showed endpoint classification worked but staged->live resolution and date extraction returned zeros for production imports, so the activation handoff needed to be durable and the alias coverage for dates/identifiers broadened.
- Preserve existing constraints: no schema changes, historical work orders remain type `historical_import` and `completed`, and all writes are scoped by `shop_id` and `session_id`.

### Description
- Persist resolved live IDs back into staged onboarding entities by writing `normalized.live_customer_id` and `normalized.live_vehicle_id` during customer/vehicle activation using a rerun-safe scoped update, implemented via a new helper `withResolvedLiveId` and batched updates. (files changed: `features/onboarding-agent/server/activateOnboardingCustomersVehicles.ts`)
- Expand history payload extraction aliases to include additional snake_case / camelCase / common import variants for identifiers and dates, improving the likelihood of finding `openedDate`/identifier fields inside layered payloads. (file changed: `features/onboarding-agent/server/activateOnboardingHistory.ts`)
- Add layered payload diagnostics for unresolved history rows by capturing per-layer key samples from `buildOnboardingEntityPayloadLayers` so real staged payload keys are visible in diagnostics when date/identifier resolution fails. (file changed: `features/onboarding-agent/server/activateOnboardingHistory.ts`)
- Keep existing safety constraints: no invoice activation changes, no orphan historical work orders are created, and all staged writes honor `shop_id` + `session_id` scoping.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit --pretty false` and it completed successfully (no type errors introduced).
- Ran onboarding tests with `npx vitest run features/onboarding-agent` and the suite for `activateOnboardingHistory` and related tests passed (tests exercise many diagnostic counters and now show non-zero counts for staged/live link resolution scenarios).
- Ran linter with `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` which produced only pre-existing warnings and no new errors.
- Unit-test diagnostics now demonstrate that `linkedCustomerStagedEntitiesFound`, `linkedVehicleStagedEntitiesFound`, `linkedCustomerLiveResolved`, `linkedVehicleLiveResolved`, and `rowsWithBothLiveCustomerAndVehicle` are non-zero in resolvable scenarios, and unresolved samples include layered key lists for further investigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17c23565c8328aed03f3a74ed337b)