### PR TITLE
Move inline server actions out of page.tsx into colocated actions.ts for App Router safety

### DIFF
--- a/app/portal/property/request/actions.ts
+++ b/app/portal/property/request/actions.ts
@@ -1,0 +1,82 @@
+"use server";
+
+import "server-only";
+
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type Severity = "emergency" | "urgent" | "routine" | "recommended";
+const ALLOWED_SEVERITIES: Severity[] = ["emergency", "urgent", "routine", "recommended"];
+
+type DB = { public: { Tables: { profiles: { Row: { id: string; shop_id: string | null } }; property_properties: { Row: { id: string; name: string } }; property_units: { Row: { id: string; property_id: string; unit_label: string } }; property_assets: { Row: { id: string; property_id: string; unit_id: string | null; name: string } }; property_maintenance_requests: { Insert: { shop_id: string; property_id: string; unit_id: string | null; asset_id: string | null; requester_profile_id: string; title: string; summary: string; category: string | null; severity: Severity; status: "open"; source: "tenant_preview"; access_notes: string | null; preferred_window: string | null; photos: unknown[]; }; }; }; }; };
+
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+const clean = (value: FormDataEntryValue | null) => typeof value === "string" && value.trim() ? value.trim() : null;
+
+export async function createTenantPreviewRequest(formData: FormData) {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) redirect("/sign-in");
+
+  const [{ data: profile }, { data: properties }, { data: units }, { data: assets }] = await Promise.all([
+    supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(),
+    supabase.from("property_properties").select("id,name").order("name"),
+    supabase.from("property_units").select("id,property_id,unit_label").order("unit_label"),
+    supabase.from("property_assets").select("id,property_id,unit_id,name").order("name"),
+  ]);
+
+  if (!profile?.shop_id) redirect("/portal/property/request?error=" + encodeURIComponent("Your profile is missing shop context."));
+
+  const propertyId = clean(formData.get("property_id"));
+  const unitId = clean(formData.get("unit_id"));
+  const assetId = clean(formData.get("asset_id"));
+  const requesterName = clean(formData.get("requester_name"));
+  const requesterEmail = clean(formData.get("requester_email"));
+  const requesterPhone = clean(formData.get("requester_phone"));
+  const title = clean(formData.get("title"));
+  const summary = clean(formData.get("summary"));
+  const category = clean(formData.get("category"));
+  const severity = (clean(formData.get("severity")) ?? "routine") as Severity;
+  const accessNotes = clean(formData.get("access_notes"));
+  const preferredWindow = clean(formData.get("preferred_window"));
+  const photoNotes = clean(formData.get("photo_notes"));
+
+  if (!propertyId || !(properties ?? []).some((property) => property.id === propertyId)) redirect("/portal/property/request?error=" + encodeURIComponent("Selected property is not visible."));
+  if (!title || !summary) redirect("/portal/property/request?error=" + encodeURIComponent("Title and summary are required."));
+  if (!ALLOWED_SEVERITIES.includes(severity)) redirect("/portal/property/request?error=" + encodeURIComponent("Invalid severity."));
+
+  const unit = unitId ? (units ?? []).find((candidate) => candidate.id === unitId) : null;
+  if (unitId && (!unit || unit.property_id !== propertyId)) redirect("/portal/property/request?error=" + encodeURIComponent("Selected unit is invalid for the chosen property."));
+
+  const asset = assetId ? (assets ?? []).find((candidate) => candidate.id === assetId) : null;
+  if (assetId && (!asset || asset.property_id !== propertyId)) redirect("/portal/property/request?error=" + encodeURIComponent("Selected asset is invalid for the chosen property."));
+
+  if (unit && asset && asset.unit_id !== unit.id && asset.unit_id !== null) redirect("/portal/property/request?error=" + encodeURIComponent("Selected asset must belong to selected unit, or be property-level."));
+
+  const requesterRollup = `Requester: ${requesterName ?? "n/a"} / ${requesterEmail ?? "n/a"} / ${requesterPhone ?? "n/a"}`;
+  const summaryWithRequester = `${summary}\n\n${requesterRollup}`;
+  const accessNotesCombined = [accessNotes, photoNotes ? `Photo notes: ${photoNotes}` : null].filter(Boolean).join("\n\n");
+
+  const { error } = await supabase.from("property_maintenance_requests").insert({
+    shop_id: profile.shop_id,
+    property_id: propertyId,
+    unit_id: unit?.id ?? null,
+    asset_id: asset?.id ?? null,
+    requester_profile_id: user.id,
+    title,
+    summary: summaryWithRequester,
+    category,
+    severity,
+    status: "open",
+    source: "tenant_preview",
+    access_notes: accessNotesCombined || null,
+    preferred_window: preferredWindow,
+    photos: [],
+  });
+
+  if (error) redirect("/portal/property/request?error=" + encodeURIComponent(`Unable to submit request: ${error.message}`));
+
+  redirect("/portal/property/request?status=submitted");
+}

