### PR TITLE
Add read-only property operations Supabase wiring

### DIFF
--- a/app/property/assets/[id]/page.tsx
+++ b/app/property/assets/[id]/page.tsx
@@ -1,4 +1,5 @@
 import PropertyAssetDetailDemo from "@/features/property/components/PropertyAssetDetailDemo";
+import { getPropertyAssetDetailData } from "@/features/property/server/propertyOperationsQueries";
 
 interface PropertyAssetPageProps {
   params: Promise<{ id: string }>;
@@ -8,11 +9,12 @@ export default async function PropertyAssetPage({
   params,
 }: PropertyAssetPageProps) {
   const { id } = await params;
+  const assetDetailData = await getPropertyAssetDetailData(id);
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] px-4 py-6 text-white md:px-8">
       <div className="mx-auto max-w-6xl">
-        <PropertyAssetDetailDemo assetId={id} />
+        <PropertyAssetDetailDemo assetId={id} liveData={assetDetailData} />
       </div>
     </main>
   );

--- a/app/property/page.tsx
+++ b/app/property/page.tsx
@@ -1,10 +1,13 @@
 import PropertyMaintenanceDashboard from "@/features/property/components/PropertyMaintenanceDashboard";
+import { getPropertyOperationsDashboardData } from "@/features/property/server/propertyOperationsQueries";
 
-export default function PropertyPage() {
+export default async function PropertyPage() {
+  const dashboardData = await getPropertyOperationsDashboardData();
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] px-4 py-6 text-white md:px-8">
       <div className="mx-auto max-w-7xl">
-        <PropertyMaintenanceDashboard />
+        <PropertyMaintenanceDashboard liveData={dashboardData} />
       </div>
     </main>
   );

--- a/features/property/components/PropertyAssetDetailDemo.tsx
+++ b/features/property/components/PropertyAssetDetailDemo.tsx
@@ -4,6 +4,7 @@ import {
   propertyOperationsTerminology,
   type OperationsAssetStat,
 } from "@/features/operations";
