### PR TITLE
Add manual Step 24A SQL draft for property inspection signatures

### DIFF
--- a/docs/plans/property-inspection-signatures-step-24a.md
+++ b/docs/plans/property-inspection-signatures-step-24a.md
@@ -1,0 +1,66 @@
+# Property Inspection Signatures / Acknowledgements (Step 24A)
+
+## Purpose
+This step defines a **manual SQL draft** for adding signature/acknowledgement support to property inspections without wiring runtime code yet.
+
+The scope is to support signing and acknowledgements for:
+- move-in inspections
+- move-out inspections
+- periodic inspections
+- maintenance follow-up inspections
+
+## What this draft adds
+- A new table: `public.property_inspection_signatures`.
+- Signature actor metadata (`signer_name`, `signer_email`, `signer_role`, optional `signer_profile_id`).
+- Signature method metadata (`signature_type`, `signature_text`, `signature_image_path`).
+- Audit metadata (`signed_at`, `ip_address`, `user_agent`, `metadata`, `created_at`).
+- Tenant-safe linkage to inspections via `shop_id` and `inspection_id`.
+- RLS policies for internal staff and scoped property members.
+
+## Signature roles covered
+Allowed `signer_role` values:
+- `tenant`
+- `property_manager`
+- `owner`
+- `internal`
+- `witness`
+
+This supports common move-in/move-out flows where both tenant and property manager signatures are needed for condition confirmation.
+
+## Signature types covered
+Allowed `signature_type` values:
+- `typed`
+- `drawn`
+- `uploaded`
+- `acknowledged`
+
+Step 24A implementation path is focused on `typed` and `acknowledged` first.
+
+`drawn` and `uploaded` are included now as forward-compatible enums, but runtime capture/upload is not introduced in this step.
+
+## Data integrity + constraints
+The SQL draft includes:
+- required `signed_at` and `signer_name`
+- check constraints for valid `signer_role` and `signature_type`
+- payload rule: `signature_text` or `signature_image_path` is required unless `signature_type = 'acknowledged'`
+- trigger enforcement so `property_inspection_signatures.shop_id` must match `property_inspections.shop_id`
+
+## RLS model (draft)
+RLS is enabled on `public.property_inspection_signatures` with policies for:
+- internal staff select/insert/update/delete scoped by profile `shop_id`
+- property members select signatures for inspections within membership scope
+- property members insert only their own signatures (`signer_profile_id = auth.uid()`) within membership scope
+
+No public unauthenticated signing is included.
+No vendor signing is included.
+
+## Explicit non-goals in Step 24A
+- No runtime wiring (no API/controller/UI changes)
+- No image upload bucket creation for signature capture
+- No service-role-based signing paths
+- No quote flow integration
+- No auth model changes
+
+## Files
+- `supabase/manual/property-inspection-signatures-step-24a.sql`
+- `docs/plans/property-inspection-signatures-step-24a.md`

