### PR TITLE
Extract server actions to colocated actions.ts for property pages

### DIFF
--- a/app/property/inspections/new/actions.ts
+++ b/app/property/inspections/new/actions.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { getPropertyInspectionTemplate, propertyInspectionTypes, type PropertyInspectionType } from "@/features/property/lib/propertyInspectionTemplates";
+
+type AllowedStatus = "ok" | "fail" | "na";
+type FindingDraft = { section: string; item: string; status: AllowedStatus; notes: string; photos: Array<{ storage_bucket: string; storage_path: string; original_filename: string; content_type: string; size_bytes: number; uploaded_at: string }> };
+type DB = { public: { Tables: { profiles: { Row: { id: string; shop_id: string | null } }; property_properties: { Row: { id: string; name: string; shop_id: string } }; property_units: { Row: { id: string; property_id: string; unit_label: string } }; property_inspections: { Row: { id: string }; Insert: { shop_id: string; property_id: string; unit_id: string | null; performed_by_profile_id: string; inspection_type: string; status: string; summary: string | null; findings: unknown; completed_at: string } } } } };
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+const parse = (v: FormDataEntryValue | null) => (typeof v === "string" && v.trim() ? v.trim() : null);
+const BUCKET = "property_request_attachments";
+const ALLOWED = new Set(["image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"]);
+const MAX = 10 * 1024 * 1024;
+const safe = (s: string) => s.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-");
+
+export async function createPropertyInspection(formData: FormData) {
+  const supabase = client(); const { data: { user } } = await supabase.auth.getUser(); if (!user) redirect("/sign-in");
+  const { data: profile } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(); if (!profile?.shop_id) redirect("/property/inspections/new?error=Missing%20shop%20context");
+  const inspectionType = parse(formData.get("inspection_type")) as PropertyInspectionType | null; if (!inspectionType || !propertyInspectionTypes.includes(inspectionType)) redirect("/property/inspections/new?error=Invalid%20inspection%20type");
+  const template = getPropertyInspectionTemplate(inspectionType); const propertyId = parse(formData.get("property_id")); const unitId = parse(formData.get("unit_id")); const summary = parse(formData.get("summary"));
+  if (!propertyId) redirect(`/property/inspections/new?type=${inspectionType}&error=Property%20is%20required`);
+  const [{ data: property }, { data: unit }] = await Promise.all([supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle(), unitId ? supabase.from("property_units").select("id,property_id").eq("id", unitId).maybeSingle() : Promise.resolve({ data: null })]);
+  if (!property || property.shop_id !== profile.shop_id) redirect(`/property/inspections/new?type=${inspectionType}&error=Selected%20property%20is%20not%20visible`);
+  if (unitId && (!unit || unit.property_id !== propertyId)) redirect(`/property/inspections/new?type=${inspectionType}&error=Selected%20unit%20is%20invalid`);
+
+  const findings: FindingDraft[] = template.sections.flatMap((section, si) => section.items.map((item, ii) => ({ section: section.title, item, status: ((parse(formData.get(`status_${si}_${ii}`)) === "fail" || parse(formData.get(`status_${si}_${ii}`)) === "na") ? parse(formData.get(`status_${si}_${ii}`)) : "ok") as AllowedStatus, notes: parse(formData.get(`notes_${si}_${ii}`)) ?? "", photos: [] })));
+  const { data: inserted, error } = await supabase.from("property_inspections").insert({ shop_id: profile.shop_id, property_id: propertyId, unit_id: unitId ?? null, performed_by_profile_id: user.id, inspection_type: inspectionType, status: "completed", summary, findings, completed_at: new Date().toISOString() }).select("id").maybeSingle();
+  if (error || !inserted) redirect(`/property/inspections/new?type=${inspectionType}&error=${encodeURIComponent(error?.message ?? "Unable to create inspection")}`);
+
+  let uploadWarnings = 0;
+  for (let si = 0; si < template.sections.length; si += 1) for (let ii = 0; ii < template.sections[si].items.length; ii += 1) {
+    const entry = formData.get(`photo_${si}_${ii}`); if (!(entry instanceof File) || entry.size === 0) continue;
+    if (!ALLOWED.has(entry.type) || entry.size > MAX) { uploadWarnings += 1; continue; }
+    const key = safe(`${template.sections[si].title}-${template.sections[si].items[ii]}`.toLowerCase());
+    const path = `${profile.shop_id}/property-inspections/${inserted.id}/${key}/${Date.now()}-${safe(entry.name || "image")}`;
+    const { error: uErr } = await supabase.storage.from(BUCKET).upload(path, entry, { contentType: entry.type, upsert: false });
+    if (uErr) { uploadWarnings += 1; continue; }
+    const finding = findings.find((f) => f.section === template.sections[si].title && f.item === template.sections[si].items[ii]);
+    if (finding) finding.photos.push({ storage_bucket: BUCKET, storage_path: path, original_filename: entry.name, content_type: entry.type, size_bytes: entry.size, uploaded_at: new Date().toISOString() });
+  }
+  await supabase.from("property_inspections").update({ findings }).eq("id", inserted.id);
+  revalidatePath("/property"); revalidatePath("/property/inspections");
+  redirect(`/property/inspections/${inserted.id}${uploadWarnings ? `?status=upload-warning&warning_count=${uploadWarnings}` : ""}`);
+}

