### PR TITLE
Fix work-order pricing carry-through across creation, WO display, and invoice snapshot

### DIFF
--- a/app/api/work-orders/add-line/route.ts
+++ b/app/api/work-orders/add-line/route.ts
@@ -6,6 +6,7 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { createClient, type PostgrestError } from "@supabase/supabase-js";
 import type { Database, TablesInsert } from "@shared/types/types/supabase";
+import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 type DB = Database;
 
@@ -163,7 +164,7 @@ export async function POST(req: Request) {
     // ✅ Always derive shop_id from the work order (keeps data consistent)
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
-      .select("id, shop_id, vehicle_id")
+      .select("id, shop_id, vehicle_id, shops(labor_rate)")
       .eq("id", workOrderId)
       .maybeSingle<Pick<WoRow, "id" | "shop_id" | "vehicle_id">>();
 
@@ -212,8 +213,11 @@ export async function POST(req: Request) {
     if (suggestion.summary?.trim()) notesParts.push(`AI: ${suggestion.summary.trim()}`);
     const notes = notesParts.length ? notesParts.join(" • ") : null;
 
-    const laborTime: number | null = finiteNumberOrNull(suggestion?.laborHours);
-    const laborRate: number | null = finiteNumberOrNull(suggestion?.laborRate);
+    const laborTime = normalizeLaborHoursInput(suggestion?.laborHours, true);
+    const shopLaborRate = finiteNumberOrNull(
+      (wo as unknown as { shops?: { labor_rate?: unknown } | null }).shops?.labor_rate,
+    );
+    const laborRate: number | null = finiteNumberOrNull(suggestion?.laborRate) ?? shopLaborRate;
     const parts = normalizeParts(suggestion?.parts);
 
     const priceEstimate = computePriceEstimate({

--- a/app/api/work-orders/lines/add-from-menu-repair/route.ts
+++ b/app/api/work-orders/lines/add-from-menu-repair/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { getActiveMenuRepairPricingSnapshot } from "@/features/parts/server/getActiveMenuRepairPricingSnapshot";
+import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 type DB = Database;
 
@@ -109,7 +110,7 @@ export async function POST(req: Request) {
       cause: repairItem.cause || null,
       correction: repairItem.correction || null,
       notes: pricingNotes || null,
-      labor_time: laborOverride ?? repairItem.labor_hours ?? null,
+      labor_time: normalizeLaborHoursInput(laborOverride ?? repairItem.labor_hours, true),
       price_estimate: activePrice ?? repairItem.price_estimate ?? null,
       job_type: "repair",
       approval_state: "pending",

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -32,6 +32,7 @@ import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import { cn } from "@shared/lib/utils";
 import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import { deriveEventsFromWorkOrder } from "@/features/shared/lib/decisionEvents";
+import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -903,52 +904,23 @@ export default function WorkOrderIdClient(): JSX.Element {
   }, [quoteLines]);
 
   const pricingByLine = useMemo(() => {
-    const toNum = (value: unknown): number | null => {
-      if (typeof value === "number" && Number.isFinite(value)) return value;
-      if (typeof value === "string") {
-        const n = Number(value);
-        if (Number.isFinite(n)) return n;
-      }
-      return null;
-    };
-
     const byLine: Record<string, { laborTotal: number; partsTotal: number; lineTotal: number }> = {};
     for (const line of lines) {
       const quoteCandidates = activeQuotesByLine[line.id] ?? [];
       const quote = quoteCandidates[quoteCandidates.length - 1];
-
-      const lineHours = toNum(line.labor_time) ?? 0;
-      const quotedHours = toNum(quote?.est_labor_hours) ?? toNum(quote?.labor_hours);
-      const effectiveHours = quotedHours ?? lineHours;
-
-      const quotedLaborTotal = toNum(quote?.labor_total);
-      const laborTotal = quotedLaborTotal ?? effectiveHours * (shopLaborRate ?? 0);
-
-      const stagedPartsTotal = (stagedPartsByLine[line.id] ?? []).reduce((sum, part) => {
-        const total = toNum(part.total_price);
-        if (total != null) return sum + total;
-        return sum + (toNum(part.quantity) ?? 0) * (toNum(part.unit_price) ?? 0);
-      }, 0);
-
-      const allocPartsTotal = (allocsByLine[line.id] ?? []).reduce((sum, part) => {
-        const allocPart = part as AllocationRow & {
-          total_price?: number | null;
-          quantity?: number | null;
-          unit_price?: number | null;
-        };
-        const total = toNum(allocPart.total_price);
-        if (total != null) return sum + total;
-        return (
-          sum +
-          (toNum(allocPart.quantity) ?? 0) *
-            ((toNum(allocPart.unit_price) ?? toNum(part.unit_cost)) ?? 0)
-        );
-      }, 0);
-
-      const partsTotal = toNum(quote?.parts_total) ?? stagedPartsTotal + allocPartsTotal;
-      const lineTotal = toNum(quote?.grand_total) ?? toNum(quote?.subtotal) ?? laborTotal + partsTotal;
-
-      byLine[line.id] = { laborTotal, partsTotal, lineTotal };
+      const resolved = resolveWorkOrderLinePricing({
+        line,
+        quote,
+        shopLaborRate,
+        stagedParts: stagedPartsByLine[line.id] ?? [],
+        allocatedParts: allocsByLine[line.id] ?? [],
+        defaultLaborHoursWhenMissing: true,
+      });
+      byLine[line.id] = {
+        laborTotal: resolved.laborTotal,
+        partsTotal: resolved.partsTotal,
+        lineTotal: resolved.lineTotal,
+      };
     }
     return byLine;
   }, [activeQuotesByLine, allocsByLine, lines, shopLaborRate, stagedPartsByLine]);

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -11,6 +11,9 @@ type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
+type WorkOrderQuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
+import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 export type InvoiceSnapshotPart = {
   id: string;
@@ -297,6 +300,26 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     >();
 
   const allocs = Array.isArray(allocRaw) ? allocRaw : [];
+  const { data: stagedPartsRaw } = await supabase
+    .from("work_order_parts")
+    .select("id, work_order_line_id, quantity, unit_price, total_price")
+    .eq("work_order_id", workOrderId)
+    .returns<
+      Array<
+        Pick<WorkOrderPartRow, "id" | "work_order_line_id" | "quantity" | "unit_price" | "total_price">
+      >
+    >();
+  const stagedParts = Array.isArray(stagedPartsRaw) ? stagedPartsRaw : [];
+
+  const { data: quoteRaw } = await supabase
+    .from("work_order_quote_lines")
+    .select("id, work_order_line_id, status, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, grand_total")
+    .eq("work_order_id", workOrderId)
+    .returns<Array<Pick<WorkOrderQuoteLineRow, "id" | "work_order_line_id" | "status" | "labor_hours" | "est_labor_hours" | "labor_total" | "parts_total" | "subtotal" | "grand_total">>>();
+  const activeQuotes = (Array.isArray(quoteRaw) ? quoteRaw : []).filter((q) => {
+    const s = String(q.status ?? "").toLowerCase();
+    return s !== "converted" && s !== "declined";
+  });
 
   const partIds = Array.from(
     new Set(
@@ -366,8 +389,39 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       ? parts.reduce((acc, p) => acc + safeNumber(p.totalPrice), 0)
       : null;
 
-  const laborCost = invLabor ?? woLabor ?? null;
-  const partsCost = invParts ?? partsTotalFromAlloc ?? woParts ?? null;
+  const byLineStaged = new Map<string, typeof stagedParts>();
+  for (const part of stagedParts) {
+    if (!part.work_order_line_id) continue;
+    byLineStaged.set(part.work_order_line_id, [...(byLineStaged.get(part.work_order_line_id) ?? []), part]);
+  }
+  const byLineAlloc = new Map<string, typeof allocs>();
+  for (const alloc of allocs) {
+    if (!alloc.work_order_line_id) continue;
+    byLineAlloc.set(alloc.work_order_line_id, [...(byLineAlloc.get(alloc.work_order_line_id) ?? []), alloc]);
+  }
+  const byLineQuote = new Map<string, typeof activeQuotes[number]>();
+  for (const q of activeQuotes) {
+    if (!q.work_order_line_id) continue;
+    byLineQuote.set(q.work_order_line_id, q);
+  }
+
+  let resolvedLabor = 0;
+  let resolvedParts = 0;
+  for (const line of lines) {
+    const resolved = resolveWorkOrderLinePricing({
+      line,
+      quote: byLineQuote.get(line.id) ?? null,
+      shopLaborRate: safeNumberOrNull(shop?.labor_rate),
+      stagedParts: byLineStaged.get(line.id) ?? [],
+      allocatedParts: byLineAlloc.get(line.id) ?? [],
+      defaultLaborHoursWhenMissing: true,
+    });
+    resolvedLabor += resolved.laborTotal;
+    resolvedParts += resolved.partsTotal;
+  }
+
+  const laborCost = invLabor ?? (resolvedLabor > 0 ? resolvedLabor : woLabor) ?? null;
+  const partsCost = invParts ?? (resolvedParts > 0 ? resolvedParts : partsTotalFromAlloc ?? woParts) ?? null;
 
   const subtotal =
     invSubtotal ??

--- a/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
+++ b/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
@@ -1,0 +1,84 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderQuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type WorkOrderPart = DB["public"]["Tables"]["work_order_parts"]["Row"];
+type WorkOrderPartAllocation = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+
+function toNum(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+export function normalizeLaborHoursInput(
+  value: unknown,
+  fallbackToOne: boolean,
+): number | null {
+  const parsed = toNum(value);
+  if (parsed != null) return parsed;
+  return fallbackToOne ? 1 : null;
+}
+
+export function resolveWorkOrderLinePricing(args: {
+  line: Pick<WorkOrderLine, "labor_time"> & { id?: string };
+  quote?: Partial<WorkOrderQuoteLine> | null;
+  shopLaborRate: number | null;
+  stagedParts?: Array<Pick<WorkOrderPart, "quantity" | "unit_price" | "total_price">>;
+  allocatedParts?: Array<
+    Pick<WorkOrderPartAllocation, "qty" | "unit_cost"> & {
+      quantity?: number | null;
+      unit_price?: number | null;
+      total_price?: number | null;
+    }
+  >;
+  defaultLaborHoursWhenMissing?: boolean;
+}): {
+  laborHours: number;
+  laborRate: number;
+  laborTotal: number;
+  partsCount: number;
+  partsTotal: number;
+  lineTotal: number;
+} {
+  const {
+    line,
+    quote,
+    shopLaborRate,
+    stagedParts = [],
+    allocatedParts = [],
+    defaultLaborHoursWhenMissing = false,
+  } = args;
+
+  const lineHoursRaw = toNum(line.labor_time);
+  const lineHours = lineHoursRaw ?? (defaultLaborHoursWhenMissing ? 1 : 0);
+  const quotedHours = toNum(quote?.est_labor_hours) ?? toNum(quote?.labor_hours);
+  const laborHours = quotedHours ?? lineHours;
+
+  const laborRate = toNum(shopLaborRate) ?? 0;
+  const quotedLaborTotal = toNum(quote?.labor_total);
+  const laborTotal = quotedLaborTotal ?? laborHours * laborRate;
+
+  const stagedPartsTotal = stagedParts.reduce((sum, part) => {
+    const total = toNum(part.total_price);
+    if (total != null) return sum + total;
+    return sum + (toNum(part.quantity) ?? 0) * (toNum(part.unit_price) ?? 0);
+  }, 0);
+
+  const allocPartsTotal = allocatedParts.reduce((sum, part) => {
+    const total = toNum(part.total_price);
+    if (total != null) return sum + total;
+    return sum + (toNum(part.quantity ?? part.qty) ?? 0) * ((toNum(part.unit_price) ?? toNum(part.unit_cost)) ?? 0);
+  }, 0);
+
+  const hasQuotePartsTotal = toNum(quote?.parts_total) != null;
+  const partsTotal = hasQuotePartsTotal ? (toNum(quote?.parts_total) ?? 0) : stagedPartsTotal + allocPartsTotal;
+  const partsCount = stagedParts.length + allocatedParts.length;
+  const lineTotal = toNum(quote?.grand_total) ?? toNum(quote?.subtotal) ?? laborTotal + partsTotal;
+
+  return { laborHours, laborRate, laborTotal, partsCount, partsTotal, lineTotal };
+}

--- a/features/work-orders/lib/saveWorkOrderLines.ts
+++ b/features/work-orders/lib/saveWorkOrderLines.ts
@@ -1,6 +1,7 @@
 // features/work-orders/lib/saveWorkOrderLines.ts
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 const supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -42,7 +43,7 @@ export async function saveWorkOrderLines(
     cause: l.cause ?? null,
     correction: l.correction ?? null,
     tools: l.tools ?? null,
-    labor_time: l.labor_time ?? null,
+    labor_time: normalizeLaborHoursInput(l.labor_time, true),
     status: l.status ?? "awaiting",
     job_type: l.job_type ?? null,
   }));

--- a/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
+++ b/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
@@ -10,6 +10,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { estimateLabor } from "@ai/lib/ai/estimateLabor";
+import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 type DB = Database;
 
@@ -117,7 +118,7 @@ export async function insertPrioritizedJobsFromInspection(
 
       if (!shouldInclude) continue;
 
-      const laborTime = await estimateLabor(item.name, jobType);
+      const laborTime = normalizeLaborHoursInput(await estimateLabor(item.name, jobType), true);
 
       const complaintParts: string[] = [];
       if (item.name) complaintParts.push(item.name);
@@ -135,7 +136,7 @@ export async function insertPrioritizedJobsFromInspection(
         punched_out_at: null,
         hold_reason: null,
         assigned_tech_id: null,
-        labor_time: laborTime ?? null,
+        labor_time: laborTime,
       };
 
       allJobs.push(job);


### PR DESCRIPTION
### Motivation
- Mobile work-order jobs created from AI/inspection often displayed `$0.00` because labor-hours and labor-rate fallbacks were inconsistent across creation, display, and invoice paths. 
- Multiple insertion paths stored `labor_time`/`laborHours` variably (null, string), and UI/invoice code applied different precedence rules resulting in mismatched totals. 
- Introduce a single, defensive pricing resolution to ensure newly created jobs default to 1.0h (unless explicitly set to 0) and that the same per-line total appears on the work order and invoice.

### Description
- Added a shared resolver `resolveWorkOrderLinePricing` and helper `normalizeLaborHoursInput` in `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts` to centralize labor/parts/line total computation and to normalize labor inputs. 
- Normalized creation paths so missing labor defaults to `1` while preserving explicit `0`: updated `app/api/work-orders/add-line/route.ts`, `app/api/work-orders/lines/add-from-menu-repair/route.ts`, `features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts`, and `features/work-orders/lib/saveWorkOrderLines.ts`. 
- Work-order UI (`app/work-orders/[id]/Client.tsx`) now uses the shared resolver for per-line `laborTotal`, `partsTotal`, and `lineTotal` instead of duplicating fragile local math. 
- Invoice snapshot assembly (`features/invoices/server/getInvoiceSnapshot.ts`) now pulls quote lines, staged `work_order_parts`, and `work_order_part_allocations` and uses the shared resolver per line so invoice totals align with the work-order view and avoid double-counting quoted parts when quote totals exist. 
- Files changed: `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts`, `app/api/work-orders/add-line/route.ts`, `app/api/work-orders/lines/add-from-menu-repair/route.ts`, `features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts`, `features/work-orders/lib/saveWorkOrderLines.ts`, `app/work-orders/[id]/Client.tsx`, and `features/invoices/server/getInvoiceSnapshot.ts`.

### Testing
- Ran TypeScript check with `npx tsc --noEmit` and it completed successfully. 
- No other automated pricing/invoice tests existed to run in-scope; the change is intentionally non-breaking and limited to normalization and deterministic resolution logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e029d2f688328bdf9f648e80783b7)