### PR TITLE
Harden property operations manual migration

### DIFF
--- a/docs/plans/property-operations-schema-plan.md
+++ b/docs/plans/property-operations-schema-plan.md
@@ -47,10 +47,19 @@ The draft proposes additive property maintenance tables for:
 
 - Every proposed table is scoped by `shop_id`.
 - RLS is enabled on every proposed table.
+- Policy creation is idempotent for manual re-runs by dropping each named policy before recreating it, because PostgreSQL does not support `CREATE POLICY IF NOT EXISTS`.
 - Internal staff policies are scoped through `profiles.id = auth.uid()` and `profiles.shop_id`.
 - Property member read policies are intentionally scoped to explicit portfolio, property, or unit memberships.
+- The current draft avoids recursive `property_members` policies. There is no existing reusable property-membership helper-function pattern in the repo, so richer future member/role write policies should introduce a reviewed helper rather than nesting broader `property_members` lookups inside that table's own RLS.
 - Tenant requesters can only draft maintenance requests inside their membership scope.
-- Vendor RLS remains a TODO because a safe user-to-vendor link is not represented yet.
+- Vendor RLS remains deferred because a safe user-to-vendor link is not represented yet; the draft does not infer vendor access from contact fields or the `vendor` member role.
+
+### Step 6 production-safety hardening
+
+- Tenant-consistency validation triggers prevent child rows from mismatching `shop_id` or parent scope across portfolios, properties, units, assets, maintenance requests, inspections, vendor assignments, and approval thresholds.
+- `property_vendor_assignments` requires at least one parent link through `request_id` or `work_order_id`.
+- Conservative `NOT VALID` check constraints define expected values for `property_members.role`, `property_maintenance_requests.severity`, and `property_maintenance_requests.status`; these remain safe for production-like data because existing rows can be audited and validated separately.
+- Optional work-order links are checked for matching `work_orders.shop_id` where present, but the draft still does not add or wire runtime work-order conversion behavior.
 
 ### Explicit exclusions
 

--- a/supabase/manual/property-operations-step-6.sql
+++ b/supabase/manual/property-operations-step-6.sql
@@ -172,6 +172,41 @@ create table if not exists public.property_approval_thresholds (
 );
 
 -- -----------------------------------------------------------------------------
+-- Conservative check constraints
+-- -----------------------------------------------------------------------------
+-- These are added as NOT VALID so this draft can be applied safely in
+-- production-like databases that may already contain imperfect rows. PostgreSQL
+-- still enforces NOT VALID CHECK constraints for new/updated rows; validate them
+-- later only after auditing/backfilling existing data.
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'property_members_role_check' and conrelid = 'public.property_members'::regclass) then
+    alter table public.property_members
+      add constraint property_members_role_check
+      check (role in ('property_manager', 'owner_approver', 'tenant_requester', 'vendor', 'viewer')) not valid;
+  end if;
+
+  if not exists (select 1 from pg_constraint where conname = 'property_maintenance_requests_severity_check' and conrelid = 'public.property_maintenance_requests'::regclass) then
+    alter table public.property_maintenance_requests
+      add constraint property_maintenance_requests_severity_check
+      check (severity in ('emergency', 'urgent', 'routine', 'recommended')) not valid;
+  end if;
+
+  if not exists (select 1 from pg_constraint where conname = 'property_maintenance_requests_status_check' and conrelid = 'public.property_maintenance_requests'::regclass) then
+    alter table public.property_maintenance_requests
+      add constraint property_maintenance_requests_status_check
+      check (status in ('open', 'triaged', 'approval_required', 'assigned', 'scheduled', 'in_progress', 'completed', 'cancelled')) not valid;
+  end if;
+
+  if not exists (select 1 from pg_constraint where conname = 'property_vendor_assignments_has_parent_check' and conrelid = 'public.property_vendor_assignments'::regclass) then
+    alter table public.property_vendor_assignments
+      add constraint property_vendor_assignments_has_parent_check
+      check (request_id is not null or work_order_id is not null) not valid;
+  end if;
+end $$;
+
+-- -----------------------------------------------------------------------------
 -- Indexes
 -- -----------------------------------------------------------------------------
 
