### PR TITLE
Step 21D: Add authenticated property member request submission

### DIFF
--- a/app/portal/property/member/page.tsx
+++ b/app/portal/property/member/page.tsx
@@ -84,6 +84,9 @@ export default async function PropertyMemberPortalPage() {
         <Link href="/portal/property/member/requests" className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">
           View maintenance requests
         </Link>
+        <Link href="/portal/property/member/requests/new" className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">
+          Submit maintenance request
+        </Link>
       </div>
 
       <div className="mt-6 overflow-x-auto">

--- a/app/portal/property/member/requests/new/actions.ts
+++ b/app/portal/property/member/requests/new/actions.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  property_members: { Row: { id: string; shop_id: string; user_id: string; property_id: string | null; unit_id: string | null } };
+  property_properties: { Row: { id: string; shop_id: string } };
+  property_units: { Row: { id: string; property_id: string } };
+  property_assets: { Row: { id: string; property_id: string; unit_id: string | null } };
+  property_maintenance_requests: { Insert: { shop_id: string; property_id: string; unit_id: string | null; asset_id: string | null; requester_profile_id: string; title: string; summary: string; category: string | null; severity: string; status: string; source: string; access_notes: string | null; photos: unknown[] }; Row: { id: string } };
+  property_request_events: { Insert: { request_id: string; shop_id: string; actor_profile_id: string | null; actor_type: string; event_type: string; visibility: string; body: string; metadata: Record<string, unknown> } };
+} } };
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+const allowedSeverity = new Set(["emergency", "urgent", "routine", "recommended"]);
+const readOptional = (formData: FormData, key: string) => {
+  const value = formData.get(key);
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+};
+const readRequired = (formData: FormData, key: string) => readOptional(formData, key);
+
+export async function createMemberPropertyMaintenanceRequest(formData: FormData) {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const propertyId = readRequired(formData, "property_id");
+  const unitId = readOptional(formData, "unit_id");
+  const assetId = readOptional(formData, "asset_id");
+  const title = readRequired(formData, "title");
+  const summary = readRequired(formData, "summary");
+  const category = readOptional(formData, "category");
+  const severity = readOptional(formData, "severity") ?? "routine";
+  const accessNotes = readOptional(formData, "access_notes");
+  const preferredWindow = readOptional(formData, "preferred_window");
+  const photoNotes = readOptional(formData, "photo_notes");
+
+  if (!propertyId || !title || !summary || !allowedSeverity.has(severity)) redirect("/portal/property/member/requests/new?error=Please%20complete%20all%20required%20fields%20with%20valid%20values.");
+
+  const { data: memberships } = await supabase.from("property_members").select("id,shop_id,user_id,property_id,unit_id").eq("user_id", user.id);
+  if (!(memberships ?? []).length) redirect("/portal/property/member/requests/new?error=No%20property%20membership%20is%20assigned%20to%20this%20account.");
+
+  const [propertiesResult, unitsResult, assetsResult] = await Promise.all([
+    supabase.from("property_properties").select("id,shop_id"),
+    supabase.from("property_units").select("id,property_id"),
+    supabase.from("property_assets").select("id,property_id,unit_id"),
+  ]);
+
+  const propertyById = new Map((propertiesResult.data ?? []).map((row) => [row.id, row]));
+  const unitById = new Map((unitsResult.data ?? []).map((row) => [row.id, row]));
+  const assetById = new Map((assetsResult.data ?? []).map((row) => [row.id, row]));
+
+  const selectedProperty = propertyById.get(propertyId);
+  const matchingMemberships = (memberships ?? []).filter((member) => !member.property_id || member.property_id === propertyId);
+  if (!selectedProperty || !matchingMemberships.length) redirect("/portal/property/member/requests/new?error=Selected%20property%20is%20outside%20your%20member%20scope.");
+
+  const shopId = matchingMemberships[0].shop_id;
+  if (selectedProperty.shop_id !== shopId) redirect("/portal/property/member/requests/new?error=Selected%20property%20is%20outside%20your%20member%20shop%20scope.");
+
+  let selectedUnitId: string | null = null;
+  if (unitId) {
+    const unit = unitById.get(unitId);
+    if (!unit || unit.property_id !== propertyId) redirect("/portal/property/member/requests/new?error=Selected%20unit%20is%20outside%20your%20member%20scope.");
+    const unitAllowed = matchingMemberships.some((member) => !member.unit_id || member.unit_id === unitId);
+    if (!unitAllowed) redirect("/portal/property/member/requests/new?error=Selected%20unit%20is%20outside%20your%20member%20scope.");
+    selectedUnitId = unit.id;
+  }
+
+  let selectedAssetId: string | null = null;
+  if (assetId) {
+    const asset = assetById.get(assetId);
+    if (!asset || asset.property_id !== propertyId) redirect("/portal/property/member/requests/new?error=Selected%20asset%20is%20outside%20your%20member%20scope.");
+    if (selectedUnitId && asset.unit_id && asset.unit_id !== selectedUnitId) redirect("/portal/property/member/requests/new?error=Selected%20asset%20must%20belong%20to%20the%20selected%20unit%20or%20be%20property-level.");
+    selectedAssetId = asset.id;
+  }
+
+  const combinedAccessNotes = [
+    accessNotes ? `Access notes: ${accessNotes}` : null,
+    preferredWindow ? `Preferred window: ${preferredWindow}` : null,
+    photoNotes ? `Photo notes (placeholder): ${photoNotes}` : null,
+  ].filter(Boolean).join("\n");
+
+  const { data: inserted, error } = await supabase.from("property_maintenance_requests").insert({
+    shop_id: shopId,
+    property_id: propertyId,
+    unit_id: selectedUnitId,
+    asset_id: selectedAssetId,
+    requester_profile_id: user.id,
+    title,
+    summary,
+    category,
+    severity,
+    status: "open",
+    source: "member_portal",
+    access_notes: combinedAccessNotes || null,
+    photos: [],
+  }).select("id").single();
+
+  if (error || !inserted) redirect(`/portal/property/member/requests/new?error=${encodeURIComponent(`Unable to submit request: ${error?.message ?? "unknown error"}`)}`);
+
+  await supabase.from("property_request_events").insert({
+    request_id: inserted.id,
+    shop_id: shopId,
+    actor_profile_id: user.id,
+    actor_type: "tenant",
+    event_type: "request_created",
+    visibility: "tenant_visible",
+    body: "Request submitted from property member portal.",
+    metadata: {},
+  });
+
+  revalidatePath("/portal/property/member/requests");
+  redirect(`/portal/property/member/requests/${inserted.id}?status=submitted`);
+}

