### PR TITLE
Implement onboarding-v2 Phase UI-2 session workflow shell

### DIFF
--- a/app/api/onboarding-v2/sessions/[sessionId]/activation-summary/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/activation-summary/route.ts
@@ -1,0 +1,10 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function GET(_: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/activation-summary`, shopId });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/activation-tick/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/activation-tick/route.ts
@@ -1,0 +1,10 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function POST(_: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  return proxyJson({ method: "POST", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/activation-tick`, shopId });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/analyze/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/analyze/route.ts
@@ -1,0 +1,10 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function POST(_: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  return proxyJson({ method: "POST", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/analyze`, shopId });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/confirm/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/confirm/route.ts
@@ -1,0 +1,10 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function POST(_: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  return proxyJson({ method: "POST", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/confirm`, shopId });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/entities/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/entities/route.ts
@@ -1,0 +1,13 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  const source = new URL(request.url).searchParams;
+  const query = new URLSearchParams();
+  ["entityType", "status", "limit", "offset"].forEach((key) => { const v = source.get(key); if (v) query.set(key, v); });
+  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/entities`, shopId, query });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/events/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/events/route.ts
@@ -1,0 +1,11 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  const query = new URL(request.url).searchParams;
+  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/events`, shopId, query });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+
+  const contentType = request.headers.get("content-type") ?? "";
+  let body: Record<string, unknown> = {};
+
+  if (contentType.includes("multipart/form-data")) {
+    const form = await request.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) return NextResponse.json({ error: "file_missing" }, { status: 400 });
+    if (file.size > MAX_BYTES) return NextResponse.json({ error: "file_too_large", maxBytes: MAX_BYTES }, { status: 413 });
+    const buffer = Buffer.from(await file.arrayBuffer());
+    body = { fileName: file.name, mimeType: file.type || "application/octet-stream", sizeBytes: file.size, contentBase64: buffer.toString("base64") };
+  } else {
+    const parsed = (await request.json().catch(() => null)) as { fileName?: string; mimeType?: string; contentBase64?: string } | null;
+    if (!parsed?.fileName || !parsed.contentBase64) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+    const approxBytes = Math.floor((parsed.contentBase64.length * 3) / 4);
+    if (approxBytes > MAX_BYTES) return NextResponse.json({ error: "file_too_large", maxBytes: MAX_BYTES }, { status: 413 });
+    body = { fileName: parsed.fileName, mimeType: (parsed.mimeType ?? "application/octet-stream"), contentBase64: parsed.contentBase64 };
+  }
+
+  return proxyJson({ method: "POST", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/files/content`, shopId, body });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/files/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/files/route.ts
@@ -1,0 +1,11 @@
+import { withOnboardingAccess, proxyJson } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  const query = new URL(request.url).searchParams;
+  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/files`, shopId, query });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/links/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/links/route.ts
@@ -1,0 +1,13 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  const source = new URL(request.url).searchParams;
+  const query = new URLSearchParams();
+  ["linkType", "status", "limit", "offset"].forEach((key) => { const v = source.get(key); if (v) query.set(key, v); });
+  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/links`, shopId, query });
+}

--- a/app/api/onboarding-v2/sessions/[sessionId]/review-items/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/review-items/route.ts
@@ -1,0 +1,13 @@
+import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+
+export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+  const access = await withOnboardingAccess();
+  if (!access.ok) return access.response;
+  const { sessionId } = await context.params;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+  const source = new URL(request.url).searchParams;
+  const query = new URLSearchParams();
+  ["status", "severity", "limit", "offset"].forEach((key) => { const v = source.get(key); if (v) query.set(key, v); });
+  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/review-items`, shopId, query });
+}

--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -1,8 +1,8 @@
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
-import { OnboardingSessionOverview } from "@/features/onboarding-v2/components/OnboardingSessionOverview";
 import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
 import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
+import { SessionWorkspace } from "@/features/onboarding-v2/components/SessionWorkspace";
 
 type Props = { params: Promise<{ sessionId: string }> };
 