@@ -315,6 +350,387 @@ before update on public.property_approval_thresholds
 for each row execute function public.set_updated_at();
 
 -- -----------------------------------------------------------------------------
+-- Tenant consistency validation triggers
+-- -----------------------------------------------------------------------------
+-- CHECK constraints cannot reference parent tables, so these conservative
+-- BEFORE triggers prevent child rows from drifting across shop_id boundaries.
+-- They deliberately validate only tenant/scope consistency and do not infer any
+-- access rights.
+
+create or replace function public.validate_property_properties_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  parent_shop_id uuid;
+begin
+  if new.portfolio_id is not null then
+    select pp.shop_id into parent_shop_id
+    from public.property_portfolios pp
+    where pp.id = new.portfolio_id;
+
+    if parent_shop_id is null or parent_shop_id <> new.shop_id then
+      raise exception 'property_properties.shop_id must match property_portfolios.shop_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_properties_tenant_consistency on public.property_properties;
+create trigger trg_property_properties_tenant_consistency
+before insert or update on public.property_properties
+for each row execute function public.validate_property_properties_tenant_consistency();
+
+create or replace function public.validate_property_units_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  parent_shop_id uuid;
+begin
+  select pp.shop_id into parent_shop_id
+  from public.property_properties pp
+  where pp.id = new.property_id;
+
+  if parent_shop_id is null or parent_shop_id <> new.shop_id then
+    raise exception 'property_units.shop_id must match property_properties.shop_id'
+      using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_units_tenant_consistency on public.property_units;
+create trigger trg_property_units_tenant_consistency
+before insert or update on public.property_units
+for each row execute function public.validate_property_units_tenant_consistency();
+
+create or replace function public.validate_property_assets_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  parent_shop_id uuid;
+  unit_record record;
+begin
+  select pp.shop_id into parent_shop_id
+  from public.property_properties pp
+  where pp.id = new.property_id;
+
+  if parent_shop_id is null or parent_shop_id <> new.shop_id then
+    raise exception 'property_assets.shop_id must match property_properties.shop_id'
+      using errcode = '23514';
+  end if;
+
+  if new.unit_id is not null then
+    select pu.shop_id, pu.property_id into unit_record
+    from public.property_units pu
+    where pu.id = new.unit_id;
+
+    if unit_record.shop_id is null
+      or unit_record.shop_id <> new.shop_id
+      or unit_record.property_id <> new.property_id then
+      raise exception 'property_assets unit_id must belong to the same shop_id and property_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_assets_tenant_consistency on public.property_assets;
+create trigger trg_property_assets_tenant_consistency
+before insert or update on public.property_assets
+for each row execute function public.validate_property_assets_tenant_consistency();
+
+create or replace function public.validate_property_members_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  portfolio_shop_id uuid;
+  property_record record;
+  unit_record record;
+begin
+  if new.portfolio_id is not null then
+    select pp.shop_id into portfolio_shop_id
+    from public.property_portfolios pp
+    where pp.id = new.portfolio_id;
+
+    if portfolio_shop_id is null or portfolio_shop_id <> new.shop_id then
+      raise exception 'property_members.shop_id must match property_portfolios.shop_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.property_id is not null then
+    select pp.shop_id, pp.portfolio_id into property_record
+    from public.property_properties pp
+    where pp.id = new.property_id;
+
+    if property_record.shop_id is null or property_record.shop_id <> new.shop_id then
+      raise exception 'property_members.shop_id must match property_properties.shop_id'
+        using errcode = '23514';
+    end if;
+
+    if new.portfolio_id is not null and property_record.portfolio_id is distinct from new.portfolio_id then
+      raise exception 'property_members.property_id must belong to portfolio_id when both are present'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.unit_id is not null then
+    select pu.shop_id, pu.property_id into unit_record
+    from public.property_units pu
+    where pu.id = new.unit_id;
+
+    if unit_record.shop_id is null or unit_record.shop_id <> new.shop_id then
+      raise exception 'property_members.shop_id must match property_units.shop_id'
+        using errcode = '23514';
+    end if;
+
+    if new.property_id is not null and unit_record.property_id <> new.property_id then
+      raise exception 'property_members.unit_id must belong to property_id when both are present'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_members_tenant_consistency on public.property_members;
+create trigger trg_property_members_tenant_consistency
+before insert or update on public.property_members
+for each row execute function public.validate_property_members_tenant_consistency();
+
+create or replace function public.validate_property_maintenance_requests_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  parent_shop_id uuid;
+  unit_record record;
+  asset_record record;
+  work_order_shop_id uuid;
+begin
+  select pp.shop_id into parent_shop_id
+  from public.property_properties pp
+  where pp.id = new.property_id;
+
+  if parent_shop_id is null or parent_shop_id <> new.shop_id then
+    raise exception 'property_maintenance_requests.shop_id must match property_properties.shop_id'
+      using errcode = '23514';
+  end if;
+
+  if new.unit_id is not null then
+    select pu.shop_id, pu.property_id into unit_record
+    from public.property_units pu
+    where pu.id = new.unit_id;
+
+    if unit_record.shop_id is null
+      or unit_record.shop_id <> new.shop_id
+      or unit_record.property_id <> new.property_id then
+      raise exception 'property_maintenance_requests unit_id must belong to the same shop_id and property_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.asset_id is not null then
+    select pa.shop_id, pa.property_id, pa.unit_id into asset_record
+    from public.property_assets pa
+    where pa.id = new.asset_id;
+
+    if asset_record.shop_id is null
+      or asset_record.shop_id <> new.shop_id
+      or asset_record.property_id <> new.property_id
+      or (asset_record.unit_id is not null and asset_record.unit_id is distinct from new.unit_id) then
+      raise exception 'property_maintenance_requests asset_id must belong to the same shop_id, property_id, and unit_id scope'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.work_order_id is not null then
+    select wo.shop_id into work_order_shop_id
+    from public.work_orders wo
+    where wo.id = new.work_order_id;
+
+    if work_order_shop_id is null or work_order_shop_id <> new.shop_id then
+      raise exception 'property_maintenance_requests.shop_id must match work_orders.shop_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_maintenance_requests_tenant_consistency on public.property_maintenance_requests;
+create trigger trg_property_maintenance_requests_tenant_consistency
+before insert or update on public.property_maintenance_requests
+for each row execute function public.validate_property_maintenance_requests_tenant_consistency();
+
+create or replace function public.validate_property_inspections_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  parent_shop_id uuid;
+  unit_record record;
+begin
+  select pp.shop_id into parent_shop_id
+  from public.property_properties pp
+  where pp.id = new.property_id;
+
+  if parent_shop_id is null or parent_shop_id <> new.shop_id then
+    raise exception 'property_inspections.shop_id must match property_properties.shop_id'
+      using errcode = '23514';
+  end if;
+
+  if new.unit_id is not null then
+    select pu.shop_id, pu.property_id into unit_record
+    from public.property_units pu
+    where pu.id = new.unit_id;
+
+    if unit_record.shop_id is null
+      or unit_record.shop_id <> new.shop_id
+      or unit_record.property_id <> new.property_id then
+      raise exception 'property_inspections unit_id must belong to the same shop_id and property_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_inspections_tenant_consistency on public.property_inspections;
+create trigger trg_property_inspections_tenant_consistency
+before insert or update on public.property_inspections
+for each row execute function public.validate_property_inspections_tenant_consistency();
+
+create or replace function public.validate_property_vendor_assignments_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  request_shop_id uuid;
+  work_order_shop_id uuid;
+  vendor_shop_id uuid;
+begin
+  select pv.shop_id into vendor_shop_id
+  from public.property_vendors pv
+  where pv.id = new.vendor_id;
+
+  if vendor_shop_id is null or vendor_shop_id <> new.shop_id then
+    raise exception 'property_vendor_assignments.shop_id must match property_vendors.shop_id'
+      using errcode = '23514';
+  end if;
+
+  if new.request_id is not null then
+    select pmr.shop_id into request_shop_id
+    from public.property_maintenance_requests pmr
+    where pmr.id = new.request_id;
+
+    if request_shop_id is null or request_shop_id <> new.shop_id then
+      raise exception 'property_vendor_assignments.shop_id must match property_maintenance_requests.shop_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.work_order_id is not null then
+    select wo.shop_id into work_order_shop_id
+    from public.work_orders wo
+    where wo.id = new.work_order_id;
+
+    if work_order_shop_id is null or work_order_shop_id <> new.shop_id then
+      raise exception 'property_vendor_assignments.shop_id must match work_orders.shop_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_vendor_assignments_tenant_consistency on public.property_vendor_assignments;
+create trigger trg_property_vendor_assignments_tenant_consistency
+before insert or update on public.property_vendor_assignments
+for each row execute function public.validate_property_vendor_assignments_tenant_consistency();
+
+create or replace function public.validate_property_approval_thresholds_tenant_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  portfolio_shop_id uuid;
+  property_record record;
+  unit_record record;
+begin
+  if new.portfolio_id is not null then
+    select pp.shop_id into portfolio_shop_id
+    from public.property_portfolios pp
+    where pp.id = new.portfolio_id;
+
+    if portfolio_shop_id is null or portfolio_shop_id <> new.shop_id then
+      raise exception 'property_approval_thresholds.shop_id must match property_portfolios.shop_id'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.property_id is not null then
+    select pp.shop_id, pp.portfolio_id into property_record
+    from public.property_properties pp
+    where pp.id = new.property_id;
+
+    if property_record.shop_id is null or property_record.shop_id <> new.shop_id then
+      raise exception 'property_approval_thresholds.shop_id must match property_properties.shop_id'
+        using errcode = '23514';
+    end if;
+
+    if new.portfolio_id is not null and property_record.portfolio_id is distinct from new.portfolio_id then
+      raise exception 'property_approval_thresholds.property_id must belong to portfolio_id when both are present'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if new.unit_id is not null then
+    select pu.shop_id, pu.property_id, pp.portfolio_id into unit_record
+    from public.property_units pu
+    join public.property_properties pp on pp.id = pu.property_id
+    where pu.id = new.unit_id;
+
+    if unit_record.shop_id is null or unit_record.shop_id <> new.shop_id then
+      raise exception 'property_approval_thresholds.shop_id must match property_units.shop_id'
+        using errcode = '23514';
+    end if;
+
+    if new.property_id is not null and unit_record.property_id <> new.property_id then
+      raise exception 'property_approval_thresholds.unit_id must belong to property_id when both are present'
+        using errcode = '23514';
+    end if;
+
+    if new.portfolio_id is not null and unit_record.portfolio_id is distinct from new.portfolio_id then
+      raise exception 'property_approval_thresholds.unit_id must belong to portfolio_id when both are present'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_approval_thresholds_tenant_consistency on public.property_approval_thresholds;
+create trigger trg_property_approval_thresholds_tenant_consistency
+before insert or update on public.property_approval_thresholds
+for each row execute function public.validate_property_approval_thresholds_tenant_consistency();
+
+-- -----------------------------------------------------------------------------
 -- Row Level Security
 -- -----------------------------------------------------------------------------
 