--- a/app/property/inspections/new/page.tsx
+++ b/app/property/inspections/new/page.tsx
@@ -1,51 +1,16 @@
 import "server-only";
 
 import Link from "next/link";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
 import { getPropertyInspectionTemplate, propertyInspectionTypes, type PropertyInspectionType } from "@/features/property/lib/propertyInspectionTemplates";
+import { createPropertyInspection } from "./actions";
 
 type AllowedStatus = "ok" | "fail" | "na";
-type FindingDraft = { section: string; item: string; status: AllowedStatus; notes: string; photos: Array<{ storage_bucket: string; storage_path: string; original_filename: string; content_type: string; size_bytes: number; uploaded_at: string }> };
 type DB = { public: { Tables: { profiles: { Row: { id: string; shop_id: string | null } }; property_properties: { Row: { id: string; name: string; shop_id: string } }; property_units: { Row: { id: string; property_id: string; unit_label: string } }; property_inspections: { Row: { id: string }; Insert: { shop_id: string; property_id: string; unit_id: string | null; performed_by_profile_id: string; inspection_type: string; status: string; summary: string | null; findings: unknown; completed_at: string } } } } };
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
-const parse = (v: FormDataEntryValue | null) => (typeof v === "string" && v.trim() ? v.trim() : null);
-const BUCKET = "property_request_attachments";
-const ALLOWED = new Set(["image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"]);
-const MAX = 10 * 1024 * 1024;
-const safe = (s: string) => s.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-");
 
