### PR TITLE
Harden Phase 1 API shop-scoped boundaries for work-order & planner routes

### DIFF
--- a/app/api/assignables/route.ts
+++ b/app/api/assignables/route.ts
@@ -1,15 +1,17 @@
 // app/api/assignables/route.ts
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY! // server-side ONLY
 );
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const shopId = searchParams.get("shopId");
+export async function GET() {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
 
   let query = supabase
     .from("profiles")
@@ -17,10 +19,7 @@ export async function GET(req: Request) {
     .in("role", ["mechanic", "tech", "foreman", "lead_hand"])
     .order("full_name", { ascending: true });
 
-  // if you pass ?shopId=... from the page, we can scope
-  if (shopId) {
-    query = query.eq("shop_id", shopId);
-  }
+  query = query.eq("shop_id", shopId);
 
   const { data, error } = await query;
 

--- a/app/api/planner/uploads/sign/route.ts
+++ b/app/api/planner/uploads/sign/route.ts
@@ -1,10 +1,9 @@
 // app/api/planner/uploads/sign/route.ts
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,15 +20,20 @@ type Body = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
-  const { data } = await supabase.auth.getUser();
-  if (!data?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
 
   const body = (await req.json().catch(() => null)) as Body | null;
   const paths = Array.isArray(body?.paths) ? body!.paths : [];
   if (paths.length === 0) return NextResponse.json({ error: "paths required" }, { status: 400 });
 
   const expiresIn = Number.isFinite(body?.expiresIn) ? Math.max(60, Number(body!.expiresIn)) : 60 * 60; // default 1h
+  const allowedPrefix = `${shopId}/`;
+  const hasOutOfScopePath = paths.some((path) => typeof path !== "string" || !path.startsWith(allowedPrefix));
+  if (hasOutOfScopePath) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const { data: signed, error } = await supabaseAdmin.storage
     .from("planner_uploads")

--- a/app/api/work-orders/assign-line/route.ts
+++ b/app/api/work-orders/assign-line/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
 
@@ -16,13 +17,14 @@ export async function POST(req: Request) {
     const body = (await req.json()) as {
       work_order_line_id?: string;
       tech_id?: string;
-      // optional, so we can record who assigned
-      assigned_by?: string | null;
     };
 
     const lineId = body.work_order_line_id;
     const techId = body.tech_id;
-    const assignedBy = body.assigned_by ?? null;
+    const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+    if (!access.ok) return access.response;
+    const assignedBy = access.profile.id;
+    const shopId = access.profile.shop_id;
 
     if (!lineId || !techId) {
       return NextResponse.json(
@@ -37,8 +39,9 @@ export async function POST(req: Request) {
 
     const { data: line, error: lineReadErr } = await supabase
       .from("work_order_lines")
-      .select("id, line_type")
+      .select("id, line_type, work_order_id, work_orders!inner(id, shop_id)")
       .eq("id", lineId)
+      .eq("work_orders.shop_id", shopId)
       .maybeSingle();
 
     if (lineReadErr) {
@@ -51,11 +54,25 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Info lines cannot be technician-assigned." }, { status: 409 });
     }
 
+    const { data: technician, error: technicianErr } = await supabase
+      .from("profiles")
+      .select("id")
+      .eq("id", techId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (technicianErr) {
+      return NextResponse.json({ error: technicianErr.message }, { status: 400 });
+    }
+    if (!technician) {
+      return NextResponse.json({ error: "Technician not found" }, { status: 404 });
+    }
+
     // 1) keep the simple column up to date
     const { error: lineErr } = await supabase
       .from("work_order_lines")
       .update({ assigned_tech_id: techId })
-      .eq("id", lineId);
+      .eq("id", lineId)
+      .eq("work_order_id", line.work_order_id);
 
     if (lineErr) {
       return NextResponse.json({ error: lineErr.message }, { status: 400 });

--- a/app/api/work-orders/update-status/create/route.ts
+++ b/app/api/work-orders/update-status/create/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 const supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -19,6 +20,10 @@ function generateWorkOrderNumber(): string {
 
 export async function POST(req: NextRequest) {
   try {
+    const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+    if (!access.ok) return access.response;
+    const shopId = access.profile.shop_id;
+
     const body = await req.json();
     const {
       customer_id,
@@ -27,11 +32,10 @@ export async function POST(req: NextRequest) {
       type = "maintenance",
       complaint,
       appointment,
-      shop_id,
     } = body;
 
     // ✅ Validate required fields
-    if (!customer_id || !vehicle_id || !type || !shop_id) {
+    if (!customer_id || !vehicle_id || !type) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 },
@@ -49,6 +53,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Compatibility route: preserve payload/response while deriving tenant from auth context.
     const workOrderNumber = generateWorkOrderNumber();
 
     const { data, error } = await supabase
@@ -63,7 +68,7 @@ export async function POST(req: NextRequest) {
         appointment: appointment ?? null,
         created_at: new Date().toISOString(),
         location: null,
-        shop_id,
+        shop_id: shopId,
         number: workOrderNumber,
       })
       .select()

--- a/app/api/work-orders/update-status/route.ts
+++ b/app/api/work-orders/update-status/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 import { syncWorkOrderToHistory } from "@/features/work-orders/server/syncWorkOrderToHistory";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export const runtime = "nodejs";
 
@@ -36,6 +37,10 @@ interface RequestBody {
 
 export async function POST(req: NextRequest) {
   try {
+    const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+    if (!access.ok) return access.response;
+    const shopId = access.profile.shop_id;
+
     const body = (await req.json()) as RequestBody;
     const { workOrderId, command, quote, summary } = body;
 
@@ -50,6 +55,7 @@ export async function POST(req: NextRequest) {
       .from("work_orders")
       .select("id, status")
       .eq("id", workOrderId)
+      .eq("shop_id", shopId)
       .maybeSingle();
 
     if (existingErr) {
@@ -92,7 +98,8 @@ export async function POST(req: NextRequest) {
     const { error } = await supabase
       .from("work_orders")
       .update(updateFields)
-      .eq("id", workOrderId);
+      .eq("id", workOrderId)
+      .eq("shop_id", shopId);
 
     if (error) {
       throw error;


### PR DESCRIPTION
### Motivation
- Close Phase 1 API boundary risks by enforcing canonical, shop-scoped authentication and preventing caller-supplied cross-tenant scope on a small set of routes.
- Preserve existing workflows and response shapes while preventing service-role misuse and arbitrary tenant access.
- Require an appropriate capability for mutating work-order routes to limit privileged operations to authorized shop actors.

### Description
- Added `requireShopScopedApiAccess()` as the canonical shop-scoped boundary to the five targeted routes and derived `shop_id` from `access.profile.shop_id` instead of trusting caller input; files changed: `app/api/assignables/route.ts`, `app/api/work-orders/assign-line/route.ts`, `app/api/work-orders/update-status/route.ts`, `app/api/planner/uploads/sign/route.ts`, `app/api/work-orders/update-status/create/route.ts`.
- `assignables` GET now ignores `?shopId` query and always scopes profile reads to the authenticated shop while preserving the `{ data }` response shape.
- `work-orders/assign-line` POST now requires `requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" })`, derives `assigned_by` from the authenticated profile, verifies the target line belongs to the authenticated shop via an inner join to the parent work order, validates the assigned technician exists in the same shop, and scopes the update by parent work order id.
- `work-orders/update-status` POST now requires `canManageWorkOrders`, verifies the target work order belongs to the authenticated shop before mutation, and applies updates with both `id` and `shop_id` filters while preserving logging and history-sync behavior.
- `planner/uploads/sign` POST now uses the canonical helper, enforces that every requested path starts with the authenticated shop prefix (`${shopId}/`), rejects out-of-scope paths with `403`, and only uses the service-role storage client after path ownership validation.
- `work-orders/update-status/create` POST now requires `canManageWorkOrders`, ignores caller `shop_id` and forces insertion with `shop_id` from the authenticated profile, and includes a compatibility comment noting its transitional nature.
- Service-role clients remain where necessary for signing or privileged multi-table writes, but are now used only after deriving and enforcing the authenticated shop context and applying explicit shop/path scoping checks.

### Testing
- Ran `npx tsc --noEmit` and TypeScript build checks passed (no emit errors).
- Ran `npm run lint` and linting failed with pre-existing repository-wide errors unrelated to this patch; no new lint errors were introduced by these changes.
- Ran targeted repository searches (`rg`) to confirm remaining service-role usage and that `shop_id`/assignment fields are now scoped in the modified files, and results matched the intended changes.
- Manual smoke expectations (local/QA): same-shop assign-line/update-status succeed and cross-shop attempts are rejected; planner signing accepts shop-prefixed paths and rejects others (these behaviors were implemented to match the audit requirements).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a470fa6c8328b5bf985fc13232cc)