### PR TITLE
Step 15: add internal property inspection templates and inspection create/fill flow

### DIFF
--- a/app/property/inspections/[id]/page.tsx
+++ b/app/property/inspections/[id]/page.tsx
@@ -1,0 +1,42 @@
+import "server-only";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type Finding = { section: string; item: string; status: "ok" | "fail" | "na"; notes: string; photo_notes?: string };
+type DB = { public: { Tables: {
+  profiles: { Row: { id: string; shop_id: string | null } };
+  property_inspections: { Row: { id: string; shop_id: string; property_id: string; unit_id: string | null; inspection_type: string; status: string; summary: string | null; performed_by_profile_id: string; findings: unknown; completed_at: string | null; created_at: string } };
+  property_properties: { Row: { id: string; name: string } };
+  property_units: { Row: { id: string; unit_label: string } };
+} } };
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export default async function PropertyInspectionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+  const { data: profile } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
+  if (!profile?.shop_id) return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6">Profile is missing shop context.</div></main>;
+
+  const { data: row } = await supabase.from("property_inspections").select("id,shop_id,property_id,unit_id,inspection_type,status,summary,performed_by_profile_id,findings,completed_at,created_at").eq("id", id).maybeSingle();
+  if (!row || row.shop_id !== profile.shop_id) return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6">Inspection not found.</div></main>;
+
+  const [{ data: property }, { data: unit }] = await Promise.all([
+    supabase.from("property_properties").select("id,name").eq("id", row.property_id).maybeSingle(),
+    row.unit_id ? supabase.from("property_units").select("id,unit_label").eq("id", row.unit_id).maybeSingle() : Promise.resolve({ data: null }),
+  ]);
+  const findings: Finding[] = Array.isArray(row.findings) ? row.findings as Finding[] : [];
+  const grouped = findings.reduce<Record<string, Finding[]>>((acc, finding) => {
+    if (!acc[finding.section]) acc[finding.section] = [];
+    acc[finding.section].push(finding);
+    return acc;
+  }, {});
+
+  const counts = findings.reduce((acc, f) => ({ ...acc, [f.status]: acc[f.status] + 1 }), { ok: 0, fail: 0, na: 0 });
+
+  return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-5xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><div className="mb-4 flex items-start justify-between"><div><h1 className="text-2xl font-semibold">Property inspection detail</h1><p className="text-sm text-neutral-400">Internal-only property maintenance inspection record.</p></div><Link href="/property/inspections" className="text-xs underline">Back to inspections</Link></div><div className="grid gap-3 md:grid-cols-2"><div className="rounded-xl border border-[color:var(--metal-border-soft)] p-3 text-sm"><div>Type: {row.inspection_type}</div><div>Status: {row.status}</div><div>Summary: {row.summary || "—"}</div><div>Property: {property?.name ?? "Unknown"}</div><div>Unit: {unit?.unit_label ?? "—"}</div><div>Completed: {row.completed_at ? new Date(row.completed_at).toLocaleString() : "—"}</div><div>Created: {new Date(row.created_at).toLocaleString()}</div><div>Performed by profile: {row.performed_by_profile_id}</div></div><div className="rounded-xl border border-[color:var(--metal-border-soft)] p-3 text-sm"><div className="font-semibold">Finding totals</div><div className="mt-2">OK: {counts.ok}</div><div>Fail: {counts.fail}</div><div>N/A: {counts.na}</div></div></div><div className="mt-4 space-y-3">{Object.entries(grouped).map(([section, sectionFindings]) => <section key={section} className="rounded-xl border border-[color:var(--metal-border-soft)] p-3"><h2 className="text-sm font-semibold">{section}</h2><div className="mt-2 space-y-2">{sectionFindings.map((finding, idx) => <article key={`${section}-${idx}`} className="rounded-lg bg-black/30 p-2 text-sm"><div className="font-medium">{finding.item} · <span className="uppercase text-xs">{finding.status}</span></div><div className="text-neutral-300">Notes: {finding.notes || "—"}</div>{finding.photo_notes ? <div className="text-neutral-400">Photo notes: {finding.photo_notes}</div> : null}</article>)}</div></section>)}</div></div></main>;
+}

