### PR TITLE
Implement onboarding-v2 UI-1 secure proxy foundation

### DIFF
--- a/app/api/onboarding-v2/agent-readiness/route.ts
+++ b/app/api/onboarding-v2/agent-readiness/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const production = await proxyOnboardingAgent({ method: "GET", path: "/onboarding/production-readiness", shopId });
+  if (!production.ok) return production;
+
+  const connector = await proxyOnboardingAgent({ method: "GET", path: "/onboarding/connector/readiness", shopId });
+  const productionJson = (await production.json()) as Record<string, unknown>;
+  const connectorJson = connector.ok ? (await connector.json()) as Record<string, unknown> : { ok: false, message: "Connector readiness unavailable" };
+
+  return NextResponse.json({ ok: true, production: productionJson, connector: connectorJson });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
+
+export async function GET(_: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const { sessionId } = await context.params;
+  // Railway onboarding-agent contract: GET /onboarding/sessions/:sessionId with shopId included server-side.
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const query = new URLSearchParams({ shopId });
+  const response = await proxyOnboardingAgent({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}`, shopId, query });
+  const payload = (await response.json().catch(() => ({ ok: false, message: "Invalid agent response" }))) as Record<string, unknown>;
+  return NextResponse.json(payload, { status: response.status });
+}

--- a/app/api/onboarding-v2/sessions/route.ts
+++ b/app/api/onboarding-v2/sessions/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
+import { StartSessionRequestSchema } from "@/features/onboarding-v2/server/schemas";
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const parsed = StartSessionRequestSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const body = JSON.stringify({ shopId, ...parsed.data });
+  const response = await proxyOnboardingAgent({ method: "POST", path: "/onboarding/sessions", shopId, body });
+  const payload = (await response.json().catch(() => ({ ok: false, message: "Invalid agent response" }))) as Record<string, unknown>;
+  return NextResponse.json(payload, { status: response.status });
+}

--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -1,0 +1,20 @@
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
+import { OnboardingSessionOverview } from "@/features/onboarding-v2/components/OnboardingSessionOverview";
+import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
+import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
+
+type Props = { params: Promise<{ sessionId: string }> };
+
+export default async function OnboardingV2SessionPage({ params }: Props) {
+  await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
+  const { sessionId } = await params;
+
+  return (
+    <OnboardingV2Shell title="Onboarding Agent Session">
+      <SafeModeVerifyOnlyBanner />
+      <AgentReadinessBanner ready={true} detail="Readiness verification proxied through server routes." />
+      <OnboardingSessionOverview sessionId={sessionId} status="pending" />
+    </OnboardingV2Shell>
+  );
+}

--- a/app/dashboard/onboarding-v2/page.tsx
+++ b/app/dashboard/onboarding-v2/page.tsx
@@ -1,0 +1,30 @@
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
+import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
+import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
+import { StartOnboardingSessionCard } from "@/features/onboarding-v2/components/StartOnboardingSessionCard";
+
+async function getReadiness(): Promise<{ ready: boolean; detail: string }> {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"}/api/onboarding-v2/agent-readiness`, { cache: "no-store" });
+    if (!response.ok) return { ready: false, detail: "Readiness unavailable." };
+    return { ready: true, detail: "Agent production and connector readiness checks are reachable." };
+  } catch {
+    return { ready: false, detail: "Readiness unavailable." };
+  }
+}
+
+export default async function OnboardingV2Page() {
+  await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
+  const readiness = await getReadiness();
+
+  return (
+    <OnboardingV2Shell title="Onboarding Agent">
+      <SafeModeVerifyOnlyBanner />
+      <AgentReadinessBanner ready={readiness.ready} detail={readiness.detail} />
+      <StartOnboardingSessionCard />
+      <div className="rounded-xl border border-dashed border-white/15 p-4 text-sm text-slate-300">Session listing coming next.</div>
+      <div className="text-xs text-slate-400">Legacy onboarding remains available at /dashboard/onboarding during transition.</div>
+    </OnboardingV2Shell>
+  );
+}

