### PR TITLE
Add authenticated property member portal surfaces (Step 21C)

### DIFF
--- a/app/portal/property/member/page.tsx
+++ b/app/portal/property/member/page.tsx
@@ -1,0 +1,121 @@
+import "server-only";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = {
+  public: {
+    Tables: {
+      property_members: {
+        Row: {
+          id: string;
+          shop_id: string;
+          user_id: string;
+          role: string;
+          portfolio_id: string | null;
+          property_id: string | null;
+          unit_id: string | null;
+          created_at: string | null;
+        };
+      };
+      property_properties: { Row: { id: string; name: string; portfolio_id: string | null } };
+      property_units: { Row: { id: string; property_id: string; unit_label: string } };
+      property_portfolios: { Row: { id: string; name: string } };
+    };
+  };
+};
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export default async function PropertyMemberPortalPage() {
+  const supabase = client();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/sign-in");
+
+  const { data: memberships } = await supabase
+    .from("property_members")
+    .select("id,shop_id,user_id,role,portfolio_id,property_id,unit_id,created_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (!(memberships ?? []).length) {
+    return (
+      <section className="metal-card rounded-3xl p-5">
+        <h1 className="text-2xl text-neutral-100">Property member portal</h1>
+        <p className="mt-3 text-sm text-neutral-300">
+          No property portal access is assigned to this account.
+        </p>
+      </section>
+    );
+  }
+
+  const propertyIds = Array.from(new Set((memberships ?? []).map((m) => m.property_id).filter(Boolean))) as string[];
+  const unitIds = Array.from(new Set((memberships ?? []).map((m) => m.unit_id).filter(Boolean))) as string[];
+  const portfolioIds = Array.from(new Set((memberships ?? []).map((m) => m.portfolio_id).filter(Boolean))) as string[];
+
+  const [propertiesResult, unitsResult, portfoliosResult] = await Promise.all([
+    propertyIds.length
+      ? supabase.from("property_properties").select("id,name,portfolio_id").in("id", propertyIds)
+      : Promise.resolve({ data: [] as DB["public"]["Tables"]["property_properties"]["Row"][], error: null }),
+    unitIds.length
+      ? supabase.from("property_units").select("id,property_id,unit_label").in("id", unitIds)
+      : Promise.resolve({ data: [] as DB["public"]["Tables"]["property_units"]["Row"][], error: null }),
+    portfolioIds.length
+      ? supabase.from("property_portfolios").select("id,name").in("id", portfolioIds)
+      : Promise.resolve({ data: [] as DB["public"]["Tables"]["property_portfolios"]["Row"][], error: null }),
+  ]);
+
+  const propertyById = new Map((propertiesResult.data ?? []).map((row) => [row.id, row]));
+  const unitById = new Map((unitsResult.data ?? []).map((row) => [row.id, row]));
+  const portfolioById = new Map((portfoliosResult.data ?? []).map((row) => [row.id, row]));
+
+  return (
+    <section className="metal-card rounded-3xl p-5">
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">Portal</p>
+      <h1 className="mt-2 text-2xl text-neutral-100">Property member portal</h1>
+      <p className="mt-2 text-sm text-neutral-300">Your access comes from assigned property membership scopes.</p>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <Link href="/portal/property/member/requests" className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">
+          View maintenance requests
+        </Link>
+      </div>
+
+      <div className="mt-6 overflow-x-auto">
+        <table className="min-w-full text-left text-sm">
+          <thead className="text-neutral-400">
+            <tr>
+              <th className="px-3 py-2">Role</th>
+              <th className="px-3 py-2">Scope</th>
+              <th className="px-3 py-2">Shop</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(memberships ?? []).map((member) => {
+              const property = member.property_id ? propertyById.get(member.property_id) : null;
+              const unit = member.unit_id ? unitById.get(member.unit_id) : null;
+              const portfolio = member.portfolio_id ? portfolioById.get(member.portfolio_id) : null;
+
+              return (
+                <tr key={member.id} className="border-t border-white/10 text-neutral-200">
+                  <td className="px-3 py-2">{member.role}</td>
+                  <td className="px-3 py-2">
+                    <div>Portfolio: {portfolio?.name ?? "All visible portfolios"}</div>
+                    <div>Property: {property?.name ?? "All visible properties"}</div>
+                    <div>Unit: {unit?.unit_label ?? "All visible units"}</div>
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs text-neutral-400">{member.shop_id}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/app/portal/property/member/requests/[id]/actions.ts
+++ b/app/portal/property/member/requests/[id]/actions.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  property_maintenance_requests: { Row: { id: string; shop_id: string } };
+  property_request_events: { Insert: { request_id: string; shop_id: string; actor_profile_id: string | null; actor_type: string; event_type: string; visibility: string; body: string; metadata: Record<string, unknown> } };
+} } };
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+const readRequired = (formData: FormData, key: string) => {
+  const value = formData.get(key);
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+};
+
+export async function addTenantVisibleComment(formData: FormData) {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const requestId = readRequired(formData, "request_id");
+  const body = readRequired(formData, "body");
+
+  if (!requestId || !body) {
+    redirect(`/portal/property/member/requests/${requestId ?? ""}?error=${encodeURIComponent("Comment body is required.")}`);
+  }
+
+  const { data: requestRow } = await supabase.from("property_maintenance_requests").select("id,shop_id").eq("id", requestId).maybeSingle();
+
+  if (!requestRow) {
+    redirect(`/portal/property/member/requests/${requestId}?error=${encodeURIComponent("Request is not visible to this account.")}`);
+  }
+
+  const { error } = await supabase.from("property_request_events").insert({
+    request_id: requestId,
+    shop_id: requestRow.shop_id,
+    actor_profile_id: user.id,
+    actor_type: "tenant",
+    event_type: "comment",
+    visibility: "tenant_visible",
+    body,
+    metadata: {},
+  });
+
+  if (error) {
+    redirect(`/portal/property/member/requests/${requestId}?error=${encodeURIComponent(`Unable to add comment: ${error.message}`)}`);
+  }
+
+  redirect(`/portal/property/member/requests/${requestId}?status=${encodeURIComponent("comment-added")}`);
+}

--- a/app/portal/property/member/requests/[id]/page.tsx
+++ b/app/portal/property/member/requests/[id]/page.tsx
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { addTenantVisibleComment } from "./actions";
+
+type DB = { public: { Tables: {
+  property_members: { Row: { id: string; user_id: string; shop_id: string } };
+  property_maintenance_requests: { Row: { id: string; shop_id: string; property_id: string; unit_id: string | null; asset_id: string | null; title: string; summary: string; status: string; severity: string; category: string | null; created_at: string } };
+  property_properties: { Row: { id: string; name: string } };
+  property_units: { Row: { id: string; unit_label: string } };
+  property_assets: { Row: { id: string; name: string } };
+  property_request_events: { Row: { id: string; event_type: string; actor_type: string; visibility: string; body: string; created_at: string } };
+  property_request_attachments: { Row: { id: string; request_id: string; storage_path: string; mime_type: string | null; file_size: number | null; created_at: string } };
+} } };
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export default async function PropertyMemberRequestDetailPage({ params, searchParams }: { params: Promise<{ id: string }>; searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const { id } = await params;
+  const qp = (await searchParams) ?? {};
+  const error = Array.isArray(qp.error) ? qp.error[0] : qp.error;
+  const status = Array.isArray(qp.status) ? qp.status[0] : qp.status;
+
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/sign-in');
+
+  const { data: memberships } = await supabase.from('property_members').select('id,user_id,shop_id').eq('user_id', user.id);
+  if (!(memberships ?? []).length) {
+    return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Request detail</h1><p className="mt-3 text-sm text-neutral-300">No property portal access is assigned to this account.</p></section>;
+  }
+
+  const shopIds = Array.from(new Set((memberships ?? []).map((m) => m.shop_id)));
+  const { data: requestRow } = await supabase.from('property_maintenance_requests').select('id,shop_id,property_id,unit_id,asset_id,title,summary,status,severity,category,created_at').eq('id', id).in('shop_id', shopIds).maybeSingle();
+  if (!requestRow) {
+    return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Request detail</h1><p className="mt-3 text-sm text-rose-300">Request is not visible to this account.</p></section>;
+  }
+
+  const [{ data: events }, { data: attachments }, { data: property }, { data: unit }, { data: asset }] = await Promise.all([
+    supabase.from('property_request_events').select('id,event_type,actor_type,visibility,body,created_at').eq('request_id', requestRow.id).in('visibility', ['tenant_visible', 'all_parties']).order('created_at', { ascending: true }),
+    supabase.from('property_request_attachments').select('id,request_id,storage_path,mime_type,file_size,created_at').eq('request_id', requestRow.id).order('created_at', { ascending: true }),
+    supabase.from('property_properties').select('id,name').eq('id', requestRow.property_id).maybeSingle(),
+    requestRow.unit_id ? supabase.from('property_units').select('id,unit_label').eq('id', requestRow.unit_id).maybeSingle() : Promise.resolve({ data: null }),
+    requestRow.asset_id ? supabase.from('property_assets').select('id,name').eq('id', requestRow.asset_id).maybeSingle() : Promise.resolve({ data: null }),
+  ]);
+
+  return (
+    <section className="metal-card rounded-3xl p-5">
+      <h1 className="text-2xl text-neutral-100">{requestRow.title}</h1>
+      <p className="mt-2 text-sm text-neutral-300">{requestRow.summary}</p>
+      <p className="mt-2 text-sm text-neutral-400">Status: {requestRow.status} · Severity: {requestRow.severity} · Category: {requestRow.category ?? '—'}</p>
+      <p className="mt-1 text-sm text-neutral-400">Property: {property?.name ?? '—'} · Unit: {unit?.unit_label ?? '—'} · Asset: {asset?.name ?? '—'}</p>
+      <p className="mt-1 text-sm text-neutral-500">Created: {new Date(requestRow.created_at).toLocaleString()}</p>
+
+      {status ? <div className="mt-4 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">Comment added.</div> : null}
+      {error ? <div className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">{error}</div> : null}
+
+      <div className="mt-6">
+        <h2 className="text-lg text-neutral-100">Timeline</h2>
+        <div className="mt-2 space-y-2">
+          {(events ?? []).map((event) => (
+            <article key={event.id} className="rounded-lg border border-white/10 bg-black/20 p-3">
+              <p className="text-sm text-neutral-200">{event.body}</p>
+              <p className="mt-1 text-xs text-neutral-500">{event.event_type} · {event.actor_type} · {event.visibility} · {new Date(event.created_at).toLocaleString()}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <h2 className="text-lg text-neutral-100">Attachments</h2>
+        <div className="mt-2 space-y-2">
+          {(attachments ?? []).map((attachment) => (
+            <article key={attachment.id} className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
+              <p>Path: {attachment.storage_path}</p>
+              <p>MIME: {attachment.mime_type ?? '—'} · Size: {attachment.file_size ?? '—'} bytes</p>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <form action={addTenantVisibleComment} className="mt-6 space-y-2">
+        <input type="hidden" name="request_id" value={requestRow.id} />
+        <label className="block text-sm text-neutral-300" htmlFor="body">Add comment</label>
+        <textarea id="body" name="body" required className="min-h-[100px] w-full rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <button type="submit" className="rounded-lg border border-cyan-400/40 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">Post comment</button>
+      </form>
+    </section>
+  );
+}

--- a/app/portal/property/member/requests/page.tsx
+++ b/app/portal/property/member/requests/page.tsx
@@ -1,0 +1,70 @@
+import "server-only";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  property_members: { Row: { id: string; shop_id: string; user_id: string; property_id: string | null; unit_id: string | null } };
+  property_maintenance_requests: { Row: { id: string; shop_id: string; property_id: string; unit_id: string | null; asset_id: string | null; title: string; status: string; severity: string; created_at: string } };
+  property_properties: { Row: { id: string; name: string } };
+  property_units: { Row: { id: string; unit_label: string } };
+  property_assets: { Row: { id: string; name: string } };
+} } };
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export default async function PropertyMemberRequestsPage() {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/sign-in');
+
+  const { data: memberships } = await supabase.from('property_members').select('id,shop_id,user_id,property_id,unit_id').eq('user_id', user.id);
+  if (!(memberships ?? []).length) {
+    return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Property member requests</h1><p className="mt-3 text-sm text-neutral-300">No property portal access is assigned to this account.</p></section>;
+  }
+
+  const shopIds = Array.from(new Set((memberships ?? []).map((m) => m.shop_id)));
+
+  const { data: requests } = await supabase
+    .from('property_maintenance_requests')
+    .select('id,shop_id,property_id,unit_id,asset_id,title,status,severity,created_at')
+    .in('shop_id', shopIds)
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  const propertyIds = Array.from(new Set((requests ?? []).map((row) => row.property_id)));
+  const unitIds = Array.from(new Set((requests ?? []).map((row) => row.unit_id).filter(Boolean))) as string[];
+  const assetIds = Array.from(new Set((requests ?? []).map((row) => row.asset_id).filter(Boolean))) as string[];
+
+  const [propertiesResult, unitsResult, assetsResult] = await Promise.all([
+    propertyIds.length ? supabase.from('property_properties').select('id,name').in('id', propertyIds) : Promise.resolve({ data: [] as DB['public']['Tables']['property_properties']['Row'][] }),
+    unitIds.length ? supabase.from('property_units').select('id,unit_label').in('id', unitIds) : Promise.resolve({ data: [] as DB['public']['Tables']['property_units']['Row'][] }),
+    assetIds.length ? supabase.from('property_assets').select('id,name').in('id', assetIds) : Promise.resolve({ data: [] as DB['public']['Tables']['property_assets']['Row'][] }),
+  ]);
+
+  const propertyById = new Map((propertiesResult.data ?? []).map((row) => [row.id, row.name]));
+  const unitById = new Map((unitsResult.data ?? []).map((row) => [row.id, row.unit_label]));
+  const assetById = new Map((assetsResult.data ?? []).map((row) => [row.id, row.name]));
+
+  return (
+    <section className="metal-card rounded-3xl p-5">
+      <h1 className="text-2xl text-neutral-100">Property member requests</h1>
+      <p className="mt-2 text-sm text-neutral-300">Requests visible to your authenticated property membership.</p>
+      <div className="mt-5 space-y-3">
+        {(requests ?? []).map((request) => (
+          <article key={request.id} className="rounded-xl border border-white/10 bg-black/20 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-base text-neutral-100">{request.title}</h2>
+              <span className="text-xs text-neutral-400">{new Date(request.created_at).toLocaleString()}</span>
+            </div>
+            <p className="mt-1 text-sm text-neutral-300">Status: {request.status} · Severity: {request.severity}</p>
+            <p className="mt-1 text-sm text-neutral-400">Property: {propertyById.get(request.property_id) ?? '—'} · Unit: {request.unit_id ? (unitById.get(request.unit_id) ?? '—') : '—'} · Asset: {request.asset_id ? (assetById.get(request.asset_id) ?? '—') : '—'}</p>
+            <Link href={`/portal/property/member/requests/${request.id}`} className="mt-2 inline-flex text-sm text-cyan-300 underline">Open request</Link>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -247,3 +247,31 @@ Any future schema expansion should be documented and applied manually.
   - no unauthenticated tenant access
   - no vendor portal behavior
 - No schema or migration changes were introduced in this step.
+
+## Step 21C: Authenticated property member portal surfaces
+
+- Added authenticated property member portal routes:
+  - `/portal/property/member`
+  - `/portal/property/member/requests`
+  - `/portal/property/member/requests/[id]`
+- Access is derived from existing `property_members` rows (`user_id = auth.user.id`) and remains RLS-authenticated only via `createServerSupabaseRSC`.
+- If no `property_members` rows exist for the logged-in user, the portal shows:
+  - `No property portal access is assigned to this account.`
+- Member dashboard now shows assigned scope context (shop/portfolio/property/unit/role) and links to member-visible requests.
+- Requests list shows RLS-visible `property_maintenance_requests` within membership shop scope with title, status, severity, labels, created date, and detail links.
+- Request detail shows tenant-visible context only:
+  - request summary/status/severity/category/property-unit-asset context
+  - timeline entries limited to `tenant_visible` and `all_parties`
+  - attachment metadata visible through existing RLS reads
+  - no internal notes rendered
+- Added tenant-visible comment server action (`actions.ts` colocated in request detail route):
+  - inserts `property_request_events` as `event_type=comment`, `actor_type=tenant`, `visibility=tenant_visible`
+  - requires body + request id and uses authenticated/RLS Supabase client only (no service role)
+  - if insert fails (including RLS policy block), an explicit error is surfaced to the user
+- Explicitly not included in this step:
+  - no public invites
+  - no unauthenticated tenant access
+  - no email invite sending
+  - no vendor portal behavior
+  - no tenant file upload yet
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Provide an authenticated member-facing portal for existing `property_members` users so they can view assigned scopes and interact with maintenance requests without adding public invites or unauthenticated access.
- Surface tenant-visible request context and allow members to post tenant-visible comments while preserving existing internal flows and RLS protections.

### Description
- Added member dashboard at `app/portal/property/member/page.tsx` that requires authentication via `createServerSupabaseRSC()`, loads `property_members` for `user.id`, shows assigned scopes/roles, and displays the message `No property portal access is assigned to this account.` when no rows exist. 
- Added requests list at `app/portal/property/member/requests/page.tsx` that loads RLS-visible `property_maintenance_requests` scoped to the member `shop_id`s and shows title, status, severity, property/unit/asset labels, created date, and links to details. 
- Added request detail at `app/portal/property/member/requests/[id]/page.tsx` that gates access by `property_members` membership/shop scope, renders tenant-visible request fields and attachments metadata, and filters timeline events to `tenant_visible` and `all_parties` only. 
- Added colocated server action `addTenantVisibleComment` in `app/portal/property/member/requests/[id]/actions.ts` which uses `createServerSupabaseRSC()` to insert into `property_request_events` with `event_type = "comment"`, `actor_type = "tenant"`, `visibility = "tenant_visible"`, requires `body` and `request_id`, surfaces clear errors when inserts fail, and does not use a service role. 
- Updated `features/operations/README.md` with a Step 21C entry documenting the new authenticated member portal and explicit non-goals. 
- Confirmations: no DB schema or migration changes, no service role usage, no public invite flow, no unauthenticated access, no email invite sending, and no vendor portal behavior were added. 

### Testing
- Ran `npm run typecheck`, which completed successfully. 
- Ran `npx eslint` across the new TypeScript route files (`app/portal/property/member/**` and colocated `actions.ts`), which passed for the code files. 
- Note: an initial lint run including `features/operations/README.md` produced a parsing error because the README is non-code, but targeted linting of the changed source files succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb43472b48328aa36e4ad82983b51)