### PR TITLE
Harden property invite base URL resolution in production

### DIFF
--- a/app/property/invites/actions.ts
+++ b/app/property/invites/actions.ts
@@ -27,6 +27,21 @@ import type { InviteCreateActionState } from "./inviteCreateState";
 
 let sendgridConfigured = false;
 
+
+function getAppBaseUrl() {
+  const configured = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (configured) return configured.replace(/\/$/, "");
+
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) return `https://${vercelUrl}`.replace(/\/$/, "");
+
+  if (process.env.NODE_ENV !== "production") {
+    return "http://localhost:3000";
+  }
+
+  throw new Error("NEXT_PUBLIC_APP_URL is required to create property portal invite links in production.");
+}
+
 function sendgridEnvReady() {
   const apiKey = process.env.SENDGRID_API_KEY?.trim() || "";
   const fromEmail = process.env.SENDGRID_FROM_EMAIL?.trim() || "";
@@ -124,6 +139,15 @@ export async function createPropertyPortalInvite(
   const tokenHash = createHash("sha256").update(rawToken, "utf8").digest("hex");
   const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
 
+  let appBaseUrl: string;
+  try {
+    appBaseUrl = getAppBaseUrl();
+  } catch {
+    return { status: "validation-error", message: "Invite could not be created because the app URL is not configured." };
+  }
+
+  const inviteLink = `${appBaseUrl}/portal/property/invite/accept?token=${rawToken}`;
+
   const { error } = await supabase.from("property_portal_invites").insert({
     shop_id: currentShopId,
     invited_email: invitedEmail,
@@ -140,9 +164,6 @@ export async function createPropertyPortalInvite(
   if (error) {
     return { status: "validation-error", message: error.message };
   }
-
-  const origin = process.env.NEXT_PUBLIC_APP_URL?.trim() || "http://localhost:3000";
-  const inviteLink = `${origin}/portal/property/invite/accept?token=${rawToken}`;
 
   revalidatePath("/property/invites");
   revalidatePath("/property");

--- a/features/operations/README.md
+++ b/features/operations/README.md
@@ -369,3 +369,9 @@ Any future schema expansion should be documented and applied manually.
 - Email sending is still not wired.
 - No auth user creation was added.
 - No schema or migration changes were introduced in this step.
+
+## Property invite link configuration
+
+- Property invite links require `NEXT_PUBLIC_APP_URL` in production.
+- If `NEXT_PUBLIC_APP_URL` is not set, `VERCEL_URL` is used as a fallback when available.
+


### PR DESCRIPTION
### Motivation
- Prevent deployed property invite links from silently falling back to `http://localhost:3000` when `NEXT_PUBLIC_APP_URL` is missing, which produced invalid links in production. 
- Fail fast and visibly when a production app base URL cannot be determined so invites are not created with unusable links.

### Description
- Added `getAppBaseUrl()` in `app/property/invites/actions.ts` to resolve the base URL in this order: `NEXT_PUBLIC_APP_URL` → `VERCEL_URL` (as `https://...`) → `http://localhost:3000` only when `NODE_ENV !== 'production'`, and throw in production when none are set. 
- Resolve the base URL before DB insert and build the one-time `inviteLink` from `getAppBaseUrl()`; if resolution fails in production return a validation error (`"Invite could not be created because the app URL is not configured."`) and do not insert the invite. 
- Preserved token safety: raw token is generated for the one-time link but only `token_hash` is inserted into `property_portal_invites`, raw token is not logged, stored, or passed through redirect query params. 
- Added a short doc note to `features/operations/README.md` explaining that property invite links require `NEXT_PUBLIC_APP_URL` in production and that `VERCEL_URL` is used as a fallback when available. 
- Files changed: `app/property/invites/actions.ts`, `features/operations/README.md`.

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully. 
- Ran linting with `npx eslint app/property/invites/actions.ts app/property/invites/InviteCreateForm.tsx app/property/invites/page.tsx` and it completed successfully with no reported errors. 
- Verified behavior: in non-production environments the helper falls back to `http://localhost:3000`, and in production missing configuration returns the validation error and prevents DB insert (invite not created). 
- Confirmed no schema/migration changes were made and that only `token_hash` is persisted (raw token not stored).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d23e3dda083288bd05e055e6b5a80)