### PR TITLE
Add authenticated member image uploads for property requests (Step 21E)

### DIFF
--- a/app/portal/property/member/requests/[id]/actions.ts
+++ b/app/portal/property/member/requests/[id]/actions.ts
@@ -1,20 +1,44 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
 
 type DB = { public: { Tables: {
   property_maintenance_requests: { Row: { id: string; shop_id: string } };
+  property_members: { Row: { id: string; user_id: string; shop_id: string } };
+  property_request_attachments: { Insert: {
+    shop_id: string;
+    request_id: string;
+    uploaded_by_profile_id: string | null;
+    file_kind: "image" | "video" | "document" | "other";
+    storage_bucket: string | null;
+    storage_path: string | null;
+    original_filename: string | null;
+    content_type: string | null;
+    size_bytes: number | null;
+    caption: string | null;
+    metadata: Record<string, unknown>;
+  } };
   property_request_events: { Insert: { request_id: string; shop_id: string; actor_profile_id: string | null; actor_type: string; event_type: string; visibility: string; body: string; metadata: Record<string, unknown> } };
 } } };
 
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+const ATTACHMENT_BUCKET = "property_request_attachments";
+const ATTACHMENT_IMAGE_CONTENT_TYPES = ["image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"] as const;
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
 
 const readRequired = (formData: FormData, key: string) => {
   const value = formData.get(key);
   return typeof value === "string" && value.trim() ? value.trim() : null;
 };