--- a/app/portal/property/member/requests/new/page.tsx
+++ b/app/portal/property/member/requests/new/page.tsx
@@ -1,0 +1,90 @@
+import "server-only";
+
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { createMemberPropertyMaintenanceRequest } from "./actions";
+
+type DB = { public: { Tables: {
+  property_members: { Row: { id: string; user_id: string; property_id: string | null; unit_id: string | null } };
+  property_properties: { Row: { id: string; name: string } };
+  property_units: { Row: { id: string; property_id: string; unit_label: string } };
+  property_assets: { Row: { id: string; property_id: string; unit_id: string | null; name: string } };
+} } };
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export default async function NewMemberPropertyRequestPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const qp = (await searchParams) ?? {};
+  const error = Array.isArray(qp.error) ? qp.error[0] : qp.error;
+
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const { data: memberships } = await supabase.from("property_members").select("id,user_id,property_id,unit_id").eq("user_id", user.id);
+  if (!(memberships ?? []).length) {
+    return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Submit maintenance request</h1><p className="mt-3 text-sm text-neutral-300">No property portal access is assigned to this account.</p></section>;
+  }
+
+  const [propertiesResult, unitsResult, assetsResult] = await Promise.all([
+    supabase.from("property_properties").select("id,name"),
+    supabase.from("property_units").select("id,property_id,unit_label"),
+    supabase.from("property_assets").select("id,property_id,unit_id,name"),
+  ]);
+
+  const allowedPropertyIds = new Set((memberships ?? []).map((m) => m.property_id).filter(Boolean));
+  const properties = (propertiesResult.data ?? []).filter((p) => !allowedPropertyIds.size || allowedPropertyIds.has(p.id));
+  const units = (unitsResult.data ?? []).filter((u) => properties.some((p) => p.id === u.property_id));
+  const assets = (assetsResult.data ?? []).filter((a) => properties.some((p) => p.id === a.property_id));
+
+  if (!properties.length) {
+    return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Submit maintenance request</h1><p className="mt-3 text-sm text-neutral-300">No member-scoped properties are available for request submission.</p></section>;
+  }
+
+  return (
+    <section className="metal-card rounded-3xl p-5">
+      <h1 className="text-2xl text-neutral-100">Submit maintenance request</h1>
+      <p className="mt-2 text-sm text-neutral-300">Authenticated member portal — public invite access is not wired yet.</p>
+      <p className="mt-1 text-sm text-neutral-400">Image upload for tenants is coming later. Use photo notes for now.</p>
+      {error ? <div className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">{error}</div> : null}
+
+      <form action={createMemberPropertyMaintenanceRequest} className="mt-6 grid gap-3">
+        <label className="text-sm text-neutral-300">Property *</label>
+        <select name="property_id" required className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100">
+          {properties.map((property) => <option key={property.id} value={property.id}>{property.name}</option>)}
+        </select>
+
+        <label className="text-sm text-neutral-300">Unit (optional)</label>
+        <select name="unit_id" className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100">
+          <option value="">None</option>
+          {units.map((unit) => <option key={unit.id} value={unit.id}>{unit.unit_label}</option>)}
+        </select>
+
+        <label className="text-sm text-neutral-300">Asset (optional)</label>
+        <select name="asset_id" className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100">
+          <option value="">None</option>
+          {assets.map((asset) => <option key={asset.id} value={asset.id}>{asset.name}</option>)}
+        </select>
+
+        <label className="text-sm text-neutral-300">Title *</label>
+        <input name="title" required className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <label className="text-sm text-neutral-300">Summary *</label>
+        <textarea name="summary" required className="min-h-[120px] rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <label className="text-sm text-neutral-300">Category (optional)</label>
+        <input name="category" className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <label className="text-sm text-neutral-300">Severity</label>
+        <select name="severity" defaultValue="routine" className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100">
+          <option value="emergency">emergency</option><option value="urgent">urgent</option><option value="routine">routine</option><option value="recommended">recommended</option>
+        </select>
+        <label className="text-sm text-neutral-300">Access notes (optional)</label>
+        <textarea name="access_notes" className="min-h-[80px] rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <label className="text-sm text-neutral-300">Preferred window (optional)</label>
+        <input name="preferred_window" className="rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <label className="text-sm text-neutral-300">Photo notes (placeholder only)</label>
+        <textarea name="photo_notes" className="min-h-[80px] rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <button type="submit" className="mt-2 rounded-lg border border-cyan-400/40 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">Submit maintenance request</button>
+      </form>
+    </section>
+  );
+}

