### PR TITLE
Implement Workforce Documents & Certifications Phase A readiness surfaces

### DIFF
--- a/app/api/workforce/certifications-readiness/route.ts
+++ b/app/api/workforce/certifications-readiness/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const EXPIRING_SOON_DAYS = 30;
+
+type CertStatus = "expired" | "expiring_soon" | "active";
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const admin = createAdminSupabase();
+  const shopId = access.profile.shop_id;
+
+  const [{ data: certs, error: certErr }, { data: people, error: peopleErr }] = await Promise.all([
+    admin
+      .from("staff_certifications")
+      .select("id, user_id, cert_name, expiry_date, status")
+      .eq("shop_id", shopId),
+    admin.from("profiles").select("id, full_name, email").eq("shop_id", shopId),
+  ]);
+
+  if (certErr) return NextResponse.json({ error: certErr.message }, { status: 500 });
+  if (peopleErr) return NextResponse.json({ error: peopleErr.message }, { status: 500 });
+
+  const profileById = new Map((people ?? []).map((person) => [person.id, person]));
+  const now = Date.now();
+  const expiringSoonCutoff = now + EXPIRING_SOON_DAYS * DAY_MS;
+
+  const items = (certs ?? []).map((cert) => {
+    let lifecycle: CertStatus = "active";
+    const expiresTs = cert.expiry_date ? new Date(cert.expiry_date).getTime() : null;
+    const normalizedStatus = String(cert.status ?? "").toLowerCase();
+
+    if (normalizedStatus === "expired" || (expiresTs !== null && Number.isFinite(expiresTs) && expiresTs < now)) {
+      lifecycle = "expired";
+    } else if (expiresTs !== null && Number.isFinite(expiresTs) && expiresTs <= expiringSoonCutoff) {
+      lifecycle = "expiring_soon";
+    }
+
+    const person = profileById.get(cert.user_id);
+    return {
+      personId: cert.user_id,
+      personName: person?.full_name ?? person?.email ?? "Unknown person",
+      certificationId: cert.id,
+      name: cert.cert_name,
+      expiresAt: cert.expiry_date,
+      status: lifecycle,
+      href: `/dashboard/workforce/people/${cert.user_id}?focus=certifications`,
+    };
+  });
+
+  const peopleAtRiskSet = new Set(items.filter((item) => item.status !== "active").map((item) => item.personId));
+
+  const summary = {
+    expired: items.filter((item) => item.status === "expired").length,
+    expiringSoon: items.filter((item) => item.status === "expiring_soon").length,
+    active: items.filter((item) => item.status === "active").length,
+    peopleAtRisk: peopleAtRiskSet.size,
+  };
+
+  return NextResponse.json({ summary, items, generatedAt: new Date().toISOString() });
+}

--- a/app/api/workforce/documents-readiness/[id]/signed-url/route.ts
+++ b/app/api/workforce/documents-readiness/[id]/signed-url/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const SIGNED_TTL_SECONDS = 60 * 5;
+
+export async function GET(_req: Request, context: { params: Promise<{ id: string }> }) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const { id } = await context.params;
+  const admin = createAdminSupabase();
+
+  const { data: doc, error } = await admin
+    .from("employee_documents")
+    .select("id, shop_id, file_path, bucket_id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!doc || doc.shop_id !== access.profile.shop_id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const bucket = doc.bucket_id || "employee_docs";
+  const { data: signed, error: signErr } = await admin.storage.from(bucket).createSignedUrl(doc.file_path, SIGNED_TTL_SECONDS);
+  if (signErr || !signed?.signedUrl) {
+    return NextResponse.json({ error: signErr?.message ?? "Unable to create signed url" }, { status: 500 });
+  }
+
+  return NextResponse.json({ signedUrl: signed.signedUrl, expiresIn: SIGNED_TTL_SECONDS });
+}

