### PR TITLE
Harden member portal: remove internal /property/setup link from tenant intake

### DIFF
--- a/app/portal/property/request/page.tsx
+++ b/app/portal/property/request/page.tsx
@@ -1,6 +1,5 @@
 import "server-only";
 
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServerSupabaseRSC } from "@shared/lib/supabase/server";
@@ -91,11 +90,8 @@ export default async function PortalPropertyRequestIntakePage({
           Tenant request intake preview — full tenant portal access is not wired yet.
         </p>
         <p className="mt-2 text-sm text-neutral-400">
-          No properties are visible yet. Internal users can set up properties first.
+          No properties are visible yet. Contact your property manager for setup assistance.
         </p>
-        <Link href="/property/setup" className="mt-4 inline-flex text-sm underline">
-          Go to property setup
-        </Link>
       </section>
     );
   }


### PR DESCRIPTION
### Motivation
- Prevent exposing an internal/admin setup route from a member-facing tenant intake page to avoid leaking internal navigation in the portal.

### Description
- Edit `app/portal/property/request/page.tsx` to remove the `next/link` import and the `/property/setup` navigation link in the no-properties fallback, replacing it with neutral guidance to contact the property manager.

### Testing
- Ran `npm run typecheck` (passed) and `npx eslint app/portal/property/request/page.tsx` (passed); attempted `npm run build` but it was blocked by Google Fonts network fetch failures for `Inter` and `Black Ops One`, which are unrelated to the property code changes; no schema changes, no service role usage, and no new features were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dfb6e7f188328aee223cbf90a1cb6)