--- a/features/onboarding-v2/components/AgentReadinessBanner.tsx
+++ b/features/onboarding-v2/components/AgentReadinessBanner.tsx
@@ -1,0 +1,8 @@
+export function AgentReadinessBanner({ ready, detail }: { ready: boolean; detail: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-200">
+      <div className="font-semibold">Agent readiness: {ready ? "Ready" : "Not ready"}</div>
+      <p className="mt-1 text-xs text-slate-400">{detail}</p>
+    </div>
+  );
+}

--- a/features/onboarding-v2/components/OnboardingSessionOverview.tsx
+++ b/features/onboarding-v2/components/OnboardingSessionOverview.tsx
@@ -1,0 +1,13 @@
+export function OnboardingSessionOverview({ sessionId, status }: { sessionId: string; status: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/50 p-4 text-sm text-slate-200">
+      <div className="font-semibold">Session {sessionId}</div>
+      <div className="mt-1 text-xs text-slate-400">Status: {status}</div>
+      <div className="mt-4 grid gap-2 text-xs text-slate-300">
+        <div>• Progress timeline placeholder</div>
+        <div>• Upload/analyze/preview placeholders</div>
+        <div>• Review/summary placeholders</div>
+      </div>
+    </div>
+  );
+}

--- a/features/onboarding-v2/components/OnboardingV2Shell.tsx
+++ b/features/onboarding-v2/components/OnboardingV2Shell.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from "react";
+
+export function OnboardingV2Shell({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4 p-4 md:p-6">
+      <h1 className="text-2xl font-semibold text-white">{title}</h1>
+      {children}
+    </div>
+  );
+}

--- a/features/onboarding-v2/components/SafeModeVerifyOnlyBanner.tsx
+++ b/features/onboarding-v2/components/SafeModeVerifyOnlyBanner.tsx
@@ -1,0 +1,7 @@
+export function SafeModeVerifyOnlyBanner() {
+  return (
+    <div className="rounded-xl border border-amber-500/30 bg-amber-950/30 p-4 text-sm text-amber-100">
+      Verify-only safe mode is active. Live materialization remains disabled.
+    </div>
+  );
+}

--- a/features/onboarding-v2/components/StartOnboardingSessionCard.tsx
+++ b/features/onboarding-v2/components/StartOnboardingSessionCard.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+
+export function StartOnboardingSessionCard() {
+  const [status, setStatus] = useState<string>("");
+
+  async function startSession(): Promise<void> {
+    setStatus("Starting session...");
+    const response = await fetch("/api/onboarding-v2/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sourceSystem: "profixiq-onboarding-v2" }),
+    });
+    const payload = (await response.json()) as { sessionId?: string; message?: string };
+    setStatus(payload.sessionId ? `Session created: ${payload.sessionId}` : payload.message ?? "Unable to create session");
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/50 p-4">
+      <div className="text-sm font-semibold text-white">Start new onboarding session</div>
+      <p className="mt-1 text-xs text-slate-400">Creates an onboarding-v2 session through the secure server proxy.</p>
+      <button onClick={startSession} className="mt-3 rounded-md bg-orange-500 px-3 py-2 text-sm font-medium text-white hover:bg-orange-400">Start session</button>
+      {status ? <p className="mt-2 text-xs text-slate-300">{status}</p> : null}
+    </div>
+  );
+}

--- a/features/onboarding-v2/lib/flags.ts
+++ b/features/onboarding-v2/lib/flags.ts
@@ -1,0 +1,4 @@
+export function isOnboardingV2NavEnabled(): boolean {
+  const raw = process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED ?? process.env.ONBOARDING_V2_ENABLED ?? "";
+  return raw.trim().toLowerCase() === "true";
+}

