### PR TITLE
Add internal onboarding-agent connector API foundation

### DIFF
--- a/app/api/internal/onboarding-agent/customer-vehicle-links/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/customer-vehicle-links/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleCustomerVehicleLinkUpsert } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleCustomerVehicleLinkUpsert(request as Request);
+}

--- a/app/api/internal/onboarding-agent/customers/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/customers/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleCustomerUpsert } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleCustomerUpsert(request as Request);
+}

--- a/app/api/internal/onboarding-agent/final-summary/route.ts
+++ b/app/api/internal/onboarding-agent/final-summary/route.ts
@@ -1,0 +1,8 @@
+import { handleSkippedSummary } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleSkippedSummary(request as Request);
+}

--- a/app/api/internal/onboarding-agent/history/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/history/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleSkippedHistory } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleSkippedHistory(request as Request);
+}

--- a/app/api/internal/onboarding-agent/invoice-history/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/invoice-history/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleSkippedInvoiceHistory } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleSkippedInvoiceHistory(request as Request);
+}

--- a/app/api/internal/onboarding-agent/parts/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/parts/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleSkippedPart } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleSkippedPart(request as Request);
+}

--- a/app/api/internal/onboarding-agent/review-items/create/route.ts
+++ b/app/api/internal/onboarding-agent/review-items/create/route.ts
@@ -1,0 +1,8 @@
+import { handleSkippedReview } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleSkippedReview(request as Request);
+}

--- a/app/api/internal/onboarding-agent/validate-shop/route.ts
+++ b/app/api/internal/onboarding-agent/validate-shop/route.ts
@@ -1,0 +1,8 @@
+import { handleValidateShop } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleValidateShop(request as Request);
+}

--- a/app/api/internal/onboarding-agent/vehicles/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/vehicles/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleVehicleUpsert } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleVehicleUpsert(request as Request);
+}

--- a/app/api/internal/onboarding-agent/vendors/upsert/route.ts
+++ b/app/api/internal/onboarding-agent/vendors/upsert/route.ts
@@ -1,0 +1,8 @@
+import { handleSkippedVendor } from "@/features/onboarding-agent/server/connector/handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  return handleSkippedVendor(request as Request);
+}

--- a/docs/onboarding-agent-internal-connector.md
+++ b/docs/onboarding-agent-internal-connector.md
@@ -1,0 +1,38 @@
+# Onboarding Agent Internal Connector (ProFixIQ)
+
+Route namespace: `/api/internal/onboarding-agent/*`
+
+## Required env
+- `ONBOARDING_AGENT_INTERNAL_SECRET` (shared with onboarding agent `PROFIXIQ_INTERNAL_SECRET`)
+
+## Signature scheme
+Required headers on every request:
+- `x-onboarding-agent-signature`
+- `x-onboarding-agent-timestamp` (epoch milliseconds)
+- `x-shop-id`
+
+Signature payload: `${timestamp}.${shopId}.${rawBody}` using HMAC SHA-256 hex digest.
+
+## Route map
+- `POST /api/internal/onboarding-agent/validate-shop`
+- `POST /api/internal/onboarding-agent/customers/upsert`
+- `POST /api/internal/onboarding-agent/vehicles/upsert`
+- `POST /api/internal/onboarding-agent/customer-vehicle-links/upsert`
+- `POST /api/internal/onboarding-agent/vendors/upsert` (skipped)
+- `POST /api/internal/onboarding-agent/parts/upsert` (skipped)
+- `POST /api/internal/onboarding-agent/history/upsert` (skipped)
+- `POST /api/internal/onboarding-agent/invoice-history/upsert` (skipped)
+- `POST /api/internal/onboarding-agent/review-items/create` (skipped)
+- `POST /api/internal/onboarding-agent/final-summary` (skipped)
+
+## Idempotency strategy
+- Customer/vehicle upserts key by `shop_id + payload.externalId` (fallback to `idempotencyKey`).
+- Customer-vehicle link updates canonical `vehicles.customer_id` idempotently.
+
+## Agent config notes
+Set in onboarding agent repo later:
+- `PROFIXIQ_CONNECTOR_MODE=http`
+- `PROFIXIQ_BASE_URL=<profixiq deployment URL>`
+- `PROFIXIQ_INTERNAL_SECRET=<same as ONBOARDING_AGENT_INTERNAL_SECRET>`
+
+Agent still defaults to null/dry-run until HTTP connector wiring is completed in onboarding-agent service.