@@ -332,142 +748,182 @@ alter table public.property_approval_thresholds enable row level security;
 -- Internal shop staff policies. These rely on profiles.shop_id and do not infer
 -- any access from existing fleet/shop tables.
 
+drop policy if exists property_portfolios_internal_staff_select on public.property_portfolios;
 create policy property_portfolios_internal_staff_select
 on public.property_portfolios for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_portfolios.shop_id));
+drop policy if exists property_portfolios_internal_staff_insert on public.property_portfolios;
 create policy property_portfolios_internal_staff_insert
 on public.property_portfolios for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_portfolios.shop_id));
+drop policy if exists property_portfolios_internal_staff_update on public.property_portfolios;
 create policy property_portfolios_internal_staff_update
 on public.property_portfolios for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_portfolios.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_portfolios.shop_id));
+drop policy if exists property_portfolios_internal_staff_delete on public.property_portfolios;
 create policy property_portfolios_internal_staff_delete
 on public.property_portfolios for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_portfolios.shop_id));
 
+drop policy if exists property_properties_internal_staff_select on public.property_properties;
 create policy property_properties_internal_staff_select
 on public.property_properties for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_properties.shop_id));
+drop policy if exists property_properties_internal_staff_insert on public.property_properties;
 create policy property_properties_internal_staff_insert
 on public.property_properties for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_properties.shop_id));
