### PR TITLE
Fix onboarding-v2 verify-only readiness rendering and session creation proxy

### DIFF
--- a/app/api/onboarding-v2/sessions/route.ts
+++ b/app/api/onboarding-v2/sessions/route.ts
@@ -17,6 +17,13 @@ export async function POST(request: Request) {
 
   const body = JSON.stringify({ shopId, ...parsed.data });
   const response = await proxyOnboardingAgent({ method: "POST", path: "/onboarding/sessions", shopId, body });
-  const payload = (await response.json().catch(() => ({ ok: false, message: "Invalid agent response" }))) as Record<string, unknown>;
-  return NextResponse.json(payload, { status: response.status });
+  const upstream = (await response.json().catch(() => ({ ok: false, failureKind: "invalid_agent_response", message: "Invalid onboarding agent response." }))) as Record<string, unknown>;
+  const safePayload = {
+    ok: upstream.ok === true,
+    sessionId: typeof upstream.sessionId === "string" ? upstream.sessionId : undefined,
+    failureKind: typeof upstream.failureKind === "string" ? upstream.failureKind : undefined,
+    message: typeof upstream.message === "string" ? upstream.message : undefined,
+    upstreamStatus: response.status,
+  };
+  return NextResponse.json(safePayload, { status: response.status });
 }

--- a/features/onboarding-v2/components/AgentReadinessBanner.tsx
+++ b/features/onboarding-v2/components/AgentReadinessBanner.tsx
@@ -1,12 +1,18 @@
 import React from "react";
