### PR TITLE
Step 22F: one-time property invite link display on create (no raw token stored)

### DIFF
--- a/app/property/invites/InviteCreateForm.tsx
+++ b/app/property/invites/InviteCreateForm.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useActionState } from "react";
+import { createPropertyPortalInvite, initialInviteCreateActionState } from "./actions";
+
+type Option = { id: string; label: string };
+
+const roles = ["property_manager", "owner_approver", "tenant_requester", "viewer"] as const;
+
+export default function InviteCreateForm({
+  portfolios,
+  properties,
+  units,
+}: {
+  portfolios: Option[];
+  properties: Option[];
+  units: Option[];
+}) {
+  const [state, action, pending] = useActionState(createPropertyPortalInvite, initialInviteCreateActionState);
+
+  return <form action={action} className="mt-4 space-y-3">
+    <input type="email" name="invited_email" required placeholder="tenant@example.com" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
+    <input name="invited_name" placeholder="Invited name (optional)" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
+    <select name="role" required className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2">{roles.map((r)=><option key={r} value={r}>{r}</option>)}</select>
+    <select name="portfolio_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No portfolio scope</option>{portfolios.map((x)=><option key={x.id} value={x.id}>{x.label}</option>)}</select>
+    <select name="property_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No property scope</option>{properties.map((x)=><option key={x.id} value={x.id}>{x.label}</option>)}</select>
+    <select name="unit_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No unit scope</option>{units.map((x)=><option key={x.id} value={x.id}>{x.label}</option>)}</select>
+    <input type="number" min={1} max={30} name="expires_in_days" defaultValue={7} required className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
+    <button type="submit" disabled={pending} className="w-full rounded-xl border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 disabled:opacity-60">{pending ? "Creating invite..." : "Create invite record"}</button>
+
+    {state.status === "validation-error" && state.message && <p className="text-sm text-rose-300">{state.message}</p>}
+
+    {state.status === "invite-created" && state.inviteLink && <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm">
+      <p className="font-medium text-emerald-200">Invite created. Copy this link now — it will not be shown again.</p>
+      <p className="mt-1 text-xs text-emerald-100/90">Email sending is not wired yet. Share this link through your approved internal process.</p>
+      <div className="mt-3 flex gap-2">
+        <input readOnly value={state.inviteLink} className="w-full rounded-xl border border-emerald-400/40 bg-black/40 px-3 py-2 text-xs"/>
+        <button type="button" onClick={() => navigator.clipboard.writeText(state.inviteLink as string)} className="rounded-xl border border-emerald-400/40 px-3 py-2 text-xs">Copy</button>
+      </div>
+      <p className="mt-2 text-xs text-emerald-100/90">Invited email: {state.invitedEmail}</p>
+      <p className="text-xs text-emerald-100/90">Expires: {state.expiresAt ? new Date(state.expiresAt).toLocaleString() : "—"}</p>
+    </div>}
+  </form>;
+}

