### PR TITLE
Restore portal home runtime and reintroduce PortalShell content wrapper

### DIFF
--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -1,47 +1,94 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import WorkOrderBoardWidget from "@shared/components/workboard/WorkOrderBoardWidget";
-import { PortalActionCard, PortalEmptyState, PortalPageHeader, PortalPrimaryButton, PortalSectionCard, PortalStatCard, PortalStatusChip } from "@/features/portal/components/PortalUi";
+import { PortalActionCard, PortalEmptyState, PortalPageHeader, PortalPrimaryButton, PortalSecondaryButton, PortalSectionCard, PortalStatCard, PortalStatusChip } from "@/features/portal/components/PortalUi";
 
 type DB = Database;
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type BookingRow = DB["public"]["Tables"]["bookings"]["Row"];
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 
-const formatWhen=(iso:string)=>{const d=new Date(iso);if(Number.isNaN(d.getTime())) return "—";return d.toLocaleString(undefined,{weekday:"short",month:"short",day:"numeric",hour:"numeric",minute:"2-digit"})};
-const formatWoRef=(wo:Pick<WorkOrderRow,"id">|null)=>wo?`#${wo.id?.slice(0,8)??"—"}`:"—";
+const formatWhen = (iso: string) => { const d = new Date(iso); if (Number.isNaN(d.getTime())) return "—"; return d.toLocaleString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }); };
+const formatWoRef = (wo: Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state"> | null) => wo ? `#${wo.id?.slice(0, 8) ?? "—"}` : "—";
 
-export default function PortalHomePage(){
- const supabase=useMemo(()=>createClientComponentClient<DB>(),[]);
- const [loading,setLoading]=useState(true);const [vehiclesCount,setVehiclesCount]=useState<number|null>(null);const [nextBookingAt,setNextBookingAt]=useState<string|null>(null);const [activeWo,setActiveWo]=useState<Pick<WorkOrderRow,"id"|"status"|"created_at"|"invoice_sent_at"|"approval_state">|null>(null);
- useEffect(()=>{let mounted=true;(async()=>{setLoading(true);const {data:{user},error:userErr}=await supabase.auth.getUser();if(!mounted) return;if(userErr||!user){setLoading(false);return;}const {data:cust,error:custErr}=await supabase.from("customers").select("id").eq("user_id",user.id).maybeSingle<Pick<CustomerRow,"id">>();if(!mounted) return;if(custErr||!cust?.id){setLoading(false);return;}const {count:vCount}=await supabase.from("vehicles").select("id",{count:"exact",head:true}).eq("customer_id",cust.id);const nowIso=new Date().toISOString();const {data:booking}=await supabase.from("bookings").select("starts_at").eq("customer_id",cust.id).gte("starts_at",nowIso).order("starts_at",{ascending:true}).limit(1).maybeSingle<Pick<BookingRow,"starts_at">>();const {data:wo}=await supabase.from("work_orders").select("id, status, created_at, invoice_sent_at, approval_state").eq("customer_id",cust.id).in("status",["awaiting_approval","queued","planned","in_progress"] as string[]).order("created_at",{ascending:false}).limit(1).maybeSingle<Pick<WorkOrderRow,"id"|"status"|"created_at"|"invoice_sent_at"|"approval_state">>();if(!mounted) return;setVehiclesCount(typeof vCount==="number"?vCount:null);setNextBookingAt(booking?.starts_at??null);setActiveWo(wo??null);setLoading(false);})();return ()=>{mounted=false}},[supabase]);
+export default function PortalHomePage() {
+  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
 
- const hasInvoice=!!activeWo&&!!activeWo.invoice_sent_at&&(activeWo.status==="ready_to_invoice"||activeWo.status==="invoiced");
- const hasQuote=!!activeWo&&(activeWo.status==="awaiting_approval"||activeWo.approval_state==="awaiting_customer"||activeWo.approval_state==="requested");
+  const [loading, setLoading] = useState(true);
+  const [vehiclesCount, setVehiclesCount] = useState<number | null>(null);
+  const [nextBookingAt, setNextBookingAt] = useState<string | null>(null);
+  const [activeWo, setActiveWo] = useState<Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state"> | null>(null);
 
- return <div className="space-y-5 text-white">
-  <PortalPageHeader eyebrow="Customer portal" title="What needs your attention today?" subtitle="Track active work, approve recommendations, and request service in one place." actions={<><PortalPrimaryButton href="/portal/request/when">Request service</PortalPrimaryButton><PortalSecondaryButton href="/portal/customer-appointments">Appointments</PortalSecondaryButton></>} />
+  useEffect(() => {
+    let mounted = true;
 
-  <PortalSectionCard title="Current status" subtitle="Your latest request and next appointment.">
-    <div className="grid gap-3 sm:grid-cols-3"><PortalStatCard title="Active request" value={formatWoRef(activeWo)} sub={activeWo?.status?`Status: ${activeWo.status}`:"No open request"}/><PortalStatCard title="Next appointment" value={nextBookingAt?formatWhen(nextBookingAt):"—"} /><PortalStatCard title="Vehicles" value={vehiclesCount==null?"—":String(vehiclesCount)} sub="Saved to your account" /></div>
-  </PortalSectionCard>
+    (async () => {
+      setLoading(true);
 
-  <PortalSectionCard title="Live work status" right={<Link href="/portal/status" className="text-xs text-neutral-300 underline">Details</Link>}>
-    <WorkOrderBoardWidget variant="portal" href="/portal/status" />
-  </PortalSectionCard>
+      const { data: { user }, error: userErr } = await supabase.auth.getUser();
+      if (!mounted) return;
 
-  <div className="grid gap-3 sm:grid-cols-3"><PortalActionCard href="/portal/request/when" title="Request service" subtitle="Start a new service request now." prominent /><PortalActionCard href="/portal/vehicles" title="Manage vehicles" subtitle="Update VIN, mileage, and details." /><PortalActionCard href="/portal/customer-appointments" title="Appointments" subtitle="View upcoming and past bookings." /></div>
+      if (userErr || !user) {
+        setVehiclesCount(null);
+        setNextBookingAt(null);
+        setActiveWo(null);
+        setLoading(false);
+        return;
+      }
 
-  <PortalSectionCard title="Recent activity" subtitle="Quote and invoice milestones are highlighted here." right={<PortalStatusChip label={loading?"Loading":"Live"} />}>
-    {loading ? <PortalEmptyState title="Loading activity" body="Checking your latest updates now." /> : hasInvoice && activeWo ? <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-neutral-500">Invoice ready</p><p className="text-sm text-neutral-100">Work Order {formatWoRef(activeWo)} sent {activeWo.invoice_sent_at?formatWhen(activeWo.invoice_sent_at):"recently"}</p></div><PortalPrimaryButton href={`/portal/invoices/${activeWo.id}`}>View invoice</PortalPrimaryButton></div> : hasQuote && activeWo ? <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-neutral-500">Quote ready</p><p className="text-sm text-neutral-100">Work Order {formatWoRef(activeWo)} is waiting for your approval.</p></div><PortalPrimaryButton href={`/portal/quotes/${activeWo.id}`}>Review quote</PortalPrimaryButton></div> : <PortalEmptyState title="No recent activity" body="After you submit a request, updates will appear here." />}
-  </PortalSectionCard>
- </div>
-}
+      const { data: cust, error: custErr } = await supabase.from("customers").select("id").eq("user_id", user.id).maybeSingle<Pick<CustomerRow, "id">>();
+      if (!mounted) return;
 
-function PortalSecondaryButton({ href, children }: { href: string; children: ReactNode }) {
-  return <Link href={href} className="inline-flex items-center justify-center rounded-xl border border-white/15 bg-black/40 px-4 py-2 text-sm font-semibold text-neutral-100 hover:bg-black/60">{children}</Link>;
+      if (custErr || !cust?.id) {
+        setVehiclesCount(null);
+        setNextBookingAt(null);
+        setActiveWo(null);
+        setLoading(false);
+        return;
+      }
+
+      const { count: vCount } = await supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("customer_id", cust.id);
+      const nowIso = new Date().toISOString();
+      const { data: booking } = await supabase.from("bookings").select("starts_at").eq("customer_id", cust.id).gte("starts_at", nowIso).order("starts_at", { ascending: true }).limit(1).maybeSingle<Pick<BookingRow, "starts_at">>();
+      const ACTIVE_STATUSES: Array<WorkOrderRow["status"]> = ["awaiting_approval", "queued", "planned", "in_progress"];
+      const { data: wo } = await supabase.from("work_orders").select("id, status, created_at, invoice_sent_at, approval_state").eq("customer_id", cust.id).in("status", ACTIVE_STATUSES as string[]).order("created_at", { ascending: false }).limit(1).maybeSingle<Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state">>();
+
+      if (!mounted) return;
+      setVehiclesCount(typeof vCount === "number" ? vCount : null);
+      setNextBookingAt(booking?.starts_at ?? null);
+      setActiveWo(wo ?? null);
+      setLoading(false);
+    })();
+
+    return () => { mounted = false; };
+  }, [supabase]);
+
+  if (loading) {
+    return <div className="space-y-5 text-white"><PortalPageHeader eyebrow="Customer portal" title="What needs your attention today?" subtitle="Loading your latest status and activity." /></div>;
+  }
+
+  const hasInvoice = !!activeWo && !!activeWo.invoice_sent_at && (activeWo.status === "ready_to_invoice" || activeWo.status === "invoiced");
+  const hasQuote = !!activeWo && (activeWo.status === "awaiting_approval" || activeWo.approval_state === "awaiting_customer" || activeWo.approval_state === "requested");
+
+  return <div className="space-y-5 text-white">
+    <PortalPageHeader eyebrow="Customer portal" title="What needs your attention today?" subtitle="Track active work, approve recommendations, and request service in one place." actions={<><PortalPrimaryButton href="/portal/request/when">Request service</PortalPrimaryButton><PortalSecondaryButton href="/portal/customer-appointments">Appointments</PortalSecondaryButton></>} />
+
+    <PortalSectionCard title="Current status" subtitle="Your latest request and next appointment.">
+      <div className="grid gap-3 sm:grid-cols-3"><PortalStatCard title="Active request" value={formatWoRef(activeWo)} sub={activeWo?.status ? `Status: ${activeWo.status}` : "No open request"} /><PortalStatCard title="Next appointment" value={nextBookingAt ? formatWhen(nextBookingAt) : "—"} /><PortalStatCard title="Vehicles" value={vehiclesCount == null ? "—" : String(vehiclesCount)} sub="Saved to your account" /></div>
+    </PortalSectionCard>
+
+    <PortalSectionCard title="Live work status" right={<Link href="/portal/status" className="text-xs text-neutral-300 underline">Details</Link>}>
+      <WorkOrderBoardWidget variant="portal" href="/portal/status" />
+    </PortalSectionCard>
+
+    <div className="grid gap-3 sm:grid-cols-3"><PortalActionCard href="/portal/request/when" title="Request service" subtitle="Start a new service request now." prominent /><PortalActionCard href="/portal/vehicles" title="Manage vehicles" subtitle="Update VIN, mileage, and details." /><PortalActionCard href="/portal/customer-appointments" title="Appointments" subtitle="View upcoming and past bookings." /></div>
+
+    <PortalSectionCard title="Recent activity" subtitle="Quote and invoice milestones are highlighted here." right={<PortalStatusChip label="Live" />}>
+      {hasInvoice && activeWo ? <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-neutral-500">Invoice ready</p><p className="text-sm text-neutral-100">Work Order {formatWoRef(activeWo)} sent {activeWo.invoice_sent_at ? formatWhen(activeWo.invoice_sent_at) : "recently"}</p></div><PortalPrimaryButton href={`/portal/invoices/${activeWo.id}`}>View invoice</PortalPrimaryButton></div> : hasQuote && activeWo ? <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-neutral-500">Quote ready</p><p className="text-sm text-neutral-100">Work Order {formatWoRef(activeWo)} is waiting for your approval.</p></div><PortalPrimaryButton href={`/portal/quotes/${activeWo.id}`}>Review quote</PortalPrimaryButton></div> : <PortalEmptyState title="No recent activity" body="After you submit a request, updates will appear here." />}
+    </PortalSectionCard>
+  </div>;
 }

--- a/features/portal/components/PortalShell.tsx
+++ b/features/portal/components/PortalShell.tsx
@@ -291,6 +291,7 @@ export default function PortalShell({
                   </div>
                 </div>
                 <button
+                  type="button"
                   className="desktop-btn-secondary rounded-full border px-3 py-1 text-xs text-neutral-100"
                   onClick={() => setMobileOpen(false)}
                 >
@@ -329,7 +330,7 @@ export default function PortalShell({
         )}
 
         <div className="min-w-0 flex-1">
-          <div className="min-h-full">{children}</div>
+          <div className="desktop-panel-soft min-h-full rounded-2xl border border-white/10 bg-black/20 p-3 backdrop-blur-md md:p-4">{children}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- A recent UI tweak regressed the customer portal home runtime/data path and removed the lightweight content framing from the portal shell, causing visual/UX regressions. 
- The intent is to restore the previous client-side customer portal data/auth flow and reapply only visual/layout fixes without changing any API/auth/routing behavior. 
- Also ensure small accessibility/markup fixes (drawer button `type`) and remove a duplicated local button component.

### Description
- Restored the original client-side Supabase auth/user lookup and the customer-scoped queries for `vehicles`, `bookings`, and `work_orders` in `app/portal/page.tsx`, preserving the exact data-loading and guard/reset behavior while updating only rendered layout and imports.  
- Removed the page-local `PortalSecondaryButton` and switched the page to use the shared `PortalSecondaryButton` from `features/portal/components/PortalUi.tsx`.  
- Reintroduced a lightweight content wrapper around `children` in `features/portal/components/PortalShell.tsx` to keep portal pages visually contained after shell-card removal, while preserving nav, notifications, sign-out, routing, and mobile drawer behavior.  
- Added missing `type="button"` to the mobile drawer close control to avoid implicit submit behavior.  
- Files changed: `app/portal/page.tsx` and `features/portal/components/PortalShell.tsx`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript type check passed.  
- No repo-wide lint was run; if repo lint fails from pre-existing unrelated files, that was not chased as out of scope.  
- Confirmed no data/auth/routing/API behavior was changed beyond restoring the prior portal-home flow and keeping only UI/layout refinements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de7e03aa08328b8f06ef98bfffcb1)