### PR TITLE
Hotfix: WorkforceOverviewClient — defensive payload rendering

### DIFF
--- a/features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx
@@ -3,10 +3,12 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+type InboxSeverity = "blocking" | "warning" | "info";
+
 type InboxItem = {
   id: string;
   type: string;
-  severity: "blocking" | "warning" | "info";
+  severity: InboxSeverity;
   title: string;
   description: string;
   personName?: string;
@@ -17,7 +19,7 @@ type OverviewPayload = {
   summary: Record<string, number>;
   inbox: InboxItem[];
   sections: Record<string, InboxItem[]>;
-  generatedAt: string;
+  generatedAt: string | null;
 };
 
 const headerActions = [
@@ -26,7 +28,7 @@ const headerActions = [
   { href: "/dashboard/workforce/people", title: "People" },
 ];
 
-const severityStyles: Record<InboxItem["severity"], { chip: string; border: string; dot: string; label: string }> = {
+const severityStyles: Record<InboxSeverity, { chip: string; border: string; dot: string; label: string }> = {
   blocking: {
     chip: "bg-red-500/15 text-red-200 border-red-400/40",
     border: "border-red-500/30 hover:border-red-400/60",
@@ -49,6 +51,51 @@ const severityStyles: Record<InboxItem["severity"], { chip: string; border: stri
 
 const sectionOrder = ["operations", "time", "payroll", "compliance", "certification"];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function normalizeSeverity(value: unknown): InboxSeverity {
+  return value === "blocking" || value === "warning" || value === "info" ? value : "info";
+}
+
+function safeHref(value: unknown): string {
+  return typeof value === "string" && value.trim().length > 0 ? value : "/dashboard/workforce/overview";
+}
+
+function buildInboxItem(item: Record<string, unknown>, fallbackId: string): InboxItem | null {
+  const title = typeof item.title === "string" ? item.title.trim() : "";
+  const description = typeof item.description === "string" ? item.description.trim() : "";
+  if (!title || !description) return null;
+
+  const normalized: InboxItem = {
+    id: typeof item.id === "string" && item.id.trim() ? item.id : fallbackId,
+    type: typeof item.type === "string" ? item.type : "info",
+    severity: normalizeSeverity(item.severity),
+    title,
+    description,
+    href: safeHref(item.href),
+  };
+
+  if (typeof item.personName === "string" && item.personName.trim()) {
+    normalized.personName = item.personName;
+  }
+  if (typeof item.count === "number" && Number.isFinite(item.count)) {
+    normalized.count = item.count;
+  }
+
+  return normalized;
+}
+
+
 function formatSectionLabel(key: string) {
   const normalized = key.replace(/[_-]/g, " ").trim();
   return normalized
@@ -57,8 +104,11 @@ function formatSectionLabel(key: string) {
     .join(" ");
 }
 
-function formatGeneratedAt(value: string) {
-  return new Date(value).toLocaleString(undefined, {
+function formatGeneratedAt(value: string | null) {
+  if (!value) return "Unknown";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     hour: "numeric",
@@ -74,15 +124,43 @@ export default function WorkforceOverviewClient() {
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    const res = await fetch("/api/workforce/overview", { cache: "no-store" });
-    if (!res.ok) {
+    try {
+      const res = await fetch("/api/workforce/overview", { cache: "no-store" });
+      if (!res.ok) {
+        setError("Unable to load workforce overview.");
+        setData(null);
+        return;
+      }
+
+      const json = (await res.json()) as unknown;
+      const summary = isRecord(json) && isRecord(json.summary) ? json.summary : {};
+      const inbox = isRecord(json) ? asArray<Record<string, unknown>>(json.inbox) : [];
+      const sections = isRecord(json) && isRecord(json.sections) ? json.sections : {};
+      const generatedAt = isRecord(json) && typeof json.generatedAt === "string" ? json.generatedAt : null;
+
+      const normalizedData: OverviewPayload = {
+        summary: Object.fromEntries(Object.entries(summary).map(([key, value]) => [key, num(value)])),
+        inbox: inbox
+          .map((item, index) => buildInboxItem(item, `inbox-${index}`))
+          .filter((item): item is InboxItem => item !== null),
+        sections: Object.fromEntries(
+          Object.entries(sections).map(([key, value]) => [
+            key,
+            asArray<Record<string, unknown>>(value)
+              .map((item, index) => buildInboxItem(item, `${key}-${index}`))
+              .filter((item): item is InboxItem => item !== null),
+          ]),
+        ),
+        generatedAt,
+      };
+
+      setData(normalizedData);
+    } catch {
       setError("Unable to load workforce overview.");
+      setData(null);
+    } finally {
       setLoading(false);
-      return;
     }
-    const json = (await res.json()) as OverviewPayload;
-    setData(json);
-    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -198,7 +276,7 @@ export default function WorkforceOverviewClient() {
       </header>
 
       <section className="overflow-x-auto pb-1" aria-label="Workforce key metrics">
-        <div className="grid min-w-[860px] gap-3 lg:min-w-0 lg:grid-cols-3">
+        <div className="grid min-w-[680px] gap-3 md:grid-cols-2 lg:min-w-0 lg:grid-cols-3">
           {kpiGroups.map((group) => (
             <article key={group.title} className="rounded-2xl border border-white/10 bg-black/30 p-4">
               <h2 className={`text-sm font-semibold ${group.accent}`}>{group.title}</h2>
@@ -206,7 +284,7 @@ export default function WorkforceOverviewClient() {
                 {group.items.map((item) => (
                   <div key={item.label} className={`rounded-lg border bg-black/25 p-3 ${item.tone}`}>
                     <p className="text-xs text-neutral-400">{item.label}</p>
-                    <p className="mt-1 text-2xl font-semibold text-white">{item.value}</p>
+                    <p className="mt-1 text-2xl font-semibold text-white">{num(item.value)}</p>
                   </div>
                 ))}
               </div>
@@ -242,7 +320,7 @@ export default function WorkforceOverviewClient() {
                       const styles = severityStyles[item.severity];
                       return (
                         <Link
-                          href={item.href}
+                          href={safeHref(item.href)}
                           key={item.id}
                           className={`block rounded-xl border bg-black/30 p-3 transition ${styles.border} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70`}
                         >
@@ -278,7 +356,7 @@ export default function WorkforceOverviewClient() {
               <ul className="mt-3 space-y-2">
                 {items.map((item) => (
                   <li key={item.id}>
-                    <Link href={item.href} className="flex items-start justify-between gap-3 rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-neutral-200 hover:border-orange-400/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70">
+                    <Link href={safeHref(item.href)} className="flex items-start justify-between gap-3 rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-neutral-200 hover:border-orange-400/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70">
                       <span>
                         <span className="font-medium text-white">{item.title}</span>
                         <span className="mt-0.5 block text-xs text-neutral-400">{item.description}</span>


### PR DESCRIPTION
### Motivation
- Post-merge review of Phase 2A found client-side regression risks in the workforce dashboard that could crash the UI on network failures or malformed JSON payloads. 
- This is a focused hotfix to harden rendering and preserve runtime stability without changing backend contracts, routes, or UX.

### Description
- Hardened `load()` to wrap `fetch('/api/workforce/overview', { cache: 'no-store' })` and `res.json()` in `try/catch/finally`, surface a controlled error UI on failures, and always clear `loading` in `finally`.
- Added defensive normalization helpers (`isRecord`, `asArray`, `num`) and a `buildInboxItem` helper to coerce and validate `summary`, `inbox`, `sections`, and `generatedAt` after JSON parse, with safe fallbacks for missing/invalid fields.
- Normalized severities so unknown/missing values map to `info` (watchlist) instead of being dropped, and preserved inbox/section links only when `href` is a non-empty string via `safeHref` (fallback `/dashboard/workforce/overview`).
- Made `formatGeneratedAt` return `Unknown` for missing/invalid timestamps to avoid rendering `Invalid Date`, enforced numeric KPI fallbacks via `num`, and applied a small responsive tweak (reduced KPI min width from `min-w-[860px]` to `min-w-[680px]`) to reduce mobile overflow risk without redesigning layout.
- File changed: `features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx`.

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` (passes; only an npm env warning about `http-proxy` which is non-fatal).
- Confirmations: no API/backend changes, no change to `/api/workforce/overview` contract, and no route/permission/nav/tile/back-end logic modifications.
- Controlled error handling: network and JSON parse errors now show the error UI and `loading` is always cleared (verified by code inspection and `tsc`).
- Crash-resilience: missing/invalid `summary`, `inbox`, `sections`, `generatedAt`, unknown severities, invalid numeric fields, and empty/invalid hrefs are normalized defensively so rendering paths no longer crash (verified by code inspection and `tsc`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e461993648328b7abf15715ca7259)