### PR TITLE
Step 22C: add authenticated property invite acceptance shell

### DIFF
--- a/app/portal/property/invite/accept/actions.ts
+++ b/app/portal/property/invite/accept/actions.ts
@@ -1,0 +1,93 @@
+"use server";
+
+import "server-only";
+
+import { createHash } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  profiles: { Row: { id: string; email: string | null } };
+  property_members: {
+    Row: { id: string };
+    Insert: { shop_id: string; user_id: string; role: string; portfolio_id?: string | null; property_id?: string | null; unit_id?: string | null };
+  };
+  property_portal_invites: {
+    Row: { id: string; shop_id: string; invited_email: string; invited_name: string | null; role: string; portfolio_id: string | null; property_id: string | null; unit_id: string | null; status: string; expires_at: string };
+  };
+  property_portfolios: { Row: { id: string; name: string | null } };
+  property_properties: { Row: { id: string; name: string | null } };
+  property_units: { Row: { id: string; unit_label: string | null } };
+} } };
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+function hashToken(token: string) { return createHash("sha256").update(token, "utf8").digest("hex"); }
+function err(token: string, msg: string) { return `/portal/property/invite/accept?token=${encodeURIComponent(token)}&error=${encodeURIComponent(msg)}`; }
+
+export async function getPropertyPortalInvitePreview(token: string) {
+  const clean = token.trim();
+  if (!clean) return { error: "Missing invite token." as const };
+
+  const supabase = client();
+  const tokenHash = hashToken(clean);
+  const { data, error } = await supabase
+    .from("property_portal_invites")
+    .select("id,shop_id,invited_email,invited_name,role,portfolio_id,property_id,unit_id,status,expires_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (error) {
+    return { error: "Invite acceptance is currently blocked by access policy. Step 22D must add a controlled invite-acceptance policy/RPC before runtime acceptance can proceed." as const };
+  }
+  if (!data) return { error: "Invite not found." as const };
+  if (data.status !== "pending") return { error: "Invite is no longer pending." as const };
+  if (new Date(data.expires_at).getTime() <= Date.now()) return { error: "Invite has expired." as const };
+
+  const [portfolio, property, unit] = await Promise.all([
+    data.portfolio_id ? supabase.from("property_portfolios").select("id,name").eq("id", data.portfolio_id).maybeSingle() : Promise.resolve({ data: null, error: null }),
+    data.property_id ? supabase.from("property_properties").select("id,name").eq("id", data.property_id).maybeSingle() : Promise.resolve({ data: null, error: null }),
+    data.unit_id ? supabase.from("property_units").select("id,unit_label").eq("id", data.unit_id).maybeSingle() : Promise.resolve({ data: null, error: null }),
+  ]);
+
+  return { invite: data, labels: { portfolio: portfolio.data?.name ?? null, property: property.data?.name ?? null, unit: unit.data?.unit_label ?? null } };
+}
+
+export async function acceptPropertyPortalInvite(formData: FormData) {
+  const token = String(formData.get("token") || "").trim();
+  if (!token) redirect("/portal/property/invite/accept?error=" + encodeURIComponent("Missing invite token."));
+
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const tokenHash = hashToken(token);
+  const inviteRes = await supabase.from("property_portal_invites").select("id,shop_id,invited_email,role,portfolio_id,property_id,unit_id,status,expires_at").eq("token_hash", tokenHash).maybeSingle();
+  if (inviteRes.error) redirect(err(token, "Invite acceptance is currently blocked by access policy. Step 22D must add a controlled invite-acceptance policy/RPC before runtime acceptance can proceed."));
+
+  const invite = inviteRes.data;
+  if (!invite) redirect(err(token, "Invite not found."));
+  if (invite.status !== "pending") redirect(err(token, "Invite is no longer pending."));
+  if (new Date(invite.expires_at).getTime() <= Date.now()) redirect(err(token, "Invite has expired."));
+
+  const [profileRes, dupeRes] = await Promise.all([
+    supabase.from("profiles").select("id,email").eq("id", user.id).maybeSingle(),
+    supabase.from("property_members").select("id").eq("shop_id", invite.shop_id).eq("user_id", user.id).eq("role", invite.role).is("portfolio_id", invite.portfolio_id).is("property_id", invite.property_id).is("unit_id", invite.unit_id).maybeSingle(),
+  ]);
+
+  const actorEmail = profileRes.data?.email?.trim().toLowerCase() ?? user.email?.trim().toLowerCase() ?? null;
+  if (actorEmail && actorEmail !== invite.invited_email.trim().toLowerCase()) redirect(err(token, "Authenticated email does not match the invited email."));
+
+  if (!dupeRes.data) {
+    const { error: insertError } = await supabase.from("property_members").insert({ shop_id: invite.shop_id, user_id: user.id, role: invite.role, portfolio_id: invite.portfolio_id, property_id: invite.property_id, unit_id: invite.unit_id });
+    if (insertError) redirect(err(token, insertError.message));
+  }
+
+  const { error: updateError } = await supabase.from("property_portal_invites").update({ status: "accepted", accepted_by_profile_id: user.id, accepted_at: new Date().toISOString() }).eq("id", invite.id).eq("status", "pending");
+  if (updateError) redirect(err(token, updateError.message));
+
+  revalidatePath("/portal/property/member");
+  redirect("/portal/property/member?status=invite-accepted");
+}

