### PR TITLE
Step 22E: use SECURITY DEFINER RPC for property invite acceptance

### DIFF
--- a/app/portal/property/invite/accept/actions.ts
+++ b/app/portal/property/invite/accept/actions.ts
@@ -2,91 +2,79 @@
 
 import "server-only";
 
-import { createHash } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
 
-type DB = { public: { Tables: {
-  profiles: { Row: { id: string; email: string | null } };
-  property_members: {
-    Row: { id: string };
-    Insert: { shop_id: string; user_id: string; role: string; portfolio_id?: string | null; property_id?: string | null; unit_id?: string | null };
+type DB = { public: { Functions: {
+  accept_property_portal_invite: {
+    Args: { p_raw_token: string };
+    Returns: {
+      ok: boolean;
+      code: string;
+      message: string;
+    };
   };
-  property_portal_invites: {
-    Row: { id: string; shop_id: string; invited_email: string; invited_name: string | null; role: string; portfolio_id: string | null; property_id: string | null; unit_id: string | null; status: string; expires_at: string };
-  };
-  property_portfolios: { Row: { id: string; name: string | null } };
-  property_properties: { Row: { id: string; name: string | null } };
-  property_units: { Row: { id: string; unit_label: string | null } };
 } } };
 
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
 
-function hashToken(token: string) { return createHash("sha256").update(token, "utf8").digest("hex"); }
-function err(token: string, msg: string) { return `/portal/property/invite/accept?token=${encodeURIComponent(token)}&error=${encodeURIComponent(msg)}`; }
+function acceptUrl(token: string, status: string) {
+  return `/portal/property/invite/accept?token=${encodeURIComponent(token)}&status=${encodeURIComponent(status)}`;
+}
+
+function mapRpcCodeToStatus(code: string | null | undefined): "invite-invalid" | "invite-expired" | "invite-email-mismatch" | "invite-error" {
+  switch ((code ?? "").toLowerCase()) {
+    case "invite_invalid":
+    case "invite-not-found":
+    case "invalid_token":
+      return "invite-invalid";
+    case "invite_expired":
+    case "invite-not-pending":
+    case "invite-already-used":
+      return "invite-expired";
+    case "invite_email_mismatch":
+    case "email_mismatch":
+      return "invite-email-mismatch";
+    default:
+      return "invite-error";
+  }
+}
 
 export async function getPropertyPortalInvitePreview(token: string) {
   const clean = token.trim();
   if (!clean) return { error: "Missing invite token." as const };
 
   const supabase = client();
-  const tokenHash = hashToken(clean);
-  const { data, error } = await supabase
-    .from("property_portal_invites")
-    .select("id,shop_id,invited_email,invited_name,role,portfolio_id,property_id,unit_id,status,expires_at")
-    .eq("token_hash", tokenHash)
-    .maybeSingle();
+  const { data: { user } } = await supabase.auth.getUser();
 
-  if (error) {
-    return { error: "Invite acceptance is currently blocked by access policy. Step 22D must add a controlled invite-acceptance policy/RPC before runtime acceptance can proceed." as const };
-  }
-  if (!data) return { error: "Invite not found." as const };
-  if (data.status !== "pending") return { error: "Invite is no longer pending." as const };
-  if (new Date(data.expires_at).getTime() <= Date.now()) return { error: "Invite has expired." as const };
+  if (!user) return { error: "You must sign in to accept this invite." as const };
 
-  const [portfolio, property, unit] = await Promise.all([
-    data.portfolio_id ? supabase.from("property_portfolios").select("id,name").eq("id", data.portfolio_id).maybeSingle() : Promise.resolve({ data: null, error: null }),
-    data.property_id ? supabase.from("property_properties").select("id,name").eq("id", data.property_id).maybeSingle() : Promise.resolve({ data: null, error: null }),
-    data.unit_id ? supabase.from("property_units").select("id,unit_label").eq("id", data.unit_id).maybeSingle() : Promise.resolve({ data: null, error: null }),
-  ]);
-
-  return { invite: data, labels: { portfolio: portfolio.data?.name ?? null, property: property.data?.name ?? null, unit: unit.data?.unit_label ?? null } };
+  return {
+    ready: true as const,
+    message: "Details will be confirmed securely after acceptance.",
+  };
 }
 
 export async function acceptPropertyPortalInvite(formData: FormData) {
   const token = String(formData.get("token") || "").trim();
-  if (!token) redirect("/portal/property/invite/accept?error=" + encodeURIComponent("Missing invite token."));
+  if (!token) redirect("/portal/property/invite/accept?status=invite-invalid");
 
   const supabase = client();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/sign-in");
+  if (!user) redirect(`/sign-in?next=${encodeURIComponent(`/portal/property/invite/accept?token=${encodeURIComponent(token)}`)}`);
 
-  const tokenHash = hashToken(token);
-  const inviteRes = await supabase.from("property_portal_invites").select("id,shop_id,invited_email,role,portfolio_id,property_id,unit_id,status,expires_at").eq("token_hash", tokenHash).maybeSingle();
-  if (inviteRes.error) redirect(err(token, "Invite acceptance is currently blocked by access policy. Step 22D must add a controlled invite-acceptance policy/RPC before runtime acceptance can proceed."));
+  const rpcRes = await supabase.rpc("accept_property_portal_invite", { p_raw_token: token });
 
-  const invite = inviteRes.data;
-  if (!invite) redirect(err(token, "Invite not found."));
-  if (invite.status !== "pending") redirect(err(token, "Invite is no longer pending."));
-  if (new Date(invite.expires_at).getTime() <= Date.now()) redirect(err(token, "Invite has expired."));
-
-  const [profileRes, dupeRes] = await Promise.all([
-    supabase.from("profiles").select("id,email").eq("id", user.id).maybeSingle(),
-    supabase.from("property_members").select("id").eq("shop_id", invite.shop_id).eq("user_id", user.id).eq("role", invite.role).is("portfolio_id", invite.portfolio_id).is("property_id", invite.property_id).is("unit_id", invite.unit_id).maybeSingle(),
-  ]);
-
-  const actorEmail = profileRes.data?.email?.trim().toLowerCase() ?? user.email?.trim().toLowerCase() ?? null;
-  if (actorEmail && actorEmail !== invite.invited_email.trim().toLowerCase()) redirect(err(token, "Authenticated email does not match the invited email."));
-
-  if (!dupeRes.data) {
-    const { error: insertError } = await supabase.from("property_members").insert({ shop_id: invite.shop_id, user_id: user.id, role: invite.role, portfolio_id: invite.portfolio_id, property_id: invite.property_id, unit_id: invite.unit_id });
-    if (insertError) redirect(err(token, insertError.message));
+  if (rpcRes.error) {
+    redirect(acceptUrl(token, "invite-error"));
   }
 
-  const { error: updateError } = await supabase.from("property_portal_invites").update({ status: "accepted", accepted_by_profile_id: user.id, accepted_at: new Date().toISOString() }).eq("id", invite.id).eq("status", "pending");
-  if (updateError) redirect(err(token, updateError.message));
+  const result = rpcRes.data;
+  if (!result?.ok) {
+    redirect(acceptUrl(token, mapRpcCodeToStatus(result?.code)));
+  }
 
   revalidatePath("/portal/property/member");
   redirect("/portal/property/member?status=invite-accepted");

--- a/app/portal/property/invite/accept/page.tsx
+++ b/app/portal/property/invite/accept/page.tsx
@@ -10,11 +10,29 @@ const client = () => createServerSupabaseRSC() as unknown as SupabaseClient;
 
 function sv(v: string | string[] | undefined) { return Array.isArray(v) ? v[0] : v; }
 
+function statusMessage(status: string | undefined) {
+  switch (status) {
+    case "invite-accepted":
+      return { tone: "ok", message: "Invite accepted. Redirecting to your property member portal." } as const;
+    case "invite-invalid":
+      return { tone: "warn", message: "This invite is invalid or no longer available." } as const;
+    case "invite-expired":
+      return { tone: "warn", message: "This invite has expired or is no longer pending." } as const;
+    case "invite-email-mismatch":
+      return { tone: "warn", message: "The signed-in email does not match the invited email for this token." } as const;
+    case "invite-error":
+      return { tone: "warn", message: "We could not accept this invite right now. Please try again." } as const;
+    default:
+      return null;
+  }
+}
+
 export default async function PropertyInviteAcceptPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const params = (await searchParams) ?? {};
   const token = sv(params.token)?.trim() ?? "";
-  const error = sv(params.error);
+  const status = sv(params.status);
   const inviteUrl = `/portal/property/invite/accept${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+  const banner = statusMessage(status);
 
   if (!token) {
     return <section className="metal-card rounded-3xl p-5"><h1 className="text-2xl text-neutral-100">Invalid invite</h1><p className="mt-3 text-sm text-neutral-300">Missing invite token.</p></section>;
@@ -25,29 +43,25 @@ export default async function PropertyInviteAcceptPage({ searchParams }: { searc
   if (!user) redirect(`/sign-in?next=${encodeURIComponent(inviteUrl)}`);
 
   const preview = await getPropertyPortalInvitePreview(token);
-  const scope = preview.invite ? [
-    preview.invite.portfolio_id ? `Portfolio: ${preview.labels.portfolio ?? preview.invite.portfolio_id}` : null,
-    preview.invite.property_id ? `Property: ${preview.labels.property ?? preview.invite.property_id}` : null,
-    preview.invite.unit_id ? `Unit: ${preview.labels.unit ?? preview.invite.unit_id}` : null,
-  ].filter(Boolean).join(" · ") || "Global (property_manager)" : null;
 
   return (
     <section className="metal-card rounded-3xl p-5 text-neutral-100">
       <p className="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">Portal</p>
       <h1 className="mt-2 text-2xl">Accept property invite</h1>
-      {(error || preview.error) && <p className="mt-3 rounded-lg border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">{error ?? preview.error}</p>}
+      {banner && (
+        <p className={`mt-3 rounded-lg border px-3 py-2 text-sm ${banner.tone === "ok" ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200" : "border-amber-400/40 bg-amber-500/10 text-amber-200"}`}>
+          {banner.message}
+        </p>
+      )}
 
-      {preview.invite && !preview.error ? <div className="mt-5 space-y-2 text-sm text-neutral-300">
-        <p><span className="text-neutral-400">Invited email:</span> {preview.invite.invited_email}</p>
-        <p><span className="text-neutral-400">Invited name:</span> {preview.invite.invited_name ?? "—"}</p>
-        <p><span className="text-neutral-400">Role:</span> {preview.invite.role}</p>
-        <p><span className="text-neutral-400">Scope:</span> {scope}</p>
-        <p><span className="text-neutral-400">Expires:</span> {new Date(preview.invite.expires_at).toLocaleString()}</p>
+      <div className="mt-5 space-y-2 text-sm text-neutral-300">
+        <p className="text-neutral-200">Ready to accept property portal invite.</p>
+        <p>{preview.message}</p>
         <form action={acceptPropertyPortalInvite} className="pt-2">
           <input type="hidden" name="token" value={token} />
           <button type="submit" className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-4 py-2 text-sm text-cyan-200">Accept invite</button>
         </form>
-      </div> : <p className="mt-4 text-sm text-neutral-300">This invite cannot be accepted in its current state.</p>}
+      </div>
 
       <div className="mt-5"><Link href="/portal/property/member" className="text-sm text-cyan-300 underline">Go to property member portal</Link></div>
     </section>

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -346,3 +346,15 @@ Any future schema expansion should be documented and applied manually.
   - no email sending flow
   - no auth user creation flow
   - no unauthenticated/public acceptance
+
+## Step 22E: Property portal invite acceptance runtime via SECURITY DEFINER RPC
+
+- Updated `/portal/property/invite/accept` acceptance action to use `public.accept_property_portal_invite(p_raw_token)` through the authenticated Supabase RLS client.
+- Acceptance no longer performs direct invite table select/update in runtime action logic.
+- No service-role client usage was added.
+- No email sending was added.
+- No Supabase Auth user creation was added.
+- No unauthenticated acceptance path was added.
+- Acceptance status handling now maps safe statuses for UI messaging: `invite-accepted`, `invite-invalid`, `invite-expired`, `invite-email-mismatch`, and `invite-error`.
+- Invite preview now uses a safe generic authenticated confirmation surface when token is present, with details confirmed after secure acceptance.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Replace runtime direct `property_portal_invites` SELECT/UPDATE logic with a controlled `SECURITY DEFINER` RPC so authenticated acceptance works despite restrictive RLS policies while preserving token secrecy and tenant boundaries.
- Keep runtime behavior strictly authenticated and non-destructive to schema or auth flows, avoiding service-role usage, email delivery, or Supabase Auth user creation.

### Description
- Updated the server action `acceptPropertyPortalInvite` to use the authenticated RLS client and call the RPC `public.accept_property_portal_invite(p_raw_token)` instead of doing direct table `SELECT`/`INSERT`/`UPDATE` in runtime code. (`app/portal/property/invite/accept/actions.ts`)
- Reworked the preview/accept page to avoid selecting invite rows under RLS; the preview now shows a generic authenticated confirmation: “Ready to accept property portal invite” and explains details are confirmed after secure acceptance. (`app/portal/property/invite/accept/page.tsx`)
- Added safe RPC result => UI status mapping and redirect handling for `invite-accepted`, `invite-invalid`, `invite-expired`, `invite-email-mismatch`, and `invite-error`, and ensured the token is never logged or stored. (`app/portal/property/invite/accept/actions.ts`, `app/portal/property/invite/accept/page.tsx`)
- Documented Step 22E in `features/operations/README.md` clarifying RPC usage and non-goals (no schema changes, no service role, no emails, no auth user creation, no unauthenticated acceptance).

### Testing
- Ran `npm run typecheck` (TypeScript `tsc --noEmit`) and it completed successfully.
- Ran `npx eslint app/portal/property/invite/accept/page.tsx app/portal/property/invite/accept/actions.ts` and it completed without errors.
- Ran `npx eslint app/portal/property/invite/accept/page.tsx app/portal/property/invite/accept/actions.ts features/operations/README.md` which reported a parsing error on the Markdown file; this is expected because the repo ESLint invocation attempted to parse a `.md` file with code parsers and does not affect the TypeScript/JS changes.

Confirmations
- No database schema or migration changes were made.
- No service-role client was added; the authenticated RLS client (`createServerSupabaseRSC`) is used.
- No email sending was added.
- No Supabase Auth user creation was added.
- No raw token persistence or token_hash exposure was introduced; the raw token is used only transiently for the RPC call and in the existing query-param redirect flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc9e56d0083289e4cc4bdd159689d)