--- a/app/property/inspections/new/page.tsx
+++ b/app/property/inspections/new/page.tsx
@@ -1,0 +1,92 @@
+import "server-only";
+
+import Link from "next/link";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { getPropertyInspectionTemplate, propertyInspectionTypes, type PropertyInspectionType } from "@/features/property/lib/propertyInspectionTemplates";
+
+type AllowedStatus = "ok" | "fail" | "na";
+type DB = { public: { Tables: {
+  profiles: { Row: { id: string; shop_id: string | null } };
+  property_properties: { Row: { id: string; name: string; shop_id: string } };
+  property_units: { Row: { id: string; property_id: string; unit_label: string } };
+  property_inspections: { Row: { id: string }; Insert: { shop_id: string; property_id: string; unit_id: string | null; performed_by_profile_id: string; inspection_type: string; status: string; summary: string | null; findings: unknown; completed_at: string } };
+} } };
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+const parse = (v: FormDataEntryValue | null) => (typeof v === "string" && v.trim() ? v.trim() : null);
+
+async function createPropertyInspection(formData: FormData) {
+  "use server";
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const { data: profile } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
+  if (!profile?.shop_id) redirect("/property/inspections/new?error=" + encodeURIComponent("Missing shop context."));
+
+  const inspectionType = parse(formData.get("inspection_type")) as PropertyInspectionType | null;
+  if (!inspectionType || !propertyInspectionTypes.includes(inspectionType)) redirect("/property/inspections/new?error=" + encodeURIComponent("Invalid inspection type."));
+  const template = getPropertyInspectionTemplate(inspectionType);
+
+  const propertyId = parse(formData.get("property_id"));
+  const unitId = parse(formData.get("unit_id"));
+  const summary = parse(formData.get("summary"));
+  if (!propertyId) redirect(`/property/inspections/new?type=${inspectionType}&error=${encodeURIComponent("Property is required.")}`);
+
+  const [{ data: property }, { data: unit }] = await Promise.all([
+    supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle(),
+    unitId ? supabase.from("property_units").select("id,property_id").eq("id", unitId).maybeSingle() : Promise.resolve({ data: null }),
+  ]);
+
+  if (!property || property.shop_id !== profile.shop_id) redirect(`/property/inspections/new?type=${inspectionType}&error=${encodeURIComponent("Selected property is not visible.")}`);
+  if (unitId && (!unit || unit.property_id !== propertyId)) redirect(`/property/inspections/new?type=${inspectionType}&error=${encodeURIComponent("Selected unit is invalid for this property.")}`);
+
+  const findings = template.sections.flatMap((section, sectionIndex) => section.items.map((item, itemIndex) => {
+    const status = parse(formData.get(`status_${sectionIndex}_${itemIndex}`));
+    const notes = parse(formData.get(`notes_${sectionIndex}_${itemIndex}`));
+    const photoNotes = parse(formData.get(`photo_notes_${sectionIndex}_${itemIndex}`));
+    const normalized: AllowedStatus = status === "fail" || status === "na" ? status : "ok";
+    return { section: section.title, item, status: normalized, notes: notes ?? "", ...(photoNotes ? { photo_notes: photoNotes } : {}) };
+  }));
+
+  const { data: inserted, error } = await supabase.from("property_inspections").insert({
+    shop_id: profile.shop_id,
+    property_id: propertyId,
+    unit_id: unitId ?? null,
+    performed_by_profile_id: user.id,
+    inspection_type: inspectionType,
+    status: "completed",
+    summary,
+    findings,
+    completed_at: new Date().toISOString(),
+  }).select("id").maybeSingle();
+
+  if (error || !inserted) redirect(`/property/inspections/new?type=${inspectionType}&error=${encodeURIComponent(error?.message ?? "Unable to create inspection.")}`);
+  revalidatePath("/property");
+  revalidatePath("/property/inspections");
+  redirect(`/property/inspections/${inserted.id}`);
+}
+
+export default async function NewPropertyInspectionPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const params = (await searchParams) ?? {};
+  const requestedType = Array.isArray(params.type) ? params.type[0] : params.type;
+  const error = Array.isArray(params.error) ? params.error[0] : params.error;
+  const type: PropertyInspectionType = propertyInspectionTypes.includes(requestedType as PropertyInspectionType) ? (requestedType as PropertyInspectionType) : "move_in";
+  const template = getPropertyInspectionTemplate(type);
+
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+  const [{ data: profile }, { data: properties }, { data: units }] = await Promise.all([
+    supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(),
+    supabase.from("property_properties").select("id,name").order("name"),
+    supabase.from("property_units").select("id,property_id,unit_label").order("unit_label"),
+  ]);
+
+  if (!profile?.shop_id) return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6">Profile is missing shop context.</div></main>;
+  if (!(properties ?? []).length) return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><h1 className="text-2xl font-semibold">New property inspection</h1><p className="mt-2 text-sm text-neutral-300">No properties are visible yet.</p><Link href="/property/setup" className="mt-4 inline-flex rounded-full border px-3 py-1 text-xs">Go to property setup</Link></div></main>;
+
+  return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-5xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><div className="mb-4 flex items-center justify-between"><div><h1 className="text-2xl font-semibold">New property inspection</h1><p className="text-sm text-neutral-400">Photo upload is not implemented yet. Use photo notes as a placeholder.</p></div><Link href="/property/inspections" className="text-xs underline">Back to inspections</Link></div>{error ? <div className="mb-3 rounded border border-rose-400/30 bg-rose-500/10 p-2 text-sm">{error}</div> : null}<div className="mb-4 flex flex-wrap gap-2">{propertyInspectionTypes.map((t) => <Link key={t} href={`/property/inspections/new?type=${t}`} className={`rounded-full border px-3 py-1 text-xs ${t===type ? "border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20" : ""}`}>{t}</Link>)}</div><form action={createPropertyInspection} className="space-y-4"><input type="hidden" name="inspection_type" value={type} /><div className="grid gap-3 md:grid-cols-2"><select name="property_id" required className="rounded border bg-black/50 p-2"><option value="">Select property</option>{(properties ?? []).map((property)=><option key={property.id} value={property.id}>{property.name}</option>)}</select><select name="unit_id" className="rounded border bg-black/50 p-2"><option value="">No unit</option>{(units ?? []).map((unit)=><option key={unit.id} value={unit.id}>{unit.unit_label} · {(properties ?? []).find((p)=>p.id===unit.property_id)?.name ?? "Unknown property"}</option>)}</select><textarea name="summary" rows={3} className="rounded border bg-black/50 p-2 md:col-span-2" placeholder="Optional inspection summary" /></div><div className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/30 p-4"><h2 className="text-lg font-semibold">{template.label}</h2><p className="text-sm text-neutral-400">{template.description}</p><div className="mt-4 space-y-4">{template.sections.map((section, sectionIndex)=><section key={section.title} className="rounded-xl border border-[color:var(--metal-border-soft)] p-3"><h3 className="text-sm font-semibold">{section.title}</h3>{section.items.map((item, itemIndex)=><div key={`${section.title}-${item}`} className="mt-3 rounded-lg bg-black/30 p-3"><div className="text-sm">{item}</div><div className="mt-2 flex gap-3 text-xs">{(["ok","fail","na"] as AllowedStatus[]).map((status)=><label key={status} className="flex items-center gap-1"><input type="radio" name={`status_${sectionIndex}_${itemIndex}`} value={status} defaultChecked={status==="ok"} />{status}</label>)}</div><textarea name={`notes_${sectionIndex}_${itemIndex}`} rows={2} placeholder="Notes" className="mt-2 w-full rounded border bg-black/50 p-2 text-sm" /><input name={`photo_notes_${sectionIndex}_${itemIndex}`} placeholder="Photo notes (placeholder until media upload step)" className="mt-2 w-full rounded border bg-black/50 p-2 text-sm" /></div>)}</section>)}</div></div><button type="submit" className="rounded-full border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 text-xs font-semibold uppercase">Create and complete inspection</button></form></div></main>;
+}

