### PR TITLE
Harden Workforce Required Matrix payload rendering in dashboard UI

### DIFF
--- a/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
@@ -31,6 +31,101 @@ type MatrixPayload = {
   generatedAt: string;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+const asArray = <T,>(value: unknown): T[] => (Array.isArray(value) ? (value as T[]) : []);
+const num = (value: unknown): number => {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+const safeString = (value: unknown): string => (typeof value === "string" ? value : "");
+const asStringArray = (value: unknown): string[] => asArray<unknown>(value).map((item) => safeString(item)).filter(Boolean);
+
+const normalizeMatrixPayload = (value: unknown): { matrix: MatrixPayload | null; error: string | null } => {
+  if (!isRecord(value)) {
+    return { matrix: null, error: "Malformed matrix payload." };
+  }
+
+  const summaryRaw = isRecord(value.summary) ? value.summary : {};
+  const normalized: MatrixPayload = {
+    summary: {
+      activePeople: num(summaryRaw.activePeople),
+      ready: num(summaryRaw.ready),
+      missingRequired: num(summaryRaw.missingRequired),
+      expiredRequired: num(summaryRaw.expiredRequired),
+      needsReview: num(summaryRaw.needsReview),
+      expiringSoon: num(summaryRaw.expiringSoon),
+    },
+    requirements: asArray<unknown>(value.requirements).map((item, idx) => {
+      const row = isRecord(item) ? item : {};
+      const key = safeString(row.key) || `requirement-${idx}`;
+      return {
+        key,
+        workforceRole: safeString(row.workforceRole) || null,
+        workforceCategory: safeString(row.workforceCategory) || null,
+        docType: safeString(row.docType),
+        label: safeString(row.label) || safeString(row.docType) || "Document",
+        required: true,
+        expiresRequired: Boolean(row.expiresRequired),
+        warningDays: num(row.warningDays),
+      };
+    }),
+    readinessItems: asArray<unknown>(value.readinessItems).map((item, idx) => {
+      const row = isRecord(item) ? item : {};
+      return {
+        personId: safeString(row.personId) || `person-${idx}`,
+        personName: safeString(row.personName) || "Unknown",
+        personEmail: safeString(row.personEmail) || null,
+        workforceRole: safeString(row.workforceRole) || null,
+        workforceCategory: safeString(row.workforceCategory) || null,
+        readiness: safeString(row.readiness) || "ready",
+        missingDocTypes: asStringArray(row.missingDocTypes),
+        expiredDocTypes: asStringArray(row.expiredDocTypes),
+        expiringDocTypes: asStringArray(row.expiringDocTypes),
+        needsReviewDocTypes: asStringArray(row.needsReviewDocTypes),
+        href: safeString(row.href) || "/dashboard/workforce/people",
+      };
+    }),
+    missingByPerson: asArray<unknown>(value.missingByPerson).map((item, idx) => {
+      const row = isRecord(item) ? item : {};
+      return {
+        personId: safeString(row.personId) || `missing-person-${idx}`,
+        personName: safeString(row.personName) || "Unknown",
+        missingDocTypes: asStringArray(row.missingDocTypes),
+        href: safeString(row.href) || "/dashboard/workforce/people",
+      };
+    }),
+    missingByDocType: asArray<unknown>(value.missingByDocType).map((item) => {
+      const row = isRecord(item) ? item : {};
+      return {
+        docType: safeString(row.docType),
+        label: safeString(row.label) || safeString(row.docType) || "Document",
+        count: num(row.count),
+      };
+    }),
+    expiringRequired: asArray<unknown>(value.expiringRequired).map((item, idx) => {
+      const row = isRecord(item) ? item : {};
+      return {
+        personId: safeString(row.personId) || `expiring-person-${idx}`,
+        personName: safeString(row.personName) || "Unknown",
+        expiredDocTypes: asStringArray(row.expiredDocTypes),
+        expiringDocTypes: asStringArray(row.expiringDocTypes),
+        href: safeString(row.href) || "/dashboard/workforce/people",
+      };
+    }),
+    generatedAt: safeString(value.generatedAt),
+  };
+
+  const hasRenderableMatrixData =
+    normalized.requirements.length > 0 ||
+    normalized.readinessItems.length > 0 ||
+    normalized.missingByPerson.length > 0 ||
+    normalized.expiringRequired.length > 0;
+  if (!hasRenderableMatrixData) {
+    return { matrix: null, error: "Matrix payload malformed or empty." };
+  }
+  return { matrix: normalized, error: null };
+};
+
 export default function WorkforceDocumentsClient() {
   const [data, setData] = useState<DocsResponsePayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -53,7 +148,9 @@ export default function WorkforceDocumentsClient() {
         if (!matrixRes.ok) {
           setMatrixError(matrixJson?.error || "Failed loading matrix readiness");
         } else {
-          setMatrix(matrixJson);
+          const normalized = normalizeMatrixPayload(matrixJson);
+          setMatrix(normalized.matrix);
+          if (normalized.error) setMatrixError(normalized.error);
         }
       } catch (err) {
         setError((err as Error).message);


### PR DESCRIPTION
### Motivation
- Prevent page crashes when the document-requirements readiness endpoint returns malformed-but-truthy JSON by normalizing the matrix payload before render.  
- Ensure existing documents sections continue to render even if the matrix payload is invalid or empty.  

### Description
- Added lightweight guard/normalization helpers: `isRecord`, `asArray`, `num`, `safeString` and `asStringArray`.  
- Introduced `normalizeMatrixPayload` which coerces the incoming matrix into a safe `MatrixPayload` shape with numeric zero defaults for summary, array fallbacks for list fields, and safe defaults for person/doc/href/readiness fields.  
- Updated the matrix fetch handling to run normalization before setting state and to set a contained `matrixError` and `matrix = null` when the payload is severely invalid, preserving base documents rendering.  
- Files changed: `features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx` (normalizers + payload normalization + fetch handling update).  

### Testing
- Type-check run: `npx tsc --noEmit` — succeeded.  
- Unit tests run: `npx vitest run tests/workforce-document-readiness.test.ts` — all tests passed (18/18).  

Confirmations: malformed matrix payloads are normalized or suppressed so they cannot crash rendering; existing documents sections render independently of matrix success; no API contract, readiness helper logic, access/scoping, upload, or signed-URL behaviors were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f14434c248328b93a0e4fbb2428de)