### PR TITLE
Step 3: extract FleetControlTower onto MaintenanceControlTower foundation

### DIFF
--- a/features/fleet/components/FleetControlTower.tsx
+++ b/features/fleet/components/FleetControlTower.tsx
@@ -7,6 +7,15 @@ import FleetAISummary from "./FleetAISummary";
 import WorkOrderBoardWidget from "@shared/components/workboard/WorkOrderBoardWidget";
 import Link from "next/link";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import {
+  MaintenanceControlTower,
+  getOperationsVerticalConfig,
+} from "@/features/operations";
+import {
+  mapDispatchAssignmentToOperationsAssignment,
+  mapFleetIssueToOperationsIssue,
+  mapFleetUnitToOperationsAsset,
+} from "@/features/fleet/lib/fleetOperationsAdapters";
 
 export type FleetUnitStatus = "in_service" | "limited" | "oos";
 
@@ -59,20 +68,11 @@ type FocusFilter = "all" | "inspection_due_30";
 
 function isDueInNextDays(nextInspectionDate?: string | null, days = 30) {
   if (!nextInspectionDate) return false;
-
   const today = new Date();
-  const startOfToday = new Date(
-    today.getFullYear(),
-    today.getMonth(),
-    today.getDate(),
-  );
-
+  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
   const next = new Date(nextInspectionDate);
   const msPerDay = 1000 * 60 * 60 * 24;
-  const diffDays = Math.floor(
-    (next.getTime() - startOfToday.getTime()) / msPerDay,
-  );
-
+  const diffDays = Math.floor((next.getTime() - startOfToday.getTime()) / msPerDay);
   return diffDays >= 0 && diffDays <= days;
 }
 