+const readOptional = (formData: FormData, key: string) => {
+  const value = formData.get(key);
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+};
+const sanitizeAttachmentFileName = (fileName: string) =>
+  fileName.trim().replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-").replace(/\.{2,}/g, ".").replace(/^[-.]+|[-.]+$/g, "").slice(0, 120) || "upload";
 
 export async function addTenantVisibleComment(formData: FormData) {
   const supabase = client();
@@ -50,4 +74,82 @@ export async function addTenantVisibleComment(formData: FormData) {
   }
 
   redirect(`/portal/property/member/requests/${requestId}?status=${encodeURIComponent("comment-added")}`);
+}
+
+export async function uploadMemberPropertyRequestAttachment(formData: FormData) {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const requestId = readRequired(formData, "request_id");
+  if (!requestId) {
+    redirect(`/portal/property/member/requests/${requestId ?? ""}?status=invalid-attachment&error=${encodeURIComponent("Request is required.")}`);
+  }
+
+  const fileEntry = formData.get("file");
+  if (!(fileEntry instanceof File)) {
+    redirect(`/portal/property/member/requests/${requestId}?status=invalid-attachment&error=${encodeURIComponent("A file is required.")}`);
+  }
+
+  if (!ATTACHMENT_IMAGE_CONTENT_TYPES.includes(fileEntry.type as (typeof ATTACHMENT_IMAGE_CONTENT_TYPES)[number])) {
+    redirect(`/portal/property/member/requests/${requestId}?status=invalid-attachment&error=${encodeURIComponent("Unsupported file type. Upload JPEG, PNG, WEBP, HEIC, or HEIF.")}`);
+  }
+  if (fileEntry.size > MAX_ATTACHMENT_SIZE_BYTES) {
+    redirect(`/portal/property/member/requests/${requestId}?status=invalid-attachment&error=${encodeURIComponent("File exceeds 10 MB limit.")}`);
+  }
+
+  const { data: requestRow } = await supabase.from("property_maintenance_requests").select("id,shop_id").eq("id", requestId).maybeSingle();
+  if (!requestRow) {
+    redirect(`/portal/property/member/requests/${requestId}?status=attachment-upload-error&error=${encodeURIComponent("Request is not visible to this account.")}`);
+  }
+
+  const { data: membershipRow } = await supabase.from("property_members").select("id,user_id,shop_id").eq("user_id", user.id).eq("shop_id", requestRow.shop_id).maybeSingle();
+  if (!membershipRow) {
+    redirect(`/portal/property/member/requests/${requestId}?status=attachment-upload-error&error=${encodeURIComponent("No property member access for this request.")}`);
+  }
+
+  const shopId = membershipRow.shop_id;
+  const caption = readOptional(formData, "caption");
+  const safeFileName = sanitizeAttachmentFileName(fileEntry.name || "upload");
+  const timestamp = Date.now();
+  const storagePath = `${shopId}/property-requests/${requestId}/member-${user.id}-${timestamp}-${safeFileName}`;
+
+  const { error: uploadError } = await supabase.storage.from(ATTACHMENT_BUCKET).upload(storagePath, fileEntry, { contentType: fileEntry.type });
+  if (uploadError) {
+    redirect(`/portal/property/member/requests/${requestId}?status=attachment-upload-error&error=${encodeURIComponent(`Unable to upload image: ${uploadError.message}`)}`);
+  }
+
+  const { error: attachmentError } = await supabase.from("property_request_attachments").insert({
+    shop_id: shopId,
+    request_id: requestId,
+    uploaded_by_profile_id: user.id,
+    file_kind: "image",
+    storage_bucket: ATTACHMENT_BUCKET,
+    storage_path: storagePath,
+    original_filename: fileEntry.name || safeFileName,
+    content_type: fileEntry.type,
+    size_bytes: fileEntry.size,
+    caption,
+    metadata: { source: "member_portal" },
+  });
+  if (attachmentError) {
+    redirect(`/portal/property/member/requests/${requestId}?status=attachment-upload-error&error=${encodeURIComponent(`Upload succeeded but metadata insert failed: ${attachmentError.message}`)}`);
+  }
+
+  const { error: eventError } = await supabase.from("property_request_events").insert({
+    request_id: requestId,
+    shop_id: shopId,
+    actor_profile_id: user.id,
+    actor_type: "tenant",
+    event_type: "attachment_added",
+    visibility: "tenant_visible",
+    body: `Image attachment uploaded from property member portal: ${fileEntry.name || safeFileName}`,
+    metadata: { storage_path: storagePath, caption, content_type: fileEntry.type, size_bytes: fileEntry.size },
+  });
+  if (eventError) {
+    redirect(`/portal/property/member/requests/${requestId}?status=attachment-upload-error&error=${encodeURIComponent(`Attachment saved, but timeline event failed: ${eventError.message}`)}`);
+  }
+
+  revalidatePath(`/portal/property/member/requests/${requestId}`);
+  redirect(`/portal/property/member/requests/${requestId}?status=attachment-uploaded`);
 }

--- a/app/portal/property/member/requests/[id]/page.tsx
+++ b/app/portal/property/member/requests/[id]/page.tsx
@@ -1,9 +1,10 @@
 import "server-only";
 