--- a/app/property/inspections/page.tsx
+++ b/app/property/inspections/page.tsx
@@ -1,0 +1,31 @@
+import "server-only";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  profiles: { Row: { id: string; shop_id: string | null } };
+  property_inspections: { Row: { id: string; shop_id: string; property_id: string; unit_id: string | null; inspection_type: string; status: string; summary: string | null; completed_at: string | null; created_at: string } };
+  property_properties: { Row: { id: string; name: string } };
+  property_units: { Row: { id: string; unit_label: string } };
+} } };
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export default async function PropertyInspectionsPage() {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const { data: profile } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
+  if (!profile?.shop_id) return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-4xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6">Profile is missing shop context.</div></main>;
+
+  const [{ data: inspections }, { data: properties }, { data: units }] = await Promise.all([
+    supabase.from("property_inspections").select("id,shop_id,property_id,unit_id,inspection_type,status,summary,completed_at,created_at").order("created_at", { ascending: false }),
+    supabase.from("property_properties").select("id,name"),
+    supabase.from("property_units").select("id,unit_label"),
+  ]);
+
+  return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-6xl rounded-3xl border border-[color:var(--metal-border-soft)] bg-black/40 p-6"><div className="mb-4 flex items-center justify-between"><div><h1 className="text-2xl font-semibold">Property inspections</h1><p className="text-sm text-neutral-400">Internal property-maintenance inspections only.</p></div><div className="flex gap-2"><Link href="/property" className="rounded-full border px-3 py-1 text-xs">Back</Link><Link href="/property/inspections/new?type=move_in" className="rounded-full border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-3 py-1 text-xs">New property inspection</Link></div></div>{!(inspections??[]).length ? <div className="rounded-2xl border border-dashed border-[color:var(--metal-border-soft)] p-6 text-sm text-neutral-300">No property inspections yet.</div> : <div className="space-y-3">{(inspections??[]).map((x)=><article key={x.id} className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/30 p-4"><div className="flex flex-wrap items-start justify-between gap-2"><div><div className="text-sm font-semibold text-neutral-100">{x.inspection_type}</div><div className="mt-1 text-xs text-neutral-400">{properties?.find((p)=>p.id===x.property_id)?.name ?? "Unknown property"}{x.unit_id ? ` · ${units?.find((u)=>u.id===x.unit_id)?.unit_label ?? "Unknown unit"}` : ""}</div><p className="mt-2 text-xs text-neutral-300">{x.summary || "No summary provided."}</p></div><div className="text-right text-xs text-neutral-400"><div>Status: {x.status}</div><div>Completed: {x.completed_at ? new Date(x.completed_at).toLocaleString() : "—"}</div><div>Created: {new Date(x.created_at).toLocaleString()}</div></div></div><div className="mt-2"><Link href={`/property/inspections/${x.id}`} className="text-xs underline">View detail →</Link></div></article>)}</div>}</div></main>;
+}

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -153,3 +153,18 @@ Any future schema expansion should be documented and applied manually.
 - Data is loaded with the existing authenticated Supabase client and RLS-scoped queries only (no service role usage).
 - Behavior is fully additive/read-only: no schema changes, no tenant/vendor auth wiring, and no vendor portal behavior were added.
 - Existing non-property work order behavior remains unchanged when no linked property request exists.