@@ -85,48 +85,34 @@ export default function FleetControlTower({
   const [data, setData] = useState<TowerPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
   const [regionFilter, setRegionFilter] = useState<string | "all">("all");
   const [focusFilter, setFocusFilter] = useState<FocusFilter>("all");
 
   useEffect(() => {
     let cancelled = false;
-
     (async () => {
       try {
         setLoading(true);
         setError(null);
-
         const res = await fetch("/api/fleet/tower", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ shopId: shopId ?? null }),
         });
-
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
-          if (!cancelled) {
-            setError(
-              (body && body.error) || "Failed to load fleet data for this shop.",
-            );
-          }
+          if (!cancelled) setError((body && body.error) || "Failed to load fleet data for this shop.");
           return;
         }
-
         const body = (await res.json()) as TowerPayload;
-        if (!cancelled) {
-          setData(body);
-        }
+        if (!cancelled) setData(body);
       } catch (err) {
         console.error("[FleetControlTower] fetch error:", err);
-        if (!cancelled) {
-          setError("Failed to load fleet data.");
-        }
+        if (!cancelled) setError("Failed to load fleet data.");
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
-
     return () => {
       cancelled = true;
     };
@@ -139,155 +125,93 @@ export default function FleetControlTower({
 
   const regions = useMemo(() => {
     const set = new Set<string>();
-    for (const u of units) {
-      if (u.location && u.location.trim().length > 0) {
-        set.add(u.location.trim());
-      }
-    }
+    for (const u of units) if (u.location?.trim()) set.add(u.location.trim());
     return Array.from(set).sort((a, b) => a.localeCompare(b));
   }, [units]);
 
   const filteredUnits = useMemo(() => {
     let list = units;
-
-    if (regionFilter !== "all") {
-      list = list.filter((u) => (u.location ?? "") === regionFilter);
-    }
-
-    if (focusFilter === "inspection_due_30") {
-      list = list.filter((u) => isDueInNextDays(u.nextInspectionDate, 30));
-    }
-
+    if (regionFilter !== "all") list = list.filter((u) => (u.location ?? "") === regionFilter);
+    if (focusFilter === "inspection_due_30") list = list.filter((u) => isDueInNextDays(u.nextInspectionDate, 30));
     return list;
   }, [units, regionFilter, focusFilter]);
 
-  const handleInspectionWindowClick = () => {
-    setFocusFilter((prev) =>
-      prev === "inspection_due_30" ? "all" : "inspection_due_30",
-    );
-  };
+  const handleInspectionWindowClick = () => setFocusFilter((prev) => (prev === "inspection_due_30" ? "all" : "inspection_due_30"));
+
+  useMemo(() => ({
+    assets: filteredUnits.map(mapFleetUnitToOperationsAsset),
+    issues: issues.map(mapFleetIssueToOperationsIssue),
+    assignments: assignments.map(mapDispatchAssignmentToOperationsAssignment),
+  }), [filteredUnits, issues, assignments]);
+  const terminology = getOperationsVerticalConfig("fleet")?.terminology;
 
   return (
-    <section className="space-y-6">
-      <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-            Fleet Control
-          </p>
-          <h1
-            className="mt-1 text-3xl text-neutral-100 md:text-4xl"
-            style={{ fontFamily: "var(--font-blackops)" }}
-          >
-            {shopName} – Fleet Tower
-          </h1>
-          <p className="mt-2 max-w-xl text-sm text-neutral-400">
-            {isExternal
-              ? "Track unit readiness, open requests, and pre-trip outcomes for your fleet scope."
-              : "See out-of-service units, upcoming inspections, pre-trips, and open service requests across the fleet."}{" "}
-            Dispatch, portal, and drivers stay in sync from one screen.
-          </p>
-          <p className="mt-1 text-[11px] text-neutral-500">
-            Actor surface: {uiContext.actorLabel}
-          </p>
-
-          {focusFilter === "inspection_due_30" && (
-            <p className="mt-2 text-[11px] text-neutral-400">
-              Filter:{" "}
-              <span className="text-neutral-200">
-                Inspections due in next 30 days
-              </span>{" "}
-              <button
-                type="button"
-                onClick={() => setFocusFilter("all")}
-                className="ml-2 underline decoration-neutral-600 underline-offset-2 hover:text-neutral-200"
-              >
-                Clear
-              </button>
-            </p>
-          )}
-        </div>
-
-        <div className="flex flex-wrap items-center gap-3">
-          <select
-            value={regionFilter}
-            onChange={(e) =>
-              setRegionFilter(e.target.value as typeof regionFilter)
-            }
-            className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/60 px-3 py-2 text-xs text-neutral-200 shadow-[0_12px_35px_rgba(0,0,0,0.85)]"
-          >
-            <option value="all">All locations</option>
-            {regions.map((r) => (
-              <option key={r} value={r}>
-                {r}
-              </option>
-            ))}
-          </select>
-
-          <span className="accent-chip px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]">
-            HD / Fleet Mode
-          </span>
-        </div>
-      </header>
-
-        {uiContext.capabilities.canViewDispatch && (
+    <MaintenanceControlTower
+      headerLabel="Fleet Control"
+      modeLabel="HD / Fleet Mode"
+      title={`${shopName} – Fleet Tower`}
+      subtitle={
+        isExternal
+          ? "Track unit readiness, open requests, and pre-trip outcomes for your fleet scope. Dispatch, portal, and drivers stay in sync from one screen."
+          : "See out-of-service units, upcoming inspections, pre-trips, and open service requests across the fleet. Dispatch, portal, and drivers stay in sync from one screen."
+      }
+      actorSurfaceLabel={uiContext.actorLabel}
+      locationFilter={{
+        value: regionFilter,
+        options: regions,
+        onChange: (value) => setRegionFilter(value as typeof regionFilter),
+      }}
+      focusFilter={{
+        active: focusFilter === "inspection_due_30",
+        label: `${terminology?.inspectionPluralLabel ?? "Inspections"} due in next 30 days`,
+        onClear: () => setFocusFilter("all"),
+      }}
+      workOrderBoard={
+        uiContext.capabilities.canViewDispatch ? (
           <div className="metal-card rounded-3xl p-4">
-          <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-              Work board
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">Work board</div>
+                <div className="mt-1 text-sm font-semibold text-neutral-100">Fleet jobs in progress</div>
+              </div>
+              <Link href={`${routePrefix}/board`} className="text-xs text-neutral-300 underline decoration-white/20 underline-offset-4 hover:text-neutral-100">
+                Open full board →
+              </Link>
             </div>
-            <div className="mt-1 text-sm font-semibold text-neutral-100">
-              Fleet jobs in progress
-            </div>
+            <WorkOrderBoardWidget variant="fleet" href={`${routePrefix}/board`} />
           </div>
-
-          <Link
-            href={`${routePrefix}/board`}
-            className="text-xs text-neutral-300 underline decoration-white/20 underline-offset-4 hover:text-neutral-100"
-          >
-            Open full board →
-          </Link>
+        ) : null
+      }
+      error={
+        error ? (
+          <div className="rounded-2xl border border-red-700 bg-red-900/30 px-4 py-3 text-xs text-red-200">{error}</div>
+        ) : null
+      }
+      loading={<div className="metal-card rounded-3xl px-4 py-4 text-xs text-neutral-400">Loading fleet data…</div>}
+      isLoading={loading && !error}
+      aiSummary={
+        <div className="metal-card rounded-3xl p-4">
+          <FleetAISummary shopId={shopId ?? null} />
         </div>
-
-        <WorkOrderBoardWidget variant="fleet" href={`${routePrefix}/board`} />
-      </div>
-        )}
-
-      {error && (
-        <div className="rounded-2xl border border-red-700 bg-red-900/30 px-4 py-3 text-xs text-red-200">
-          {error}
-        </div>
-      )}
-
-      {loading && !error && (
-        <div className="metal-card rounded-3xl px-4 py-4 text-xs text-neutral-400">
-          Loading fleet data…
-        </div>
-      )}
-
-      {!loading && !error && (
-        <>
-          <div className="metal-card rounded-3xl p-4">
-            <FleetAISummary shopId={shopId ?? null} />
-          </div>
-
-          <FleetSummaryCards
-            units={filteredUnits}
-            issues={issues}
-            assignments={assignments}
-            onClickInspectionWindow={handleInspectionWindowClick}
-            inspectionWindowActive={focusFilter === "inspection_due_30"}
-          />
-
-          <FleetIssueTables
-            units={filteredUnits}
-            issues={issues}
-            assignments={assignments}
-            uiContext={uiContext}
-            routePrefix={routePrefix}
-          />
-        </>
-      )}
-    </section>
+      }
+      summaryCards={
+        <FleetSummaryCards
+          units={filteredUnits}
+          issues={issues}
+          assignments={assignments}
+          onClickInspectionWindow={handleInspectionWindowClick}
+          inspectionWindowActive={focusFilter === "inspection_due_30"}
+        />
+      }
+      issueTables={
+        <FleetIssueTables
+          units={filteredUnits}
+          issues={issues}
+          assignments={assignments}
+          uiContext={uiContext}
+          routePrefix={routePrefix}
+        />
+      }
+    />
   );
 }

--- a/features/fleet/lib/fleetOperationsAdapters.ts
+++ b/features/fleet/lib/fleetOperationsAdapters.ts
@@ -1,0 +1,60 @@
+import type {
+  OperationsAsset,
+  OperationsAssignment,
+  OperationsIssue,
+} from "@/features/operations";
+import type {
+  DispatchAssignment,
+  FleetIssue,
+  FleetUnit,
+} from "../components/FleetControlTower";
+
+export function mapFleetUnitToOperationsAsset(unit: FleetUnit): OperationsAsset {
+  return {
+    id: unit.id,
+    label: unit.label,
+    identifier: unit.plate,
+    secondaryIdentifier: unit.vin,
+    class: unit.class,
+    location: unit.location,
+    status:
+      unit.status === "in_service"
+        ? "active"
+        : unit.status === "limited"
+          ? "limited"
+          : "offline",
+    nextInspectionDate: unit.nextInspectionDate,
+  };
+}
+
+export function mapFleetIssueToOperationsIssue(issue: FleetIssue): OperationsIssue {
+  return {
+    id: issue.id,
+    assetId: issue.unitId,
+    assetLabel: issue.unitLabel,
+    severity: issue.severity,
+    summary: issue.summary,
+    createdAt: issue.createdAt,
+    status: issue.status,
+  };
+}
+
+export function mapDispatchAssignmentToOperationsAssignment(
+  assignment: DispatchAssignment,
+): OperationsAssignment {
+  return {
+    id: assignment.id,
+    requesterName: assignment.driverName,
+    requesterId: assignment.driverId,
+    assetLabel: assignment.unitLabel,
+    assetId: assignment.unitId,
+    routeLabel: assignment.routeLabel,
+    nextInspectionDue: assignment.nextPreTripDue,
+    state:
+      assignment.state === "pretrip_due"
+        ? "inspection_due"
+        : assignment.state === "en_route"
+          ? "active"
+          : "in_progress",
+  };
+}

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -37,3 +37,11 @@ Any future schema expansion should be documented and applied manually.
 - This provides reusable portal shell structure for operations verticals while preserving existing fleet portal behavior and routes.
 - Property operations can later reuse this shell with property terminology/routes.
 - This step is UI-structure extraction only: no live property routes/pages and no database changes were introduced.
+
+
+## Step 3: MaintenanceControlTower
+
+- `FleetControlTower` now uses a shared `MaintenanceControlTower` foundation under `features/operations/components`.
+- Fleet remains the only live operations vertical in-app.
+- Property can later reuse this layout via property-specific adapters and property data sources.
+- This step introduces no schema, migration, or route changes.

--- a/features/operations/components/MaintenanceControlTower.tsx
+++ b/features/operations/components/MaintenanceControlTower.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export type MaintenanceControlTowerProps = {
+  headerLabel: string;
+  title: string;
+  subtitle: string;
+  actorSurfaceLabel: string;
+  locationFilter: {
+    value: string;
+    options: string[];
+    onChange: (value: string) => void;
+    allLabel?: string;
+  };
+  modeLabel?: string;
+  focusFilter?: {
+    active: boolean;
+    label: string;
+    onClear: () => void;
+  };
+  summaryCards: ReactNode;
+  issueTables: ReactNode;
+  aiSummary?: ReactNode;
+  workOrderBoard?: ReactNode;
+  loading?: ReactNode;
+  error?: ReactNode;
+  isLoading?: boolean;
+};
+
+export function MaintenanceControlTower({
+  headerLabel,
+  title,
+  subtitle,
+  actorSurfaceLabel,
+  locationFilter,
+  modeLabel,
+  focusFilter,
+  summaryCards,
+  issueTables,
+  aiSummary,
+  workOrderBoard,
+  loading,
+  error,
+  isLoading = false,
+}: MaintenanceControlTowerProps) {
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
+            {headerLabel}
+          </p>
+          <h1
+            className="mt-1 text-3xl text-neutral-100 md:text-4xl"
+            style={{ fontFamily: "var(--font-blackops)" }}
+          >
+            {title}
+          </h1>
+          <p className="mt-2 max-w-xl text-sm text-neutral-400">{subtitle}</p>
+          <p className="mt-1 text-[11px] text-neutral-500">
+            Actor surface: {actorSurfaceLabel}
+          </p>
+
+          {focusFilter?.active && (
+            <p className="mt-2 text-[11px] text-neutral-400">
+              Filter: <span className="text-neutral-200">{focusFilter.label}</span>{" "}
+              <button
+                type="button"
+                onClick={focusFilter.onClear}
+                className="ml-2 underline decoration-neutral-600 underline-offset-2 hover:text-neutral-200"
+              >
+                Clear
+              </button>
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={locationFilter.value}
+            onChange={(e) => locationFilter.onChange(e.target.value)}
+            className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/60 px-3 py-2 text-xs text-neutral-200 shadow-[0_12px_35px_rgba(0,0,0,0.85)]"
+          >
+            <option value="all">{locationFilter.allLabel ?? "All locations"}</option>
+            {locationFilter.options.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+
+          {modeLabel && (
+            <span className="accent-chip px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]">
+              {modeLabel}
+            </span>
+          )}
+        </div>
+      </header>
+
+      {workOrderBoard}
+
+      {error}
+
+      {isLoading && loading}
+
+      {!isLoading && !error && (
+        <>
+          {aiSummary}
+          {summaryCards}
+          {issueTables}
+        </>
+      )}
+    </section>
+  );
+}
+
+export default MaintenanceControlTower;

--- a/features/operations/index.ts
+++ b/features/operations/index.ts
@@ -4,3 +4,5 @@ export * from "./routes";
 export * from "./verticals";
 
 export * from "./components/OperationsPortalShell";
+
+export * from "./components/MaintenanceControlTower";

--- a/features/operations/types.ts
+++ b/features/operations/types.ts
@@ -34,3 +34,42 @@ export type OperationsVerticalConfig = {
   terminology: OperationsTerminology;
   routes: OperationsRoutes;
 };
+
+
+export type OperationsAssetStatus = "active" | "limited" | "offline";
+
+export type OperationsAsset = {
+  id: string;
+  label: string;
+  identifier?: string | null;
+  secondaryIdentifier?: string | null;
+  class?: string | null;
+  location?: string | null;
+  status: OperationsAssetStatus;
+  nextInspectionDate?: string | null;
+};
+
+export type OperationsIssueSeverity = "safety" | "compliance" | "recommend" | "urgent";
+
+export type OperationsIssueStatus = "open" | "scheduled" | "completed";
+
+export type OperationsIssue = {
+  id: string;
+  assetId: string;
+  assetLabel: string;
+  severity: OperationsIssueSeverity;
+  summary: string;
+  createdAt: string;
+  status: OperationsIssueStatus;
+};
+
+export type OperationsAssignment = {
+  id: string;
+  requesterName: string;
+  requesterId: string;
+  assetLabel: string;
+  assetId: string;
+  routeLabel?: string | null;
+  nextInspectionDue?: string | null;
+  state: "inspection_due" | "active" | "in_service" | "in_progress" | "blocked";
+};


### PR DESCRIPTION
### Motivation

- Provide a reusable, vertical-agnostic control-tower layout for maintenance/operations screens so future verticals (e.g., property) can reuse the same foundation. 
- Preserve the existing Fleet behavior and UI while enabling a small, safe adapter layer to map fleet data into the operations shape for future reuse.

### Description

- Added a generic `MaintenanceControlTower` component that owns the shared header/filter/layout and exposes slots for `workOrderBoard`, `aiSummary`, `summaryCards`, `issueTables`, `loading`, and `error` (file: `features/operations/components/MaintenanceControlTower.tsx`).
- Extended operations types with generic entities `OperationsAsset`, `OperationsIssue`, `OperationsAssignment` and supporting enums/types (file: `features/operations/types.ts`) and exported the new component from the operations barrel (file: `features/operations/index.ts`).
- Introduced `fleetOperationsAdapters` mapping `FleetUnit -> OperationsAsset`, `FleetIssue -> OperationsIssue`, and `DispatchAssignment -> OperationsAssignment` to keep a clear adapter boundary (file: `features/fleet/lib/fleetOperationsAdapters.ts`).
- Refactored `FleetControlTower` to remain the public fleet component but delegate layout to `MaintenanceControlTower` while preserving the existing `/api/fleet/tower` fetch, loading/error UX, `region` filtering, inspection-due focus behavior, `routePrefix` links, and original child components (`FleetAISummary`, `FleetSummaryCards`, `FleetIssueTables`, `WorkOrderBoardWidget`) (file: `features/fleet/components/FleetControlTower.tsx`).
- Updated documentation to note Step 3 and that no schema or route changes were made (file: `features/operations/README.md`).

Files changed: `features/operations/components/MaintenanceControlTower.tsx`, `features/operations/types.ts`, `features/operations/index.ts`, `features/operations/README.md`, `features/fleet/components/FleetControlTower.tsx`, and `features/fleet/lib/fleetOperationsAdapters.ts`.

### Testing

- Ran `npm run typecheck`, which completed successfully with `tsc --noEmit` (typecheck passed).
- Ran `npm run lint`, which surfaced pre-existing repository-wide lint issues (repo reported many warnings/errors unrelated to this change) so lint did not pass cleanly for the whole repo; these are pre-existing and outside the scope of this PR.
- Ran `npm run build`, which could not complete in this environment due to external network/font fetch failures (Google Fonts fetch errors), so the production build was impeded by environment/network issues rather than the changes made here.

Notes: No database migrations or schema changes were added or applied, Supabase RLS and request→work-order conversion logic were not modified, and existing fleet routes/pages remain unchanged and continue to use `FleetControlTower` as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b86ad66b48328a35dde112f3ef30b)