### PR TITLE
Harden property invite base URL handling in production

### DIFF
--- a/app/property/invites/actions.ts
+++ b/app/property/invites/actions.ts
@@ -30,7 +30,24 @@ let sendgridConfigured = false;
 
 function getAppBaseUrl() {
   const configured = process.env.NEXT_PUBLIC_APP_URL?.trim();
-  if (configured) return configured.replace(/\/$/, "");
+  if (configured) {
+    const normalized = configured.replace(/\/$/, "");
+    if (process.env.NODE_ENV === "production") {
+      let parsed: URL;
+      try {
+        parsed = new URL(normalized);
+      } catch {
+        throw new Error("NEXT_PUBLIC_APP_URL must be a valid absolute URL in production.");
+      }
+      if (parsed.protocol !== "https:") {
+        throw new Error("NEXT_PUBLIC_APP_URL must use https in production.");
+      }
+      if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+        throw new Error("NEXT_PUBLIC_APP_URL cannot point to localhost in production.");
+      }
+    }
+    return normalized;
+  }
 
   const vercelUrl = process.env.VERCEL_URL?.trim();
   if (vercelUrl) return `https://${vercelUrl}`.replace(/\/$/, "");


### PR DESCRIPTION
### Motivation
- Prevent accidental or unsafe invite links in production by ensuring `NEXT_PUBLIC_APP_URL` is a valid absolute `https:` URL and does not point to localhost when used to generate property portal invite links.

### Description
- Tightened `getAppBaseUrl()` in `app/property/invites/actions.ts` to normalize the configured URL and, when `NODE_ENV === "production"`, require it to parse as an absolute URL, use the `https:` protocol, and not target `localhost` or `127.0.0.1`, while preserving the local `http://localhost:3000` fallback for non-production environments.

### Testing
- Ran `npm run typecheck` which completed successfully; ran `npx eslint app/property/invites/actions.ts` which completed successfully; attempted `npm run build` which failed in this environment due to Google Fonts network fetch errors unrelated to the property invite code (documented and expected in CI-less environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de46004988328a40fa8acb40232c4)