### PR TITLE
Phase 3.2: enforce AI budgets, rate limits, and anomaly alerts on core endpoints

### DIFF
--- a/app/api/ai/summarize-stats/route.ts
+++ b/app/api/ai/summarize-stats/route.ts
@@ -5,6 +5,11 @@ import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-mo
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
 import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import {
+  enforceAIOperationalPolicy,
+  estimateAICostUsd,
+  registerAIUsageEvent,
+} from "@/features/shared/lib/server/ai-ops-guard";
 
 const openai = isOpenAIConfigured() ? getOpenAIClient() : null;
 
@@ -15,6 +20,11 @@ export async function POST(req: Request) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  const enforcement = enforceAIOperationalPolicy({
+    feature: "ai_summarize_stats",
+    endpoint: "/api/ai/summarize-stats",
+    shopId: null,
+  });
 
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -25,6 +35,11 @@ export async function POST(req: Request) {
       { error: "OPENAI_API_KEY is not set" },
       { status: 500 }
     );
+  }
+  if (!enforcement.allowed) {
+    return NextResponse.json({
+      summary: "Summary is temporarily unavailable due to usage limits. Please retry shortly.",
+    });
   }
 
   const body = await req.json().catch(() => null);
@@ -65,9 +80,20 @@ ${JSON.stringify(body.stats, null, 2)}
       prompt_tokens: res.usage?.prompt_tokens ?? null,
       completion_tokens: res.usage?.completion_tokens ?? null,
       total_tokens: res.usage?.total_tokens ?? null,
+      estimated_cost_usd: estimateAICostUsd("ai_summarize_stats", res.usage?.total_tokens ?? null),
       status: "success",
       error_code: null,
       error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: "ai_summarize_stats",
