### PR TITLE
Harden invoice send flow sequencing and canonical snapshot usage

### DIFF
--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -508,7 +508,8 @@ export async function POST(req: Request) {
       .limit(1)
       .maybeSingle<{ id: string }>();
 
-    const invoiceWrite: DB["public"]["Tables"]["invoices"]["Update"] = {
+    const nowIso = new Date().toISOString();
+    const invoiceWriteBeforeSend: DB["public"]["Tables"]["invoices"]["Update"] = {
       shop_id: wo.shop_id,
       work_order_id: workOrderId,
       customer_id: wo.customer_id,
@@ -519,15 +520,35 @@ export async function POST(req: Request) {
       discount_total: snapshot.discountTotal ?? 0,
       tax_total: snapshot.taxTotal ?? 0,
       total: computedInvoiceTotal,
-      status: "issued",
-      issued_at: new Date().toISOString(),
+      status: "issued_pending_send",
+      issued_at: nowIso,
     };
+    let persistedInvoiceId: string | null = existingInvoice?.id ?? null;
     if (existingInvoice?.id) {
-      await supabaseAdmin.from("invoices").update(invoiceWrite).eq("id", existingInvoice.id);
-    } else {
-      await supabaseAdmin
+      const { error: updateErr } = await supabaseAdmin
         .from("invoices")
-        .insert(invoiceWrite as DB["public"]["Tables"]["invoices"]["Insert"]);
+        .update(invoiceWriteBeforeSend)
+        .eq("id", existingInvoice.id)
+        .eq("shop_id", wo.shop_id);
+      if (updateErr) {
+        return NextResponse.json(
+          { error: `Failed to persist invoice before send: ${updateErr.message}` },
+          { status: 500 },
+        );
+      }
+    } else {
+      const { data: insertedInvoice, error: insertErr } = await supabaseAdmin
+        .from("invoices")
+        .insert(invoiceWriteBeforeSend as DB["public"]["Tables"]["invoices"]["Insert"])
+        .select("id")
+        .maybeSingle<{ id: string }>();
+      if (insertErr || !insertedInvoice?.id) {
+        return NextResponse.json(
+          { error: `Failed to create invoice before send: ${insertErr?.message ?? "unknown error"}` },
+          { status: 500 },
+        );
+      }
+      persistedInvoiceId = insertedInvoice.id;
     }
 
     await sendInvoiceReadyEmail({
@@ -547,6 +568,38 @@ export async function POST(req: Request) {
     });
 
     const postSendWarnings = await runPostSendPersistence([
+      {
+        step: "invoice_status_after_send",
+        run: async () => {
+          if (!persistedInvoiceId) throw new Error("Missing persisted invoice id");
+
+          const sentUpdateBase: DB["public"]["Tables"]["invoices"]["Update"] = {
+            status: "issued",
+            issued_at: nowIso,
+          };
+
+          const sentUpdateWithOptionalCols = {
+            ...sentUpdateBase,
+            sent_at: nowIso,
+            sent_to: resolvedCustomerEmail,
+          } as DB["public"]["Tables"]["invoices"]["Update"];
+
+          const withOptional = await supabaseAdmin
+            .from("invoices")
+            .update(sentUpdateWithOptionalCols)
+            .eq("id", persistedInvoiceId)
+            .eq("shop_id", wo.shop_id);
+
+          if (withOptional.error) {
+            const fallback = await supabaseAdmin
+              .from("invoices")
+              .update(sentUpdateBase)
+              .eq("id", persistedInvoiceId)
+              .eq("shop_id", wo.shop_id);
+            if (fallback.error) throw new Error(fallback.error.message);
+          }
+        },
+      },
       {
         step: "work_order_invoice_state_update",
         run: async () => {

--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -24,14 +24,28 @@ export async function reviewWorkOrder({
 }: Args): Promise<{ ok: boolean; issues: ReviewIssue[] }> {
   const { data: allocRows } = await supabase
     .from("work_order_part_allocations")
-    .select("work_order_line_id, qty")
+    .select("work_order_line_id, qty, unit_cost")
     .eq("work_order_id", workOrderId)
     .eq("shop_id", shopId);
   const hasBillablePartsByLine = new Map<string, boolean>();
   for (const row of allocRows ?? []) {
     const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
     const qty = Number(row.qty ?? 0);
-    if (lineId && qty > 0) hasBillablePartsByLine.set(lineId, true);
+    const unitCostRaw = (row as Record<string, unknown>).unit_cost;
+    const unitCost =
+      typeof unitCostRaw === "number"
+        ? unitCostRaw
+        : typeof unitCostRaw === "string"
+          ? Number(unitCostRaw)
+          : null;
+    // Fallback behavior: if unit_cost is unavailable/non-numeric in this row,
+    // preserve existing qty-only billable detection to avoid false negatives.
+    const billableByQtyAndUnitCost =
+      qty > 0 && unitCost !== null && Number.isFinite(unitCost) && unitCost > 0;
+    const billableByQtyFallback = qty > 0 && unitCost === null;
+    if (lineId && (billableByQtyAndUnitCost || billableByQtyFallback)) {
+      hasBillablePartsByLine.set(lineId, true);
+    }
   }
   const { data: wo, error: woErr } = await supabase
     .from("work_orders")

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -532,7 +532,7 @@ export async function GET(
     }
   }
 
-  // ---- Derived totals (fallback) ----
+  // ---- Derived totals (fallback only) ----
   const derivedPartsCost = allPartRows.reduce(
     (sum, p) => sum + safeMoney(p.totalPrice),
     0,
@@ -548,17 +548,30 @@ export async function GET(
 
   const derivedSubtotal = derivedLaborCost + derivedPartsCost;
 
-  const derivedTaxTotal = 0;
-  // Totals: ALWAYS prefer live derived values from current work order lines + parts.
-  // Keep invoice row only for metadata such as invoice number / notes / issued_at.
-  const invDiscount = safeMoney(inv?.discount_total);
-  const invTax = safeMoney(inv?.tax_total);
-  const subtotal = derivedSubtotal;
-  const laborCost = derivedLaborCost;
-  const partsCost = derivedPartsCost;
-  const discountTotal = invDiscount > 0 ? invDiscount : 0;
-  const taxTotal = invTax > 0 ? invTax : derivedTaxTotal;
-  const grandTotal = Math.max(0, subtotal - discountTotal + taxTotal);
+  const subtotal =
+    snapshot.subtotal != null && Number.isFinite(snapshot.subtotal)
+      ? snapshot.subtotal
+      : derivedSubtotal;
+  const laborCost =
+    snapshot.laborCost != null && Number.isFinite(snapshot.laborCost)
+      ? snapshot.laborCost
+      : derivedLaborCost;
+  const partsCost =
+    snapshot.partsCost != null && Number.isFinite(snapshot.partsCost)
+      ? snapshot.partsCost
+      : derivedPartsCost;
+  const discountTotal =
+    snapshot.discountTotal != null && Number.isFinite(snapshot.discountTotal)
+      ? Math.max(0, snapshot.discountTotal)
+      : 0;
+  const taxTotal =
+    snapshot.taxTotal != null && Number.isFinite(snapshot.taxTotal)
+      ? Math.max(0, snapshot.taxTotal)
+      : 0;
+  const grandTotal =
+    snapshot.total != null && Number.isFinite(snapshot.total)
+      ? Math.max(0, snapshot.total)
+      : Math.max(0, subtotal - discountTotal + taxTotal);
 
   // ---------------- PDF (multi-page) ----------------
   const pdfDoc = await PDFDocument.create();

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -225,6 +225,7 @@ export default function InvoicePreviewPageClient({
   const [shopInfo, setShopInfo] = useState<ShopInfo | undefined>(undefined);
   const [invoiceId, setInvoiceId] = useState<string | null>(null);
   const [canonicalInvoiceTotal, setCanonicalInvoiceTotal] = useState<number>(0);
+  const [snapshotWarning, setSnapshotWarning] = useState<string | null>(null);
 
   const [reviewLoading, setReviewLoading] = useState(false);
   const [reviewOk, setReviewOk] = useState<boolean>(false);
@@ -404,14 +405,27 @@ export default function InvoicePreviewPageClient({
 
       if (cancelled) return;
       setInvoiceId(invoiceRow?.id ?? null);
-      const snapshotRes = await fetch(`/api/work-orders/${workOrderId}/invoice`, { method: "GET" });
-      const snapshotJson = (await snapshotRes.json().catch(() => null)) as
-        | { snapshot?: { total?: number | null } }
-        | null;
-      const snapshotTotal = snapshotJson?.snapshot?.total;
-      setCanonicalInvoiceTotal(
-        typeof snapshotTotal === "number" && Number.isFinite(snapshotTotal) ? Math.max(0, snapshotTotal) : 0,
-      );
+      try {
+        const snapshotRes = await fetch(`/api/work-orders/${workOrderId}/invoice`, { method: "GET" });
+        const snapshotJson = (await snapshotRes.json().catch(() => null)) as
+          | { snapshot?: { total?: number | null } }
+          | null;
+        const snapshotTotal = snapshotJson?.snapshot?.total;
+        if (!snapshotRes.ok) {
+          setSnapshotWarning("Using locally derived totals; canonical invoice snapshot is unavailable.");
+          setCanonicalInvoiceTotal(0);
+        } else {
+          setCanonicalInvoiceTotal(
+            typeof snapshotTotal === "number" && Number.isFinite(snapshotTotal)
+              ? Math.max(0, snapshotTotal)
+              : 0,
+          );
+          setSnapshotWarning(null);
+        }
+      } catch {
+        setSnapshotWarning("Using locally derived totals; canonical invoice snapshot is unavailable.");
+        setCanonicalInvoiceTotal(0);
+      }
 
       // ✅ include labor_rate
       const { data: shop, error: sErr } = await supabase
@@ -908,6 +922,11 @@ export default function InvoicePreviewPageClient({
         </div>
 
         <WorkOrderCloseoutGatePreview workOrderId={workOrderId} />
+        {snapshotWarning ? (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[0.75rem] text-amber-100">
+            {snapshotWarning}
+          </div>
+        ) : null}
 
         {/* Review issues panel */}
         {!reviewOk ? (


### PR DESCRIPTION
### Motivation
- Ensure invoice persistence and status sequencing are correct and fail-fast before any email is sent to avoid silent inconsistencies. 
- Use the canonical invoice snapshot as the primary source for invoice totals in PDF generation to prevent drift between UI, email, PDF, and persisted rows. 
- Reduce accidental cross-shop updates by scoping invoice persistence to `shop_id` and make review logic more accurate for billable parts. 

### Description
- Make invoice persistence blocking in `app/api/invoices/send/route.ts` by writing an `issued_pending_send` row before sending and returning a 500/400 if the insert/update fails, and scope updates with `.eq("id", ...).eq("shop_id", wo.shop_id)`. 
- Implement post-send invoice state update as a post-send step that flips status to `issued`, and attempt to set `sent_at`/`sent_to` if present with a graceful fallback when those columns are absent. 
- Change `app/api/work-orders/[id]/_lib/reviewWorkOrder.ts` so parts are considered billable only when `qty > 0` and `unit_cost > 0` when `unit_cost` is available, while preserving a qty-only fallback when `unit_cost` is missing or non-numeric. 
- Canonicalize totals in `app/api/work-orders/[id]/invoice-pdf/route.ts` to prefer values from `getInvoiceSnapshotForWorkOrder` (subtotal/labor/parts/discount/tax/total) and use local derived totals only as fallback, without changing PDF layout. 
- Surface a small non-blocking warning in `features/work-orders/components/InvoicePreviewPageClient.tsx` if the canonical snapshot fetch fails while continuing to use locally derived totals so the page remains usable. 
- Files changed: `app/api/invoices/send/route.ts`, `app/api/work-orders/[id]/_lib/reviewWorkOrder.ts`, `app/api/work-orders/[id]/invoice-pdf/route.ts`, and `features/work-orders/components/InvoicePreviewPageClient.tsx`. 
- Schema assumptions discovered: `invoices` status flow supports `issued_pending_send` and `issued`; `invoices.sent_at`/`invoices.sent_to` may be missing in some environments; and `work_order_part_allocations.unit_cost` may be absent or non-numeric. 

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build completed successfully. 
- No other automated tests were added or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db748ab348328bb4fafcb42eb12b5)