+import type { PropertyAssetDetailData } from "../server/propertyOperationsQueries";
 import {
   getPropertyDemoAssetById,
   getPropertyDemoIssuesForAsset,
@@ -11,18 +12,27 @@ import {
 
 type PropertyAssetDetailDemoProps = {
   assetId: string;
+  liveData?: PropertyAssetDetailData;
 };
 
 export default function PropertyAssetDetailDemo({
   assetId,
+  liveData,
 }: PropertyAssetDetailDemoProps) {
-  const asset = getPropertyDemoAssetById(assetId);
-  const issues = asset ? getPropertyDemoIssuesForAsset(asset.id) : [];
+  const liveAsset = liveData?.asset ?? null;
+  const demoAsset = liveAsset ? null : getPropertyDemoAssetById(assetId);
+  const asset = liveAsset ?? demoAsset;
+  const issues = liveAsset
+    ? (liveData?.issues ?? [])
+    : demoAsset
+      ? getPropertyDemoIssuesForAsset(demoAsset.id)
+      : [];
   const openIssueCount = issues.filter(
     (issue) => issue.status !== "completed",
   ).length;
+  const isLive = Boolean(liveAsset);
 
-  const stats: OperationsAssetStat[] = [
+  const demoStats: OperationsAssetStat[] = [
     {
       label: "Open Requests",
       value: openIssueCount,
@@ -51,44 +61,64 @@ export default function PropertyAssetDetailDemo({
     },
   ];
 
+  const stats = isLive ? (liveData?.stats ?? []) : demoStats;
+  const metadata = isLive
+    ? (liveData?.metadata ?? [])
+    : demoAsset
+      ? [
+          { label: "Address", value: demoAsset.metadata.address },
+          { label: "Unit", value: demoAsset.metadata.unit },
+          { label: "Asset Type", value: demoAsset.metadata.assetType },
+          { label: "Occupancy", value: demoAsset.metadata.occupancy },
+        ]
+      : [];
+
   return (
     <OperationsAssetDetailScreen
       terminology={propertyOperationsTerminology}
       asset={asset}
       issues={issues}
       stats={stats}
-      metadata={
-        asset
-          ? [
-              { label: "Address", value: asset.metadata.address },
-              { label: "Unit", value: asset.metadata.unit },
-              { label: "Asset Type", value: asset.metadata.assetType },
-              { label: "Occupancy", value: asset.metadata.occupancy },
+      metadata={metadata}
+      actions={
+        isLive
+          ? []
+          : [
+              { href: "#", label: "Create maintenance request" },
+              { href: "#", label: "Schedule inspection", variant: "secondary" },
             ]
-          : []
       }
-      actions={[
-        { href: "#", label: "Create maintenance request" },
-        { href: "#", label: "Schedule inspection", variant: "secondary" },
-      ]}
       nextInspectionLabel="Next property inspection"
       notFoundLabel="Property demo asset not found. This placeholder only includes static demo records."
-      headerLabel="Property asset demo"
+      headerLabel={isLive ? "Property asset" : "Property asset demo"}
       issuesTitle="Open maintenance requests"
-      issuesDescription="Static tenant/site maintenance requests attached to this demo asset."
-      issuesEmptyLabel="No open demo maintenance requests for this property asset."
+      issuesDescription={
+        isLive
+          ? "Read-only property maintenance requests visible through RLS."
+          : "Static tenant/site maintenance requests attached to this demo asset."
+      }
+      issuesEmptyLabel={
+        isLive
+          ? "No live maintenance requests visible for this property asset."
+          : "No open demo maintenance requests for this property asset."
+      }
       allInspectionsHref={propertyOperationsRoutes.portalInspections}
       allInspectionsLabel="Inspection history"
       statsTitle="Property maintenance snapshot"
-      statsDescription="Demo history and cost indicators only — no accounting, leases, rent, or live work order conversion is wired."
+      statsDescription={
+        isLive
+          ? "Live read-only request status counts only — no spend, accounting, leases, rent, or work-order conversion is wired."
+          : "Demo history and cost indicators only — no accounting, leases, rent, or live work order conversion is wired."
+      }
     >
       <div className="mt-4 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-[11px] text-neutral-300">
         <div className="font-semibold text-neutral-100">
-          Property placeholder note
+          {isLive ? "Read-only property note" : "Property placeholder note"}
         </div>
         <p className="mt-1 text-neutral-400">
-          This screen proves the reusable operations asset detail layout with
-          property terminology and static data only.
+          {isLive
+            ? "This screen reads property operations data through the logged-in user's Supabase RLS context and does not add write actions yet."
+            : "This screen proves the reusable operations asset detail layout with property terminology and static data only."}
         </p>
       </div>
     </OperationsAssetDetailScreen>

--- a/features/property/components/PropertyMaintenanceDashboard.tsx
+++ b/features/property/components/PropertyMaintenanceDashboard.tsx
@@ -7,6 +7,7 @@ import {
   propertyOperationsRoutes,
   propertyOperationsTerminology,
 } from "@/features/operations";
+import type { PropertyOperationsDashboardData } from "../server/propertyOperationsQueries";
 import {
   propertyDemoAssets,
   propertyDemoAssignments,
@@ -17,6 +18,7 @@ type PropertyMaintenanceDashboardProps = {
   title?: string;
   subtitle?: string;
   modeLabel?: string;
+  liveData?: PropertyOperationsDashboardData;
 };
 
 type FocusFilter = "all" | "open_requests";
@@ -24,34 +26,55 @@ type FocusFilter = "all" | "open_requests";
 export default function PropertyMaintenanceDashboard({
   title = "Property Maintenance Tower",
   subtitle = "Track open requests, inspections, vendor work, and asset history across properties.",
-  modeLabel = "Static property demo",
+  modeLabel,
+  liveData,
 }: PropertyMaintenanceDashboardProps) {
+  const hasLiveData = Boolean(
+    liveData &&
+    (liveData.assets.length > 0 ||
+      liveData.issues.length > 0 ||
+      liveData.assignments.length > 0),
+  );
+  const assets = hasLiveData ? liveData!.assets : propertyDemoAssets;
+  const issues = hasLiveData ? liveData!.issues : propertyDemoIssues;
+  const assignments = hasLiveData
+    ? liveData!.assignments
+    : propertyDemoAssignments;
+  const effectiveModeLabel =
+    modeLabel ??
+    (hasLiveData
+      ? "Live property data · RLS read-only"
+      : "Static property demo");
   const [locationFilter, setLocationFilter] = useState<string | "all">("all");
   const [focusFilter, setFocusFilter] = useState<FocusFilter>("all");
 
   const locations = useMemo(() => {
     const set = new Set<string>();
-    for (const asset of propertyDemoAssets) {
+    for (const asset of assets) {
       if (asset.location?.trim()) set.add(asset.location.trim());
     }
     return Array.from(set).sort((a, b) => a.localeCompare(b));
-  }, []);
+  }, [assets]);
 
   const filteredAssets = useMemo(() => {
-    let assets = propertyDemoAssets;
+    let nextAssets = assets;
     if (locationFilter !== "all") {
-      assets = assets.filter((asset) => asset.location === locationFilter);
+      nextAssets = nextAssets.filter(
+        (asset) => asset.location === locationFilter,
+      );
     }
     if (focusFilter === "open_requests") {
       const assetIdsWithOpenIssues = new Set(
-        propertyDemoIssues
+        issues
           .filter((issue) => issue.status !== "completed")
           .map((issue) => issue.assetId),
       );
-      assets = assets.filter((asset) => assetIdsWithOpenIssues.has(asset.id));
+      nextAssets = nextAssets.filter((asset) =>
+        assetIdsWithOpenIssues.has(asset.id),
+      );
     }
-    return assets;
-  }, [focusFilter, locationFilter]);
+    return nextAssets;
+  }, [assets, focusFilter, issues, locationFilter]);
 
   const filteredAssetIds = useMemo(
     () => new Set(filteredAssets.map((asset) => asset.id)),
@@ -59,9 +82,8 @@ export default function PropertyMaintenanceDashboard({
   );
 
   const visibleIssues = useMemo(
-    () =>
-      propertyDemoIssues.filter((issue) => filteredAssetIds.has(issue.assetId)),
-    [filteredAssetIds],
+    () => issues.filter((issue) => filteredAssetIds.has(issue.assetId)),
+    [filteredAssetIds, issues],
   );
 
   const summary = useMemo(() => {
@@ -72,12 +94,16 @@ export default function PropertyMaintenanceDashboard({
       {
         label: propertyOperationsTerminology.assetPluralLabel,
         value: filteredAssets.length,
-        helper: "Static demo assets in current filter",
+        helper: hasLiveData
+          ? "Live property records visible through RLS"
+          : "Static demo assets in current filter",
       },
       {
         label: `Open ${propertyOperationsTerminology.requestPluralLabel}`,
         value: openIssues.length,
-        helper: "Tenant and site requests awaiting action",
+        helper: hasLiveData
+          ? "Property requests visible to internal staff"
+          : "Tenant and site requests awaiting action",
       },
       {
         label: "Limited / Offline",
@@ -87,20 +113,22 @@ export default function PropertyMaintenanceDashboard({
       },
       {
         label: "Vendor Follow-ups",
-        value: propertyDemoAssignments.filter((assignment) =>
+        value: assignments.filter((assignment) =>
           ["blocked", "in_progress", "inspection_due"].includes(
             assignment.state,
           ),
         ).length,
-        helper: "Demo assignments only — no dispatch integration",
+        helper: hasLiveData
+          ? "Read-only vendor assignment status"
+          : "Demo assignments only — no dispatch integration",
       },
     ];
-  }, [filteredAssets, visibleIssues]);
+  }, [assignments, filteredAssets, hasLiveData, visibleIssues]);
 
   return (
     <MaintenanceControlTower
       headerLabel="Property Operations"
-      modeLabel={modeLabel}
+      modeLabel={effectiveModeLabel}
       title={title}
       subtitle={subtitle}
       actorSurfaceLabel="Property operations"
@@ -118,13 +146,12 @@ export default function PropertyMaintenanceDashboard({
       aiSummary={
         <section className="metal-card rounded-3xl p-4">
           <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-            Placeholder scope
+            {hasLiveData ? "Read-only live scope" : "Placeholder scope"}
           </div>
           <p className="mt-2 text-sm text-neutral-300">
-            This property branch is intentionally powered by static demo data.
-            It proves the operations shell, control tower, terminology, and
-            routes without property tables, RLS changes, live requests, or
-            tenant/vendor authentication.
+            {hasLiveData
+              ? "Internal staff are viewing property operations rows through Supabase RLS. This screen remains read-only: no property writes, tenant/vendor authentication, request creation, or work-order conversion is wired yet."
+              : "This property branch is intentionally powered by static demo data. It proves the operations shell, control tower, terminology, and routes while no live property rows are visible through RLS."}
           </p>
         </section>
       }
@@ -160,11 +187,14 @@ export default function PropertyMaintenanceDashboard({
             <div className="mb-3 flex items-center justify-between gap-3 border-b border-[color:var(--metal-border-soft)] pb-2">
               <div>
                 <div className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                  Demo maintenance requests
+                  {hasLiveData
+                    ? "Live maintenance requests"
+                    : "Demo maintenance requests"}
                 </div>
                 <p className="mt-1 text-xs text-neutral-400">
-                  Static property maintenance requests for architecture
-                  validation.
+                  {hasLiveData
+                    ? "Read-only property maintenance requests visible through RLS."
+                    : "Static property maintenance requests for architecture validation."}
                 </p>
               </div>
               <Link
@@ -217,7 +247,7 @@ export default function PropertyMaintenanceDashboard({
               Vendor work placeholders
             </div>
             <div className="mt-3 space-y-3">
-              {propertyDemoAssignments.map((assignment) => (
+              {assignments.map((assignment) => (
                 <div
                   key={assignment.id}
                   className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-xs"

--- a/features/property/server/propertyOperationsQueries.ts
+++ b/features/property/server/propertyOperationsQueries.ts
@@ -1,0 +1,551 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import type {
+  OperationsAsset,
+  OperationsAssignment,
+  OperationsIssue,
+  OperationsIssueSeverity,
+  OperationsIssueStatus,
+} from "@/features/operations";
+import type {
+  OperationsAssetMetadataItem,
+  OperationsAssetStat,
+} from "@/features/operations/components/OperationsAssetDetailScreen";
+
+type PropertyTable<Row> = {
+  Row: Row;
+  Insert: never;
+  Update: never;
+  Relationships: [];
+};
+
+type PropertyOperationsDatabase = {
+  public: {
+    Tables: {
+      property_properties: PropertyTable<PropertyPropertyRow>;
+      property_units: PropertyTable<PropertyUnitRow>;
+      property_assets: PropertyTable<PropertyAssetRow>;
+      property_maintenance_requests: PropertyTable<PropertyMaintenanceRequestRow>;
+      property_vendor_assignments: PropertyTable<PropertyVendorAssignmentRow>;
+      property_vendors: PropertyTable<PropertyVendorRow>;
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+};
+
+type PropertyPropertyRow = {
+  id: string;
+  name: string;
+  property_type: string | null;
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  region: string | null;
+  postal_code: string | null;
+  country: string | null;
+  status: string;
+  created_at: string;
+};
+
+type PropertyUnitRow = {
+  id: string;
+  property_id: string;
+  unit_label: string;
+  unit_type: string | null;
+  occupancy_status: string | null;
+  status: string;
+  created_at: string;
+};
+
+type PropertyAssetRow = {
+  id: string;
+  property_id: string;
+  unit_id: string | null;
+  name: string;
+  asset_type: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  serial_number: string | null;
+  install_date: string | null;
+  warranty_expires_on: string | null;
+  location_note: string | null;
+  status: string;
+  next_service_date: string | null;
+  created_at: string;
+};
+
+type PropertyMaintenanceRequestRow = {
+  id: string;
+  property_id: string;
+  unit_id: string | null;
+  asset_id: string | null;
+  requester_profile_id: string | null;
+  title: string;
+  summary: string;
+  category: string | null;
+  severity: string;
+  status: string;
+  preferred_window: string | null;
+  created_at: string;
+};
+
+type PropertyVendorAssignmentRow = {
+  id: string;
+  request_id: string | null;
+  vendor_id: string;
+  status: string;
+  scheduled_for: string | null;
+  notes: string | null;
+  created_at: string;
+};
+
+type PropertyVendorRow = {
+  id: string;
+  name: string;
+  trade: string | null;
+  contact_name: string | null;
+  status: string;
+};
+
+export type PropertyOperationsDashboardData = {
+  assets: OperationsAsset[];
+  issues: OperationsIssue[];
+  assignments: OperationsAssignment[];
+};
+
+export type PropertyAssetDetailData = {
+  asset: OperationsAsset | null;
+  metadata: OperationsAssetMetadataItem[];
+  issues: OperationsIssue[];
+  stats: OperationsAssetStat[];
+  assignments: OperationsAssignment[];
+};
+
+type PropertyQueryRows = {
+  properties: PropertyPropertyRow[];
+  units: PropertyUnitRow[];
+  assets: PropertyAssetRow[];
+  requests: PropertyMaintenanceRequestRow[];
+  vendorAssignments: PropertyVendorAssignmentRow[];
+  vendors: PropertyVendorRow[];
+};
+
+type AssetLookupEntry = {
+  asset: OperationsAsset;
+  property?: PropertyPropertyRow;
+  unit?: PropertyUnitRow;
+  rawAsset?: PropertyAssetRow;
+};
+
+function createPropertySupabaseClient() {
+  return createServerSupabaseRSC() as unknown as SupabaseClient<PropertyOperationsDatabase>;
+}
+
+export async function getPropertyOperationsDashboardData(): Promise<PropertyOperationsDashboardData> {
+  const rows = await getPropertyRows();
+  const { assets, lookup } = mapOperationsAssets(rows);
+
+  return {
+    assets,
+    issues: mapOperationsIssues(rows.requests, lookup),
+    assignments: mapOperationsAssignments(
+      rows.vendorAssignments,
+      rows.vendors,
+      rows.requests,
+      lookup,
+    ),
+  };
+}
+
+export async function getPropertyAssetDetailData(
+  assetId: string,
+): Promise<PropertyAssetDetailData> {
+  const rows = await getPropertyRows();
+  const { lookup } = mapOperationsAssets(rows);
+  const entry = lookup.get(assetId);
+
+  if (!entry) {
+    return {
+      asset: null,
+      metadata: [],
+      issues: [],
+      stats: [],
+      assignments: [],
+    };
+  }
+
+  const requests = rows.requests.filter(
+    (request) =>
+      request.asset_id === assetId ||
+      request.unit_id === assetId ||
+      request.property_id === assetId ||
+      (entry.rawAsset && request.asset_id === entry.rawAsset.id) ||
+      (entry.unit && request.unit_id === entry.unit.id) ||
+      (entry.property && request.property_id === entry.property.id),
+  );
+  const requestIds = new Set(requests.map((request) => request.id));
+  const vendorAssignments = rows.vendorAssignments.filter(
+    (assignment) =>
+      assignment.request_id && requestIds.has(assignment.request_id),
+  );
+  const issues = mapOperationsIssues(requests, lookup);
+
+  return {
+    asset: entry.asset,
+    metadata: buildAssetMetadata(entry),
+    issues,
+    stats: buildAssetStats(requests),
+    assignments: mapOperationsAssignments(
+      vendorAssignments,
+      rows.vendors,
+      rows.requests,
+      lookup,
+    ),
+  };
+}
+
+async function getPropertyRows(): Promise<PropertyQueryRows> {
+  const supabase = createPropertySupabaseClient();
+
+  const [properties, units, assets, requests, vendorAssignments, vendors] =
+    await Promise.all([
+      supabase
+        .from("property_properties")
+        .select(
+          "id,name,property_type,address_line1,address_line2,city,region,postal_code,country,status,created_at",
+        )
+        .order("name", { ascending: true }),
+      supabase
+        .from("property_units")
+        .select(
+          "id,property_id,unit_label,unit_type,occupancy_status,status,created_at",
+        )
+        .order("unit_label", { ascending: true }),
+      supabase
+        .from("property_assets")
+        .select(
+          "id,property_id,unit_id,name,asset_type,manufacturer,model,serial_number,install_date,warranty_expires_on,location_note,status,next_service_date,created_at",
+        )
+        .order("name", { ascending: true }),
+      supabase
+        .from("property_maintenance_requests")
+        .select(
+          "id,property_id,unit_id,asset_id,requester_profile_id,title,summary,category,severity,status,preferred_window,created_at",
+        )
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("property_vendor_assignments")
+        .select("id,request_id,vendor_id,status,scheduled_for,notes,created_at")
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("property_vendors")
+        .select("id,name,trade,contact_name,status")
+        .order("name", { ascending: true }),
+    ]);
+
+  logPropertyQueryError("property_properties", properties.error);
+  logPropertyQueryError("property_units", units.error);
+  logPropertyQueryError("property_assets", assets.error);
+  logPropertyQueryError("property_maintenance_requests", requests.error);
+  logPropertyQueryError("property_vendor_assignments", vendorAssignments.error);
+  logPropertyQueryError("property_vendors", vendors.error);
+
+  return {
+    properties: properties.data ?? [],
+    units: units.data ?? [],
+    assets: assets.data ?? [],
+    requests: requests.data ?? [],
+    vendorAssignments: vendorAssignments.data ?? [],
+    vendors: vendors.data ?? [],
+  };
+}
+
+function mapOperationsAssets(rows: PropertyQueryRows) {
+  const propertiesById = new Map(
+    rows.properties.map((property) => [property.id, property]),
+  );
+  const unitsById = new Map(rows.units.map((unit) => [unit.id, unit]));
+  const assets: OperationsAsset[] = [];
+  const lookup = new Map<string, AssetLookupEntry>();
+
+  for (const property of rows.properties) {
+    const asset: OperationsAsset = {
+      id: property.id,
+      label: property.name,
+      identifier: property.property_type,
+      secondaryIdentifier: formatAddress(property),
+      class: property.property_type ?? "Property",
+      location: formatLocation(property),
+      status: mapAssetStatus(property.status),
+    };
+    assets.push(asset);
+    lookup.set(property.id, { asset, property });
+  }
+
+  for (const unit of rows.units) {
+    const property = propertiesById.get(unit.property_id);
+    const asset: OperationsAsset = {
+      id: unit.id,
+      label: property
+        ? `${property.name} — ${unit.unit_label}`
+        : unit.unit_label,
+      identifier: unit.unit_label,
+      secondaryIdentifier: unit.occupancy_status,
+      class: unit.unit_type ?? "Unit",
+      location: property ? formatLocation(property) : null,
+      status: mapAssetStatus(unit.status),
+    };
+    assets.push(asset);
+    lookup.set(unit.id, { asset, property, unit });
+  }
+
+  for (const propertyAsset of rows.assets) {
+    const property = propertiesById.get(propertyAsset.property_id);
+    const unit = propertyAsset.unit_id
+      ? unitsById.get(propertyAsset.unit_id)
+      : undefined;
+    const asset: OperationsAsset = {
+      id: propertyAsset.id,
+      label: buildPropertyAssetLabel(propertyAsset, property, unit),
+      identifier: propertyAsset.serial_number ?? propertyAsset.model,
+      secondaryIdentifier:
+        propertyAsset.location_note ?? unit?.unit_label ?? null,
+      class: propertyAsset.asset_type ?? "Property Asset",
+      location: property ? formatLocation(property) : null,
+      status: mapAssetStatus(propertyAsset.status),
+      nextInspectionDate: propertyAsset.next_service_date,
+    };
+    assets.push(asset);
+    lookup.set(propertyAsset.id, {
+      asset,
+      property,
+      unit,
+      rawAsset: propertyAsset,
+    });
+  }
+
+  return { assets, lookup };
+}
+
+function mapOperationsIssues(
+  requests: PropertyMaintenanceRequestRow[],
+  lookup: Map<string, AssetLookupEntry>,
+): OperationsIssue[] {
+  return requests.map((request) => {
+    const assetEntry =
+      (request.asset_id ? lookup.get(request.asset_id) : undefined) ??
+      (request.unit_id ? lookup.get(request.unit_id) : undefined) ??
+      lookup.get(request.property_id);
+
+    return {
+      id: request.id,
+      assetId:
+        assetEntry?.asset.id ??
+        request.asset_id ??
+        request.unit_id ??
+        request.property_id,
+      assetLabel: assetEntry?.asset.label ?? "Property asset",
+      severity: mapIssueSeverity(request.severity),
+      summary: request.summary || request.title,
+      createdAt: request.created_at,
+      status: mapIssueStatus(request.status),
+    };
+  });
+}
+
+function mapOperationsAssignments(
+  assignments: PropertyVendorAssignmentRow[],
+  vendors: PropertyVendorRow[],
+  requests: PropertyMaintenanceRequestRow[],
+  lookup: Map<string, AssetLookupEntry>,
+): OperationsAssignment[] {
+  const vendorsById = new Map(vendors.map((vendor) => [vendor.id, vendor]));
+  const requestsById = new Map(
+    requests.map((request) => [request.id, request]),
+  );
+
+  return assignments.map((assignment) => {
+    const request = assignment.request_id
+      ? requestsById.get(assignment.request_id)
+      : undefined;
+    const vendor = vendorsById.get(assignment.vendor_id);
+    const assetEntry = request
+      ? ((request.asset_id ? lookup.get(request.asset_id) : undefined) ??
+        (request.unit_id ? lookup.get(request.unit_id) : undefined) ??
+        lookup.get(request.property_id))
+      : undefined;
+
+    return {
+      id: assignment.id,
+      requesterName: request?.requester_profile_id
+        ? "Property requester"
+        : "Internal staff",
+      requesterId: request?.requester_profile_id ?? "internal-staff",
+      assetLabel: assetEntry?.asset.label ?? "Property asset",
+      assetId:
+        assetEntry?.asset.id ??
+        request?.asset_id ??
+        request?.unit_id ??
+        request?.property_id ??
+        assignment.id,
+      routeLabel: vendor
+        ? `Vendor: ${vendor.name}${vendor.trade ? ` (${vendor.trade})` : ""}`
+        : "Vendor assignment",
+      nextInspectionDue: assignment.scheduled_for,
+      state: mapAssignmentState(assignment.status),
+    };
+  });
+}
+
+function buildAssetMetadata(
+  entry: AssetLookupEntry,
+): OperationsAssetMetadataItem[] {
+  const metadata: OperationsAssetMetadataItem[] = [];
+
+  if (entry.property) {
+    metadata.push({ label: "Property", value: entry.property.name });
+    metadata.push({ label: "Address", value: formatAddress(entry.property) });
+  }
+
+  if (entry.unit) {
+    metadata.push({ label: "Unit", value: entry.unit.unit_label });
+    metadata.push({ label: "Occupancy", value: entry.unit.occupancy_status });
+  }
+
+  if (entry.rawAsset) {
+    metadata.push({ label: "Asset Type", value: entry.rawAsset.asset_type });
+    metadata.push({
+      label: "Manufacturer",
+      value: entry.rawAsset.manufacturer,
+    });
+    metadata.push({ label: "Model", value: entry.rawAsset.model });
+    metadata.push({
+      label: "Serial",
+      value: entry.rawAsset.serial_number,
+      mono: true,
+    });
+    metadata.push({
+      label: "Location Note",
+      value: entry.rawAsset.location_note,
+    });
+    metadata.push({
+      label: "Warranty Expires",
+      value: entry.rawAsset.warranty_expires_on,
+    });
+  }
+
+  return metadata.filter((item) => item.value);
+}
+
+function buildAssetStats(
+  requests: PropertyMaintenanceRequestRow[],
+): OperationsAssetStat[] {
+  return [
+    {
+      label: "Open Requests",
+      value: requests.filter(
+        (request) => mapIssueStatus(request.status) === "open",
+      ).length,
+      helper: "Live property requests visible through RLS",
+    },
+    {
+      label: "Pending Approvals",
+      value: requests.filter(
+        (request) => request.status === "approval_required",
+      ).length,
+      helper: "Approval-required property requests",
+    },
+    {
+      label: "Scheduled Work",
+      value: requests.filter(
+        (request) => mapIssueStatus(request.status) === "scheduled",
+      ).length,
+      helper: "Assigned, scheduled, or in-progress requests",
+    },
+    {
+      label: "Completed Requests",
+      value: requests.filter(
+        (request) => mapIssueStatus(request.status) === "completed",
+      ).length,
+      helper: "Completed or cancelled requests",
+    },
+  ];
+}
+
+function mapAssetStatus(status: string): OperationsAsset["status"] {
+  const normalized = status.toLowerCase();
+  if (normalized === "limited") return "limited";
+  if (normalized === "offline" || normalized === "retired") return "offline";
+  return "active";
+}
+
+function mapIssueSeverity(severity: string): OperationsIssueSeverity {
+  const normalized = severity.toLowerCase();
+  if (normalized === "emergency") return "safety";
+  if (normalized === "urgent") return "urgent";
+  return "recommend";
+}
+
+function mapIssueStatus(status: string): OperationsIssueStatus {
+  const normalized = status.toLowerCase();
+  if (normalized === "completed" || normalized === "cancelled")
+    return "completed";
+  if (["assigned", "scheduled", "in_progress"].includes(normalized))
+    return "scheduled";
+  return "open";
+}
+
+function mapAssignmentState(status: string): OperationsAssignment["state"] {
+  const normalized = status.toLowerCase();
+  if (["blocked", "cancelled"].includes(normalized)) return "blocked";
+  if (["in_progress", "scheduled", "assigned"].includes(normalized))
+    return "in_progress";
+  if (normalized === "completed") return "in_service";
+  return "active";
+}
+
+function buildPropertyAssetLabel(
+  asset: PropertyAssetRow,
+  property?: PropertyPropertyRow,
+  unit?: PropertyUnitRow,
+) {
+  if (property && unit)
+    return `${property.name} — ${unit.unit_label} — ${asset.name}`;
+  if (property) return `${property.name} — ${asset.name}`;
+  return asset.name;
+}
+
+function formatLocation(property: PropertyPropertyRow) {
+  return (
+    [property.city, property.region].filter(Boolean).join(", ") ||
+    property.country
+  );
+}
+
+function formatAddress(property: PropertyPropertyRow) {
+  return [
+    property.address_line1,
+    property.address_line2,
+    property.city,
+    property.region,
+    property.postal_code,
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
+
+function logPropertyQueryError(
+  table: string,
+  error: { message: string } | null,
+) {
+  if (error) {
+    console.warn(
+      `Unable to load ${table} for property operations dashboard: ${error.message}`,
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Enable internal staff to view property operations data through Supabase using the logged-in user's RLS context while keeping the existing static demo surface when no live rows are visible.
- Deliver read-only server-side queries for the property dashboard and asset detail to prepare for later write/auth/work-order integration without changing schema or adding API routes.

### Description
- Added a new server module `features/property/server/propertyOperationsQueries.ts` that uses the existing `createServerSupabaseRSC()` pattern to perform RLS-backed reads and exports `getPropertyOperationsDashboardData()` and `getPropertyAssetDetailData()` which map property tables into `OperationsAsset[]`, `OperationsIssue[]`, and `OperationsAssignment[]` shapes.
- Implemented mapping/normalization rules for asset statuses (`active|limited|offline`), request severities (`safety|urgent|recommend`), and request statuses (`open|scheduled|completed`) and added simple asset stats (open, pending approvals, scheduled, completed) without calculating spend.
- Wired server-side data loading into the app routes `app/property/page.tsx` and `app/property/assets/[id]/page.tsx` and updated `PropertyMaintenanceDashboard` and `PropertyAssetDetailDemo` to accept optional `liveData` props and gracefully fall back to the existing static demo data when no live rows or matching assets are returned.
- Confirmed no writes, no DB schema changes, no tenant/vendor auth, and no new API routes were introduced; the server module only issues `.select()` queries through the logged-in Supabase client.
- Files changed: `features/property/server/propertyOperationsQueries.ts`, `app/property/page.tsx`, `app/property/assets/[id]/page.tsx`, `features/property/components/PropertyMaintenanceDashboard.tsx`, and `features/property/components/PropertyAssetDetailDemo.tsx`.

### Testing
- Ran `npm run typecheck` (which completed successfully) to ensure no TypeScript errors.
- Ran targeted ESLint on the changed files via `npx eslint app/property/page.tsx app/property/assets/[id]/page.tsx features/property/components/PropertyMaintenanceDashboard.tsx features/property/components/PropertyAssetDetailDemo.tsx features/property/server/propertyOperationsQueries.ts` and it passed without errors.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b99e0dcb48328ad8ec0dd59f43f15)