### PR TITLE
Add Property Maintenance Context card to linked work orders

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -80,6 +80,22 @@ type WorkOrderLineWithInspectionMeta = WorkOrderLine & {
 };
 type JobLinePriority = "low" | "normal" | "high" | "urgent";
 
+
+type PropertyContext = {
+  requestId: string;
+  requestTitle: string | null;
+  requestStatus: string | null;
+  severity: string | null;
+  category: string | null;
+  preferredWindow: string | null;
+  accessNotes: string | null;
+  propertyName: string | null;
+  unitLabel: string | null;
+  assetName: string | null;
+  assetType: string | null;
+  latestVendorAssignment: string | null;
+};
+
 const looksLikeUuid = (s: string) => s.includes("-") && s.length >= 36;
 
 function splitCustomId(raw: string): { prefix: string; n: number | null } {
@@ -247,6 +263,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const [reviewIssuesByLine, setReviewIssuesByLine] = useState<Record<string, ReviewIssue[]>>(
     {},
   );
+  const [propertyContext, setPropertyContext] = useState<PropertyContext | null>(null);
 
   // ✅ read job from query (desktop panel)
   const jobFromQuery = searchParams?.get("job") || null;
@@ -501,7 +518,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           setWarnedMissing(true);
         }
 
-        const [linesRes, quoteRes, vehRes, custRes, shopRes] = await Promise.all([
+        const [linesRes, quoteRes, vehRes, custRes, shopRes, propertyReqRes] = await Promise.all([
           supabase
             .from("work_order_lines")
             .select("*")
@@ -533,6 +550,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                 .eq("id", woRow.shop_id)
                 .maybeSingle<WorkOrderShopRateRow>()
             : Promise.resolve({ data: null, error: null } as const),
+          supabase
+            .from("property_maintenance_requests")
+            .select("*")
+            .eq("work_order_id", woRow.id)
+            .maybeSingle(),
         ]);
 
         if (linesRes.error) throw linesRes.error;
@@ -555,6 +577,64 @@ export default function WorkOrderIdClient(): JSX.Element {
             ? shopRes.data.labor_rate
             : null,
         );
+
+        if (propertyReqRes?.error) throw propertyReqRes.error;
+        const propertyRequest = (propertyReqRes?.data as Record<string, unknown> | null) ?? null;
+        if (!propertyRequest) {
+          setPropertyContext(null);
+        } else {
+          const requestId = String(propertyRequest.id ?? "");
+          const [propertyRes, unitRes, assetRes, assignmentRes] = await Promise.all([
+            propertyRequest.property_id
+              ? supabase.from("property_properties").select("name").eq("id", String(propertyRequest.property_id)).maybeSingle()
+              : Promise.resolve({ data: null, error: null } as const),
+            propertyRequest.unit_id
+              ? supabase.from("property_units").select("label").eq("id", String(propertyRequest.unit_id)).maybeSingle()
+              : Promise.resolve({ data: null, error: null } as const),
+            propertyRequest.asset_id
+              ? supabase.from("property_assets").select("name, asset_type").eq("id", String(propertyRequest.asset_id)).maybeSingle()
+              : Promise.resolve({ data: null, error: null } as const),
+            supabase
+              .from("property_vendor_assignments")
+              .select("vendor_id, created_at")
+              .eq("property_request_id", requestId)
+              .order("created_at", { ascending: false })
+              .limit(1)
+              .maybeSingle(),
+          ]);
+
+          if (propertyRes?.error) throw propertyRes.error;
+          if (unitRes?.error) throw unitRes.error;
+          if (assetRes?.error) throw assetRes.error;
+          if (assignmentRes?.error) throw assignmentRes.error;
+
+          let latestVendorAssignment: string | null = null;
+          const latestAssignment = assignmentRes.data as { vendor_id?: string | null } | null;
+          if (latestAssignment?.vendor_id) {
+            const vendorRes = await supabase
+              .from("property_vendors")
+              .select("name")
+              .eq("id", latestAssignment.vendor_id)
+              .maybeSingle();
+            if (vendorRes.error) throw vendorRes.error;
+            latestVendorAssignment = (vendorRes.data as { name?: string | null } | null)?.name ?? null;
+          }
+
+          setPropertyContext({
+            requestId,
+            requestTitle: (propertyRequest.title as string | null) ?? null,
+            requestStatus: (propertyRequest.status as string | null) ?? null,
+            severity: (propertyRequest.severity as string | null) ?? null,
+            category: (propertyRequest.category as string | null) ?? null,
+            preferredWindow: (propertyRequest.preferred_window as string | null) ?? null,
+            accessNotes: (propertyRequest.access_notes as string | null) ?? null,
+            propertyName: (propertyRes.data as { name?: string | null } | null)?.name ?? null,
+            unitLabel: (unitRes.data as { label?: string | null } | null)?.label ?? null,
+            assetName: (assetRes.data as { name?: string | null } | null)?.name ?? null,
+            assetType: (assetRes.data as { asset_type?: string | null } | null)?.asset_type ?? null,
+            latestVendorAssignment,
+          });
+        }
 
         // allocations + line techs
         if (lineRows.length) {
@@ -1399,6 +1479,28 @@ export default function WorkOrderIdClient(): JSX.Element {
             ) : null}
             <WorkOrderAiFreshnessBadge workOrderId={wo.id} />
             <WorkOrderAiOperationalRecommendations workOrderId={wo.id} />
+
+            {propertyContext ? (
+              <section className={cn(PANEL_VARIANTS.secondary, "p-2") }>
+                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  Property Maintenance Context
+                </div>
+                <div className="mt-2 grid gap-2 sm:grid-cols-2 xl:grid-cols-3 text-xs">
+                  <div className={cardInner}><div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">Request</div><div className="mt-1 text-sm text-foreground">{propertyContext.requestTitle ?? "—"}</div><div className="mt-1 text-muted-foreground">{propertyContext.requestStatus ?? "—"} • {propertyContext.severity ?? "—"}</div></div>
+                  <div className={cardInner}><div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">Category</div><div className="mt-1 text-foreground">{propertyContext.category ?? "—"}</div><div className="mt-1 text-muted-foreground">Property: {propertyContext.propertyName ?? "—"}</div>{propertyContext.unitLabel ? <div className="text-muted-foreground">Unit: {propertyContext.unitLabel}</div> : null}</div>
+                  <div className={cardInner}><div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">Asset / Vendor</div><div className="mt-1 text-foreground">{propertyContext.assetName ?? "—"}{propertyContext.assetType ? ` (${propertyContext.assetType})` : ""}</div><div className="mt-1 text-muted-foreground">Vendor: {propertyContext.latestVendorAssignment ?? "—"}</div></div>
+                </div>
+                {(propertyContext.preferredWindow || propertyContext.accessNotes) ? (
+                  <div className="mt-2 rounded-md border border-[color:var(--metal-border-soft,#374151)] bg-black/20 p-2 text-xs text-muted-foreground">
+                    {propertyContext.preferredWindow ? <div>Preferred window: {propertyContext.preferredWindow}</div> : null}
+                    {propertyContext.accessNotes ? <div>Access notes: {propertyContext.accessNotes}</div> : null}
+                  </div>
+                ) : null}
+                <Link href={`/property/requests/${propertyContext.requestId}`} className="mt-2 inline-flex text-[11px] font-medium text-[rgba(184,115,51,0.95)] hover:underline">
+                  View property request →
+                </Link>
+              </section>
+            ) : null}
 
             <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
               <div className="grid gap-1.5 sm:grid-cols-2 xl:grid-cols-3">

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -145,3 +145,11 @@ Any future schema expansion should be documented and applied manually.
 - This step remains internal-only: no tenant/vendor auth wiring, no vendor portal behavior, and no public request submission were added.
 - No schema or migration changes were introduced in this step.
 - Source-context limitation remains: no `source_property_maintenance_request_id` column is used because it is not part of the current applied `work_orders` schema/types.
+
+## Step 14: Property context card on linked work orders
+
+- Work order detail (`/work-orders/[id]`) now renders a compact, read-only **Property Maintenance Context** card only when the current work order is linked from `property_maintenance_requests.work_order_id`.
+- The card shows request metadata (title/status/severity/category), property/unit/asset context, preferred window/access notes, latest vendor assignment, and a link back to `/property/requests/[id]`.
+- Data is loaded with the existing authenticated Supabase client and RLS-scoped queries only (no service role usage).
+- Behavior is fully additive/read-only: no schema changes, no tenant/vendor auth wiring, and no vendor portal behavior were added.
+- Existing non-property work order behavior remains unchanged when no linked property request exists.


### PR DESCRIPTION
### Motivation
- Surface property maintenance context on a work order when the work order was created from a property maintenance request so staff have quick read-only reference without changing existing work order flows.

### Description
- Added a `PropertyContext` type and `propertyContext` state to the main work order client at `app/work-orders/[id]/Client.tsx` and extended the existing fetch flow to load `property_maintenance_requests` by `work_order_id` using the existing authenticated Supabase client and RLS only.
- When a linked request exists the code loads related `property_properties`, `property_units`, `property_assets`, the latest `property_vendor_assignments`, and the vendor name (via additional RLS-scoped queries) and maps those fields into `propertyContext`.
- Rendered a compact, read-only “Property Maintenance Context” card on the work order detail surface showing request title/status/severity/category, property name, unit label, asset name/type, preferred window, access notes, latest vendor assignment, and a link back to `/property/requests/[id]` while leaving overall layout and work order behavior unchanged when no request is linked.
- Updated `features/operations/README.md` with Step 14 rollout notes and guardrails clarifying this is additive, read-only, and that no schema/auth/vendor portal changes were introduced.

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully.
- Ran targeted lint on the changed client file with `npx eslint app/work-orders/[id]/Client.tsx` which succeeded for the touched file.
- Running the repository lint command `npm run lint -- app/work-orders/[id]/Client.tsx features/operations/README.md` surfaced many pre-existing repo-wide warnings/errors (unrelated to this change) including a markdown parse warning in the docs, and those issues are pre-existing and not introduced by this patch.

No database schema changes were made, no service-role usage was added, and no tenant/vendor auth or vendor portal behavior was introduced, and existing work order flows remain unchanged when there is no linked property request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7eb05efc83289ac5a0526831a5e2)