--- a/app/portal/property/request/page.tsx
+++ b/app/portal/property/request/page.tsx
@@ -4,14 +4,10 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { createTenantPreviewRequest } from "./actions";
 
 type Severity = "emergency" | "urgent" | "routine" | "recommended";
-const ALLOWED_SEVERITIES: Severity[] = [
-  "emergency",
-  "urgent",
-  "routine",
-  "recommended",
-];
+const ALLOWED_SEVERITIES: Severity[] = ["emergency", "urgent", "routine", "recommended"];
 
 type DB = {
   public: {
@@ -51,130 +47,6 @@ type DB = {
 
 const client = () =>
   createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
-
-const clean = (value: FormDataEntryValue | null) =>
-  typeof value === "string" && value.trim() ? value.trim() : null;
-
-async function createTenantPreviewRequest(formData: FormData) {
-  "use server";
-
-  const supabase = client();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    redirect("/sign-in");
-  }
-
-  const [{ data: profile }, { data: properties }, { data: units }, { data: assets }] =
-    await Promise.all([
-      supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle(),
-      supabase.from("property_properties").select("id,name").order("name"),
-      supabase.from("property_units").select("id,property_id,unit_label").order("unit_label"),
-      supabase.from("property_assets").select("id,property_id,unit_id,name").order("name"),
-    ]);
-
-  if (!profile?.shop_id) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent("Your profile is missing shop context."),
-    );
-  }
-
-  const propertyId = clean(formData.get("property_id"));
-  const unitId = clean(formData.get("unit_id"));
-  const assetId = clean(formData.get("asset_id"));
-  const requesterName = clean(formData.get("requester_name"));
-  const requesterEmail = clean(formData.get("requester_email"));
-  const requesterPhone = clean(formData.get("requester_phone"));
-  const title = clean(formData.get("title"));
-  const summary = clean(formData.get("summary"));
-  const category = clean(formData.get("category"));
-  const severity = (clean(formData.get("severity")) ?? "routine") as Severity;
-  const accessNotes = clean(formData.get("access_notes"));
-  const preferredWindow = clean(formData.get("preferred_window"));
-  const photoNotes = clean(formData.get("photo_notes"));
-
-  if (!propertyId || !(properties ?? []).some((property) => property.id === propertyId)) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent("Selected property is not visible."),
-    );
-  }
-
-  if (!title || !summary) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent("Title and summary are required."),
-    );
-  }
-
-  if (!ALLOWED_SEVERITIES.includes(severity)) {
-    redirect(
-      "/portal/property/request?error=" + encodeURIComponent("Invalid severity."),
-    );
-  }
-
-  const unit = unitId ? (units ?? []).find((candidate) => candidate.id === unitId) : null;
-  if (unitId && (!unit || unit.property_id !== propertyId)) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent("Selected unit is invalid for the chosen property."),
-    );
-  }
-
-  const asset = assetId
-    ? (assets ?? []).find((candidate) => candidate.id === assetId)
-    : null;
-  if (assetId && (!asset || asset.property_id !== propertyId)) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent("Selected asset is invalid for the chosen property."),
-    );
-  }
-
-  if (unit && asset && asset.unit_id !== unit.id && asset.unit_id !== null) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent(
-          "Selected asset must belong to selected unit, or be property-level.",
-        ),
-    );
-  }
-
-  const requesterRollup = `Requester: ${requesterName ?? "n/a"} / ${requesterEmail ?? "n/a"} / ${requesterPhone ?? "n/a"}`;
-  const summaryWithRequester = `${summary}\n\n${requesterRollup}`;
-  const accessNotesCombined = [accessNotes, photoNotes ? `Photo notes: ${photoNotes}` : null]
-    .filter(Boolean)
-    .join("\n\n");
-
-  const { error } = await supabase.from("property_maintenance_requests").insert({
-    shop_id: profile.shop_id,
-    property_id: propertyId,
-    unit_id: unit?.id ?? null,
-    asset_id: asset?.id ?? null,
-    requester_profile_id: user.id,
-    title,
-    summary: summaryWithRequester,
-    category,
-    severity,
-    status: "open",
-    source: "tenant_preview",
-    access_notes: accessNotesCombined || null,
-    preferred_window: preferredWindow,
-    photos: [],
-  });
-
-  if (error) {
-    redirect(
-      "/portal/property/request?error=" +
-        encodeURIComponent(`Unable to submit request: ${error.message}`),
-    );
-  }
-
-  redirect("/portal/property/request?status=submitted");
-}
 
 export default async function PortalPropertyRequestIntakePage({
   searchParams,

--- a/app/property/members/actions.ts
+++ b/app/property/members/actions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import "server-only";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+
+type DB = { public: { Tables: {
+  profiles: { Row: { id: string; shop_id: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_portfolios: { Row: { id: string; shop_id: string; name: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_properties: { Row: { id: string; shop_id: string; name: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_units: { Row: { id: string; shop_id: string; property_id: string; unit_label: string | null }; Insert: never; Update: never; Relationships: [] };
+  property_members: { Row: { id: string; shop_id: string; user_id: string; role: string; portfolio_id: string | null; property_id: string | null; unit_id: string | null; created_at: string | null }; Insert: { shop_id: string; user_id: string; role: string; portfolio_id?: string | null; property_id?: string | null; unit_id?: string | null }; Update: never; Relationships: [] };
+} } };
+
+const roles = ["property_manager", "owner_approver", "tenant_requester", "vendor", "viewer"] as const;
+const roleSet = new Set<string>(roles);
+const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
+
+export async function createMember(formData: FormData) {
+  const supabase = client();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/signin");
+  const { data: me } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
+  if (!me?.shop_id) redirect("/property/members?error=" + encodeURIComponent("No shop scope on current profile."));
+  const shopId = me.shop_id;
+
+  const userId = String(formData.get("user_id") || "").trim();
+  const role = String(formData.get("role") || "").trim();
+  const portfolioId = String(formData.get("portfolio_id") || "").trim() || null;
+  const propertyId = String(formData.get("property_id") || "").trim() || null;
+  const unitId = String(formData.get("unit_id") || "").trim() || null;
+
+  if (!userId) redirect("/property/members?error=" + encodeURIComponent("User is required."));
+  if (!roleSet.has(role)) redirect("/property/members?error=" + encodeURIComponent("Invalid role."));
+  if (role !== "property_manager" && !portfolioId && !propertyId && !unitId) redirect("/property/members?error=" + encodeURIComponent("Scope required unless role is property_manager."));
+
+  const { data: target } = await supabase.from("profiles").select("id,shop_id").eq("id", userId).maybeSingle();
+  if (!target || target.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Selected user is outside your shop scope."));
+
+  if (portfolioId) {
+    const { data } = await supabase.from("property_portfolios").select("id,shop_id").eq("id", portfolioId).maybeSingle();
+    if (!data || data.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Invalid portfolio scope."));
+  }
+  if (propertyId) {
+    const { data } = await supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle();
+    if (!data || data.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Invalid property scope."));
+  }
+  if (unitId) {
+    const { data } = await supabase.from("property_units").select("id,shop_id,property_id").eq("id", unitId).maybeSingle();
+    if (!data || data.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Invalid unit scope."));
+    if (propertyId && data.property_id !== propertyId) redirect("/property/members?error=" + encodeURIComponent("Unit does not belong to property."));
+  }
+
+  const { data: dupe } = await supabase.from("property_members").select("id").eq("shop_id", shopId).eq("user_id", userId).eq("role", role).is("portfolio_id", portfolioId).is("property_id", propertyId).is("unit_id", unitId).maybeSingle();
+  if (dupe) redirect("/property/members?status=member-exists");
+
+  const { error } = await supabase.from("property_members").insert({ shop_id: shopId, user_id: userId, role, portfolio_id: portfolioId, property_id: propertyId, unit_id: unitId });
+  if (error) redirect("/property/members?error=" + encodeURIComponent(error.message));
+
+  revalidatePath("/property/members");
+  revalidatePath("/property");
+  redirect("/property/members?status=member-created");
+}

--- a/app/property/members/page.tsx
+++ b/app/property/members/page.tsx
@@ -1,10 +1,10 @@
 import "server-only";
 
 import Link from "next/link";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
+import { createMember } from "./actions";
 
 type DB = { public: { Tables: {
   profiles: { Row: { id: string; shop_id: string | null; role: string | null; full_name: string | null; name: string | null; display_name: string | null; email: string | null }; Insert: never; Update: never; Relationships: [] };
@@ -15,7 +15,6 @@ type DB = { public: { Tables: {
 } } };
 
 const roles = ["property_manager", "owner_approver", "tenant_requester", "vendor", "viewer"] as const;
-const roleSet = new Set<string>(roles);
 const client = () => createServerSupabaseRSC() as unknown as SupabaseClient<DB>;
 
 function label(p: DB["public"]["Tables"]["profiles"]["Row"]) { return p.full_name || p.display_name || p.name || p.email || p.id; }
@@ -37,53 +36,6 @@ export default async function Page({ searchParams }: { searchParams?: Promise<Re
     supabase.from("property_units").select("id,shop_id,property_id,unit_label").eq("shop_id", shopId),
     supabase.from("property_members").select("id,shop_id,user_id,role,portfolio_id,property_id,unit_id,created_at").eq("shop_id", shopId).order("created_at", { ascending: false }),
   ]);
-
-  async function createMember(formData: FormData) {
-    "use server";
-    const supabase = client();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) redirect("/signin");
-    const { data: me } = await supabase.from("profiles").select("id,shop_id").eq("id", user.id).maybeSingle();
-    if (!me?.shop_id) redirect("/property/members?error=" + encodeURIComponent("No shop scope on current profile."));
-    const shopId = me.shop_id;
-
-    const userId = String(formData.get("user_id") || "").trim();
-    const role = String(formData.get("role") || "").trim();
-    const portfolioId = String(formData.get("portfolio_id") || "").trim() || null;
-    const propertyId = String(formData.get("property_id") || "").trim() || null;
-    const unitId = String(formData.get("unit_id") || "").trim() || null;
-
-    if (!userId) redirect("/property/members?error=" + encodeURIComponent("User is required."));
-    if (!roleSet.has(role)) redirect("/property/members?error=" + encodeURIComponent("Invalid role."));
-    if (role !== "property_manager" && !portfolioId && !propertyId && !unitId) redirect("/property/members?error=" + encodeURIComponent("Scope required unless role is property_manager."));
-
-    const { data: target } = await supabase.from("profiles").select("id,shop_id").eq("id", userId).maybeSingle();
-    if (!target || target.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Selected user is outside your shop scope."));
-
-    if (portfolioId) {
-      const { data } = await supabase.from("property_portfolios").select("id,shop_id").eq("id", portfolioId).maybeSingle();
-      if (!data || data.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Invalid portfolio scope."));
-    }
-    if (propertyId) {
-      const { data } = await supabase.from("property_properties").select("id,shop_id").eq("id", propertyId).maybeSingle();
-      if (!data || data.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Invalid property scope."));
-    }
-    if (unitId) {
-      const { data } = await supabase.from("property_units").select("id,shop_id,property_id").eq("id", unitId).maybeSingle();
-      if (!data || data.shop_id !== shopId) redirect("/property/members?error=" + encodeURIComponent("Invalid unit scope."));
-      if (propertyId && data.property_id !== propertyId) redirect("/property/members?error=" + encodeURIComponent("Unit does not belong to property."));
-    }
-
-    const { data: dupe } = await supabase.from("property_members").select("id").eq("shop_id", shopId).eq("user_id", userId).eq("role", role).is("portfolio_id", portfolioId).is("property_id", propertyId).is("unit_id", unitId).maybeSingle();
-    if (dupe) redirect("/property/members?status=member-exists");
-
-    const { error } = await supabase.from("property_members").insert({ shop_id: shopId, user_id: userId, role, portfolio_id: portfolioId, property_id: propertyId, unit_id: unitId });
-    if (error) redirect("/property/members?error=" + encodeURIComponent(error.message));
-
-    revalidatePath("/property/members");
-    revalidatePath("/property");
-    redirect("/property/members?status=member-created");
-  }
 
   const pRows = profiles.data ?? []; const poRows = portfolios.data ?? []; const prRows = properties.data ?? []; const uRows = units.data ?? []; const mRows = members.data ?? [];
   const pMap = new Map(pRows.map((p) => [p.id, p])); const poMap = new Map(poRows.map((p) => [p.id, p])); const prMap = new Map(prRows.map((p) => [p.id, p])); const uMap = new Map(uRows.map((u) => [u.id, u]));


### PR DESCRIPTION
### Motivation
- Page components contained inline server actions (`"use server"` blocks) which violates App Router server-action placement safety and can block deploys.  
- Ensure `page.tsx` files export only render logic and wire server actions from colocated modules to follow Next.js conventions and avoid accidental client-side exposure.  
- Preserve existing property invite/accept and tenant flows without changing schema, auth posture, or adding features.

### Description
- Added `app/property/members/actions.ts` and moved the `createMember` server action out of `app/property/members/page.tsx`, updating the page to import `createMember` and use it as the form action.  
- Added `app/portal/property/request/actions.ts` and moved the `createTenantPreviewRequest` server action out of `app/portal/property/request/page.tsx`, updating the page to import and use the new action.  
- Removed an unused `roleSet` local from the members page and preserved all original validation, redirects and Supabase RSC usage; invite acceptance remains RPC-based and no service-role client was introduced.  
- No database/schema files were modified and no new features were added; this is a safety/hardening change only.

### Testing
- Type-checking was run with `npm run typecheck` (alias for `tsc --noEmit`) and passed.  
- ESLint was run against the changed files with `npx eslint app/property/members/page.tsx app/property/members/actions.ts app/portal/property/request/page.tsx app/portal/property/request/actions.ts` and passed.  
- `npm run build` was attempted but the build was blocked by external Google Fonts network fetch failures for `Inter` and `Black Ops One` in this environment and not by the property code; this is an external network issue rather than a code regression.  
- Verified there are no remaining inline `"use server"` blocks inside `page.tsx` under the audited paths using the repo search patterns requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcb2bb998832889ece13eef03efe1)