@@ -14,7 +14,7 @@ export default async function OnboardingV2SessionPage({ params }: Props) {
     <OnboardingV2Shell title="Onboarding Agent Session">
       <SafeModeVerifyOnlyBanner />
       <AgentReadinessBanner ready={true} detail="Readiness verification proxied through server routes." />
-      <OnboardingSessionOverview sessionId={sessionId} status="pending" />
+      <SessionWorkspace sessionId={sessionId} />
     </OnboardingV2Shell>
   );
 }

--- a/app/dashboard/onboarding-v2/[sessionId]/review/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/review/page.tsx
@@ -1,0 +1,11 @@
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
+import { ReviewItemsQueue } from "@/features/onboarding-v2/components/ReviewItemsQueue";
+
+type Props = { params: Promise<{ sessionId: string }> };
+
+export default async function ReviewPage({ params }: Props) {
+  await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
+  const { sessionId } = await params;
+  return <OnboardingV2Shell title="Onboarding Exception Review"><ReviewItemsQueue sessionId={sessionId} /></OnboardingV2Shell>;
+}

--- a/features/onboarding-v2/components/ActivationSummaryPanel.tsx
+++ b/features/onboarding-v2/components/ActivationSummaryPanel.tsx
@@ -1,0 +1,3 @@
+export function ActivationSummaryPanel() {
+  return null;
+}

--- a/features/onboarding-v2/components/ConfirmActivationPanel.tsx
+++ b/features/onboarding-v2/components/ConfirmActivationPanel.tsx
@@ -1,0 +1,3 @@
+export function ConfirmActivationPanel() {
+  return null;
+}

--- a/features/onboarding-v2/components/EntitySummaryCards.tsx
+++ b/features/onboarding-v2/components/EntitySummaryCards.tsx
@@ -1,0 +1,3 @@
+export function EntitySummaryCards() {
+  return null;
+}

--- a/features/onboarding-v2/components/FilesStatusCard.tsx
+++ b/features/onboarding-v2/components/FilesStatusCard.tsx
@@ -1,0 +1,3 @@
+export function FilesStatusCard() {
+  return null;
+}

--- a/features/onboarding-v2/components/OnboardingProgressRail.tsx
+++ b/features/onboarding-v2/components/OnboardingProgressRail.tsx
@@ -1,0 +1,3 @@
+export function OnboardingProgressRail() {
+  return null;
+}

--- a/features/onboarding-v2/components/ReviewItemsQueue.tsx
+++ b/features/onboarding-v2/components/ReviewItemsQueue.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Item = { id?: string; severity?: string; status?: string; title?: string; message?: string };
+
+export function ReviewItemsQueue({ sessionId }: { sessionId: string }) {
+  const [items, setItems] = useState<Item[]>([]);
+  const [status, setStatus] = useState("open");
+  useEffect(() => {
+    void fetch(`/api/onboarding-v2/sessions/${sessionId}/review-items?status=${encodeURIComponent(status)}&limit=100`, { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j: { items?: Item[] }) => setItems(j.items ?? []));
+  }, [sessionId, status]);
+
+  return <div className="space-y-4">
+    <div className="rounded-xl border border-white/10 p-4">Normal records do not require manual review; only exceptions appear here.</div>
+    <div className="flex gap-2">{["open","resolved"].map((s)=><button key={s} onClick={()=>setStatus(s)} className="rounded border border-white/20 px-3 py-1">{s}</button>)}</div>
+    <div className="rounded-xl border border-white/10 p-4">
+      {items.length===0 ? <div>No exceptions found</div> : items.map((item, i)=><div key={item.id ?? i} className="border-b border-white/10 py-2"><span>{item.severity ?? "unknown"}</span> • <span>{item.status ?? "unknown"}</span> • {item.title ?? item.message ?? "Review item"}</div>)}
+    </div>
+  </div>;
+}

--- a/features/onboarding-v2/components/SessionTimeline.tsx
+++ b/features/onboarding-v2/components/SessionTimeline.tsx
@@ -1,0 +1,3 @@
+export function SessionTimeline() {
+  return null;
+}

