### PR TITLE
Fix property invite acceptance status handling for JSONB RPC responses

### DIFF
--- a/app/portal/property/invite/accept/actions.ts
+++ b/app/portal/property/invite/accept/actions.ts
@@ -11,9 +11,12 @@ type DB = { public: { Functions: {
   accept_property_portal_invite: {
     Args: { p_raw_token: string };
     Returns: {
-      ok: boolean;
-      code: string;
-      message: string;
+      success?: boolean;
+      ok?: boolean;
+      code?: string;
+      message?: string;
+      invite_id?: string;
+      member_id?: string;
     };
   };
 } } };
@@ -42,6 +45,15 @@ function mapRpcCodeToStatus(code: string | null | undefined): "invite-invalid" |
   }
 }
 
+function mapRpcMessageToStatus(message: string | null | undefined): "invite-invalid" | "invite-expired" | "invite-email-mismatch" | "invite-error" {
+  const lower = (message ?? "").toLowerCase();
+  if (lower.includes("expired") || lower.includes("already handled")) return "invite-expired";
+  if (lower.includes("does not match")) return "invite-email-mismatch";
+  if (lower.includes("authentication required")) return "invite-error";
+  if (lower) return "invite-invalid";
+  return "invite-error";
+}
+
 export async function getPropertyPortalInvitePreview(token: string) {
   const clean = token.trim();
   if (!clean) return { error: "Missing invite token." as const };
@@ -68,12 +80,20 @@ export async function acceptPropertyPortalInvite(formData: FormData) {
   const rpcRes = await supabase.rpc("accept_property_portal_invite", { p_raw_token: token });
 
   if (rpcRes.error) {
+    console.warn("accept_property_portal_invite rpc error", {
+      message: rpcRes.error.message,
+      userId: user.id,
+      tokenPresent: true,
+    });
     redirect(acceptUrl(token, "invite-error"));
   }
 
   const result = rpcRes.data;
-  if (!result?.ok) {
-    redirect(acceptUrl(token, mapRpcCodeToStatus(result?.code)));
+  const isSuccess = result?.success === true || result?.ok === true;
+  if (!isSuccess) {
+    const statusFromCode = result?.code ? mapRpcCodeToStatus(result.code) : null;
+    const status = statusFromCode ?? mapRpcMessageToStatus(result?.message);
+    redirect(acceptUrl(token, status));
   }
 
   revalidatePath("/portal/property/member");


### PR DESCRIPTION
### Motivation
- The client expected the RPC to return `{ ok, code, message }` but the DB function returns a JSONB shape with `{ success, message, invite_id?, member_id? }`, which made successful RPC responses be treated as failures and produced a generic error for valid invites.

### Description
- Updated the `accept_property_portal_invite` RPC typing in `app/portal/property/invite/accept/actions.ts` to include `success`, optional `ok`, `code`, `message`, `invite_id`, and `member_id` to match the actual JSONB response.
- Added `mapRpcMessageToStatus` to map common message text (expired/already handled, does not match, authentication required) to UX status codes when `code` is absent.
- Changed success detection to treat either `result.success === true` or `result.ok === true` as success and to redirect to `/portal/property/member?status=invite-accepted` on success.
- Added a safe `console.warn` for RPC transport errors that logs only `error.message`, `userId`, and `tokenPresent: true`, and preserved `mapRpcCodeToStatus` for future code-based RPC responses.

### Testing
- Ran `npm run typecheck` and it completed successfully with no type errors.
- Ran `npx eslint app/portal/property/invite/accept/actions.ts app/portal/property/invite/accept/page.tsx` and it completed with no reported lint errors.
- Files changed: `app/portal/property/invite/accept/actions.ts`.
- No SQL/schema changes, no service-role usage, and no raw token or token_hash are logged or stored; RPC `success: true` responses now redirect to the member portal as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2a4424888328b202b506c8096ca8)