### PR TITLE
Add owner/admin-gated Onboarding Agent nav entry for onboarding-v2

### DIFF
--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -139,7 +139,7 @@ export const TILES: Tile[] = [
   },
   {
     href: "/dashboard/onboarding",
-    title: "Onboarding Agent",
+    title: "Legacy Onboarding",
     subtitle: "Stage files and prepare activation safely",
     roles: ["owner", "admin"],
     scopes: ["management", "all"],
@@ -147,11 +147,11 @@ export const TILES: Tile[] = [
   },
   {
     href: "/dashboard/onboarding-v2",
-    title: "Onboarding v2",
-    subtitle: "Verify-only onboarding foundation",
+    title: "Onboarding Agent",
+    subtitle: "Guided onboarding workspace",
     roles: ["owner", "admin"],
     scopes: ["management", "all"],
-    section: "Tools",
+    section: "Admin",
   },
 
   /* ---------------------------------------------------------------------- */

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -52,6 +52,7 @@ const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
   "/dashboard/admin/shops": "Admin & Oversight",
   "/dashboard/admin/audit": "Admin & Oversight",
   "/dashboard/onboarding": "Admin & Oversight",
+  "/dashboard/onboarding-v2": "Admin & Oversight",
   "/dashboard/marketing": "Growth",
   "/dashboard/reviews": "Growth",
   "/compare-plans": "Billing & Plan",
@@ -68,6 +69,7 @@ const OWNER_TITLE_OVERRIDES_BY_HREF: Record<string, string> = {
   "/billing": "Customer Billing",
   "/parts/requests": "Parts Requests",
   "/dashboard/onboarding": "Data Onboarding",
+  "/dashboard/onboarding-v2": "Onboarding Agent",
 };
 
 export function getOwnerTileOverrides(tile: Tile): Pick<Tile, "section" | "title"> {

--- a/tests/onboarding-v2/nav-entry-visibility.test.ts
+++ b/tests/onboarding-v2/nav-entry-visibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { TILES } from "@/features/shared/config/tiles";
+import { isOnboardingV2NavEnabled } from "@/features/onboarding-v2/lib/flags";
+
+function resolveOnboardingNavForRole(role: string) {
+  const navEnabled = isOnboardingV2NavEnabled();
+  return TILES
+    .filter((tile) => tile.roles.includes(role as never))
+    .filter((tile) => (tile.href === "/dashboard/onboarding-v2" ? navEnabled : true))
+    .some((tile) => tile.href === "/dashboard/onboarding-v2");
+}
+
+describe("onboarding v2 nav entry visibility", () => {
+  it("shows Onboarding Agent to owner/admin when ONBOARDING_V2_ENABLED=true", () => {
+    const existing = process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED;
+    process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED = "true";
+
+    expect(resolveOnboardingNavForRole("owner")).toBe(true);
+    expect(resolveOnboardingNavForRole("admin")).toBe(true);
+
+    process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED = existing;
+  });
+
+  it("hides Onboarding Agent when ONBOARDING_V2_ENABLED=false", () => {
+    const existing = process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED;
+    process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED = "false";
+
+    expect(resolveOnboardingNavForRole("owner")).toBe(false);
+    expect(resolveOnboardingNavForRole("admin")).toBe(false);
+
+    process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED = existing;
+  });
+
+  it("never shows Onboarding Agent to non-owner/admin roles", () => {
+    const existing = process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED;
+    process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED = "true";
+
+    expect(resolveOnboardingNavForRole("advisor")).toBe(false);
+    expect(resolveOnboardingNavForRole("mechanic")).toBe(false);
+    expect(resolveOnboardingNavForRole("parts")).toBe(false);
+
+    process.env.NEXT_PUBLIC_ONBOARDING_V2_ENABLED = existing;
+  });
+});

--- a/tests/owner-sidebar-nav.test.ts
+++ b/tests/owner-sidebar-nav.test.ts
@@ -54,6 +54,17 @@ describe("owner sidebar IA", () => {
     }
   });
 
+  it("keeps onboarding routes in admin oversight with explicit legacy/new labels", () => {
+    const tiles = ownerTiles();
+    const legacy = tiles.find((tile) => tile.href === "/dashboard/onboarding");
+    const v2 = tiles.find((tile) => tile.href === "/dashboard/onboarding-v2");
+
+    expect(legacy?.section).toBe("Admin & Oversight");
+    expect(legacy?.title).toBe("Data Onboarding");
+    expect(v2?.section).toBe("Admin & Oversight");
+    expect(v2?.title).toBe("Onboarding Agent");
+  });
+
   it("does not remove expected primary routes for tech/admin/parts roles", () => {
     const roleToHrefs: Record<Role, string[]> = {
       mechanic: ["/dashboard", "/tech/queue"],


### PR DESCRIPTION
### Motivation
- Expose the new onboarding-v2 workspace in the sidebar so owner/admin users can reach `/dashboard/onboarding-v2` without a direct link.
- Preserve existing legacy onboarding surfaces and Shop Boost routes while surfacing the new flow alongside them.
- Ensure the entry is feature-flag gated and restricted to owner/admin roles only per product access rules.

### Description
- Updated `features/shared/config/tiles.ts` to relabel the legacy `/dashboard/onboarding` tile as `Legacy Onboarding` and to add the `/dashboard/onboarding-v2` tile titled `Onboarding Agent` (placed in the `Admin` grouping).
- Updated `features/shared/lib/ownerSidebarNav.ts` to map both onboarding routes into the `Admin & Oversight` owner section and to override owner-facing titles (`Data Onboarding` for legacy and `Onboarding Agent` for v2).
- Added a new test `tests/onboarding-v2/nav-entry-visibility.test.ts` and extended `tests/owner-sidebar-nav.test.ts` to assert correct sectioning and title behavior for owner IA.
- The existing runtime gate remains `isOnboardingV2NavEnabled()` so the nav item is shown only when `ONBOARDING_V2_ENABLED` (or `NEXT_PUBLIC_ONBOARDING_V2_ENABLED`) is true and remains owner/admin-only via tile roles.

### Testing
- Ran unit tests with `npx vitest run tests/owner-sidebar-nav.test.ts tests/onboarding-v2/summary-proxy-nav.test.ts tests/onboarding-v2/nav-entry-visibility.test.ts` and all tests passed.
- Ran TypeScript validation with `npx tsc --noEmit` and it succeeded.
- Verified tests cover the acceptance criteria: owner/admin see `Onboarding Agent` when the feature flag is true, owner/admin do not see it when false, and non-owner/admin roles never see it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7383a61483288f82164332970ceb)