### PR TITLE
Add branch-aware operations foundation and wire FleetShell to fleet config

### DIFF
--- a/app/portal/fleet/FleetShell.tsx
+++ b/app/portal/fleet/FleetShell.tsx
@@ -8,6 +8,10 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 
 import ForcePasswordChangeModal from "@/features/auth/components/ForcePasswordChangeModal";
+import {
+  fleetOperationsRoutes,
+  fleetOperationsTerminology,
+} from "@/features/operations";
 
 type DB = Database;
 
@@ -17,9 +21,15 @@ type NavItem = {
 };
 
 const NAV: NavItem[] = [
-  { href: "/portal/fleet", label: "Dashboard" },
-  { href: "/portal/fleet/service-requests", label: "Service Requests" },
-  { href: "/portal/fleet/pretrip-history", label: "Pre-trip History" },
+  { href: fleetOperationsRoutes.portalHome, label: "Dashboard" },
+  {
+    href: fleetOperationsRoutes.portalRequests,
+    label: fleetOperationsTerminology.requestPluralLabel,
+  },
+  {
+    href: fleetOperationsRoutes.portalInspections,
+    label: fleetOperationsTerminology.inspectionPluralLabel,
+  },
 ];
 
 function cx(...parts: Array<string | false | null | undefined>) {
@@ -75,8 +85,8 @@ function NavPill({
 }
 
 export default function FleetShell({
-  title = "Fleet Portal",
-  subtitle = "Dispatch view for pre-trips, service requests, and fleet history",
+  title = fleetOperationsTerminology.portalLabel,
+  subtitle = `Dispatch view for pre-trips, ${fleetOperationsTerminology.requestPluralLabel.toLowerCase()}, and fleet history`,
   children,
 }: {
   title?: string;
@@ -99,9 +109,9 @@ export default function FleetShell({
     if (exact) return exact.href;
 
     const starts = NAV.find(
-      (x) => x.href !== "/portal/fleet" && pathname.startsWith(x.href),
+      (x) => x.href !== fleetOperationsRoutes.portalHome && pathname.startsWith(x.href),
     );
-    return starts?.href ?? "/portal/fleet";
+    return starts?.href ?? fleetOperationsRoutes.portalHome;
   }, [pathname]);
 
   // Load session + must_change_password (fleet portal)
@@ -214,7 +224,7 @@ export default function FleetShell({
 
         <div className="flex items-center gap-2">
           <Link
-            href="/portal/fleet"
+            href={fleetOperationsRoutes.portalHome}
             className="inline-flex items-center rounded-full border border-white/18 bg-black/40 px-3 py-1 text-[0.7rem] font-semibold text-neutral-100 transition hover:bg-black/70 active:scale-95"
           >
             <span style={{ color: FLEET_ACCENT }}>Dashboard</span>

--- a/docs/plans/property-operations-schema-plan.md
+++ b/docs/plans/property-operations-schema-plan.md
@@ -1,0 +1,26 @@
+# Property Operations Schema Plan (Future)
+
+This note is a planning artifact only. No migrations are executed by this change.
+
+## Goals
+
+Support a future property vertical while preserving existing shop/fleet behavior and tenant isolation.
+
+## Likely Future Additions
+
+- `operations_vertical` or `source_vertical` on `work_orders`
+- `source_request_type` / `source_request_id` on `work_orders`
+- `property_profiles` or `property_portfolios`
+- `property_units`
+- `property_assets`
+- `property_members`
+- `property_maintenance_requests`
+- `property_inspections`
+- vendor assignment relationships
+- approval thresholds/rules for property organizations
+
+## Notes
+
+- Keep additions additive and backfill-safe.
+- Preserve `shop_id`/tenant boundary semantics as the schema evolves.
+- Apply all SQL manually in Supabase SQL Editor during future implementation phases.

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -1,0 +1,31 @@
+# Operations Foundation (Step 1)
+
+This folder introduces a shared, branch-aware maintenance operations foundation for ProFixIQ.
+
+## Purpose
+
+- Establish reusable vertical-level terminology and route configuration.
+- Keep fleet as the first live vertical with no behavioral changes.
+- Define property terminology/routes for future use only.
+
+## Current State
+
+- **Fleet** is the only actively integrated vertical in this step.
+- **Property** is represented in config only (no live routes/pages wired).
+- Existing fleet screens, APIs, auth behavior, and Supabase query behavior are unchanged.
+
+## Planned Extraction Path
+
+Future iterations can incrementally extract shared modules for:
+
+1. Shell/navigation containers
+2. Control tower/dashboard widgets
+3. Request list/detail surfaces
+4. Asset list/detail surfaces
+5. Vertical-aware permissions/roles
+6. Request-to-work-order conversion adapters
+
+## Database
+
+No database migrations are applied as part of this step.
+Any future schema expansion should be documented and applied manually.

--- a/features/operations/index.ts
+++ b/features/operations/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./terminology";
+export * from "./routes";
+export * from "./verticals";

--- a/features/operations/routes.ts
+++ b/features/operations/routes.ts
@@ -1,0 +1,17 @@
+import type { OperationsRoutes } from "./types";
+
+export const fleetOperationsRoutes = {
+  portalHome: "/portal/fleet",
+  portalRequests: "/portal/fleet/service-requests",
+  portalInspections: "/portal/fleet/pretrip-history",
+  assetDetailBase: "/portal/fleet/units",
+  workOrders: "/work-orders",
+} satisfies OperationsRoutes;
+
+export const propertyOperationsRoutes = {
+  portalHome: "/portal/property",
+  portalRequests: "/portal/property/requests",
+  portalInspections: "/portal/property/inspections",
+  assetDetailBase: "/portal/property/assets",
+  workOrders: "/work-orders",
+} satisfies OperationsRoutes;

--- a/features/operations/terminology.ts
+++ b/features/operations/terminology.ts
@@ -1,0 +1,33 @@
+import type { OperationsTerminology } from "./types";
+
+export const fleetOperationsTerminology = {
+  vertical: "fleet",
+  productLabel: "Fleet Operations",
+  portalLabel: "Fleet Portal",
+  assetLabel: "Unit",
+  assetPluralLabel: "Units",
+  requestLabel: "Service Request",
+  requestPluralLabel: "Service Requests",
+  requesterLabel: "Driver",
+  inspectionLabel: "Pre-trip",
+  inspectionPluralLabel: "Pre-trip History",
+  approvalLabel: "Fleet Approval",
+  vendorLabel: "Shop",
+  workOrderLabel: "Work Order",
+} satisfies OperationsTerminology;
+
+export const propertyOperationsTerminology = {
+  vertical: "property",
+  productLabel: "Property Maintenance",
+  portalLabel: "Property Portal",
+  assetLabel: "Property / Unit",
+  assetPluralLabel: "Properties / Units",
+  requestLabel: "Maintenance Request",
+  requestPluralLabel: "Maintenance Requests",
+  requesterLabel: "Tenant",
+  inspectionLabel: "Inspection",
+  inspectionPluralLabel: "Inspection History",
+  approvalLabel: "Owner Approval",
+  vendorLabel: "Vendor",
+  workOrderLabel: "Work Order",
+} satisfies OperationsTerminology;

--- a/features/operations/types.ts
+++ b/features/operations/types.ts
@@ -1,0 +1,36 @@
+export type OperationsVertical =
+  | "shop"
+  | "fleet"
+  | "property"
+  | "equipment"
+  | "facilities";
+
+export type OperationsTerminology = {
+  vertical: OperationsVertical;
+  productLabel: string;
+  portalLabel: string;
+  assetLabel: string;
+  assetPluralLabel: string;
+  requestLabel: string;
+  requestPluralLabel: string;
+  requesterLabel: string;
+  inspectionLabel: string;
+  inspectionPluralLabel: string;
+  approvalLabel: string;
+  vendorLabel: string;
+  workOrderLabel: string;
+};
+
+export type OperationsRoutes = {
+  portalHome: string;
+  portalRequests: string;
+  portalInspections: string;
+  assetDetailBase?: string;
+  workOrders?: string;
+};
+
+export type OperationsVerticalConfig = {
+  vertical: OperationsVertical;
+  terminology: OperationsTerminology;
+  routes: OperationsRoutes;
+};

--- a/features/operations/verticals.ts
+++ b/features/operations/verticals.ts
@@ -1,0 +1,27 @@
+import {
+  fleetOperationsTerminology,
+  propertyOperationsTerminology,
+} from "./terminology";
+import { fleetOperationsRoutes, propertyOperationsRoutes } from "./routes";
+import type { OperationsVertical, OperationsVerticalConfig } from "./types";
+
+export const operationsVerticalConfigs: Partial<
+  Record<OperationsVertical, OperationsVerticalConfig>
+> = {
+  fleet: {
+    vertical: "fleet",
+    terminology: fleetOperationsTerminology,
+    routes: fleetOperationsRoutes,
+  },
+  property: {
+    vertical: "property",
+    terminology: propertyOperationsTerminology,
+    routes: propertyOperationsRoutes,
+  },
+};
+
+export function getOperationsVerticalConfig(
+  vertical: OperationsVertical,
+): OperationsVerticalConfig | null {
+  return operationsVerticalConfigs[vertical] ?? null;
+}


### PR DESCRIPTION
### Motivation

- Establish a small, safe, reusable foundation for a branch-aware maintenance operations engine to support multiple verticals (fleet first, property later).
- Ensure existing fleet behavior and routes remain unchanged while enabling labels and route lookups to be read from a shared config.
- Provide a documented extraction path and a minimal planning note for future property/schema work without applying any migrations.

### Description

- Add a new `features/operations` foundation with typed exports in `types.ts`, `terminology.ts`, `routes.ts`, `verticals.ts`, `index.ts`, and a `README.md` describing the planned extraction path. 
- Introduce fleet and property terminology and route configs (`fleetOperationsTerminology`, `propertyOperationsTerminology`, `fleetOperationsRoutes`, `propertyOperationsRoutes`) and a vertical config map with `getOperationsVerticalConfig` for lookup. 
- Perform a minimal, backwards-compatible integration in `app/portal/fleet/FleetShell.tsx` so nav labels, the default portal title, subtitle, and route references consume `fleetOperationsTerminology` and `fleetOperationsRoutes` rather than hardcoded strings. 
- Add a planning note `docs/plans/property-operations-schema-plan.md` outlining likely future schema additions; no SQL/migrations are executed or applied in this change.

### Testing

- Ran `npm run typecheck`, which passed after addressing a TypeScript index typing issue in `features/operations/verticals.ts` by giving the config an explicit `Partial<Record<OperationsVertical, OperationsVerticalConfig>>` type. ✅
- Ran `npm run lint`, which failed due to pre-existing, repo-wide lint/errors outside the scope of this change (multiple errors/warnings unrelated to the new files). ❌
- Attempted `npm run build` (Next.js), which failed in this environment due to network/font fetch issues with `next/font` (failed to fetch Google Fonts `Inter` and `Black Ops One`), and is not caused by this change. ⚠️
- No database migrations were created or run as part of this PR. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8e68e1d08328b81879e3ba1c6227)