### PR TITLE
Add internal vendor assignment on property request detail (Step 12)

### DIFF
--- a/app/property/requests/[id]/page.tsx
+++ b/app/property/requests/[id]/page.tsx
@@ -8,7 +8,7 @@ import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
 
 type RequestStatus = "open" | "triaged" | "approval_required" | "assigned" | "scheduled" | "in_progress" | "completed" | "cancelled";
 const ALLOWED_STATUSES: RequestStatus[] = ["open", "triaged", "approval_required", "assigned", "scheduled", "in_progress", "completed", "cancelled"];
-type DB = { public: { Tables: { profiles: { Row: { id: string; shop_id: string | null } }; property_maintenance_requests: { Row: { id: string; shop_id: string; property_id: string; unit_id: string | null; asset_id: string | null; requester_profile_id: string | null; title: string; summary: string; category: string | null; severity: string; status: string; source: string; access_notes: string | null; preferred_window: string | null; work_order_id: string | null; created_at: string } }; property_properties: { Row: { id: string; name: string } }; property_units: { Row: { id: string; unit_label: string } }; property_assets: { Row: { id: string; name: string } }; property_vendor_assignments: { Row: { id: string; request_id: string | null; vendor_id: string; status: string } }; property_vendors: { Row: { id: string; name: string; trade: string | null } }; } } };
+type DB = { public: { Tables: { profiles: { Row: { id: string; shop_id: string | null } }; property_maintenance_requests: { Row: { id: string; shop_id: string; property_id: string; unit_id: string | null; asset_id: string | null; requester_profile_id: string | null; title: string; summary: string; category: string | null; severity: string; status: string; source: string; access_notes: string | null; preferred_window: string | null; work_order_id: string | null; created_at: string } }; property_properties: { Row: { id: string; name: string } }; property_units: { Row: { id: string; unit_label: string } }; property_assets: { Row: { id: string; name: string } }; property_vendor_assignments: { Row: { id: string; request_id: string | null; vendor_id: string; status: string; scheduled_for: string | null; notes: string | null; created_at: string } }; property_vendors: { Row: { id: string; shop_id: string; name: string; trade: string | null } }; } } };
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
 const parseStatus = (v: FormDataEntryValue | null) => (typeof v === "string" && ALLOWED_STATUSES.includes(v.trim() as RequestStatus) ? (v.trim() as RequestStatus) : null);
 
@@ -37,10 +37,65 @@ export async function updatePropertyMaintenanceRequestStatus(formData: FormData)
   redirect(`/property/requests/${requestId}`);
 }
 
