### PR TITLE
Add manual internal-only Supabase Storage plan for property request attachments

### DIFF
--- a/docs/property-request-attachments-step-19b.md
+++ b/docs/property-request-attachments-step-19b.md
@@ -1,0 +1,47 @@
+# Step 19B: Property Request Attachments (Internal-Only Upload Plan)
+
+## Findings from existing storage patterns
+
+- Property request attachments currently store metadata only; runtime upload is not wired yet.
+- Existing property request UI explicitly labels attachments as placeholders.
+- Repo currently uses Supabase Storage uploads in isolated features, but no existing bucket/policy setup was found for property request attachments.
+
+## Bucket plan
+
+- **Bucket id/name:** `property_request_attachments`
+- **Visibility:** private (`public = false`)
+- **Allowed mime types:** `image/jpeg`, `image/png`, `image/webp`, `image/heic`, `image/heif`
+- **File size limit (draft):** 10 MB
+- **Object path convention (required):**
+  - `<shop_id>/property-requests/<request_id>/<timestamp>-<random>-<sanitized_filename>`
+
+This path convention enables RLS checks against the caller's `profiles.shop_id` without service-role usage.
+
+## Storage policy draft
+
+- Manual SQL draft is provided in:
+  - `supabase/manual/property-request-attachments-storage-step-19b.sql`
+- Policies are scoped to `authenticated` users and enforce:
+  - `bucket_id = 'property_request_attachments'`
+  - first path segment matches `profiles.shop_id`
+
+## Runtime gating
+
+Per rollout constraints:
+
+- Do **not** wire runtime upload until this bucket + policies are applied in the target Supabase project.
+- Do **not** use service role in runtime.
+- Do **not** create buckets automatically in runtime.
+
+## Next implementation step (after manual setup is applied)
+
+1. Replace placeholder form on `/property/requests/[id]` with internal image upload form.
+2. Upload image via user-scoped Supabase client to `property_request_attachments`.
+3. Insert `property_request_attachments` metadata:
+   - `storage_bucket`
+   - `storage_path`
+   - `size_bytes`
+   - `content_type`
+   - `original_filename`
+4. Create `attachment_added` timeline event.
+5. Render linked attachments as internal file/image links on request detail.

--- a/supabase/manual/property-request-attachments-storage-step-19b.sql
+++ b/supabase/manual/property-request-attachments-storage-step-19b.sql
@@ -1,0 +1,98 @@
+-- Step 19B (manual draft only)
+-- Internal-only storage setup for property request attachments.
+--
+-- IMPORTANT:
+-- - This is a manual setup draft. Do not auto-apply in runtime code.
+-- - Do not use service role in runtime upload flows.
+-- - Keep bucket private (no public URLs/policies).
+-- - This draft assumes object names are prefixed with `<shop_id>/property-requests/<request_id>/...`.
+
+begin;
+
+-- 1) Create a private bucket for property request attachments.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'property_request_attachments',
+  'property_request_attachments',
+  false,
+  10485760,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']::text[]
+)
+on conflict (id) do update
+set public = excluded.public,
+    file_size_limit = excluded.file_size_limit,
+    allowed_mime_types = excluded.allowed_mime_types;
+
+-- 2) Internal staff can upload/select/update/delete files only inside their shop prefix.
+-- Path contract: <shop_id>/property-requests/<request_id>/<filename>
+
+drop policy if exists property_request_attachments_internal_select on storage.objects;
+create policy property_request_attachments_internal_select
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'property_request_attachments'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id::text = split_part(name, '/', 1)
+  )
+);
+
+drop policy if exists property_request_attachments_internal_insert on storage.objects;
+create policy property_request_attachments_internal_insert
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'property_request_attachments'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id::text = split_part(name, '/', 1)
+  )
+);
+
+drop policy if exists property_request_attachments_internal_update on storage.objects;
+create policy property_request_attachments_internal_update
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'property_request_attachments'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id::text = split_part(name, '/', 1)
+  )
+)
+with check (
+  bucket_id = 'property_request_attachments'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id::text = split_part(name, '/', 1)
+  )
+);
+
+drop policy if exists property_request_attachments_internal_delete on storage.objects;
+create policy property_request_attachments_internal_delete
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'property_request_attachments'
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id::text = split_part(name, '/', 1)
+  )
+);
+
+commit;


### PR DESCRIPTION
### Motivation
- Provide a safe, internal-only plan for real file uploads for property request attachments while honoring rollout gating that forbids runtime wiring until storage and policies are created. 
- The current UI stores placeholder metadata only, so a manual SQL/policy draft and documentation are needed before wiring runtime upload and metadata insertion. 

### Description
- Add a manual SQL draft `supabase/manual/property-request-attachments-storage-step-19b.sql` that inserts/updates a private bucket `property_request_attachments` and creates `storage.objects` policies scoped to `authenticated` users with a path contract that expects `<shop_id>/property-requests/<request_id>/...`. 
- Policy draft enforces `bucket_id = 'property_request_attachments'` and checks the first path segment against `profiles.shop_id` so runtime uploads can be user-scoped without using a service role. 
- Add documentation `docs/property-request-attachments-step-19b.md` that describes the bucket plan, allowed MIME types, path convention, runtime gating rules, and the next implementation steps (upload form, metadata insert, timeline `attachment_added` event, and rendering linked files). 
- Do not modify runtime code, tenant/vendor auth, public access, or schema in this change, and do not create buckets automatically in runtime as required by the rollout constraints. 

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npx eslint app/property/requests/[id]/page.tsx app/property/requests/[id]/actions.ts` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca8898784832893fb44c07b50b64f)