-async function createPropertyInspection(formData: FormData) { "use server";
-  const supabase = client(); const { data: { user } } = await supabase.auth.getUser(); if (!user) redirect("/sign-in");
-  const { data: profile } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(); if (!profile?.shop_id) redirect("/property/inspections/new?error=Missing%20shop%20context");
-  const inspectionType = parse(formData.get("inspection_type")) as PropertyInspectionType | null; if (!inspectionType || !propertyInspectionTypes.includes(inspectionType)) redirect("/property/inspections/new?error=Invalid%20inspection%20type");
-  const template = getPropertyInspectionTemplate(inspectionType); const propertyId = parse(formData.get("property_id")); const unitId = parse(formData.get("unit_id")); const summary = parse(formData.get("summary"));
-  if (!propertyId) redirect(`/property/inspections/new?type=${inspectionType}&error=Property%20is%20required`);
-  const [{ data: property }, { data: unit }] = await Promise.all([supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle(), unitId ? supabase.from("property_units").select("id,property_id").eq("id", unitId).maybeSingle() : Promise.resolve({ data: null })]);
-  if (!property || property.shop_id !== profile.shop_id) redirect(`/property/inspections/new?type=${inspectionType}&error=Selected%20property%20is%20not%20visible`);
-  if (unitId && (!unit || unit.property_id !== propertyId)) redirect(`/property/inspections/new?type=${inspectionType}&error=Selected%20unit%20is%20invalid`);
-
-  const findings: FindingDraft[] = template.sections.flatMap((section, si) => section.items.map((item, ii) => ({ section: section.title, item, status: ((parse(formData.get(`status_${si}_${ii}`)) === "fail" || parse(formData.get(`status_${si}_${ii}`)) === "na") ? parse(formData.get(`status_${si}_${ii}`)) : "ok") as AllowedStatus, notes: parse(formData.get(`notes_${si}_${ii}`)) ?? "", photos: [] })));
-  const { data: inserted, error } = await supabase.from("property_inspections").insert({ shop_id: profile.shop_id, property_id: propertyId, unit_id: unitId ?? null, performed_by_profile_id: user.id, inspection_type: inspectionType, status: "completed", summary, findings, completed_at: new Date().toISOString() }).select("id").maybeSingle();
-  if (error || !inserted) redirect(`/property/inspections/new?type=${inspectionType}&error=${encodeURIComponent(error?.message ?? "Unable to create inspection")}`);
-
-  let uploadWarnings = 0;
-  for (let si = 0; si < template.sections.length; si += 1) for (let ii = 0; ii < template.sections[si].items.length; ii += 1) {
-    const entry = formData.get(`photo_${si}_${ii}`); if (!(entry instanceof File) || entry.size === 0) continue;
-    if (!ALLOWED.has(entry.type) || entry.size > MAX) { uploadWarnings += 1; continue; }
-    const key = safe(`${template.sections[si].title}-${template.sections[si].items[ii]}`.toLowerCase());
-    const path = `${profile.shop_id}/property-inspections/${inserted.id}/${key}/${Date.now()}-${safe(entry.name || "image")}`;
-    const { error: uErr } = await supabase.storage.from(BUCKET).upload(path, entry, { contentType: entry.type, upsert: false });
-    if (uErr) { uploadWarnings += 1; continue; }
-    const finding = findings.find((f) => f.section === template.sections[si].title && f.item === template.sections[si].items[ii]);
-    if (finding) finding.photos.push({ storage_bucket: BUCKET, storage_path: path, original_filename: entry.name, content_type: entry.type, size_bytes: entry.size, uploaded_at: new Date().toISOString() });
-  }
-  await supabase.from("property_inspections").update({ findings }).eq("id", inserted.id);
-  revalidatePath("/property"); revalidatePath("/property/inspections");
-  redirect(`/property/inspections/${inserted.id}${uploadWarnings ? `?status=upload-warning&warning_count=${uploadWarnings}` : ""}`);
-}
 
 export default async function Page({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
  const params = (await searchParams) ?? {}; const type = (propertyInspectionTypes.includes((Array.isArray(params.type) ? params.type[0] : params.type) as PropertyInspectionType) ? (Array.isArray(params.type) ? params.type[0] : params.type) : "move_in") as PropertyInspectionType; const error = Array.isArray(params.error) ? params.error[0] : params.error;

--- a/app/property/requests/new/actions.ts
+++ b/app/property/requests/new/actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type Sev = "emergency"|"urgent"|"routine"|"recommended";
+const SEV: Sev[] = ["emergency","urgent","routine","recommended"];
+type DB={public:{Tables:{profiles:{Row:{id:string;shop_id:string|null}};property_properties:{Row:{id:string;name:string}};property_units:{Row:{id:string;property_id:string;unit_label:string}};property_assets:{Row:{id:string;property_id:string;unit_id:string|null;name:string}};property_maintenance_requests:{Insert:{shop_id:string;property_id:string;unit_id:string|null;asset_id:string|null;requester_profile_id:string;title:string;summary:string;category:string|null;severity:Sev;status:"open";source:"internal";access_notes:string|null;preferred_window:string|null}}}}};
+const client=()=>createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+const v=(x:FormDataEntryValue|null)=>typeof x==="string"&&x.trim()?x.trim():null;
+
+export async function createPropertyMaintenanceRequest(formData: FormData){
+  const supabase=client();
+  const {data:{user}}=await supabase.auth.getUser();
+  if(!user) redirect('/sign-in');
+  const [{data:profile},{data:properties},{data:units},{data:assets}] = await Promise.all([
+    supabase.from('profiles').select('id,shop_id').eq('id',user.id).maybeSingle(),
+    supabase.from('property_properties').select('id,name').order('name'),
+    supabase.from('property_units').select('id,property_id,unit_label').order('unit_label'),
+    supabase.from('property_assets').select('id,property_id,unit_id,name').order('name'),
+  ]);
+  if(!profile?.shop_id) redirect('/property/requests/new?error='+encodeURIComponent('Your profile is missing shop_id.'));
+  const property_id=v(formData.get('property_id')); const unit_id=v(formData.get('unit_id')); const asset_id=v(formData.get('asset_id'));
+  const title=v(formData.get('title')); const summary=v(formData.get('summary')); const category=v(formData.get('category')); const access_notes=v(formData.get('access_notes')); const preferred_window=v(formData.get('preferred_window'));
+  const severity=(v(formData.get('severity'))??'routine') as Sev;
+  if(!title||!summary) redirect('/property/requests/new?error='+encodeURIComponent('Title and summary are required.'));
+  if(!property_id||!(properties??[]).some(p=>p.id===property_id)) redirect('/property/requests/new?error='+encodeURIComponent('Selected property is not visible.'));
+  if(!SEV.includes(severity)) redirect('/property/requests/new?error='+encodeURIComponent('Invalid severity.'));
+  const unit=unit_id?(units??[]).find(u=>u.id===unit_id):null;
+  if(unit_id&&(!unit||unit.property_id!==property_id)) redirect('/property/requests/new?error='+encodeURIComponent('Selected unit is invalid for the chosen property.'));
+  const asset=asset_id?(assets??[]).find(a=>a.id===asset_id):null;
+  if(asset_id&&(!asset||asset.property_id!==property_id)) redirect('/property/requests/new?error='+encodeURIComponent('Selected asset is invalid for the chosen property.'));
+  if(unit&&asset&&asset.unit_id!==unit.id&&asset.unit_id!==null) redirect('/property/requests/new?error='+encodeURIComponent('Selected asset must belong to selected unit, or be shared for property.'));
+  const {error}=await supabase.from('property_maintenance_requests').insert({shop_id:profile.shop_id,property_id,unit_id:unit?.id??null,asset_id:asset?.id??null,requester_profile_id:user.id,title,summary,category,severity,status:'open',source:'internal',access_notes,preferred_window});
+  if(error) redirect('/property/requests/new?error='+encodeURIComponent(`Unable to create request: ${error.message}`));
+  revalidatePath('/property'); redirect('/property');
+}

--- a/app/property/requests/new/page.tsx
+++ b/app/property/requests/new/page.tsx
@@ -1,45 +1,16 @@
 import "server-only";
 
 import Link from "next/link";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { createPropertyMaintenanceRequest } from "./actions";
 
 type Sev = "emergency"|"urgent"|"routine"|"recommended";
 const SEV: Sev[] = ["emergency","urgent","routine","recommended"];
 
 type DB={public:{Tables:{profiles:{Row:{id:string;shop_id:string|null}};property_properties:{Row:{id:string;name:string}};property_units:{Row:{id:string;property_id:string;unit_label:string}};property_assets:{Row:{id:string;property_id:string;unit_id:string|null;name:string}};property_maintenance_requests:{Row:{id:string};Insert:{shop_id:string;property_id:string;unit_id:string|null;asset_id:string|null;requester_profile_id:string;title:string;summary:string;category:string|null;severity:Sev;status:"open";source:"internal";access_notes:string|null;preferred_window:string|null}}}}};
 const client=()=>createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
-const v=(x:FormDataEntryValue|null)=>typeof x==="string"&&x.trim()?x.trim():null;
-
-async function createPropertyMaintenanceRequest(formData: FormData){
-  "use server";
-  const supabase=client();
-  const {data:{user}}=await supabase.auth.getUser();
-  if(!user) redirect('/sign-in');
-  const [{data:profile},{data:properties},{data:units},{data:assets}] = await Promise.all([
-    supabase.from('profiles').select('id,shop_id').eq('id',user.id).maybeSingle(),
-    supabase.from('property_properties').select('id,name').order('name'),
-    supabase.from('property_units').select('id,property_id,unit_label').order('unit_label'),
-    supabase.from('property_assets').select('id,property_id,unit_id,name').order('name'),
-  ]);
-  if(!profile?.shop_id) redirect('/property/requests/new?error='+encodeURIComponent('Your profile is missing shop_id.'));
-  const property_id=v(formData.get('property_id')); const unit_id=v(formData.get('unit_id')); const asset_id=v(formData.get('asset_id'));
-  const title=v(formData.get('title')); const summary=v(formData.get('summary')); const category=v(formData.get('category')); const access_notes=v(formData.get('access_notes')); const preferred_window=v(formData.get('preferred_window'));
-  const severity=(v(formData.get('severity'))??'routine') as Sev;
-  if(!title||!summary) redirect('/property/requests/new?error='+encodeURIComponent('Title and summary are required.'));
-  if(!property_id||!(properties??[]).some(p=>p.id===property_id)) redirect('/property/requests/new?error='+encodeURIComponent('Selected property is not visible.'));
-  if(!SEV.includes(severity)) redirect('/property/requests/new?error='+encodeURIComponent('Invalid severity.'));
-  const unit=unit_id?(units??[]).find(u=>u.id===unit_id):null;
-  if(unit_id&&(!unit||unit.property_id!==property_id)) redirect('/property/requests/new?error='+encodeURIComponent('Selected unit is invalid for the chosen property.'));
-  const asset=asset_id?(assets??[]).find(a=>a.id===asset_id):null;
-  if(asset_id&&(!asset||asset.property_id!==property_id)) redirect('/property/requests/new?error='+encodeURIComponent('Selected asset is invalid for the chosen property.'));
-  if(unit&&asset&&asset.unit_id!==unit.id&&asset.unit_id!==null) redirect('/property/requests/new?error='+encodeURIComponent('Selected asset must belong to selected unit, or be shared for property.'));
-  const {error}=await supabase.from('property_maintenance_requests').insert({shop_id:profile.shop_id,property_id,unit_id:unit?.id??null,asset_id:asset?.id??null,requester_profile_id:user.id,title,summary,category,severity,status:'open',source:'internal',access_notes,preferred_window});
-  if(error) redirect('/property/requests/new?error='+encodeURIComponent(`Unable to create request: ${error.message}`));
-  revalidatePath('/property'); redirect('/property');
-}
 
 export default async function NewPage({searchParams}:{searchParams?:Promise<Record<string,string|string[]|undefined>>}){
   const p=(await searchParams)??{}; const err=Array.isArray(p.error)?p.error[0]:p.error;


### PR DESCRIPTION
### Motivation
- Reduce App Router page module surface area by moving inline server actions out of `page.tsx` files to improve build safety and Next.js export hygiene. 
- Prepare the property vertical for further work by enforcing `"use server"` modules that export only async functions and rely on authenticated/profile shop context.

### Description
- Created `app/property/inspections/new/actions.ts` and exported the async `createPropertyInspection` server action, and updated `app/property/inspections/new/page.tsx` to import and call it. 
- Created `app/property/requests/new/actions.ts` and exported the async `createPropertyMaintenanceRequest` server action, and updated `app/property/requests/new/page.tsx` to import and call it. 
- Ensured the new `actions.ts` files are top-level `"use server"` modules that export only async functions and keep existing auth/profile/shop checks; no UI or business-feature changes were introduced. 
- Files changed: `app/property/inspections/new/page.tsx`, `app/property/inspections/new/actions.ts`, `app/property/requests/new/page.tsx`, `app/property/requests/new/actions.ts`.

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Linted the modified files with `npx eslint app/property/inspections/new/page.tsx app/property/inspections/new/actions.ts app/property/requests/new/page.tsx app/property/requests/new/actions.ts` and no issues were reported. 
- Attempted `npm run build` but the build was blocked in this environment by external Google Fonts fetch failures (`Inter`, `Black Ops One`); no property-specific compile errors surfaced prior to that external failure.
- Confirmations: no database schema changes, no service role usage added, and no new features or UI rewrites were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3800d0f08328844a6638c5e59794)