+
+
+export async function assignPropertyVendorToRequest(formData: FormData) {
+  "use server";
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+  const { data: profile } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
+  if (!profile?.shop_id) redirect("/property?error=" + encodeURIComponent("Missing shop context."));
+
+  const requestId = typeof formData.get("request_id") === "string" ? String(formData.get("request_id")).trim() : "";
+  const vendorId = typeof formData.get("vendor_id") === "string" ? String(formData.get("vendor_id")).trim() : "";
+  const scheduledInput = typeof formData.get("scheduled_for") === "string" ? String(formData.get("scheduled_for")).trim() : "";
+  const notesInput = typeof formData.get("notes") === "string" ? String(formData.get("notes")).trim() : "";
+
+  if (!requestId) redirect("/property?error=" + encodeURIComponent("Missing request id."));
+  if (!vendorId) redirect(`/property/requests/${requestId}?error=${encodeURIComponent("Vendor is required.")}`);
+
+  const { data: requestRow } = await supabase.from("property_maintenance_requests").select("id,shop_id").eq("id", requestId).maybeSingle();
+  if (!requestRow) redirect("/property?error=" + encodeURIComponent("Request not found or not visible."));
+  if (requestRow.shop_id !== profile.shop_id) redirect("/property?error=" + encodeURIComponent("Unauthorized shop scope for request."));
+
+  const { data: vendorRow } = await supabase.from("property_vendors").select("id,shop_id").eq("id", vendorId).maybeSingle();
+  if (!vendorRow) redirect(`/property/requests/${requestId}?error=${encodeURIComponent("Vendor not found or not visible.")}`);
+  if (vendorRow.shop_id !== profile.shop_id) redirect(`/property/requests/${requestId}?error=${encodeURIComponent("Vendor does not belong to your shop scope.")}`);
+
+  const { data: duplicate } = await supabase
+    .from("property_vendor_assignments")
+    .select("id")
+    .eq("request_id", requestId)
+    .eq("vendor_id", vendorId)
+    .in("status", ["assigned", "scheduled", "in_progress"])
+    .limit(1)
+    .maybeSingle();
+  if (duplicate) redirect(`/property/requests/${requestId}?status=vendor-already-assigned`);
+
+  const scheduledFor = scheduledInput ? scheduledInput : null;
+  const notes = notesInput ? notesInput : null;
+
+  const { error: insertError } = await supabase.from("property_vendor_assignments").insert({
+    shop_id: profile.shop_id,
+    request_id: requestId,
+    vendor_id: vendorId,
+    status: "assigned",
+    scheduled_for: scheduledFor,
+    notes,
+  });
+  if (insertError) redirect(`/property/requests/${requestId}?error=${encodeURIComponent(`Unable to assign vendor: ${insertError.message}`)}`);
+
+  revalidatePath("/property");
+  revalidatePath(`/property/requests/${requestId}`);
+  redirect(`/property/requests/${requestId}`);
+}
+
 export default async function Page({ params, searchParams }: { params: Promise<{ id: string }>; searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const { id } = await params;
   const p = (await searchParams) ?? {};
   const err = Array.isArray(p.error) ? p.error[0] : p.error;
+  const status = Array.isArray(p.status) ? p.status[0] : p.status;
 
   const supabase = client();
   const { data: { user } } = await supabase.auth.getUser();
@@ -51,15 +106,16 @@ export default async function Page({ params, searchParams }: { params: Promise<{
   const { data: requestRow } = await supabase.from("property_maintenance_requests").select("id,shop_id,property_id,unit_id,asset_id,requester_profile_id,title,summary,category,severity,status,source,access_notes,preferred_window,work_order_id,created_at").eq("id", id).maybeSingle();
   if (!requestRow || requestRow.shop_id !== profile.shop_id) return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><div className="text-xs uppercase tracking-[0.16em] text-neutral-500">Property request detail</div><h1 className="mt-2 text-2xl font-semibold">Request not found or unauthorized</h1><p className="mt-2 text-sm text-neutral-300">The requested maintenance record is not visible for your current access scope.</p><Link href="/property" className="mt-4 inline-flex text-sm underline">Back to property dashboard</Link></div></main>;
 
-  const [{ data: property }, { data: unit }, { data: asset }, { data: assignment }] = await Promise.all([
+  const [{ data: property }, { data: unit }, { data: asset }, { data: assignment }, { data: vendors }] = await Promise.all([
     supabase.from("property_properties").select("id,name").eq("id", requestRow.property_id).maybeSingle(),
     requestRow.unit_id ? supabase.from("property_units").select("id,unit_label").eq("id", requestRow.unit_id).maybeSingle() : Promise.resolve({ data: null }),
     requestRow.asset_id ? supabase.from("property_assets").select("id,name").eq("id", requestRow.asset_id).maybeSingle() : Promise.resolve({ data: null }),
-    supabase.from("property_vendor_assignments").select("id,request_id,vendor_id,status").eq("request_id", requestRow.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    supabase.from("property_vendor_assignments").select("id,request_id,vendor_id,status,scheduled_for,notes,created_at").eq("request_id", requestRow.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    supabase.from("property_vendors").select("id,shop_id,name,trade").eq("shop_id", profile.shop_id).order("name", { ascending: true }),
   ]);
   const vendor = assignment?.vendor_id ? (await supabase.from("property_vendors").select("id,name,trade").eq("id", assignment.vendor_id).maybeSingle()).data : null;
 
-  return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><div className="mb-4 flex items-center justify-between gap-2"><div><div className="text-xs uppercase tracking-[0.16em] text-neutral-500">Internal only · Property request detail</div><h1 className="mt-1 text-2xl font-semibold">{requestRow.title}</h1></div><Link href="/property" className="text-xs underline">Back to dashboard</Link></div>{err ? <div className="mb-4 rounded border border-rose-400/30 bg-rose-500/10 p-2 text-sm">{err}</div> : null}<div className="grid gap-3 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4 text-sm md:grid-cols-2"><Field label="Summary" value={requestRow.summary} wide /><Field label="Status" value={requestRow.status} /><Field label="Severity" value={requestRow.severity} /><Field label="Category" value={requestRow.category ?? "—"} /><Field label="Source" value={requestRow.source} /><Field label="Created" value={new Date(requestRow.created_at).toLocaleString()} /><Field label="Preferred window" value={requestRow.preferred_window ?? "—"} /><Field label="Access notes" value={requestRow.access_notes ?? "—"} /><Field label="Property" value={property?.name ?? requestRow.property_id} /><Field label="Unit" value={unit?.unit_label ?? "—"} /><Field label="Asset" value={asset?.name ?? "—"} /><Field label="Requester profile" value={requestRow.requester_profile_id ?? "—"} /><Field label="Vendor assignment" value={assignment ? `${vendor?.name ?? assignment.vendor_id} (${assignment.status})` : "—"} /><Field label="Work order" value={requestRow.work_order_id ?? "—"} /></div><form action={updatePropertyMaintenanceRequestStatus} className="mt-4 flex flex-wrap items-center gap-2 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4"><input type="hidden" name="request_id" value={requestRow.id} /><label className="text-xs uppercase tracking-[0.12em] text-neutral-400" htmlFor="status">Update status</label><select id="status" name="status" defaultValue={requestRow.status} className="rounded border bg-black/50 p-2 text-sm">{ALLOWED_STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}</select><button type="submit" className="rounded-full border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 text-xs font-semibold uppercase">Save status</button></form></div></main>;
+  return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><div className="mb-4 flex items-center justify-between gap-2"><div><div className="text-xs uppercase tracking-[0.16em] text-neutral-500">Internal only · Property request detail</div><h1 className="mt-1 text-2xl font-semibold">{requestRow.title}</h1></div><Link href="/property" className="text-xs underline">Back to dashboard</Link></div>{err ? <div className="mb-4 rounded border border-rose-400/30 bg-rose-500/10 p-2 text-sm">{err}</div> : null}{status === "vendor-already-assigned" ? <div className="mb-4 rounded border border-amber-300/40 bg-amber-500/10 p-2 text-sm text-amber-100">This vendor is already actively assigned to this request.</div> : null}<div className="grid gap-3 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4 text-sm md:grid-cols-2"><Field label="Summary" value={requestRow.summary} wide /><Field label="Status" value={requestRow.status} /><Field label="Severity" value={requestRow.severity} /><Field label="Category" value={requestRow.category ?? "—"} /><Field label="Source" value={requestRow.source} /><Field label="Created" value={new Date(requestRow.created_at).toLocaleString()} /><Field label="Preferred window" value={requestRow.preferred_window ?? "—"} /><Field label="Access notes" value={requestRow.access_notes ?? "—"} /><Field label="Property" value={property?.name ?? requestRow.property_id} /><Field label="Unit" value={unit?.unit_label ?? "—"} /><Field label="Asset" value={asset?.name ?? "—"} /><Field label="Requester profile" value={requestRow.requester_profile_id ?? "—"} /><Field label="Vendor assignment" value={assignment ? `${vendor?.name ?? assignment.vendor_id} (${assignment.status})` : "—"} /><Field label="Work order" value={requestRow.work_order_id ?? "—"} /></div><form action={updatePropertyMaintenanceRequestStatus} className="mt-4 flex flex-wrap items-center gap-2 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4"><input type="hidden" name="request_id" value={requestRow.id} /><label className="text-xs uppercase tracking-[0.12em] text-neutral-400" htmlFor="status">Update status</label><select id="status" name="status" defaultValue={requestRow.status} className="rounded border bg-black/50 p-2 text-sm">{ALLOWED_STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}</select><button type="submit" className="rounded-full border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 text-xs font-semibold uppercase">Save status</button></form><section className="mt-4 rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/40 p-4"><h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-neutral-200">Vendor assignment</h2><p className="mt-2 text-xs text-neutral-400">Vendor contacts are records only. Vendor portal access is not wired yet.</p>{assignment ? <div className="mt-3 grid gap-2 rounded-xl border border-[color:var(--metal-border-soft)] bg-black/30 p-3 text-sm md:grid-cols-2"><Field label="Vendor" value={vendor?.name ?? assignment.vendor_id} /><Field label="Trade" value={vendor?.trade ?? "—"} /><Field label="Status" value={assignment.status} /><Field label="Scheduled for" value={assignment.scheduled_for ? new Date(assignment.scheduled_for).toLocaleString() : "—"} /><Field label="Notes" value={assignment.notes ?? "—"} wide /></div> : <p className="mt-3 text-sm text-neutral-300">No vendor assignment yet.</p>}{(vendors?.length ?? 0) === 0 ? <p className="mt-3 text-sm text-neutral-300">Create a vendor in Property Setup first. <Link href="/property/setup" className="underline">Go to Property Setup</Link>.</p> : <form action={assignPropertyVendorToRequest} className="mt-3 grid gap-3"><input type="hidden" name="request_id" value={requestRow.id} /><label className="grid gap-1 text-xs uppercase tracking-[0.12em] text-neutral-400" htmlFor="vendor_id">Vendor<select id="vendor_id" name="vendor_id" required className="rounded border bg-black/50 p-2 text-sm"><option value="">Select vendor</option>{vendors?.map((v) => <option key={v.id} value={v.id}>{v.name}{v.trade ? ` (${v.trade})` : ""}</option>)}</select></label><label className="grid gap-1 text-xs uppercase tracking-[0.12em] text-neutral-400" htmlFor="scheduled_for">Scheduled for (optional)<input id="scheduled_for" name="scheduled_for" type="datetime-local" className="rounded border bg-black/50 p-2 text-sm" /></label><label className="grid gap-1 text-xs uppercase tracking-[0.12em] text-neutral-400" htmlFor="notes">Notes (optional)<textarea id="notes" name="notes" rows={3} className="rounded border bg-black/50 p-2 text-sm" /></label><div><button type="submit" className="rounded-full border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 text-xs font-semibold uppercase">Assign vendor</button></div></form>}</section></div></main>;
 }
 
 function Field({ label, value, wide = false }: { label: string; value: string; wide?: boolean }) {

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -124,3 +124,13 @@ Any future schema expansion should be documented and applied manually.
 - No tenant/vendor auth wiring was added.
 - No request-to-work-order conversion was added.
 - No schema or migration changes were introduced in this step.
+
+## Step 12: Internal vendor assignment on property request detail
+
+- `/property/requests/[id]` now supports internal-only vendor assignment using RLS-visible vendor records.
+- Assignment captures vendor, optional scheduled datetime, and optional notes into `property_vendor_assignments` with assigned status.
+- Request detail now shows the latest/current vendor assignment summary and an internal assignment form.
+- Vendor contacts remain records only in this step: no vendor portal behavior, no vendor auth, and no vendor-user linking were added.
+- No tenant auth changes were added.
+- No request-to-work-order conversion was added.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Provide internal staff the ability to assign vendors to a property maintenance request from the request detail page while preserving tenant/shop scoping and RLS visibility.
- Keep the change conservative and internal-only: no vendor portal, no vendor auth/linking, no request→work-order conversion, and no DB schema changes.

### Description
- Added a server action `assignPropertyVendorToRequest(formData)` in `app/property/requests/[id]/page.tsx` that requires an authenticated user, loads the current `profiles` row, verifies `profile.shop_id`, validates RLS visibility and `shop_id` scope for both the request and vendor, trims optional `scheduled_for`/`notes`, inserts into `property_vendor_assignments` using `shop_id` from the profile, revalidates paths, and redirects back to the request detail.
- Prevents duplicate active assignments for the same vendor by redirecting with `status=vendor-already-assigned` when an active assignment exists.
- UI changes on `/property/requests/[id]`: new "Vendor assignment" section that shows the latest/current assignment (vendor name, trade, status, scheduled_for, notes), an internal assignment form (vendor dropdown, `datetime-local` scheduled input, notes textarea, hidden `request_id`), an empty-state directing users to `/property/setup` when no vendors exist, and a note that vendor portal access is not wired yet.
- Fetches visible `property_vendors` scoped to `profile.shop_id` and the latest `property_vendor_assignments` for display.
- Documentation: appended Step 12 to `features/operations/README.md` describing the feature and explicit non-goals.
- Guardrails maintained: no schema/migration changes, no use of service role, and no tenant/vendor auth or request→work-order conversion added.

### Testing
- Ran `npm run typecheck` (which runs `tsc --noEmit`) and it succeeded.
- Ran `npx eslint app/property/requests/[id]/page.tsx` and it succeeded for the modified TSX file.
- Running `npx eslint app/property/requests/[id]/page.tsx features/operations/README.md` produced a parsing error for the markdown file because it is not a JS/TS lint target in the current config; this is an expected tooling mismatch and does not affect runtime or TypeScript validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7856d7248328b52a4dff532cd51d)