--- a/app/api/workforce/documents-readiness/route.ts
+++ b/app/api/workforce/documents-readiness/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const RECENT_WINDOW_DAYS = 14;
+const EXPIRING_SOON_DAYS = 30;
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const admin = createAdminSupabase();
+  const shopId = access.profile.shop_id;
+
+  const { data, error } = await admin
+    .from("employee_documents")
+    .select("id, doc_type, status, uploaded_at, expires_at, user_id")
+    .eq("shop_id", shopId)
+    .order("uploaded_at", { ascending: false });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const userIds = Array.from(new Set((data ?? []).map((row) => row.user_id).filter(Boolean)));
+  const { data: profiles } = userIds.length === 0
+    ? { data: [] }
+    : await admin.from("profiles").select("id, full_name, email").in("id", userIds).eq("shop_id", shopId);
+
+  const profileById = new Map((profiles ?? []).map((row) => [row.id, row]));
+  const now = Date.now();
+  const recentCutoff = now - RECENT_WINDOW_DAYS * DAY_MS;
+  const expiringSoonCutoff = now + EXPIRING_SOON_DAYS * DAY_MS;
+
+  const documents = (data ?? []).map((row) => {
+    const profile = profileById.get(row.user_id);
+    return {
+      id: row.id,
+      docType: row.doc_type,
+      status: row.status,
+      uploadedAt: row.uploaded_at,
+      expiresAt: row.expires_at,
+      userId: row.user_id,
+      personName: profile?.full_name ?? null,
+      personEmail: profile?.email ?? null,
+      viewPath: `/api/workforce/documents-readiness/${row.id}/signed-url`,
+    };
+  });
+
+  const summary = documents.reduce(
+    (acc, doc) => {
+      const uploadedTs = doc.uploadedAt ? new Date(doc.uploadedAt).getTime() : 0;
+      const expiresTs = doc.expiresAt ? new Date(doc.expiresAt).getTime() : null;
+      const status = String(doc.status ?? "").toLowerCase();
+
+      acc.total += 1;
+      if (uploadedTs >= recentCutoff) acc.recent += 1;
+      if (["received", "pending", "review", "needs_review"].includes(status)) acc.needsReview += 1;
+      if (expiresTs !== null && Number.isFinite(expiresTs)) {
+        if (expiresTs < now) acc.expired += 1;
+        else if (expiresTs <= expiringSoonCutoff) acc.expiringSoon += 1;
+      }
+      return acc;
+    },
+    { total: 0, recent: 0, needsReview: 0, expired: 0, expiringSoon: 0 },
+  );
+
+  return NextResponse.json({ summary, documents, generatedAt: new Date().toISOString() });
+}

--- a/app/dashboard/workforce/certifications/page.tsx
+++ b/app/dashboard/workforce/certifications/page.tsx
@@ -1,14 +1,7 @@
-import Link from "next/link";
+import WorkforceCertificationsClient from "@/features/dashboard/app/dashboard/workforce/WorkforceCertificationsClient";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
 export default async function WorkforceCertificationsPage() {
   await requireAdminPageAccess({ allow: ["owner", "admin"] });
-
-  return (
-    <div className="space-y-4 rounded-2xl border border-white/10 bg-black/25 p-5">
-      <h1 className="text-2xl font-semibold text-white">Certifications</h1>
-      <p className="text-sm text-neutral-300">Certification records are managed on each person profile in People.</p>
-      <Link href="/dashboard/workforce/people" className="inline-block rounded-lg border border-white/15 bg-black/35 px-3 py-2 text-sm font-medium text-orange-300 hover:text-orange-200">Open People</Link>
-    </div>
-  );
+  return <WorkforceCertificationsClient />;
 }

--- a/app/dashboard/workforce/documents/page.tsx
+++ b/app/dashboard/workforce/documents/page.tsx
@@ -1,7 +1,7 @@
-import EmployeeDocsClient from "@/features/dashboard/app/dashboard/admin/EmployeeDocsClient";
+import WorkforceDocumentsClient from "@/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
 export default async function WorkforceDocumentsPage() {
   await requireAdminPageAccess({ allow: ["owner", "admin"] });
-  return <EmployeeDocsClient />;
+  return <WorkforceDocumentsClient />;
 }