+drop policy if exists property_properties_internal_staff_update on public.property_properties;
 create policy property_properties_internal_staff_update
 on public.property_properties for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_properties.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_properties.shop_id));
+drop policy if exists property_properties_internal_staff_delete on public.property_properties;
 create policy property_properties_internal_staff_delete
 on public.property_properties for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_properties.shop_id));
 
+drop policy if exists property_units_internal_staff_select on public.property_units;
 create policy property_units_internal_staff_select
 on public.property_units for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_units.shop_id));
+drop policy if exists property_units_internal_staff_insert on public.property_units;
 create policy property_units_internal_staff_insert
 on public.property_units for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_units.shop_id));
+drop policy if exists property_units_internal_staff_update on public.property_units;
 create policy property_units_internal_staff_update
 on public.property_units for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_units.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_units.shop_id));
+drop policy if exists property_units_internal_staff_delete on public.property_units;
 create policy property_units_internal_staff_delete
 on public.property_units for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_units.shop_id));
 
+drop policy if exists property_assets_internal_staff_select on public.property_assets;
 create policy property_assets_internal_staff_select
 on public.property_assets for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_assets.shop_id));
+drop policy if exists property_assets_internal_staff_insert on public.property_assets;
 create policy property_assets_internal_staff_insert
 on public.property_assets for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_assets.shop_id));
