### PR TITLE
Polish Workforce Scheduling Phase A — Scheduling Command UX

### DIFF
--- a/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx
@@ -88,6 +88,16 @@ export default function WorkforceSchedulingClient() {
   }, [selectedStaffId]);
 
   const selected = useMemo(() => staff.find((s) => s.id === selectedStaffId) ?? null, [staff, selectedStaffId]);
+  const coverage = useMemo(() => {
+    const awayToday = staff.filter((s) => s.is_away_today).length;
+    const activeCount = staff.length;
+    const availableCount = Math.max(activeCount - awayToday, 0);
+    const missingTemplates = staff.filter((s) => s.recurring_template_rows === 0).length;
+    const overrideCount = staff.reduce((sum, s) => sum + s.override_count_in_range, 0);
+
+    return { awayToday, activeCount, availableCount, missingTemplates, overrideCount };
+  }, [staff]);
+
   const focus = searchParams.get("focus");
   const status = searchParams.get("status");
   const conflictType = searchParams.get("type");
@@ -139,12 +149,12 @@ export default function WorkforceSchedulingClient() {
     await load();
   }
 
-  async function reviewRequest(id: string, status: "approved" | "declined") {
+  async function reviewRequest(id: string, statusValue: "approved" | "declined") {
     setBusy(true);
     const res = await fetch(`/api/time-off/requests/${id}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ status }),
+      body: JSON.stringify({ status: statusValue }),
     });
     const body = await res.json().catch(() => null);
     setBusy(false);
@@ -156,8 +166,8 @@ export default function WorkforceSchedulingClient() {
     <AdminPageShell>
       <AdminPageHeader
         eyebrow="Workforce Operations"
-        title="Staff Scheduling + Time Away"
-        subtitle="Recurring templates, one-off shift overrides, and time off approvals in one scheduling surface tied to People and Payroll Time."
+        title="Scheduling Command"
+        subtitle="Coverage, time away, and shift readiness for today’s workforce."
       />
       {filterLabel ? (
         <div className="mb-4 flex items-center justify-between rounded-lg border border-orange-400/40 bg-orange-500/10 px-4 py-2 text-xs text-orange-200">
@@ -166,73 +176,138 @@ export default function WorkforceSchedulingClient() {
         </div>
       ) : null}
 
-      <AdminPanel>
-        <AdminPanelTitle title="Team Weekly Posture" description="Scan schedule readiness, override volume, and approved away blocks." />
-        <div className="overflow-x-auto p-4">
-          <table className="min-w-full text-sm">
-            <thead className="text-xs uppercase text-neutral-400"><tr><th className="text-left">Staff</th><th className="text-left">Role</th><th className="text-left">Recurring hrs/wk</th><th className="text-left">Template rows</th><th className="text-left">Overrides (7d)</th><th className="text-left">Away blocks (7d)</th><th className="text-left">Status</th></tr></thead>
-            <tbody className="divide-y divide-white/10">
-              {staff.map((s) => (
-                <tr key={s.id} onClick={() => setSelectedStaffId(s.id)} className={`cursor-pointer ${selectedStaffId === s.id ? "bg-white/10" : "hover:bg-white/5"} ${focus === "schedule-gaps" && s.recurring_template_rows === 0 ? "bg-amber-500/10" : ""} ${focus === "away" && ((awayDate === "today" && s.is_away_today) || awayDate === "tomorrow") ? "ring-1 ring-amber-400/40" : ""} ${focus === "workload" && personId === s.id ? "ring-1 ring-orange-400/40" : ""}`}>
-                  <td className="py-2">{s.full_name ?? "Unnamed"}</td>
-                  <td>{s.role ?? "staff"}</td>
-                  <td>{minsToHours(s.weekly_recurring_minutes)}</td>
-                  <td>{s.recurring_template_rows}</td>
-                  <td>{s.override_count_in_range}</td>
-                  <td>{s.approved_away_blocks_in_range}</td>
-                  <td className={s.is_away_today ? "text-amber-300" : "text-emerald-300"}>{s.is_away_today ? "Away today" : "Available"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      <section className="mb-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+          <p className="text-xs text-neutral-400">Available / Working</p>
+          <p className="text-xl font-semibold text-emerald-200">{coverage.availableCount} / {coverage.activeCount}</p>
         </div>
-      </AdminPanel>
+        <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+          <p className="text-xs text-neutral-400">Away Today</p>
+          <p className="text-xl font-semibold text-amber-200">{coverage.awayToday}</p>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+          <p className="text-xs text-neutral-400">Pending Time-Off</p>
+          <p className="text-xl font-semibold text-orange-200">{pending.length}</p>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+          <p className="text-xs text-neutral-400">Missing Templates</p>
+          <p className="text-xl font-semibold text-rose-200">{coverage.missingTemplates}</p>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+          <p className="text-xs text-neutral-400">Overrides (Range)</p>
+          <p className="text-xl font-semibold text-sky-200">{coverage.overrideCount}</p>
+        </div>
+      </section>
+
+      <div className="mb-4 grid gap-4 lg:grid-cols-2">
+        <AdminPanel>
+          <AdminPanelTitle title="Today Roster" description="Real-time posture for today's assigned workforce." />
+          <div className="space-y-2 p-4 text-sm">
+            <p className="text-xs text-neutral-300">Available: {coverage.availableCount} · Away: {coverage.awayToday}</p>
+            {staff.length === 0 ? <p className="text-neutral-400">No staff in current range.</p> : staff.map((s) => (
+              <div key={`today-${s.id}`} className="flex items-center justify-between rounded border border-white/10 bg-black/20 px-3 py-2">
+                <span>{s.full_name ?? "Unnamed"}</span>
+                <span className={s.is_away_today ? "text-amber-300" : "text-emerald-300"}>{s.is_away_today ? "Away today" : "Available"}</span>
+              </div>
+            ))}
+          </div>
+        </AdminPanel>
+
+        <AdminPanel>
+          <AdminPanelTitle title="Tomorrow Roster" description="No explicit tomorrow-away signal is currently available from this API payload." />
+          <div className="p-4 text-sm text-neutral-300">
+            <p>Use approved away blocks and staffing templates in the posture table below to plan tomorrow coverage.</p>
+          </div>
+        </AdminPanel>
+      </div>
 
       <AdminPanel className={focus === "time-off" && status === "pending" ? "ring-1 ring-orange-400/50" : ""}>
-        <AdminPanelTitle title="Pending Time Off Requests" description="Approve or decline from here; approvals automatically create schedule availability blocks." />
+        <AdminPanelTitle title={`Time-Off Review Queue (${pending.length})`} description="Approve or decline requests. Existing review actions and semantics are unchanged." />
         <div className="space-y-2 p-4 text-sm">
           {pending.length === 0 ? <p className="text-neutral-400">No pending requests.</p> : pending.map((r) => (
             <div key={r.id} className="rounded-lg border border-white/10 bg-black/30 p-3">
               <p className="font-medium">{r.request_type} • {new Date(r.starts_at).toLocaleString()} → {new Date(r.ends_at).toLocaleString()}</p>
               <p className="text-xs text-neutral-400">{r.reason ?? "No note"}</p>
               <div className="mt-2 flex gap-2">
-                <button disabled={busy} onClick={() => void reviewRequest(r.id, "approved")} className="rounded border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">Approve</button>
-                <button disabled={busy} onClick={() => void reviewRequest(r.id, "declined")} className="rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-200">Decline</button>
+                <button type="button" disabled={busy} onClick={() => void reviewRequest(r.id, "approved")} className="rounded border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">Approve</button>
+                <button type="button" disabled={busy} onClick={() => void reviewRequest(r.id, "declined")} className="rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-200">Decline</button>
               </div>
             </div>
           ))}
         </div>
       </AdminPanel>
 
-      <AdminPanel>
-        <AdminPanelTitle title="Staff Schedule Detail" description="Edit recurring weekly template and create one-off override shifts." />
-        <div className="grid gap-4 p-4 lg:grid-cols-2">
-          <div>
-            <p className="mb-2 text-xs text-neutral-400">Selected: {selected?.full_name ?? "None"}</p>
-            <div className="space-y-2">
-              {templates.sort((a, b) => a.day_of_week - b.day_of_week).map((row, i) => (
-                <div key={row.day_of_week} className="grid grid-cols-12 items-center gap-2 text-xs">
-                  <div className="col-span-2">{DAYS[row.day_of_week]}</div>
-                  <input type="checkbox" checked={row.is_working_day} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, is_working_day: e.target.checked } : x))} />
-                  <input type="time" value={row.start_time ?? ""} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, start_time: e.target.value } : x))} className="col-span-3 rounded border border-white/10 bg-black/30 px-2 py-1" />
-                  <input type="time" value={row.end_time ?? ""} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, end_time: e.target.value } : x))} className="col-span-3 rounded border border-white/10 bg-black/30 px-2 py-1" />
-                  <input type="number" value={row.unpaid_break_minutes} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, unpaid_break_minutes: Number(e.target.value) } : x))} className="col-span-2 rounded border border-white/10 bg-black/30 px-2 py-1" />
-                </div>
-              ))}
+      <div className="grid gap-4 xl:grid-cols-5">
+        <div className="xl:col-span-3">
+          <AdminPanel>
+            <AdminPanelTitle title="Team Weekly Posture" description="Scan readiness, schedule gaps, override volume, and approved away blocks." />
+            <div className="overflow-x-auto p-4">
+              <table className="min-w-full text-sm">
+                <thead className="text-xs uppercase text-neutral-400"><tr><th className="text-left">Staff</th><th className="text-left">Role</th><th className="text-left">Recurring hrs/wk</th><th className="text-left">Template rows</th><th className="text-left">Overrides (7d)</th><th className="text-left">Away blocks (7d)</th><th className="text-left">Status</th></tr></thead>
+                <tbody className="divide-y divide-white/10">
+                  {staff.map((s) => (
+                    <tr key={s.id} onClick={() => setSelectedStaffId(s.id)} className={`cursor-pointer ${selectedStaffId === s.id ? "bg-white/10" : "hover:bg-white/5"} ${focus === "schedule-gaps" && s.recurring_template_rows === 0 ? "bg-amber-500/10 ring-1 ring-amber-400/40" : ""} ${focus === "away" && ((awayDate === "today" && s.is_away_today) || awayDate === "tomorrow") ? "ring-1 ring-amber-400/40" : ""} ${focus === "workload" && personId === s.id ? "ring-1 ring-orange-400/40" : ""}`}>
+                      <td className="py-2">{s.full_name ?? "Unnamed"}</td>
+                      <td>{s.role ?? "staff"}</td>
+                      <td>{minsToHours(s.weekly_recurring_minutes)}</td>
+                      <td className={s.recurring_template_rows === 0 ? "text-amber-200" : ""}>{s.recurring_template_rows}</td>
+                      <td>{s.override_count_in_range}</td>
+                      <td>{s.approved_away_blocks_in_range}</td>
+                      <td className={s.is_away_today ? "text-amber-300" : "text-emerald-300"}>{s.is_away_today ? "Away today" : "Available"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-            <button disabled={busy || !selectedStaffId} onClick={() => void saveTemplate()} className="mt-3 rounded border border-white/20 bg-white/10 px-3 py-2 text-xs">Save recurring template</button>
-          </div>
-          <div className="space-y-3 text-sm">
-            <p className="text-xs text-neutral-400">One-off override shift</p>
-            <input type="date" value={overrideDate} onChange={(e) => setOverrideDate(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
-            <input type="time" value={overrideStart} onChange={(e) => setOverrideStart(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
-            <input type="time" value={overrideEnd} onChange={(e) => setOverrideEnd(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
-            <button disabled={busy || !selectedStaffId || !overrideDate} onClick={() => void addOverride()} className="rounded border border-white/20 bg-white/10 px-3 py-2 text-xs">Add override</button>
-            <div className="text-xs text-neutral-400">Cross links: <Link className="text-orange-300" href="/dashboard/admin/people">People</Link> · <Link className="text-orange-300" href="/dashboard/admin/payroll-time">Payroll Time</Link></div>
-          </div>
+          </AdminPanel>
         </div>
-        {error ? <p className="px-4 pb-4 text-xs text-red-300">{error}</p> : null}
-      </AdminPanel>
+
+        <div className="xl:col-span-2">
+          <AdminPanel>
+            <AdminPanelTitle title="Staff Schedule Editor" description="Selected staff summary, recurring weekly template, and one-off override creation." />
+            <div className="space-y-4 p-4">
+              <div className="rounded border border-white/10 bg-black/20 p-3 text-sm">
+                <p className="text-xs text-neutral-400">Selected Staff</p>
+                <p className="font-medium">{selected?.full_name ?? "None"}</p>
+                <p className="text-xs text-neutral-400">{selected?.role ?? "staff"}</p>
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-300">Weekly Template</p>
+                <div className="space-y-2">
+                  {templates.sort((a, b) => a.day_of_week - b.day_of_week).map((row, i) => (
+                    <div key={row.day_of_week} className="grid grid-cols-12 items-center gap-2 text-xs">
+                      <div className="col-span-2">{DAYS[row.day_of_week]}</div>
+                      <label className="col-span-2 flex items-center gap-1">
+                        <span className="sr-only">{DAYS[row.day_of_week]} working day</span>
+                        <input type="checkbox" checked={row.is_working_day} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, is_working_day: e.target.checked } : x))} />
+                        <span>Work</span>
+                      </label>
+                      <input aria-label={`${DAYS[row.day_of_week]} start time`} type="time" value={row.start_time ?? ""} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, start_time: e.target.value } : x))} className="col-span-3 rounded border border-white/10 bg-black/30 px-2 py-1" />
+                      <input aria-label={`${DAYS[row.day_of_week]} end time`} type="time" value={row.end_time ?? ""} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, end_time: e.target.value } : x))} className="col-span-3 rounded border border-white/10 bg-black/30 px-2 py-1" />
+                      <input aria-label={`${DAYS[row.day_of_week]} unpaid break minutes`} type="number" value={row.unpaid_break_minutes} onChange={(e) => setTemplates((prev) => prev.map((x, idx) => idx === i ? { ...x, unpaid_break_minutes: Number(e.target.value) } : x))} className="col-span-2 rounded border border-white/10 bg-black/30 px-2 py-1" />
+                    </div>
+                  ))}
+                </div>
+                <button type="button" disabled={busy || !selectedStaffId} onClick={() => void saveTemplate()} className="mt-3 rounded border border-white/20 bg-white/10 px-3 py-2 text-xs">Save recurring template</button>
+              </div>
+
+              <div className="space-y-2 border-t border-white/10 pt-3 text-sm">
+                <p className="text-xs font-medium uppercase tracking-wide text-neutral-300">One-off Override</p>
+                <label className="text-xs text-neutral-400" htmlFor="override-date">Date</label>
+                <input id="override-date" type="date" value={overrideDate} onChange={(e) => setOverrideDate(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
+                <label className="text-xs text-neutral-400" htmlFor="override-start">Start time</label>
+                <input id="override-start" type="time" value={overrideStart} onChange={(e) => setOverrideStart(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
+                <label className="text-xs text-neutral-400" htmlFor="override-end">End time</label>
+                <input id="override-end" type="time" value={overrideEnd} onChange={(e) => setOverrideEnd(e.target.value)} className="w-full rounded border border-white/10 bg-black/30 px-2 py-1" />
+                <button type="button" disabled={busy || !selectedStaffId || !overrideDate} onClick={() => void addOverride()} className="rounded border border-white/20 bg-white/10 px-3 py-2 text-xs">Add override</button>
+                <div className="text-xs text-neutral-400">Cross links: <Link className="text-orange-300" href="/dashboard/admin/people">People</Link> · <Link className="text-orange-300" href="/dashboard/admin/payroll-time">Payroll Time</Link></div>
+              </div>
+            </div>
+            {error ? <p className="px-4 pb-4 text-xs text-red-300">{error}</p> : null}
+          </AdminPanel>
+        </div>
+      </div>
     </AdminPageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Reframe the Workforce Scheduling surface from an editor/admin view into an operational daily manager surface while reusing existing APIs and preserving behavior.
- Provide a quicker operational overview (coverage, roster, pending queue, gaps) to help managers make day-of staffing decisions without adding backend changes.

### Description
- Updated the page header to `Scheduling Command` with the subtitle `Coverage, time away, and shift readiness for today’s workforce.`.
- Added a derived Daily Roster / Coverage strip that computes `available/working`, `away today`, `pending time-off`, `missing templates`, and `overrides` from the loaded `staff` and `pending` arrays (implemented in a `coverage` `useMemo`).
- Added `Today` and `Tomorrow` roster panels where `Tomorrow` explicitly shows a note when the payload lacks an explicit tomorrow-away signal and does not fabricate data.
- Reworked the pending time-off area into an operational `Time-Off Review Queue` with request cards and preserved approve/decline actions (still calling `PATCH /api/time-off/requests/:id`) and visual emphasis when `focus=time-off&status=pending` is active.
- Improved schedule-gap visibility by highlighting rows where `recurring_template_rows === 0` and retained focus-based highlighting for `schedule-gaps`, `away`, and `workload` query contexts.
- Reorganized the staff schedule editor into clear operational blocks (selected staff summary, weekly template editor, one-off override form) and added small accessibility improvements such as `type="button"`, `label` elements, and `aria-label` on time inputs.
- Preserved all APIs, permissions, tenant scoping, and semantics: `GET /api/scheduling/staff`, `GET /api/scheduling/staff/:id`, `PUT /api/scheduling/staff/:id`, and `POST /api/scheduling/staff/:id/overrides` are unchanged, and no DB migrations or backend endpoints were added.
- Exact file changed: `features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e69df3ce08328943f4c563fb45de3)