+
+## Step 15: Internal property inspection templates + create/fill/list/detail flow
+
+- Added dedicated property inspection templates (move-in, move-out, periodic, maintenance follow-up) in `features/property/lib/propertyInspectionTemplates.ts` for property-maintenance-specific forms (separate from vehicle inspection builders).
+- Added internal-only property inspection routes:
+  - `/property/inspections` (list)
+  - `/property/inspections/new` (template-driven create/fill)
+  - `/property/inspections/[id]` (read-only detail)
+- Findings are persisted to `property_inspections.findings` JSONB with section/item/status/notes and optional `photo_notes` placeholder.
+- No image upload was added in this step; `photo_notes` is a temporary placeholder until later tenant/request media work.
+- No tenant request form was added.
+- No tenant auth or vendor auth was added.
+- No quote flow wiring was added.
+- No failed-item conversion or inspection-findings-to-request/work-order conversion was added.
+- No schema or migration changes were introduced in this step.

--- a/features/property/components/PropertyMaintenanceDashboard.tsx
+++ b/features/property/components/PropertyMaintenanceDashboard.tsx
@@ -212,6 +212,18 @@ export default function PropertyMaintenanceDashboard({
                   New maintenance request
                 </Link>
                 <Link
+                  href="/property/inspections"
+                  className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900/60"
+                >
+                  Inspections
+                </Link>
+                <Link
+                  href="/property/inspections/new?type=move_in"
+                  className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900/60"
+                >
+                  New inspection
+                </Link>
+                <Link
                   href={propertyOperationsRoutes.portalRequests}
                   className="rounded-full border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neutral-200 hover:bg-neutral-900/60"
                 >

--- a/features/property/lib/propertyInspectionTemplates.ts
+++ b/features/property/lib/propertyInspectionTemplates.ts
@@ -1,0 +1,82 @@
+export type PropertyInspectionType =
+  | "move_in"
+  | "move_out"
+  | "periodic"
+  | "maintenance_follow_up";
+
+export type PropertyInspectionTemplate = {
+  type: PropertyInspectionType;
+  label: string;
+  description: string;
+  sections: Array<{
+    title: string;
+    items: string[];
+  }>;
+};
+
+const MOVE_SECTION_TITLES = [
+  "Entry / doors / locks",
+  "Walls / ceilings / floors",
+  "Windows / blinds",
+  "Kitchen",
+  "Bathroom",
+  "Bedrooms",
+  "Laundry",
+  "HVAC / heat",
+  "Plumbing",
+  "Electrical / lights / outlets",
+  "Appliances",
+  "Smoke / CO detectors",
+  "Exterior / parking / access devices",
+];
+
+const templates: Record<PropertyInspectionType, PropertyInspectionTemplate> = {
+  move_in: {
+    type: "move_in",
+    label: "Move-in inspection",
+    description: "Document property condition before tenant occupancy.",
+    sections: MOVE_SECTION_TITLES.map((title) => ({ title, items: ["Condition check"] })),
+  },
+  move_out: {
+    type: "move_out",
+    label: "Move-out inspection",
+    description: "Document condition at end of occupancy for turnover planning.",
+    sections: MOVE_SECTION_TITLES.map((title) => ({ title, items: ["Condition check"] })),
+  },
+  periodic: {
+    type: "periodic",
+    label: "Periodic inspection",
+    description: "Routine internal property maintenance and safety review.",
+    sections: [
+      "Safety",
+      "Leaks / moisture",
+      "HVAC",
+      "Plumbing",
+      "Electrical",
+      "Appliances",
+      "Exterior",
+      "Pest signs",
+      "General condition",
+      "Tenant-reported concerns",
+    ].map((title) => ({ title, items: ["Inspection check"] })),
+  },
+  maintenance_follow_up: {
+    type: "maintenance_follow_up",
+    label: "Maintenance follow-up",
+    description: "Verify completed work and confirm resolution quality.",
+    sections: [
+      "Work completed",
+      "Area clean",
+      "Issue resolved",
+      "Photos attached",
+      "Tenant satisfied",
+      "Follow-up required",
+    ].map((title) => ({ title, items: ["Follow-up check"] })),
+  },
+};
+
+export function getPropertyInspectionTemplate(type: PropertyInspectionType): PropertyInspectionTemplate {
+  return templates[type];
+}
+
+export const propertyInspectionTypes = Object.keys(templates) as PropertyInspectionType[];


### PR DESCRIPTION
### Motivation
- Provide an internal-only property inspection feature set for property-maintenance workflows using dedicated templates rather than reusing vehicle inspection builders.
- Keep the work internal to shop staff with RLS-scoped reads/writes and avoid touching auth, vendor, tenant, or schema surfaces at this step.
- Capture structured findings in the existing `property_inspections.findings` JSONB field so later steps can build on recorded inspections without schema changes.

### Description
- Added a template module at `features/property/lib/propertyInspectionTemplates.ts` exporting `PropertyInspectionType`, `PropertyInspectionTemplate`, `getPropertyInspectionTemplate`, and `propertyInspectionTypes` with `move_in`, `move_out`, `periodic`, and `maintenance_follow_up` templates.
- Added an inspections list page at `app/property/inspections/page.tsx` that loads RLS-visible `property_inspections` and shows inspection metadata and links to details and new inspection flow.
- Added a new/create page at `app/property/inspections/new/page.tsx` that loads RLS-visible `property_properties` and `property_units`, renders template-driven sections, validates inputs server-side with `createServerSupabaseRSC()` and `profile.shop_id`, builds findings only from the selected template items, inserts a completed inspection row, revalidates paths, and redirects to the new inspection detail.
- Added a read-only detail page at `app/property/inspections/[id]/page.tsx` that enforces RLS visibility, loads property/unit context, groups findings by section, and displays OK/FAIL/NA counts; added quick links from the property dashboard to inspections and new inspection flows.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully with no TypeScript errors.
- Ran ESLint against the changed source files with `npx eslint app/property/inspections/page.tsx app/property/inspections/new/page.tsx app/property/inspections/[id]/page.tsx features/property/lib/propertyInspectionTemplates.ts features/property/components/PropertyMaintenanceDashboard.tsx`, and the lint pass for those code files succeeded.
- Note: attempting to lint `features/operations/README.md` as part of a broader pattern produced a parser error because it is non-code Markdown, so README is only updated as documentation and not a source-code lint target.

Confirmations
- No database schema/migration changes were made.
- No Supabase service-role usage was added; only `createServerSupabaseRSC()` (authenticated/RLS) is used.
- No tenant/public request form, tenant auth, vendor auth, vendor portal behavior, quote flow wiring, or conversion from inspection findings to maintenance requests/work orders were introduced.
- Existing property setup, property requests, and work-order/property context flows were not altered; this change is additive and internal-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c873f2aac8328a7f6ad31a91940c7)