### PR TITLE
Fix Step 24A property inspection signature policies to use property_members

### DIFF
--- a/supabase/manual/property-inspection-signatures-step-24a.sql
+++ b/supabase/manual/property-inspection-signatures-step-24a.sql
@@ -167,15 +167,25 @@ to authenticated
 using (
   exists (
     select 1
-    from public.property_member_units pmu
-    join public.property_inspections pi
-      on pi.id = property_inspection_signatures.inspection_id
-     and pi.shop_id = property_inspection_signatures.shop_id
-    where pmu.profile_id = auth.uid()
-      and pmu.shop_id = property_inspection_signatures.shop_id
+    from public.property_inspections pi
+    join public.property_members pm
+      on pm.shop_id = pi.shop_id
+    where pi.id = property_inspection_signatures.inspection_id
+      and pi.shop_id = property_inspection_signatures.shop_id
+      and pm.user_id = auth.uid()
+      and pm.shop_id = property_inspection_signatures.shop_id
       and (
-        pmu.unit_id = pi.unit_id
-        or pmu.property_id = pi.property_id
+        pm.unit_id = pi.unit_id
+        or pm.property_id = pi.property_id
+        or (
+          pm.portfolio_id is not null
+          and exists (
+            select 1
+            from public.property_properties pp
+            where pp.id = pi.property_id
+              and pp.portfolio_id = pm.portfolio_id
+          )
+        )
       )
   )
 );
@@ -190,15 +200,25 @@ with check (
   signer_profile_id = auth.uid()
   and exists (
     select 1
-    from public.property_member_units pmu
-    join public.property_inspections pi
-      on pi.id = property_inspection_signatures.inspection_id
-     and pi.shop_id = property_inspection_signatures.shop_id
-    where pmu.profile_id = auth.uid()
-      and pmu.shop_id = property_inspection_signatures.shop_id
+    from public.property_inspections pi
+    join public.property_members pm
+      on pm.shop_id = pi.shop_id
+    where pi.id = property_inspection_signatures.inspection_id
+      and pi.shop_id = property_inspection_signatures.shop_id
+      and pm.user_id = auth.uid()
+      and pm.shop_id = property_inspection_signatures.shop_id
       and (
-        pmu.unit_id = pi.unit_id
-        or pmu.property_id = pi.property_id
+        pm.unit_id = pi.unit_id
+        or pm.property_id = pi.property_id
+        or (
+          pm.portfolio_id is not null
+          and exists (
+            select 1
+            from public.property_properties pp
+            where pp.id = pi.property_id
+              and pp.portfolio_id = pm.portfolio_id
+          )
+        )
       )
   )
 );


### PR DESCRIPTION
### Motivation
- The Step 24A manual SQL draft referenced a non-existent `public.property_member_units` relation and used `profile_id`, causing Supabase errors. 
- The repository's actual table is `public.property_members` which exposes member identity as `user_id`, so policies must use that shape. 
- Member-scoped RLS must correctly allow unit/property/portfolio-scoped access for property inspection signatures to match app membership semantics.

### Description
- Replaced all `public.property_member_units` usage with `public.property_members` in `supabase/manual/property-inspection-signatures-step-24a.sql`. 
- Replaced `pmu.profile_id = auth.uid()` checks with `pm.user_id = auth.uid()` and adjusted joins to use `pm.shop_id = pi.shop_id`. 
- Updated the member-scoped `SELECT` and `INSERT` policies to use the provided `exists (...)` clause that enforces unit/property/portfolio scope via `property_inspections`, `property_members`, and `property_properties` while keeping internal staff policies unchanged.

### Testing
- Ran `rg -n "property_member_units|pmu\.profile_id|pmu\.|property_members|pm\.user_id" supabase/manual/property-inspection-signatures-step-24a.sql docs/plans/property-inspection-signatures-step-24a.md` to confirm old references were removed and `property_members.user_id` is present, and this check succeeded. 
- Ran `git diff --check` to validate there are no whitespace or diff errors, and this check succeeded; no SQL was executed and no runtime app code was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d30aebac0832898d6ac6b8c8abb89)