### PR TITLE
Harden planner upload path validation and add assign-line technician role checks

### DIFF
--- a/app/api/planner/uploads/sign/route.ts
+++ b/app/api/planner/uploads/sign/route.ts
@@ -19,18 +19,41 @@ type Body = {
   expiresIn?: number; // seconds
 };
 
+function isSafeStoragePath(path: string, shopId: string): boolean {
+  if (!path || typeof path !== "string") return false;
+  if (path.startsWith("/")) return false;
+  if (path.includes("\\")) return false;
+  if (path.includes("//")) return false;
+
+  let decodedPath = path;
+  try {
+    decodedPath = decodeURIComponent(path);
+  } catch {
+    return false;
+  }
+
+  const hasTraversalSegment = (candidate: string) =>
+    candidate
+      .split("/")
+      .some((segment) => segment === ".." || segment.trim().toLowerCase() === "%2e%2e");
+
+  if (hasTraversalSegment(path) || hasTraversalSegment(decodedPath)) return false;
+
+  return path.startsWith(`${shopId}/`);
+}
+
 export async function POST(req: NextRequest) {
   const access = await requireShopScopedApiAccess();
   if (!access.ok) return access.response;
   const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const body = (await req.json().catch(() => null)) as Body | null;
   const paths = Array.isArray(body?.paths) ? body!.paths : [];
   if (paths.length === 0) return NextResponse.json({ error: "paths required" }, { status: 400 });
 
   const expiresIn = Number.isFinite(body?.expiresIn) ? Math.max(60, Number(body!.expiresIn)) : 60 * 60; // default 1h
-  const allowedPrefix = `${shopId}/`;
-  const hasOutOfScopePath = paths.some((path) => typeof path !== "string" || !path.startsWith(allowedPrefix));
+  const hasOutOfScopePath = paths.some((path) => typeof path !== "string" || !isSafeStoragePath(path, shopId));
   if (hasOutOfScopePath) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/app/api/work-orders/assign-line/route.ts
+++ b/app/api/work-orders/assign-line/route.ts
@@ -6,6 +6,8 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 
 type DB = Database;
 
+const ASSIGNABLE_TECH_ROLES = ["mechanic", "tech", "foreman", "lead_hand"] as const;
+
 function must(name: string): string {
   const v = process.env[name];
   if (!v) throw new Error(`Missing env ${name}`);
@@ -56,7 +58,7 @@ export async function POST(req: Request) {
 
     const { data: technician, error: technicianErr } = await supabase
       .from("profiles")
-      .select("id")
+      .select("id, role")
       .eq("id", techId)
       .eq("shop_id", shopId)
       .maybeSingle();
@@ -64,6 +66,9 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: technicianErr.message }, { status: 400 });
     }
     if (!technician) {
+      return NextResponse.json({ error: "Technician not found" }, { status: 404 });
+    }
+    if (!technician.role || !ASSIGNABLE_TECH_ROLES.includes(technician.role as (typeof ASSIGNABLE_TECH_ROLES)[number])) {
       return NextResponse.json({ error: "Technician not found" }, { status: 404 });
     }
 


### PR DESCRIPTION
### Motivation
- Prevent path-canonicalization edge cases (repeated/leading slashes, backslashes, traversal segments and encoded traversal) from bypassing shop-scoped planner upload signing.  
- Ensure `assign-line` only allows assignment to explicit, intended technician roles to avoid accidentally assigning non-technician staff.

### Description
- Added `isSafeStoragePath(path, shopId)` to `app/api/planner/uploads/sign/route.ts` which rejects empty paths, leading slashes, backslashes, duplicate `//` segments, `..` segments, decoded `%2e%2e` traversal, and any path not starting with the required `${shopId}/` prefix, and applied this check before calling `createSignedUrls`; response shape for success and error remains unchanged (`{ signed: [...] }` and `403 { error: "Forbidden" }`).
- Added a defensive guard to return `403` when `shop_id` is missing from the access profile in the planner upload route.  
- Added `ASSIGNABLE_TECH_ROLES = ["mechanic","tech","foreman","lead_hand"]` to `app/api/work-orders/assign-line/route.ts`, updated the technician lookup to select `role`, and reject the assignment when the target profile has a missing or non-assignable role while preserving the existing `404 { error: "Technician not found" }` response style for compatibility.
- Evidence for the allowlist: `app/api/assignables/route.ts` already filters `.in('role', ['mechanic','tech','foreman','lead_hand'])`, so the same role set was reused as the authoritative source.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully.  
- Ran `npm run lint` and it failed due to pre-existing, repo-wide lint errors unrelated to these changes (summary: many warnings and 16 errors across unrelated files); examples include hook-order errors in `features/shared/components/nav/NavFromTiles.tsx` and `no-var` in `features/shared/types/types/global.d.ts`.  
- Ran targeted grep checks (`rg`) to confirm the new helper and role strings are present in the modified files and that `assignables` uses the same role list, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9039e59f08328a39d9c9313e04554)