--- a/app/property/invites/actions.ts
+++ b/app/property/invites/actions.ts
@@ -1,0 +1,117 @@
+"use server";
+
+import { createHash, randomBytes } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  profiles: { Row: { id: string; shop_id: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_portfolios: { Row: { id: string; shop_id: string; name: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_properties: { Row: { id: string; shop_id: string; name: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_units: { Row: { id: string; shop_id: string; property_id: string; unit_label: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_portal_invites: {
+    Row: { id: string; shop_id: string; invited_email: string; invited_name: string | null; role: string; portfolio_id: string | null; property_id: string | null; unit_id: string | null; status: string; expires_at: string; created_at: string; accepted_at: string | null };
+    Insert: { shop_id: string; invited_email: string; invited_name?: string | null; role: string; portfolio_id?: string | null; property_id?: string | null; unit_id?: string | null; token_hash: string; expires_at: string; created_by_profile_id: string };
+    Update: never;
+    Relationships: [];
+  };
+} } };
+
+const roles = ["property_manager", "owner_approver", "tenant_requester", "viewer"] as const;
+const roleSet = new Set<string>(roles);
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export type InviteCreateActionState = {
+  status: "idle" | "validation-error" | "invite-created";
+  message?: string;
+  inviteLink?: string;
+  invitedEmail?: string;
+  expiresAt?: string;
+};
+
+export const initialInviteCreateActionState: InviteCreateActionState = { status: "idle" };
+
+export async function createPropertyPortalInvite(
+  _prevState: InviteCreateActionState,
+  formData: FormData,
+): Promise<InviteCreateActionState> {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { status: "validation-error", message: "You must be signed in to create invites." };
+  }
+
+  const { data: me } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
+  if (!me?.shop_id) {
+    return { status: "validation-error", message: "No shop scope on current profile." };
+  }
+  const currentShopId = me.shop_id;
+
+  const invitedEmail = String(formData.get("invited_email") || "").trim().toLowerCase();
+  const invitedName = String(formData.get("invited_name") || "").trim() || null;
+  const role = String(formData.get("role") || "").trim();
+  const portfolioId = String(formData.get("portfolio_id") || "").trim() || null;
+  const propertyId = String(formData.get("property_id") || "").trim() || null;
+  const unitId = String(formData.get("unit_id") || "").trim() || null;
+  const expiresInDays = Number.parseInt(String(formData.get("expires_in_days") || "7").trim(), 10);
+
+  if (!invitedEmail) return { status: "validation-error", message: "Invited email is required." };
+  if (!roleSet.has(role)) return { status: "validation-error", message: "Invalid role." };
+  if (!Number.isFinite(expiresInDays) || expiresInDays < 1 || expiresInDays > 30) {
+    return { status: "validation-error", message: "Expires in days must be between 1 and 30." };
+  }
+  if (role !== "property_manager" && !portfolioId && !propertyId && !unitId) {
+    return { status: "validation-error", message: "Scope required unless role is property_manager." };
+  }
+
+  if (portfolioId) {
+    const { data } = await supabase.from("property_portfolios").select("id,shop_id").eq("id", portfolioId).maybeSingle();
+    if (!data || data.shop_id !== currentShopId) return { status: "validation-error", message: "Invalid portfolio scope." };
+  }
+
+  if (propertyId) {
+    const { data } = await supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle();
+    if (!data || data.shop_id !== currentShopId) return { status: "validation-error", message: "Invalid property scope." };
+  }
+
+  if (unitId) {
+    const { data } = await supabase.from("property_units").select("id,shop_id,property_id").eq("id", unitId).maybeSingle();
+    if (!data || data.shop_id !== currentShopId) return { status: "validation-error", message: "Invalid unit scope." };
+    if (propertyId && data.property_id !== propertyId) return { status: "validation-error", message: "Unit does not belong to property." };
+  }
+
+  const rawToken = randomBytes(32).toString("hex");
+  const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
+  const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const { error } = await supabase.from("property_portal_invites").insert({
+    shop_id: currentShopId,
+    invited_email: invitedEmail,
+    invited_name: invitedName,
+    role,
+    portfolio_id: portfolioId,
+    property_id: propertyId,
+    unit_id: unitId,
+    token_hash: tokenHash,
+    expires_at: expiresAt,
+    created_by_profile_id: user.id,
+  });
+
+  if (error) {
+    return { status: "validation-error", message: error.message };
+  }
+
+  const origin = process.env.NEXT_PUBLIC_APP_URL?.trim() || "http://localhost:3000";
+  const inviteLink = `${origin}/portal/property/invite/accept?token=${rawToken}`;
+
+  revalidatePath("/property/invites");
+  revalidatePath("/property");
+
+  return {
+    status: "invite-created",
+    inviteLink,
+    invitedEmail,
+    expiresAt,
+  };
+}

--- a/app/property/invites/page.tsx
+++ b/app/property/invites/page.tsx
@@ -1,11 +1,10 @@
 import "server-only";
 
-import { createHash, randomBytes } from "node:crypto";
 import Link from "next/link";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import InviteCreateForm from "./InviteCreateForm";
 
 type DB = { public: { Tables: {
   profiles: { Row: { id: string; shop_id: string | null }; Insert: never; Update: never; Relationships: [] };
@@ -20,8 +19,6 @@ type DB = { public: { Tables: {
   };
 } } };
 
-const roles = ["property_manager", "owner_approver", "tenant_requester", "viewer"] as const;
-const roleSet = new Set<string>(roles);
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
 
 function sv(v: string | string[] | undefined) { return Array.isArray(v) ? v[0] : v; }
@@ -51,69 +48,6 @@ export default async function PropertyInvitesPage({ searchParams }: { searchPara
     supabase.from("property_portal_invites").select("id,shop_id,invited_email,invited_name,role,portfolio_id,property_id,unit_id,status,expires_at,created_at,accepted_at").eq("shop_id", shopId).order("created_at", { ascending: false }),
   ]);
 
-  async function createInvite(formData: FormData) {
-    "use server";
-    const supabase = client();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) redirect("/signin");
-
-    const { data: me } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
-    if (!me?.shop_id) redirect("/property/invites?error=" + encodeURIComponent("No shop scope on current profile."));
-    const currentShopId = me.shop_id;
-
-    const invitedEmail = String(formData.get("invited_email") || "").trim().toLowerCase();
-    const invitedName = String(formData.get("invited_name") || "").trim() || null;
-    const role = String(formData.get("role") || "").trim();
-    const portfolioId = String(formData.get("portfolio_id") || "").trim() || null;
-    const propertyId = String(formData.get("property_id") || "").trim() || null;
-    const unitId = String(formData.get("unit_id") || "").trim() || null;
-    const expiresInDays = Number.parseInt(String(formData.get("expires_in_days") || "7").trim(), 10);
-
-    if (!invitedEmail) redirect("/property/invites?error=" + encodeURIComponent("Invited email is required."));
-    if (!roleSet.has(role)) redirect("/property/invites?error=" + encodeURIComponent("Invalid role."));
-    if (!Number.isFinite(expiresInDays) || expiresInDays < 1 || expiresInDays > 30) redirect("/property/invites?error=" + encodeURIComponent("Expires in days must be between 1 and 30."));
-    if (role !== "property_manager" && !portfolioId && !propertyId && !unitId) redirect("/property/invites?error=" + encodeURIComponent("Scope required unless role is property_manager."));
-
-    if (portfolioId) {
-      const { data } = await supabase.from("property_portfolios").select("id,shop_id").eq("id", portfolioId).maybeSingle();
-      if (!data || data.shop_id !== currentShopId) redirect("/property/invites?error=" + encodeURIComponent("Invalid portfolio scope."));
-    }
-
-    if (propertyId) {
-      const { data } = await supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle();
-      if (!data || data.shop_id !== currentShopId) redirect("/property/invites?error=" + encodeURIComponent("Invalid property scope."));
-    }
-
-    if (unitId) {
-      const { data } = await supabase.from("property_units").select("id,shop_id,property_id").eq("id", unitId).maybeSingle();
-      if (!data || data.shop_id !== currentShopId) redirect("/property/invites?error=" + encodeURIComponent("Invalid unit scope."));
-      if (propertyId && data.property_id !== propertyId) redirect("/property/invites?error=" + encodeURIComponent("Unit does not belong to property."));
-    }
-
-    const rawToken = randomBytes(32).toString("hex");
-    const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
-    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
-
-    const { error } = await supabase.from("property_portal_invites").insert({
-      shop_id: currentShopId,
-      invited_email: invitedEmail,
-      invited_name: invitedName,
-      role,
-      portfolio_id: portfolioId,
-      property_id: propertyId,
-      unit_id: unitId,
-      token_hash: tokenHash,
-      expires_at: expiresAt,
-      created_by_profile_id: user.id,
-    });
-
-    if (error) redirect("/property/invites?error=" + encodeURIComponent(error.message));
-
-    revalidatePath("/property/invites");
-    revalidatePath("/property");
-    redirect("/property/invites?status=invite-created");
-  }
-
   const portfolioRows = portfolios.data ?? [];
   const propertyRows = properties.data ?? [];
   const unitRows = units.data ?? [];
@@ -125,17 +59,14 @@ export default async function PropertyInvitesPage({ searchParams }: { searchPara
 
   return <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(193,122,74,0.18),transparent_34%),#020617] p-6 text-white"><div className="mx-auto max-w-6xl space-y-6">
     <div className="flex gap-2 text-xs uppercase tracking-[0.16em]"><Link href="/property" className="rounded-full border border-[color:var(--metal-border-soft)] px-3 py-1">Back to /property</Link><Link href="/property/members" className="rounded-full border border-[color:var(--metal-border-soft)] px-3 py-1">Property Members</Link></div>
-    <section className="metal-card rounded-3xl p-6"><h1 className="text-3xl font-semibold">Property Portal Invites</h1><p className="mt-2 text-sm text-neutral-300">Create internal invite records for property portal access scopes.</p><p className="mt-2 text-xs text-neutral-400">Invite created. Email sending and token acceptance will be wired in the next phase.</p>{sv(params.status)==="invite-created"&&<p className="mt-2 text-emerald-300">Invite record created successfully.</p>}{sv(params.error)&&<p className="mt-2 text-rose-300">{sv(params.error)}</p>}</section>
-    <section className="grid gap-6 lg:grid-cols-2"><article className="metal-card rounded-3xl p-6"><h2 className="text-lg font-semibold">Create invite record</h2><form action={createInvite} className="mt-4 space-y-3">
-      <input type="email" name="invited_email" required placeholder="tenant@example.com" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
-      <input name="invited_name" placeholder="Invited name (optional)" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
-      <select name="role" required className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2">{roles.map((r)=><option key={r} value={r}>{r}</option>)}</select>
-      <select name="portfolio_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No portfolio scope</option>{portfolioRows.map((x)=><option key={x.id} value={x.id}>{x.name??x.id}</option>)}</select>
-      <select name="property_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No property scope</option>{propertyRows.map((x)=><option key={x.id} value={x.id}>{x.name??x.id}</option>)}</select>
-      <select name="unit_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No unit scope</option>{unitRows.map((x)=><option key={x.id} value={x.id}>{x.unit_label??x.id}</option>)}</select>
-      <input type="number" min={1} max={30} name="expires_in_days" defaultValue={7} required className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
-      <button type="submit" className="w-full rounded-xl border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2">Create invite record</button>
-    </form></article>
-    <article className="metal-card rounded-3xl p-6"><h2 className="text-lg font-semibold">Existing invite records</h2><div className="mt-4 space-y-3">{inviteRows.length===0?<p className="text-sm text-neutral-400">No property portal invites found for this shop.</p>:inviteRows.map((invite)=><div key={invite.id} className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/30 p-3 text-sm"><div className="flex justify-between"><span>{invite.invited_email}</span><span>{invite.status}</span></div><div className="text-xs text-neutral-400">Name: {invite.invited_name||"—"}<br/>Role: {invite.role}<br/>Scope: {scopeLabel(invite, portfolioMap, propertyMap, unitMap)}<br/>Expires: {invite.expires_at?new Date(invite.expires_at).toLocaleString():"—"}<br/>Created: {invite.created_at?new Date(invite.created_at).toLocaleString():"—"}<br/>Accepted: {invite.accepted_at?new Date(invite.accepted_at).toLocaleString():"—"}</div></div>)}</div></article></section>
+    <section className="metal-card rounded-3xl p-6"><h1 className="text-3xl font-semibold">Property Portal Invites</h1><p className="mt-2 text-sm text-neutral-300">Create internal invite records for property portal access scopes.</p><p className="mt-2 text-xs text-neutral-400">Invite created. Email sending and token acceptance will be wired in the next phase.</p>{sv(params.error)&&<p className="mt-2 text-rose-300">{sv(params.error)}</p>}</section>
+    <section className="grid gap-6 lg:grid-cols-2"><article className="metal-card rounded-3xl p-6"><h2 className="text-lg font-semibold">Create invite record</h2>
+      <InviteCreateForm
+        portfolios={portfolioRows.map((x) => ({ id: x.id, label: x.name ?? x.id }))}
+        properties={propertyRows.map((x) => ({ id: x.id, label: x.name ?? x.id }))}
+        units={unitRows.map((x) => ({ id: x.id, label: x.unit_label ?? x.id }))}
+      />
+    </article>
+    <article className="metal-card rounded-3xl p-6"><h2 className="text-lg font-semibold">Existing invite records</h2><div className="mt-4 space-y-3">{inviteRows.length===0?<p className="text-sm text-neutral-400">No property portal invites found for this shop.</p>:inviteRows.map((invite)=><div key={invite.id} className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-black/30 p-3 text-sm"><div className="flex justify-between"><span>{invite.invited_email}</span><span>{invite.status}</span></div><div className="text-xs text-neutral-400">Name: {invite.invited_name||"—"}<br/>Role: {invite.role}<br/>Scope: {scopeLabel(invite, portfolioMap, propertyMap, unitMap)}<br/>Link: Link not available. Create a new invite to generate a one-time link.<br/>Expires: {invite.expires_at?new Date(invite.expires_at).toLocaleString():"—"}<br/>Created: {invite.created_at?new Date(invite.created_at).toLocaleString():"—"}<br/>Accepted: {invite.accepted_at?new Date(invite.accepted_at).toLocaleString():"—"}</div></div>)}</div></article></section>
   </div></main>;
 }

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -358,3 +358,14 @@ Any future schema expansion should be documented and applied manually.
 - Acceptance status handling now maps safe statuses for UI messaging: `invite-accepted`, `invite-invalid`, `invite-expired`, `invite-email-mismatch`, and `invite-error`.
 - Invite preview now uses a safe generic authenticated confirmation surface when token is present, with details confirmed after secure acceptance.
 - No schema or migration changes were introduced in this step.
+
+## Step 22F: One-time property invite link display on create
+
+- Updated `/property/invites` invite creation UX to show a one-time invite acceptance link immediately after a successful invite insert.
+- The invite link is returned only in server action state for the current request lifecycle and is not persisted.
+- Raw invite token continues to be generated server-side and only `token_hash` is stored in `property_portal_invites`.
+- Raw token is not passed through redirect query params and no token is exposed in invite list rows.
+- Existing invite rows remain token-blind and now explicitly show: `Link not available. Create a new invite to generate a one-time link.`
+- Email sending is still not wired.
+- No auth user creation was added.
+- No schema or migration changes were introduced in this step.


### PR DESCRIPTION
### Motivation
- Internal staff need a safe way to copy a freshly-created property portal invite link immediately after creation, while preserving the existing security posture that raw tokens are not recoverable or persisted.
- The flow must not persist raw tokens, must not place raw tokens in redirect query params, and must not add email delivery, auth user creation, service-role usage, or schema changes.

### Description
- Added a server action `createPropertyPortalInvite` at `app/property/invites/actions.ts` that preserves all existing validation (auth, `profile.shop_id`, role allowlist, scope checks, normalized email, expires 1–30 days), generates the raw token server-side, stores only the SHA-256 `token_hash` in `property_portal_invites`, and returns a one-time `inviteLink` in the action state without persisting or logging the raw token.
- Implemented `InviteCreateForm` at `app/property/invites/InviteCreateForm.tsx` as a client component using `useActionState` to call the action and render a secure one-time box with a readonly link field, a copy button, invited email, expiry date, and a clear note that email sending is not wired.
- Updated `app/property/invites/page.tsx` to remain a server component that loads lists and mounts the client `InviteCreateForm`, removed the previous redirect-based server action, and made existing invite rows explicitly show: “Link not available. Create a new invite to generate a one-time link.”
- Documented the change under `features/operations/README.md` as Step 22F describing the one-time link behavior and security constraints.

### Testing
- Ran `npm run typecheck`, which completed successfully.
- Ran `npx eslint app/property/invites/page.tsx app/property/invites/actions.ts app/property/invites/InviteCreateForm.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cce4e59c88328a6d6cf43f67c7332)