### PR TITLE
Harden customer signed invoice document access checks

### DIFF
--- a/app/api/invoices/[id]/documents/[kind]/signed/route.ts
+++ b/app/api/invoices/[id]/documents/[kind]/signed/route.ts
@@ -8,14 +8,31 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 
+type SupportedInvoiceDocumentKind = "invoice_pdf";
+const SUPPORTED_KINDS: ReadonlySet<SupportedInvoiceDocumentKind> = new Set(["invoice_pdf"]);
+
 function extract(req: NextRequest): { invoiceId: string | null; kind: string | null } {
   const m = req.nextUrl.pathname.match(/\/api\/invoices\/([^/]+)\/documents\/([^/]+)\/signed$/);
   return { invoiceId: m?.[1] ?? null, kind: m?.[2] ?? null };
 }
 
+function isSupportedKind(kind: string): kind is SupportedInvoiceDocumentKind {
+  return SUPPORTED_KINDS.has(kind as SupportedInvoiceDocumentKind);
+}
+
+function isSafeStoragePath(path: string): boolean {
+  if (!path || path.startsWith("/")) return false;
+  if (path.includes("..")) return false;
+  if (path.includes("//")) return false;
+  return true;
+}
+
 export async function GET(req: NextRequest) {
   const { invoiceId, kind } = extract(req);
   if (!invoiceId || !kind) return NextResponse.json({ ok: false, error: "Missing params" }, { status: 400 });
+  if (!isSupportedKind(kind)) {
+    return NextResponse.json({ ok: false, error: "Invalid kind" }, { status: 400 });
+  }
 
   const supabase = createRouteHandlerClient<DB>({ cookies });
   const {
@@ -29,7 +46,7 @@ export async function GET(req: NextRequest) {
 
   const { data: invoice, error: invErr } = await supabase
     .from("invoices")
-    .select("id, customer_id")
+    .select("id, customer_id, shop_id, work_order_id")
     .eq("id", invoiceId)
     .maybeSingle();
 
@@ -40,25 +57,57 @@ export async function GET(req: NextRequest) {
 
   const { data: customer, error: customerErr } = await supabase
     .from("customers")
-    .select("id")
+    .select("id, shop_id")
     .eq("id", invoice.customer_id)
     .eq("user_id", user.id)
     .maybeSingle();
 
   if (customerErr) return NextResponse.json({ ok: false, error: customerErr.message }, { status: 400 });
   if (!customer?.id) {
-    return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+    return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+  }
+
+  if (invoice.shop_id !== customer.shop_id) {
+    return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+  }
+
+  if (invoice.work_order_id) {
+    const { data: workOrder, error: workOrderErr } = await supabase
+      .from("work_orders")
+      .select("id, customer_id, shop_id")
+      .eq("id", invoice.work_order_id)
+      .maybeSingle();
+
+    if (workOrderErr) return NextResponse.json({ ok: false, error: workOrderErr.message }, { status: 400 });
+    if (!workOrder?.id) {
+      return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+    }
+
+    if (
+      workOrder.customer_id !== invoice.customer_id ||
+      workOrder.customer_id !== customer.id ||
+      workOrder.shop_id !== invoice.shop_id ||
+      workOrder.shop_id !== customer.shop_id
+    ) {
+      return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+    }
   }
 
   const { data: doc, error } = await supabase
     .from("invoice_documents")
-    .select("storage_bucket, storage_path")
+    .select("storage_bucket, storage_path, shop_id, invoice_id")
     .eq("invoice_id", invoiceId)
     .eq("kind", kind)
     .maybeSingle();
 
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
   if (!doc?.storage_bucket || !doc?.storage_path) return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+  if (doc.invoice_id !== invoice.id || doc.shop_id !== invoice.shop_id || doc.shop_id !== customer.shop_id) {
+    return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+  }
+  if (!isSafeStoragePath(doc.storage_path)) {
+    return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+  }
 
   const { data: signed, error: sErr } = await supabase.storage
     .from(doc.storage_bucket)


### PR DESCRIPTION
### Motivation
- Reduce risk of cross-tenant/owner disclosure when customers fetch signed invoice documents by tightening validation around document kind, ownership, tenancy, and storage paths.
- Preserve existing customer-facing behavior (route-handler Supabase client, authenticated user access, and signed URL response shape) while adding defensive checks.

### Description
- Added a typed allowlist for document kinds and reject unknown `kind` values with `400`; the only supported kind is `invoice_pdf`.
- Tightened ownership checks by ensuring the invoice links to a customer owned by the authenticated `user`, and return `404` for visibility mismatches to avoid leaking existence information.
- Added optional tenant/work-order consistency checks when `invoice.work_order_id` is present by validating the referenced work order’s `customer_id` and `shop_id` align with the invoice and customer row.
- Hardened storage path safety by selecting bucket/path only from the `invoice_documents` row and rejecting unsafe paths (empty, leading `/`, `..` segments, or `//`) before calling `createSignedUrl`; preserved the 10-minute TTL and returned JSON shape `{ ok: true, url }` on success.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully with no new type errors introduced by this change.
- Ran `npm run lint` and observed repo-wide pre-existing lint failures unrelated to this route; examples include hook-order errors in `features/shared/components/nav/NavFromTiles.tsx` and prefer-spread errors in `features/ai/server/actionApprovals.*.test.ts` (lint run reported 16 errors / 404 warnings overall, pre-existing).
- Ran targeted searches to validate changed symbols: used `rg` for terms such as `kind|invoice|invoice_id|customer|user_id|shop_id|work_order|signed|createSignedUrl|bucket|path|storage` against the modified route and scanned for service-role markers to confirm no service-role or `requireShopScopedApiAccess` usage was introduced.

Files changed: `app/api/invoices/[id]/documents/[kind]/signed/route.ts`
Supported document kinds: `invoice_pdf` only
Service role: not introduced (still uses `createRouteHandlerClient` + `auth.getUser()`)
Storage path validation: added (`isSafeStoragePath`) and enforced before signing
Response behavior: unchanged success response and TTL; error codes: `401` unauthenticated, `400` invalid kind / query errors, `404` not found/visibility mismatches, `500` signed URL failure
Caller compatibility risks: requests using non-`invoice_pdf` kinds will receive `400`, and documents with legacy/unsafe `storage_path` or inconsistent tenant links may now return `404` instead of being signed
Commit hash: `155fa9e`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fde537f4832885df417511a46ebd)