### PR TITLE
Scope technician assignments to shop-scoped work_order_lines in workforce overview

### DIFF
--- a/app/api/workforce/overview/route.ts
+++ b/app/api/workforce/overview/route.ts
@@ -14,12 +14,13 @@ export async function GET() {
   const admin: AdminClient = createAdminSupabase();
   const shopId = access.profile.shop_id;
   const now = new Date();
+  // TODO: Normalize "today" boundaries to the shop timezone instead of server-local midnight.
   const todayStart = new Date(now); todayStart.setHours(0, 0, 0, 0);
   const todayEnd = new Date(todayStart); todayEnd.setDate(todayEnd.getDate() + 1);
   const tomorrowEnd = new Date(todayEnd); tomorrowEnd.setDate(tomorrowEnd.getDate() + 1);
   const in30 = new Date(todayStart); in30.setDate(in30.getDate() + 30);
 
-  const [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes, lineTechRes] = await Promise.all([
+  const [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes] = await Promise.all([
     admin.from("profiles").select("id, full_name").eq("shop_id", shopId),
     admin.from("people_workforce_profiles").select("user_id, employment_status").eq("shop_id", shopId),
     admin.from("staff_time_off_requests").select("id, created_at").eq("shop_id", shopId).eq("status", "pending").order("created_at", { ascending: true }),
@@ -28,10 +29,17 @@ export async function GET() {
     admin.from("staff_schedule_templates").select("user_id").eq("shop_id", shopId),
     admin.from("staff_availability_blocks").select("user_id, starts_at, ends_at").eq("shop_id", shopId).lte("starts_at", tomorrowEnd.toISOString()).gte("ends_at", todayStart.toISOString()),
     admin.from("work_order_lines").select("id, assigned_tech_id, line_status, status, voided_at").eq("shop_id", shopId).is("voided_at", null),
-    admin.from("work_order_line_technicians").select("work_order_line_id, technician_id"),
   ]);
-  const firstError = [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes, lineTechRes].find((r) => r.error);
+  const firstError = [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes].find((r) => r.error);
   if (firstError?.error) return NextResponse.json({ error: firstError.error.message }, { status: 500 });
+  const activeLineIds = (linesRes.data ?? [])
+    .filter((l) => !ACTIVE_LINE_EXCLUDED.includes((l.line_status || l.status || "").toLowerCase()))
+    .map((l) => l.id);
+  // Two-step scope: technician assignments are constrained by already shop-scoped line IDs to prevent cross-tenant leakage.
+  const lineTechRes = activeLineIds.length > 0
+    ? await admin.from("work_order_line_technicians").select("work_order_line_id, technician_id").in("work_order_line_id", activeLineIds)
+    : { data: [], error: null };
+  if (lineTechRes.error) return NextResponse.json({ error: lineTechRes.error.message }, { status: 500 });
 
   const profileName = new Map((profilesRes.data ?? []).map((p) => [p.id, p.full_name || "Unknown"]));
   const activeStaff = new Set((workforceRes.data ?? []).filter((w) => w.employment_status === "active").map((w) => w.user_id));
@@ -84,7 +92,11 @@ export async function GET() {
   for (const [personId, count] of overloaded) add("operations", { id: `overloaded-${personId}`, type: "overloaded_tech", severity: "warning", title: "Technician workload is high", description: `${profileName.get(personId) ?? "A technician"} has ${count} active assigned jobs.`, count, personId, personName: profileName.get(personId) ?? undefined, href: "/dashboard/workforce/people" });
 
   const severityOrder: Record<Severity, number> = { blocking: 0, warning: 1, info: 2 };
-  const inbox = Object.values(sections).flat().sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity] || ((a.createdAt && b.createdAt) ? (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) : 0));
+  const inbox = Object.values(sections).flat().sort((a, b) =>
+    severityOrder[a.severity] - severityOrder[b.severity]
+    || ((a.createdAt && b.createdAt) ? (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) : 0)
+    || a.id.localeCompare(b.id),
+  );
 
   return NextResponse.json({ summary: { workingToday: Math.max(activeStaff.size - awayTodayUsers.size, 0), awayToday: awayTodayUsers.size, awayTomorrow: awayTomorrowUsers.size, pendingTimeOff, payrollBlocking, payrollWarnings, expiringCertifications, expiredCertifications, scheduleGaps, unassignedJobs, assignedToUnavailable, overloadedTechs: overloaded.length }, inbox, sections, generatedAt: new Date().toISOString() });
 }


### PR DESCRIPTION
### Motivation
- A regression allowed `work_order_line_technicians` to be read without explicit shop scoping, risking cross-tenant leakage in workload signals. 
- This affected `unassignedJobs`, `assignedToUnavailable`, and overloaded technician counts which are derived from assignment rows. 
- The fix must preserve the endpoint contract, role checks, and KPI/inbox behavior while restoring tenant safety. 

### Description
- Stop querying `work_order_line_technicians` globally and instead first derive `activeLineIds` from `work_order_lines` already filtered by `shop_id` and then fetch technician rows with `.in('work_order_line_id', activeLineIds)` to ensure assignments belong to shop-scoped lines. 
- Add an explicit empty-`activeLineIds` fallback (`activeLineIds.length > 0 ? ... : { data: [], error: null }`) to avoid `.in([], ...)` edge behavior. 
- Preserve existing role checks and behaviors, add a brief inline comment explaining the two-step scoping defense-in-depth, and keep aggregation single-pass (no N+1). 
- Add a deterministic inbox sort tie-break by `id` when `createdAt` is missing/equal and a TODO comment noting future shop-timezone normalization for day boundaries. 

### Testing
- Run: `npx tsc --noEmit`. The TypeScript build check completed successfully. 
- The change ensures all technician assignment calculations are now derived only from `work_order_lines` IDs that were already shop-scoped, so `unassignedJobs`, `assignedToUnavailable`, and overloaded counts consume only tenant-safe assignment rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e29826c548328a4f67cbbdbd2c183)