### PR TITLE
Step 22D: Add SECURITY DEFINER RPC draft for authenticated property invite acceptance

### DIFF
--- a/docs/plans/property-portal-invites-step-22a.md
+++ b/docs/plans/property-portal-invites-step-22a.md
@@ -67,3 +67,38 @@ Key goals:
 - This draft is additive and non-breaking, but should be reviewed against live table shapes (`property_portfolios`, `property_properties`, `property_units`, `profiles`) before application.
 - Trigger assumptions about hierarchy columns should be confirmed in staging.
 - Because public access is intentionally not added, this draft does not yet enable external self-serve acceptance.
+
+## Step 22D: Manual SQL draft for authenticated invite acceptance (SECURITY DEFINER RPC)
+
+- Added manual SQL draft at `supabase/manual/property-portal-invite-acceptance-step-22d.sql`.
+- This draft intentionally does **not** execute SQL and does **not** change runtime code.
+- The proposed acceptance path is a narrow `SECURITY DEFINER` RPC:
+  - `public.accept_property_portal_invite(p_raw_token text)`
+- The function design keeps invite table RLS internal-only and avoids broad invite lookup policies.
+
+### Why RPC over broad RLS lookup
+
+Authenticated invitees cannot safely query `property_portal_invites` by `token_hash` with broad read policies without risking invite record exposure. The function validates token hash + email + invite state and performs membership upsert + invite acceptance atomically.
+
+### Function behavior summary
+
+- Requires `auth.uid()` and non-empty raw token input.
+- Hashes token using `pgcrypto` `encode(digest(..., 'sha256'), 'hex')`.
+- Resolves authenticated email from `auth.users` (no service role).
+- Accepts only matching invite rows where:
+  - `status = pending`
+  - `expires_at > now()`
+  - `lower(invited_email) = lower(authenticated_email)`
+- Reuses an identical `property_members` row when present.
+- Otherwise inserts a safe scoped `property_members` row from invite values.
+- Marks invite as accepted (`status`, `accepted_by_profile_id`, `accepted_at`).
+- Returns JSON payload with `success`, `message`, `invite_id`, `member_id`.
+
+### Explicitly deferred/non-goals (unchanged)
+
+- Email delivery remains deferred.
+- Auth user creation remains deferred.
+- Invite creation remains internal-only.
+- Public/unauthenticated acceptance is not supported.
+- Runtime route wiring changes are deferred to a later step.
+- No broad invite RLS lookup policy is added.

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -332,3 +332,17 @@ Any future schema expansion should be documented and applied manually.
 - On successful validation, acceptance attempts to insert `property_members` (duplicate-safe), mark invite accepted, revalidate `/portal/property/member`, and redirect to `?status=invite-accepted`.
 - **RLS blocker handling:** if current `property_portal_invites` RLS blocks invitee `SELECT/UPDATE` by token hash, the route/action surfaces a controlled blocker message indicating Step 22D must add a controlled acceptance policy or RPC before runtime acceptance can proceed.
 - No schema or migration changes were introduced in this step.
+
+## Step 22D: Manual SQL draft for authenticated property invite acceptance
+
+- Added manual SQL draft at `supabase/manual/property-portal-invite-acceptance-step-22d.sql`.
+- Draft proposes a `SECURITY DEFINER` RPC (`public.accept_property_portal_invite(text)`) so authenticated acceptance can be handled without adding broad invite token/email read policies.
+- Function validates token hash match, pending status, expiry, and authenticated email match before membership creation/reuse and invite acceptance update.
+- RLS posture remains conservative: `property_portal_invites` stays internal-only and no broad token lookup policy is added.
+- This step is documentation + manual SQL draft only:
+  - no SQL executed
+  - no runtime code wiring
+  - no service role usage
+  - no email sending flow
+  - no auth user creation flow
+  - no unauthenticated/public acceptance