+import Image from "next/image";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
-import { addTenantVisibleComment } from "./actions";
+import { addTenantVisibleComment, uploadMemberPropertyRequestAttachment } from "./actions";
 
 type DB = { public: { Tables: {
   property_members: { Row: { id: string; user_id: string; shop_id: string } };
@@ -12,7 +13,7 @@ type DB = { public: { Tables: {
   property_units: { Row: { id: string; unit_label: string } };
   property_assets: { Row: { id: string; name: string } };
   property_request_events: { Row: { id: string; event_type: string; actor_type: string; visibility: string; body: string; created_at: string } };
-  property_request_attachments: { Row: { id: string; request_id: string; storage_path: string; mime_type: string | null; file_size: number | null; created_at: string } };
+  property_request_attachments: { Row: { id: string; request_id: string; uploaded_by_profile_id: string | null; file_kind: string; visibility: string | null; storage_bucket: string | null; storage_path: string | null; original_filename: string | null; content_type: string | null; size_bytes: number | null; caption: string | null; created_at: string } };
 } } };
 
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
@@ -40,11 +41,17 @@ export default async function PropertyMemberRequestDetailPage({ params, searchPa
 
   const [{ data: events }, { data: attachments }, { data: property }, { data: unit }, { data: asset }] = await Promise.all([
     supabase.from('property_request_events').select('id,event_type,actor_type,visibility,body,created_at').eq('request_id', requestRow.id).in('visibility', ['tenant_visible', 'all_parties']).order('created_at', { ascending: true }),
-    supabase.from('property_request_attachments').select('id,request_id,storage_path,mime_type,file_size,created_at').eq('request_id', requestRow.id).order('created_at', { ascending: true }),
+    supabase.from('property_request_attachments').select('id,request_id,uploaded_by_profile_id,file_kind,visibility,storage_bucket,storage_path,original_filename,content_type,size_bytes,caption,created_at').eq('request_id', requestRow.id).order('created_at', { ascending: true }),
     supabase.from('property_properties').select('id,name').eq('id', requestRow.property_id).maybeSingle(),
     requestRow.unit_id ? supabase.from('property_units').select('id,unit_label').eq('id', requestRow.unit_id).maybeSingle() : Promise.resolve({ data: null }),
     requestRow.asset_id ? supabase.from('property_assets').select('id,name').eq('id', requestRow.asset_id).maybeSingle() : Promise.resolve({ data: null }),
   ]);
+  const signedAttachmentUrls = await Promise.all((attachments ?? []).map(async (attachment) => {
+    if (!attachment.storage_bucket || !attachment.storage_path || attachment.file_kind !== "image") return [attachment.id, null] as const;
+    const { data } = await supabase.storage.from(attachment.storage_bucket).createSignedUrl(attachment.storage_path, 60 * 15);
+    return [attachment.id, data?.signedUrl ?? null] as const;
+  }));
+  const signedUrlByAttachmentId = new Map(signedAttachmentUrls);
 
   return (
     <section className="metal-card rounded-3xl p-5">
@@ -54,7 +61,10 @@ export default async function PropertyMemberRequestDetailPage({ params, searchPa
       <p className="mt-1 text-sm text-neutral-400">Property: {property?.name ?? '—'} · Unit: {unit?.unit_label ?? '—'} · Asset: {asset?.name ?? '—'}</p>
       <p className="mt-1 text-sm text-neutral-500">Created: {new Date(requestRow.created_at).toLocaleString()}</p>
 
-      {status ? <div className="mt-4 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">Comment added.</div> : null}
+      {status === "comment-added" ? <div className="mt-4 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">Comment added.</div> : null}
+      {status === "attachment-uploaded" ? <div className="mt-4 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">Image uploaded.</div> : null}
+      {status === "attachment-upload-error" ? <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">Upload failed. Review the error below and try again.</div> : null}
+      {status === "invalid-attachment" ? <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">Invalid attachment. Use a supported image type up to 10 MB.</div> : null}
       {error ? <div className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">{error}</div> : null}
 
       <div className="mt-6">
@@ -74,12 +84,25 @@ export default async function PropertyMemberRequestDetailPage({ params, searchPa
         <div className="mt-2 space-y-2">
           {(attachments ?? []).map((attachment) => (
             <article key={attachment.id} className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
-              <p>Path: {attachment.storage_path}</p>
-              <p>MIME: {attachment.mime_type ?? '—'} · Size: {attachment.file_size ?? '—'} bytes</p>
+              <p>Filename: {attachment.original_filename ?? "—"}</p>
+              <p>Caption: {attachment.caption ?? "—"}</p>
+              <p>MIME: {attachment.content_type ?? '—'} · Size: {attachment.size_bytes ?? '—'} bytes</p>
+              <p>Created: {new Date(attachment.created_at).toLocaleString()}</p>
+              {signedUrlByAttachmentId.get(attachment.id) ? <Image src={signedUrlByAttachmentId.get(attachment.id) ?? ""} alt={attachment.original_filename ?? "Attachment"} width={640} height={360} unoptimized className="mt-2 h-auto max-h-64 w-full rounded-lg border border-white/10 object-cover" /> : null}
             </article>
           ))}
         </div>
       </div>
+
+      <form action={uploadMemberPropertyRequestAttachment} className="mt-6 space-y-2">
+        <input type="hidden" name="request_id" value={requestRow.id} />
+        <label className="block text-sm text-neutral-300" htmlFor="file">Upload image</label>
+        <input id="file" name="file" type="file" accept="image/jpeg,image/png,image/webp,image/heic,image/heif" required className="w-full rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <label className="block text-sm text-neutral-300" htmlFor="caption">Caption (optional)</label>
+        <input id="caption" name="caption" className="w-full rounded-lg border border-neutral-700 bg-black/30 p-2 text-sm text-neutral-100" />
+        <p className="text-xs text-neutral-400">Images are private and visible only to authorized property users.</p>
+        <button type="submit" className="rounded-lg border border-cyan-400/40 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">Upload image</button>
+      </form>
 
       <form action={addTenantVisibleComment} className="mt-6 space-y-2">
         <input type="hidden" name="request_id" value={requestRow.id} />

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -285,3 +285,12 @@ Any future schema expansion should be documented and applied manually.
 - New requests are inserted into `property_maintenance_requests` with `status: open`, `source: member_portal`, `photos: []`, and tenant actor timeline bootstrap event in `property_request_events`.
 - This step does **not** add public invite flow, unauthenticated access, tenant image upload, or vendor portal behavior.
 - No schema or migration changes were introduced in this step.
+
+## Step 21E: Authenticated property member request image upload
+
+- Added authenticated property member image upload on `/portal/property/member/requests/[id]` using server-action writes with Supabase RLS and no service role.
+- Uploads are restricted to private bucket `property_request_attachments` with scoped storage path: `<shop_id>/property-requests/<request_id>/member-<user_id>-<timestamp>-<safeFileName>`.
+- Server-side validation enforces authenticated user, request visibility via `property_members` membership scope, allowed image MIME types (JPEG/PNG/WEBP/HEIC/HEIF), and 10 MB max size.
+- Attachment metadata is inserted into `property_request_attachments` and corresponding tenant-visible `attachment_added` timeline events are inserted into `property_request_events`.
+- Member request detail now includes image upload form, status banners, and attachment listing with signed previews when available.
+- No public invite flow, no unauthenticated access, no vendor portal behavior, no public bucket behavior, and no schema/migration changes were added.


### PR DESCRIPTION
### Motivation
- Provide authenticated property members the ability to upload image attachments on the member request detail page while preserving existing RLS and tenant privacy constraints. 
- Keep uploads private to the shop-scoped `property_request_attachments` bucket and ensure membership-derived `shop_id` is used rather than trusting form input. 

### Description
- Added server action `uploadMemberPropertyRequestAttachment(formData)` which requires an authenticated user, validates `property_members` membership for request visibility, enforces allowed image MIME types and a 10 MB limit, and uploads using the authenticated Supabase storage client. 
- Uploads are written to the private bucket `property_request_attachments` with the path format `${shopId}/property-requests/${requestId}/member-${userId}-${timestamp}-${safeFileName}` and do not generate public URLs. 
- After successful upload the code inserts attachment metadata into `property_request_attachments` and a tenant-visible `attachment_added` row into `property_request_events` with `metadata` containing storage details and `source: "member_portal"`. 
- Updated the member request detail UI to list tenant-visible attachments (filename, caption, created_at, mime/size), show signed previews when available, add an image upload form (`request_id`, `file`, optional `caption`), and show status banners; also added Step 21E notes to `features/operations/README.md`. 

### Testing
- Ran `npm run typecheck` (TypeScript `tsc --noEmit`) and it completed successfully. 
- Ran `npx eslint` targeted to the modified files and the reported issues were resolved; the lint pass completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbbc5401c8328bc20a5a242efcfaf)