### PR TITLE
Extract operations asset detail foundation (OperationsAssetDetailScreen)

### DIFF
--- a/features/fleet/components/AssetDetailScreen.tsx
+++ b/features/fleet/components/AssetDetailScreen.tsx
@@ -5,6 +5,17 @@ import Link from "next/link";
 import type { FleetUnit, FleetIssue } from "./FleetControlTower";
 import { formatCurrency } from "@shared/lib/formatters";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import {
+  OperationsAssetDetailScreen,
+  fleetOperationsTerminology,
+  type OperationsAssetAction,
+  type OperationsAssetStat,
+} from "@/features/operations";
+import {
+  mapFleetIssueToOperationsIssue,
+  mapFleetUnitToOperationsAsset,
+  mapFleetUnitToOperationsAssetMetadata,
+} from "@/features/fleet/lib/fleetOperationsAdapters";
 
 type AssetDetailScreenProps = {
   unitId: string;
@@ -85,291 +96,117 @@ export default function AssetDetailScreen({
     [issues],
   );
 
-  if (loading && !unit && !issues.length) {
-    return (
-      <section className="rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/60 px-4 py-6 text-xs text-neutral-300">
-        Loading asset detail…
-      </section>
-    );
-  }
+  const operationsAsset = useMemo(
+    () => (unit ? mapFleetUnitToOperationsAsset(unit) : null),
+    [unit],
+  );
 
-  if (error) {
-    return (
-      <section className="rounded-3xl border border-red-700 bg-red-900/30 px-4 py-6 text-xs text-red-200">
-        {error}
-      </section>
-    );
-  }
+  const metadata = useMemo(
+    () => (unit ? mapFleetUnitToOperationsAssetMetadata(unit) : []),
+    [unit],
+  );
 
-  if (!unit) {
-    return (
-      <section className="rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/60 px-4 py-6 text-xs text-neutral-300">
-        Asset not found.
-      </section>
-    );
-  }
+  const operationsIssues = useMemo(
+    () => openIssues.map(mapFleetIssueToOperationsIssue),
+    [openIssues],
+  );
+
+  const actions = useMemo<OperationsAssetAction[]>(() => {
+    if (!unit) return [];
+
+    const items: OperationsAssetAction[] = [
+      {
+        href:
+          routePrefix === "/portal/fleet"
+            ? `/portal/fleet/pretrip/${unit.id}`
+            : `/mobile/fleet/pretrip/${unit.id}`,
+        label: "Start pre-trip",
+        variant: "primary",
+      },
+    ];
+
+    if (routePrefix !== "/portal/fleet") {
+      items.push({
+        href: `/portal/fleet/units/${unit.id}`,
+        label: "Open in fleet portal",
+        variant: "secondary",
+      });
+    }
+
+    return items;
+  }, [routePrefix, unit]);
+
+  const statItems = useMemo<OperationsAssetStat[]>(
+    () => [
+      {
+        label: "Lifetime WOs",
+        value: stats ? String(stats.lifetimeWorkOrders) : "–",
+      },
+      {
+        label: "Last 12 months spend",
+        value: stats ? formatCurrency(stats.last12MonthsSpend || 0) : "–",
+      },
+      {
+        label: "Days since last OOS",
+        value:
+          stats && stats.daysSinceLastOos != null
+            ? String(stats.daysSinceLastOos)
+            : "—",
+      },
+      {
+        label: "Open approvals",
+        value: stats ? String(stats.openApprovals) : "0",
+      },
+    ],
+    [stats],
+  );
 
   return (
-    <section className="space-y-6">
-      <header className="metal-card rounded-3xl p-5">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-              Fleet unit
-            </p>
-            <h1
-              className="mt-1 text-3xl text-neutral-100"
-              style={{ fontFamily: "var(--font-blackops)" }}
-            >
-              {unit.label}
-            </h1>
-
-            <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2">
-              <div>
-                <span className="text-neutral-500">Plate:</span>{" "}
-                <span className="font-mono text-[11px] text-neutral-100">
-                  {unit.plate ?? "—"}
-                </span>
-              </div>
-              <div>
-                <span className="text-neutral-500">VIN:</span>{" "}
-                <span className="font-mono text-[11px] text-neutral-100">
-                  {unit.vin ?? "—"}
-                </span>
-              </div>
-              <div>
-                <span className="text-neutral-500">Class:</span>{" "}
-                <span className="text-neutral-100">{unit.class ?? "—"}</span>
-              </div>
-              <div>
-                <span className="text-neutral-500">Location:</span>{" "}
-                <span className="text-neutral-100">{unit.location ?? "—"}</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex flex-col items-end gap-3">
-            <UnitStatusBadge status={unit.status} />
-
-            {unit.nextInspectionDate && (
-              <div className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-right">
-                <div className="text-[11px] text-neutral-400">
-                  Next inspection / CVIP
-                </div>
-                <div className="text-sm font-semibold text-sky-200">
-                  {new Date(unit.nextInspectionDate).toLocaleDateString()}
-                </div>
-              </div>
-            )}
-
-            <div className="flex flex-wrap justify-end gap-2 text-xs">
-              <Link
-                href={
-                  routePrefix === "/portal/fleet"
-                    ? `/portal/fleet/pretrip/${unit.id}`
-                    : `/mobile/fleet/pretrip/${unit.id}`
-                }
-                className="rounded-full bg-[color:var(--accent-copper)] px-3 py-1.5 font-semibold text-black shadow-[0_0_16px_rgba(193,102,59,0.7)] hover:opacity-95"
-              >
-                Start pre-trip
-              </Link>
-              {routePrefix !== "/portal/fleet" && (
-                <Link
-                  href={`/portal/fleet/units/${unit.id}`}
-                  className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1.5 font-semibold text-neutral-200 hover:bg-neutral-900/50"
-                >
-                  Open in fleet portal
-                </Link>
-              )}
-            </div>
-          </div>
-        </div>
-      </header>
-
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,2.2fr)_minmax(0,1.8fr)]">
-        <section className="metal-card rounded-3xl p-4">
-          <header className="mb-3 flex items-center justify-between gap-3 border-b border-[color:var(--metal-border-soft)] pb-2">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
-                Safety & inspections
-              </p>
-              <p className="mt-1 text-xs text-neutral-500">
-                Most recent failures, recommendations, and inspection history.
-              </p>
-            </div>
+    <OperationsAssetDetailScreen
+      terminology={fleetOperationsTerminology}
+      asset={operationsAsset}
+      issues={operationsIssues}
+      stats={statItems}
+      metadata={metadata}
+      actions={actions}
+      nextInspectionLabel="Next inspection / CVIP"
+      loading={loading}
+      error={error}
+      notFoundLabel="Asset not found."
+      headerLabel="Fleet unit"
+      issuesTitle="Safety & inspections"
+      issuesDescription="Most recent failures, recommendations, and inspection history."
+      issuesEmptyLabel="No open safety or compliance issues for this unit."
+      allInspectionsHref={`/inspections?unitId=${encodeURIComponent(unitId)}`}
+      allInspectionsLabel="All inspections"
+      renderIssueActions={() => (
+        <>
+          {uiContext.capabilities.canCreateFleetWorkOrders && (
             <Link
-              href={`/inspections?unitId=${encodeURIComponent(unitId)}`}
-              className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900/60"
+              href={`/work-orders/create?unitId=${encodeURIComponent(unitId)}`}
+              className="rounded-full bg-[color:var(--accent-copper)] px-3 py-1 text-[10px] font-semibold text-black shadow-[0_0_16px_rgba(193,102,59,0.7)] hover:opacity-95"
             >
-              All inspections
+              Create work order
             </Link>
-          </header>
-
-          <div className="space-y-3 text-xs">
-            {openIssues.length === 0 && (
-              <p className="py-4 text-center text-xs text-neutral-500">
-                No open safety or compliance issues for this unit.
-              </p>
-            )}
-
-            {openIssues.map((i) => (
-              <div
-                key={i.id}
-                className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <SeverityChip severity={i.severity} />
-                  <span className="text-[10px] text-neutral-500">
-                    {new Date(i.createdAt).toLocaleDateString()}
-                  </span>
-                </div>
-                <p className="mt-1 text-[11px] text-neutral-200">
-                  {i.summary}
-                </p>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {uiContext.capabilities.canCreateFleetWorkOrders && (
-                    <Link
-                      href={`/work-orders/create?unitId=${encodeURIComponent(
-                        unitId,
-                      )}`}
-                      className="rounded-full bg-[color:var(--accent-copper)] px-3 py-1 text-[10px] font-semibold text-black shadow-[0_0_16px_rgba(193,102,59,0.7)] hover:opacity-95"
-                    >
-                      Create work order
-                    </Link>
-                  )}
-                  <Link
-                    href={`${routePrefix}/board`}
-                    className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold text-neutral-200 hover:bg-neutral-900/50"
-                  >
-                    Send to dispatch
-                  </Link>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="metal-card rounded-3xl p-4">
-          <header className="mb-3 border-b border-[color:var(--metal-border-soft)] pb-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
-              History & cost snapshot
-            </p>
-            <p className="mt-1 text-xs text-neutral-500">
-              High-level unit performance and maintenance at a glance.
-            </p>
-          </header>
-
-          <div className="grid gap-3 text-xs sm:grid-cols-2">
-            <StatBlock
-              label="Lifetime WOs"
-              value={stats ? String(stats.lifetimeWorkOrders) : "–"}
-            />
-            <StatBlock
-              label="Last 12 months spend"
-              value={stats ? formatCurrency(stats.last12MonthsSpend || 0) : "–"}
-            />
-            <StatBlock
-              label="Days since last OOS"
-              value={
-                stats && stats.daysSinceLastOos != null
-                  ? String(stats.daysSinceLastOos)
-                  : "—"
-              }
-            />
-            <StatBlock
-              label="Open approvals"
-              value={stats ? String(stats.openApprovals) : "0"}
-            />
-          </div>
-
-          <div className="mt-4 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-[11px] text-neutral-300">
-            <div className="font-semibold text-neutral-100">
-              Fleet note (internal)
-            </div>
-            <p className="mt-1 text-neutral-400">
-              Numbers above aggregate this unit&apos;s linked work orders and
-              fleet service requests for quick decision-making.
-            </p>
-          </div>
-        </section>
-      </div>
-    </section>
-  );
-}
-
-function UnitStatusBadge({
-  status,
-}: {
-  status: FleetUnit["status"];
-}) {
-  const map: Record<
-    FleetUnit["status"],
-    { label: string; className: string }
-  > = {
-    in_service: {
-      label: "In service",
-      className:
-        "border-emerald-500/70 bg-emerald-500/15 text-emerald-200",
-    },
-    limited: {
-      label: "Limited use",
-      className:
-        "border-amber-400/70 bg-amber-500/15 text-amber-200",
-    },
-    oos: {
-      label: "Out of service",
-      className: "border-red-500/80 bg-red-500/15 text-red-300",
-    },
-  };
-
-  const item = map[status];
-
-  return (
-    <span
-      className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${item.className}`}
+          )}
+          <Link
+            href={`${routePrefix}/board`}
+            className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold text-neutral-200 hover:bg-neutral-900/50"
+          >
+            Send to dispatch
+          </Link>
+        </>
+      )}
     >
-      {item.label}
-    </span>
-  );
-}
-
-function SeverityChip({ severity }: { severity: FleetIssue["severity"] }) {
-  const map: Record<
-    FleetIssue["severity"],
-    { label: string; className: string }
-  > = {
-    safety: {
-      label: "Safety",
-      className: "border-red-500/60 bg-red-500/10 text-red-300",
-    },
-    compliance: {
-      label: "Compliance",
-      className: "border-amber-400/60 bg-amber-500/10 text-amber-200",
-    },
-    recommend: {
-      label: "Recommend",
-      className: "border-sky-400/60 bg-sky-500/10 text-sky-200",
-    },
-  };
-
-  const item = map[severity];
-
-  return (
-    <span
-      className={`inline-flex rounded-full border px-2 py-[2px] text-[10px] font-semibold uppercase tracking-[0.16em] ${item.className}`}
-    >
-      {item.label}
-    </span>
-  );
-}
-
-function StatBlock({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2">
-      <div className="text-[11px] text-neutral-500">{label}</div>
-      <div className="mt-1 text-lg font-semibold text-neutral-100">
-        {value}
+      <div className="mt-4 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-[11px] text-neutral-300">
+        <div className="font-semibold text-neutral-100">
+          Fleet note (internal)
+        </div>
+        <p className="mt-1 text-neutral-400">
+          Numbers above aggregate this unit&apos;s linked work orders and fleet
+          service requests for quick decision-making.
+        </p>
       </div>
-    </div>
+    </OperationsAssetDetailScreen>
   );
 }

--- a/features/fleet/lib/fleetOperationsAdapters.ts
+++ b/features/fleet/lib/fleetOperationsAdapters.ts
@@ -3,6 +3,7 @@ import type {
   OperationsAssignment,
   OperationsIssue,
 } from "@/features/operations";
+import type { OperationsAssetMetadataItem } from "@/features/operations/components/OperationsAssetDetailScreen";
 import type {
   DispatchAssignment,
   FleetIssue,
@@ -25,6 +26,17 @@ export function mapFleetUnitToOperationsAsset(unit: FleetUnit): OperationsAsset 
           : "offline",
     nextInspectionDate: unit.nextInspectionDate,
   };
+}
+
+export function mapFleetUnitToOperationsAssetMetadata(
+  unit: FleetUnit,
+): OperationsAssetMetadataItem[] {
+  return [
+    { label: "Plate", value: unit.plate, mono: true },
+    { label: "VIN", value: unit.vin, mono: true },
+    { label: "Class", value: unit.class },
+    { label: "Location", value: unit.location },
+  ];
 }
 
 export function mapFleetIssueToOperationsIssue(issue: FleetIssue): OperationsIssue {

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -45,3 +45,10 @@ Any future schema expansion should be documented and applied manually.
 - Fleet remains the only live operations vertical in-app.
 - Property can later reuse this layout via property-specific adapters and property data sources.
 - This step introduces no schema, migration, or route changes.
+
+## Step 4: OperationsAssetDetailScreen
+
+- `Fleet AssetDetailScreen` now delegates the shared asset detail layout to `OperationsAssetDetailScreen` under `features/operations/components`.
+- Fleet remains the only live implementation; the existing fleet asset detail fetch, actions, issue actions, stats, and routes are preserved.
+- Property operations can later reuse this foundation for property, unit, appliance, or asset records once those pages are intentionally built.
+- This step introduces no schema changes, migrations, route changes, or Supabase RLS changes.

--- a/features/operations/components/OperationsAssetDetailScreen.tsx
+++ b/features/operations/components/OperationsAssetDetailScreen.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import type {
+  OperationsAsset,
+  OperationsAssetStatus,
+  OperationsIssue,
+  OperationsIssueSeverity,
+  OperationsTerminology,
+} from "../types";
+
+export type OperationsAssetMetadataItem = {
+  label: string;
+  value?: string | null;
+  mono?: boolean;
+};
+
+export type OperationsAssetAction = {
+  href: string;
+  label: string;
+  variant?: "primary" | "secondary";
+};
+
+export type OperationsAssetStat = {
+  label: string;
+  value: string | number;
+  helper?: string;
+};
+
+export type OperationsAssetDetailScreenProps = {
+  terminology: OperationsTerminology;
+  asset: OperationsAsset | null;
+  issues?: OperationsIssue[];
+  stats?: OperationsAssetStat[];
+  metadata?: OperationsAssetMetadataItem[];
+  actions?: OperationsAssetAction[];
+  nextInspectionLabel?: string;
+  loading?: boolean;
+  error?: string | null;
+  notFoundLabel?: string;
+  headerLabel?: string;
+  issuesTitle?: string;
+  issuesDescription?: string;
+  issuesEmptyLabel?: string;
+  allInspectionsHref?: string;
+  allInspectionsLabel?: string;
+  renderIssueActions?: (issue: OperationsIssue) => ReactNode;
+  statsTitle?: string;
+  statsDescription?: string;
+  children?: ReactNode;
+};
+
+export function OperationsAssetDetailScreen({
+  terminology,
+  asset,
+  issues = [],
+  stats = [],
+  metadata = [],
+  actions = [],
+  nextInspectionLabel,
+  loading = false,
+  error = null,
+  notFoundLabel,
+  headerLabel,
+  issuesTitle = "Open issues",
+  issuesDescription,
+  issuesEmptyLabel,
+  allInspectionsHref,
+  allInspectionsLabel = `All ${terminology.inspectionPluralLabel.toLowerCase()}`,
+  renderIssueActions,
+  statsTitle = "History & cost snapshot",
+  statsDescription = `High-level ${terminology.assetLabel.toLowerCase()} performance and maintenance at a glance.`,
+  children,
+}: OperationsAssetDetailScreenProps) {
+  if (loading && !asset && !issues.length) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/60 px-4 py-6 text-xs text-neutral-300">
+        Loading asset detail…
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="rounded-3xl border border-red-700 bg-red-900/30 px-4 py-6 text-xs text-red-200">
+        {error}
+      </section>
+    );
+  }
+
+  if (!asset) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/60 px-4 py-6 text-xs text-neutral-300">
+        {notFoundLabel ?? `${terminology.assetLabel} not found.`}
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="metal-card rounded-3xl p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
+              {headerLabel ?? terminology.assetLabel}
+            </p>
+            <h1
+              className="mt-1 text-3xl text-neutral-100"
+              style={{ fontFamily: "var(--font-blackops)" }}
+            >
+              {asset.label}
+            </h1>
+
+            {metadata.length > 0 && (
+              <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2">
+                {metadata.map((item) => (
+                  <div key={item.label}>
+                    <span className="text-neutral-500">{item.label}:</span>{" "}
+                    <span
+                      className={
+                        item.mono
+                          ? "font-mono text-[11px] text-neutral-100"
+                          : "text-neutral-100"
+                      }
+                    >
+                      {item.value ?? "—"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col items-end gap-3">
+            <OperationsAssetStatusBadge status={asset.status} />
+
+            {asset.nextInspectionDate && (
+              <div className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-right">
+                <div className="text-[11px] text-neutral-400">
+                  {nextInspectionLabel ?? `Next ${terminology.inspectionLabel.toLowerCase()}`}
+                </div>
+                <div className="text-sm font-semibold text-sky-200">
+                  {new Date(asset.nextInspectionDate).toLocaleDateString()}
+                </div>
+              </div>
+            )}
+
+            {actions.length > 0 && (
+              <div className="flex flex-wrap justify-end gap-2 text-xs">
+                {actions.map((action) => (
+                  <Link
+                    key={`${action.href}:${action.label}`}
+                    href={action.href}
+                    className={
+                      action.variant === "secondary"
+                        ? "rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1.5 font-semibold text-neutral-200 hover:bg-neutral-900/50"
+                        : "rounded-full bg-[color:var(--accent-copper)] px-3 py-1.5 font-semibold text-black shadow-[0_0_16px_rgba(193,102,59,0.7)] hover:opacity-95"
+                    }
+                  >
+                    {action.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2.2fr)_minmax(0,1.8fr)]">
+        <section className="metal-card rounded-3xl p-4">
+          <header className="mb-3 flex items-center justify-between gap-3 border-b border-[color:var(--metal-border-soft)] pb-2">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
+                {issuesTitle}
+              </p>
+              {issuesDescription && (
+                <p className="mt-1 text-xs text-neutral-500">
+                  {issuesDescription}
+                </p>
+              )}
+            </div>
+            {allInspectionsHref && (
+              <Link
+                href={allInspectionsHref}
+                className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900/60"
+              >
+                {allInspectionsLabel}
+              </Link>
+            )}
+          </header>
+
+          <div className="space-y-3 text-xs">
+            {issues.length === 0 && (
+              <p className="py-4 text-center text-xs text-neutral-500">
+                {issuesEmptyLabel ??
+                  `No open issues for this ${terminology.assetLabel.toLowerCase()}.`}
+              </p>
+            )}
+
+            {issues.map((issue) => (
+              <div
+                key={issue.id}
+                className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <OperationsIssueSeverityChip severity={issue.severity} />
+                  <span className="text-[10px] text-neutral-500">
+                    {new Date(issue.createdAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <p className="mt-1 text-[11px] text-neutral-200">
+                  {issue.summary}
+                </p>
+                {renderIssueActions && (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {renderIssueActions(issue)}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="metal-card rounded-3xl p-4">
+          <header className="mb-3 border-b border-[color:var(--metal-border-soft)] pb-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">
+              {statsTitle}
+            </p>
+            {statsDescription && (
+              <p className="mt-1 text-xs text-neutral-500">
+                {statsDescription}
+              </p>
+            )}
+          </header>
+
+          {stats.length > 0 && (
+            <div className="grid gap-3 text-xs sm:grid-cols-2">
+              {stats.map((stat) => (
+                <StatBlock
+                  key={stat.label}
+                  label={stat.label}
+                  value={String(stat.value)}
+                  helper={stat.helper}
+                />
+              ))}
+            </div>
+          )}
+
+          {children}
+        </section>
+      </div>
+    </section>
+  );
+}
+
+function OperationsAssetStatusBadge({
+  status,
+}: {
+  status: OperationsAssetStatus;
+}) {
+  const map: Record<
+    OperationsAssetStatus,
+    { label: string; className: string }
+  > = {
+    active: {
+      label: "In service",
+      className:
+        "border-emerald-500/70 bg-emerald-500/15 text-emerald-200",
+    },
+    limited: {
+      label: "Limited use",
+      className:
+        "border-amber-400/70 bg-amber-500/15 text-amber-200",
+    },
+    offline: {
+      label: "Out of service",
+      className: "border-red-500/80 bg-red-500/15 text-red-300",
+    },
+  };
+
+  const item = map[status];
+
+  return (
+    <span
+      className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${item.className}`}
+    >
+      {item.label}
+    </span>
+  );
+}
+
+function OperationsIssueSeverityChip({
+  severity,
+}: {
+  severity: OperationsIssueSeverity;
+}) {
+  const map: Record<
+    OperationsIssueSeverity,
+    { label: string; className: string }
+  > = {
+    safety: {
+      label: "Safety",
+      className: "border-red-500/60 bg-red-500/10 text-red-300",
+    },
+    compliance: {
+      label: "Compliance",
+      className: "border-amber-400/60 bg-amber-500/10 text-amber-200",
+    },
+    recommend: {
+      label: "Recommend",
+      className: "border-sky-400/60 bg-sky-500/10 text-sky-200",
+    },
+    urgent: {
+      label: "Urgent",
+      className: "border-red-500/70 bg-red-500/15 text-red-200",
+    },
+  };
+
+  const item = map[severity];
+
+  return (
+    <span
+      className={`inline-flex rounded-full border px-2 py-[2px] text-[10px] font-semibold uppercase tracking-[0.16em] ${item.className}`}
+    >
+      {item.label}
+    </span>
+  );
+}
+
+function StatBlock({
+  label,
+  value,
+  helper,
+}: {
+  label: string;
+  value: string;
+  helper?: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2">
+      <div className="text-[11px] text-neutral-500">{label}</div>
+      <div className="mt-1 text-lg font-semibold text-neutral-100">
+        {value}
+      </div>
+      {helper && <div className="mt-1 text-[10px] text-neutral-500">{helper}</div>}
+    </div>
+  );
+}

--- a/features/operations/index.ts
+++ b/features/operations/index.ts
@@ -6,3 +6,4 @@ export * from "./verticals";
 export * from "./components/OperationsPortalShell";
 
 export * from "./components/MaintenanceControlTower";
+export * from "./components/OperationsAssetDetailScreen";


### PR DESCRIPTION
### Motivation
- Provide a reusable, vertical-aware foundation for asset detail screens so fleet and future verticals can share layout and copy without changing live fleet behavior.
- Preserve all existing fleet fetch, routes, actions, status semantics, and UI while enabling property/equipment reuse later.
- Keep changes additive and non-disruptive with no DB/migration or Supabase RLS modifications.

### Description
- Added a new shared component `OperationsAssetDetailScreen` that renders loading, error, not-found states, header, asset title, status badge, metadata grid, next inspection card, action slots, stats grid, issues list, and a children/content slot at `features/operations/components/OperationsAssetDetailScreen.tsx`.
- Refactored `features/fleet/components/AssetDetailScreen.tsx` to delegate UI/layout to `OperationsAssetDetailScreen` while keeping the existing `/api/fleet/asset-detail` fetch, `routePrefix` behavior, pre-trip/portal actions, status mapping, stats, and issue actions intact.
- Extended fleet adapters with `mapFleetUnitToOperationsAssetMetadata` to produce metadata items (Plate, VIN, Class, Location) and preserved mono styling and missing-value fallback at `features/fleet/lib/fleetOperationsAdapters.ts`.
- Exported the new component from the operations barrel and updated docs with a Step 4 note; files changed: `features/operations/components/OperationsAssetDetailScreen.tsx`, `features/fleet/components/AssetDetailScreen.tsx`, `features/fleet/lib/fleetOperationsAdapters.ts`, `features/operations/index.ts`, `features/operations/README.md`.
- No schema, migration, route, or request→work-order conversion changes were made.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran targeted ESLint on the changed files with `npx eslint features/operations/components/OperationsAssetDetailScreen.tsx features/fleet/components/AssetDetailScreen.tsx features/fleet/lib/fleetOperationsAdapters.ts features/operations/index.ts` and it passed for the modified files.
- Ran `npm run lint` which failed due to pre-existing repo-wide lint errors unrelated to this change (examples: unused `_error` in `features/ai/...`, many existing warnings); these are pre-existing and not introduced by this PR.
- Ran `npm run build` which failed in this environment due to network/font fetch issues for Google Fonts (`Black Ops One`, `Inter`) and an existing `experimental.turbo` config warning; these are environment/build infra issues and not caused by the changes in this PR.

No migrations were added or applied, and existing fleet asset detail routes/pages remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8ba88cd083289272298705b92f00)