+drop policy if exists property_assets_internal_staff_update on public.property_assets;
 create policy property_assets_internal_staff_update
 on public.property_assets for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_assets.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_assets.shop_id));
+drop policy if exists property_assets_internal_staff_delete on public.property_assets;
 create policy property_assets_internal_staff_delete
 on public.property_assets for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_assets.shop_id));
 
+drop policy if exists property_members_internal_staff_select on public.property_members;
 create policy property_members_internal_staff_select
 on public.property_members for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_members.shop_id));
+drop policy if exists property_members_internal_staff_insert on public.property_members;
 create policy property_members_internal_staff_insert
 on public.property_members for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_members.shop_id));
+drop policy if exists property_members_internal_staff_update on public.property_members;
 create policy property_members_internal_staff_update
 on public.property_members for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_members.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_members.shop_id));
+drop policy if exists property_members_internal_staff_delete on public.property_members;
 create policy property_members_internal_staff_delete
 on public.property_members for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_members.shop_id));
 
+drop policy if exists property_maintenance_requests_internal_staff_select on public.property_maintenance_requests;
 create policy property_maintenance_requests_internal_staff_select
 on public.property_maintenance_requests for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_maintenance_requests.shop_id));
+drop policy if exists property_maintenance_requests_internal_staff_insert on public.property_maintenance_requests;
 create policy property_maintenance_requests_internal_staff_insert
 on public.property_maintenance_requests for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_maintenance_requests.shop_id));
+drop policy if exists property_maintenance_requests_internal_staff_update on public.property_maintenance_requests;
 create policy property_maintenance_requests_internal_staff_update
 on public.property_maintenance_requests for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_maintenance_requests.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_maintenance_requests.shop_id));
+drop policy if exists property_maintenance_requests_internal_staff_delete on public.property_maintenance_requests;
 create policy property_maintenance_requests_internal_staff_delete
 on public.property_maintenance_requests for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_maintenance_requests.shop_id));
 
+drop policy if exists property_inspections_internal_staff_select on public.property_inspections;
 create policy property_inspections_internal_staff_select
 on public.property_inspections for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_inspections.shop_id));
+drop policy if exists property_inspections_internal_staff_insert on public.property_inspections;
 create policy property_inspections_internal_staff_insert
 on public.property_inspections for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_inspections.shop_id));