--- a/features/onboarding-v2/components/SessionWorkspace.tsx
+++ b/features/onboarding-v2/components/SessionWorkspace.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type Generic = Record<string, unknown>;
+
+async function getJson(path: string): Promise<Generic> { const r = await fetch(path, { cache: "no-store" }); return (await r.json()) as Generic; }
+
+export function SessionWorkspace({ sessionId }: { sessionId: string }) {
+  const [session, setSession] = useState<Generic | null>(null);
+  const [events, setEvents] = useState<Generic[]>([]);
+  const [summary, setSummary] = useState<Generic | null>(null);
+  const [files, setFiles] = useState<Generic[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const terminal = ["completed", "failed", "cancelled"].includes(String(session?.status ?? ""));
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      const [s, e, a, f] = await Promise.all([
+        getJson(`/api/onboarding-v2/sessions/${sessionId}`),
+        getJson(`/api/onboarding-v2/sessions/${sessionId}/events?limit=50`),
+        getJson(`/api/onboarding-v2/sessions/${sessionId}/activation-summary`),
+        getJson(`/api/onboarding-v2/sessions/${sessionId}/files`),
+      ]);
+      if (!active) return;
+      setSession(s); setEvents((e.items as Generic[]) ?? []); setSummary(a); setFiles((f.items as Generic[]) ?? []); setLoading(false);
+    };
+    void run();
+    const id = setInterval(() => { void run(); }, terminal ? 15000 : 7000);
+    return () => { active = false; clearInterval(id); };
+  }, [sessionId, terminal]);
+
+  const metrics = useMemo(() => ({
+    entities: Number(summary?.entityCount ?? 0), links: Number(summary?.linkCount ?? 0), review: Number(summary?.reviewCount ?? 0), staged: Number(summary?.stagedCount ?? 0),
+  }), [summary]);
+
+  const triggerAnalyze = async () => { await fetch(`/api/onboarding-v2/sessions/${sessionId}/analyze`, { method: "POST" }); };
+
+  if (loading) return <div className="rounded-xl border border-white/10 p-4">Loading session…</div>;
+  return <div className="space-y-4 text-sm text-slate-200">
+    <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">Verify-only mode: activation can be previewed/smoked but live writes are blocked.</div>
+    <div className="rounded-xl border border-white/10 p-4">Session <b>{sessionId}</b> • Status: {String(session?.status ?? "unknown")}</div>
+    <div className="grid gap-4 lg:grid-cols-2">
+      <UploadCard sessionId={sessionId} />
+      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Analyze</div><button onClick={triggerAnalyze} className="mt-3 rounded bg-cyan-600 px-3 py-2">Start processing</button></div>
+    </div>
+    <div className="grid gap-4 lg:grid-cols-4">{Object.entries(metrics).map(([k,v])=><div key={k} className="rounded-xl border border-white/10 p-3"><div className="text-xs text-slate-400">{k}</div><div className="text-xl">{v}</div></div>)}</div>
+    <div className="grid gap-4 lg:grid-cols-2">
+      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Files</div>{files.length===0?<div className="text-slate-400">No files yet.</div>:files.map((f,i)=><div key={i}>{String(f.fileName ?? "file")}</div>)}</div>
+      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Timeline</div>{events.length===0?<div className="text-slate-400">No events.</div>:events.map((e,i)=><div key={i} className="text-xs">{String(e.type ?? "event")} • {String(e.status ?? "")}</div>)}</div>
+    </div>
+    <div className="rounded-xl border border-white/10 p-4">Historical work remains historical and is not converted to live work orders.</div>
+    <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Confirm Activation</div><button disabled className="mt-2 rounded bg-slate-700 px-3 py-2 text-slate-300">Confirm activation (disabled)</button></div>
+    <div className="flex gap-3"><Link href={`/dashboard/onboarding-v2/${sessionId}/review`} className="underline">Review exceptions</Link><Link href="#" className="opacity-50">Summary (Phase UI-3)</Link></div>
+  </div>;
+}
+
+function UploadCard({ sessionId }: { sessionId: string }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<string>("");
+  const upload = async () => {
+    if (!file) return;
+    const form = new FormData(); form.append("file", file);
+    const res = await fetch(`/api/onboarding-v2/sessions/${sessionId}/files/content`, { method: "POST", body: form });
+    setStatus(res.ok ? "Uploaded" : "Upload failed");
+  };
+  return <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Upload legacy files</div><input type="file" className="mt-2" onChange={(e)=>setFile(e.target.files?.[0] ?? null)} /><button onClick={upload} className="ml-2 rounded bg-cyan-700 px-3 py-1">Upload</button><div className="text-xs text-slate-400 mt-2">{status}</div></div>;
+}

