### PR TITLE
Workforce Required Document Matrix (Phase B1): defaults, readiness helper, API & UI

### DIFF
--- a/app/api/workforce/document-requirements/readiness/route.ts
+++ b/app/api/workforce/document-requirements/readiness/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { buildDocumentRequirementsReadiness } from "@/features/shared/lib/workforce/documentReadiness";
+import { DEFAULT_DOCUMENT_REQUIREMENTS } from "@/features/shared/lib/workforce/documentRequirementsDefaults";
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const admin = createAdminSupabase();
+  const shopId = access.profile.shop_id;
+
+  const [{ data: workforceProfiles, error: workforceError }, { data: docs, error: docsError }, { data: people, error: peopleError }] = await Promise.all([
+    admin
+      .from("people_workforce_profiles")
+      .select("user_id, workforce_role, workforce_category, employment_status")
+      .eq("shop_id", shopId),
+    admin
+      .from("employee_documents")
+      .select("id, user_id, doc_type, status, expires_at, uploaded_at")
+      .eq("shop_id", shopId),
+    admin.from("profiles").select("id, full_name, email").eq("shop_id", shopId),
+  ]);
+
+  const firstError = workforceError ?? docsError ?? peopleError;
+  if (firstError) return NextResponse.json({ error: firstError.message }, { status: 500 });
+
+  const personById = new Map((people ?? []).map((p) => [p.id, p]));
+  const joinedPeople = (workforceProfiles ?? []).map((workforce) => {
+    const profile = personById.get(workforce.user_id);
+    return {
+      id: workforce.user_id,
+      full_name: profile?.full_name ?? null,
+      email: profile?.email ?? null,
+      workforce_role: workforce.workforce_role,
+      workforce_category: workforce.workforce_category,
+      employment_status: workforce.employment_status,
+    };
+  });
+
+  const readiness = buildDocumentRequirementsReadiness({
+    people: joinedPeople,
+    documents: docs ?? [],
+    requirements: DEFAULT_DOCUMENT_REQUIREMENTS,
+    warningDays: 30,
+  });
+
+  return NextResponse.json({
+    ...readiness,
+    generatedAt: new Date().toISOString(),
+  });
+}

--- a/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
@@ -15,24 +15,46 @@ type WorkforceDocument = {
   viewPath: string;
 };
 
