### PR TITLE
Step 16: Tenant property request intake preview (portal route)

### DIFF
--- a/app/portal/property/request/page.tsx
+++ b/app/portal/property/request/page.tsx
@@ -1,0 +1,319 @@
+import "server-only";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type Severity = "emergency" | "urgent" | "routine" | "recommended";
+const ALLOWED_SEVERITIES: Severity[] = [
+  "emergency",
+  "urgent",
+  "routine",
+  "recommended",
+];
+
+type DB = {
+  public: {
+    Tables: {
+      profiles: { Row: { id: string; shop_id: string | null } };
+      property_properties: { Row: { id: string; name: string } };
+      property_units: { Row: { id: string; property_id: string; unit_label: string } };
+      property_assets: {
+        Row: {
+          id: string;
+          property_id: string;
+          unit_id: string | null;
+          name: string;
+        };
+      };
+      property_maintenance_requests: {
+        Insert: {
+          shop_id: string;
+          property_id: string;
+          unit_id: string | null;
+          asset_id: string | null;
+          requester_profile_id: string;
+          title: string;
+          summary: string;
+          category: string | null;
+          severity: Severity;
+          status: "open";
+          source: "tenant_preview";
+          access_notes: string | null;
+          preferred_window: string | null;
+          photos: unknown[];
+        };
+      };
+    };
+  };
+};
+
+const client = () =>
+  createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+const clean = (value: FormDataEntryValue | null) =>
+  typeof value === "string" && value.trim() ? value.trim() : null;
+
+async function createTenantPreviewRequest(formData: FormData) {
+  "use server";
+
+  const supabase = client();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const [{ data: profile }, { data: properties }, { data: units }, { data: assets }] =
+    await Promise.all([
+      supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(),
+      supabase.from("property_properties").select("id,name").order("name"),
+      supabase.from("property_units").select("id,property_id,unit_label").order("unit_label"),
+      supabase.from("property_assets").select("id,property_id,unit_id,name").order("name"),
+    ]);
+
+  if (!profile?.shop_id) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent("Your profile is missing shop context."),
+    );
+  }
+
+  const propertyId = clean(formData.get("property_id"));
+  const unitId = clean(formData.get("unit_id"));
+  const assetId = clean(formData.get("asset_id"));
+  const requesterName = clean(formData.get("requester_name"));
+  const requesterEmail = clean(formData.get("requester_email"));
+  const requesterPhone = clean(formData.get("requester_phone"));
+  const title = clean(formData.get("title"));
+  const summary = clean(formData.get("summary"));
+  const category = clean(formData.get("category"));
+  const severity = (clean(formData.get("severity")) ?? "routine") as Severity;
+  const accessNotes = clean(formData.get("access_notes"));
+  const preferredWindow = clean(formData.get("preferred_window"));
+  const photoNotes = clean(formData.get("photo_notes"));
+
+  if (!propertyId || !(properties ?? []).some((property) => property.id === propertyId)) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent("Selected property is not visible."),
+    );
+  }
+
+  if (!title || !summary) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent("Title and summary are required."),
+    );
+  }
+
+  if (!ALLOWED_SEVERITIES.includes(severity)) {
+    redirect(
+      "/portal/property/request?error=" + encodeURIComponent("Invalid severity."),
+    );
+  }
+
+  const unit = unitId ? (units ?? []).find((candidate) => candidate.id === unitId) : null;
+  if (unitId && (!unit || unit.property_id !== propertyId)) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent("Selected unit is invalid for the chosen property."),
+    );
+  }
+
+  const asset = assetId
+    ? (assets ?? []).find((candidate) => candidate.id === assetId)
+    : null;
+  if (assetId && (!asset || asset.property_id !== propertyId)) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent("Selected asset is invalid for the chosen property."),
+    );
+  }
+
+  if (unit && asset && asset.unit_id !== unit.id && asset.unit_id !== null) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent(
+          "Selected asset must belong to selected unit, or be property-level.",
+        ),
+    );
+  }
+
+  const requesterRollup = `Requester: ${requesterName ?? "n/a"} / ${requesterEmail ?? "n/a"} / ${requesterPhone ?? "n/a"}`;
+  const summaryWithRequester = `${summary}\n\n${requesterRollup}`;
+  const accessNotesCombined = [accessNotes, photoNotes ? `Photo notes: ${photoNotes}` : null]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const { error } = await supabase.from("property_maintenance_requests").insert({
+    shop_id: profile.shop_id,
+    property_id: propertyId,
+    unit_id: unit?.id ?? null,
+    asset_id: asset?.id ?? null,
+    requester_profile_id: user.id,
+    title,
+    summary: summaryWithRequester,
+    category,
+    severity,
+    status: "open",
+    source: "tenant_preview",
+    access_notes: accessNotesCombined || null,
+    preferred_window: preferredWindow,
+    photos: [],
+  });
+
+  if (error) {
+    redirect(
+      "/portal/property/request?error=" +
+        encodeURIComponent(`Unable to submit request: ${error.message}`),
+    );
+  }
+
+  redirect("/portal/property/request?status=submitted");
+}
+
+export default async function PortalPropertyRequestIntakePage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = (await searchParams) ?? {};
+  const error = Array.isArray(params.error) ? params.error[0] : params.error;
+  const status = Array.isArray(params.status) ? params.status[0] : params.status;
+
+  const supabase = client();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const [{ data: profile }, { data: properties }, { data: units }, { data: assets }] =
+    await Promise.all([
+      supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(),
+      supabase.from("property_properties").select("id,name").order("name"),
+      supabase.from("property_units").select("id,property_id,unit_label").order("unit_label"),
+      supabase.from("property_assets").select("id,property_id,unit_id,name").order("name"),
+    ]);
+
+  if (!profile?.shop_id) {
+    return (
+      <section className="metal-card rounded-3xl p-5">
+        <h1 className="text-xl text-neutral-100">Property request intake preview</h1>
+        <p className="mt-2 text-sm text-amber-300">Your profile is missing shop context.</p>
+      </section>
+    );
+  }
+
+  if (!(properties ?? []).length) {
+    return (
+      <section className="metal-card rounded-3xl p-5">
+        <h1 className="text-xl text-neutral-100">Property request intake preview</h1>
+        <p className="mt-2 text-sm text-neutral-300">
+          Tenant request intake preview — full tenant portal access is not wired yet.
+        </p>
+        <p className="mt-2 text-sm text-neutral-400">
+          No properties are visible yet. Internal users can set up properties first.
+        </p>
+        <Link href="/property/setup" className="mt-4 inline-flex text-sm underline">
+          Go to property setup
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="metal-card rounded-3xl p-5">
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
+        Property maintenance request intake
+      </p>
+      <h1 className="mt-2 text-2xl text-neutral-100">Tenant request intake preview</h1>
+      <p className="mt-2 text-sm text-neutral-300">
+        Tenant request intake preview — full tenant portal access is not wired yet.
+      </p>
+      <p className="mt-2 text-sm text-neutral-400">
+        Read receipts and two-party request timeline will be added in a later phase.
+      </p>
+
+      {status === "submitted" ? (
+        <div className="mt-4 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+          Request submitted. A property manager can now review it.
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+          {error}
+        </div>
+      ) : null}
+
+      <form action={createTenantPreviewRequest} className="mt-5 grid gap-3 md:grid-cols-2">
+        <select name="property_id" required className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm md:col-span-2">
+          <option value="">Select property</option>
+          {(properties ?? []).map((property) => (
+            <option key={property.id} value={property.id}>
+              {property.name}
+            </option>
+          ))}
+        </select>
+
+        <select name="unit_id" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm">
+          <option value="">No unit</option>
+          {(units ?? []).map((unit) => (
+            <option key={unit.id} value={unit.id}>
+              {unit.unit_label}
+            </option>
+          ))}
+        </select>
+
+        <select name="asset_id" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm">
+          <option value="">No asset</option>
+          {(assets ?? []).map((asset) => (
+            <option key={asset.id} value={asset.id}>
+              {asset.name}
+            </option>
+          ))}
+        </select>
+
+        <input name="requester_name" placeholder="Requester name (optional)" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm" />
+        <input name="requester_email" placeholder="Requester email (optional)" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm" />
+        <input name="requester_phone" placeholder="Requester phone (optional)" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm md:col-span-2" />
+
+        <input name="title" required placeholder="Request title" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm md:col-span-2" />
+        <textarea name="summary" required rows={4} placeholder="Describe the issue" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm md:col-span-2" />
+
+        <input name="category" placeholder="Category (optional)" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm" />
+        <select name="severity" defaultValue="routine" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm">
+          {ALLOWED_SEVERITIES.map((level) => (
+            <option key={level} value={level}>
+              {level}
+            </option>
+          ))}
+        </select>
+
+        <input name="access_notes" placeholder="Access notes (optional)" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm" />
+        <input name="preferred_window" placeholder="Preferred window (optional)" className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm" />
+
+        <textarea
+          name="photo_notes"
+          rows={3}
+          placeholder="Describe any photos/videos you would attach. File upload comes later."
+          className="rounded-lg border border-neutral-700 bg-black/40 p-2 text-sm md:col-span-2"
+        />
+
+        <button
+          type="submit"
+          className="md:col-span-2 rounded-full border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 text-xs font-semibold uppercase"
+        >
+          Submit request preview
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -168,3 +168,16 @@ Any future schema expansion should be documented and applied manually.
 - No quote flow wiring was added.
 - No failed-item conversion or inspection-findings-to-request/work-order conversion was added.
 - No schema or migration changes were introduced in this step.
+
+## Step 16: Tenant-side maintenance request intake preview foundation
+
+- Added `/portal/property/request` as a tenant/customer-facing **preview** intake form for property maintenance requests.
+- This route currently uses the existing authenticated Supabase RSC + RLS path only (`createServerSupabaseRSC` with logged-in user and `profile.shop_id`), because full tenant portal auth is not wired yet.
+- Form submission validates RLS-visible property/unit/asset relationships server-side and inserts into `property_maintenance_requests` with:
+  - `status: open`
+  - `source: tenant_preview`
+  - `photos: []` placeholder
+- No public tenant auth, vendor auth, vendor portal behavior, or request-to-work-order conversion changes were added in this step.
+- No real file/media upload was added; `photo_notes` is placeholder-only text (`"Describe any photos/videos you would attach. File upload comes later."`).
+- No read receipts schema or two-party timeline schema was added yet; UI includes a note that these arrive in a later phase.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Provide a controlled tenant/customer-facing preview intake form so tenants can submit property maintenance requests using the existing authenticated RLS path without wiring full tenant portal auth yet.
- Keep the change additive and safe by validating RLS-visible property/unit/asset relationships server-side and avoiding any schema, service-role, vendor, or work-order conversion changes.

### Description
- Added `app/portal/property/request/page.tsx` which implements a tenant request intake preview UI and server action `createTenantPreviewRequest` using `createServerSupabaseRSC()` and the authenticated Supabase RSC pattern.
- The server action validates `property_id` visibility and optional `unit_id`/`asset_id` relationships, enforces required `title` and `summary`, constrains `severity` to the allowed set, and prevents inserts when validation fails.
- Inserts into `property_maintenance_requests` with `shop_id` from the authenticated profile only, `requester_profile_id` from the logged-in user, `status: "open"`, `source: "tenant_preview"`, `photos: []`, and safely rolls requester contact fields into `summary` and `access_notes` (`photo_notes` appended as labeled text) to avoid schema changes.
- Updated `features/operations/README.md` with Step 16 notes describing the preview intent, RLS/auth path, placeholders for photo upload and read receipts, and confirmations that no schema/service-role/vendor/tenant-auth/work-order changes were made.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.
- Ran `npx eslint app/portal/property/request/page.tsx` and the new page file passed linting.
- Running `npx eslint app/portal/property/request/page.tsx features/operations/README.md` produced a parsing error because the README markdown is not parseable by the current ESLint config, which does not affect runtime or TypeScript validation.
- Files changed and committed: `app/portal/property/request/page.tsx` (new) and `features/operations/README.md` (updated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8cc5fddc8328849aa54e543aa574)