+      endpoint: "/api/ai/summarize-stats",
+      shopId: null,
+      model,
+      totalTokens: res.usage?.total_tokens ?? null,
+      estimatedCostUsd: estimateAICostUsd("ai_summarize_stats", res.usage?.total_tokens ?? null),
+      status: "success",
+      errorCode: null,
     });
 
     return NextResponse.json({
@@ -85,9 +111,20 @@ ${JSON.stringify(body.stats, null, 2)}
       prompt_tokens: null,
       completion_tokens: null,
       total_tokens: null,
+      estimated_cost_usd: 0,
       status: "error",
       error_code: "ai_summary_error",
       error_message: message,
+    });
+    registerAIUsageEvent({
+      feature: "ai_summarize_stats",
+      endpoint: "/api/ai/summarize-stats",
+      shopId: null,
+      model,
+      totalTokens: null,
+      estimatedCostUsd: 0,
+      status: "error",
+      errorCode: "ai_summary_error",
     });
 
     if (policy.fallbackMode === "graceful_empty") {

--- a/app/api/branding/generate/route.ts
+++ b/app/api/branding/generate/route.ts
@@ -5,6 +5,11 @@ import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/l
 import { buildLogoPrompt, getOpenAIClient } from "@/features/branding/server/logo-generation";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
 import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import {
+  enforceAIOperationalPolicy,
+  estimateAICostUsd,
+  registerAIUsageEvent,
+} from "@/features/shared/lib/server/ai-ops-guard";
 
 type DB = Database;
 
@@ -85,6 +90,18 @@ export async function POST(req: Request) {
   });
 
   try {
+    const enforcement = enforceAIOperationalPolicy({
+      feature: "branding_generate_logo",
+      endpoint: "/api/branding/generate",
+      shopId: auth.shopId,
+    });
+    if (!enforcement.allowed) {
+      return NextResponse.json(
+        { error: "AI branding generation temporarily limited", code: enforcement.code },
+        { status: 429 },
+      );
+    }
+
     const openai = getOpenAIClient();
     const model = "gpt-image-1.5";
 
@@ -183,9 +200,26 @@ export async function POST(req: Request) {
       prompt_tokens: (result.usage as { input_tokens?: number } | undefined)?.input_tokens ?? null,
       completion_tokens: (result.usage as { output_tokens?: number } | undefined)?.output_tokens ?? null,
       total_tokens: (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      estimated_cost_usd: estimateAICostUsd(
+        "branding_generate_logo",
+        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      ),
       status: "success",
       error_code: null,
       error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: "branding_generate_logo",
+      endpoint: "/api/branding/generate",
+      shopId: auth.shopId,
+      model,
+      totalTokens: (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      estimatedCostUsd: estimateAICostUsd(
+        "branding_generate_logo",
+        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      ),
+      status: "success",
+      errorCode: null,
     });
 
     return NextResponse.json({
@@ -205,9 +239,20 @@ export async function POST(req: Request) {
       prompt_tokens: null,
       completion_tokens: null,
       total_tokens: null,
+      estimated_cost_usd: 0,
       status: "error",
       error_code: "branding_generate_error",
       error_message: message,
+    });
+    registerAIUsageEvent({
+      feature: "branding_generate_logo",
+      endpoint: "/api/branding/generate",
+      shopId: auth.shopId,
+      model: "gpt-image-1.5",
+      totalTokens: null,
+      estimatedCostUsd: 0,
+      status: "error",
+      errorCode: "branding_generate_error",
     });
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/app/api/openai/realtime-token/route.ts
+++ b/app/api/openai/realtime-token/route.ts
@@ -3,6 +3,11 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 import { getOpenAIRealtimeTranscriptionModel } from "@/features/shared/lib/openai-realtime-models";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
 import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import {
+  enforceAIOperationalPolicy,
+  estimateAICostUsd,
+  registerAIUsageEvent,
+} from "@/features/shared/lib/server/ai-ops-guard";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -80,6 +85,17 @@ export async function GET() {
   const access = await requireShopScopedApiAccess();
   if (!access.ok) {
     return access.response;
+  }
+  const enforcement = enforceAIOperationalPolicy({
+    feature: "openai_realtime_token",
+    endpoint: "/api/openai/realtime-token",
+    shopId: access.profile.shop_id,
+  });
+  if (!enforcement.allowed) {
+    return NextResponse.json(
+      { error: "AI token issuance temporarily limited", code: enforcement.code },
+      { status: 429 },
+    );
   }
 
   try {
@@ -187,9 +203,20 @@ export async function GET() {
       prompt_tokens: null,
       completion_tokens: null,
       total_tokens: null,
+      estimated_cost_usd: estimateAICostUsd("openai_realtime_token", 1),
       status: "success",
       error_code: null,
       error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: "openai_realtime_token",
+      endpoint: "/api/openai/realtime-token",
+      shopId: access.profile.shop_id,
+      model: transcriptionModel,
+      totalTokens: 1,
+      estimatedCostUsd: estimateAICostUsd("openai_realtime_token", 1),
+      status: "success",
+      errorCode: null,
     });
 
     return NextResponse.json(
@@ -211,9 +238,20 @@ export async function GET() {
       prompt_tokens: null,
       completion_tokens: null,
       total_tokens: null,
+      estimated_cost_usd: 0,
       status: "error",
       error_code: "realtime_token_error",
       error_message: message,
+    });
+    registerAIUsageEvent({
+      feature: "openai_realtime_token",
+      endpoint: "/api/openai/realtime-token",
+      shopId: access.profile.shop_id,
+      model: getOpenAIRealtimeTranscriptionModel(),
+      totalTokens: null,
+      estimatedCostUsd: 0,
+      status: "error",
+      errorCode: "realtime_token_error",
     });
     console.error("[realtime-token] Unhandled error", err);
     return NextResponse.json(

--- a/app/api/work-orders/suggest-lines/route.ts
+++ b/app/api/work-orders/suggest-lines/route.ts
@@ -8,6 +8,11 @@ import { openai } from "lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
 import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import {
+  enforceAIOperationalPolicy,
+  estimateAICostUsd,
+  registerAIUsageEvent,
+} from "@/features/shared/lib/server/ai-ops-guard";
 
 export const runtime = "nodejs";
 
@@ -240,6 +245,18 @@ export async function POST(req: Request) {
       "Only output raw JSON (no markdown).",
     ].join(" ");
 
+    const enforcement = enforceAIOperationalPolicy({
+      feature: "work_orders_suggest_lines",
+      endpoint: "/api/work-orders/suggest-lines",
+      shopId: shopIdForContext,
+    });
+    if (!enforcement.allowed) {
+      return NextResponse.json({
+        suggestions: [],
+        message: "AI suggestions are temporarily limited for this shop. Please retry shortly.",
+      });
+    }
+
     const completion = await Promise.race([
       openai.chat.completions.create({
         model,
@@ -281,9 +298,20 @@ export async function POST(req: Request) {
       prompt_tokens: completion.usage?.prompt_tokens ?? null,
       completion_tokens: completion.usage?.completion_tokens ?? null,
       total_tokens: completion.usage?.total_tokens ?? null,
+      estimated_cost_usd: estimateAICostUsd("work_orders_suggest_lines", completion.usage?.total_tokens ?? null),
       status: "success",
       error_code: null,
       error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: "work_orders_suggest_lines",
+      endpoint: "/api/work-orders/suggest-lines",
+      shopId: shopIdForContext,
+      model,
+      totalTokens: completion.usage?.total_tokens ?? null,
+      estimatedCostUsd: estimateAICostUsd("work_orders_suggest_lines", completion.usage?.total_tokens ?? null),
+      status: "success",
+      errorCode: null,
     });
 
     return NextResponse.json({ suggestions });
@@ -299,9 +327,20 @@ export async function POST(req: Request) {
       prompt_tokens: null,
       completion_tokens: null,
       total_tokens: null,
+      estimated_cost_usd: 0,
       status: "error",
       error_code: "suggest_lines_error",
       error_message: message,
+    });
+    registerAIUsageEvent({
+      feature: "work_orders_suggest_lines",
+      endpoint: "/api/work-orders/suggest-lines",
+      shopId: shopIdForContext,
+      model,
+      totalTokens: null,
+      estimatedCostUsd: 0,
+      status: "error",
+      errorCode: "suggest_lines_error",
     });
     if (policy.fallbackMode === "graceful_empty") {
       return NextResponse.json({ suggestions: [] });

--- a/features/shared/lib/server/ai-ops-guard.ts
+++ b/features/shared/lib/server/ai-ops-guard.ts
@@ -1,0 +1,191 @@
+import "server-only";
+
+import type { AIFeature } from "@/features/shared/lib/server/ai-policy";
+
+type AIOpsPolicy = {
+  budgetSoftUsd: number;
+  budgetHardUsd: number;
+  rateLimitMax: number;
+  rateLimitWindowMs: number;
+  anomalySpikeThreshold: number;
+  anomalyFailureThreshold: number;
+  anomalyHighCostUsd: number;
+  anomalyHardDenialThreshold: number;
+};
+
+type EnforceInput = {
+  feature: AIFeature;
+  endpoint: string;
+  shopId: string | null;
+};
+
+type UsageEventInput = {
+  feature: AIFeature;
+  endpoint: string;
+  shopId: string | null;
+  model: string | null;
+  totalTokens: number | null;
+  estimatedCostUsd: number;
+  status: "success" | "error";
+  errorCode: string | null;
+};
+
+const monthUsage = new Map<string, number>();
+const rateBuckets = new Map<string, number[]>();
+const failureBuckets = new Map<string, number[]>();
+const hardDenialBuckets = new Map<string, number[]>();
+
+function envNum(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function startOfMonthEpoch(now: Date): number {
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0);
+}
+
+function usageKey(shopId: string | null, feature: AIFeature, now: Date): string {
+  const shopScope = shopId ?? "unknown_shop";
+  return `${shopScope}:${feature}:${startOfMonthEpoch(now)}`;
+}
+
+function scopedKey(shopId: string | null, endpoint: string): string {
+  return `${shopId ?? "unknown_shop"}:${endpoint}`;
+}
+
+const FEATURE_POLICY: Record<AIFeature, AIOpsPolicy> = {
+  work_orders_suggest_lines: {
+    budgetSoftUsd: envNum("AI_BUDGET_SOFT_USD_SUGGEST_LINES", 40),
+    budgetHardUsd: envNum("AI_BUDGET_HARD_USD_SUGGEST_LINES", 60),
+    rateLimitMax: envNum("AI_RATE_LIMIT_SUGGEST_LINES_MAX", 30),
+    rateLimitWindowMs: envNum("AI_RATE_LIMIT_SUGGEST_LINES_WINDOW_MS", 5 * 60 * 1000),
+    anomalySpikeThreshold: envNum("AI_ANOMALY_SPIKE_SUGGEST_LINES", 20),
+    anomalyFailureThreshold: envNum("AI_ANOMALY_FAIL_SUGGEST_LINES", 6),
+    anomalyHighCostUsd: envNum("AI_ANOMALY_COST_SUGGEST_LINES", 0.2),
+    anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_SUGGEST_LINES", 4),
+  },
+  ai_summarize_stats: {
+    budgetSoftUsd: envNum("AI_BUDGET_SOFT_USD_SUMMARIZE_STATS", 30),
+    budgetHardUsd: envNum("AI_BUDGET_HARD_USD_SUMMARIZE_STATS", 50),
+    rateLimitMax: envNum("AI_RATE_LIMIT_SUMMARIZE_STATS_MAX", 20),
+    rateLimitWindowMs: envNum("AI_RATE_LIMIT_SUMMARIZE_STATS_WINDOW_MS", 5 * 60 * 1000),
+    anomalySpikeThreshold: envNum("AI_ANOMALY_SPIKE_SUMMARIZE_STATS", 15),
+    anomalyFailureThreshold: envNum("AI_ANOMALY_FAIL_SUMMARIZE_STATS", 6),
+    anomalyHighCostUsd: envNum("AI_ANOMALY_COST_SUMMARIZE_STATS", 0.15),
+    anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_SUMMARIZE_STATS", 4),
+  },
+  openai_realtime_token: {
+    budgetSoftUsd: envNum("AI_BUDGET_SOFT_USD_REALTIME_TOKEN", 15),
+    budgetHardUsd: envNum("AI_BUDGET_HARD_USD_REALTIME_TOKEN", 30),
+    rateLimitMax: envNum("AI_RATE_LIMIT_REALTIME_TOKEN_MAX", 60),
+    rateLimitWindowMs: envNum("AI_RATE_LIMIT_REALTIME_TOKEN_WINDOW_MS", 5 * 60 * 1000),
+    anomalySpikeThreshold: envNum("AI_ANOMALY_SPIKE_REALTIME_TOKEN", 30),
+    anomalyFailureThreshold: envNum("AI_ANOMALY_FAIL_REALTIME_TOKEN", 8),
+    anomalyHighCostUsd: envNum("AI_ANOMALY_COST_REALTIME_TOKEN", 0.05),
+    anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_REALTIME_TOKEN", 8),
+  },
+  branding_generate_logo: {
+    budgetSoftUsd: envNum("AI_BUDGET_SOFT_USD_BRANDING", 80),
+    budgetHardUsd: envNum("AI_BUDGET_HARD_USD_BRANDING", 120),
+    rateLimitMax: envNum("AI_RATE_LIMIT_BRANDING_MAX", 10),
+    rateLimitWindowMs: envNum("AI_RATE_LIMIT_BRANDING_WINDOW_MS", 10 * 60 * 1000),
+    anomalySpikeThreshold: envNum("AI_ANOMALY_SPIKE_BRANDING", 7),
+    anomalyFailureThreshold: envNum("AI_ANOMALY_FAIL_BRANDING", 4),
+    anomalyHighCostUsd: envNum("AI_ANOMALY_COST_BRANDING", 1.5),
+    anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_BRANDING", 3),
+  },
+};
+
+export function estimateAICostUsd(feature: AIFeature, totalTokens: number | null): number {
+  const tokens = Math.max(totalTokens ?? 0, 0);
+  const perThousand =
+    feature === "branding_generate_logo"
+      ? envNum("AI_COST_PER_1K_TOKENS_BRANDING", 0.04)
+      : envNum("AI_COST_PER_1K_TOKENS_DEFAULT", 0.006);
+  const minimumFlat = feature === "openai_realtime_token" ? 0.001 : 0;
+  return Number(((tokens / 1000) * perThousand + minimumFlat).toFixed(6));
+}
+
+export function enforceAIOperationalPolicy(input: EnforceInput):
+  | { allowed: true; softBudgetWarning: boolean }
+  | { allowed: false; reason: "rate_limited" | "hard_budget_exceeded"; code: string } {
+  const now = Date.now();
+  const nowDate = new Date(now);
+  const policy = FEATURE_POLICY[input.feature];
+  const key = scopedKey(input.shopId, input.endpoint);
+
+  const bucket = rateBuckets.get(key) ?? [];
+  const filtered = bucket.filter((ts) => now - ts <= policy.rateLimitWindowMs);
+  if (filtered.length >= policy.rateLimitMax) {
+    hardDenialBuckets.set(key, [...(hardDenialBuckets.get(key) ?? []), now]);
+    emitAlert("rate_limit_exceeded", input, { windowMs: policy.rateLimitWindowMs, max: policy.rateLimitMax });
+    return { allowed: false, reason: "rate_limited", code: "ai_rate_limit_exceeded" };
+  }
+  filtered.push(now);
+  rateBuckets.set(key, filtered);
+
+  const mKey = usageKey(input.shopId, input.feature, nowDate);
+  const currentBudget = monthUsage.get(mKey) ?? 0;
+
+  if (currentBudget >= policy.budgetHardUsd) {
+    hardDenialBuckets.set(key, [...(hardDenialBuckets.get(key) ?? []), now]);
+    emitAlert("hard_budget_denial", input, { currentBudget, hardLimit: policy.budgetHardUsd });
+    return { allowed: false, reason: "hard_budget_exceeded", code: "ai_budget_hard_limit_exceeded" };
+  }
+
+  return { allowed: true, softBudgetWarning: currentBudget >= policy.budgetSoftUsd };
+}
+
+export function registerAIUsageEvent(event: UsageEventInput): void {
+  const now = Date.now();
+  const nowDate = new Date(now);
+  const policy = FEATURE_POLICY[event.feature];
+  const mKey = usageKey(event.shopId, event.feature, nowDate);
+  monthUsage.set(mKey, (monthUsage.get(mKey) ?? 0) + Math.max(event.estimatedCostUsd, 0));
+
+  const key = scopedKey(event.shopId, event.endpoint);
+
+  if (event.status === "error") {
+    const failures = [...(failureBuckets.get(key) ?? []), now].filter(
+      (ts) => now - ts <= policy.rateLimitWindowMs,
+    );
+    failureBuckets.set(key, failures);
+    if (failures.length >= policy.anomalyFailureThreshold) {
+      emitAlert("failure_spike", { feature: event.feature, endpoint: event.endpoint, shopId: event.shopId }, { count: failures.length });
+    }
+  }
+
+  const requestsInWindow = (rateBuckets.get(key) ?? []).filter(
+    (ts) => now - ts <= policy.rateLimitWindowMs,
+  ).length;
+  if (requestsInWindow >= policy.anomalySpikeThreshold) {
+    emitAlert("request_spike", { feature: event.feature, endpoint: event.endpoint, shopId: event.shopId }, { count: requestsInWindow });
+  }
+
+  if (event.estimatedCostUsd >= policy.anomalyHighCostUsd) {
+    emitAlert("high_request_cost", { feature: event.feature, endpoint: event.endpoint, shopId: event.shopId }, { estimatedCostUsd: event.estimatedCostUsd, model: event.model });
+  }
+
+  const denialCount = (hardDenialBuckets.get(key) ?? []).filter(
+    (ts) => now - ts <= policy.rateLimitWindowMs,
+  ).length;
+  if (denialCount >= policy.anomalyHardDenialThreshold) {
+    emitAlert("repeated_denials", { feature: event.feature, endpoint: event.endpoint, shopId: event.shopId }, { denialCount });
+  }
+}
+
+function emitAlert(type: string, input: EnforceInput, details: Record<string, unknown>): void {
+  console.warn(
+    JSON.stringify({
+      type: "ai_anomaly_alert",
+      alert_type: type,
+      feature: input.feature,
+      endpoint: input.endpoint,
+      shop_id: input.shopId,
+      emitted_at: new Date().toISOString(),
+      details,
+    }),
+  );
+}

--- a/features/shared/lib/server/ai-telemetry.ts
+++ b/features/shared/lib/server/ai-telemetry.ts
@@ -12,6 +12,7 @@ export type AITelemetryEvent = {
   prompt_tokens: number | null;
   completion_tokens: number | null;
   total_tokens: number | null;
+  estimated_cost_usd?: number | null;
   status: "success" | "error";
   error_code: string | null;
   error_message: string | null;


### PR DESCRIPTION
### Motivation
- Introduce per-shop operational controls (monthly budget soft/hard limits, per-endpoint rate limits) and basic anomaly detection for high-volume AI endpoints while avoiding breaking changes.
- Ensure endpoints have non-breaking fallbacks when limits are hit and emit structured alerts/telemetry to observe and tune policies.

### Description
- Added a new shared guard module `features/shared/lib/server/ai-ops-guard.ts` that implements per-feature configurable policies, an in-memory monthly budget counter, fixed-window rate buckets, cost estimation helper `estimateAICostUsd`, enforcement API `enforceAIOperationalPolicy`, usage registration `registerAIUsageEvent`, and anomaly alert emission via structured `console.warn` JSON.
- Extended telemetry event shape in `features/shared/lib/server/ai-telemetry.ts` to include optional `estimated_cost_usd` so cost signals are carried without breaking existing consumers.
- Wired enforcement, cost estimation, and usage registration into the four scoped endpoints so enforcement happens before upstream AI calls and usage is recorded after calls: `app/api/work-orders/suggest-lines/route.ts`, `app/api/ai/summarize-stats/route.ts`, `app/api/openai/realtime-token/route.ts`, and `app/api/branding/generate/route.ts`.
- Implemented endpoint-specific non-breaking fallbacks on enforcement denies: `suggest-lines` returns empty `suggestions` with a message, `summarize-stats` returns a deterministic unavailable summary message, `realtime-token` and `branding/generate` return `429` JSON with machine-readable `code`, and ensured `branding/generate` checks limits before any storage/writes.
- Kept changes additive and tenant-scoped where shop context exists, and deliberately used an in-memory guard for low-risk incremental rollout (recommend DB-backed counters in follow-up for global enforcement).

### Testing
- Ran TypeScript compile: `npx tsc --noEmit` (passed).
- Ran ESLint on the touched files: `npx eslint` for the modified endpoints and new guard file (passed).
- No database migrations were added for this phase (in-memory tracking used); manual/operational follow-up recommended to migrate to DB-backed counters for cross-instance consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051d8dc6e08328bed076211e661c41)