### PR TITLE
Phase 3.1: AI governance and reliability hardening for core AI endpoints

### DIFF
--- a/app/api/ai/summarize-stats/route.ts
+++ b/app/api/ai/summarize-stats/route.ts
@@ -3,10 +3,14 @@ import { NextResponse } from "next/server";
 import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 
 const openai = isOpenAIConfigured() ? getOpenAIClient() : null;
 
 export async function POST(req: Request) {
+  const startedAt = Date.now();
+  const policy = getAIPolicy("ai_summarize_stats");
   const supabase = createServerSupabaseRoute();
   const {
     data: { user },
@@ -37,12 +41,58 @@ Summarize the following shop performance stats:
 ${JSON.stringify(body.stats, null, 2)}
 `;
 
-  const res = await openai.chat.completions.create({
-    model: getOpenAIModelForPurpose("fast"),
-    messages: [{ role: "user", content: prompt }],
-  });
+  const model = getOpenAIModelForPurpose(policy.modelPurpose);
 
-  return NextResponse.json({
-    summary: res.choices[0]?.message?.content ?? "",
-  });
+  try {
+    const res = await Promise.race([
+      openai.chat.completions.create({
+        model,
+        max_tokens: policy.maxTokens,
+        messages: [{ role: "user", content: prompt }],
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("AI request timed out")), policy.timeoutMs),
+      ),
+    ]);
+
+    recordAITelemetry({
+      feature: "ai_summarize_stats",
+      endpoint: "/api/ai/summarize-stats",
+      shop_id: null,
+      user_id: user.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: res.usage?.prompt_tokens ?? null,
+      completion_tokens: res.usage?.completion_tokens ?? null,
+      total_tokens: res.usage?.total_tokens ?? null,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+
+    return NextResponse.json({
+      summary: res.choices[0]?.message?.content ?? "",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "AI summary failed";
+    recordAITelemetry({
+      feature: "ai_summarize_stats",
+      endpoint: "/api/ai/summarize-stats",
+      shop_id: null,
+      user_id: user.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      status: "error",
+      error_code: "ai_summary_error",
+      error_message: message,
+    });
+
+    if (policy.fallbackMode === "graceful_empty") {
+      return NextResponse.json({ summary: "" });
+    }
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/app/api/branding/generate/route.ts
+++ b/app/api/branding/generate/route.ts
@@ -3,6 +3,8 @@ import type { Database } from "@shared/types/types/supabase";
 import { requireBrandShopWriteAccess, safeFilePart } from "@/features/branding/server/brand";
 import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 import { buildLogoPrompt, getOpenAIClient } from "@/features/branding/server/logo-generation";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 
 type DB = Database;
 
@@ -20,6 +22,8 @@ function decodeBase64Image(b64: string): Buffer {
 }
 
 export async function POST(req: Request) {
+  const startedAt = Date.now();
+  const policy = getAIPolicy("branding_generate_logo");
   const body = (await req.json().catch(() => ({}))) as GenerateLogoBody;
 
   const auth = await requireBrandShopWriteAccess(body.shopId);
@@ -82,17 +86,23 @@ export async function POST(req: Request) {
 
   try {
     const openai = getOpenAIClient();
+    const model = "gpt-image-1.5";
 
-    const result = await openai.images.generate({
-      model: "gpt-image-1.5",
-      prompt: finalPrompt,
-      n: count,
-      size: "1024x1024",
-      quality: "medium",
-      output_format: "png",
-      background: transparentBackground ? "transparent" : "auto",
-      user: auth.userId,
-    });
+    const result = await Promise.race([
+      openai.images.generate({
+        model,
+        prompt: finalPrompt,
+        n: count,
+        size: "1024x1024",
+        quality: "medium",
+        output_format: "png",
+        background: transparentBackground ? "transparent" : "auto",
+        user: auth.userId,
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("AI request timed out")), policy.timeoutMs),
+      ),
+    ]);
 
     const images = result.data ?? [];
     if (!images.length) {
@@ -163,6 +173,21 @@ export async function POST(req: Request) {
       createdAssets.push(asset);
     }
 
+    recordAITelemetry({
+      feature: "branding_generate_logo",
+      endpoint: "/api/branding/generate",
+      shop_id: auth.shopId,
+      user_id: auth.userId,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: (result.usage as { input_tokens?: number } | undefined)?.input_tokens ?? null,
+      completion_tokens: (result.usage as { output_tokens?: number } | undefined)?.output_tokens ?? null,
+      total_tokens: (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+
     return NextResponse.json({
       ok: true,
       assets: createdAssets,
@@ -170,6 +195,20 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Logo generation failed";
+    recordAITelemetry({
+      feature: "branding_generate_logo",
+      endpoint: "/api/branding/generate",
+      shop_id: auth.shopId,
+      user_id: auth.userId,
+      model: "gpt-image-1.5",
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      status: "error",
+      error_code: "branding_generate_error",
+      error_message: message,
+    });
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/openai/realtime-token/route.ts
+++ b/app/api/openai/realtime-token/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { getOpenAIRealtimeTranscriptionModel } from "@/features/shared/lib/openai-realtime-models";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -73,6 +75,8 @@ function extractToken(
 /* ----------------------------- Route ----------------------------- */
 
 export async function GET() {
+  const startedAt = Date.now();
+  const policy = getAIPolicy("openai_realtime_token");
   const access = await requireShopScopedApiAccess();
   if (!access.ok) {
     return access.response;
@@ -117,17 +121,19 @@ export async function GET() {
       },
     };
 
-    const response = await fetch(
-      "https://api.openai.com/v1/realtime/client_secrets",
-      {
+    const response = await Promise.race([
+      fetch("https://api.openai.com/v1/realtime/client_secrets", {
         method: "POST",
         headers: {
           Authorization: `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(sessionConfig),
-      },
-    );
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("AI request timed out")), policy.timeoutMs),
+      ),
+    ]);
 
     const rawText = await response.text();
 