--- a/features/dashboard/app/dashboard/workforce/WorkforceCertificationsClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceCertificationsClient.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type Item = { personId: string; personName: string; certificationId: string; name: string | null; expiresAt: string | null; status: "expired" | "expiring_soon" | "active"; href: string };
+type Payload = { summary: { expired: number; expiringSoon: number; active: number; peopleAtRisk: number }; items: Item[]; generatedAt: string };
+
+export default function WorkforceCertificationsClient() {
+  const [data, setData] = useState<Payload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { void (async () => { try { const r = await fetch('/api/workforce/certifications-readiness', { cache: 'no-store' }); const j = await r.json(); if (!r.ok) throw new Error(j?.error || 'Failed'); setData(j); } catch (e) { setError((e as Error).message); } finally { setLoading(false);} })(); }, []);
+
+  const grouped = useMemo(() => ({ expired: (data?.items ?? []).filter(i => i.status === 'expired'), expiring: (data?.items ?? []).filter(i => i.status === 'expiring_soon'), active: (data?.items ?? []).filter(i => i.status === 'active') }), [data]);
+
+  const section = (label: string, rows: Item[]) => <section><h2 className="mb-2 text-sm font-semibold text-neutral-200">{label}</h2><div className="grid gap-2">{rows.length===0?<div className="rounded border border-white/10 bg-black/20 p-3 text-sm text-neutral-400">No records.</div>:rows.map(r=><div key={r.certificationId} className="rounded border border-white/10 bg-black/20 p-3 flex items-center justify-between"><div><div className="font-medium text-white">{r.name ?? 'Certification'}</div><div className="text-sm text-neutral-300">{r.personName}</div><div className="text-xs text-neutral-400">Expires: {r.expiresAt ? new Date(r.expiresAt).toLocaleDateString() : '—'}</div></div><Link href={r.href} className="rounded border border-white/15 px-2 py-1 text-xs text-orange-300">Edit</Link></div>)}</div></section>;
+
+  if (loading) return <div className="rounded-2xl border border-white/10 bg-black/25 p-5 text-neutral-300">Loading Certifications Command…</div>;
+  if (error) return <div className="rounded-2xl border border-red-500/30 bg-red-950/20 p-5 text-red-200">{error}</div>;
+
+  return <div className="space-y-5"><div className="rounded-2xl border border-white/10 bg-black/25 p-5"><h1 className="text-2xl font-semibold text-white">Certifications Command</h1><p className="text-sm text-neutral-300">Certification readiness and renewal risk view.</p></div><div className="grid gap-3 sm:grid-cols-4">{Object.entries({Expired:data?.summary.expired??0,'Expiring Soon':data?.summary.expiringSoon??0,Active:data?.summary.active??0,'People At Risk':data?.summary.peopleAtRisk??0}).map(([k,v])=><div key={k} className="rounded-xl border border-white/10 bg-black/20 p-3"><div className="text-xs text-neutral-400">{k}</div><div className="text-xl font-semibold text-white">{v}</div></div>)}</div>{section('Expired', grouped.expired)}{section('Expiring Soon', grouped.expiring)}{section('Active', grouped.active)}</div>;
+}

