### PR TITLE
Restyle Work Orders History page to cool operational theme

### DIFF
--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -199,7 +199,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
   }
 
   return (
-    <div className="min-h-[calc(100vh-4rem)] desktop-backdrop px-4 py-6 text-white">
+    <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_34%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.06),transparent_32%),#050914] px-4 py-6 text-white">
       <div className="mx-auto max-w-6xl space-y-4">
         <section className="overflow-hidden rounded-[26px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_18px_48px_rgba(2,6,23,0.58)]">
           <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(96,165,250,0.12),rgba(15,23,42,0.04))] px-4 py-4 sm:px-6">
@@ -293,7 +293,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
           </div>
         </section>
 
-        <section className="desktop-panel px-4 py-5 sm:px-6 sm:py-6">
+        <section className="rounded-[26px] border border-slate-700/60 bg-slate-950/70 px-4 py-5 shadow-[0_18px_48px_rgba(2,6,23,0.58)] sm:px-6 sm:py-6">
           {err ? (
             <div className="mb-4 rounded-xl border border-red-500/60 bg-red-950/80 px-4 py-2 text-sm text-red-100">
               {err}
@@ -320,7 +320,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                 return (
                   <div
                     key={r.id}
-                    className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-3 shadow-[0_14px_38px_rgba(0,0,0,0.9)]"
+                    className="rounded-2xl border border-slate-700/60 bg-slate-950/70 p-3 shadow-[0_14px_38px_rgba(2,6,23,0.82)]"
                   >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                       <div className="min-w-0 space-y-1">
@@ -342,12 +342,12 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                       </div>
                     </div>
 
-                    <div className="mt-3 rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-sm text-neutral-200">
+                    <div className="mt-3 rounded-xl border border-slate-700/55 bg-slate-900/60 px-3 py-2 text-sm text-neutral-200">
                       {r.description || "Imported historical service record"}
                     </div>
 
                     {r.notes ? (
-                      <pre className="mt-2 whitespace-pre-wrap rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-[11px] leading-relaxed text-neutral-400">
+                      <pre className="mt-2 whitespace-pre-wrap rounded-xl border border-slate-700/55 bg-slate-900/50 px-3 py-2 text-[11px] leading-relaxed text-neutral-400">
                         {r.notes}
                       </pre>
                     ) : null}


### PR DESCRIPTION
### Motivation
- The History page was inheriting a warm/brown/copper backdrop from shared desktop backdrop styles and needed to match the cooler ProFixIQ operational shell without changing behavior.
- This is a UI-only cleanup limited to page-level visuals so data loading, RLS, onboarding, and sync logic remain untouched.

### Description
- Replaced the page root `desktop-backdrop` with a page-local cool dark radial backdrop (`bg-[radial-gradient(...),#050914]`) to remove the warm glow in `app/work-orders/history/WorkOrdersHistoryClient.tsx`.
- Replaced the `desktop-panel` wrapper on the results section with explicit cool slate panel styles (`border-slate-700/60 bg-slate-950/70`) to avoid inherited warm tinting.
- Normalized individual history cards, description, and notes surfaces to cool slate tones (`border-slate-700/60`, `bg-slate-900/*`) while preserving all displayed fields and layout.
- Ensured Export CSV and the `Read only` badge use cool sky/cyan styling and removed any page-level copper/orange background usage.

### Testing
- Ran `npx eslint app/work-orders/history/WorkOrdersHistoryClient.tsx --max-warnings=0`, which completed without errors.
- Ran `npx tsc --noEmit`, which completed successfully with no type errors.
- Ran the grep check `grep -n "accent-copper\|copper\|orange\|amber\|desktop-backdrop\|rgba(197,122,74\|C57A4A" app/work-orders/history/WorkOrdersHistoryClient.tsx || true` to confirm no warm/copper references remain in the modified file and it returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37683b5608328b04d9951c9a5bc3e)