### PR TITLE
Harden invoice send route shop-scoped consistency

### DIFF
--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -21,6 +21,9 @@ const supabaseAdmin = createClient<DB>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
+// Service role is intentionally retained for post-auth privileged invoice-send
+// side effects (email/persistence/logging). Ownership is validated against the
+// caller's shop boundary before any privileged operations execute.
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://profixiq.com";
 
@@ -262,6 +265,7 @@ export async function POST(req: Request) {
         "id, shop_id, customer_id, vehicle_id, labor_total, parts_total, invoice_total, customer_name, status",
       )
       .eq("id", workOrderId)
+      .eq("shop_id", access.profile.shop_id)
       .maybeSingle<
         Pick<
           WorkOrderRow,
@@ -524,7 +528,8 @@ export async function POST(req: Request) {
               invoice_url: portalInvoiceUrl,
               invoice_pdf_url: invoicePdfUrl,
             } as DB["public"]["Tables"]["work_orders"]["Update"])
-            .eq("id", workOrderId);
+            .eq("id", workOrderId)
+            .eq("shop_id", wo.shop_id);
           if (error) throw new Error(error.message);
         },
       },


### PR DESCRIPTION
### Motivation
- Tighten the Phase 2D boundary on `app/api/invoices/send/route.ts` to ensure all invoice/work-order operations are guarded by the caller's `shop_id` while preserving existing send behavior and privileged post-auth side effects.

### Description
- Added an inline rationale comment explaining why the Supabase service role is retained for post-auth privileged side effects and that ownership is validated first, constrained the initial `work_orders` lookup with `.eq("shop_id", access.profile.shop_id)`, and constrained the post-send `work_orders` update with `.eq("shop_id", wo.shop_id)` while keeping capability/role policy unchanged and leaving idempotency/resend behavior as-is.

### Testing
- Ran `npx tsc --noEmit` (passed) and `npm run lint` (failed due to pre-existing repo-wide lint issues outside this route); also ran targeted `rg` checks to verify access helpers and invoice/work-order fields; changes committed as `04528c6`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8faa3504c83288224b4c7d86800f4)