+drop policy if exists property_inspections_internal_staff_update on public.property_inspections;
 create policy property_inspections_internal_staff_update
 on public.property_inspections for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_inspections.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_inspections.shop_id));
+drop policy if exists property_inspections_internal_staff_delete on public.property_inspections;
 create policy property_inspections_internal_staff_delete
 on public.property_inspections for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_inspections.shop_id));
 
+drop policy if exists property_vendors_internal_staff_select on public.property_vendors;
 create policy property_vendors_internal_staff_select
 on public.property_vendors for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendors.shop_id));
+drop policy if exists property_vendors_internal_staff_insert on public.property_vendors;
 create policy property_vendors_internal_staff_insert
 on public.property_vendors for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendors.shop_id));
+drop policy if exists property_vendors_internal_staff_update on public.property_vendors;
 create policy property_vendors_internal_staff_update
 on public.property_vendors for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendors.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendors.shop_id));
+drop policy if exists property_vendors_internal_staff_delete on public.property_vendors;
 create policy property_vendors_internal_staff_delete
 on public.property_vendors for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendors.shop_id));
 
+drop policy if exists property_vendor_assignments_internal_staff_select on public.property_vendor_assignments;
 create policy property_vendor_assignments_internal_staff_select
 on public.property_vendor_assignments for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendor_assignments.shop_id));
+drop policy if exists property_vendor_assignments_internal_staff_insert on public.property_vendor_assignments;
 create policy property_vendor_assignments_internal_staff_insert
 on public.property_vendor_assignments for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendor_assignments.shop_id));
+drop policy if exists property_vendor_assignments_internal_staff_update on public.property_vendor_assignments;
 create policy property_vendor_assignments_internal_staff_update
 on public.property_vendor_assignments for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendor_assignments.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendor_assignments.shop_id));
+drop policy if exists property_vendor_assignments_internal_staff_delete on public.property_vendor_assignments;
 create policy property_vendor_assignments_internal_staff_delete
 on public.property_vendor_assignments for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_vendor_assignments.shop_id));
 
+drop policy if exists property_approval_thresholds_internal_staff_select on public.property_approval_thresholds;
 create policy property_approval_thresholds_internal_staff_select
 on public.property_approval_thresholds for select to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_approval_thresholds.shop_id));
+drop policy if exists property_approval_thresholds_internal_staff_insert on public.property_approval_thresholds;
 create policy property_approval_thresholds_internal_staff_insert
 on public.property_approval_thresholds for insert to authenticated
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_approval_thresholds.shop_id));
+drop policy if exists property_approval_thresholds_internal_staff_update on public.property_approval_thresholds;
 create policy property_approval_thresholds_internal_staff_update
 on public.property_approval_thresholds for update to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_approval_thresholds.shop_id))
 with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_approval_thresholds.shop_id));
+drop policy if exists property_approval_thresholds_internal_staff_delete on public.property_approval_thresholds;
 create policy property_approval_thresholds_internal_staff_delete
 on public.property_approval_thresholds for delete to authenticated
 using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = property_approval_thresholds.shop_id));
@@ -475,11 +931,21 @@ using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.sho
 -- Property member read policies. A member may see rows within their explicit
 -- portfolio/property/unit scope. Narrower unit membership only unlocks that unit
 -- and directly attached assets/requests/inspections.
+--
+-- RLS recursion review: this repo does not currently include a reusable
+-- SECURITY DEFINER property-membership helper pattern. The property_members
+-- policies below intentionally avoid querying property_members from a
+-- property_members policy; other member-scoped SELECT policies query
+-- property_members only to check the current auth.uid() row. If future write
+-- policies need richer member/role checks, add a reviewed helper function first
+-- rather than nesting broader property_members lookups inside its own RLS.
 
+drop policy if exists property_members_self_select on public.property_members;
 create policy property_members_self_select
 on public.property_members for select to authenticated
 using (user_id = auth.uid());
 
