### PR TITLE
Add safe diagnostics for onboarding agent Invalid signature failures

### DIFF
--- a/features/onboarding-v2/server/agentClient.ts
+++ b/features/onboarding-v2/server/agentClient.ts
@@ -3,6 +3,44 @@ import { signOnboardingAgentPayload } from "@/features/onboarding-v2/server/sign
 
 const REQUEST_TIMEOUT_MS = 20_000;
 
+function maskEdge(value: string, edge: number): string {
+  if (!value) return "";
+  if (value.length <= edge * 2) return value;
+  return `${value.slice(0, edge)}...${value.slice(-edge)}`;
+}
+
+async function logInvalidSignatureDiagnostic(input: {
+  response: Response;
+  path: string;
+  method: "GET" | "POST";
+  shopId: string;
+  rawBody: string;
+  timestampMs: number;
+  signature: string;
+  secret: string;
+}): Promise<void> {
+  if (input.response.status !== 400) return;
+  const text = (await input.response.clone().text().catch(() => "")).toLowerCase();
+  if (!text.includes("invalid signature")) return;
+
+  const ageMs = Date.now() - input.timestampMs;
+  console.error("[onboarding-auth-diagnostic] Invalid signature", {
+    routePath: input.path,
+    method: input.method,
+    shopIdPresent: Boolean(input.shopId),
+    shopIdMasked: maskEdge(input.shopId, 4),
+    timestampMs: input.timestampMs,
+    ageMs,
+    rawBodyLength: input.rawBody.length,
+    candidatePayloadLabelsTested: ["timestamp.shopId.rawBody"],
+    signatureLength: input.signature.length,
+    signatureMasked: maskEdge(input.signature, 6),
+    envSecretName: "INTERNAL_HMAC_SECRET",
+    secretLength: input.secret.length,
+    nodeEnv: process.env.NODE_ENV ?? "",
+  });
+}
+
 export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path: string; shopId: string; body?: string; query?: URLSearchParams }): Promise<Response> {
   const config = getOnboardingAgentConfig();
 
@@ -24,7 +62,7 @@ export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
   try {
-    return await fetch(url, {
+    const response = await fetch(url, {
       method: input.method,
       headers: {
         "content-type": "application/json",
@@ -36,6 +74,17 @@ export async function proxyOnboardingAgent(input: { method: "GET" | "POST"; path
       cache: "no-store",
       signal: controller.signal,
     });
+    await logInvalidSignatureDiagnostic({
+      response,
+      path: input.path,
+      method: input.method,
+      shopId: input.shopId,
+      rawBody,
+      timestampMs,
+      signature,
+      secret: config.internalSecret,
+    });
+    return response;
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       return Response.json({ ok: false, failureKind: "agent_timeout", message: "Onboarding agent timed out." }, { status: 504 });

--- a/tests/onboarding-v2/agent-client-diagnostics.test.ts
+++ b/tests/onboarding-v2/agent-client-diagnostics.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { proxyOnboardingAgent } from "@/features/onboarding-v2/server/agentClient";
+
+const originalEnv = process.env;
+
+describe("onboarding agent diagnostics", () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      ONBOARDING_AGENT_ENABLED: "true",
+      ONBOARDING_AGENT_BASE_URL: "https://agent.example.com",
+      ONBOARDING_AGENT_INTERNAL_SECRET: "super-secret-value",
+      NODE_ENV: "test",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("logs safe diagnostics for invalid signature failures without leaking secret/body", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"message":"Invalid signature"}', { status: 400, headers: { "content-type": "application/json" } }),
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await proxyOnboardingAgent({
+      method: "POST",
+      path: "/onboarding/sessions",
+      shopId: "shop_12345678",
+      body: '{"private":"abc123secret"}',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    const [, payload] = errorSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(payload.envSecretName).toBe("INTERNAL_HMAC_SECRET");
+    expect(payload.secretLength).toBe("super-secret-value".length);
+    expect(payload.rawBodyLength).toBe('{"private":"abc123secret"}'.length);
+    expect(payload.shopIdMasked).toBe("shop...5678");
+    expect(payload.signatureMasked).toMatch(/^[a-f0-9]{6}\.\.\.[a-f0-9]{6}$/);
+    expect(JSON.stringify(payload)).not.toContain("super-secret-value");
+    expect(JSON.stringify(payload)).not.toContain('{"private":"abc123secret"}');
+  });
+
+  it("does not log diagnostics for non-signature 400 responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response('{"message":"Bad request"}', { status: 400 }));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await proxyOnboardingAgent({ method: "POST", path: "/onboarding/sessions", shopId: "shop_1234", body: "{}" });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- When POSTing to the onboarding agent the proxy sometimes receives a 400 `Invalid signature` response and we need safe telemetry to determine whether this is a payload format, stale deploy, or env secret mismatch issue. 
- The change aims to emit only non-sensitive metadata to aid debugging while ensuring no secret or raw body data is logged and the proxy behavior remains unchanged.

### Description
- Added `maskEdge` helper and `logInvalidSignatureDiagnostic` to `features/onboarding-v2/server/agentClient.ts` and invoke it after the upstream `fetch` returns. 
- Diagnostics are emitted only when the upstream response is HTTP 400 and contains the phrase `invalid signature` (case-insensitive). 
- Logged metadata includes route/path and method, `shopId` presence and masked first/last 4 chars, timestamp and computed `ageMs`, `rawBody` length only, candidate payload labels tested, signature length and masked first/last 6 chars, environment secret name used (`INTERNAL_HMAC_SECRET`) and secret length only, and `NODE_ENV`. 
- Added `tests/onboarding-v2/agent-client-diagnostics.test.ts` to assert that diagnostics are emitted only for invalid-signature 400s and that they do not contain secret values or the raw body contents.

### Testing
- Ran the targeted diagnostics test with `npm test -- --run tests/onboarding-v2/agent-client-diagnostics.test.ts` and it passed. 
- Ran `npm run build` which failed in this environment due to external Google Fonts fetch/network errors during Next.js build and not due to the change. 
- Ran the full `npm test`; the repository test run surfaced existing failing tests in the `features/onboarding-agent/server/activateOnboardingHistory.test.ts` suite that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0606977c8328a8ecceffe3bd0c6e)