### PR TITLE
Harden onboarding-v2 UI-2 proxy, upload, and workspace flows

### DIFF
--- a/app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts
@@ -2,6 +2,28 @@ import { NextResponse } from "next/server";
 import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
 
 const MAX_BYTES = 10 * 1024 * 1024;
+const SUPPORTED_MIME = new Set(["text/csv", "application/csv", "application/vnd.ms-excel"]);
+
+function parseApproxBase64Bytes(contentBase64: string): number {
+  return Math.floor((contentBase64.length * 3) / 4);
+}
+
+function isCsvLikeExcel(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".csv");
+}
+
+function isAllowedUploadType(mimeType: string, fileName: string): { ok: boolean; message?: string } {
+  if (mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
+    return { ok: false, message: "xlsx_not_supported_by_agent" };
+  }
+  if (SUPPORTED_MIME.has(mimeType)) {
+    if (mimeType === "application/vnd.ms-excel" && !isCsvLikeExcel(fileName)) {
+      return { ok: false, message: "excel_mime_requires_csv_extension" };
+    }
+    return { ok: true };
+  }
+  return { ok: false, message: "unsupported_file_type" };
+}
 
 export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
   const access = await withOnboardingAccess();
@@ -9,6 +31,11 @@ export async function POST(request: Request, context: { params: Promise<{ sessio
   const { sessionId } = await context.params;
   const shopId = access.profile.shop_id;
   if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
+
+  const contentLength = Number(request.headers.get("content-length") ?? "0");
+  if (Number.isFinite(contentLength) && contentLength > MAX_BYTES + 256_000) {
+    return NextResponse.json({ error: "file_too_large", maxBytes: MAX_BYTES }, { status: 413 });
+  }
 
   const contentType = request.headers.get("content-type") ?? "";
   let body: Record<string, unknown> = {};
@@ -18,15 +45,26 @@ export async function POST(request: Request, context: { params: Promise<{ sessio
     const file = form.get("file");
     if (!(file instanceof File)) return NextResponse.json({ error: "file_missing" }, { status: 400 });
     if (file.size > MAX_BYTES) return NextResponse.json({ error: "file_too_large", maxBytes: MAX_BYTES }, { status: 413 });
+
+    const mimeType = file.type || "application/octet-stream";
+    const allowed = isAllowedUploadType(mimeType, file.name);
+    if (!allowed.ok) return NextResponse.json({ error: allowed.message }, { status: 415 });
+
     const buffer = Buffer.from(await file.arrayBuffer());
-    body = { fileName: file.name, mimeType: file.type || "application/octet-stream", sizeBytes: file.size, contentBase64: buffer.toString("base64") };
+    body = { originalFilename: file.name, mimeType, contentBase64: buffer.toString("base64") };
   } else {
-    const parsed = (await request.json().catch(() => null)) as { fileName?: string; mimeType?: string; contentBase64?: string } | null;
-    if (!parsed?.fileName || !parsed.contentBase64) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
-    const approxBytes = Math.floor((parsed.contentBase64.length * 3) / 4);
-    if (approxBytes > MAX_BYTES) return NextResponse.json({ error: "file_too_large", maxBytes: MAX_BYTES }, { status: 413 });
-    body = { fileName: parsed.fileName, mimeType: (parsed.mimeType ?? "application/octet-stream"), contentBase64: parsed.contentBase64 };
+    const parsed = (await request.json().catch(() => null)) as { originalFilename?: string; mimeType?: string; contentBase64?: string } | null;
+    if (!parsed?.originalFilename || !parsed.contentBase64 || !parsed.mimeType) return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+
+    const allowed = isAllowedUploadType(parsed.mimeType, parsed.originalFilename);
+    if (!allowed.ok) return NextResponse.json({ error: allowed.message }, { status: 415 });
+
+    if (parseApproxBase64Bytes(parsed.contentBase64) > MAX_BYTES) return NextResponse.json({ error: "file_too_large", maxBytes: MAX_BYTES }, { status: 413 });
+
+    body = { originalFilename: parsed.originalFilename, mimeType: parsed.mimeType, contentBase64: parsed.contentBase64 };
   }
 
   return proxyJson({ method: "POST", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/files/content`, shopId, body });
 }
+
+export const __testables = { isAllowedUploadType, parseApproxBase64Bytes, MAX_BYTES };

--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -13,7 +13,7 @@ export default async function OnboardingV2SessionPage({ params }: Props) {
   return (
     <OnboardingV2Shell title="Onboarding Agent Session">
       <SafeModeVerifyOnlyBanner />
-      <AgentReadinessBanner ready={true} detail="Readiness verification proxied through server routes." />
+      <AgentReadinessBanner ready detail="Readiness verification is served via ProFixIQ proxy routes only." />
       <SessionWorkspace sessionId={sessionId} />
     </OnboardingV2Shell>
   );

--- a/features/onboarding-v2/components/ReviewItemsQueue.tsx
+++ b/features/onboarding-v2/components/ReviewItemsQueue.tsx
@@ -1,22 +1,29 @@
 "use client";
 import { useEffect, useState } from "react";
 
-type Item = { id?: string; severity?: string; status?: string; title?: string; message?: string };
+type Item = { id?: string; severity?: string; status?: string; title?: string; message?: string; kind?: string };
 
 export function ReviewItemsQueue({ sessionId }: { sessionId: string }) {
   const [items, setItems] = useState<Item[]>([]);
   const [status, setStatus] = useState("open");
+  const [severity, setSeverity] = useState("all");
+
   useEffect(() => {
-    void fetch(`/api/onboarding-v2/sessions/${sessionId}/review-items?status=${encodeURIComponent(status)}&limit=100`, { cache: "no-store" })
+    const query = new URLSearchParams({ status, limit: "100" });
+    if (severity !== "all") query.set("severity", severity);
+    void fetch(`/api/onboarding-v2/sessions/${sessionId}/review-items?${query.toString()}`, { cache: "no-store" })
       .then((r) => r.json())
       .then((j: { items?: Item[] }) => setItems(j.items ?? []));
-  }, [sessionId, status]);
+  }, [sessionId, severity, status]);
+
+  const displayItems = items.filter((item) => String(item.kind ?? "exception") !== "normal");
 
   return <div className="space-y-4">
-    <div className="rounded-xl border border-white/10 p-4">Normal records do not require manual review; only exceptions appear here.</div>
-    <div className="flex gap-2">{["open","resolved"].map((s)=><button key={s} onClick={()=>setStatus(s)} className="rounded border border-white/20 px-3 py-1">{s}</button>)}</div>
+    <div className="rounded-xl border border-white/10 p-4">Read-only exception queue. Resolve actions are intentionally disabled until the backend resolve endpoint is finalized.</div>
+    <div className="flex gap-2">{["open", "resolved"].map((s) => <button key={s} onClick={() => setStatus(s)} className="rounded border border-white/20 px-3 py-1">{s}</button>)}</div>
+    <div className="flex gap-2">{["all", "low", "medium", "high", "critical"].map((s) => <button key={s} onClick={() => setSeverity(s)} className="rounded border border-white/20 px-3 py-1">{s}</button>)}</div>
     <div className="rounded-xl border border-white/10 p-4">
-      {items.length===0 ? <div>No exceptions found</div> : items.map((item, i)=><div key={item.id ?? i} className="border-b border-white/10 py-2"><span>{item.severity ?? "unknown"}</span> • <span>{item.status ?? "unknown"}</span> • {item.title ?? item.message ?? "Review item"}</div>)}
+      {displayItems.length === 0 ? <div>No exceptions found.</div> : displayItems.map((item, i) => <div key={item.id ?? i} className="border-b border-white/10 py-2"><span>{item.severity ?? "unknown"}</span> • <span>{item.status ?? "unknown"}</span> • {item.title ?? item.message ?? "Review item"}</div>)}
     </div>
   </div>;
 }

--- a/features/onboarding-v2/components/SessionWorkspace.tsx
+++ b/features/onboarding-v2/components/SessionWorkspace.tsx
@@ -3,15 +3,20 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
-type Generic = Record<string, unknown>;
+type JsonMap = Record<string, unknown>;
+type ApiListResponse = { items?: JsonMap[]; message?: string };
 
-async function getJson(path: string): Promise<Generic> { const r = await fetch(path, { cache: "no-store" }); return (await r.json()) as Generic; }
+async function getJson<T>(path: string): Promise<T> {
+  const r = await fetch(path, { cache: "no-store" });
+  return (await r.json()) as T;
+}
 
 export function SessionWorkspace({ sessionId }: { sessionId: string }) {
-  const [session, setSession] = useState<Generic | null>(null);
-  const [events, setEvents] = useState<Generic[]>([]);
-  const [summary, setSummary] = useState<Generic | null>(null);
-  const [files, setFiles] = useState<Generic[]>([]);
+  const [session, setSession] = useState<JsonMap | null>(null);
+  const [events, setEvents] = useState<JsonMap[]>([]);
+  const [summary, setSummary] = useState<JsonMap | null>(null);
+  const [files, setFiles] = useState<JsonMap[]>([]);
+  const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState(true);
 
   const terminal = ["completed", "failed", "cancelled"].includes(String(session?.status ?? ""));
@@ -19,43 +24,67 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     let active = true;
     const run = async () => {
-      const [s, e, a, f] = await Promise.all([
-        getJson(`/api/onboarding-v2/sessions/${sessionId}`),
-        getJson(`/api/onboarding-v2/sessions/${sessionId}/events?limit=50`),
-        getJson(`/api/onboarding-v2/sessions/${sessionId}/activation-summary`),
-        getJson(`/api/onboarding-v2/sessions/${sessionId}/files`),
-      ]);
-      if (!active) return;
-      setSession(s); setEvents((e.items as Generic[]) ?? []); setSummary(a); setFiles((f.items as Generic[]) ?? []); setLoading(false);
+      try {
+        const [s, e, a, f] = await Promise.all([
+          getJson<JsonMap>(`/api/onboarding-v2/sessions/${sessionId}`),
+          getJson<ApiListResponse>(`/api/onboarding-v2/sessions/${sessionId}/events?limit=50`),
+          getJson<JsonMap>(`/api/onboarding-v2/sessions/${sessionId}/activation-summary`),
+          getJson<ApiListResponse>(`/api/onboarding-v2/sessions/${sessionId}/files`),
+        ]);
+        if (!active) return;
+        setSession(s);
+        setEvents(e.items ?? []);
+        setSummary(a);
+        setFiles(f.items ?? []);
+        setError("");
+      } catch {
+        if (!active) return;
+        setError("Unable to load onboarding session data.");
+      } finally {
+        if (active) setLoading(false);
+      }
     };
     void run();
-    const id = setInterval(() => { void run(); }, terminal ? 15000 : 7000);
-    return () => { active = false; clearInterval(id); };
+    const id = setInterval(() => void run(), terminal ? 15000 : 7000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
   }, [sessionId, terminal]);
 
-  const metrics = useMemo(() => ({
-    entities: Number(summary?.entityCount ?? 0), links: Number(summary?.linkCount ?? 0), review: Number(summary?.reviewCount ?? 0), staged: Number(summary?.stagedCount ?? 0),
-  }), [summary]);
+  const metrics = useMemo(
+    () => ({
+      entities: Number(summary?.entityCount ?? 0),
+      links: Number(summary?.linkCount ?? 0),
+      review: Number(summary?.reviewCount ?? 0),
+      staged: Number(summary?.stagedCount ?? 0),
+    }),
+    [summary],
+  );
 
-  const triggerAnalyze = async () => { await fetch(`/api/onboarding-v2/sessions/${sessionId}/analyze`, { method: "POST" }); };
+  const triggerAnalyze = async () => {
+    await fetch(`/api/onboarding-v2/sessions/${sessionId}/analyze`, { method: "POST" });
+  };
 
   if (loading) return <div className="rounded-xl border border-white/10 p-4">Loading session…</div>;
-  return <div className="space-y-4 text-sm text-slate-200">
-    <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">Verify-only mode: activation can be previewed/smoked but live writes are blocked.</div>
-    <div className="rounded-xl border border-white/10 p-4">Session <b>{sessionId}</b> • Status: {String(session?.status ?? "unknown")}</div>
-    <div className="grid gap-4 lg:grid-cols-2">
-      <UploadCard sessionId={sessionId} />
-      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Analyze</div><button onClick={triggerAnalyze} className="mt-3 rounded bg-cyan-600 px-3 py-2">Start processing</button></div>
+  if (error) return <div className="rounded-xl border border-rose-500/40 bg-rose-950/30 p-4">{error}</div>;
+
+  return (
+    <div className="space-y-4 text-sm text-slate-200">
+      <div className="rounded-xl border border-white/10 p-4">Session <b>{sessionId}</b> • Status: {String(session?.status ?? "unknown")}</div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <UploadCard sessionId={sessionId} />
+        <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Analyze</div><button onClick={triggerAnalyze} className="mt-3 rounded bg-cyan-600 px-3 py-2">Start processing</button></div>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-4">{Object.entries(metrics).map(([k, v]) => <div key={k} className="rounded-xl border border-white/10 p-3"><div className="text-xs text-slate-400">{k}</div><div className="text-xl">{v}</div></div>)}</div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Files</div>{files.length === 0 ? <div className="text-slate-400">No files yet.</div> : files.map((f, i) => <div key={`${String(f.fileName ?? "file")}-${i}`}>{String(f.fileName ?? "file")}</div>)}</div>
+        <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Timeline</div>{events.length === 0 ? <div className="text-slate-400">No events.</div> : events.map((e, i) => <div key={`${String(e.type ?? "event")}-${i}`} className="text-xs">{String(e.type ?? "event")} • {String(e.status ?? "")}</div>)}</div>
+      </div>
+      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Confirm Activation</div><button disabled className="mt-2 rounded bg-slate-700 px-3 py-2 text-slate-300">Confirm activation (verify-only mode)</button></div>
+      <div className="flex gap-3"><Link href={`/dashboard/onboarding-v2/${sessionId}/review`} className="underline">Review exceptions</Link></div>
     </div>
-    <div className="grid gap-4 lg:grid-cols-4">{Object.entries(metrics).map(([k,v])=><div key={k} className="rounded-xl border border-white/10 p-3"><div className="text-xs text-slate-400">{k}</div><div className="text-xl">{v}</div></div>)}</div>
-    <div className="grid gap-4 lg:grid-cols-2">
-      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Files</div>{files.length===0?<div className="text-slate-400">No files yet.</div>:files.map((f,i)=><div key={i}>{String(f.fileName ?? "file")}</div>)}</div>
-      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Timeline</div>{events.length===0?<div className="text-slate-400">No events.</div>:events.map((e,i)=><div key={i} className="text-xs">{String(e.type ?? "event")} • {String(e.status ?? "")}</div>)}</div>
-    </div>
-    <div className="rounded-xl border border-white/10 p-4">Historical work remains historical and is not converted to live work orders.</div>
-    <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Confirm Activation</div><button disabled className="mt-2 rounded bg-slate-700 px-3 py-2 text-slate-300">Confirm activation (disabled)</button></div>
-    <div className="flex gap-3"><Link href={`/dashboard/onboarding-v2/${sessionId}/review`} className="underline">Review exceptions</Link><Link href="#" className="opacity-50">Summary (Phase UI-3)</Link></div>
-  </div>;
+  );
 }
 
 function UploadCard({ sessionId }: { sessionId: string }) {
@@ -63,9 +92,10 @@ function UploadCard({ sessionId }: { sessionId: string }) {
   const [status, setStatus] = useState<string>("");
   const upload = async () => {
     if (!file) return;
-    const form = new FormData(); form.append("file", file);
+    const form = new FormData();
+    form.append("file", file);
     const res = await fetch(`/api/onboarding-v2/sessions/${sessionId}/files/content`, { method: "POST", body: form });
     setStatus(res.ok ? "Uploaded" : "Upload failed");
   };
-  return <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Upload legacy files</div><input type="file" className="mt-2" onChange={(e)=>setFile(e.target.files?.[0] ?? null)} /><button onClick={upload} className="ml-2 rounded bg-cyan-700 px-3 py-1">Upload</button><div className="text-xs text-slate-400 mt-2">{status}</div></div>;
+  return <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Upload legacy files</div><input type="file" accept=".csv,text/csv,application/csv,application/vnd.ms-excel" className="mt-2" onChange={(e) => setFile(e.target.files?.[0] ?? null)} /><button onClick={upload} className="ml-2 rounded bg-cyan-700 px-3 py-1">Upload</button><div className="mt-2 text-xs text-slate-400">{status}</div></div>;
 }

--- a/features/onboarding-v2/server/agentClient.ts
+++ b/features/onboarding-v2/server/agentClient.ts
@@ -1,6 +1,8 @@
 import { getOnboardingAgentConfig } from "@/features/onboarding-v2/server/config";
 import { signOnboardingAgentPayload } from "@/features/onboarding-v2/server/signing";
 
+const REQUEST_TIMEOUT_MS = 20_000;
+
 export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path: string; shopId: string; body?: string; query?: URLSearchParams }): Promise<Response> {
   const config = getOnboardingAgentConfig();
 
@@ -16,9 +18,10 @@ export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path
   const timestampMs = Date.now();
   const signature = signOnboardingAgentPayload({ secret: config.internalSecret, shopId: input.shopId, timestampMs, rawBody });
   const url = new URL(input.path, config.baseUrl.endsWith("/") ? config.baseUrl : `${config.baseUrl}/`);
-  if (input.query) {
-    input.query.forEach((value, key) => url.searchParams.set(key, value));
-  }
+  if (input.query) input.query.forEach((value, key) => url.searchParams.set(key, value));
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
   try {
     return await fetch(url, {
@@ -31,8 +34,14 @@ export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path
       },
       body: input.method === "POST" ? rawBody : undefined,
       cache: "no-store",
+      signal: controller.signal,
     });
-  } catch {
-    return Response.json({ ok: false, status: "unreachable", message: "Onboarding agent is unreachable." }, { status: 502 });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return Response.json({ ok: false, failureKind: "agent_timeout", message: "Onboarding agent timed out." }, { status: 504 });
+    }
+    return Response.json({ ok: false, failureKind: "agent_unreachable", message: "Onboarding agent is unreachable." }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/features/onboarding-v2/server/apiProxy.ts
+++ b/features/onboarding-v2/server/apiProxy.ts
@@ -2,6 +2,23 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
 
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+function sanitizeJson(value: unknown): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map((item) => sanitizeJson(item));
+  if (typeof value === "object") {
+    const cleaned: JsonObject = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "raw_data") continue;
+      cleaned[key] = sanitizeJson(nested);
+    }
+    return cleaned;
+  }
+  return String(value);
+}
+
 export async function withOnboardingAccess() {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access;
@@ -12,7 +29,15 @@ export async function withOnboardingAccess() {
 }
 
 export async function proxyJson(params: { method: "GET" | "POST"; path: string; shopId: string; body?: unknown; query?: URLSearchParams }) {
-  const response = await proxyOnboardingAgent({ method: params.method, path: params.path, shopId: params.shopId, body: params.body === undefined ? undefined : JSON.stringify(params.body), query: params.query });
-  const payload = (await response.json().catch(() => ({ ok: false, error: "invalid_agent_response" }))) as Record<string, unknown>;
+  const response = await proxyOnboardingAgent({
+    method: params.method,
+    path: params.path,
+    shopId: params.shopId,
+    body: params.body === undefined ? undefined : JSON.stringify(params.body),
+    query: params.query,
+  });
+
+  const payloadRaw = (await response.json().catch(() => ({ ok: false, failureKind: "invalid_agent_response", message: "Invalid onboarding agent response." }))) as unknown;
+  const payload = sanitizeJson(payloadRaw);
   return NextResponse.json(payload, { status: response.status });
 }

--- a/tests/onboarding-v2/client-proxy-usage.test.ts
+++ b/tests/onboarding-v2/client-proxy-usage.test.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const componentsDir = path.join(process.cwd(), "features/onboarding-v2/components");
+
+describe("client onboarding components use server proxy", () => {
+  it("contains no direct Railway/onboarding agent URL", () => {
+    const files = fs.readdirSync(componentsDir).filter((f) => f.endsWith(".tsx"));
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(componentsDir, file), "utf8");
+      expect(content.includes("railway")).toBe(false);
+      expect(content.includes("ONBOARDING_AGENT_BASE_URL")).toBe(false);
+      expect(content.includes("/onboarding/")).toBe(false);
+    }
+  });
+});

--- a/tests/onboarding-v2/proxy-and-upload.test.ts
+++ b/tests/onboarding-v2/proxy-and-upload.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { signOnboardingAgentPayload } from "@/features/onboarding-v2/server/signing";
+import { __testables } from "../../app/api/onboarding-v2/sessions/[sessionId]/files/content/route";
+
+describe("onboarding v2 signing", () => {
+  it("signs timestamp.shopId.rawBody format", () => {
+    const signature = signOnboardingAgentPayload({ secret: "abc123", timestampMs: 1700000000000, shopId: "shop_1", rawBody: '{"a":1}' });
+    expect(signature).toBe("6f6255f4f77c713131697f277134af3947e59f51d651ef0dfa0cdc466bd406d0");
+  });
+});
+
+describe("upload guardrails", () => {
+  it("rejects xlsx as unsupported", () => {
+    expect(__testables.isAllowedUploadType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "sample.xlsx").ok).toBe(false);
+  });
+
+  it("rejects oversized base64 payload", () => {
+    const bytes = __testables.parseApproxBase64Bytes("A".repeat(__testables.MAX_BYTES * 2));
+    expect(bytes).toBeGreaterThan(__testables.MAX_BYTES);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make UI-2 robust and safe to test against the deployed ProFixIQ-Onboarding-Agent by enforcing server-side signing, tenant scoping, and safe proxy behavior. 
- Prevent client-side calls to Railway and avoid leaking secrets or raw agent payloads while keeping the UI read-only/verify-only for this phase.

### Description
- Hardened the server proxy by adding recursive `raw_data` stripping and safe JSON normalization in `proxyJson` to avoid leaking raw payloads while preserving `failureKind`/`message` when present (`features/onboarding-v2/server/apiProxy.ts`).
- Added request timeout handling and explicit failure kinds (`agent_timeout`/`agent_unreachable`) and ensured every agent call is signed using `ONBOARDING_AGENT_INTERNAL_SECRET` with `x-shop-id`, `x-onboarding-agent-timestamp`, and `x-onboarding-agent-signature` (`features/onboarding-v2/server/agentClient.ts`).
- Hardened the upload route with a 10 MB limit, `content-length` precheck, CSV-focused MIME allowlist (`text/csv`, `application/csv`, `application/vnd.ms-excel` when `.csv`), explicit XLSX rejection for UI-2, safe multipart→base64 conversion and consistent outbound payload keys (`originalFilename`, `mimeType`, `contentBase64`) plus testables export (`app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts`).
- Improved the session workspace and review UI to be owner/admin gated, use only ProFixIQ proxy endpoints, handle loading/error/empty states, show verify-only messaging and keep confirm CTA disabled in verify-only mode (`features/onboarding-v2/components/SessionWorkspace.tsx`, `features/onboarding-v2/components/ReviewItemsQueue.tsx`, `app/dashboard/onboarding-v2/[sessionId]/page.tsx`).
- Added focused tests that validate signing format, upload guardrails (XLSX reject and oversize check), and ensure client components do not reference direct agent URLs (`tests/onboarding-v2/*`).

### Testing
- Ran unit tests with `npx vitest run tests/onboarding-v2/*.test.ts`, and the focused test suite passed (all onboarding-v2 tests passed).
- Ran TypeScript check with `npx tsc --noEmit` which succeeded for this patch (no type errors introduced by these changes).
- Ran `npm run lint` which reported pre-existing, repo-wide lint errors unrelated to this patch, so lint is currently failing at repository scope but not because of the onboarding-v2 changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb52492a74832886a0191aa5b7fc6a)