--- a/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type WorkforceDocument = {
+  id: string;
+  docType: string | null;
+  status: string | null;
+  uploadedAt: string | null;
+  expiresAt: string | null;
+  userId: string;
+  personName: string | null;
+  personEmail: string | null;
+  viewPath: string;
+};
+
+type ResponsePayload = {
+  summary: { total: number; recent: number; needsReview: number; expired: number; expiringSoon: number };
+  documents: WorkforceDocument[];
+  generatedAt: string;
+};
+
+export default function WorkforceDocumentsClient() {
+  const [data, setData] = useState<ResponsePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const res = await fetch("/api/workforce/documents-readiness", { cache: "no-store" });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json?.error || "Failed loading documents readiness");
+        setData(json);
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void run();
+  }, []);
+
+  const now = Date.now();
+  const in30 = now + 1000 * 60 * 60 * 24 * 30;
+  const recentCutoff = now - 1000 * 60 * 60 * 24 * 14;
+
+  const sections = useMemo(() => {
+    const docs = data?.documents ?? [];
+    return {
+      needsReview: docs.filter((doc) => ["received", "pending", "review", "needs_review"].includes(String(doc.status ?? "").toLowerCase())),
+      expiringSoon: docs.filter((doc) => {
+        const ts = doc.expiresAt ? new Date(doc.expiresAt).getTime() : null;
+        return ts !== null && Number.isFinite(ts) && ts >= now && ts <= in30;
+      }),
+      expired: docs.filter((doc) => {
+        const ts = doc.expiresAt ? new Date(doc.expiresAt).getTime() : null;
+        return ts !== null && Number.isFinite(ts) && ts < now;
+      }),
+      recent: docs.filter((doc) => (doc.uploadedAt ? new Date(doc.uploadedAt).getTime() >= recentCutoff : false)),
+      all: docs,
+    };
+  }, [data, in30, now, recentCutoff]);
+
+  const openDoc = async (doc: WorkforceDocument) => {
+    const res = await fetch(doc.viewPath, { cache: "no-store" });
+    const json = await res.json();
+    if (!res.ok || !json?.signedUrl) {
+      alert(json?.error ?? "Unable to open document");
+      return;
+    }
+    window.open(json.signedUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const renderRows = (rows: WorkforceDocument[]) => (
+    <div className="overflow-hidden rounded-xl border border-white/10 bg-black/20">
+      <table className="min-w-full text-sm text-neutral-200">
+        <thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400">
+          <tr><th className="px-3 py-2 text-left">Type</th><th className="px-3 py-2 text-left">Status</th><th className="px-3 py-2 text-left">Person</th><th className="px-3 py-2 text-left">Uploaded</th><th className="px-3 py-2 text-left">Expires</th><th className="px-3 py-2 text-right">Action</th></tr>
+        </thead>
+        <tbody>
+          {rows.map((doc) => (
+            <tr key={doc.id} className="border-t border-white/10">
+              <td className="px-3 py-2 capitalize">{(doc.docType ?? "other").replaceAll("_", " ")}</td>
+              <td className="px-3 py-2">{doc.status ?? "—"}</td>
+              <td className="px-3 py-2">{doc.personName ?? "Unknown"}<div className="text-xs text-neutral-400">{doc.personEmail ?? doc.userId}</div></td>
+              <td className="px-3 py-2">{doc.uploadedAt ? new Date(doc.uploadedAt).toLocaleDateString() : "—"}</td>
+              <td className="px-3 py-2">{doc.expiresAt ? new Date(doc.expiresAt).toLocaleDateString() : "—"}</td>
+              <td className="px-3 py-2 text-right"><button onClick={() => void openDoc(doc)} className="rounded border border-white/15 px-2 py-1 hover:bg-white/10">Open</button></td>
+            </tr>
+          ))}
+          {rows.length === 0 ? <tr><td colSpan={6} className="px-3 py-4 text-center text-neutral-400">No documents in this section.</td></tr> : null}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  if (loading) return <div className="rounded-2xl border border-white/10 bg-black/25 p-5 text-neutral-300">Loading Documents Command…</div>;
+  if (error) return <div className="rounded-2xl border border-red-500/30 bg-red-950/20 p-5 text-red-200">{error}</div>;
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-2xl border border-white/10 bg-black/25 p-5">
+        <h1 className="text-2xl font-semibold text-white">Documents Command</h1>
+        <p className="mt-1 text-sm text-neutral-300">Workforce readiness for document collection and compliance.</p>
+        <div className="mt-3 flex flex-wrap gap-2 text-xs"><Link href="/dashboard/workforce/people" className="rounded border border-white/15 px-2 py-1 text-orange-300">Open People</Link><Link href="/dashboard/admin/employee-docs" className="rounded border border-white/15 px-2 py-1 text-neutral-300">Open Upload Console</Link></div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-5">{Object.entries({Total: data?.summary.total ?? 0, Recent: data?.summary.recent ?? 0, "Needs Review": data?.summary.needsReview ?? 0, Expired: data?.summary.expired ?? 0, "Expiring Soon": data?.summary.expiringSoon ?? 0}).map(([k, v]) => <div key={k} className="rounded-xl border border-white/10 bg-black/20 p-3"><div className="text-xs text-neutral-400">{k}</div><div className="text-xl font-semibold text-white">{v}</div></div>)}</div>
+      <div className="space-y-4">
+        <section><h2 className="mb-2 text-sm font-semibold text-orange-300">Needs Review</h2>{renderRows(sections.needsReview)}</section>
+        <section><h2 className="mb-2 text-sm font-semibold text-yellow-300">Expiring Soon</h2>{renderRows(sections.expiringSoon)}</section>
+        <section><h2 className="mb-2 text-sm font-semibold text-red-300">Expired</h2>{renderRows(sections.expired)}</section>
+        <section><h2 className="mb-2 text-sm font-semibold text-cyan-300">Recent Uploads</h2>{renderRows(sections.recent)}</section>
+        <section><h2 className="mb-2 text-sm font-semibold text-neutral-200">All Documents</h2>{renderRows(sections.all)}</section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide owner/admin-facing readiness surfaces for Workforce Documents and Certifications to surface upload status, expirations, and review needs for DriveHRIS gap closure phase A.
- Replace stub/passthrough UI with dedicated client pages that use shop-scoped server APIs while preserving existing upload/CRUD behavior and tenant boundaries.
- Prevent public URL leakage by replacing direct public storage links with short-lived signed URL access scoped to the document row's shop.

### Description
- Added server APIs: `GET /api/workforce/documents-readiness` (summary + document list), `GET /api/workforce/documents-readiness/[id]/signed-url` (short-lived signed URL, 5 minute TTL, verifies `row.shop_id === actor.shop_id`), and `GET /api/workforce/certifications-readiness` (cert lifecycle items + summary).
- Implemented client readiness UIs: `WorkforceDocumentsClient` and `WorkforceCertificationsClient` and wired them into the existing pages at `app/dashboard/workforce/documents` and `app/dashboard/workforce/certifications` while keeping owner/admin gating.
- Document list includes doc type, status, uploaded/expiry dates, person/uploader context when available, and an Open action that requests the signed URL from the server instead of using a public URL.
- No DB migrations, no changes to certification CRUD endpoints, no changes to payroll/punch/scheduling behavior, and preserved multi-tenant scoping and owner/admin-only access.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed.
- No repo-wide lint was run as part of this change to avoid chasing unrelated baseline issues.
- Manual sanity: new pages call the shop-scoped APIs and use the signed-url endpoint to open documents (behavior exercised during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7e2b6d8c8328bf45a4455e8b080b)