--- a/app/portal/property/invite/accept/page.tsx
+++ b/app/portal/property/invite/accept/page.tsx
@@ -1,0 +1,55 @@
+import "server-only";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { acceptPropertyPortalInvite, getPropertyPortalInvitePreview } from "./actions";
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient;
+
+function sv(v: string | string[] | undefined) { return Array.isArray(v) ? v[0] : v; }
+
+export default async function PropertyInviteAcceptPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const params = (await searchParams) ?? {};
+  const token = sv(params.token)?.trim() ?? "";
+  const error = sv(params.error);
+  const inviteUrl = `/portal/property/invite/accept${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+
+  if (!token) {
+    return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Invalid invite</h1><p className="mt-3 text-sm text-neutral-300">Missing invite token.</p></section>;
+  }
+
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect(`/sign-in?next=${encodeURIComponent(inviteUrl)}`);
+
+  const preview = await getPropertyPortalInvitePreview(token);
+  const scope = preview.invite ? [
+    preview.invite.portfolio_id ? `Portfolio: ${preview.labels.portfolio ?? preview.invite.portfolio_id}` : null,
+    preview.invite.property_id ? `Property: ${preview.labels.property ?? preview.invite.property_id}` : null,
+    preview.invite.unit_id ? `Unit: ${preview.labels.unit ?? preview.invite.unit_id}` : null,
+  ].filter(Boolean).join(" · ") || "Global (property_manager)" : null;
+
+  return (
+    <section className="metal-card rounded-3xl p-5 text-neutral-100">
+      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">Portal</p>
+      <h1 className="mt-2 text-2xl">Accept property invite</h1>
+      {(error || preview.error) && <p className="mt-3 rounded-lg border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">{error ?? preview.error}</p>}
+
+      {preview.invite && !preview.error ? <div className="mt-5 space-y-2 text-sm text-neutral-300">
+        <p><span className="text-neutral-400">Invited email:</span> {preview.invite.invited_email}</p>
+        <p><span className="text-neutral-400">Invited name:</span> {preview.invite.invited_name ?? "—"}</p>
+        <p><span className="text-neutral-400">Role:</span> {preview.invite.role}</p>
+        <p><span className="text-neutral-400">Scope:</span> {scope}</p>
+        <p><span className="text-neutral-400">Expires:</span> {new Date(preview.invite.expires_at).toLocaleString()}</p>
+        <form action={acceptPropertyPortalInvite} className="pt-2">
+          <input type="hidden" name="token" value={token} />
+          <button type="submit" className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-4 py-2 text-sm text-cyan-200">Accept invite</button>
+        </form>
+      </div> : <p className="mt-4 text-sm text-neutral-300">This invite cannot be accepted in its current state.</p>}
+
+      <div className="mt-5"><Link href="/portal/property/member" className="text-sm text-cyan-300 underline">Go to property member portal</Link></div>
+    </section>
+  );
+}

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -323,3 +323,12 @@ Any future schema expansion should be documented and applied manually.
   - service-role usage
   - vendor portal behavior
   - schema or migration changes.
+
+## Step 22C: Authenticated property invite acceptance shell
+
+- Added authenticated acceptance route at `/portal/property/invite/accept?token=<raw_token>` with invite summary + accept action wiring.
+- Acceptance flow is designed to hash the raw token server-side (`sha256`) and query by `token_hash` only; raw token storage is not added.
+- Flow intentionally does **not** send emails, does **not** create Supabase Auth users, and does **not** add unauthenticated/public invite acceptance.
+- On successful validation, acceptance attempts to insert `property_members` (duplicate-safe), mark invite accepted, revalidate `/portal/property/member`, and redirect to `?status=invite-accepted`.
+- **RLS blocker handling:** if current `property_portal_invites` RLS blocks invitee `SELECT/UPDATE` by token hash, the route/action surfaces a controlled blocker message indicating Step 22D must add a controlled acceptance policy or RPC before runtime acceptance can proceed.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Provide a controlled, authenticated acceptance flow for existing `property_portal_invites` records so invited users can accept scoped property access without exposing raw tokens or creating auth users.
- Respect current security boundaries by hashing the raw token server-side, avoiding service-role usage, and surfacing a clear blocker if existing RLS prevents invite-row reads/updates.

### Description
- Added an authenticated page at `app/portal/property/invite/accept/page.tsx` that requires a `token` query param and redirects unauthenticated users to `sign-in` with a `next` return URL.
- Added server actions in `app/portal/property/invite/accept/actions.ts` including `getPropertyPortalInvitePreview(token)` and `acceptPropertyPortalInvite(formData)` which compute a SHA-256 `token_hash` server-side and only query by that hash.
- Acceptance validates `status === "pending"`, `expires_at > now()`, enforces authenticated user, compares available profile/auth email to `invited_email` when present, prevents duplicate `property_members` rows, inserts `property_members` when allowed, and updates the invite to `accepted` with acceptance metadata.
- Implemented controlled RLS-blocker handling that surfaces a clear message and aborts if the current `property_portal_invites` RLS denies invitee `SELECT/UPDATE` by `token_hash`, and updated `features/operations/README.md` with Step 22C notes and the Step 22D blocker requirement; no schema/migrations, email sending, auth-user creation, raw-token storage, or service-role usage were added.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npx eslint app/portal/property/invite/accept/page.tsx app/portal/property/invite/accept/actions.ts` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc634bc2083288be514c2a6d172ed)