### PR TITLE
Unify Payroll Review access policy to include managers across Workforce and Admin surfaces

### DIFF
--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -512,7 +512,7 @@ export const TILES: Tile[] = [
     href: "/dashboard/admin/payroll-time",
     title: "Payroll Time",
     subtitle: "Pay period review, exception triage, and export workflow",
-    roles: ["owner", "admin"],
+    roles: ["owner", "admin", "manager"],
     scopes: ["management", "all"],
     section: "Admin",
   },

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -334,6 +334,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/dashboard/workforce/payroll-review": {
     title: () => "Payroll Review",
     icon: "⏱️",
+    // Payroll Review is operational Workforce access and intentionally includes manager.
     roles: ["owner", "admin", "manager"],
   },
   "/dashboard/workforce/documents": {
@@ -376,7 +377,8 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/dashboard/admin/payroll-time": {
     title: () => "Payroll Time",
     icon: "⏱️",
-    roles: ["owner", "admin"],
+    // Legacy mirror of Payroll Review keeps the same operational access policy.
+    roles: ["owner", "admin", "manager"],
   },
   "/dashboard/admin/employee-docs": {
     title: () => "Employee Documents",


### PR DESCRIPTION
### Motivation
- QA found a mismatch where the Workforce Payroll Review surface allowed `manager` but legacy Admin surfacing only signaled `owner/admin`, so access should be unified without changing payroll logic.
- The goal is a minimal surfacing/policy fix so managers can access the operational Payroll Review UI consistently across Workforce and Admin routes.

### Description
- Updated route metadata in `features/shared/lib/routeMeta.ts` to explicitly allow `owner`, `admin`, and `manager` for both `/dashboard/workforce/payroll-review` and `/dashboard/admin/payroll-time`, with clarifying comments added.
- Updated the Admin tile in `features/shared/config/tiles.ts` so `/dashboard/admin/payroll-time` surfaces to `owner`, `admin`, and `manager` consistently.
- No changes were made to payroll business logic, calculations, API behavior, tenant/shop scoping, or to People/Documents/Certifications access policies.
- Verified that the page wrappers (`app/dashboard/workforce/payroll-review/page.tsx` and `app/dashboard/admin/payroll-time/page.tsx`) already call `requireAdminPageAccess({ allow: ["owner","admin","manager"] })` and that the API gate uses `getActorCapabilities(...).canManageScheduling`, which supports manager access.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully.
- Performed targeted grep checks to confirm policy strings and wrappers are consistent for `/dashboard/workforce/payroll-review`, `/dashboard/admin/payroll-time`, and that People/Documents/Certifications remain `owner/admin` only; checks passed.
- Confirmed no API or payroll server-side logic files were modified and that `app/api/payroll-time/_lib/auth.ts` still enforces `canManageScheduling` so manager access to the API remains intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e660ef3dc8328947b23dc007f4b1c)