### PR TITLE
Remove duplicate /dashboard/appointments tile entry from Admin section

### DIFF
--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -540,15 +540,6 @@ export const TILES: Tile[] = [
     scopes: ["management", "all"],
     section: "Admin",
   },
-  {
-    href: "/dashboard/appointments",
-    title: "Scheduling",
-    subtitle: "Calendar & bookings",
-    roles: ["owner", "admin", "manager", "advisor"],
-    scopes: ["management", "all"],
-    section: "Admin",
-  },
-
   /* ---------------------------------------------------------------------- */
   /* BILLING                                                                 */
   /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
### Motivation
- A duplicate `href` (`/dashboard/appointments`) existed in `TILES` and caused key collisions in `RoleSidebar` because tiles are keyed by `t.href`, so the Admin duplicate should be removed while preserving the Operations entry.

### Description
- Deleted the Admin `Scheduling` tile pointing to `/dashboard/appointments` from `features/shared/config/tiles.ts` and left the Operations `Appointments` tile targeting `/dashboard/appointments` unchanged, touching only `features/shared/config/tiles.ts`.

### Testing
- Ran `npx tsc --noEmit` (passed) and ran a Node duplicate-href check (`node -e "const {TILES}=require('./features/shared/config/tiles.ts'); const counts=new Map(); for(const t of TILES) counts.set(t.href,(counts.get(t.href)||0)+1); const d=[...counts.entries()].filter(([,c])=>c>1); if(d.length){console.log('DUPLICATES',d); process.exit(1);} console.log('No duplicate hrefs in TILES.');"`) which reported no duplicates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2f2f4a2c8328a12d7d52bf44b1f1)