--- a/features/onboarding-agent/server/connector/handlers.test.ts
+++ b/features/onboarding-agent/server/connector/handlers.test.ts
@@ -1,0 +1,46 @@
+import crypto from "crypto";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const shopId = "11111111-1111-4111-8111-111111111111";
+const secret = "test-secret";
+
+function sign(body: string, ts: number) {
+  return crypto.createHmac("sha256", secret).update(`${ts}.${shopId}.${body}`).digest("hex");
+}
+
+describe("onboarding connector handlers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.ONBOARDING_AGENT_INTERNAL_SECRET = secret;
+  });
+
+  it("rejects missing signature", async () => {
+    const { handleValidateShop } = await import("./handlers");
+    const res = await handleValidateShop(new Request("http://x", { method: "POST", body: JSON.stringify({ shopId, expectedShopId: shopId }) }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects stale signature", async () => {
+    const { handleValidateShop } = await import("./handlers");
+    const body = JSON.stringify({ shopId, expectedShopId: shopId });
+    const ts = Date.now() - 10 * 60 * 1000;
+    const res = await handleValidateShop(new Request("http://x", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": sign(body, ts) } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid signature", async () => {
+    const { handleValidateShop } = await import("./handlers");
+    const body = JSON.stringify({ shopId, expectedShopId: shopId });
+    const ts = Date.now();
+    const res = await handleValidateShop(new Request("http://x", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": "bad" } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects shop mismatch", async () => {
+    const { handleCustomerUpsert } = await import("./handlers");
+    const body = JSON.stringify({ shopId: "22222222-2222-4222-8222-222222222222", idempotencyKey: "k", payload: {} });
+    const ts = Date.now();
+    const res = await handleCustomerUpsert(new Request("http://x", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": sign(body, ts) } }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/features/onboarding-agent/server/connector/handlers.ts
+++ b/features/onboarding-agent/server/connector/handlers.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { connectorActionBodySchema, CONNECTOR_CAPABILITIES, type ConnectorResponse, validateShopBodySchema } from "./types";
+import { verifySignedRequest } from "./internal-auth";
+
+function skipped(message: string): ConnectorResponse {
+  return { ok: false, status: "skipped", message };
+}
+
+async function parseAndAuthorize<T>(request: Request, schema: { safeParse: (v: unknown) => { success: boolean; data?: T } }): Promise<{ ok: true; body: T; shopId: string } | { ok: false; response: NextResponse }> {
+  const rawBody = await request.text();
+  const auth = verifySignedRequest(request, rawBody);
+  if (!auth.ok) return auth;
+  const parsedJson = rawBody ? JSON.parse(rawBody) : {};
+  const parsed = schema.safeParse(parsedJson);
+  if (!parsed.success) return { ok: false, response: NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 }) };
+  const bodyRecord = parsed.data as Record<string, unknown>;
+  const bodyShopId = typeof bodyRecord.shopId === "string" ? bodyRecord.shopId : undefined;
+  if (!bodyShopId || bodyShopId !== auth.shopId) return { ok: false, response: NextResponse.json({ ok: false, error: "shopId mismatch" }, { status: 403 }) };
+  return { ok: true, body: parsed.data as T, shopId: auth.shopId };
+}
+
+export async function handleValidateShop(request: Request) {
+  const parsed = await parseAndAuthorize(request, validateShopBodySchema);
+  if (!parsed.ok) return parsed.response;
+  const admin = createAdminSupabase();
+  const { data } = await admin.from("shops").select("id").eq("id", parsed.body.shopId).maybeSingle();
+  return NextResponse.json({ ok: !!data && parsed.body.shopId === parsed.body.expectedShopId, capabilities: CONNECTOR_CAPABILITIES });
+}
+
+export async function handleCustomerUpsert(request: Request) {
+  const parsed = await parseAndAuthorize(request, connectorActionBodySchema);
+  if (!parsed.ok) return parsed.response;
+  const admin = createAdminSupabase();
+  const p = parsed.body.payload;
+  const name = typeof p.name === "string" ? p.name : null;
+  const email = typeof p.email === "string" ? p.email : null;
+  const phone = typeof p.phone === "string" ? p.phone : null;
+  const externalId = typeof p.externalId === "string" ? p.externalId : parsed.body.idempotencyKey;
+  const { data: existing } = await admin.from("customers").select("id").eq("shop_id", parsed.shopId).eq("external_id", externalId).maybeSingle();
+  if (existing?.id) {
+    await admin.from("customers").update({ name, email, phone }).eq("shop_id", parsed.shopId).eq("id", existing.id);
+    return NextResponse.json({ ok: true, status: "succeeded", externalId: existing.id });
+  }
+  const { data, error } = await admin.from("customers").insert({ shop_id: parsed.shopId, external_id: externalId, name, email, phone }).select("id").single();
+  if (error || !data) return NextResponse.json({ ok: false, status: "failed", message: "customer upsert failed" }, { status: 500 });
+  return NextResponse.json({ ok: true, status: "succeeded", externalId: data.id });
+}
+
+export async function handleVehicleUpsert(request: Request) { /* similar */
+  const parsed = await parseAndAuthorize(request, connectorActionBodySchema);
+  if (!parsed.ok) return parsed.response;
+  const admin = createAdminSupabase();
+  const p = parsed.body.payload;
+  const externalId = typeof p.externalId === "string" ? p.externalId : parsed.body.idempotencyKey;
+  const vin = typeof p.vin === "string" ? p.vin : null;
+  const plate = typeof p.licensePlate === "string" ? p.licensePlate : null;
+  const make = typeof p.make === "string" ? p.make : null;
+  const model = typeof p.model === "string" ? p.model : null;
+  const year = typeof p.year === "number" ? p.year : null;
+  const { data: existing } = await admin.from("vehicles").select("id").eq("shop_id", parsed.shopId).eq("external_id", externalId).maybeSingle();
+  if (existing?.id) {
+    await admin.from("vehicles").update({ vin, license_plate: plate, make, model, year }).eq("shop_id", parsed.shopId).eq("id", existing.id);
+    return NextResponse.json({ ok: true, status: "succeeded", externalId: existing.id });
+  }
+  const { data, error } = await admin.from("vehicles").insert({ shop_id: parsed.shopId, external_id: externalId, vin, license_plate: plate, make, model, year }).select("id").single();
+  if (error || !data) return NextResponse.json({ ok: false, status: "failed", message: "vehicle upsert failed" }, { status: 500 });
+  return NextResponse.json({ ok: true, status: "succeeded", externalId: data.id });
+}
+
+export async function handleCustomerVehicleLinkUpsert(request: Request) {
+  const parsed = await parseAndAuthorize(request, connectorActionBodySchema);
+  if (!parsed.ok) return parsed.response;
+  const p = parsed.body.payload;
+  const customerId = typeof p.customerId === "string" ? p.customerId : null;
+  const vehicleId = typeof p.vehicleId === "string" ? p.vehicleId : null;
+  if (!customerId || !vehicleId) return NextResponse.json(skipped("customerId and vehicleId are required"));
+  const admin = createAdminSupabase();
+  await admin.from("vehicles").update({ customer_id: customerId }).eq("shop_id", parsed.shopId).eq("id", vehicleId);
+  return NextResponse.json({ ok: true, status: "succeeded", externalId: vehicleId });
+}
+
+export const handleSkippedVendor = async (_request: Request) => NextResponse.json(skipped("vendor materialization unsupported in this ProFixIQ connector pass"));
+export const handleSkippedPart = async (_request: Request) => NextResponse.json(skipped("part materialization unsupported in this ProFixIQ connector pass"));
+export const handleSkippedHistory = async (_request: Request) => NextResponse.json(skipped("historical work materialization requires safe historical import mapping"));
+export const handleSkippedInvoiceHistory = async (_request: Request) => NextResponse.json(skipped("invoice history materialization requires safe historical import mapping"));
+export const handleSkippedReview = async (_request: Request) => NextResponse.json(skipped("review item materialization unsupported in this connector pass"));
+export const handleSkippedSummary = async (_request: Request) => NextResponse.json(skipped("summary persistence unsupported in this connector pass"));

--- a/features/onboarding-agent/server/connector/internal-auth.ts
+++ b/features/onboarding-agent/server/connector/internal-auth.ts
@@ -1,0 +1,40 @@
+import crypto from "crypto";
+import { NextResponse } from "next/server";
+
+const HEADER_SIGNATURE = "x-onboarding-agent-signature";
+const HEADER_TIMESTAMP = "x-onboarding-agent-timestamp";
+const HEADER_SHOP_ID = "x-shop-id";
+const MAX_SKEW_MS = 5 * 60 * 1000;
+
+function safeCompare(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) return false;
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+export function verifySignedRequest(request: Request, rawBody: string): { ok: true; shopId: string } | { ok: false; response: NextResponse } {
+  const secret = process.env.ONBOARDING_AGENT_INTERNAL_SECRET;
+  if (!secret) return { ok: false, response: NextResponse.json({ ok: false, error: "connector not configured" }, { status: 500 }) };
+
+  const signature = request.headers.get(HEADER_SIGNATURE);
+  const timestamp = request.headers.get(HEADER_TIMESTAMP);
+  const shopId = request.headers.get(HEADER_SHOP_ID);
+
+  if (!signature || !timestamp || !shopId) {
+    return { ok: false, response: NextResponse.json({ ok: false, error: "missing connector auth headers" }, { status: 401 }) };
+  }
+
+  const tsMillis = Number(timestamp);
+  if (!Number.isFinite(tsMillis) || Math.abs(Date.now() - tsMillis) > MAX_SKEW_MS) {
+    return { ok: false, response: NextResponse.json({ ok: false, error: "stale timestamp" }, { status: 401 }) };
+  }
+
+  const payload = `${timestamp}.${shopId}.${rawBody}`;
+  const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  if (!safeCompare(signature, expected)) {
+    return { ok: false, response: NextResponse.json({ ok: false, error: "invalid signature" }, { status: 401 }) };
+  }
+
+  return { ok: true, shopId };
+}

--- a/features/onboarding-agent/server/connector/types.ts
+++ b/features/onboarding-agent/server/connector/types.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const connectorCapabilitiesSchema = z.object({
+  canWriteCustomers: z.boolean(),
+  canWriteVehicles: z.boolean(),
+  canWriteCustomerVehicleLinks: z.boolean(),
+  canWriteVendors: z.boolean(),
+  canWriteParts: z.boolean(),
+  canWriteHistoricalWork: z.boolean(),
+  canWriteInvoiceHistory: z.boolean(),
+  canCreateRecommendations: z.boolean(),
+  canSubmitSummary: z.boolean(),
+  dryRunOnly: z.boolean(),
+});
+
+export type ConnectorCapabilities = z.infer<typeof connectorCapabilitiesSchema>;
+
+export const validateShopBodySchema = z.object({
+  shopId: z.string().uuid(),
+  expectedShopId: z.string().uuid(),
+});
+
+export const connectorActionBodySchema = z.object({
+  shopId: z.string().uuid(),
+  idempotencyKey: z.string().min(1),
+  payload: z.record(z.string(), z.unknown()),
+});
+
+export type ConnectorActionBody = z.infer<typeof connectorActionBodySchema>;
+
+export const connectorResponseSchema = z.object({
+  ok: z.boolean(),
+  externalId: z.string().optional(),
+  status: z.enum(["dry_run", "skipped", "succeeded", "failed"]),
+  message: z.string().optional(),
+});
+
+export type ConnectorResponse = z.infer<typeof connectorResponseSchema>;
+
+export const CONNECTOR_CAPABILITIES: ConnectorCapabilities = {
+  canWriteCustomers: true,
+  canWriteVehicles: true,
+  canWriteCustomerVehicleLinks: true,
+  canWriteVendors: false,
+  canWriteParts: false,
+  canWriteHistoricalWork: false,
+  canWriteInvoiceHistory: false,
+  canCreateRecommendations: false,
+  canSubmitSummary: false,
+  dryRunOnly: false,
+};


### PR DESCRIPTION
### Motivation
- Provide a stable ProFixIQ-side HTTP connector boundary that matches the onboarding-agent Phase 5 typed contract and enforces shop scoping and signed internal requests. 
- Implement a safe, incremental foundation that materializes low-risk entities (customers, vehicles, links) while explicitly skipping high-risk historical/invoice/work-order materialization. 
- Keep changes non-breaking and consistent with existing Supabase/service-role patterns and RLS assumptions. 

### Description
- Added a new internal route namespace under `/api/internal/onboarding-agent/*` with POST handlers for `validate-shop`, `customers/upsert`, `vehicles/upsert`, `customer-vehicle-links/upsert`, and stub/skipped routes for `vendors`, `parts`, `history`, `invoice-history`, `review-items`, and `final-summary`.
- Introduced typed Zod schemas and types that mirror the connector contract and a `CONNECTOR_CAPABILITIES` object reflecting supported capabilities in this pass (`features/onboarding-agent/server/connector/types.ts`).
- Implemented HMAC SHA-256 signed-request verification with headers `x-onboarding-agent-signature`, `x-onboarding-agent-timestamp`, and `x-shop-id`, timing-safe comparison, and a 5-minute skew tolerance in `verifySignedRequest` (`features/onboarding-agent/server/connector/internal-auth.ts`).
- Implemented handler logic that uses the canonical admin Supabase client (`createAdminSupabase`) to safely idempotent-upsert customers and vehicles keyed by `shop_id + payload.externalId` (fallback to `idempotencyKey`), and idempotent linking by updating `vehicles.customer_id`, while returning structured `skipped` responses for unsupported/unsafe endpoints (`features/onboarding-agent/server/connector/handlers.ts`).

### Testing
- Ran type checking with `npm run typecheck`, which passed successfully.
- Ran the new unit tests with `npm run test -- features/onboarding-agent/server/connector/handlers.test.ts`, which passed (tests cover missing signature, stale signature, invalid signature, and shop mismatch cases).
- Ran lint with `npm run lint`, which reported failures, but these are pre-existing unrelated repo lint issues and not introduced by this change set.
- The new connector handlers tests assert the signed-request gate and shop-scoping behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41a5e270483288bfcf1eeaf8c947a)