--- a/supabase/manual/property-inspection-signatures-step-24a.sql
+++ b/supabase/manual/property-inspection-signatures-step-24a.sql
@@ -1,0 +1,204 @@
+-- Step 24A: Manual SQL draft for property inspection signatures/acknowledgements.
+-- IMPORTANT:
+-- - Manual draft only; do not auto-apply.
+-- - No public unauthenticated signing in this step.
+-- - No vendor signing in this step.
+-- - No signature image upload bucket in this step.
+-- - signature_image_path is reserved for a later phase.
+-- - typed/acknowledged signatures are the first implementation path.
+
+create table if not exists public.property_inspection_signatures (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  inspection_id uuid not null references public.property_inspections(id) on delete cascade,
+  signer_profile_id uuid references public.profiles(id) on delete set null,
+  signer_name text not null,
+  signer_email text,
+  signer_role text not null,
+  signature_type text not null default 'typed',
+  signature_text text,
+  signature_image_path text,
+  signed_at timestamptz not null default now(),
+  ip_address inet,
+  user_agent text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint property_inspection_signatures_signer_role_check
+    check (signer_role in ('tenant', 'property_manager', 'owner', 'internal', 'witness')),
+  constraint property_inspection_signatures_signature_type_check
+    check (signature_type in ('typed', 'drawn', 'uploaded', 'acknowledged')),
+  constraint property_inspection_signatures_payload_check
+    check (
+      signature_type = 'acknowledged'
+      or nullif(btrim(coalesce(signature_text, '')), '') is not null
+      or nullif(btrim(coalesce(signature_image_path, '')), '') is not null
+    )
+);
+
+create index if not exists property_inspection_signatures_shop_id_idx
+  on public.property_inspection_signatures (shop_id);
+
+create index if not exists property_inspection_signatures_inspection_id_idx
+  on public.property_inspection_signatures (inspection_id);
+
+create index if not exists property_inspection_signatures_signer_profile_id_idx
+  on public.property_inspection_signatures (signer_profile_id);
+
+create index if not exists property_inspection_signatures_signer_role_idx
+  on public.property_inspection_signatures (signer_role);
+
+create index if not exists property_inspection_signatures_signed_at_idx
+  on public.property_inspection_signatures (signed_at desc);
+
+create or replace function public.enforce_property_inspection_signature_shop_id()
+returns trigger
+language plpgsql
+as $$
+declare
+  inspection_shop_id uuid;
+begin
+  select pi.shop_id
+  into inspection_shop_id
+  from public.property_inspections pi
+  where pi.id = new.inspection_id;
+
+  if inspection_shop_id is null then
+    raise exception 'property_inspection % not found', new.inspection_id;
+  end if;
+
+  if new.shop_id is distinct from inspection_shop_id then
+    raise exception using
+      message = format(
+        'shop_id mismatch for property inspection signature: signature.shop_id=%s inspection.shop_id=%s',
+        new.shop_id,
+        inspection_shop_id
+      ),
+      errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_property_inspection_signatures_shop_id
+  on public.property_inspection_signatures;
+
+create trigger trg_property_inspection_signatures_shop_id
+before insert or update on public.property_inspection_signatures
+for each row
+execute function public.enforce_property_inspection_signature_shop_id();
+
+alter table public.property_inspection_signatures enable row level security;
+
+drop policy if exists "Internal staff can select property inspection signatures"
+  on public.property_inspection_signatures;
+create policy "Internal staff can select property inspection signatures"
+on public.property_inspection_signatures
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = property_inspection_signatures.shop_id
+  )
+);
+
+drop policy if exists "Internal staff can insert property inspection signatures"
+  on public.property_inspection_signatures;
+create policy "Internal staff can insert property inspection signatures"
+on public.property_inspection_signatures
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = property_inspection_signatures.shop_id
+  )
+);
+
+drop policy if exists "Internal staff can update property inspection signatures"
+  on public.property_inspection_signatures;
+create policy "Internal staff can update property inspection signatures"
+on public.property_inspection_signatures
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = property_inspection_signatures.shop_id
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = property_inspection_signatures.shop_id
+  )
+);
+
+drop policy if exists "Internal staff can delete property inspection signatures"
+  on public.property_inspection_signatures;
+create policy "Internal staff can delete property inspection signatures"
+on public.property_inspection_signatures
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = property_inspection_signatures.shop_id
+  )
+);
+
+drop policy if exists "Property members can select scoped property inspection signatures"
+  on public.property_inspection_signatures;
+create policy "Property members can select scoped property inspection signatures"
+on public.property_inspection_signatures
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.property_member_units pmu
+    join public.property_inspections pi
+      on pi.id = property_inspection_signatures.inspection_id
+     and pi.shop_id = property_inspection_signatures.shop_id
+    where pmu.profile_id = auth.uid()
+      and pmu.shop_id = property_inspection_signatures.shop_id
+      and (
+        pmu.unit_id = pi.unit_id
+        or pmu.property_id = pi.property_id
+      )
+  )
+);
+
+drop policy if exists "Property members can insert own scoped property inspection signatures"
+  on public.property_inspection_signatures;
+create policy "Property members can insert own scoped property inspection signatures"
+on public.property_inspection_signatures
+for insert
+to authenticated
+with check (
+  signer_profile_id = auth.uid()
+  and exists (
+    select 1
+    from public.property_member_units pmu
+    join public.property_inspections pi
+      on pi.id = property_inspection_signatures.inspection_id
+     and pi.shop_id = property_inspection_signatures.shop_id
+    where pmu.profile_id = auth.uid()
+      and pmu.shop_id = property_inspection_signatures.shop_id
+      and (
+        pmu.unit_id = pi.unit_id
+        or pmu.property_id = pi.property_id
+      )
+  )
+);


### PR DESCRIPTION
### Motivation
- Add schema support for signatures/acknowledgements on property inspections (move-in, move-out, periodic, maintenance follow-up) while keeping runtime wiring for a later step.
- Provide a tenant-safe, RLS-first draft that enforces `shop_id` consistency with `property_inspections` and captures typed/acknowledged signatures first.
- Include forward-compatible fields for drawn/uploaded signatures and reserve image path handling for a future phase.

### Description
- Add `supabase/manual/property-inspection-signatures-step-24a.sql` which creates `public.property_inspection_signatures` with the requested columns, fk relations, indexes, check constraints for `signer_role` and `signature_type`, and a payload constraint requiring `signature_text` or `signature_image_path` unless `signature_type = 'acknowledged'`.
- Implement a trigger function `public.enforce_property_inspection_signature_shop_id()` and trigger to ensure `property_inspection_signatures.shop_id` matches the linked `property_inspections.shop_id` on insert/update.
- Enable row-level security on the table and add `DROP POLICY IF EXISTS` + `CREATE POLICY` statements that grant scoped select/insert/update/delete for internal staff and scoped select/insert for property members, and require `signer_profile_id = auth.uid()` for member inserts.
- Add planning doc `docs/plans/property-inspection-signatures-step-24a.md` describing use cases, roles/types supported, constraints, RLS model, and explicit non-goals (no runtime wiring, no image bucket, no public or vendor signing in this step).

### Testing
- Ran `git diff --check` which succeeded with no whitespace or diff-check errors.
- Confirmed manually that no SQL was executed and no runtime code or live schema changes were applied as part of this draft.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2e4a58548328aaeff8975d0f05d0)