--- a/supabase/manual/property-portal-invite-acceptance-step-22d.sql
+++ b/supabase/manual/property-portal-invite-acceptance-step-22d.sql
@@ -1,0 +1,145 @@
+-- Property Portal Invites - Step 22D (Manual SQL Draft)
+--
+-- Purpose:
+--   Safely allow authenticated invite acceptance without broad invite token/email RLS lookups.
+--
+-- Explicit non-goals in this step:
+--   - No SQL execution from this rollout step (manual draft only)
+--   - No runtime/app wiring changes
+--   - No service role usage
+--   - No email sending wiring
+--   - No Supabase Auth user creation flow
+--   - No unauthenticated/public invite acceptance
+
+create extension if not exists pgcrypto;
+
+create or replace function public.accept_property_portal_invite(p_raw_token text)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_email text;
+  v_now timestamptz := now();
+  v_token_hash text;
+
+  v_invite_id uuid;
+  v_shop_id uuid;
+  v_role text;
+  v_portfolio_id uuid;
+  v_property_id uuid;
+  v_unit_id uuid;
+
+  v_member_id uuid;
+begin
+  v_uid := auth.uid();
+
+  if v_uid is null then
+    return jsonb_build_object(
+      'success', false,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_raw_token is null or btrim(p_raw_token) = '' then
+    return jsonb_build_object(
+      'success', false,
+      'message', 'Invite token is required'
+    );
+  end if;
+
+  -- Raw token is never stored; hash-only lookup.
+  v_token_hash := encode(digest(p_raw_token, 'sha256'), 'hex');
+
+  -- Authenticated email lookup from auth.users. If this is inaccessible in a target
+  -- environment, stop and provide an explicit fallback plan rather than broadening RLS.
+  select lower(u.email)
+    into v_email
+  from auth.users u
+  where u.id = v_uid
+  limit 1;
+
+  if v_email is null or v_email = '' then
+    return jsonb_build_object(
+      'success', false,
+      'message', 'No authenticated email available for this user'
+    );
+  end if;
+
+  -- Lock pending invite row by hash for atomic acceptance.
+  select i.id, i.shop_id, i.role, i.portfolio_id, i.property_id, i.unit_id
+    into v_invite_id, v_shop_id, v_role, v_portfolio_id, v_property_id, v_unit_id
+  from public.property_portal_invites i
+  where i.token_hash = v_token_hash
+    and i.status = 'pending'
+    and i.expires_at > v_now
+    and lower(i.invited_email) = v_email
+  for update;
+
+  if v_invite_id is null then
+    return jsonb_build_object(
+      'success', false,
+      'message', 'Invite is invalid, expired, already handled, or does not match this account'
+    );
+  end if;
+
+  -- Reuse existing member row when it already exists for the same assignment scope.
+  select pm.id
+    into v_member_id
+  from public.property_members pm
+  where pm.shop_id = v_shop_id
+    and pm.user_id = v_uid
+    and pm.role = v_role
+    and pm.portfolio_id is not distinct from v_portfolio_id
+    and pm.property_id is not distinct from v_property_id
+    and pm.unit_id is not distinct from v_unit_id
+  limit 1;
+
+  if v_member_id is null then
+    insert into public.property_members (
+      shop_id,
+      user_id,
+      role,
+      portfolio_id,
+      property_id,
+      unit_id
+    )
+    values (
+      v_shop_id,
+      v_uid,
+      v_role,
+      v_portfolio_id,
+      v_property_id,
+      v_unit_id
+    )
+    returning id into v_member_id;
+  end if;
+
+  update public.property_portal_invites
+  set
+    status = 'accepted',
+    accepted_by_profile_id = v_uid,
+    accepted_at = v_now,
+    updated_at = v_now
+  where id = v_invite_id;
+
+  return jsonb_build_object(
+    'success', true,
+    'message', 'Invite accepted',
+    'invite_id', v_invite_id,
+    'member_id', v_member_id
+  );
+end;
+$$;
+
+grant execute on function public.accept_property_portal_invite(text) to authenticated;
+
+comment on function public.accept_property_portal_invite(text) is
+'Step 22D manual draft: authenticated-only invite acceptance via SECURITY DEFINER RPC. Email delivery deferred. Auth user creation deferred. Invite creation remains internal-only. Public unauthenticated acceptance is unsupported.';
+
+-- RLS posture note:
+-- Keep property_portal_invites RLS internal-only.
+-- Do NOT add broad SELECT by token_hash or invited_email.
+-- Acceptance should flow through this narrow SECURITY DEFINER RPC.


### PR DESCRIPTION
### Motivation

- Prevent leaking `property_portal_invites` records via broad RLS by providing a narrow, server-side acceptance path for authenticated invitees.
- Allow an already-authenticated user to accept an invite atomically while validating token hash, pending status, expiry, and email match.
- Keep invite RLS conservative and avoid service-role or unauthenticated token lookups in this step.

### Description

- Added a manual SQL draft `supabase/manual/property-portal-invite-acceptance-step-22d.sql` that creates the `public.accept_property_portal_invite(p_raw_token text)` `SECURITY DEFINER` RPC and ensures `pgcrypto` is available via `create extension if not exists pgcrypto;`.
- The function computes `sha256` of the provided raw token, resolves the authenticated user's email from `auth.users`, locates and locks the pending invite by `token_hash` + email + expiry, and returns a constrained JSON payload without exposing token data.
- The RPC reuses an existing `property_members` row when present or inserts a new scoped member row, then updates the invite to `status = 'accepted'` with audit fields, and grants `execute` to `authenticated` while documenting RLS posture and deferred/non-goals in comments.
- Updated docs: extended `docs/plans/property-portal-invites-step-22a.md` with a Step 22D section and added a Step 22D entry in `features/operations/README.md`; no runtime code, email sending, auth user creation, or public acceptance was added.

### Testing

- Ran `git diff --check` and it completed successfully.
- Ran `npx tsc --noEmit` and TypeScript validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc7febc14832880f220891ae81e65)