### PR TITLE
Harden attendance day range to use shop timezone bounds

### DIFF
--- a/app/dashboard/workforce/attendance/page.tsx
+++ b/app/dashboard/workforce/attendance/page.tsx
@@ -1,8 +1,25 @@
-import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 import { AttendanceOverviewClient } from "@/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { getShopDayRange } from "@/features/shared/lib/utils/shopDayWindow";
 
 export default async function WorkforceAttendancePage() {
-  await requireAdminPageAccess({ allow: ["owner", "admin", "manager"] });
+  const { profile } = await requireAdminPageAccess({ allow: ["owner", "admin", "manager"] });
 
-  return <AttendanceOverviewClient />;
+  const supabase = createServerSupabaseRSC();
+  const { data: shop } = await supabase
+    .from("shops")
+    .select("timezone")
+    .eq("id", profile.shop_id)
+    .maybeSingle<{ timezone: string | null }>();
+
+  const shopDay = getShopDayRange(shop?.timezone, new Date());
+
+  return (
+    <AttendanceOverviewClient
+      from={shopDay.start}
+      to={shopDay.end}
+      timezone={shop?.timezone ?? null}
+    />
+  );
 }

--- a/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx
@@ -80,7 +80,13 @@ function shiftStateFromPunches(punches: PunchRow[]): NowBucket {
   return "no_activity";
 }
 
-export function AttendanceOverviewClient() {
+type AttendanceOverviewClientProps = {
+  from: string;
+  to: string;
+  timezone?: string | null;
+};
+
+export function AttendanceOverviewClient({ from, to, timezone }: AttendanceOverviewClientProps) {
   const [data, setData] = useState<AttendanceResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -90,15 +96,8 @@ export function AttendanceOverviewClient() {
     setError(null);
 
     try {
-      const now = new Date();
-      // TODO: normalize this range to shop-specific timezone boundaries.
-      const start = new Date(now);
-      start.setHours(0, 0, 0, 0);
-      const end = new Date(now);
-      end.setHours(23, 59, 59, 999);
-
       const res = await fetch(
-        `/api/scheduling/shifts?from=${encodeURIComponent(start.toISOString())}&to=${encodeURIComponent(end.toISOString())}`,
+        `/api/scheduling/shifts?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
         { cache: "no-store" },
       );
 
@@ -115,7 +114,7 @@ export function AttendanceOverviewClient() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [from, to]);
 
   useEffect(() => {
     void fetchAttendance();
@@ -197,6 +196,9 @@ export function AttendanceOverviewClient() {
       <section className="rounded-2xl border border-white/10 bg-black/25 p-5">
         <h1 className="text-2xl font-semibold text-white">Attendance Command</h1>
         <p className="mt-1 text-sm text-neutral-300">Live shift posture, break states, and payroll handoff for today.</p>
+        <p className="mt-2 inline-flex rounded-full border border-white/15 bg-white/5 px-2.5 py-1 text-xs text-neutral-300">
+          {timezone ? `Today based on shop timezone: ${timezone}` : "Today based on shop day window (UTC fallback)"}
+        </p>
         <div className="mt-4 flex flex-wrap gap-2">
           <Link href="/dashboard/workforce/scheduling" className="rounded-lg border border-white/15 bg-black/35 px-3 py-2 text-sm font-medium text-orange-300 hover:text-orange-200">Scheduling</Link>
           <Link href="/dashboard/workforce/payroll-review" className="rounded-lg border border-white/15 bg-black/35 px-3 py-2 text-sm font-medium text-orange-300 hover:text-orange-200">Payroll Review</Link>


### PR DESCRIPTION
### Motivation
- Attendance previously computed “today” using the browser/local time which led to mismatched day windows for shops in different timezones. 
- The goal is to harden Attendance to use the shop-local day bounds already available via the shared shop day helper without changing scheduling APIs or permissions.

### Description
- Server page `app/dashboard/workforce/attendance/page.tsx` now resolves the authenticated actor’s `shop_id` and `shops.timezone` via the server Supabase client and computes the shop-local day window using `getShopDayRange(...)`, then passes `from`, `to`, and `timezone` into the client component. 
- Client `features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx` now accepts props `from: string`, `to: string`, and optional `timezone?: string | null`, and uses the provided `from`/`to` when calling `/api/scheduling/shifts` instead of building a browser-local `setHours` range. 
- A small, lightweight helper copy chip was added to the Attendance header to indicate the day interpretation as the shop timezone or a UTC fallback. 
- No database migrations, no new APIs, and no changes were made to `/api/scheduling/shifts`, punch mutations, payroll, permissions, or tenant scoping.
- Files changed: `app/dashboard/workforce/attendance/page.tsx`, `features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed with no errors (only an unrelated npm env warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e78d038108328bec535295296ac82)