### PR TITLE
Fix Next.js server action export error in property invites

### DIFF
--- a/app/property/invites/InviteCreateForm.tsx
+++ b/app/property/invites/InviteCreateForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useActionState } from "react";
-import { createPropertyPortalInvite, initialInviteCreateActionState } from "./actions";
+import { createPropertyPortalInvite } from "./actions";
+import { initialInviteCreateActionState } from "./inviteCreateState";
 
 type Option = { id: string; label: string };
 

--- a/app/property/invites/actions.ts
+++ b/app/property/invites/actions.ts
@@ -23,16 +23,7 @@ const roles = ["property_manager", "owner_approver", "tenant_requester", "viewer
 const roleSet = new Set<string>(roles);
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
 
-export type InviteCreateActionState = {
-  status: "idle" | "validation-error" | "invite-created";
-  message?: string;
-  warning?: string;
-  inviteLink?: string;
-  invitedEmail?: string;
-  expiresAt?: string;
-};
-
-export const initialInviteCreateActionState: InviteCreateActionState = { status: "idle" };
+import type { InviteCreateActionState } from "./inviteCreateState";
 
 let sendgridConfigured = false;
 

--- a/app/property/invites/inviteCreateState.ts
+++ b/app/property/invites/inviteCreateState.ts
@@ -1,0 +1,10 @@
+export type InviteCreateActionState = {
+  status: "idle" | "validation-error" | "invite-created";
+  message?: string;
+  warning?: string;
+  inviteLink?: string;
+  invitedEmail?: string;
+  expiresAt?: string;
+};
+
+export const initialInviteCreateActionState: InviteCreateActionState = { status: "idle" };


### PR DESCRIPTION
### Motivation
- Next.js server action files with a top-level `"use server"` may only export async functions, and `app/property/invites/actions.ts` exported non-async type/const values which caused a runtime error.
- The intent is to preserve the existing invite creation behavior while making the file compliant with Next.js server-action constraints.

### Description
- Moved the `InviteCreateActionState` type and `initialInviteCreateActionState` constant from `app/property/invites/actions.ts` into a new non-server module `app/property/invites/inviteCreateState.ts`.
- Updated `app/property/invites/InviteCreateForm.tsx` to import `initialInviteCreateActionState` from `./inviteCreateState` and continue importing the server action `createPropertyPortalInvite` from `./actions`.
- Modified `app/property/invites/actions.ts` to remove non-async exports and only export the async server action `createPropertyPortalInvite` while keeping all invite logic (token generation, hashing, DB insert, optional email flow) unchanged.
- Files changed: `app/property/invites/actions.ts`, `app/property/invites/InviteCreateForm.tsx`, and new `app/property/invites/inviteCreateState.ts`.

### Testing
- Ran `npm run typecheck` and it completed successfully with no type errors.
- Ran `npx eslint app/property/invites/actions.ts app/property/invites/InviteCreateForm.tsx app/property/invites/page.tsx` and no lint failures were reported.
- Scanned `app/property` and `app/portal/property` with `rg --no-ignore-vcs -n '"use server"|export const|export type|export interface'` to identify similar patterns and confirmed this invite file was the actionable case fixed in this change.
- Confirmed `app/property/invites/actions.ts` now only exports async server functions and that token generation/hash, no raw token storage, and schema assumptions remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d202370e48328b6c0f6022495cbcc)