### PR TITLE
Improve onboarding-v2 CSV upload UX and add contract test

### DIFF
--- a/features/onboarding-v2/components/SessionWorkspace.tsx
+++ b/features/onboarding-v2/components/SessionWorkspace.tsx
@@ -94,9 +94,14 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
       }
     };
     void run();
+    const refreshHandler = () => {
+      void run();
+    };
+    window.addEventListener("onboarding-v2:refresh-session", refreshHandler);
     const id = setInterval(() => void run(), terminal ? 15000 : 7000);
     return () => {
       active = false;
+      window.removeEventListener("onboarding-v2:refresh-session", refreshHandler);
       clearInterval(id);
     };
   }, [sessionId, terminal]);
@@ -143,12 +148,31 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
 function UploadCard({ sessionId }: { sessionId: string }) {
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<string>("");
+  const [uploading, setUploading] = useState(false);
+
+  const refreshFiles = async () => {
+    window.dispatchEvent(new CustomEvent("onboarding-v2:refresh-session"));
+  };
+
   const upload = async () => {
     if (!file) return;
-    const form = new FormData();
-    form.append("file", file);
-    const res = await fetch(`/api/onboarding-v2/sessions/${sessionId}/files/content`, { method: "POST", body: form });
-    setStatus(res.ok ? "Uploaded" : "Upload failed");
+    setUploading(true);
+    setStatus("Uploading…");
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch(`/api/onboarding-v2/sessions/${sessionId}/files/content`, { method: "POST", body: form });
+      if (res.ok) {
+        setStatus("Uploaded");
+        await refreshFiles();
+        setFile(null);
+        return;
+      }
+      const payload = (await res.json().catch(() => null)) as { error?: string; message?: string } | null;
+      setStatus(payload?.error ?? payload?.message ?? "Upload failed");
+    } finally {
+      setUploading(false);
+    }
   };
-  return <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Upload legacy files</div><input type="file" accept=".csv,text/csv,application/csv,application/vnd.ms-excel" className="mt-2" onChange={(e) => setFile(e.target.files?.[0] ?? null)} /><button onClick={upload} className="ml-2 rounded bg-cyan-700 px-3 py-1">Upload</button><div className="mt-2 text-xs text-slate-400">{status}</div></div>;
+  return <div className="rounded-xl border border-white/10 p-4"><div className="font-semibold">Upload legacy files</div><input type="file" accept=".csv,text/csv,application/csv,application/vnd.ms-excel" className="mt-2" onChange={(e) => setFile(e.target.files?.[0] ?? null)} /><button onClick={upload} disabled={!file || uploading} className="ml-2 rounded bg-cyan-700 px-3 py-1 disabled:opacity-50">Upload</button><div className="mt-2 text-xs text-slate-400">{status}</div></div>;
 }

--- a/tests/onboarding-v2/files-content-route.test.ts
+++ b/tests/onboarding-v2/files-content-route.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const withOnboardingAccessMock = vi.fn();
+const proxyJsonMock = vi.fn();
+
+vi.mock("@/features/onboarding-v2/server/apiProxy", () => ({
+  withOnboardingAccess: withOnboardingAccessMock,
+  proxyJson: proxyJsonMock,
+}));
+
+describe("files content route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    withOnboardingAccessMock.mockResolvedValue({ ok: true, profile: { shop_id: "shop_123" } });
+    proxyJsonMock.mockResolvedValue(Response.json({ ok: true }, { status: 200 }));
+  });
+
+  it("forwards JSON upload body shape expected by the agent", async () => {
+    const { POST } = await import("../../app/api/onboarding-v2/sessions/[sessionId]/files/content/route");
+
+    const payload = {
+      originalFilename: "legacy.csv",
+      mimeType: "text/csv",
+      contentBase64: Buffer.from("a,b\n1,2\n").toString("base64"),
+    };
+
+    const request = new Request("http://localhost/api/onboarding-v2/sessions/s_1/files/content", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    await POST(request, { params: Promise.resolve({ sessionId: "s_1" }) });
+
+    expect(proxyJsonMock).toHaveBeenCalledTimes(1);
+    expect(proxyJsonMock).toHaveBeenCalledWith({
+      method: "POST",
+      path: "/onboarding/sessions/s_1/files/content",
+      shopId: "shop_123",
+      body: payload,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Users reported clicking Upload on `/dashboard/onboarding-v2/:sessionId` appeared to do nothing because the session file/timeline UI only updated on the next poll tick and gave no immediate feedback. 
- The upload path must continue to convert multipart to JSON/base64 and preserve the HMAC signing contract, and we need test coverage that the exact JSON shape is forwarded to the agent.

### Description
- UI: `features/onboarding-v2/components/SessionWorkspace.tsx` now shows an in-flight state (`Uploading…`), disables the Upload button while active, surfaces server error messages, and dispatches a refresh event after a successful upload so the workspace reloads immediately. 
- Polling hook: the workspace polling now listens for the `onboarding-v2:refresh-session` event and triggers an immediate refresh when fired. 
- Test: added `tests/onboarding-v2/files-content-route.test.ts` to assert that `POST /api/onboarding-v2/sessions/:sessionId/files/content` forwards JSON to the proxy with the exact body keys `originalFilename`, `mimeType`, and `contentBase64`. 
- No changes were made to the agent signing/proxy logic; the HMAC signing contract (`timestamp.shopId.rawBody`) and `application/json` proxy headers remain unchanged.
- Files changed: `features/onboarding-v2/components/SessionWorkspace.tsx`, `tests/onboarding-v2/files-content-route.test.ts`.
- Final JSON body shape forwarded to agent (as proxied JSON): `{ "originalFilename": "<name>", "mimeType": "<mime>", "contentBase64": "<base64>" }`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check succeeded. 
- Ran `npx vitest run tests/onboarding-v2/*.test.ts tests/onboarding-v2/*.test.tsx` and all tests passed (26 tests across onboarding-v2 suite). 
- The new contract test verifying the forwarded JSON body shape passed. 
- `ProFixIQ-Onboarding-Agent` build/tests were not run because that repository was not available at the inspected path in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0b3ac5208328a9ecde09869376f6)