@@ -171,6 +177,21 @@ export async function GET() {
       );
     }
 
+    recordAITelemetry({
+      feature: "openai_realtime_token",
+      endpoint: "/api/openai/realtime-token",
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model: transcriptionModel,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+
     return NextResponse.json(
       {
         token: extracted.token,
@@ -179,6 +200,21 @@ export async function GET() {
       { status: 200 },
     );
   } catch (err) {
+    const message = err instanceof Error ? err.message : "Unhandled realtime token error";
+    recordAITelemetry({
+      feature: "openai_realtime_token",
+      endpoint: "/api/openai/realtime-token",
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model: getOpenAIRealtimeTranscriptionModel(),
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      status: "error",
+      error_code: "realtime_token_error",
+      error_message: message,
+    });
     console.error("[realtime-token] Unhandled error", err);
     return NextResponse.json(
       { error: "Unhandled realtime token error" },

--- a/app/api/work-orders/suggest-lines/route.ts
+++ b/app/api/work-orders/suggest-lines/route.ts
@@ -6,6 +6,8 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { openai } from "lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 
 export const runtime = "nodejs";
 
@@ -77,7 +79,12 @@ function coerceSuggestion(u: unknown): Suggestion | null {
 }
 
 export async function POST(req: Request) {
+  const startedAt = Date.now();
+  const policy = getAIPolicy("work_orders_suggest_lines");
+  const model = getOpenAIModelForPurpose(policy.modelPurpose);
   const supabase = createServerComponentClient<DB>({ cookies });
+  let userId: string | null = null;
+  let shopIdForContext: string | null = null;
 
   try {
     const body = (await req.json()) as ReqBody;
@@ -90,9 +97,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Not signed in" }, { status: 401 });
     }
 
-    // We’ll set shop context if we can determine a shop id from the WO (best effort).
-    // This reduces “RLS hidden” reads for work_order_lines in shops that rely on current_shop_id().
-    let shopIdForContext: string | null = null;
+    userId = user.id;
 
     // Gather context
     let complaint: string | null = null;
@@ -235,15 +240,20 @@ export async function POST(req: Request) {
       "Only output raw JSON (no markdown).",
     ].join(" ");
 
-    const completion = await openai.chat.completions.create({
-      model: getOpenAIModelForPurpose("fast"),
-      temperature: 0.4,
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: userContext },
-      ],
-      max_tokens: 500,
-    });
+    const completion = await Promise.race([
+      openai.chat.completions.create({
+        model,
+        temperature: 0.4,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: userContext },
+        ],
+        max_tokens: policy.maxTokens,
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("AI request timed out")), policy.timeoutMs),
+      ),
+    ]);
 
     const raw = completion.choices[0]?.message?.content ?? "[]";
 
@@ -261,8 +271,41 @@ export async function POST(req: Request) {
           .slice(0, 6)
       : [];
 
+    recordAITelemetry({
+      feature: "work_orders_suggest_lines",
+      endpoint: "/api/work-orders/suggest-lines",
+      shop_id: shopIdForContext,
+      user_id: userId,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: completion.usage?.prompt_tokens ?? null,
+      completion_tokens: completion.usage?.completion_tokens ?? null,
+      total_tokens: completion.usage?.total_tokens ?? null,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+
     return NextResponse.json({ suggestions });
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to generate suggestions";
+    recordAITelemetry({
+      feature: "work_orders_suggest_lines",
+      endpoint: "/api/work-orders/suggest-lines",
+      shop_id: shopIdForContext,
+      user_id: userId,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      status: "error",
+      error_code: "suggest_lines_error",
+      error_message: message,
+    });
+    if (policy.fallbackMode === "graceful_empty") {
+      return NextResponse.json({ suggestions: [] });
+    }
     return NextResponse.json(
       { error: "Failed to generate suggestions" },
       { status: 500 },

--- a/features/shared/lib/server/ai-policy.ts
+++ b/features/shared/lib/server/ai-policy.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+export type AIFallbackMode = "hard_fail" | "graceful_empty" | "cached_if_available";
+
+export type AIPolicy = {
+  feature: AIFeature;
+  modelPurpose: "fast" | "reasoning" | "extraction" | "vision" | "onboarding";
+  timeoutMs: number;
+  maxTokens: number;
+  fallbackMode: AIFallbackMode;
+};
+
+export type AIFeature =
+  | "work_orders_suggest_lines"
+  | "ai_summarize_stats"
+  | "openai_realtime_token"
+  | "branding_generate_logo";
+
+const AI_POLICIES: Record<AIFeature, AIPolicy> = {
+  work_orders_suggest_lines: {
+    feature: "work_orders_suggest_lines",
+    modelPurpose: "fast",
+    timeoutMs: 15000,
+    maxTokens: 500,
+    fallbackMode: "graceful_empty",
+  },
+  ai_summarize_stats: {
+    feature: "ai_summarize_stats",
+    modelPurpose: "fast",
+    timeoutMs: 12000,
+    maxTokens: 300,
+    fallbackMode: "graceful_empty",
+  },
+  openai_realtime_token: {
+    feature: "openai_realtime_token",
+    modelPurpose: "fast",
+    timeoutMs: 10000,
+    maxTokens: 0,
+    fallbackMode: "hard_fail",
+  },
+  branding_generate_logo: {
+    feature: "branding_generate_logo",
+    modelPurpose: "vision",
+    timeoutMs: 30000,
+    maxTokens: 0,
+    fallbackMode: "hard_fail",
+  },
+};
+
+export function getAIPolicy(feature: AIFeature): AIPolicy {
+  return AI_POLICIES[feature];
+}

--- a/features/shared/lib/server/ai-telemetry.ts
+++ b/features/shared/lib/server/ai-telemetry.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import type { AIFeature } from "@/features/shared/lib/server/ai-policy";
+
+export type AITelemetryEvent = {
+  feature: AIFeature;
+  endpoint: string;
+  shop_id: string | null;
+  user_id: string | null;
+  model: string | null;
+  latency_ms: number;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  total_tokens: number | null;
+  status: "success" | "error";
+  error_code: string | null;
+  error_message: string | null;
+};
+
+export function recordAITelemetry(event: AITelemetryEvent): void {
+  console.info(JSON.stringify({ type: "ai_telemetry", ...event }));
+}


### PR DESCRIPTION
### Motivation
- Centralize conservative AI runtime guardrails and telemetry for a small set of AI surfaces to improve observability and reliability without changing business logic or tenant security.
- Add standardized event shape and safe logging so AI successes/failures (including token usage and latency) are captured for future analysis while avoiding DB/RLS changes.
- Apply non-breaking timeouts and per-feature fallback modes so slow or failing downstream AI calls degrade gracefully when appropriate.

### Description
- Added a server-only AI policy module at `features/shared/lib/server/ai-policy.ts` that defines per-feature policies (model purpose, `timeoutMs`, `maxTokens`, `fallbackMode`) for the four targeted features.
- Added a server-only telemetry helper at `features/shared/lib/server/ai-telemetry.ts` that defines a typed `AITelemetryEvent` and `recordAITelemetry()` which emits structured JSON to the console (safe, non-persistent by design).
- Hardened the four endpoints to capture `startedAt`, resolve the feature policy, apply a bounded timeout via `Promise.race`, select the configured model, and call `recordAITelemetry()` on both success and error while preserving auth/tenant checks and existing response contracts for each endpoint: `app/api/work-orders/suggest-lines/route.ts`, `app/api/ai/summarize-stats/route.ts`, `app/api/openai/realtime-token/route.ts`, and `app/api/branding/generate/route.ts`.

### Testing
- Ran TypeScript compilation: `npx tsc --noEmit`, which completed successfully with no type errors.
- No additional automated tests or DB migrations were added in this incremental patch; telemetry currently logs to console (no persistence) and timeout handling uses `Promise.race` (intentional minimal approach).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051c45abac8328805cbe55c1baed78)