### PR TITLE
onboarding-v2: fix session events polling & ensure shopId in proxy queries

### DIFF
--- a/app/api/onboarding-v2/sessions/[sessionId]/events/route.ts
+++ b/app/api/onboarding-v2/sessions/[sessionId]/events/route.ts
@@ -1,11 +1,10 @@
-import { proxyJson, withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
+import { withOnboardingAccess } from "@/features/onboarding-v2/server/apiProxy";
 
-export async function GET(request: Request, context: { params: Promise<{ sessionId: string }> }) {
+export async function GET(_: Request) {
   const access = await withOnboardingAccess();
   if (!access.ok) return access.response;
-  const { sessionId } = await context.params;
-  const shopId = access.profile.shop_id;
-  if (!shopId) return Response.json({ error: "Missing shop context" }, { status: 403 });
-  const query = new URL(request.url).searchParams;
-  return proxyJson({ method: "GET", path: `/onboarding/sessions/${encodeURIComponent(sessionId)}/events`, shopId, query });
+
+  // Compatibility route: events are keyed by runId upstream, not sessionId.
+  // Return a safe empty list until run-aware polling is available in the UI.
+  return Response.json({ items: [] });
 }

--- a/features/onboarding-v2/components/OnboardingSummaryPage.tsx
+++ b/features/onboarding-v2/components/OnboardingSummaryPage.tsx
@@ -15,6 +15,14 @@ function toCount(value: unknown): number {
 type JsonObj = Record<string, unknown>;
 type Recommendation = { title?: string; summary?: string; details?: string; type?: string; category?: string; label?: string };
 
+function toRecommendations(payload: unknown): Recommendation[] {
+  if (Array.isArray(payload)) return payload as Recommendation[];
+  if (payload && typeof payload === "object" && Array.isArray((payload as { items?: unknown }).items)) {
+    return (payload as { items: Recommendation[] }).items;
+  }
+  return [];
+}
+
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(path, { cache: "no-store" });
   return (await response.json()) as T;
@@ -35,7 +43,7 @@ export function OnboardingSummaryPage({ sessionId }: { sessionId: string }) {
         getJson<unknown>("/api/onboarding-v2/agent-readiness"),
         getJson<JsonObj>(`/api/onboarding-v2/sessions/${sessionId}`),
         getJson<JsonObj>(`/api/onboarding-v2/sessions/${sessionId}/summary`),
-        getJson<{ items?: Recommendation[] }>(`/api/onboarding-v2/sessions/${sessionId}/recommendations`),
+        getJson<unknown>(`/api/onboarding-v2/sessions/${sessionId}/recommendations`),
         getJson<JsonObj>(`/api/onboarding-v2/sessions/${sessionId}/activation-summary`),
         getJson<JsonObj>(`/api/onboarding-v2/sessions/${sessionId}/materialization-records`),
       ]);
@@ -43,7 +51,7 @@ export function OnboardingSummaryPage({ sessionId }: { sessionId: string }) {
       setReadiness(normalizeAgentReadiness(r));
       setSession(s);
       setSummary(f);
-      setRecommendations(rec.items ?? []);
+      setRecommendations(toRecommendations(rec));
       setActivationSummary(act);
       setMaterializationRecords(mat);
     };

--- a/features/onboarding-v2/components/ReviewItemsQueue.tsx
+++ b/features/onboarding-v2/components/ReviewItemsQueue.tsx
@@ -9,6 +9,14 @@ import { defaultAgentReadiness, normalizeAgentReadiness, type AgentReadiness } f
 
 type Item = { id?: string; severity?: string; status?: string; title?: string; message?: string; kind?: string };
 
+function toItems(payload: unknown): Item[] {
+  if (Array.isArray(payload)) return payload as Item[];
+  if (payload && typeof payload === "object" && Array.isArray((payload as { items?: unknown }).items)) {
+    return (payload as { items: Item[] }).items;
+  }
+  return [];
+}
+
 export function ReviewItemsQueue({ sessionId }: { sessionId: string }) {
   const [items, setItems] = useState<Item[]>([]);
   const [status, setStatus] = useState("open");
@@ -27,7 +35,7 @@ export function ReviewItemsQueue({ sessionId }: { sessionId: string }) {
     if (severity !== "all") query.set("severity", severity);
     void fetch(`/api/onboarding-v2/sessions/${sessionId}/review-items?${query.toString()}`, { cache: "no-store" })
       .then((r) => r.json())
-      .then((j: { items?: Item[] }) => setItems(j.items ?? []));
+      .then((j: unknown) => setItems(toItems(j)));
   }, [sessionId, severity, status]);
 
   const displayItems = items.filter((item) => String(item.kind ?? "exception") !== "normal");

--- a/features/onboarding-v2/components/SessionWorkspace.tsx
+++ b/features/onboarding-v2/components/SessionWorkspace.tsx
@@ -11,6 +11,14 @@ import { defaultAgentReadiness, normalizeAgentReadiness, type AgentReadiness } f
 type JsonMap = Record<string, unknown>;
 type ApiListResponse = { items?: JsonMap[]; message?: string };
 
+function toItems(payload: unknown): JsonMap[] {
+  if (Array.isArray(payload)) return payload.filter((item): item is JsonMap => typeof item === "object" && item !== null);
+  if (payload && typeof payload === "object" && Array.isArray((payload as { items?: unknown }).items)) {
+    return (payload as { items: unknown[] }).items.filter((item): item is JsonMap => typeof item === "object" && item !== null);
+  }
+  return [];
+}
+
 async function getJson<T>(path: string): Promise<T> {
   const r = await fetch(path, { cache: "no-store" });
   const response = r as Response & { json?: () => Promise<unknown>; text?: () => Promise<string> };
@@ -76,9 +84,9 @@ export function SessionWorkspace({ sessionId }: { sessionId: string }) {
         ]);
         if (!active) return;
         setSession(s);
-        setEvents(e.items ?? []);
+        setEvents(toItems(e));
         setSummary(a);
-        setFiles(f.items ?? []);
+        setFiles(toItems(f));
         setReadiness(r === null ? defaultAgentReadiness() : normalizeAgentReadiness(r));
         setError("");
         setReadinessError(r === null ? "Readiness check unavailable. Verify-only safe mode remains enforced." : "");

--- a/features/onboarding-v2/server/apiProxy.ts
+++ b/features/onboarding-v2/server/apiProxy.ts
@@ -29,12 +29,15 @@ export async function withOnboardingAccess() {
 }
 
 export async function proxyJson(params: { method: "GET" | "POST"; path: string; shopId: string; body?: unknown; query?: URLSearchParams }) {
+  const query = new URLSearchParams(params.query);
+  if (!query.get("shopId")) query.set("shopId", params.shopId);
+
   const response = await proxyOnboardingAgent({
     method: params.method,
     path: params.path,
     shopId: params.shopId,
     body: params.body === undefined ? undefined : JSON.stringify(params.body),
-    query: params.query,
+    query,
   });
 
   const payloadRaw = (await response.json().catch(() => ({ ok: false, failureKind: "invalid_agent_response", message: "Invalid onboarding agent response." }))) as unknown;


### PR DESCRIPTION
### Motivation
- The frontend polls `GET /onboarding/sessions/:sessionId/events` while the agent exposes run-scoped events and some agent GET endpoints require `shopId` in the query, causing 403 shop-mismatch errors. 
- The UI assumed list responses always arrive as `{ items: [...] }`, which broke when the agent returned a raw array; list normalization is needed.

### Description
- Ensure `shopId` is always included in proxied queries by updating `proxyJson` to merge a `shopId` query param when missing in `features/onboarding-v2/server/apiProxy.ts`.
- Add a compatibility session events route that does not proxy sessionId to run-based events and safely returns `{ items: [] }` in `app/api/onboarding-v2/sessions/[sessionId]/events/route.ts`.
- Normalize list parsing in the UI by accepting either a raw array or `{ items: [...] }` in `features/onboarding-v2/components/SessionWorkspace.tsx`, `features/onboarding-v2/components/ReviewItemsQueue.tsx`, and `features/onboarding-v2/components/OnboardingSummaryPage.tsx` (including a small type/fetch adjustment for recommendations to `unknown`).

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build check succeeded.
- Ran `npx vitest run tests/onboarding-v2/*.test.ts tests/onboarding-v2/*.test.tsx` and all onboarding-v2 tests passed (10 files, 26 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc94837b008328bfdd675df681d97d)