### PR TITLE
Remove invalid route export and move onboarding-v2 upload helpers

### DIFF
--- a/app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts
@@ -1,29 +1,6 @@
 import { NextResponse } from "next/server";
 import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
-
-const MAX_BYTES = 10 * 1024 * 1024;
-const SUPPORTED_MIME = new Set(["text/csv", "application/csv", "application/vnd.ms-excel"]);
-
-function parseApproxBase64Bytes(contentBase64: string): number {
-  return Math.floor((contentBase64.length * 3) / 4);
-}
-
-function isCsvLikeExcel(fileName: string): boolean {
-  return fileName.toLowerCase().endsWith(".csv");
-}
-
-function isAllowedUploadType(mimeType: string, fileName: string): { ok: boolean; message?: string } {
-  if (mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
-    return { ok: false, message: "xlsx_not_supported_by_agent" };
-  }
-  if (SUPPORTED_MIME.has(mimeType)) {
-    if (mimeType === "application/vnd.ms-excel" && !isCsvLikeExcel(fileName)) {
-      return { ok: false, message: "excel_mime_requires_csv_extension" };
-    }
-    return { ok: true };
-  }
-  return { ok: false, message: "unsupported_file_type" };
-}
+import { isAllowedUploadType, MAX_BYTES, parseApproxBase64Bytes } from "@/features/onboarding-v2/server/fileUpload";
 
 export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
   const access = await withOnboardingAccess();
@@ -67,4 +44,3 @@ export async function POST(request: Request, context: { params: Promise<{ sessio
   return proxyJson({ method: "POST", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/files/content`, shopId, body });
 }
 
-export const __testables = { isAllowedUploadType, parseApproxBase64Bytes, MAX_BYTES };

--- a/features/onboarding-v2/server/fileUpload.ts
+++ b/features/onboarding-v2/server/fileUpload.ts
@@ -1,0 +1,24 @@
+export const MAX_BYTES = 10 * 1024 * 1024;
+
+const SUPPORTED_MIME = new Set(["text/csv", "application/csv", "application/vnd.ms-excel"]);
+
+export function parseApproxBase64Bytes(contentBase64: string): number {
+  return Math.floor((contentBase64.length * 3) / 4);
+}
+
+function isCsvLikeExcel(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".csv");
+}
+
+export function isAllowedUploadType(mimeType: string, fileName: string): { ok: boolean; message?: string } {
+  if (mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
+    return { ok: false, message: "xlsx_not_supported_by_agent" };
+  }
+  if (SUPPORTED_MIME.has(mimeType)) {
+    if (mimeType === "application/vnd.ms-excel" && !isCsvLikeExcel(fileName)) {
+      return { ok: false, message: "excel_mime_requires_csv_extension" };
+    }
+    return { ok: true };
+  }
+  return { ok: false, message: "unsupported_file_type" };
+}

--- a/tests/onboarding-v2/proxy-and-upload.test.ts
+++ b/tests/onboarding-v2/proxy-and-upload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { signOnboardingAgentPayload } from "@/features/onboarding-v2/server/signing";
-import { __testables } from "../../app/api/onboarding-v2/sessions/[sessionId]/files/content/route";
+import { isAllowedUploadType, MAX_BYTES, parseApproxBase64Bytes } from "@/features/onboarding-v2/server/fileUpload";
 
 describe("onboarding v2 signing", () => {
   it("signs timestamp.shopId.rawBody format", () => {
@@ -11,11 +11,11 @@ describe("onboarding v2 signing", () => {
 
 describe("upload guardrails", () => {
   it("rejects xlsx as unsupported", () => {
-    expect(__testables.isAllowedUploadType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "sample.xlsx").ok).toBe(false);
+    expect(isAllowedUploadType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "sample.xlsx").ok).toBe(false);
   });
 
   it("rejects oversized base64 payload", () => {
-    const bytes = __testables.parseApproxBase64Bytes("A".repeat(__testables.MAX_BYTES * 2));
-    expect(bytes).toBeGreaterThan(__testables.MAX_BYTES);
+    const bytes = parseApproxBase64Bytes("A".repeat(MAX_BYTES * 2));
+    expect(bytes).toBeGreaterThan(MAX_BYTES);
   });
 });


### PR DESCRIPTION
### Motivation
- Next.js rejected `app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts` because it exported a test-only field (`__testables`) that is not allowed on App Router route files. 
- Helper logic needed to remain testable but not exported from a route file, so it must be moved to a separate server module to satisfy Next.js route export constraints. 

### Description
- Removed the `__testables` export from `app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts` so the route only exports supported Next.js handlers. 
- Added a new module `features/onboarding-v2/server/fileUpload.ts` which exports `MAX_BYTES`, `isAllowedUploadType`, and `parseApproxBase64Bytes`. 
- Updated the route to `import { isAllowedUploadType, MAX_BYTES, parseApproxBase64Bytes } from "@/features/onboarding-v2/server/fileUpload"` and left runtime behavior unchanged. 
- Updated tests to import helpers from `features/onboarding-v2/server/fileUpload.ts` instead of the route file. 

### Testing
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `npx vitest run tests/onboarding-v2/*.test.ts` and all onboarding-v2 tests passed (`3` test files, `6` tests passed). 
- Attempted `npm run build`, which reached Next.js build but failed due to network font fetch errors unrelated to the change (Google Fonts fetch failure), so the build failure is environmental and not caused by the route export fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6841d7d083289e7164521a36d8f3)