### PR TITLE
Fix onboarding-v2 dashboard readiness to use authenticated API payload

### DIFF
--- a/app/dashboard/onboarding-v2/page.tsx
+++ b/app/dashboard/onboarding-v2/page.tsx
@@ -2,22 +2,12 @@ import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-acces
 import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
 import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
 import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
-import { normalizeAgentReadiness, defaultAgentReadiness, type AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+import { getAgentReadinessForDashboard } from "@/features/onboarding-v2/lib/agentReadinessServer";
 import { StartOnboardingSessionCard } from "@/features/onboarding-v2/components/StartOnboardingSessionCard";
-
-async function getReadiness(): Promise<AgentReadiness> {
-  try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"}/api/onboarding-v2/agent-readiness`, { cache: "no-store" });
-    if (!response.ok) return defaultAgentReadiness();
-    return normalizeAgentReadiness(await response.json());
-  } catch {
-    return defaultAgentReadiness();
-  }
-}
 
 export default async function OnboardingV2Page() {
   await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
-  const readiness = await getReadiness();
+  const readiness = await getAgentReadinessForDashboard();
 
   return (
     <OnboardingV2Shell title="Onboarding Agent">

--- a/features/onboarding-v2/lib/agentReadinessServer.ts
+++ b/features/onboarding-v2/lib/agentReadinessServer.ts
@@ -1,0 +1,18 @@
+import { cookies } from "next/headers";
+import { defaultAgentReadiness, normalizeAgentReadiness, type AgentReadiness } from "@/features/onboarding-v2/lib/agentReadiness";
+
+export async function getAgentReadinessForDashboard(): Promise<AgentReadiness> {
+  try {
+    const cookieStore = await cookies();
+    const cookieHeader = cookieStore.toString();
+    const response = await fetch("/api/onboarding-v2/agent-readiness", {
+      cache: "no-store",
+      headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+    });
+
+    if (!response.ok) return defaultAgentReadiness();
+    return normalizeAgentReadiness(await response.json());
+  } catch {
+    return defaultAgentReadiness();
+  }
+}

--- a/tests/onboarding-v2/readiness-server.test.ts
+++ b/tests/onboarding-v2/readiness-server.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const cookiesMock = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}));
+
+describe("dashboard readiness fetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the api route with auth cookies and maps verify-only readiness", async () => {
+    cookiesMock.mockResolvedValue({ toString: () => "sb-access-token=abc" });
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        rolloutStage: "http_verify_only",
+        connector: {
+          configured: true,
+          canValidateShop: true,
+          canWriteLive: false,
+          liveMaterializationEnabled: false,
+          mode: "unknown",
+        },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAgentReadinessForDashboard } = await import("@/features/onboarding-v2/lib/agentReadinessServer");
+    const readiness = await getAgentReadinessForDashboard();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/agent-readiness",
+      expect.objectContaining({ cache: "no-store", headers: { cookie: "sb-access-token=abc" } }),
+    );
+    expect(readiness.ok).toBe(true);
+    expect(readiness.rolloutStage).toBe("http_verify_only");
+    expect(readiness.connector.configured).toBe(true);
+    expect(readiness.connector.canValidateShop).toBe(true);
+    expect(readiness.connector.canWriteLive).toBe(false);
+    expect(readiness.connector.liveMaterializationEnabled).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- The dashboard page was falling back to `defaultAgentReadiness()` because its server-side fetch used an absolute URL (no forwarded cookies/shop context), causing configured verify-only agents to render as "Disabled / not configured". 

### Description
- Replaced the page's inline readiness fetch with a server helper `getAgentReadinessForDashboard` that forwards request cookies via `next/headers` and calls the internal route `"/api/onboarding-v2/agent-readiness"` with `cache: "no-store"`.
- Updated `app/dashboard/onboarding-v2/page.tsx` to import and use `getAgentReadinessForDashboard()` instead of the old inline request and fallback behavior.
- Added `features/onboarding-v2/lib/agentReadinessServer.ts` which normalizes the API response using the existing `normalizeAgentReadiness` and preserves the verify-only mapping (no live materialization enabled and `canWriteLive` stays false).
- Added `tests/onboarding-v2/readiness-server.test.ts` to assert that the internal API is called with forwarded cookies and that a verify-only response is normalized and returned.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` which completed successfully.
- Ran unit tests with `npx vitest run tests/onboarding-v2/*.test.ts` and the suite passed including the new `readiness-server.test.ts` (test run: 6 files, 13 tests passed).
- The change preserves existing normalization and UI behavior so verify-only responses render as "Connected / verify-only" while CTAs remain disabled because live writes are off.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb98a54b248328b71916f3eff193ef)