+drop policy if exists property_portfolios_member_select on public.property_portfolios;
 create policy property_portfolios_member_select
 on public.property_portfolios for select to authenticated
 using (exists (
@@ -489,6 +955,7 @@ using (exists (
     and pm.portfolio_id = property_portfolios.id
 ));
 
+drop policy if exists property_properties_member_select on public.property_properties;
 create policy property_properties_member_select
 on public.property_properties for select to authenticated
 using (exists (
@@ -501,6 +968,7 @@ using (exists (
     )
 ));
 
+drop policy if exists property_units_member_select on public.property_units;
 create policy property_units_member_select
 on public.property_units for select to authenticated
 using (exists (
@@ -515,6 +983,7 @@ using (exists (
     )
 ));
 
+drop policy if exists property_assets_member_select on public.property_assets;
 create policy property_assets_member_select
 on public.property_assets for select to authenticated
 using (exists (
@@ -529,6 +998,7 @@ using (exists (
     )
 ));
 
+drop policy if exists property_maintenance_requests_member_select on public.property_maintenance_requests;
 create policy property_maintenance_requests_member_select
 on public.property_maintenance_requests for select to authenticated
 using (exists (
@@ -543,6 +1013,7 @@ using (exists (
     )
 ));
 
+drop policy if exists property_inspections_member_select on public.property_inspections;
 create policy property_inspections_member_select
 on public.property_inspections for select to authenticated
 using (exists (
@@ -561,6 +1032,7 @@ using (exists (
 -- only inside their membership scope and only for themselves or with a null
 -- requester_profile_id for later server-side normalization.
 
+drop policy if exists property_maintenance_requests_tenant_requester_insert on public.property_maintenance_requests;
 create policy property_maintenance_requests_tenant_requester_insert
 on public.property_maintenance_requests for insert to authenticated
 with check (


### PR DESCRIPTION
### Motivation
- Make the Step 6 manual Supabase SQL draft safe and idempotent for manual production runs. 
- Prevent tenant/tenant-boundary drift by ensuring child rows cannot reference parents in other `shop_id` scopes. 
- Enforce conservative domain rules (roles/status/severity and required parent linkage) without breaking existing production data. 
- Avoid introducing risky RLS recursion or implicit vendor access in this draft.

### Description
- Added `DROP POLICY IF EXISTS ... ON ...;` before every `CREATE POLICY` in `supabase/manual/property-operations-step-6.sql` so policy recreation is safe for repeated manual runs. 
- Added conservative `NOT VALID` check constraints (added inside a guarded `DO $$ ... $$;`) for `property_members.role`, `property_maintenance_requests.severity`, `property_maintenance_requests.status`, and a parent-link requirement on `property_vendor_assignments` so new/updated rows are validated but existing rows are not forced to pass until audited/backfilled. 
- Implemented conservative PL/pgSQL `BEFORE INSERT OR UPDATE` triggers and helper functions to validate tenant consistency (matching `shop_id` / parent relationships) for portfolios/properties, units, assets, members, maintenance requests, inspections, vendor assignments, and approval thresholds. 
- Added a conservative RLS recursion review note and left vendor RLS deferred (documented TODO and explicit comment requiring a user-to-vendor linkage before opening vendor SELECT policies). 
- Updated documentation at `docs/plans/property-operations-schema-plan.md` to describe idempotent policy creation, the tenant-consistency triggers, `NOT VALID` constraints, RLS recursion guidance, and the deferred vendor RLS stance.
- Files changed: `supabase/manual/property-operations-step-6.sql` and `docs/plans/property-operations-schema-plan.md`.

### Testing
- Ran `npx tsc --noEmit` to ensure TypeScript validation for the repository and observed no blocking errors (only unrelated npm warnings). 
- Ran a small Python/static check that verified every `CREATE POLICY` in `supabase/manual/property-operations-step-6.sql` is preceded by a corresponding `DROP POLICY IF EXISTS ... ON ...;` and the check passed. 
- Performed local static inspections of the updated SQL (search/line checks and sanity reviews) to ensure triggers, functions, and `NOT VALID` constraints are present and properly guarded. 
- Confirmations: no SQL was executed against any database, and no runtime/application code was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b9515b6d883288ed77ed3accdcd5a)