### PR TITLE
Fix pricing regression: disable runtime 1h labor fallback in read paths

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -914,7 +914,6 @@ export default function WorkOrderIdClient(): JSX.Element {
         shopLaborRate,
         stagedParts: stagedPartsByLine[line.id] ?? [],
         allocatedParts: allocsByLine[line.id] ?? [],
-        defaultLaborHoursWhenMissing: true,
       });
       byLine[line.id] = {
         laborTotal: resolved.laborTotal,

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -414,7 +414,6 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       shopLaborRate: safeNumberOrNull(shop?.labor_rate),
       stagedParts: byLineStaged.get(line.id) ?? [],
       allocatedParts: byLineAlloc.get(line.id) ?? [],
-      defaultLaborHoursWhenMissing: true,
     });
     resolvedLabor += resolved.laborTotal;
     resolvedParts += resolved.partsTotal;

--- a/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
+++ b/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
@@ -45,6 +45,10 @@ export function resolveWorkOrderLinePricing(args: {
   partsTotal: number;
   lineTotal: number;
 } {
+  // NOTE:
+  // - Creation/insert paths may normalize missing labor_time to 1 hour before persisting.
+  // - Read/display/invoice paths should generally keep this runtime fallback disabled so
+  //   historical rows with null labor_time remain unchanged unless a caller explicitly opts in.
   const {
     line,
     quote,


### PR DESCRIPTION
### Motivation
- A previous change normalized missing labor to 1 hour at creation but also enabled a runtime 1-hour fallback during display/invoice resolution, which caused historical/null/non-billable lines to be charged unexpectedly. 
- The intent is to keep the 1-hour default on creation paths only and make read/display/invoice pricing safe by default so historical rows remain $0 labor unless explicitly stored or quoted.

### Description
- Removed the runtime `defaultLaborHoursWhenMissing: true` option from display pricing in `app/work-orders/[id]/Client.tsx` so work-order UI resolution no longer injects a 1-hour fallback. 
- Removed the runtime `defaultLaborHoursWhenMissing: true` option from invoice snapshot pricing in `features/invoices/server/getInvoiceSnapshot.ts` so snapshots do not silently charge old/null lines. 
- Added a guardrail comment to `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts` and kept the helper default `defaultLaborHoursWhenMissing = false` so callers must opt-in to the 1-hour runtime fallback. 
- Left creation/write normalization unchanged; existing insertion paths still call `normalizeLaborHoursInput(..., true)` in `app/api/work-orders/add-line/route.ts`, `app/api/work-orders/lines/add-from-menu-repair/route.ts`, `features/work-orders/lib/saveWorkOrderLines.ts`, and `features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts` so newly created billable jobs still default to 1 hour on write.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check completed successfully. 
- Confirmed changed files: `app/work-orders/[id]/Client.tsx`, `features/invoices/server/getInvoiceSnapshot.ts`, and `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts`, and validated that display/invoice resolution now uses the safe default (no runtime 1-hour fallback) while creation paths still normalize to 1 hour on write.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0685b94c8328b817fb68cc285f5a)