### PR TITLE
Harden and canonicalize quote send API routes with shop-scoped access

### DIFF
--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -3,8 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { runPostSendPersistence, sendQuoteReadyEmail } from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
 
@@ -83,19 +82,16 @@ export async function POST(req: Request) {
 
   try {
 
-    const actor = createServerSupabaseRoute();
-    const {
-      data: { user },
-      error: userErr,
-    } = await actor.auth.getUser();
-
-    if (userErr) {
-      return NextResponse.json({ ok: false, trace, error: userErr.message }, { status: 500 });
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canAuthorizeQuotes",
+    });
+    if (!access.ok) {
+      const payload = await access.response.json().catch(() => ({ error: "Forbidden" }));
+      return NextResponse.json(
+        { ok: false, trace, error: safeStr(payload?.error) || "Forbidden" },
+        { status: access.response.status },
+      );
     }
-    if (!user) {
-      return NextResponse.json({ ok: false, trace, error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = (await req.json().catch(() => null)) as RequestBody | null;
     const workOrderId = safeStr(body?.workOrderId).trim();
 
@@ -123,6 +119,7 @@ export async function POST(req: Request) {
       .from("work_orders")
       .select("id, customer_id, shop_id, vehicle_id, quote_url")
       .eq("id", workOrderId)
+      .eq("shop_id", access.profile.shop_id)
       .maybeSingle<
         Pick<
           WorkOrderRow,
@@ -157,28 +154,13 @@ export async function POST(req: Request) {
     }
 
 
-    const { data: me, error: meErr } = await actor
-      .from("profiles")
-      .select("id, role, shop_id")
-      .eq("id", user.id)
-      .maybeSingle();
-
-    if (meErr || !me) {
-      return NextResponse.json({ ok: false, trace, error: "Unable to load actor profile" }, { status: 403 });
-    }
-    const actorCaps = getActorCapabilities({ role: me.role });
-    if (!actorCaps.isKnownRole || !actorCaps.canAuthorizeQuotes) {
-      return NextResponse.json({ ok: false, trace, error: "Forbidden" }, { status: 403 });
-    }
-    if (!me.shop_id || me.shop_id !== wo.shop_id) {
-      return NextResponse.json({ ok: false, trace, error: "Cross-shop access denied" }, { status: 403 });
-    }
-
     let portalUserId: string | null = null;
     let portalCustomerId: string | null = null;
     let customerEmail = safeStr(body?.customerEmail).trim() || "";
     let customerName = safeStr(body?.customerName).trim() || "";
 
+    // Service-role client is intentionally retained after canonical shop-scoped auth
+    // for privileged quote-send side effects (email/persistence/notifications).
     if (wo.customer_id) {
       const { data: customer, error: customerErr } = await supabaseAdmin
         .from("customers")
@@ -369,10 +351,15 @@ export async function POST(req: Request) {
       ? `${normalizedAppUrl}/portal/quotes/${workOrderId}`
       : null;
 
-    await sendQuoteReadyEmail({
+    const requestAllowsResend = req.headers.get("x-profix-resend") === "1";
+    const quoteUrlForSend = portalQuoteUrl ?? pdfUrl ?? wo.quote_url ?? "";
+    const shouldSkipAsDuplicate = Boolean(wo.quote_url) && wo.quote_url === quoteUrlForSend && !requestAllowsResend;
+
+    if (!shouldSkipAsDuplicate) {
+      await sendQuoteReadyEmail({
       shopId: wo.shop_id,
       to: customerEmail,
-      quoteUrl: portalQuoteUrl ?? pdfUrl ?? wo.quote_url ?? "",
+      quoteUrl: quoteUrlForSend,
       quoteTotal: quoteTotal ?? null,
       vehicleLabel: buildVehicleLabel(vehicleInfo),
       shopName: shopName || undefined,
@@ -380,6 +367,7 @@ export async function POST(req: Request) {
       brandPrimaryColor: brand?.colors.primary ?? null,
       brandSecondaryColor: brand?.colors.secondary ?? null,
     });
+    }
 
     const newQuoteUrl = portalQuoteUrl ?? pdfUrl ?? wo.quote_url ?? null;
 
@@ -426,12 +414,13 @@ export async function POST(req: Request) {
       return NextResponse.json({
         ok: true,
         trace,
+        deduped: shouldSkipAsDuplicate,
         sentWithWarnings: true,
         warnings: postSendWarnings,
       });
     }
 
-    return NextResponse.json({ ok: true, trace });
+    return NextResponse.json({ ok: true, trace, deduped: shouldSkipAsDuplicate });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Unknown error sending quote";

--- a/app/api/work-orders/[id]/send-quote/route.ts
+++ b/app/api/work-orders/[id]/send-quote/route.ts
@@ -1,33 +1,20 @@
 // /app/api/work-orders/[id]/send-quote/route.ts
 import { NextResponse, type NextRequest } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
-
-function isUuid(v: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-    v,
-  );
-}
-
-async function resolveWorkOrderId(rawId: string): Promise<string | null> {
+async function resolveWorkOrderId(
+  rawId: string,
+  shopId: string,
+  accessSupabase: ReturnType<typeof createServerSupabaseRoute>,
+): Promise<string | null> {
   const id = rawId.trim();
   if (!id) return null;
-  if (isUuid(id)) return id;
-
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_KEY;
-
-  if (!url || !key) return null;
-
-  const sb = createClient<DB>(url, key);
-
-  const { data, error } = await sb
+  const { data, error } = await accessSupabase
     .from("work_orders")
     .select("id")
-    .eq("custom_id", id)
+    .eq("shop_id", shopId)
+    .or(`id.eq.${id},custom_id.eq.${id}`)
     .maybeSingle<{ id: string }>();
 
   if (error) return null;
@@ -58,7 +45,22 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     .toString(16)
     .slice(2)}`;
 
-  const resolvedId = await resolveWorkOrderId(id);
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) {
+    const payload = await access.response.json().catch(() => ({ error: "Forbidden" }));
+    return NextResponse.json(
+      { ok: false, trace, error: payload?.error ?? "Forbidden" },
+      { status: access.response.status },
+    );
+  }
+  const shopId = access.profile.shop_id;
+  if (!shopId) {
+    return NextResponse.json({ ok: false, trace, error: "Profile for current user not found" }, { status: 403 });
+  }
+
+  const resolvedId = await resolveWorkOrderId(id, shopId, access.supabase);
 
   if (!resolvedId) {
     return NextResponse.json(
@@ -86,6 +88,7 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
   };
 
   const url = new URL(req.url);
+  // Compatibility wrapper: canonical quote send behavior lives at /api/quotes/send.
   url.pathname = "/api/quotes/send";
   url.search = "";
 


### PR DESCRIPTION
### Motivation
- Ensure the canonical quote send path enforces a trusted shop boundary and canonical RBAC checks so staff cannot send quotes across shops or via global lookups.
- Preserve the existing compatibility wrapper while removing unsafe global `custom_id` resolution and making the wrapper verify same-shop ownership before forwarding. 
- Add a small, safe dedupe guard to reduce accidental duplicate sends without changing lifecycle semantics or schema.

### Description
- Replaced ad-hoc profile/capability checks in `app/api/quotes/send/route.ts` with `requireShopScopedApiAccess({ requiredCapability: "canAuthorizeQuotes" })` and map access failures into the route's JSON envelope. 
- Enforced the shop boundary by constraining the canonical work order lookup to `access.profile.shop_id` and retained the service-role Supabase client only for privileged post-auth side effects (email, persistence, notifications) with an inline comment explaining why. 
- Added a minimal dedupe/idempotency guard that skips sending an immediate duplicate email when the computed quote URL equals the existing `work_orders.quote_url`, while allowing explicit resends via header `x-profix-resend: 1` and returning an additive `deduped` boolean in success responses. 
- Hardened the compatibility wrapper `app/api/work-orders/[id]/send-quote/route.ts` by applying the same `requireShopScopedApiAccess` check and resolving `id` (UUID or `custom_id`) only within the authenticated `shop_id` using the route Supabase client before forwarding to `/api/quotes/send`, and added a short compatibility comment.

### Testing
- Ran `npx tsc --noEmit` and it passed without type errors for the modified files. 
- Ran `npm run lint` which failed due to many pre-existing, repo-wide lint issues; the lint failures shown are unrelated to the changed files and no new lint errors were introduced in the touched routes. 
- Searched for relevant patterns with `rg` to verify changes: `requireShopScopedApiAccess` and `canAuthorizeQuotes` references exist in both modified files and shop/work-order/quote lookups are constrained to the authenticated shop. 
- Commit hash: `696b57c`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8eeb685bc8328994ef600cd7c7840)