### PR TITLE
onboarding-agent: fix validate-shop auth handling and add safe diagnostics

### DIFF
--- a/features/onboarding-agent/server/connector/handlers.test.ts
+++ b/features/onboarding-agent/server/connector/handlers.test.ts
@@ -14,6 +14,22 @@ describe("onboarding connector handlers", () => {
     process.env.ONBOARDING_AGENT_INTERNAL_SECRET = secret;
   });
 
+  it("accepts valid signed validate-shop request for existing shop", async () => {
+    vi.doMock("@/features/shared/lib/supabase/server", () => ({
+      createAdminSupabase: () => ({
+        from: () => ({
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: shopId } }) }) }),
+        }),
+      }),
+    }));
+    const { handleValidateShop } = await import("./handlers");
+    const body = JSON.stringify({ shopId, expectedShopId: shopId });
+    const ts = Date.now();
+    const res = await handleValidateShop(new Request("http://x/api/internal/onboarding-agent/validate-shop", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": sign(body, ts) } }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, capabilities: { canWriteCustomers: true } });
+  });
+
   it("rejects missing signature", async () => {
     const { handleValidateShop } = await import("./handlers");
     const res = await handleValidateShop(new Request("http://x", { method: "POST", body: JSON.stringify({ shopId, expectedShopId: shopId }) }));
@@ -42,5 +58,40 @@ describe("onboarding connector handlers", () => {
     const ts = Date.now();
     const res = await handleCustomerUpsert(new Request("http://x", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": sign(body, ts) } }));
     expect(res.status).toBe(403);
+  });
+
+  it("rejects invalid body with safe error", async () => {
+    const { handleValidateShop } = await import("./handlers");
+    const body = JSON.stringify({ shopId });
+    const ts = Date.now();
+    const res = await handleValidateShop(new Request("http://x/api/internal/onboarding-agent/validate-shop", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": sign(body, ts) } }));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ ok: false, error: "invalid body" });
+  });
+
+  it("returns 404 when shop does not exist", async () => {
+    vi.doMock("@/features/shared/lib/supabase/server", () => ({
+      createAdminSupabase: () => ({
+        from: () => ({
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+        }),
+      }),
+    }));
+    const { handleValidateShop } = await import("./handlers");
+    const body = JSON.stringify({ shopId, expectedShopId: shopId });
+    const ts = Date.now();
+    const res = await handleValidateShop(new Request("http://x/api/internal/onboarding-agent/validate-shop", { method: "POST", body, headers: { "x-shop-id": shopId, "x-onboarding-agent-timestamp": String(ts), "x-onboarding-agent-signature": sign(body, ts) } }));
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ ok: false, error: "shop not found" });
+  });
+
+  it("logs no secret values on rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { handleValidateShop } = await import("./handlers");
+    const res = await handleValidateShop(new Request("http://x/api/internal/onboarding-agent/validate-shop", { method: "POST", body: JSON.stringify({ shopId, expectedShopId: shopId }) }));
+    expect(res.status).toBe(401);
+    expect(warn).toHaveBeenCalled();
+    const logged = JSON.stringify(warn.mock.calls);
+    expect(logged).not.toContain(secret);
   });
 });

--- a/features/onboarding-agent/server/connector/handlers.ts
+++ b/features/onboarding-agent/server/connector/handlers.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { connectorActionBodySchema, CONNECTOR_CAPABILITIES, type ConnectorResponse, validateShopBodySchema } from "./types";
-import { verifySignedRequest } from "./internal-auth";
+import { logConnectorReject, timestampAgeBucket, verifySignedRequest } from "./internal-auth";
 
 function skipped(message: string): ConnectorResponse {
   return { ok: false, status: "skipped", message };
@@ -9,23 +9,76 @@ function skipped(message: string): ConnectorResponse {
 
 async function parseAndAuthorize<T>(request: Request, schema: { safeParse: (v: unknown) => { success: boolean; data?: T } }): Promise<{ ok: true; body: T; shopId: string } | { ok: false; response: NextResponse }> {
   const rawBody = await request.text();
+  const timestamp = request.headers.get("x-onboarding-agent-timestamp");
+  const shopHeader = request.headers.get("x-shop-id");
+  const signature = request.headers.get("x-onboarding-agent-signature");
+  const baseMeta = {
+    route: new URL(request.url).pathname,
+    method: request.method,
+    hasShopIdHeader: !!shopHeader,
+    hasTimestampHeader: !!timestamp,
+    hasSignatureHeader: !!signature,
+    timestampAgeBucket: timestampAgeBucket(timestamp),
+  } as const;
+
   const auth = verifySignedRequest(request, rawBody);
-  if (!auth.ok) return auth;
-  const parsedJson = rawBody ? JSON.parse(rawBody) : {};
+  if (!auth.ok) {
+    let bodyKeys: string[] = [];
+    try {
+      const parsed = rawBody ? JSON.parse(rawBody) : {};
+      bodyKeys = parsed && typeof parsed === "object" ? Object.keys(parsed as Record<string, unknown>) : [];
+    } catch {
+      bodyKeys = [];
+    }
+    logConnectorReject({ ...baseMeta, bodyKeys, shopIdMismatch: false, signatureVerificationFailed: true });
+    return auth;
+  }
+
+  let parsedJson: unknown = {};
+  try {
+    parsedJson = rawBody ? JSON.parse(rawBody) : {};
+  } catch {
+    logConnectorReject({ ...baseMeta, bodyKeys: [], shopIdMismatch: false, signatureVerificationFailed: false, schemaFailure: "invalid JSON" });
+    return { ok: false, response: NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 }) };
+  }
+
   const parsed = schema.safeParse(parsedJson);
-  if (!parsed.success) return { ok: false, response: NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 }) };
+  if (!parsed.success) {
+    const bodyKeys = parsedJson && typeof parsedJson === "object" ? Object.keys(parsedJson as Record<string, unknown>) : [];
+    logConnectorReject({ ...baseMeta, bodyKeys, shopIdMismatch: false, signatureVerificationFailed: false, schemaFailure: "schema validation failed" });
+    return { ok: false, response: NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 }) };
+  }
   const bodyRecord = parsed.data as Record<string, unknown>;
   const bodyShopId = typeof bodyRecord.shopId === "string" ? bodyRecord.shopId : undefined;
