### PR TITLE
Use dark shell background for Work Order History page

### DIFF
--- a/app/work-orders/history/page.tsx
+++ b/app/work-orders/history/page.tsx
@@ -1,8 +1,19 @@
+import type { CSSProperties } from "react";
+
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 import WorkOrdersHistoryClient from "./WorkOrdersHistoryClient";
 
+const historyShellStyle: CSSProperties = {
+  ["--dashboard-shell-bg" as string]:
+    "radial-gradient(1100px_700px_at_100%_100%, rgba(2,6,23,0.45), transparent 64%), linear-gradient(180deg, var(--theme-app-bg, #050910) 0%, var(--theme-app-bg, #050910) 100%)",
+};
+
 export default function Page() {
-  return <WorkOrdersHistoryClient />;
+  return (
+    <div style={historyShellStyle}>
+      <WorkOrdersHistoryClient />
+    </div>
+  );
 }


### PR DESCRIPTION
### Motivation
- Replace the copper-tinted backdrop around the main car on the Work Order History page with the app's dark shell background so the page matches other screens visually.

### Description
- Override the `--dashboard-shell-bg` CSS variable by wrapping `WorkOrdersHistoryClient` in a div with an inline `historyShellStyle` in `app/work-orders/history/page.tsx`, importing `CSSProperties` to keep TypeScript happy and leaving all page content and behavior unchanged.

### Testing
- Ran `npx tsc --noEmit` and the type check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39558462483289ebd0f26ca238ea3)