-import type { AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+import { isVerifyOnlyConfigured, type AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
 
 function statusLabel(readiness: AgentReadiness): string {
   if (!readiness.connector.configured) return "Disabled / not configured";
   if (!readiness.ok) return "Degraded";
+  if (isVerifyOnlyConfigured(readiness)) return "Connected / verify-only";
   if (readiness.connector.liveMaterializationEnabled || readiness.connector.canWriteLive || readiness.rolloutStage === "live_enabled") return "Live-enabled (warning)";
   if (readiness.rolloutStage === "dry_run" || readiness.rolloutStage === "http_verify_only") return "Verify-only";
   return "Healthy";
+}
+
+function connectorModeLabel(readiness: AgentReadiness): string {
+  if (readiness.connector.mode !== "unknown") return readiness.connector.mode;
+  return isVerifyOnlyConfigured(readiness) ? "verify-only" : "unknown";
 }
 
 export function AgentReadinessBanner({ readiness, loading, degradedMessage }: { readiness: AgentReadiness; loading?: boolean; degradedMessage?: string }) {
@@ -14,7 +20,8 @@ export function AgentReadinessBanner({ readiness, loading, degradedMessage }: { 
     <div className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-200">
       <div className="font-semibold">Agent readiness: {loading ? "Loading…" : statusLabel(readiness)}</div>
       {degradedMessage ? <p className="mt-1 text-xs text-amber-300">{degradedMessage}</p> : null}
-      <p className="mt-1 text-xs text-slate-400">Rollout stage: {readiness.rolloutStage ?? "unknown"} • Connector mode: {readiness.connector.mode}</p>
+      <p className="mt-1 text-xs text-slate-400">Rollout stage: {readiness.rolloutStage ?? "unknown"} • Connector mode: {connectorModeLabel(readiness)}</p>
+      <p className="mt-1 text-xs text-slate-400">Live materialization: {readiness.connector.liveMaterializationEnabled ? "enabled" : "disabled"} • canValidateShop: {String(readiness.connector.canValidateShop)} • canWriteLive: {String(readiness.connector.canWriteLive)}</p>
       {readiness.warnings.length > 0 ? <ul className="mt-2 list-disc pl-4 text-xs text-amber-200">{readiness.warnings.map((warning) => <li key={warning}>{warning}</li>)}</ul> : null}
     </div>
   );

--- a/features/onboarding-v2/components/StartOnboardingSessionCard.tsx
+++ b/features/onboarding-v2/components/StartOnboardingSessionCard.tsx
@@ -12,8 +12,13 @@ export function StartOnboardingSessionCard() {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ sourceSystem: "profixiq-onboarding-v2" }),
     });
-    const payload = (await response.json()) as { sessionId?: string; message?: string };
-    setStatus(payload.sessionId ? `Session created: ${payload.sessionId}` : payload.message ?? "Unable to create session");
+    const payload = (await response.json()) as { ok?: boolean; sessionId?: string; message?: string; failureKind?: string; upstreamStatus?: number };
+    if (payload.sessionId) {
+      setStatus(`Session created: ${payload.sessionId}`);
+      return;
+    }
+    const detail = payload.failureKind ? `${payload.failureKind}${payload.upstreamStatus ? ` (${payload.upstreamStatus})` : ""}` : "";
+    setStatus(payload.message ? `${payload.message}${detail ? ` — ${detail}` : ""}` : "Unable to create session");
   }
 
   return (

--- a/features/onboarding-v2/lib/agentReadiness.ts
+++ b/features/onboarding-v2/lib/agentReadiness.ts
@@ -14,6 +14,16 @@ export type AgentReadiness = {
   requiredEnv?: string[];
 };
 
+export function isVerifyOnlyConfigured(readiness: AgentReadiness): boolean {
+  return (
+    readiness.ok &&
+    readiness.rolloutStage === "http_verify_only" &&
+    readiness.connector.configured &&
+    !readiness.connector.liveMaterializationEnabled &&
+    readiness.connector.canValidateShop
+  );
+}
+
 export function defaultAgentReadiness(): AgentReadiness {
   return {
     ok: false,

--- a/tests/onboarding-v2/readiness-ui.test.tsx
+++ b/tests/onboarding-v2/readiness-ui.test.tsx
@@ -15,7 +15,19 @@ describe("readiness UI", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
     render(<SessionWorkspace sessionId="sess_1" />);
-    expect(await screen.findByText(/Agent readiness: Verify-only/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Agent readiness: Connected \/ verify-only/i)).toBeInTheDocument();
+  });
+
+  it("normalizer maps configured http_verify_only as connected verify-only", () => {
+    const readiness = normalizeAgentReadiness({
+      ok: true,
+      rolloutStage: "http_verify_only",
+      connector: { mode: "unknown", configured: true, liveMaterializationEnabled: false, canValidateShop: true, canWriteLive: false },
+      warnings: [],
+    });
+    expect(readiness.ok).toBe(true);
+    expect(readiness.connector.configured).toBe(true);
+    expect(readiness.rolloutStage).toBe("http_verify_only");
   });
 
   it("confirm panel disables when canWriteLive is false", () => {

--- a/tests/onboarding-v2/session-proxy-contract.test.ts
+++ b/tests/onboarding-v2/session-proxy-contract.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("onboarding session proxy contract", () => {
+  it("session creation route includes shopId and source system in outbound body", () => {
+    const route = fs.readFileSync(path.join(process.cwd(), "app/api/onboarding-v2/sessions/route.ts"), "utf8");
+    expect(route.includes('JSON.stringify({ shopId, ...parsed.data })')).toBe(true);
+    expect(route.includes('path: "/onboarding/sessions"')).toBe(true);
+  });
+
+  it("proxy client signs outbound request and includes required headers", () => {
+    const client = fs.readFileSync(path.join(process.cwd(), "features/onboarding-v2/server/agentClient.ts"), "utf8");
+    expect(client.includes("signOnboardingAgentPayload")).toBe(true);
+    expect(client.includes('"x-shop-id": input.shopId')).toBe(true);
+    expect(client.includes('"x-onboarding-agent-timestamp"')).toBe(true);
+    expect(client.includes('"x-onboarding-agent-signature"')).toBe(true);
+  });
+
+  it("session creation route returns safe upstream error details", () => {
+    const route = fs.readFileSync(path.join(process.cwd(), "app/api/onboarding-v2/sessions/route.ts"), "utf8");
+    expect(route.includes("failureKind")).toBe(true);
+    expect(route.includes("upstreamStatus")).toBe(true);
+    expect(route.includes("raw_data")).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- The onboarding-v2 UI treated an `ok:true` readiness with `rolloutStage: "http_verify_only"` and `connector.configured:true` as disabled/not configured and the Start session flow showed an opaque "Unable to create session" error.
- The server proxy needed to return a safe, normalized upstream error payload while preserving owner/admin and shop scoping and signing outbound Railway requests from the server.
- Keep verify-only behavior obvious in the UI and ensure the browser only calls ProFixIQ `/api/onboarding-v2/*` routes.

### Description
- Added `isVerifyOnlyConfigured` predicate in `features/onboarding-v2/lib/agentReadiness.ts` to encapsulate the contract for a configured verify-only state (`ok:true`, `rolloutStage:"http_verify_only"`, `connector.configured:true`, `!liveMaterializationEnabled`, `canValidateShop:true`).
- Updated `features/onboarding-v2/components/AgentReadinessBanner.tsx` to display `Connected / verify-only` for the new predicate, provide a `connectorModeLabel` fallback of `verify-only` when `mode` is `unknown`, and show live materialization + `canValidateShop`/`canWriteLive` details.
- Changed `app/api/onboarding-v2/sessions/route.ts` to proxy the POST to `/onboarding/sessions` with `JSON.stringify({ shopId, ...parsed.data })` and return a safe normalized payload: `{ ok, sessionId?, failureKind?, message?, upstreamStatus }` so no secrets/raw_data are leaked to the client.
- Updated `features/onboarding-v2/components/StartOnboardingSessionCard.tsx` to surface the safe error details returned by the server (shows `message` and `failureKind (status)` when present) instead of a generic message.
- Added `tests/onboarding-v2/session-proxy-contract.test.ts` and adjusted `tests/onboarding-v2/readiness-ui.test.tsx` to assert the new readiness rendering and proxy contract (signing headers presence, outbound path/body presence, and safe error shaping), and preserved the client-side prohibition on direct Railway URLs.
- Kept server proxy signing and header format in `features/onboarding-v2/server/agentClient.ts` (`x-shop-id`, `x-onboarding-agent-timestamp`, `x-onboarding-agent-signature`) unchanged and enforced; browser continues to call only `/api/onboarding-v2/*`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully.
- Unit tests: ran `npx vitest run tests/onboarding-v2/readiness-ui.test.tsx tests/onboarding-v2/session-proxy-contract.test.ts tests/onboarding-v2/client-proxy-usage.test.ts` and all targeted tests passed (3 files, 9 tests passed).
- Tests cover: readiness normalizer and banner rendering for configured verify-only state, Start session proxy contract including outbound body/path and signing header presence, and safe upstream error shaping returned to the client.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8e095f308328b1b93f61425a5511)