### PR TITLE
Expose permissions in workforce overview API and conditionally render People action on client

### DIFF
--- a/app/api/workforce/overview/route.ts
+++ b/app/api/workforce/overview/route.ts
@@ -5,6 +5,28 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 type Severity = "blocking" | "warning" | "info";
 type WorkforceInboxItem = { id: string; type: string; severity: Severity; title: string; description: string; count?: number; personId?: string; personName?: string; href: string; createdAt?: string };
+type WorkforceOverviewResponse = {
+  summary: {
+    workingToday: number;
+    awayToday: number;
+    awayTomorrow: number;
+    pendingTimeOff: number;
+    payrollBlocking: number;
+    payrollWarnings: number;
+    expiringCertifications: number;
+    expiredCertifications: number;
+    scheduleGaps: number;
+    unassignedJobs: number;
+    assignedToUnavailable: number;
+    overloadedTechs: number;
+  };
+  inbox: WorkforceInboxItem[];
+  sections: Record<string, WorkforceInboxItem[]>;
+  generatedAt: string;
+  permissions: {
+    canAccessPeople: boolean;
+  };
+};
 const ACTIVE_LINE_EXCLUDED = ["completed", "cancelled", "closed", "invoiced", "declined"];
 const OVERLOAD_THRESHOLD = 6;
 const OVERLOADED_INBOX_CAP = 10;
@@ -131,5 +153,28 @@ export async function GET() {
     )
     .slice(0, INBOX_MAX_ITEMS);
 
-  return NextResponse.json({ summary: { workingToday: Math.max(activeStaff.size - awayTodayUsers.size, 0), awayToday: awayTodayUsers.size, awayTomorrow: awayTomorrowUsers.size, pendingTimeOff, payrollBlocking, payrollWarnings, expiringCertifications, expiredCertifications, scheduleGaps, unassignedJobs, assignedToUnavailable, overloadedTechs: overloaded.length }, inbox, sections, generatedAt: new Date().toISOString() });
+  const response: WorkforceOverviewResponse = {
+    summary: {
+      workingToday: Math.max(activeStaff.size - awayTodayUsers.size, 0),
+      awayToday: awayTodayUsers.size,
+      awayTomorrow: awayTomorrowUsers.size,
+      pendingTimeOff,
+      payrollBlocking,
+      payrollWarnings,
+      expiringCertifications,
+      expiredCertifications,
+      scheduleGaps,
+      unassignedJobs,
+      assignedToUnavailable,
+      overloadedTechs: overloaded.length,
+    },
+    inbox,
+    sections,
+    generatedAt: new Date().toISOString(),
+    permissions: {
+      canAccessPeople,
+    },
+  };
+
+  return NextResponse.json(response);
 }

--- a/features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx
@@ -20,12 +20,13 @@ type OverviewPayload = {
   inbox: InboxItem[];
   sections: Record<string, InboxItem[]>;
   generatedAt: string | null;
+  permissions: {
+    canAccessPeople: boolean;
+  };
 };
-
-const headerActions = [
+const baseHeaderActions = [
   { href: "/dashboard/workforce/scheduling", title: "Scheduling" },
   { href: "/dashboard/workforce/payroll-review", title: "Payroll Review" },
-  { href: "/dashboard/workforce/people", title: "People" },
 ];
 
 const severityStyles: Record<InboxSeverity, { chip: string; border: string; dot: string; label: string }> = {
@@ -137,6 +138,7 @@ export default function WorkforceOverviewClient() {
       const inbox = isRecord(json) ? asArray<Record<string, unknown>>(json.inbox) : [];
       const sections = isRecord(json) && isRecord(json.sections) ? json.sections : {};
       const generatedAt = isRecord(json) && typeof json.generatedAt === "string" ? json.generatedAt : null;
+      const permissions = isRecord(json) && isRecord(json.permissions) ? json.permissions : {};
 
       const normalizedData: OverviewPayload = {
         summary: Object.fromEntries(Object.entries(summary).map(([key, value]) => [key, num(value)])),
@@ -152,6 +154,9 @@ export default function WorkforceOverviewClient() {
           ]),
         ),
         generatedAt,
+        permissions: {
+          canAccessPeople: permissions.canAccessPeople === true,
+        },
       };
 
       setData(normalizedData);
@@ -246,6 +251,9 @@ export default function WorkforceOverviewClient() {
     });
     return ordered;
   }, [data.sections]);
+  const headerActions = data.permissions.canAccessPeople
+    ? [...baseHeaderActions, { href: "/dashboard/workforce/people", title: "People" }]
+    : baseHeaderActions;
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
### Motivation

- Ensure the workforce overview payload includes caller permissions so the UI can tailor available actions. 
- Prevent showing the "People" quick-action to users without `canAccessPeople` privileges. 

### Description

- Added a `WorkforceOverviewResponse` type and return a structured response object from `app/api/workforce/overview/route.ts` that includes a `permissions` block with `canAccessPeople` and `generatedAt`. 
- Populated `permissions.canAccessPeople` based on the caller role when building the API response. 
- Updated `features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx` to parse `permissions` from the API, include it in the `OverviewPayload` type, and compute `headerActions` so the "People" action is only present when `canAccessPeople` is true. 
- Renamed the static header actions to `baseHeaderActions` and appended the People action conditionally. 

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) against the workspace and it succeeded. 
- Built the application (`npm run build`) to validate client/server integration and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e600dfa288328b20d60c4c219919b)