-  if (!bodyShopId || bodyShopId !== auth.shopId) return { ok: false, response: NextResponse.json({ ok: false, error: "shopId mismatch" }, { status: 403 }) };
+  if (!bodyShopId || bodyShopId !== auth.shopId) {
+    logConnectorReject({ ...baseMeta, bodyKeys: Object.keys(bodyRecord), shopIdMismatch: true, signatureVerificationFailed: false });
+    return { ok: false, response: NextResponse.json({ ok: false, error: "shopId mismatch" }, { status: 403 }) };
+  }
   return { ok: true, body: parsed.data as T, shopId: auth.shopId };
 }
 
 export async function handleValidateShop(request: Request) {
   const parsed = await parseAndAuthorize(request, validateShopBodySchema);
   if (!parsed.ok) return parsed.response;
+  if (parsed.body.shopId !== parsed.body.expectedShopId) {
+    logConnectorReject({
+      route: new URL(request.url).pathname,
+      method: request.method,
+      bodyKeys: Object.keys(parsed.body),
+      hasShopIdHeader: true,
+      hasTimestampHeader: true,
+      hasSignatureHeader: true,
+      timestampAgeBucket: "le_5m",
+      shopIdMismatch: true,
+      signatureVerificationFailed: false,
+      schemaFailure: "body shopId does not equal expectedShopId",
+    });
+    return NextResponse.json({ ok: false, error: "shopId mismatch" }, { status: 400 });
+  }
   const admin = createAdminSupabase();
   const { data } = await admin.from("shops").select("id").eq("id", parsed.body.shopId).maybeSingle();
-  return NextResponse.json({ ok: !!data && parsed.body.shopId === parsed.body.expectedShopId, capabilities: CONNECTOR_CAPABILITIES });
+  if (!data) return NextResponse.json({ ok: false, error: "shop not found" }, { status: 404 });
+  return NextResponse.json({ ok: true, capabilities: CONNECTOR_CAPABILITIES });
 }
 
 export async function handleCustomerUpsert(request: Request) {

--- a/features/onboarding-agent/server/connector/internal-auth.ts
+++ b/features/onboarding-agent/server/connector/internal-auth.ts
@@ -6,6 +6,30 @@ const HEADER_TIMESTAMP = "x-onboarding-agent-timestamp";
 const HEADER_SHOP_ID = "x-shop-id";
 const MAX_SKEW_MS = 5 * 60 * 1000;
 
+type AuthDiagnosticMeta = {
+  route: string;
+  method: string;
+  bodyKeys: string[];
+  hasShopIdHeader: boolean;
+  hasTimestampHeader: boolean;
+  hasSignatureHeader: boolean;
+  timestampAgeBucket: "missing" | "invalid" | "le_5m" | "gt_5m";
+  shopIdMismatch: boolean;
+  signatureVerificationFailed: boolean;
+  schemaFailure?: string;
+};
+
+export function logConnectorReject(meta: AuthDiagnosticMeta): void {
+  console.warn("[onboarding-agent][connector][reject]", meta);
+}
+
+export function timestampAgeBucket(timestamp: string | null): AuthDiagnosticMeta["timestampAgeBucket"] {
+  if (!timestamp) return "missing";
+  const tsMillis = Number(timestamp);
+  if (!Number.isFinite(tsMillis)) return "invalid";
+  return Math.abs(Date.now() - tsMillis) <= MAX_SKEW_MS ? "le_5m" : "gt_5m";
+}
+
 function safeCompare(a: string, b: string): boolean {
   const aBuf = Buffer.from(a);
   const bBuf = Buffer.from(b);


### PR DESCRIPTION
### Motivation
- The `validate-shop` route returned opaque `400` failures with no safe diagnostics, making cross-repo verification brittle and hard to triage.
- The onboarding-agent signing contract (`${timestamp}.${shopId}.${rawBody}` with 5-minute skew and `ONBOARDING_AGENT_INTERNAL_SECRET`) must be strictly enforced while preserving tenant safety and not leaking secrets.
- Need explicit success/failure shapes compatible with the agent and safe metadata logging for rejected requests.

### Description
- Added structured, non-secret diagnostics and helpers in `features/onboarding-agent/server/connector/internal-auth.ts` (`logConnectorReject`, `timestampAgeBucket`, diagnostic type) and kept timing-safe HMAC validation against `process.env.ONBOARDING_AGENT_INTERNAL_SECRET`.
- Hardened request parsing in `features/onboarding-agent/server/connector/handlers.ts` by adding safe JSON parse guards, schema-validation diagnostics, header presence metadata, and explicit logging for signature/shop mismatch failures.
- Enforced `validate-shop` semantics: require `shopId === expectedShopId`, verify `x-shop-id` matches body `shopId`, check shop existence via `createAdminSupabase()` and return `404 { ok:false, error:"shop not found" }` if absent, and return `200 { ok:true, capabilities: ... }` on success.
- Preserved auth contract (`x-onboarding-agent-timestamp` as unix ms, 5-minute tolerance, header names) and used HMAC SHA256 signature over `${timestamp}.${shopId}.${rawBody}`.
- Added focused tests in `features/onboarding-agent/server/connector/handlers.test.ts` covering valid signed validate-shop, missing signature, stale timestamp, invalid signature, header/body mismatch, invalid body, non-existent shop, and asserting no secret leakage in logs.

### Testing
- Ran targeted unit tests: `npx vitest run features/onboarding-agent/server/connector/handlers.test.ts` — all tests passed (8/8).
- Ran repo checks: `npm run typecheck` — completed without new type errors in this run; `npm run lint` — reported pre-existing lint issues outside changed files; `npm test` — ran full suite and surfaced unrelated, pre-existing failures in `features/onboarding-agent/server/activateOnboardingHistory.test.ts` (not introduced by this change).
- Ran grep safety checks for secret/header/log usage: `grep -R "ONBOARDING_AGENT_INTERNAL_SECRET" -n app features src || true`, `grep -R "x-onboarding-agent-signature" -n app features src || true`, and `grep -R "console\.log.*SECRET\|console\.error.*SECRET\|signature.*secret" -n app features src || true` — results show secret/env usage and no unsafe secret logging introduced.
- Files changed: `features/onboarding-agent/server/connector/internal-auth.ts`, `features/onboarding-agent/server/connector/handlers.ts`, `features/onboarding-agent/server/connector/handlers.test.ts`.

Notes: This is a focused, incremental fix to unblocking verify-only onboarding; no public auth flows, RLS boundaries, or live materialization behaviors were changed. After deploying this change to Vercel and ensuring `ONBOARDING_AGENT_INTERNAL_SECRET` exactly matches the agent-side secret, the Railway verify command should return `ok: true` for an existing shop and valid signature. If issues persist, the added diagnostics will identify whether failure is due to headers, timestamp skew, schema mismatch, shop mismatch, signature verification, or a missing shop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4eeb3597483288307434d83b0fcd7)