--- a/app/portal/property/member/requests/page.tsx
+++ b/app/portal/property/member/requests/page.tsx
@@ -52,6 +52,11 @@ export default async function PropertyMemberRequestsPage() {
     <section className="metal-card rounded-3xl p-5">
       <h1 className="text-2xl text-neutral-100">Property member requests</h1>
       <p className="mt-2 text-sm text-neutral-300">Requests visible to your authenticated property membership.</p>
+      <div className="mt-4">
+        <Link href="/portal/property/member/requests/new" className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">
+          Submit maintenance request
+        </Link>
+      </div>
       <div className="mt-5 space-y-3">
         {(requests ?? []).map((request) => (
           <article key={request.id} className="rounded-xl border border-white/10 bg-black/20 p-4">

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -275,3 +275,13 @@ Any future schema expansion should be documented and applied manually.
   - no vendor portal behavior
   - no tenant file upload yet
 - No schema or migration changes were introduced in this step.
+
+## Step 21D: Authenticated property member request submission
+
+- Added authenticated member portal request submission route: `/portal/property/member/requests/new`.
+- Submission uses a colocated server action (`createMemberPropertyMaintenanceRequest`) with authenticated `createServerSupabaseRSC` + RLS only.
+- Access requires an existing `property_members` row for `auth.user.id`; users without member rows see no-access messaging.
+- Validation enforces member-scope property/unit/asset constraints and severity allowlist, and does not trust `shop_id` from form data.
+- New requests are inserted into `property_maintenance_requests` with `status: open`, `source: member_portal`, `photos: []`, and tenant actor timeline bootstrap event in `property_request_events`.
+- This step does **not** add public invite flow, unauthenticated access, tenant image upload, or vendor portal behavior.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Provide authenticated property members a way to submit maintenance requests from the member portal while preserving existing RLS and membership-scoped authorization.
- Keep submission tenant-scoped and conservative: no public invite flow, no unauthenticated access, no tenant image upload, and no vendor portal behavior.

### Description
- Added a new member-facing request page at `app/portal/property/member/requests/new/page.tsx` with required fields (`property_id`, `title`, `summary`) and optional fields (`unit_id`, `asset_id`, `category`, `access_notes`, `preferred_window`, `photo_notes`) and portal notices about invite/upload non-goals.
- Implemented colocated server action `createMemberPropertyMaintenanceRequest(formData)` in `app/portal/property/member/requests/new/actions.ts` that uses `createServerSupabaseRSC()` (authenticated RLS client only), validates membership scope, validates property/unit/asset relationships, allowlists severity (`emergency|urgent|routine|recommended`), and inserts into `property_maintenance_requests` with `shop_id` derived from membership scope, `status: open`, `source: member_portal`, and `photos: []`.
- Bootstraps a tenant-visible timeline event by inserting a `property_request_events` row (`event_type=request_created`, `actor_type=tenant`, `visibility=tenant_visible`) after successful request insert, then revalidates `'/portal/property/member/requests'` and redirects to `/portal/property/member/requests/[id]?status=submitted`.
- Added “Submit maintenance request” CTA links from `app/portal/property/member/page.tsx` and `app/portal/property/member/requests/page.tsx` and documented Step 21D in `features/operations/README.md`.

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully.
- Ran targeted linting with `npx eslint` on the changed files and it completed successfully.
- Note: `npm run eslint -- ...` is not available in this repo (no `eslint` npm script), so targeted `npx eslint` was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb7d235508328b9ecc154bb70c247)