### PR TITLE
Introduce checkpointed bounded-chunk activation for customers/vehicles route

### DIFF
--- a/app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts
+++ b/app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts
@@ -1,15 +1,39 @@
 import { NextResponse } from "next/server";
-import { activateOnboardingCustomersVehicles } from "@/features/onboarding-agent/server/activateOnboardingCustomersVehicles";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RouteContext = { params: Promise<{ sessionId: string }> };
-
 type Mode = "start" | "advance" | "status" | "run_until_limit";
+type Stage = "initialize" | "customers" | "vehicles" | "bridge_writeback" | "links" | "completed";
 
-const SAFE_TOTAL_LIMIT = 500;
+const CUSTOMER_CHUNK_SIZE = 100;
+const VEHICLE_CHUNK_SIZE = 100;
+const LINK_CHUNK_SIZE = 250;
+const RUN_UNTIL_LIMIT_STEPS = 8;
 
-function getCheckpoint(summary: any) {
+type Checkpoint = {
+  phase: "customers_vehicles";
+  status: "idle" | "running" | "completed" | "failed";
+  stage: Stage;
+  lastCustomerEntityId: string | null;
+  lastVehicleEntityId: string | null;
+  lastLinkId: string | null;
+  customersProcessed: number;
+  customersTotal: number;
+  vehiclesProcessed: number;
+  vehiclesTotal: number;
+  linksProcessed: number;
+  linksTotal: number;
+  processedCount: number;
+  totalCount: number;
+  startedAt: string | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+  failedAt: string | null;
+  lastError: string | null;
+} & Record<string, number | string | null>;
+
+function getCheckpoint(summary: any): Checkpoint | null {
   return summary?.onboardingActivation?.customersVehicles ?? null;
 }
 
@@ -22,87 +46,137 @@ async function getTotals(admin: any, shopId: string, sessionId: string) {
   return { customersTotal: Number(c.count ?? 0), vehiclesTotal: Number(v.count ?? 0), linksTotal: Number(l.count ?? 0) };
 }
 
-async function writeCheckpoint(admin: any, shopId: string, sessionId: string, patch: Record<string, unknown>) {
+async function saveCheckpoint(admin: any, shopId: string, sessionId: string, patch: Partial<Checkpoint>) {
   const { data } = await admin.from("onboarding_sessions").select("summary").eq("shop_id", shopId).eq("id", sessionId).maybeSingle();
   const summary = data?.summary && typeof data.summary === "object" ? { ...data.summary } : {};
-  const existing = getCheckpoint(summary) ?? {};
+  const current = getCheckpoint(summary);
+  const merged: Checkpoint = {
+    phase: "customers_vehicles",
+    status: "idle",
+    stage: "initialize",
+    lastCustomerEntityId: null,
+    lastVehicleEntityId: null,
+    lastLinkId: null,
+    customersProcessed: 0,
+    customersTotal: 0,
+    vehiclesProcessed: 0,
+    vehiclesTotal: 0,
+    linksProcessed: 0,
+    linksTotal: 0,
+    processedCount: 0,
+    totalCount: 0,
+    startedAt: null,
+    completedAt: null,
+    failedAt: null,
+    lastError: null,
+    customersInserted: 0,
+    customersUpdated: 0,
+    customersMatchedExisting: 0,
+    customersSkippedDuplicateStaged: 0,
+    customersSkippedAmbiguous: 0,
+    customersRecoveredFromUniqueConflict: 0,
+    customersSkipped: 0,
+    vehiclesInserted: 0,
+    vehiclesUpdated: 0,
+    vehiclesMatchedExisting: 0,
+    vehiclesSkipped: 0,
+    vehicleCustomerLinksCreated: 0,
+    vehicleCustomerLinksUpdated: 0,
+    vehicleCustomerLinksAlreadyCorrect: 0,
+    vehicleCustomerLinksSkipped: 0,
+    vehicleCustomerLinksMaterialized: 0,
+    vehicleCustomerLinksUnresolved: 0,
+    ...(current ?? {}),
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  };
   (summary as any).onboardingActivation = (summary as any).onboardingActivation ?? {};
-  (summary as any).onboardingActivation.customersVehicles = { ...existing, ...patch, phase: "customers_vehicles", updatedAt: new Date().toISOString() };
+  (summary as any).onboardingActivation.customersVehicles = merged;
   await admin.from("onboarding_sessions").update({ summary }).eq("shop_id", shopId).eq("id", sessionId);
+  return merged;
+}
+
+async function processChunk(admin: any, shopId: string, sessionId: string, checkpoint: Checkpoint): Promise<Checkpoint> {
+  if (checkpoint.stage === "initialize") {
+    return saveCheckpoint(admin, shopId, sessionId, { status: "running", stage: "customers" });
+  }
+  if (checkpoint.stage === "customers") {
+    const query = admin.from("onboarding_entities").select("id").eq("shop_id", shopId).eq("session_id", sessionId).eq("entity_type", "customer").in("status", ["ready", "matched", "activated"]).order("id", { ascending: true }).limit(CUSTOMER_CHUNK_SIZE);
+    const { data } = checkpoint.lastCustomerEntityId ? await query.gt("id", checkpoint.lastCustomerEntityId) : await query;
+    const rows = data ?? [];
+    if (rows.length === 0) return saveCheckpoint(admin, shopId, sessionId, { stage: "vehicles" });
+    return saveCheckpoint(admin, shopId, sessionId, {
+      lastCustomerEntityId: rows[rows.length - 1].id,
+      customersProcessed: checkpoint.customersProcessed + rows.length,
+      processedCount: checkpoint.processedCount + rows.length,
+      customersSkipped: Number(checkpoint.customersSkipped ?? 0) + rows.length,
+    });
+  }
+  if (checkpoint.stage === "vehicles") {
+    const query = admin.from("onboarding_entities").select("id").eq("shop_id", shopId).eq("session_id", sessionId).eq("entity_type", "vehicle").in("status", ["ready", "matched", "activated"]).order("id", { ascending: true }).limit(VEHICLE_CHUNK_SIZE);
+    const { data } = checkpoint.lastVehicleEntityId ? await query.gt("id", checkpoint.lastVehicleEntityId) : await query;
+    const rows = data ?? [];
+    if (rows.length === 0) return saveCheckpoint(admin, shopId, sessionId, { stage: "bridge_writeback" });
+    return saveCheckpoint(admin, shopId, sessionId, {
+      lastVehicleEntityId: rows[rows.length - 1].id,
+      vehiclesProcessed: checkpoint.vehiclesProcessed + rows.length,
+      processedCount: checkpoint.processedCount + rows.length,
+      vehiclesSkipped: Number(checkpoint.vehiclesSkipped ?? 0) + rows.length,
+    });
+  }
+  if (checkpoint.stage === "bridge_writeback") {
+    return saveCheckpoint(admin, shopId, sessionId, { stage: "links" });
+  }
+  if (checkpoint.stage === "links") {
+    const query = admin.from("onboarding_entity_links").select("id").eq("shop_id", shopId).eq("session_id", sessionId).eq("link_type", "customer_vehicle").order("id", { ascending: true }).limit(LINK_CHUNK_SIZE);
+    const { data } = checkpoint.lastLinkId ? await query.gt("id", checkpoint.lastLinkId) : await query;
+    const rows = data ?? [];
+    if (rows.length === 0) {
+      return saveCheckpoint(admin, shopId, sessionId, { stage: "completed", status: "completed", completedAt: new Date().toISOString() });
+    }
+    return saveCheckpoint(admin, shopId, sessionId, {
+      lastLinkId: rows[rows.length - 1].id,
+      linksProcessed: checkpoint.linksProcessed + rows.length,
+      processedCount: checkpoint.processedCount + rows.length,
+      vehicleCustomerLinksSkipped: Number(checkpoint.vehicleCustomerLinksSkipped ?? 0) + rows.length,
+    });
+  }
+  return checkpoint;
 }
 
 export async function POST(request: Request, context: RouteContext) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
-
   const shopId = access.profile.shop_id as string;
   const admin = createAdminSupabase();
   const { sessionId } = await context.params;
-
   let mode: Mode = "run_until_limit";
-  try {
-    const body = await request.json();
-    if (body?.mode) mode = body.mode;
-  } catch {}
+  try { const body = await request.json(); if (body?.mode) mode = body.mode; } catch {}
 
   try {
-    const { data: session } = await admin.from("onboarding_sessions").select("summary").eq("shop_id", shopId).eq("id", sessionId).maybeSingle();
-    const checkpoint = getCheckpoint(session?.summary);
     const totals = await getTotals(admin, shopId, sessionId);
+    const { data: session } = await admin.from("onboarding_sessions").select("summary").eq("shop_id", shopId).eq("id", sessionId).maybeSingle();
+    let checkpoint = getCheckpoint(session?.summary);
 
     if (mode === "status") return NextResponse.json({ ok: true, mode, checkpoint, totals });
-
-    if (mode === "start") {
-      await writeCheckpoint(admin, shopId, sessionId, {
-        status: "running",
-        stage: "initialize",
-        startedAt: new Date().toISOString(),
-        failedAt: null,
-        completedAt: null,
-        lastError: null,
-        ...totals,
-      });
-      return NextResponse.json({ ok: true, mode, checkpoint: { status: "running", stage: "initialize", ...totals } });
+    if (mode === "start" || !checkpoint) {
+      checkpoint = await saveCheckpoint(admin, shopId, sessionId, { status: "running", stage: "initialize", startedAt: new Date().toISOString(), ...totals, totalCount: totals.customersTotal + totals.vehiclesTotal + totals.linksTotal });
+      if (mode === "start") return NextResponse.json({ ok: true, mode, checkpoint, totals });
     }
 
-    const totalCount = totals.customersTotal + totals.vehiclesTotal + totals.linksTotal;
-    if (totalCount > SAFE_TOTAL_LIMIT) {
-      await writeCheckpoint(admin, shopId, sessionId, {
-        status: "running",
-        stage: "customers",
-        lastError: `Session too large for single-request activation (${totalCount}). Use chunked advance flow.`,
-        ...totals,
-      });
-      return NextResponse.json({ ok: false, error: "session_too_large_for_unbounded_activation", mode, totals, checkpoint: getCheckpoint((await admin.from("onboarding_sessions").select("summary").eq("shop_id", shopId).eq("id", sessionId).maybeSingle()).data?.summary) }, { status: 409 });
+    if (mode === "advance") {
+      checkpoint = await processChunk(admin, shopId, sessionId, checkpoint);
+      return NextResponse.json({ ok: true, mode, checkpoint, totals });
     }
 
-    const result = await activateOnboardingCustomersVehicles({ supabase: admin, shopId, sessionId });
-    await writeCheckpoint(admin, shopId, sessionId, {
-      status: "completed",
-      stage: "completed",
-      completedAt: new Date().toISOString(),
-      totals,
-      resultCounters: {
-        customersInserted: result.customersInserted,
-        customersUpdated: result.customersUpdated,
-        customersMatchedExisting: result.customersMatchedExisting,
-        vehiclesInserted: result.vehiclesInserted,
-        vehiclesUpdated: result.vehiclesUpdated,
-        vehiclesMatchedExisting: result.vehiclesMatchedExisting,
-        linksMaterialized: result.vehicleCustomerLinksMaterialized,
-        linksUnresolved: result.vehicleCustomerLinksUnresolved,
-      },
-    });
-    return NextResponse.json({ ...result, mode, totals });
+    for (let i = 0; i < RUN_UNTIL_LIMIT_STEPS; i += 1) {
+      if (checkpoint.stage === "completed" || checkpoint.status === "failed") break;
+      checkpoint = await processChunk(admin, shopId, sessionId, checkpoint);
+    }
+    return NextResponse.json({ ok: true, mode, checkpoint, totals });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to activate customers and vehicles";
-    await writeCheckpoint(admin, shopId, sessionId, {
-      status: "failed",
-      stage: "customers",
-      failedAt: new Date().toISOString(),
-      lastError: message,
-    });
-    const status = message.includes("Session not found") ? 404 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    const failed = await saveCheckpoint(admin, shopId, sessionId, { status: "failed", failedAt: new Date().toISOString(), lastError: message });
+    return NextResponse.json({ ok: false, error: message, checkpoint: failed }, { status: 500 });
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent unbounded full-session activation from the API route by introducing a resumable, checkpointed chunking flow for the customers/vehicles activation phase. 
- Persist progress and counters to `onboarding_sessions.summary.onboardingActivation.customersVehicles` so large sessions can be resumed safely and avoid timeouts or single-request overloads. 
- Preserve shop/session scoping and avoid schema or UI surface changes in this route-scoped implementation. 

### Description
- Replaced the route-level fallthrough to the legacy `activateOnboardingCustomersVehicles(...)` call with a checkpoint-driven flow that supports `start`, `status`, `advance`, and `run_until_limit` modes and stores state in `summary.onboardingActivation.customersVehicles`. 
- Added `saveCheckpoint` and `processChunk` helpers implementing staged, cursored chunk progression across `initialize`, `customers`, `vehicles`, `bridge_writeback`, `links`, and `completed` stages while merging cumulative counters into the checkpoint. 
- Implemented stable-id cursoring and bounded chunk sizes (`CUSTOMER_CHUNK_SIZE = 100`, `VEHICLE_CHUNK_SIZE = 100`, `LINK_CHUNK_SIZE = 250`) and a `RUN_UNTIL_LIMIT_STEPS = 8` loop for `run_until_limit`. 
- Kept the legacy full activation function in the codebase (unchanged) but removed its unbounded invocation from this route and preserved no-body POST backwards compatibility by defaulting to bounded `run_until_limit`. 

### Testing
- Run typecheck: `npx tsc --noEmit --pretty false` succeeded with the change. 
- Unit tests: `npx vitest run features/onboarding-agent` completed with one failing test; 122 of 123 tests passed and `features/onboarding-agent/server/activateOnboardingCustomersVehicles.test.ts` had one timeout in the case `maps duplicate staged customer ids to one live customer and links past 1000 stay idempotent`. 
- Lint: `npx eslint app/api/onboarding-agent app/dashboard/onboarding features/onboarding-agent` ran and produced warnings only (no errors). 
- SAFE TO PUSH: no (the route change implements checkpoint/cursor scaffolding but does not yet perform the chunk-level materialization/matching/writeback/link-resolution parity required for full safe activation). 
- Real chunking implemented: partially (cursored, bounded chunk traversal and checkpoint scaffolding are in place, but per-row matching/upsert/materialization logic per chunk is not yet fully extracted/ported from the legacy activator). 
- No route mode can run unbounded activation for large sessions: yes, the route no longer falls through to the legacy unbounded call and `advance` processes only one bounded chunk while `run_until_limit` loops a bounded number of steps. 
- Exact file changed: `app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts`. 
- Checkpoint shape (stored at `onboarding_sessions.summary.onboardingActivation.customersVehicles`) includes: `phase`, `status`, `stage`, `lastCustomerEntityId`, `lastVehicleEntityId`, `lastLinkId`, `customersProcessed`, `customersTotal`, `vehiclesProcessed`, `vehiclesTotal`, `linksProcessed`, `linksTotal`, `processedCount`, `totalCount`, `startedAt`, `updatedAt`, `completedAt`, `failedAt`, `lastError`, plus the accumulated numeric counters scaffolded (e.g. `customersInserted`, `customersUpdated`, `customersMatchedExisting`, `vehiclesInserted`, `vehicleCustomerLinksMaterialized`, `vehicleCustomerLinksUnresolved`, etc.). 
- Chunk sizes: customers = `100`, vehicles = `100`, links = `250`, `run_until_limit` steps per request = `8`. 
- Resume behavior: `start` initializes totals/checkpoint, `status` returns checkpoint, `advance` processes exactly one cursor-bounded chunk and updates checkpoint, `run_until_limit` runs up to the configured steps then returns the checkpoint, and no-body POST defaults to `run_until_limit`. 
- Test outputs summary: `npx tsc` success; `npx vitest run features/onboarding-agent` -> 122/123 tests passed (1 timeout); `npx eslint ...` -> warnings only. 
- Remaining risks: per-chunk materialization/matching/upsert/link-resolution is not yet implemented so `advance` currently only advances cursors and updates counters scaffolding and therefore does not provide full functional parity with the legacy activator; UI polling/resume changes to `OnboardingSessionPage` were not implemented in this patch; the failing timeout test must be investigated and fixed before this can be considered safe to push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25a2fe2288328bf9c47aa600b2c4a)