### PR TITLE
Step 11B: add create forms for property portfolios and properties

### DIFF
--- a/app/property/setup/page.tsx
+++ b/app/property/setup/page.tsx
@@ -2,6 +2,7 @@ import "server-only";
 
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
 
@@ -48,12 +49,15 @@ type PropertyRow = {
 
 type PropertyInsert = {
   shop_id: string;
-  portfolio_id: string;
+  portfolio_id?: string | null;
   name: string;
-  property_type: string;
-  city: string;
-  region: string;
-  country: string;
+  property_type?: string | null;
+  address_line1?: string | null;
+  address_line2?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postal_code?: string | null;
+  country?: string | null;
   status?: string;
 };
 
@@ -384,6 +388,134 @@ async function createPropertyDemoDataset() {
   redirect("/property/setup?status=created");
 }
 
+async function createPropertyPortfolio(formData: FormData) {
+  "use server";
+  const supabase = createPropertySetupClient();
+  const { user, profile } = await getCurrentProfile(supabase);
+  if (!user) redirect("/sign-in");
+  const shopId = profile?.shop_id;
+  if (!shopId) redirect("/property/setup?status=missing-shop");
+
+  const name = String(formData.get("name") ?? "").trim();
+  const descriptionRaw = String(formData.get("description") ?? "").trim();
+  const description = descriptionRaw.length > 0 ? descriptionRaw : null;
+
+  if (!name) {
+    redirect("/property/setup?status=validation-error&message=Portfolio%20name%20is%20required.");
+  }
+
+  const { data: duplicate, error: duplicateError } = await supabase
+    .from("property_portfolios")
+    .select("id")
+    .eq("shop_id", shopId)
+    .eq("name", name)
+    .maybeSingle();
+
+  if (duplicateError) {
+    redirect(
+      `/property/setup?status=error&message=${encodeURIComponent(duplicateError.message)}`,
+    );
+  }
+
+  if (duplicate) {
+    redirect(
+      "/property/setup?status=validation-error&message=Portfolio%20name%20already%20exists%20for%20this%20shop.",
+    );
+  }
+
+  const { error } = await supabase.from("property_portfolios").insert({
+    shop_id: shopId,
+    name,
+    description,
+  });
+
+  if (error) {
+    redirect(
+      `/property/setup?status=error&message=${encodeURIComponent(error.message)}`,
+    );
+  }
+
+  revalidatePath("/property");
+  revalidatePath("/property/setup");
+  redirect("/property/setup?status=portfolio-created");
+}
+
+async function createPropertyProperty(formData: FormData) {
+  "use server";
+  const supabase = createPropertySetupClient();
+  const { user, profile } = await getCurrentProfile(supabase);
+  if (!user) redirect("/sign-in");
+  const shopId = profile?.shop_id;
+  if (!shopId) redirect("/property/setup?status=missing-shop");
+
+  const portfolioIdRaw = String(formData.get("portfolio_id") ?? "").trim();
+  const portfolioId = portfolioIdRaw.length > 0 ? portfolioIdRaw : null;
+  const name = String(formData.get("name") ?? "").trim();
+  const propertyType = String(formData.get("property_type") ?? "").trim() || null;
+  const addressLine1 = String(formData.get("address_line1") ?? "").trim() || null;
+  const addressLine2 = String(formData.get("address_line2") ?? "").trim() || null;
+  const city = String(formData.get("city") ?? "").trim() || null;
+  const region = String(formData.get("region") ?? "").trim() || null;
+  const postalCode = String(formData.get("postal_code") ?? "").trim() || null;
+  const country = String(formData.get("country") ?? "").trim() || "CA";
+  const status = String(formData.get("status") ?? "active").trim() || "active";
+
+  if (!name) {
+    redirect("/property/setup?status=validation-error&message=Property%20name%20is%20required.");
+  }
+
+  if (!["active", "limited", "inactive"].includes(status)) {
+    redirect(
+      "/property/setup?status=validation-error&message=Property%20status%20must%20be%20active%2C%20limited%2C%20or%20inactive.",
+    );
+  }
+
+  if (portfolioId) {
+    const { data: portfolio, error: portfolioError } = await supabase
+      .from("property_portfolios")
+      .select("id,shop_id")
+      .eq("id", portfolioId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+
+    if (portfolioError) {
+      redirect(
+        `/property/setup?status=error&message=${encodeURIComponent(portfolioError.message)}`,
+      );
+    }
+
+    if (!portfolio) {
+      redirect(
+        "/property/setup?status=validation-error&message=Selected%20portfolio%20is%20not%20available%20for%20this%20shop.",
+      );
+    }
+  }
+
+  const { error } = await supabase.from("property_properties").insert({
+    shop_id: shopId,
+    portfolio_id: portfolioId,
+    name,
+    property_type: propertyType,
+    address_line1: addressLine1,
+    address_line2: addressLine2,
+    city,
+    region,
+    postal_code: postalCode,
+    country,
+    status,
+  });
+
+  if (error) {
+    redirect(
+      `/property/setup?status=error&message=${encodeURIComponent(error.message)}`,
+    );
+  }
+
+  revalidatePath("/property");
+  revalidatePath("/property/setup");
+  redirect("/property/setup?status=property-created");
+}
+
 export default async function PropertySetupPage({
   searchParams,
 }: SetupPageProps) {
@@ -584,6 +716,93 @@ export default async function PropertySetupPage({
           </p>
         </section>
 
+        {hasShop ? (
+          <section className="grid gap-4 md:grid-cols-2">
+            <article className="metal-card rounded-3xl p-5">
+              <h2 className="text-base font-semibold text-neutral-100">
+                Create portfolio
+              </h2>
+              <form action={createPropertyPortfolio} className="mt-4 space-y-3">
+                <label className="block text-xs uppercase tracking-[0.14em] text-neutral-400">
+                  Name
+                  <input
+                    name="name"
+                    required
+                    className="mt-2 w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2"
+                  />
+                </label>
+                <label className="block text-xs uppercase tracking-[0.14em] text-neutral-400">
+                  Description (optional)
+                  <textarea
+                    name="description"
+                    rows={3}
+                    className="mt-2 w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2"
+                  />
+                </label>
+                <button
+                  type="submit"
+                  className="rounded-full bg-[color:var(--accent-copper)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-black transition hover:brightness-110"
+                >
+                  Create portfolio
+                </button>
+              </form>
+            </article>
+
+            <article className="metal-card rounded-3xl p-5">
+              <h2 className="text-base font-semibold text-neutral-100">
+                Create property
+              </h2>
+              <form action={createPropertyProperty} className="mt-4 space-y-3">
+                <label className="block text-xs uppercase tracking-[0.14em] text-neutral-400">
+                  Portfolio (optional)
+                  <select
+                    name="portfolio_id"
+                    defaultValue=""
+                    className="mt-2 w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2"
+                  >
+                    <option value="">No portfolio</option>
+                    {(portfoliosResult?.data ?? []).map((portfolio) => (
+                      <option key={portfolio.id} value={portfolio.id}>
+                        {portfolio.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block text-xs uppercase tracking-[0.14em] text-neutral-400">
+                  Name
+                  <input
+                    name="name"
+                    required
+                    className="mt-2 w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2"
+                  />
+                </label>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <input name="property_type" placeholder="Property type" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                  <input name="address_line1" placeholder="Address line 1" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                  <input name="address_line2" placeholder="Address line 2" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                  <input name="city" placeholder="City" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                  <input name="region" placeholder="Region / province" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                  <input name="postal_code" placeholder="Postal code" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <input name="country" defaultValue="CA" placeholder="Country" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2" />
+                  <select name="status" defaultValue="active" className="rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2 text-sm text-neutral-100 outline-none ring-[color:var(--accent-copper)]/50 transition focus:ring-2">
+                    <option value="active">active</option>
+                    <option value="limited">limited</option>
+                    <option value="inactive">inactive</option>
+                  </select>
+                </div>
+                <button
+                  type="submit"
+                  className="rounded-full bg-[color:var(--accent-copper)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-black transition hover:brightness-110"
+                >
+                  Create property
+                </button>
+              </form>
+            </article>
+          </section>
+        ) : null}
+
         {status ? (
           <SetupStatusCard status={status} message={message} />
         ) : null}
@@ -683,6 +902,39 @@ function SetupStatusCard({
         <p className="mt-2 text-amber-100/80">
           Your authenticated profile does not have a shop_id, so setup did not
           insert property data.
+        </p>
+      </section>
+    );
+  }
+
+  if (status === "portfolio-created") {
+    return (
+      <section className="rounded-3xl border border-emerald-400/30 bg-emerald-500/10 p-5 text-sm text-emerald-100">
+        <div className="font-semibold">Portfolio created.</div>
+        <p className="mt-2 text-emerald-100/80">
+          The new portfolio is now available in setup overview and property creation.
+        </p>
+      </section>
+    );
+  }
+
+  if (status === "property-created") {
+    return (
+      <section className="rounded-3xl border border-emerald-400/30 bg-emerald-500/10 p-5 text-sm text-emerald-100">
+        <div className="font-semibold">Property created.</div>
+        <p className="mt-2 text-emerald-100/80">
+          The new property is now available in setup overview for this shop.
+        </p>
+      </section>
+    );
+  }
+
+  if (status === "validation-error") {
+    return (
+      <section className="rounded-3xl border border-amber-400/30 bg-amber-500/10 p-5 text-sm text-amber-100">
+        <div className="font-semibold">Validation error.</div>
+        <p className="mt-2 text-amber-100/80">
+          {message ?? "Please review form values and try again."}
         </p>
       </section>
     );

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -88,3 +88,16 @@ Any future schema expansion should be documented and applied manually.
 - Create forms for setup entities are still pending.
 - No tenant/vendor auth wiring was added.
 - No request-to-work-order conversion was added.
+
+## Step 11B: Property setup create forms (portfolio + property only)
+
+- `/property/setup` now includes internal create forms for:
+  - Property portfolios
+  - Properties
+- Portfolio creation supports required `name` and optional `description`, scoped to `profile.shop_id`.
+- Property creation supports optional portfolio selection plus property address/status fields, with server-side validation and RLS-visible portfolio checks.
+- Setup status handling now includes `portfolio-created`, `property-created`, and `validation-error`.
+- Unit, asset, and vendor create forms are still pending for a later step.
+- No tenant/vendor auth wiring was added.
+- No request-to-work-order conversion was added.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Expand the Property Setup workspace to allow internal staff to create portfolios and properties during Step 11B while keeping the change small and non-breaking.
- Preserve existing constraints: use `profile.shop_id` for scoping, avoid schema/service-role/tenant/vendor changes, and keep demo seed behavior intact.

### Description
- Added two server actions in `app/property/setup/page.tsx`: `createPropertyPortfolio(formData)` and `createPropertyProperty(formData)` that require an authenticated user and derive `shop_id` only from `profile.shop_id` before inserting.
- Implemented server-side validation including non-empty `name` for both entities, duplicate-name check for portfolios, allowed `status` enum (`active|limited|inactive`) for properties, and RLS-visible portfolio ownership check when a `portfolio_id` is provided.
- Added compact dark/copper UI cards and forms on `/property/setup` for creating portfolios (name + optional description) and properties (optional portfolio dropdown, name, property/address fields, country default `CA`, status default `active`) and call the new server actions.
- On success the actions call `revalidatePath('/property')` and `revalidatePath('/property/setup')` then redirect back to `/property/setup` with status query params; the status card was extended to include `portfolio-created`, `property-created`, and `validation-error` while preserving existing demo statuses.
- Updated `features/operations/README.md` with Step 11B notes and explicitly document that unit/asset/vendor forms, tenant/vendor auth, request-to-work-order conversion, service role usage, and schema changes are not included.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npx eslint app/property/setup/page.tsx` and it passed for the modified TSX file.
- Ran `npx eslint app/property/setup/page.tsx features/operations/README.md` which reported a parse error for the README (the README file is not parseable by the current ESLint parser), so combined linting for both files failed due to the README parse error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7272ef5c832890c6c2995784ca09)