### PR TITLE
Phase 1: Harden Workforce day boundaries to shop timezone

### DIFF
--- a/app/api/scheduling/staff/route.ts
+++ b/app/api/scheduling/staff/route.ts
@@ -2,15 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { getShopDayRange } from "@/features/shared/lib/utils/shopDayWindow";
 type AdminClient = ReturnType<typeof createAdminSupabase>;
-
-function toDayBounds(date: Date) {
-  const start = new Date(date);
-  start.setHours(0, 0, 0, 0);
-  const end = new Date(start);
-  end.setDate(end.getDate() + 1);
-  return { start: start.toISOString(), end: end.toISOString() };
-}
 
 export async function GET(req: NextRequest) {
   const access = await requireShopScopedApiAccess();
@@ -22,6 +15,9 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const from = url.searchParams.get("from") ?? new Date().toISOString();
   const to = url.searchParams.get("to") ?? new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString();
+  const shopRes = await admin.from("shops").select("timezone").eq("id", access.profile.shop_id).maybeSingle();
+  if (shopRes.error) return NextResponse.json({ error: shopRes.error.message }, { status: 500 });
+  const todayBounds = getShopDayRange(shopRes.data?.timezone, new Date());
 
   const [profilesRes, templatesRes, overridesRes, blocksRes, requestsRes] = await Promise.all([
     admin.from("profiles").select("id, full_name, email, role").eq("shop_id", access.profile.shop_id).order("full_name", { ascending: true }),
@@ -54,7 +50,6 @@ export async function GET(req: NextRequest) {
       recurringMinutes += Math.max(0, (eh * 60 + em) - (sh * 60 + sm) - (row.unpaid_break_minutes ?? 0));
     }
 
-    const todayBounds = toDayBounds(new Date());
     const isAwayToday = personBlocks.some((b) => b.starts_at < todayBounds.end && b.ends_at > todayBounds.start);
 
     return {

--- a/app/api/workforce/overview/route.ts
+++ b/app/api/workforce/overview/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { getShopTodayTomorrowRanges } from "@/features/shared/lib/utils/shopDayWindow";
 
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 type Severity = "blocking" | "warning" | "info";
@@ -53,11 +54,14 @@ export async function GET() {
   const admin: AdminClient = createAdminSupabase();
   const shopId = access.profile.shop_id;
   const now = new Date();
-  // TODO: Normalize "today" boundaries to the shop timezone instead of server-local midnight.
-  const todayStart = new Date(now); todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date(todayStart); todayEnd.setDate(todayEnd.getDate() + 1);
-  const tomorrowEnd = new Date(todayEnd); tomorrowEnd.setDate(tomorrowEnd.getDate() + 1);
-  const in30 = new Date(todayStart); in30.setDate(in30.getDate() + 30);
+  const in30 = new Date(now); in30.setDate(in30.getDate() + 30);
+  const shopRes = await admin.from("shops").select("timezone").eq("id", shopId).maybeSingle();
+  if (shopRes.error) return NextResponse.json({ error: shopRes.error.message }, { status: 500 });
+  // Workforce day views intentionally use shop-local timezone day boundaries.
+  const dayRanges = getShopTodayTomorrowRanges(shopRes.data?.timezone, now);
+  const todayStartIso = dayRanges.today.start;
+  const todayEndIso = dayRanges.today.end;
+  const tomorrowEndIso = dayRanges.tomorrow.end;
 
   const [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes] = await Promise.all([
     admin.from("profiles").select("id, full_name").eq("shop_id", shopId),
@@ -66,7 +70,7 @@ export async function GET() {
     admin.from("payroll_pay_periods").select("id, period_start").eq("shop_id", shopId).order("period_start", { ascending: false }).limit(1),
     admin.from("staff_certifications").select("expiry_date, status").eq("shop_id", shopId),
     admin.from("staff_schedule_templates").select("user_id").eq("shop_id", shopId),
-    admin.from("staff_availability_blocks").select("user_id, starts_at, ends_at").eq("shop_id", shopId).lte("starts_at", tomorrowEnd.toISOString()).gte("ends_at", todayStart.toISOString()),
+    admin.from("staff_availability_blocks").select("user_id, starts_at, ends_at").eq("shop_id", shopId).lte("starts_at", tomorrowEndIso).gte("ends_at", todayStartIso),
     admin.from("work_order_lines").select("id, assigned_tech_id, line_status, status, voided_at").eq("shop_id", shopId).is("voided_at", null),
   ]);
   const firstError = [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes].find((r) => r.error);
@@ -85,8 +89,8 @@ export async function GET() {
   const templateUsers = new Set((templatesRes.data ?? []).map((t) => t.user_id));
   const blocks = blocksRes.data ?? [];
   const overlap = (start: string, end: string, from: Date, to: Date) => new Date(start) < to && new Date(end) > from;
-  const awayTodayUsers = new Set(blocks.filter((b) => overlap(b.starts_at, b.ends_at, todayStart, todayEnd)).map((b) => b.user_id));
-  const awayTomorrowUsers = new Set(blocks.filter((b) => overlap(b.starts_at, b.ends_at, todayEnd, tomorrowEnd)).map((b) => b.user_id));
+  const awayTodayUsers = new Set(blocks.filter((b) => overlap(b.starts_at, b.ends_at, new Date(todayStartIso), new Date(todayEndIso))).map((b) => b.user_id));
+  const awayTomorrowUsers = new Set(blocks.filter((b) => overlap(b.starts_at, b.ends_at, new Date(todayEndIso), new Date(tomorrowEndIso))).map((b) => b.user_id));
 
   let payrollBlocking = 0; let payrollWarnings = 0;
   const periodId = periodsRes.data?.[0]?.id;

--- a/features/shared/lib/utils/shopDayWindow.ts
+++ b/features/shared/lib/utils/shopDayWindow.ts
@@ -134,3 +134,44 @@ export function getShopLocalDayWindow(
     dayEndMs,
   };
 }
+
+function normalizeTimezone(timezone?: string | null): string {
+  if (!timezone) return "UTC";
+  try {
+    // Throws for invalid IANA timezone names.
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return timezone;
+  } catch {
+    return "UTC";
+  }
+}
+
+export function getShopDayRange(
+  timezone?: string | null,
+  referenceDate: Date = new Date(),
+): { timezone: string; start: string; end: string } {
+  const safeTimezone = normalizeTimezone(timezone);
+  const window = getShopLocalDayWindow(safeTimezone, referenceDate);
+  return {
+    timezone: safeTimezone,
+    start: window.dayStartIso,
+    end: window.dayEndIso,
+  };
+}
+
+export function getShopTodayTomorrowRanges(
+  timezone?: string | null,
+  now: Date = new Date(),
+): {
+  timezone: string;
+  today: { start: string; end: string };
+  tomorrow: { start: string; end: string };
+} {
+  const today = getShopDayRange(timezone, now);
+  const tomorrow = getShopDayRange(today.timezone, new Date(today.end));
+  return {
+    timezone: today.timezone,
+    today: { start: today.start, end: today.end },
+    tomorrow: { start: tomorrow.start, end: tomorrow.end },
+  };
+}


### PR DESCRIPTION
### Motivation
- Current Workforce and Scheduling APIs used server- or browser-local midnight to compute “today” which is incorrect when a shop's timezone differs from the server/user timezone.
- Small, low-risk hardening is needed to make away/today and tomorrow overlap checks shop-local without changing scheduling/punch/payroll/permission behavior.
- No DB migrations or tenant/scoping changes are required for this phase.

### Description
- Added timezone-safe convenience helpers in `features/shared/lib/utils/shopDayWindow.ts`: `getShopDayRange(timezone, referenceDate?)` and `getShopTodayTomorrowRanges(timezone, now?)`, which reuse the existing DST-aware `getShopLocalDayWindow` and normalize invalid/missing timezones to `UTC`.
- Updated `app/api/workforce/overview/route.ts` to fetch `shops.timezone` for the authenticated shop and compute shop-local today/tomorrow UTC ranges for availability/away overlap checks, replacing the previous server-local `setHours` day-boundary logic while preserving response shape and role/scoping checks.
- Updated `app/api/scheduling/staff/route.ts` to fetch `shops.timezone` and replace the previous server-local `toDayBounds(new Date())` usage for computing `is_away_today` with `getShopDayRange(...)`, while keeping `from`/`to` query semantics and payload unchanged.
- Attendance was intentionally not modified in this pass (left for Phase 2) and no scheduling/punch/payroll/permissions or tenant boundaries were altered.

### Testing
- Ran `npx tsc --noEmit` and TypeScript check passed successfully.
- Performed a grep/manual check confirming no remaining server-local `setHours`/`toDayBounds` day-boundary logic in `app/api/workforce/overview/route.ts` and `app/api/scheduling/staff/route.ts`.
- Changes committed and small patch contains only code edits to `features/shared/lib/utils/shopDayWindow.ts`, `app/api/workforce/overview/route.ts`, and `app/api/scheduling/staff/route.ts` with no DB migration required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e744e264483289facd3b03fc70894)