--- a/features/onboarding-v2/server/agentClient.ts
+++ b/features/onboarding-v2/server/agentClient.ts
@@ -1,0 +1,38 @@
+import { getOnboardingAgentConfig } from "@/features/onboarding-v2/server/config";
+import { signOnboardingAgentPayload } from "@/features/onboarding-v2/server/signing";
+
+export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path: string; shopId: string; body?: string; query?: URLSearchParams }): Promise<Response> {
+  const config = getOnboardingAgentConfig();
+
+  if (!config.enabled) {
+    return Response.json({ ok: false, status: "disabled", message: "Onboarding agent is disabled." }, { status: 503 });
+  }
+
+  if (!config.baseUrl || !config.internalSecret) {
+    return Response.json({ ok: false, status: "not_configured", message: "Onboarding agent is not configured." }, { status: 503 });
+  }
+
+  const rawBody = input.body ?? "";
+  const timestampMs = Date.now();
+  const signature = signOnboardingAgentPayload({ secret: config.internalSecret, shopId: input.shopId, timestampMs, rawBody });
+  const url = new URL(input.path, config.baseUrl.endsWith("/") ? config.baseUrl : `${config.baseUrl}/`);
+  if (input.query) {
+    input.query.forEach((value, key) => url.searchParams.set(key, value));
+  }
+
+  try {
+    return await fetch(url, {
+      method: input.method,
+      headers: {
+        "content-type": "application/json",
+        "x-shop-id": input.shopId,
+        "x-onboarding-agent-timestamp": String(timestampMs),
+        "x-onboarding-agent-signature": signature,
+      },
+      body: input.method === "POST" ? rawBody : undefined,
+      cache: "no-store",
+    });
+  } catch {
+    return Response.json({ ok: false, status: "unreachable", message: "Onboarding agent is unreachable." }, { status: 502 });
+  }
+}

--- a/features/onboarding-v2/server/config.ts
+++ b/features/onboarding-v2/server/config.ts
@@ -1,0 +1,26 @@
+export type OnboardingAgentConfig = {
+  enabled: boolean;
+  baseUrl: string | null;
+  internalSecret: string | null;
+  v2Enabled: boolean;
+};
+
+function asEnabled(raw: string | undefined): boolean {
+  return String(raw ?? "").trim().toLowerCase() === "true";
+}
+
+export function getOnboardingAgentConfig(): OnboardingAgentConfig {
+  const baseUrl = process.env.ONBOARDING_AGENT_BASE_URL?.trim() ?? null;
+  const internalSecret = process.env.ONBOARDING_AGENT_INTERNAL_SECRET?.trim() ?? null;
+
+  return {
+    enabled: asEnabled(process.env.ONBOARDING_AGENT_ENABLED),
+    baseUrl,
+    internalSecret,
+    v2Enabled: asEnabled(process.env.ONBOARDING_V2_ENABLED),
+  };
+}
+
+export function getOnboardingV2NavEnabled(): boolean {
+  return asEnabled(process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED) || asEnabled(process.env.ONBOARDING_V2_ENABLED);
+}

--- a/features/onboarding-v2/server/schemas.ts
+++ b/features/onboarding-v2/server/schemas.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const StartSessionRequestSchema = z.object({
+  displayName: z.string().trim().min(1).max(120).optional(),
+  sourceSystem: z.string().trim().min(1).max(120).optional(),
+});
+
+export type StartSessionRequest = z.infer<typeof StartSessionRequestSchema>;

--- a/features/onboarding-v2/server/signing.ts
+++ b/features/onboarding-v2/server/signing.ts
@@ -1,0 +1,6 @@
+import crypto from "node:crypto";
+
+export function signOnboardingAgentPayload(input: { secret: string; shopId: string; timestampMs: number; rawBody: string }): string {
+  const payload = `${input.timestampMs}.${input.shopId}.${input.rawBody}`;
+  return crypto.createHmac("sha256", input.secret).update(payload).digest("hex");
+}