-type ResponsePayload = {
+type DocsResponsePayload = {
   summary: { total: number; recent: number; needsReview: number; expired: number; expiringSoon: number };
   documents: WorkforceDocument[];
   generatedAt: string;
 };
 
+type MatrixPayload = {
+  requirements: Array<{ key: string; workforceRole: string | null; workforceCategory: string | null; docType: string; label: string; required: true; expiresRequired: boolean; warningDays: number }>;
+  readinessItems: Array<{ personId: string; personName: string; personEmail: string | null; workforceRole: string | null; workforceCategory: string | null; readiness: string; missingDocTypes: string[]; expiredDocTypes: string[]; expiringDocTypes: string[]; needsReviewDocTypes: string[]; href: string }>;
+  missingByPerson: Array<{ personId: string; personName: string; missingDocTypes: string[]; href: string }>;
+  missingByDocType: Array<{ docType: string; label: string; count: number }>;
+  expiringRequired: Array<{ personId: string; personName: string; expiredDocTypes: string[]; expiringDocTypes: string[]; href: string }>;
+  summary: { activePeople: number; ready: number; missingRequired: number; expiredRequired: number; needsReview: number; expiringSoon: number };
+  generatedAt: string;
+};
+
 export default function WorkforceDocumentsClient() {
-  const [data, setData] = useState<ResponsePayload | null>(null);
+  const [data, setData] = useState<DocsResponsePayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [matrix, setMatrix] = useState<MatrixPayload | null>(null);
+  const [matrixError, setMatrixError] = useState<string | null>(null);
 
   useEffect(() => {
     const run = async () => {
       try {
-        const res = await fetch("/api/workforce/documents-readiness", { cache: "no-store" });
-        const json = await res.json();
-        if (!res.ok) throw new Error(json?.error || "Failed loading documents readiness");
-        setData(json);
+        const [docsRes, matrixRes] = await Promise.all([
+          fetch("/api/workforce/documents-readiness", { cache: "no-store" }),
+          fetch("/api/workforce/document-requirements/readiness", { cache: "no-store" }),
+        ]);
+        const docsJson = await docsRes.json();
+        if (!docsRes.ok) throw new Error(docsJson?.error || "Failed loading documents readiness");
+        setData(docsJson);
+
+        const matrixJson = await matrixRes.json();
+        if (!matrixRes.ok) {
+          setMatrixError(matrixJson?.error || "Failed loading matrix readiness");
+        } else {
+          setMatrix(matrixJson);
+        }
       } catch (err) {
         setError((err as Error).message);
       } finally {
@@ -63,6 +85,22 @@ export default function WorkforceDocumentsClient() {
     };
   }, [data, in30, now, recentCutoff]);
 
+  const byRole = useMemo(() => {
+    const map = new Map<string, { role: string; total: number; missing: number; expired: number; needsReview: number; expiring: number; ready: number }>();
+    for (const item of matrix?.readinessItems ?? []) {
+      const role = item.workforceRole ?? item.workforceCategory ?? "unassigned";
+      const current = map.get(role) ?? { role, total: 0, missing: 0, expired: 0, needsReview: 0, expiring: 0, ready: 0 };
+      current.total += 1;
+      if (item.readiness === "missing_required") current.missing += 1;
+      else if (item.readiness === "expired_required") current.expired += 1;
+      else if (item.readiness === "needs_review") current.needsReview += 1;
+      else if (item.readiness === "expiring_soon") current.expiring += 1;
+      else current.ready += 1;
+      map.set(role, current);
+    }
+    return Array.from(map.values()).sort((a, b) => b.total - a.total);
+  }, [matrix]);
+
   const openDoc = async (doc: WorkforceDocument) => {
     const res = await fetch(doc.viewPath, { cache: "no-store" });
     const json = await res.json();
@@ -75,45 +113,40 @@ export default function WorkforceDocumentsClient() {
 
   const renderRows = (rows: WorkforceDocument[]) => (
     <div className="overflow-hidden rounded-xl border border-white/10 bg-black/20">
-      <table className="min-w-full text-sm text-neutral-200">
-        <thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400">
-          <tr><th className="px-3 py-2 text-left">Type</th><th className="px-3 py-2 text-left">Status</th><th className="px-3 py-2 text-left">Person</th><th className="px-3 py-2 text-left">Uploaded</th><th className="px-3 py-2 text-left">Expires</th><th className="px-3 py-2 text-right">Action</th></tr>
-        </thead>
-        <tbody>
-          {rows.map((doc) => (
-            <tr key={doc.id} className="border-t border-white/10">
-              <td className="px-3 py-2 capitalize">{(doc.docType ?? "other").replaceAll("_", " ")}</td>
-              <td className="px-3 py-2">{doc.status ?? "—"}</td>
-              <td className="px-3 py-2">{doc.personName ?? "Unknown"}<div className="text-xs text-neutral-400">{doc.personEmail ?? doc.userId}</div></td>
-              <td className="px-3 py-2">{doc.uploadedAt ? new Date(doc.uploadedAt).toLocaleDateString() : "—"}</td>
-              <td className="px-3 py-2">{doc.expiresAt ? new Date(doc.expiresAt).toLocaleDateString() : "—"}</td>
-              <td className="px-3 py-2 text-right"><button onClick={() => void openDoc(doc)} className="rounded border border-white/15 px-2 py-1 hover:bg-white/10">Open</button></td>
-            </tr>
-          ))}
-          {rows.length === 0 ? <tr><td colSpan={6} className="px-3 py-4 text-center text-neutral-400">No documents in this section.</td></tr> : null}
-        </tbody>
-      </table>
+      <table className="min-w-full text-sm text-neutral-200"><thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400"><tr><th className="px-3 py-2 text-left">Type</th><th className="px-3 py-2 text-left">Status</th><th className="px-3 py-2 text-left">Person</th><th className="px-3 py-2 text-left">Uploaded</th><th className="px-3 py-2 text-left">Expires</th><th className="px-3 py-2 text-right">Action</th></tr></thead><tbody>{rows.map((doc) => <tr key={doc.id} className="border-t border-white/10"><td className="px-3 py-2 capitalize">{(doc.docType ?? "other").replaceAll("_", " ")}</td><td className="px-3 py-2">{doc.status ?? "—"}</td><td className="px-3 py-2">{doc.personName ?? "Unknown"}<div className="text-xs text-neutral-400">{doc.personEmail ?? doc.userId}</div></td><td className="px-3 py-2">{doc.uploadedAt ? new Date(doc.uploadedAt).toLocaleDateString() : "—"}</td><td className="px-3 py-2">{doc.expiresAt ? new Date(doc.expiresAt).toLocaleDateString() : "—"}</td><td className="px-3 py-2 text-right"><button onClick={() => void openDoc(doc)} className="rounded border border-white/15 px-2 py-1 hover:bg-white/10">Open</button></td></tr>)}{rows.length === 0 ? <tr><td colSpan={6} className="px-3 py-4 text-center text-neutral-400">No documents in this section.</td></tr> : null}</tbody></table>
     </div>
   );
 
   if (loading) return <div className="rounded-2xl border border-white/10 bg-black/25 p-5 text-neutral-300">Loading Documents Command…</div>;
   if (error) return <div className="rounded-2xl border border-red-500/30 bg-red-950/20 p-5 text-red-200">{error}</div>;
 
-  return (
-    <div className="space-y-5">
-      <div className="rounded-2xl border border-white/10 bg-black/25 p-5">
-        <h1 className="text-2xl font-semibold text-white">Documents Command</h1>
-        <p className="mt-1 text-sm text-neutral-300">Workforce readiness for document collection and compliance.</p>
-        <div className="mt-3 flex flex-wrap gap-2 text-xs"><Link href="/dashboard/workforce/people" className="rounded border border-white/15 px-2 py-1 text-orange-300">Open People</Link><Link href="/dashboard/admin/employee-docs" className="rounded border border-white/15 px-2 py-1 text-neutral-300">Open Upload Console</Link></div>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-5">{Object.entries({Total: data?.summary.total ?? 0, Recent: data?.summary.recent ?? 0, "Needs Review": data?.summary.needsReview ?? 0, Expired: data?.summary.expired ?? 0, "Expiring Soon": data?.summary.expiringSoon ?? 0}).map(([k, v]) => <div key={k} className="rounded-xl border border-white/10 bg-black/20 p-3"><div className="text-xs text-neutral-400">{k}</div><div className="text-xl font-semibold text-white">{v}</div></div>)}</div>
-      <div className="space-y-4">
-        <section><h2 className="mb-2 text-sm font-semibold text-orange-300">Needs Review</h2>{renderRows(sections.needsReview)}</section>
-        <section><h2 className="mb-2 text-sm font-semibold text-yellow-300">Expiring Soon</h2>{renderRows(sections.expiringSoon)}</section>
-        <section><h2 className="mb-2 text-sm font-semibold text-red-300">Expired</h2>{renderRows(sections.expired)}</section>
-        <section><h2 className="mb-2 text-sm font-semibold text-cyan-300">Recent Uploads</h2>{renderRows(sections.recent)}</section>
-        <section><h2 className="mb-2 text-sm font-semibold text-neutral-200">All Documents</h2>{renderRows(sections.all)}</section>
-      </div>
+  return <div className="space-y-5">
+    <div className="rounded-2xl border border-white/10 bg-black/25 p-5"><h1 className="text-2xl font-semibold text-white">Documents Command</h1><p className="mt-1 text-sm text-neutral-300">Workforce readiness for document collection and compliance.</p><div className="mt-3 flex flex-wrap gap-2 text-xs"><Link href="/dashboard/workforce/people" className="rounded border border-white/15 px-2 py-1 text-orange-300">Open People</Link><Link href="/dashboard/admin/employee-docs" className="rounded border border-white/15 px-2 py-1 text-neutral-300">Open Upload Console</Link></div></div>
+    <div className="grid gap-3 sm:grid-cols-5">{Object.entries({ Total: data?.summary.total ?? 0, Recent: data?.summary.recent ?? 0, "Needs Review": data?.summary.needsReview ?? 0, Expired: data?.summary.expired ?? 0, "Expiring Soon": data?.summary.expiringSoon ?? 0 }).map(([k, v]) => <div key={k} className="rounded-xl border border-white/10 bg-black/20 p-3"><div className="text-xs text-neutral-400">{k}</div><div className="text-xl font-semibold text-white">{v}</div></div>)}</div>
+
+    {matrixError ? <div className="rounded-xl border border-yellow-500/30 bg-yellow-950/20 p-4 text-sm text-yellow-100">Required Matrix readiness unavailable: {matrixError}</div> : null}
+    {matrix ? <>
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-cyan-300">Required Matrix</h2>
+        <div className="grid gap-3 sm:grid-cols-6">{Object.entries({ "Active People": matrix.summary.activePeople, Ready: matrix.summary.ready, Missing: matrix.summary.missingRequired, Expired: matrix.summary.expiredRequired, "Needs Review": matrix.summary.needsReview, "Expiring Soon": matrix.summary.expiringSoon }).map(([k, v]) => <div key={k} className="rounded-xl border border-white/10 bg-black/20 p-3"><div className="text-xs text-neutral-400">{k}</div><div className="text-xl font-semibold text-white">{v}</div></div>)}</div>
+        <div className="overflow-hidden rounded-xl border border-white/10 bg-black/20"><table className="min-w-full text-sm text-neutral-200"><thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400"><tr><th className="px-3 py-2 text-left">Role</th><th className="px-3 py-2 text-left">Category</th><th className="px-3 py-2 text-left">Document</th><th className="px-3 py-2 text-left">Expires Required</th></tr></thead><tbody>{matrix.requirements.map((r) => <tr key={r.key} className="border-t border-white/10"><td className="px-3 py-2">{r.workforceRole ?? "—"}</td><td className="px-3 py-2">{r.workforceCategory ?? "—"}</td><td className="px-3 py-2">{r.label}</td><td className="px-3 py-2">{r.expiresRequired ? `Yes (${r.warningDays}d warning)` : "No"}</td></tr>)}</tbody></table></div>
+      </section>
+
+      <section><h2 className="mb-2 text-sm font-semibold text-orange-300">Missing Required</h2><div className="overflow-hidden rounded-xl border border-white/10 bg-black/20"><table className="min-w-full text-sm text-neutral-200"><thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400"><tr><th className="px-3 py-2 text-left">Person</th><th className="px-3 py-2 text-left">Missing Types</th><th className="px-3 py-2 text-right">Action</th></tr></thead><tbody>{matrix.missingByPerson.map((row) => <tr key={row.personId} className="border-t border-white/10"><td className="px-3 py-2">{row.personName}</td><td className="px-3 py-2 capitalize">{row.missingDocTypes.join(", ").replaceAll("_", " ")}</td><td className="px-3 py-2 text-right"><Link className="rounded border border-white/15 px-2 py-1 hover:bg-white/10" href={row.href}>Open</Link></td></tr>)}{matrix.missingByPerson.length === 0 ? <tr><td colSpan={3} className="px-3 py-4 text-center text-neutral-400">No missing required documents.</td></tr> : null}</tbody></table></div></section>
+
+      <section><h2 className="mb-2 text-sm font-semibold text-yellow-300">Expiring Required</h2><div className="overflow-hidden rounded-xl border border-white/10 bg-black/20"><table className="min-w-full text-sm text-neutral-200"><thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400"><tr><th className="px-3 py-2 text-left">Person</th><th className="px-3 py-2 text-left">Expired Types</th><th className="px-3 py-2 text-left">Expiring Soon Types</th><th className="px-3 py-2 text-right">Action</th></tr></thead><tbody>{matrix.expiringRequired.map((row) => <tr key={row.personId} className="border-t border-white/10"><td className="px-3 py-2">{row.personName}</td><td className="px-3 py-2 capitalize">{row.expiredDocTypes.join(", ").replaceAll("_", " ") || "—"}</td><td className="px-3 py-2 capitalize">{row.expiringDocTypes.join(", ").replaceAll("_", " ") || "—"}</td><td className="px-3 py-2 text-right"><Link className="rounded border border-white/15 px-2 py-1 hover:bg-white/10" href={row.href}>Open</Link></td></tr>)}{matrix.expiringRequired.length === 0 ? <tr><td colSpan={4} className="px-3 py-4 text-center text-neutral-400">No expiring required documents.</td></tr> : null}</tbody></table></div></section>
+
+      <section><h2 className="mb-2 text-sm font-semibold text-indigo-300">By Role</h2><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{byRole.map((row) => <div key={row.role} className="rounded-xl border border-white/10 bg-black/20 p-3 text-sm"><div className="font-semibold capitalize text-white">{row.role.replaceAll("_", " ")}</div><div className="mt-2 text-neutral-300">Total: {row.total} · Ready: {row.ready}</div><div className="text-neutral-400">Missing: {row.missing} · Expired: {row.expired} · Review: {row.needsReview} · Expiring: {row.expiring}</div></div>)}</div></section>
+
+      <section><h2 className="mb-2 text-sm font-semibold text-emerald-300">By Person Readiness</h2><div className="overflow-hidden rounded-xl border border-white/10 bg-black/20"><table className="min-w-full text-sm text-neutral-200"><thead className="bg-white/5 text-xs uppercase tracking-wide text-neutral-400"><tr><th className="px-3 py-2 text-left">Person</th><th className="px-3 py-2 text-left">Role</th><th className="px-3 py-2 text-left">Readiness</th><th className="px-3 py-2 text-left">Flags</th><th className="px-3 py-2 text-right">Action</th></tr></thead><tbody>{matrix.readinessItems.map((row) => <tr key={row.personId} className="border-t border-white/10"><td className="px-3 py-2">{row.personName}</td><td className="px-3 py-2">{row.workforceRole ?? row.workforceCategory ?? "—"}</td><td className="px-3 py-2 capitalize">{row.readiness.replaceAll("_", " ")}</td><td className="px-3 py-2 text-xs text-neutral-300">M:{row.missingDocTypes.length} E:{row.expiredDocTypes.length} R:{row.needsReviewDocTypes.length} S:{row.expiringDocTypes.length}</td><td className="px-3 py-2 text-right"><Link className="rounded border border-white/15 px-2 py-1 hover:bg-white/10" href={row.href}>Open</Link></td></tr>)}{matrix.readinessItems.length === 0 ? <tr><td colSpan={5} className="px-3 py-4 text-center text-neutral-400">No active workforce people found.</td></tr> : null}</tbody></table></div></section>
+    </> : null}
+
+    <div className="space-y-4">
+      <section><h2 className="mb-2 text-sm font-semibold text-orange-300">Needs Review</h2>{renderRows(sections.needsReview)}</section>
+      <section><h2 className="mb-2 text-sm font-semibold text-yellow-300">Expiring Soon</h2>{renderRows(sections.expiringSoon)}</section>
+      <section><h2 className="mb-2 text-sm font-semibold text-red-300">Expired</h2>{renderRows(sections.expired)}</section>
+      <section><h2 className="mb-2 text-sm font-semibold text-cyan-300">Recent Uploads</h2>{renderRows(sections.recent)}</section>
+      <section><h2 className="mb-2 text-sm font-semibold text-neutral-200">All Documents</h2>{renderRows(sections.all)}</section>
     </div>
-  );
+  </div>;
 }

--- a/features/shared/lib/workforce/documentReadiness.ts
+++ b/features/shared/lib/workforce/documentReadiness.ts
@@ -1,0 +1,174 @@
+import { DEFAULT_DOCUMENT_REQUIREMENTS, type RequiredDocType, type RequirementRule } from "./documentRequirementsDefaults";
+
+type WorkforcePerson = {
+  id: string;
+  full_name: string | null;
+  email?: string | null;
+  workforce_role: string | null;
+  workforce_category: string | null;
+  employment_status: string | null;
+};
+
+type WorkforceDocument = {
+  id: string;
+  user_id: string;
+  doc_type: string | null;
+  status: string | null;
+  expires_at: string | null;
+  uploaded_at: string | null;
+};
+
+export type PersonReadiness = "missing_required" | "expired_required" | "needs_review" | "expiring_soon" | "ready";
+
+const ACCEPTED_STATUSES = new Set(["active", "approved", "accepted"]);
+const REVIEW_STATUSES = new Set(["received", "pending", "review", "needs_review"]);
+const ACTIVE_EMPLOYMENT = new Set(["active"]);
+
+const normalize = (value: string | null | undefined) => String(value ?? "").trim().toLowerCase();
+
+const docTypeLabel: Record<RequiredDocType, string> = {
+  drivers_license: "Driver's License",
+  certification: "Certification",
+  tax_form: "Tax Form",
+  other: "Other",
+};
+
+function getRequirementsForPerson(person: WorkforcePerson, requirements: RequirementRule[]): RequirementRule[] {
+  const role = normalize(person.workforce_role);
+  const category = normalize(person.workforce_category);
+
+  const matched = requirements.filter((requirement) => {
+    const reqRole = normalize(requirement.workforceRole);
+    const reqCategory = normalize(requirement.workforceCategory);
+
+    if (!reqRole && !reqCategory) return true;
+    if (reqRole && reqRole === role) return true;
+    return !!reqCategory && reqCategory === category;
+  });
+
+  const dedup = new Map<RequiredDocType, RequirementRule>();
+  for (const rule of matched) {
+    if (!dedup.has(rule.docType)) dedup.set(rule.docType, rule);
+  }
+
+  return Array.from(dedup.values());
+}
+
+export function buildDocumentRequirementsReadiness({
+  people,
+  documents,
+  requirements = DEFAULT_DOCUMENT_REQUIREMENTS,
+  warningDays = 30,
+}: {
+  people: WorkforcePerson[];
+  documents: WorkforceDocument[];
+  requirements?: RequirementRule[];
+  warningDays?: number;
+}) {
+  const now = Date.now();
+  const warningCutoff = now + warningDays * 24 * 60 * 60 * 1000;
+
+  const docsByUser = new Map<string, WorkforceDocument[]>();
+  for (const doc of documents) {
+    const userDocs = docsByUser.get(doc.user_id) ?? [];
+    userDocs.push(doc);
+    docsByUser.set(doc.user_id, userDocs);
+  }
+
+  const activePeople = people.filter((person) => ACTIVE_EMPLOYMENT.has(normalize(person.employment_status)));
+
+  const readinessItems = activePeople.map((person) => {
+    const neededRules = getRequirementsForPerson(person, requirements);
+    const userDocs = docsByUser.get(person.id) ?? [];
+
+    const missingDocTypes: RequiredDocType[] = [];
+    const expiredDocTypes: RequiredDocType[] = [];
+    const expiringDocTypes: RequiredDocType[] = [];
+    const needsReviewDocTypes: RequiredDocType[] = [];
+
+    for (const rule of neededRules) {
+      const docsForType = userDocs.filter((doc) => normalize(doc.doc_type) === rule.docType);
+      const accepted = docsForType.filter((doc) => ACCEPTED_STATUSES.has(normalize(doc.status)));
+      const review = docsForType.filter((doc) => REVIEW_STATUSES.has(normalize(doc.status)));
+
+      if (accepted.length === 0) {
+        if (review.length > 0) needsReviewDocTypes.push(rule.docType);
+        else missingDocTypes.push(rule.docType);
+        continue;
+      }
+
+      if (rule.expiresRequired) {
+        const acceptedWithTs = accepted
+          .map((doc) => ({ doc, ts: doc.expires_at ? new Date(doc.expires_at).getTime() : null }))
+          .filter((item) => item.ts !== null && Number.isFinite(item.ts)) as { doc: WorkforceDocument; ts: number }[];
+
+        if (acceptedWithTs.length === 0) {
+          missingDocTypes.push(rule.docType);
+          continue;
+        }
+
+        const bestAccepted = acceptedWithTs.sort((a, b) => b.ts - a.ts)[0];
+        if (bestAccepted.ts < now) expiredDocTypes.push(rule.docType);
+        else if (bestAccepted.ts <= warningCutoff) expiringDocTypes.push(rule.docType);
+      }
+    }
+
+    let readiness: PersonReadiness = "ready";
+    if (missingDocTypes.length > 0) readiness = "missing_required";
+    else if (expiredDocTypes.length > 0) readiness = "expired_required";
+    else if (needsReviewDocTypes.length > 0) readiness = "needs_review";
+    else if (expiringDocTypes.length > 0) readiness = "expiring_soon";
+
+    return {
+      personId: person.id,
+      personName: person.full_name ?? person.email ?? "Unknown person",
+      personEmail: person.email ?? null,
+      workforceRole: person.workforce_role,
+      workforceCategory: person.workforce_category,
+      readiness,
+      missingDocTypes,
+      expiredDocTypes,
+      expiringDocTypes,
+      needsReviewDocTypes,
+      href: `/dashboard/workforce/people/${person.id}?focus=documents`,
+      requiredDocTypes: neededRules.map((rule) => ({
+        docType: rule.docType,
+        label: rule.label || docTypeLabel[rule.docType],
+      })),
+    };
+  });
+
+  const summary = {
+    activePeople: activePeople.length,
+    ready: readinessItems.filter((item) => item.readiness === "ready").length,
+    missingRequired: readinessItems.filter((item) => item.readiness === "missing_required").length,
+    expiredRequired: readinessItems.filter((item) => item.readiness === "expired_required").length,
+    needsReview: readinessItems.filter((item) => item.readiness === "needs_review").length,
+    expiringSoon: readinessItems.filter((item) => item.readiness === "expiring_soon").length,
+  };
+
+  const missingByPerson = readinessItems
+    .filter((item) => item.missingDocTypes.length > 0)
+    .map((item) => ({ personId: item.personId, personName: item.personName, missingDocTypes: item.missingDocTypes, href: item.href }));
+
+  const missingCounts = new Map<RequiredDocType, number>();
+  for (const item of readinessItems) {
+    for (const docType of item.missingDocTypes) {
+      missingCounts.set(docType, (missingCounts.get(docType) ?? 0) + 1);
+    }
+  }
+
+  const missingByDocType = Array.from(missingCounts.entries()).map(([docType, count]) => ({ docType, label: docTypeLabel[docType], count }));
+
+  const expiringRequired = readinessItems
+    .filter((item) => item.expiredDocTypes.length > 0 || item.expiringDocTypes.length > 0)
+    .map((item) => ({
+      personId: item.personId,
+      personName: item.personName,
+      expiredDocTypes: item.expiredDocTypes,
+      expiringDocTypes: item.expiringDocTypes,
+      href: item.href,
+    }));
+
+  return { requirements, readinessItems, missingByPerson, missingByDocType, expiringRequired, summary };
+}

--- a/features/shared/lib/workforce/documentRequirementsDefaults.ts
+++ b/features/shared/lib/workforce/documentRequirementsDefaults.ts
@@ -1,0 +1,97 @@
+export type RequiredDocType = "drivers_license" | "certification" | "tax_form" | "other";
+
+export type RequirementRule = {
+  key: string;
+  workforceRole: string | null;
+  workforceCategory: string | null;
+  docType: RequiredDocType;
+  label: string;
+  required: true;
+  expiresRequired: boolean;
+  warningDays: number;
+};
+
+const DEFAULT_WARNING_DAYS = 30;
+
+export const DEFAULT_DOCUMENT_REQUIREMENTS: RequirementRule[] = [
+  {
+    key: "role:technician:drivers_license",
+    workforceRole: "technician",
+    workforceCategory: null,
+    docType: "drivers_license",
+    label: "Driver's License",
+    required: true,
+    expiresRequired: true,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "role:technician:certification",
+    workforceRole: "technician",
+    workforceCategory: null,
+    docType: "certification",
+    label: "Certification",
+    required: true,
+    expiresRequired: true,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "category:mechanic:drivers_license",
+    workforceRole: null,
+    workforceCategory: "mechanic",
+    docType: "drivers_license",
+    label: "Driver's License",
+    required: true,
+    expiresRequired: true,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "category:mechanic:certification",
+    workforceRole: null,
+    workforceCategory: "mechanic",
+    docType: "certification",
+    label: "Certification",
+    required: true,
+    expiresRequired: true,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "category:driver:drivers_license",
+    workforceRole: null,
+    workforceCategory: "driver",
+    docType: "drivers_license",
+    label: "Driver's License",
+    required: true,
+    expiresRequired: true,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "category:admin:tax_form",
+    workforceRole: null,
+    workforceCategory: "admin",
+    docType: "tax_form",
+    label: "Tax Form",
+    required: true,
+    expiresRequired: false,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "category:office:tax_form",
+    workforceRole: null,
+    workforceCategory: "office",
+    docType: "tax_form",
+    label: "Tax Form",
+    required: true,
+    expiresRequired: false,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+  {
+    key: "default:active:tax_form",
+    workforceRole: null,
+    workforceCategory: null,
+    docType: "tax_form",
+    label: "Tax Form",
+    required: true,
+    expiresRequired: false,
+    warningDays: DEFAULT_WARNING_DAYS,
+  },
+];

--- a/tests/workforce-document-readiness.test.ts
+++ b/tests/workforce-document-readiness.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildDocumentRequirementsReadiness } from "@/features/shared/lib/workforce/documentReadiness";
+
+describe("buildDocumentRequirementsReadiness", () => {
+  it("marks active employee missing required doc", () => {
+    const result = buildDocumentRequirementsReadiness({
+      people: [{ id: "1", full_name: "Tech", workforce_role: "technician", workforce_category: null, employment_status: "active" }],
+      documents: [],
+    });
+    expect(result.readinessItems[0].readiness).toBe("missing_required");
+  });
+
+  it("ignores inactive employee", () => {
+    const result = buildDocumentRequirementsReadiness({
+      people: [{ id: "1", full_name: "Old", workforce_role: "technician", workforce_category: null, employment_status: "inactive" }],
+      documents: [],
+    });
+    expect(result.summary.activePeople).toBe(0);
+  });
+
+  it("marks expired required documents", () => {
+    const result = buildDocumentRequirementsReadiness({
+      people: [{ id: "1", full_name: "Driver", workforce_role: null, workforce_category: "driver", employment_status: "active" }],
+      documents: [
+        { id: "d0", user_id: "1", doc_type: "tax_form", status: "accepted", expires_at: null, uploaded_at: "2019-01-01" },
+        { id: "d1", user_id: "1", doc_type: "drivers_license", status: "accepted", expires_at: "2020-01-01", uploaded_at: "2019-01-01" },
+      ],
+    });
+    expect(result.readinessItems[0].readiness).toBe("expired_required");
+  });
+
+  it("keeps accepted older doc valid even when newer pending exists", () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24 * 180).toISOString();
+    const result = buildDocumentRequirementsReadiness({
+      people: [{ id: "1", full_name: "Driver", workforce_role: null, workforce_category: "driver", employment_status: "active" }],
+      documents: [
+        { id: "d0", user_id: "1", doc_type: "tax_form", status: "accepted", expires_at: null, uploaded_at: "2024-01-01" },
+        { id: "d1", user_id: "1", doc_type: "drivers_license", status: "accepted", expires_at: future, uploaded_at: "2024-01-01" },
+        { id: "d2", user_id: "1", doc_type: "drivers_license", status: "pending", expires_at: future, uploaded_at: "2025-01-01" },
+      ],
+    });
+    expect(result.readinessItems[0].readiness).toBe("ready");
+  });
+
+  it("matches role and category requirements", () => {
+    const result = buildDocumentRequirementsReadiness({
+      people: [{ id: "1", full_name: "Office", workforce_role: null, workforce_category: "office", employment_status: "active" }],
+      documents: [],
+    });
+    expect(result.readinessItems[0].missingDocTypes).toContain("tax_form");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a conservative, code-level default Required Document Matrix for Phase B1 so shops have readiness insight without a DB migration.
- Compute per-person readiness from existing `people_workforce_profiles`, `profiles`, and `employee_documents` tables while preserving `shop_id` isolation.
- Keep access restricted to owner/admin and avoid any changes to uploads, signed URLs, or manager privileges in this phase.

### Description
- Added a small, editable code default matrix in `features/shared/lib/workforce/documentRequirementsDefaults.ts` covering `drivers_license`, `certification`, `tax_form`, and a safe default rule. 
- Implemented a pure helper `buildDocumentRequirementsReadiness` in `features/shared/lib/workforce/documentReadiness.ts` that applies active-only filtering, accepted/review status buckets, expiration/expiring logic (30d warning), duplicate-handling, and per-person readiness priority. 
- Exposed an owner/admin-only API endpoint `GET /api/workforce/document-requirements/readiness` in `app/api/workforce/document-requirements/readiness/route.ts` that uses the authenticated `profile.shop_id` and returns the required payload shape (requirements, readinessItems, missing/expiring aggregations, summary, `generatedAt`). 
- Updated the dashboard client `features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx` to fetch the new endpoint (in addition to existing `/api/workforce/documents-readiness`) and render KPI cards and sections: Required Matrix, Missing Required, Expiring Required, By Role, and By Person Readiness while preserving existing document sections and showing a contained warning if the matrix fetch fails. 
- Added unit tests `tests/workforce-document-readiness.test.ts` for the helper covering missing/expired/duplicate/role-category matching cases; no DB migrations or upload/sign-url behavior changes were introduced.

### Testing
- Ran typecheck: `npx tsc --noEmit` and it completed successfully. 
- Executed unit tests: `npx vitest run tests/workforce-document-readiness.test.ts` and all tests passed (5/5). 
- Confirmations: endpoint enforces `requireShopScopedApiAccess({ allowRoles: ["owner","admin"] })`, uses server-side `profile.shop_id`, and no migrations or signed-URL/upload semantics were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0a31f6648328b4d7825f76c99949)