### PR TITLE
Harden onboarding-v2 readiness rendering via ProFixIQ proxy

### DIFF
--- a/app/api/onboarding-v2/agent-readiness/route.ts
+++ b/app/api/onboarding-v2/agent-readiness/route.ts
@@ -1,6 +1,26 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
+import { defaultAgentReadiness, normalizeAgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+
+function pickReadiness(productionRaw: unknown, connectorRaw: unknown) {
+  const production = (typeof productionRaw === "object" && productionRaw !== null ? productionRaw : {}) as Record<string, unknown>;
+  const connector = (typeof connectorRaw === "object" && connectorRaw !== null ? connectorRaw : {}) as Record<string, unknown>;
+
+  return normalizeAgentReadiness({
+    ok: production.ok === true,
+    rolloutStage: production.rolloutStage,
+    connector: {
+      mode: connector.mode,
+      configured: connector.configured,
+      liveMaterializationEnabled: connector.liveMaterializationEnabled,
+      canValidateShop: connector.canValidateShop,
+      canWriteLive: connector.canWriteLive,
+    },
+    warnings: production.warnings,
+    requiredEnv: production.requiredEnv,
+  });
+}
 
 export async function GET() {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
@@ -10,11 +30,13 @@ export async function GET() {
   if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
 
   const production = await proxyOnboardingAgent({ method: "GET", path: "/onboarding/production-readiness", shopId });
-  if (!production.ok) return production;
+  if (!production.ok) {
+    return NextResponse.json(defaultAgentReadiness(), { status: production.status });
+  }
 
   const connector = await proxyOnboardingAgent({ method: "GET", path: "/onboarding/connector/readiness", shopId });
-  const productionJson = (await production.json()) as Record<string, unknown>;
-  const connectorJson = connector.ok ? (await connector.json()) as Record<string, unknown> : { ok: false, message: "Connector readiness unavailable" };
+  const productionJson = (await production.json().catch(() => ({}))) as unknown;
+  const connectorJson = connector.ok ? ((await connector.json().catch(() => ({}))) as unknown) : {};
 
-  return NextResponse.json({ ok: true, production: productionJson, connector: connectorJson });
+  return NextResponse.json(pickReadiness(productionJson, connectorJson));
 }

--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -1,7 +1,5 @@
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
-import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
 import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
-import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
 import { SessionWorkspace } from "@/features/onboarding-v2/components/SessionWorkspace";
 
 type Props = { params: Promise<{ sessionId: string }> };
@@ -12,8 +10,6 @@ export default async function OnboardingV2SessionPage({ params }: Props) {
 
   return (
     <OnboardingV2Shell title="Onboarding Agent Session">
-      <SafeModeVerifyOnlyBanner />
-      <AgentReadinessBanner ready detail="Readiness verification is served via ProFixIQ proxy routes only." />
       <SessionWorkspace sessionId={sessionId} />
     </OnboardingV2Shell>
   );

--- a/app/dashboard/onboarding-v2/page.tsx
+++ b/app/dashboard/onboarding-v2/page.tsx
@@ -2,15 +2,16 @@ import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-acces
 import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
 import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
 import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
+import { normalizeAgentReadiness, defaultAgentReadiness, type AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
 import { StartOnboardingSessionCard } from "@/features/onboarding-v2/components/StartOnboardingSessionCard";
 
-async function getReadiness(): Promise<{ ready: boolean; detail: string }> {
+async function getReadiness(): Promise<AgentReadiness> {
   try {
     const response = await fetch(`${process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"}/api/onboarding-v2/agent-readiness`, { cache: "no-store" });
-    if (!response.ok) return { ready: false, detail: "Readiness unavailable." };
-    return { ready: true, detail: "Agent production and connector readiness checks are reachable." };
+    if (!response.ok) return defaultAgentReadiness();
+    return normalizeAgentReadiness(await response.json());
   } catch {
-    return { ready: false, detail: "Readiness unavailable." };
+    return defaultAgentReadiness();
   }
 }
 
@@ -21,7 +22,7 @@ export default async function OnboardingV2Page() {
   return (
     <OnboardingV2Shell title="Onboarding Agent">
       <SafeModeVerifyOnlyBanner />
-      <AgentReadinessBanner ready={readiness.ready} detail={readiness.detail} />
+      <AgentReadinessBanner readiness={readiness} />
       <StartOnboardingSessionCard />
       <div className="rounded-xl border border-dashed border-white/15 p-4 text-sm text-slate-300">Session listing coming next.</div>
       <div className="text-xs text-slate-400">Legacy onboarding remains available at /dashboard/onboarding during transition.</div>

--- a/features/onboarding-v2/components/AgentReadinessBanner.tsx
+++ b/features/onboarding-v2/components/AgentReadinessBanner.tsx
@@ -1,8 +1,21 @@
-export function AgentReadinessBanner({ ready, detail }: { ready: boolean; detail: string }) {
+import React from "react";
+import type { AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+
+function statusLabel(readiness: AgentReadiness): string {
+  if (!readiness.connector.configured) return "Disabled / not configured";
+  if (!readiness.ok) return "Degraded";
+  if (readiness.connector.liveMaterializationEnabled || readiness.connector.canWriteLive || readiness.rolloutStage === "live_enabled") return "Live-enabled (warning)";
+  if (readiness.rolloutStage === "dry_run" || readiness.rolloutStage === "http_verify_only") return "Verify-only";
+  return "Healthy";
+}
+
+export function AgentReadinessBanner({ readiness, loading, degradedMessage }: { readiness: AgentReadiness; loading?: boolean; degradedMessage?: string }) {
   return (
     <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-200">
-      <div className="font-semibold">Agent readiness: {ready ? "Ready" : "Not ready"}</div>
-      <p className="mt-1 text-xs text-slate-400">{detail}</p>
+      <div className="font-semibold">Agent readiness: {loading ? "Loading…" : statusLabel(readiness)}</div>
+      {degradedMessage ? <p className="mt-1 text-xs text-amber-300">{degradedMessage}</p> : null}
+      <p className="mt-1 text-xs text-slate-400">Rollout stage: {readiness.rolloutStage ?? "unknown"} • Connector mode: {readiness.connector.mode}</p>
+      {readiness.warnings.length > 0 ? <ul className="mt-2 list-disc pl-4 text-xs text-amber-200">{readiness.warnings.map((warning) => <li key={warning}>{warning}</li>)}</ul> : null}
     </div>
   );
 }

--- a/features/onboarding-v2/components/ConfirmActivationPanel.tsx
+++ b/features/onboarding-v2/components/ConfirmActivationPanel.tsx
@@ -1,3 +1,18 @@
-export function ConfirmActivationPanel() {
-  return null;
+import React from "react";
+import type { AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+
+type ActivationSummary = { canConfirm?: boolean };
+
+export function ConfirmActivationPanel({ readiness, summary }: { readiness: AgentReadiness; summary: ActivationSummary | null }) {
+  const blockedByReadiness = readiness.rolloutStage === null || readiness.rolloutStage === "dry_run" || readiness.rolloutStage === "http_verify_only" || !readiness.connector.canWriteLive || !readiness.connector.liveMaterializationEnabled;
+  const blocked = blockedByReadiness || summary?.canConfirm !== true;
+  const reason = blockedByReadiness ? "Verify-only mode is active. Live activation is blocked until explicitly enabled." : "Activation checks are incomplete for this session.";
+
+  return (
+    <div className="rounded-xl border border-white/10 p-4">
+      <div className="font-semibold">Confirm Activation</div>
+      <button disabled={blocked} className="mt-2 rounded bg-slate-700 px-3 py-2 text-slate-300 disabled:cursor-not-allowed disabled:opacity-70">Confirm activation</button>
+      {blocked ? <div className="mt-2 text-xs text-amber-200">{reason}</div> : null}
+    </div>
+  );
 }

--- a/features/onboarding-v2/components/ReviewItemsQueue.tsx
+++ b/features/onboarding-v2/components/ReviewItemsQueue.tsx
@@ -1,5 +1,8 @@
+import React from "react";
 "use client";
 import { useEffect, useState } from "react";
+import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
+import { defaultAgentReadiness, normalizeAgentReadiness, type AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
 
 type Item = { id?: string; severity?: string; status?: string; title?: string; message?: string; kind?: string };
 
@@ -7,6 +10,14 @@ export function ReviewItemsQueue({ sessionId }: { sessionId: string }) {
   const [items, setItems] = useState<Item[]>([]);
   const [status, setStatus] = useState("open");
   const [severity, setSeverity] = useState("all");
+  const [readiness, setReadiness] = useState<AgentReadiness>(defaultAgentReadiness());
+
+  useEffect(() => {
+    void fetch(`/api/onboarding-v2/agent-readiness`, { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j: unknown) => setReadiness(normalizeAgentReadiness(j)))
+      .catch(() => setReadiness(defaultAgentReadiness()));
+  }, []);
 
   useEffect(() => {
     const query = new URLSearchParams({ status, limit: "100" });
@@ -19,6 +30,7 @@ export function ReviewItemsQueue({ sessionId }: { sessionId: string }) {
   const displayItems = items.filter((item) => String(item.kind ?? "exception") !== "normal");
 
   return <div className="space-y-4">
+    <AgentReadinessBanner readiness={readiness} />
     <div className="rounded-xl border border-white/10 p-4">Read-only exception queue. Resolve actions are intentionally disabled until the backend resolve endpoint is finalized.</div>
     <div className="flex gap-2">{["open", "resolved"].map((s) => <button key={s} onClick={() => setStatus(s)} className="rounded border border-white/20 px-3 py-1">{s}</button>)}</div>
     <div className="flex gap-2">{["all", "low", "medium", "high", "critical"].map((s) => <button key={s} onClick={() => setSeverity(s)} className="rounded border border-white/20 px-3 py-1">{s}</button>)}</div>

--- a/features/onboarding-v2/components/SafeModeVerifyOnlyBanner.tsx
+++ b/features/onboarding-v2/components/SafeModeVerifyOnlyBanner.tsx
@@ -1,7 +1,3 @@
 export function SafeModeVerifyOnlyBanner() {
-  return (
-    <div className="rounded-xl border border-amber-500/30 bg-amber-950/30 p-4 text-sm text-amber-100">
-      Verify-only safe mode is active. Live materialization remains disabled.
-    </div>
-  );
+  return <div className="rounded-xl border border-amber-500/30 bg-amber-950/30 p-4 text-sm text-amber-100">Verify-only safe mode is active. Live activation is blocked until explicitly enabled.</div>;
 }

--- a/features/onboarding-v2/components/SessionWorkspace.tsx
+++ b/features/onboarding-v2/components/SessionWorkspace.tsx
@@ -1,7 +1,11 @@
+import React from "react";
 "use client";
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
+import { ConfirmActivationPanel } from "@/features/onboarding-v2/components/ConfirmActivationPanel";
+import { defaultAgentReadiness, normalizeAgentReadiness, type AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
 
 type JsonMap = Record<string, unknown>;
 type ApiListResponse = { items?: JsonMap[]; message?: string };
@@ -18,6 +22,9 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
   const [files, setFiles] = useState<JsonMap[]>([]);
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState(true);
+  const [readiness, setReadiness] = useState<AgentReadiness>(defaultAgentReadiness());
+  const [readinessLoading, setReadinessLoading] = useState(true);
+  const [readinessError, setReadinessError] = useState("");
 
   const terminal = ["completed", "failed", "cancelled"].includes(String(session?.status ?? ""));
 
@@ -25,23 +32,32 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
     let active = true;
     const run = async () => {
       try {
-        const [s, e, a, f] = await Promise.all([
+        const [s, e, a, f, r] = await Promise.all([
           getJson<JsonMap>(`/api/onboarding-v2/sessions/${sessionId}`),
           getJson<ApiListResponse>(`/api/onboarding-v2/sessions/${sessionId}/events?limit=50`),
           getJson<JsonMap>(`/api/onboarding-v2/sessions/${sessionId}/activation-summary`),
           getJson<ApiListResponse>(`/api/onboarding-v2/sessions/${sessionId}/files`),
+          getJson<unknown>(`/api/onboarding-v2/agent-readiness`),
         ]);
         if (!active) return;
         setSession(s);
         setEvents(e.items ?? []);
         setSummary(a);
         setFiles(f.items ?? []);
+        setReadiness(normalizeAgentReadiness(r));
         setError("");
-      } catch {
+        setReadinessError("");
+      } catch (fetchError) {
         if (!active) return;
+        const message = fetchError instanceof Error ? fetchError.message : "";
         setError("Unable to load onboarding session data.");
+        setReadiness(defaultAgentReadiness());
+        setReadinessError(message ? "Readiness check unavailable. Verify-only safe mode remains enforced." : "");
       } finally {
-        if (active) setLoading(false);
+        if (active) {
+          setLoading(false);
+          setReadinessLoading(false);
+        }
       }
     };
     void run();
@@ -71,6 +87,7 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="space-y-4 text-sm text-slate-200">
+      <AgentReadinessBanner readiness={readiness} loading={readinessLoading} degradedMessage={readinessError} />
       <div className="rounded-xl border border-white/10 p-4">Session <b>{sessionId}</b> • Status: {String(session?.status ?? "unknown")}</div>
       <div className="grid gap-4 lg:grid-cols-2">
         <UploadCard sessionId={sessionId} />
@@ -81,7 +98,7 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
         <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Files</div>{files.length === 0 ? <div className="text-slate-400">No files yet.</div> : files.map((f, i) => <div key={`${String(f.fileName ?? "file")}-${i}`}>{String(f.fileName ?? "file")}</div>)}</div>
         <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Timeline</div>{events.length === 0 ? <div className="text-slate-400">No events.</div> : events.map((e, i) => <div key={`${String(e.type ?? "event")}-${i}`} className="text-xs">{String(e.type ?? "event")} • {String(e.status ?? "")}</div>)}</div>
       </div>
-      <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Confirm Activation</div><button disabled className="mt-2 rounded bg-slate-700 px-3 py-2 text-slate-300">Confirm activation (verify-only mode)</button></div>
+      <ConfirmActivationPanel readiness={readiness} summary={summary as { canConfirm?: boolean } | null} />
       <div className="flex gap-3"><Link href={`/dashboard/onboarding-v2/${sessionId}/review`} className="underline">Review exceptions</Link></div>
     </div>
   );

--- a/features/onboarding-v2/lib/agentReadiness.ts
+++ b/features/onboarding-v2/lib/agentReadiness.ts
@@ -1,0 +1,60 @@
+export type ReadinessRolloutStage = "dry_run" | "http_verify_only" | "live_enabled" | null;
+
+export type AgentReadiness = {
+  ok: boolean;
+  rolloutStage: ReadinessRolloutStage;
+  connector: {
+    mode: string;
+    configured: boolean;
+    liveMaterializationEnabled: boolean;
+    canValidateShop: boolean;
+    canWriteLive: boolean;
+  };
+  warnings: string[];
+  requiredEnv?: string[];
+};
+
+export function defaultAgentReadiness(): AgentReadiness {
+  return {
+    ok: false,
+    rolloutStage: null,
+    connector: {
+      mode: "unknown",
+      configured: false,
+      liveMaterializationEnabled: false,
+      canValidateShop: false,
+      canWriteLive: false,
+    },
+    warnings: ["Readiness unavailable. Verify-only safe mode remains enforced."],
+  };
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+export function normalizeAgentReadiness(input: unknown): AgentReadiness {
+  const source = (typeof input === "object" && input !== null ? input : {}) as Record<string, unknown>;
+  const connectorInput = (typeof source.connector === "object" && source.connector !== null ? source.connector : {}) as Record<string, unknown>;
+  const stage = source.rolloutStage;
+  const rolloutStage: ReadinessRolloutStage = stage === "dry_run" || stage === "http_verify_only" || stage === "live_enabled" ? stage : null;
+
+  return {
+    ok: asBoolean(source.ok),
+    rolloutStage,
+    connector: {
+      mode: typeof connectorInput.mode === "string" ? connectorInput.mode : "unknown",
+      configured: asBoolean(connectorInput.configured),
+      liveMaterializationEnabled: asBoolean(connectorInput.liveMaterializationEnabled),
+      canValidateShop: asBoolean(connectorInput.canValidateShop),
+      canWriteLive: asBoolean(connectorInput.canWriteLive),
+    },
+    warnings: asStringArray(source.warnings),
+    requiredEnv: asStringArray(source.requiredEnv),
+  };
+}

--- a/tests/onboarding-v2/readiness-ui.test.tsx
+++ b/tests/onboarding-v2/readiness-ui.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConfirmActivationPanel } from "@/features/onboarding-v2/components/ConfirmActivationPanel";
+import { SessionWorkspace } from "@/features/onboarding-v2/components/SessionWorkspace";
+import { ReviewItemsQueue } from "@/features/onboarding-v2/components/ReviewItemsQueue";
+import { normalizeAgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+
+describe("readiness UI", () => {
+  it("session workspace renders verify-only readiness from proxy", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("agent-readiness")) return { json: async () => ({ ok: true, rolloutStage: "http_verify_only", connector: { mode: "proxy", configured: true, liveMaterializationEnabled: false, canValidateShop: true, canWriteLive: false }, warnings: ["verify"] }) };
+      if (url.includes("events") || url.includes("files")) return { json: async () => ({ items: [] }) };
+      return { json: async () => ({ status: "running", canConfirm: false }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<SessionWorkspace sessionId="sess_1" />);
+    expect(await screen.findByText(/Agent readiness: Verify-only/i)).toBeInTheDocument();
+  });
+
+  it("confirm panel disables when canWriteLive is false", () => {
+    render(<ConfirmActivationPanel readiness={normalizeAgentReadiness({ ok: true, rolloutStage: "live_enabled", connector: { mode: "x", configured: true, liveMaterializationEnabled: true, canValidateShop: true, canWriteLive: false }, warnings: [] })} summary={{ canConfirm: true }} />);
+    expect(screen.getByRole("button", { name: /confirm activation/i })).toBeDisabled();
+    expect(screen.getByText(/Verify-only mode is active/i)).toBeInTheDocument();
+  });
+
+  it("review page banner renders verify-only status", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("agent-readiness")) return { json: async () => ({ ok: true, rolloutStage: "dry_run", connector: { mode: "proxy", configured: true, liveMaterializationEnabled: false, canValidateShop: true, canWriteLive: false }, warnings: [] }) };
+      return { json: async () => ({ items: [] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ReviewItemsQueue sessionId="sess_2" />);
+    expect(await screen.findByText(/Agent readiness: Verify-only/i)).toBeInTheDocument();
+  });
+
+  it("normalizer strips raw_data from readiness payload", () => {
+    const readiness = normalizeAgentReadiness({ ok: true, raw_data: { secret: "x" }, connector: { configured: false } });
+    expect(JSON.stringify(readiness)).not.toContain("raw_data");
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the static session readiness presentation with a safe, normalized readiness contract served from the ProFixIQ server proxy so owners/admins see real agent state while preserving verify-only safety and preventing any browser calls to Railway.
- Ensure the UI is strictly typed, does not expose raw agent payloads or secrets, and keeps live materialization disabled unless explicitly allowed by server readiness and owner/admin gating.

### Description
- Add a shared `AgentReadiness` type plus `normalizeAgentReadiness` and `defaultAgentReadiness` utilities in `features/onboarding-v2/lib/agentReadiness.ts` to enforce a stable, UI-safe shape and to strip raw/untrusted fields.
- Normalize and sanitize upstream responses in the server route `GET /api/onboarding-v2/agent-readiness` so the proxy returns only safe fields (`ok`, `rolloutStage`, `connector.{mode,configured,liveMaterializationEnabled,canValidateShop,canWriteLive}`, `warnings`, and optional `requiredEnv`).
- Update the session workspace (`features/onboarding-v2/components/SessionWorkspace.tsx`) and session page to fetch readiness via the server proxy, show loading/degraded/verify-only/live-warning states, surface warnings, and preserve read-only/verify-only UX.
- Update the review queue (`features/onboarding-v2/components/ReviewItemsQueue.tsx`) to render the same compact readiness banner and implement confirm gating in `features/onboarding-v2/components/ConfirmActivationPanel.tsx` so confirm is disabled when rollout stage or connector flags block live writes.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` and it completed successfully.
- Ran targeted test suite with `npx vitest run tests/onboarding-v2/readiness-ui.test.tsx tests/onboarding-v2/client-proxy-usage.test.ts tests/onboarding-v2/proxy-and-upload.test.ts tests/onboarding-v2-signing.test.ts` and all targeted onboarding-v2 tests passed.
- Added `tests/onboarding-v2/readiness-ui.test.tsx` which validates verify-only rendering from the proxy, disabled confirm behavior when `canWriteLive` is false, review-page readiness banner rendering, and that `raw_data` is not exposed; these tests passed.
- Did not run repo-wide lint due to unrelated pre-existing failures outside onboarding-v2, and touched onboarding-v2 files are TypeScript-clean and covered by the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb55ef1d2c832886a19678aaadc9a6)