### PR TITLE
Add optional email sending for property portal invites

### DIFF
--- a/app/property/invites/InviteCreateForm.tsx
+++ b/app/property/invites/InviteCreateForm.tsx
@@ -26,13 +26,17 @@ export default function InviteCreateForm({
     <select name="property_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No property scope</option>{properties.map((x)=><option key={x.id} value={x.id}>{x.label}</option>)}</select>
     <select name="unit_id" className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"><option value="">No unit scope</option>{units.map((x)=><option key={x.id} value={x.id}>{x.label}</option>)}</select>
     <input type="number" min={1} max={30} name="expires_in_days" defaultValue={7} required className="w-full rounded-xl border border-[color:var(--metal-border-soft)] bg-black/40 px-3 py-2"/>
+    <label className="flex items-center gap-2 text-sm text-neutral-200">
+      <input type="checkbox" name="email_invite" className="h-4 w-4"/>
+      Email this invite
+    </label>
     <button type="submit" disabled={pending} className="w-full rounded-xl border border-[color:var(--accent-copper)]/70 bg-[color:var(--accent-copper)]/20 px-4 py-2 disabled:opacity-60">{pending ? "Creating invite..." : "Create invite record"}</button>
 
     {state.status === "validation-error" && state.message && <p className="text-sm text-rose-300">{state.message}</p>}
 
     {state.status === "invite-created" && state.inviteLink && <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm">
       <p className="font-medium text-emerald-200">Invite created. Copy this link now — it will not be shown again.</p>
-      <p className="mt-1 text-xs text-emerald-100/90">Email sending is not wired yet. Share this link through your approved internal process.</p>
+      {state.warning ? <p className="mt-1 text-xs text-amber-200">{state.warning}</p> : <p className="mt-1 text-xs text-emerald-100/90">If emailed, keep this for backup in case delivery fails.</p>}
       <div className="mt-3 flex gap-2">
         <input readOnly value={state.inviteLink} className="w-full rounded-xl border border-emerald-400/40 bg-black/40 px-3 py-2 text-xs"/>
         <button type="button" onClick={() => navigator.clipboard.writeText(state.inviteLink as string)} className="rounded-xl border border-emerald-400/40 px-3 py-2 text-xs">Copy</button>

--- a/app/property/invites/actions.ts
+++ b/app/property/invites/actions.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import sgMail from "@sendgrid/mail";
 
 type DB = { public: { Tables: {
   profiles: { Row: { id: string; shop_id: string | null }; Insert: never; Update: never; Relationships: [] };
@@ -25,12 +26,58 @@ const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
 export type InviteCreateActionState = {
   status: "idle" | "validation-error" | "invite-created";
   message?: string;
+  warning?: string;
   inviteLink?: string;
   invitedEmail?: string;
   expiresAt?: string;
 };
 
 export const initialInviteCreateActionState: InviteCreateActionState = { status: "idle" };
+
+let sendgridConfigured = false;
+
+function sendgridEnvReady() {
+  const apiKey = process.env.SENDGRID_API_KEY?.trim() || "";
+  const fromEmail = process.env.SENDGRID_FROM_EMAIL?.trim() || "";
+  return { apiKey, fromEmail, ready: Boolean(apiKey && fromEmail) };
+}
+
+async function sendPropertyInviteEmail(input: {
+  to: string;
+  invitedName: string | null;
+  inviteLink: string;
+  expiresAt: string;
+}) {
+  const { apiKey, fromEmail, ready } = sendgridEnvReady();
+  if (!ready) {
+    throw new Error("SendGrid is not configured (missing SENDGRID_API_KEY or SENDGRID_FROM_EMAIL).");
+  }
+
+  if (!sendgridConfigured) {
+    sgMail.setApiKey(apiKey);
+    sendgridConfigured = true;
+  }
+
+  const expiresLabel = new Date(input.expiresAt).toLocaleString();
+  const greeting = input.invitedName ? `Hello ${input.invitedName},` : "Hello,";
+
+  await sgMail.send({
+    to: input.to,
+    from: fromEmail,
+    subject: "Your property maintenance portal invite",
+    text: [
+      greeting,
+      "",
+      "You were invited to access the property maintenance portal.",
+      "Use this one-time invite link:",
+      input.inviteLink,
+      "",
+      `This invite expires on: ${expiresLabel}`,
+      "",
+      "This portal access is only for property maintenance requests.",
+    ].join("\n"),
+  });
+}
 
 export async function createPropertyPortalInvite(
   _prevState: InviteCreateActionState,
@@ -55,6 +102,7 @@ export async function createPropertyPortalInvite(
   const propertyId = String(formData.get("property_id") || "").trim() || null;
   const unitId = String(formData.get("unit_id") || "").trim() || null;
   const expiresInDays = Number.parseInt(String(formData.get("expires_in_days") || "7").trim(), 10);
+  const shouldEmailInvite = String(formData.get("email_invite") || "") === "on";
 
   if (!invitedEmail) return { status: "validation-error", message: "Invited email is required." };
   if (!roleSet.has(role)) return { status: "validation-error", message: "Invalid role." };
@@ -108,8 +156,23 @@ export async function createPropertyPortalInvite(
   revalidatePath("/property/invites");
   revalidatePath("/property");
 
+  let warning: string | undefined;
+  if (shouldEmailInvite) {
+    try {
+      await sendPropertyInviteEmail({
+        to: invitedEmail,
+        invitedName,
+        inviteLink,
+        expiresAt,
+      });
+    } catch {
+      warning = "Invite created, but email could not be sent. Copy the link manually.";
+    }
+  }
+
   return {
     status: "invite-created",
+    warning,
     inviteLink,
     invitedEmail,
     expiresAt,


### PR DESCRIPTION
### Motivation
- Provide an optional, safe UX to email property portal invites so admins can deliver one-time invite links from the create flow while preserving the existing secure token model.
- Keep the existing server-side invite lifecycle unchanged (only store `token_hash`, show the raw link once) and avoid creating auth users, exposing hashes, using service-role keys, or changing schema.

### Description
- Added an `Email this invite` checkbox to the create form (`app/property/invites/InviteCreateForm.tsx`) and surface a delivery warning in the success UI when present.
- Implemented a small SendGrid helper inside the server action to send the one-time invite via `@sendgrid/mail` (`app/property/invites/actions.ts`) using `SENDGRID_API_KEY` and `SENDGRID_FROM_EMAIL` environment variables, and subject `Your property maintenance portal invite`.
- Email body includes optional invited name, short explanation, the one-time invite link, an expiry date, and a maintenance-only access note, and the helper throws if env is missing so the send path is gated.
- On email failure the invite record remains created and the action returns a warning state: `Invite created, but email could not be sent. Copy the link manually.`

### Testing
- Ran type checks with `npm run typecheck` and it completed successfully.
- Ran targeted linting with `npx eslint app/property/invites/actions.ts app/property/invites/InviteCreateForm.tsx` and it completed successfully.

Notes / confirmations: no raw tokens are stored (only `token_hash`), no `token_hash` is exposed in responses or UI, no Supabase Auth user creation was added, no unauthenticated acceptance or service-role usage was introduced, and no DB schema changes were made. The invite creation still succeeds if email sending fails (warning returned for manual copy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1e11b578832885e557f645a6c909)