--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/features/shared/lib/ownerSidebarNav";
 import { cn } from "@/features/shared/utils/cn";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { isOnboardingV2NavEnabled } from "@/features/onboarding-v2/lib/flags";
 
 const GROUP_ORDER = [
   "Tech",
@@ -86,9 +87,10 @@ export default function RoleSidebar() {
   const tiles = useMemo(() => {
     if (!role) return [] as Tile[];
 
-    const filteredTiles = TILES.filter((t) => t.roles.includes(role)).filter(
-      (t) => t.scopes.includes("all") || t.scopes.includes(scopeFilter),
-    );
+    const navV2Enabled = isOnboardingV2NavEnabled();
+    const filteredTiles = TILES.filter((t) => t.roles.includes(role))
+      .filter((t) => t.scopes.includes("all") || t.scopes.includes(scopeFilter))
+      .filter((t) => (t.href === "/dashboard/onboarding-v2" ? navV2Enabled : true));
 
     if (role === "owner") return getOwnerSidebarTiles(filteredTiles);
     return filteredTiles;

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -145,6 +145,14 @@ export const TILES: Tile[] = [
     scopes: ["management", "all"],
     section: "Tools",
   },
+  {
+    href: "/dashboard/onboarding-v2",
+    title: "Onboarding v2",
+    subtitle: "Verify-only onboarding foundation",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Tools",
+  },
 
   /* ---------------------------------------------------------------------- */
   /* APPOINTMENTS                                                            */

--- a/tests/onboarding-v2-signing.test.ts
+++ b/tests/onboarding-v2-signing.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { signOnboardingAgentPayload } from "@/features/onboarding-v2/server/signing";
+
+describe("onboarding-v2 signing", () => {
+  it("creates deterministic HMAC signature", () => {
+    const signature = signOnboardingAgentPayload({
+      secret: "top-secret",
+      shopId: "shop_123",
+      timestampMs: 1710000000000,
+      rawBody: '{"shopId":"shop_123"}',
+    });
+
+    expect(signature).toBe("866f85f23f656b88c4dc95c0b53a2cedbdf7b8fb98c06236231e4c48e321161b");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a safe, owner/admin-only Phase UI-1 foundation for Onboarding v2 that proxies requests to the external Railway onboarding agent without exposing internal secrets or enabling live materialization.
- Ensure server-side signing and shop-scoped auth so the browser never calls the agent directly and `shop_id` is derived from authenticated server context only.

### Description
- Added typed onboarding-v2 server utilities including `getOnboardingAgentConfig`, HMAC signing (`signOnboardingAgentPayload`), and a proxy client `proxyOnboardingAgent` that attaches `x-shop-id`, `x-onboarding-agent-timestamp`, and `x-onboarding-agent-signature` headers and implements the `${timestamp}.${shopId}.${rawBody}` payload convention.
- Implemented owner/admin-gated server proxy routes: `GET /api/onboarding-v2/agent-readiness`, `POST /api/onboarding-v2/sessions`, and `GET /api/onboarding-v2/sessions/[sessionId]`, each resolving `shopId` from `requireShopScopedApiAccess` and returning safe JSON when the agent is disabled/not configured/unreachable.
- Added minimal owner/admin UI pages and components at `/dashboard/onboarding-v2` and `/dashboard/onboarding-v2/[sessionId]` with `OnboardingV2Shell`, `AgentReadinessBanner`, `SafeModeVerifyOnlyBanner`, `StartOnboardingSessionCard`, and `OnboardingSessionOverview` as placeholders (no activation/production writes in this phase).
- Introduced a nav tile for Onboarding v2 and gated it behind the `ONBOARDING_V2_ENABLED` flag; confirmed env helpers read `ONBOARDING_AGENT_BASE_URL`, `ONBOARDING_AGENT_INTERNAL_SECRET`, `ONBOARDING_AGENT_ENABLED`, and `ONBOARDING_V2_ENABLED`.

### Testing
- Ran `npx tsc --noEmit` and TypeScript validation passed for the introduced code.
- Ran the focused unit test `npx vitest run tests/onboarding-v2-signing.test.ts` and it passed, verifying deterministic HMAC output for the signing helper.
- Ran `npm run lint` which reported pre-existing repo-wide lint issues unrelated to this change and therefore did not block this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb45545e408328ad79093b0f43430f)