--- a/features/onboarding-v2/components/UploadLegacyFilesCard.tsx
+++ b/features/onboarding-v2/components/UploadLegacyFilesCard.tsx
@@ -1,0 +1,3 @@
+export function UploadLegacyFilesCard() {
+  return null;
+}

--- a/features/onboarding-v2/server/apiProxy.ts
+++ b/features/onboarding-v2/server/apiProxy.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
+
+export async function withOnboardingAccess() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access;
+  if (!access.profile.shop_id) {
+    return { ok: false as const, response: NextResponse.json({ error: "Missing shop context" }, { status: 403 }) };
+  }
+  return access;
+}
+
+export async function proxyJson(params: { method: "GET" | "POST"; path: string; shopId: string; body?: unknown; query?: URLSearchParams }) {
+  const response = await proxyOnboardingAgent({ method: params.method, path: params.path, shopId: params.shopId, body: params.body === undefined ? undefined : JSON.stringify(params.body), query: params.query });
+  const payload = (await response.json().catch(() => ({ ok: false, error: "invalid_agent_response" }))) as Record<string, unknown>;
+  return NextResponse.json(payload, { status: response.status });
+}


### PR DESCRIPTION
### Motivation
- Provide a usable Phase UI-2 session workspace for onboarding-v2 so owners/admins can upload legacy files, trigger analysis, view progress and review exceptions while keeping live materialization disabled. 
- Ensure all agent interactions are proxied and signed server-side with strict shop-scoped RBAC so the browser never calls the Railway agent or receives internal secrets.

### Description
- Added a shop-scoped proxy helper `features/onboarding-v2/server/apiProxy.ts` that enforces owner/admin RBAC and normalizes JSON pass-through to the onboarding agent via the existing `proxyOnboardingAgent` signing helper. 
- Implemented server API proxy routes under `app/api/onboarding-v2/sessions/[sessionId]/*` for `files/content`, `files`, `analyze`, `events`, `entities`, `links`, `review-items`, `activation-summary`, `activation-tick`, and `confirm`, each of which validates shop context and forwards requests to the agent contract. 
- Built the session workspace shell component `features/onboarding-v2/components/SessionWorkspace.tsx` and replaced the placeholder page to include verify-only messaging, session status, upload UI, analyze trigger, files list, event timeline polling, summary metric cards, historical-work notice, and a guarded disabled confirm CTA; polling uses a ~7s interval and slows to ~15s when terminal. 
- Added owner/admin-only review route at `app/dashboard/onboarding-v2/[sessionId]/review` and a client-side `ReviewItemsQueue` read-only shell that shows exception-only items and an empty-state message; no resolve/accept mutations are implemented. 
- Implemented safe upload behavior in the server proxy supporting `multipart/form-data` and JSON base64 payloads with a `10MB` limit; uploads are converted server-side to the agent contract and do not expose secrets or call Railway from the client. 
- Added non-functional component stubs for Phase UI-2 surface area (`ActivationSummaryPanel`, `ConfirmActivationPanel`, `EntitySummaryCards`, `FilesStatusCard`, `OnboardingProgressRail`, `SessionTimeline`, `UploadLegacyFilesCard`) to be expanded in Phase UI-3; live materialization remains disabled.

### Testing
- Ran TypeScript compile check with `npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4cdc408c83289e2ed5fee568c331)