### PR TITLE
Workforce: read-path shop overrides for document requirements (B2.2)

### DIFF
--- a/app/api/workforce/document-requirements/readiness/route.ts
+++ b/app/api/workforce/document-requirements/readiness/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildDocumentRequirementsReadiness } from "@/features/shared/lib/workforce/documentReadiness";
-import { DEFAULT_DOCUMENT_REQUIREMENTS } from "@/features/shared/lib/workforce/documentRequirementsDefaults";
+import {
+  DEFAULT_DOCUMENT_REQUIREMENTS,
+  buildEffectiveDocumentRequirements,
+} from "@/features/shared/lib/workforce/documentRequirementsDefaults";
 
 export async function GET() {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
@@ -11,19 +14,24 @@ export async function GET() {
   const admin = createAdminSupabase();
   const shopId = access.profile.shop_id;
 
-  const [{ data: workforceProfiles, error: workforceError }, { data: docs, error: docsError }, { data: people, error: peopleError }] = await Promise.all([
-    admin
-      .from("people_workforce_profiles")
-      .select("user_id, workforce_role, workforce_category, employment_status")
-      .eq("shop_id", shopId),
-    admin
-      .from("employee_documents")
-      .select("id, user_id, doc_type, status, expires_at, uploaded_at")
-      .eq("shop_id", shopId),
-    admin.from("profiles").select("id, full_name, email").eq("shop_id", shopId),
-  ]);
+  const [{ data: workforceProfiles, error: workforceError }, { data: docs, error: docsError }, { data: people, error: peopleError }, { data: requirementOverrides, error: requirementsError }] =
+    await Promise.all([
+      admin
+        .from("people_workforce_profiles")
+        .select("user_id, workforce_role, workforce_category, employment_status")
+        .eq("shop_id", shopId),
+      admin
+        .from("employee_documents")
+        .select("id, user_id, doc_type, status, expires_at, uploaded_at")
+        .eq("shop_id", shopId),
+      admin.from("profiles").select("id, full_name, email").eq("shop_id", shopId),
+      admin
+        .from("workforce_document_requirements")
+        .select("id, workforce_role, workforce_category, doc_type, label, required, expires_required, warning_days, priority, is_active")
+        .eq("shop_id", shopId),
+    ]);
 
-  const firstError = workforceError ?? docsError ?? peopleError;
+  const firstError = workforceError ?? docsError ?? peopleError ?? requirementsError;
   if (firstError) return NextResponse.json({ error: firstError.message }, { status: 500 });
 
   const personById = new Map((people ?? []).map((p) => [p.id, p]));
@@ -39,10 +47,12 @@ export async function GET() {
     };
   });
 
+  const effectiveRequirements = buildEffectiveDocumentRequirements(DEFAULT_DOCUMENT_REQUIREMENTS, requirementOverrides ?? []);
+
   const readiness = buildDocumentRequirementsReadiness({
     people: joinedPeople,
     documents: docs ?? [],
-    requirements: DEFAULT_DOCUMENT_REQUIREMENTS,
+    requirements: effectiveRequirements,
     warningDays: 30,
   });
 

--- a/features/shared/lib/workforce/documentRequirementsDefaults.ts
+++ b/features/shared/lib/workforce/documentRequirementsDefaults.ts
@@ -11,6 +11,19 @@ export type RequirementRule = {
   warningDays: number;
 };
 
+export type WorkforceDocumentRequirementOverrideRow = {
+  id: string;
+  workforce_role: string | null;
+  workforce_category: string | null;
+  doc_type: string;
+  label: string | null;
+  required: boolean;
+  expires_required: boolean;
+  warning_days: number | null;
+  priority: number | null;
+  is_active: boolean;
+};
+
 const DEFAULT_WARNING_DAYS = 30;
 
 export const DEFAULT_DOCUMENT_REQUIREMENTS: RequirementRule[] = [
@@ -95,3 +108,103 @@ export const DEFAULT_DOCUMENT_REQUIREMENTS: RequirementRule[] = [
     warningDays: DEFAULT_WARNING_DAYS,
   },
 ];
+
+const REQUIRED_DOC_TYPES = new Set<RequiredDocType>(["drivers_license", "certification", "tax_form", "other"]);
+
+const normalize = (value: string | null | undefined) => String(value ?? "").trim().toLowerCase();
+
+export function buildEffectiveDocumentRequirements(
+  defaults: RequirementRule[],
+  overrides: WorkforceDocumentRequirementOverrideRow[]
+): RequirementRule[] {
+  const defaultCandidates = defaults.map((rule, index) => ({
+    source: "default" as const,
+    rule,
+    precedenceRank: rule.workforceRole ? 4 : rule.workforceCategory ? 3 : 2,
+    priority: 0,
+    index,
+    tieKey: rule.key,
+  }));
+
+  // B2.2 behavior: inactive rows are ignored, so defaults continue to apply.
+  const overrideCandidates = overrides
+    .filter((row) => row.is_active)
+    .map((row, index) => {
+      const docType = normalize(row.doc_type) as RequiredDocType;
+      if (!REQUIRED_DOC_TYPES.has(docType)) return null;
+
+      const workforceRole = row.workforce_role ? normalize(row.workforce_role) : null;
+      const workforceCategory = row.workforce_category ? normalize(row.workforce_category) : null;
+      const label =
+        (row.label && row.label.trim()) ||
+        defaults.find((rule) => rule.docType === docType)?.label ||
+        docType;
+
+      return {
+        source: "override" as const,
+        rule: {
+          key: `override:${row.id}`,
+          workforceRole,
+          workforceCategory,
+          docType,
+          label,
+          required: true as const,
+          expiresRequired: row.expires_required,
+          warningDays: row.warning_days ?? DEFAULT_WARNING_DAYS,
+        },
+        precedenceRank: workforceRole ? 4 : workforceCategory ? 3 : 2,
+        priority: row.priority ?? 0,
+        index,
+        tieKey: row.id,
+      };
+    })
+    .filter((candidate): candidate is NonNullable<typeof candidate> => candidate !== null);
+
+  const candidates = [...defaultCandidates, ...overrideCandidates];
+  const winningByScopeAndType = new Map<string, (typeof candidates)[number]>();
+
+  const scopedKey = (rule: RequirementRule) =>
+    `${normalize(rule.workforceRole) || "*"}|${normalize(rule.workforceCategory) || "*"}|${rule.docType}`;
+
+  for (const candidate of candidates) {
+    const key = scopedKey(candidate.rule);
+    const existing = winningByScopeAndType.get(key);
+    if (!existing) {
+      winningByScopeAndType.set(key, candidate);
+      continue;
+    }
+
+    if (candidate.precedenceRank !== existing.precedenceRank) {
+      if (candidate.precedenceRank > existing.precedenceRank) winningByScopeAndType.set(key, candidate);
+      continue;
+    }
+
+    if (candidate.priority !== existing.priority) {
+      if (candidate.priority > existing.priority) winningByScopeAndType.set(key, candidate);
+      continue;
+    }
+
+    if (candidate.rule.docType !== existing.rule.docType) {
+      if (candidate.rule.docType < existing.rule.docType) winningByScopeAndType.set(key, candidate);
+      continue;
+    }
+
+    if (candidate.tieKey < existing.tieKey) {
+      winningByScopeAndType.set(key, candidate);
+      continue;
+    }
+
+    if (candidate.tieKey === existing.tieKey && candidate.index < existing.index) {
+      winningByScopeAndType.set(key, candidate);
+    }
+  }
+
+  return Array.from(winningByScopeAndType.values())
+    .sort((a, b) => {
+      if (a.precedenceRank !== b.precedenceRank) return b.precedenceRank - a.precedenceRank;
+      if (a.priority !== b.priority) return b.priority - a.priority;
+      if (a.rule.docType !== b.rule.docType) return a.rule.docType.localeCompare(b.rule.docType);
+      return a.tieKey.localeCompare(b.tieKey);
+    })
+    .map((candidate) => candidate.rule);
+}

--- a/tests/workforce-document-readiness.test.ts
+++ b/tests/workforce-document-readiness.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { buildDocumentRequirementsReadiness } from "@/features/shared/lib/workforce/documentReadiness";
+import {
+  DEFAULT_DOCUMENT_REQUIREMENTS,
+  buildEffectiveDocumentRequirements,
+  type WorkforceDocumentRequirementOverrideRow,
+} from "@/features/shared/lib/workforce/documentRequirementsDefaults";
 
 const makePerson = (overrides?: Partial<{ id: string; full_name: string; workforce_role: string | null; workforce_category: string | null; employment_status: string }>) => ({
   id: "1",
@@ -16,6 +21,9 @@ const makeDocuments = (status: string, expiresAt: string | null) => [
 ];
 
 describe("buildDocumentRequirementsReadiness", () => {
+  const applyOverrides = (overrides: WorkforceDocumentRequirementOverrideRow[]) =>
+    buildEffectiveDocumentRequirements(DEFAULT_DOCUMENT_REQUIREMENTS, overrides);
+
   it("marks active employee missing required doc", () => {
     const result = buildDocumentRequirementsReadiness({
       people: [{ id: "1", full_name: "Tech", workforce_role: "technician", workforce_category: null, employment_status: "active" }],
@@ -164,5 +172,172 @@ describe("buildDocumentRequirementsReadiness", () => {
     });
 
     expect(result.readinessItems[0].readiness).toBe("needs_review");
+  });
+
+  it("keeps B1 defaults unchanged when no override rows exist", () => {
+    const effective = applyOverrides([]);
+    expect(effective.slice().sort((a, b) => a.key.localeCompare(b.key))).toEqual(
+      DEFAULT_DOCUMENT_REQUIREMENTS.slice().sort((a, b) => a.key.localeCompare(b.key))
+    );
+  });
+
+  it("applies global override over global default and allows additive doc types", () => {
+    const effective = applyOverrides([
+      {
+        id: "g-tax",
+        workforce_role: null,
+        workforce_category: null,
+        doc_type: "tax_form",
+        label: "Shop Tax Form",
+        required: true,
+        expires_required: true,
+        warning_days: 15,
+        priority: 1,
+        is_active: true,
+      },
+      {
+        id: "g-other",
+        workforce_role: null,
+        workforce_category: null,
+        doc_type: "other",
+        label: "Custom Shop Doc",
+        required: true,
+        expires_required: false,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+    ]);
+    const globalTax = effective.find((rule) => rule.workforceRole === null && rule.workforceCategory === null && rule.docType === "tax_form");
+    const globalOther = effective.find((rule) => rule.workforceRole === null && rule.workforceCategory === null && rule.docType === "other");
+    expect(globalTax?.expiresRequired).toBe(true);
+    expect(globalTax?.warningDays).toBe(15);
+    expect(globalOther?.label).toBe("Custom Shop Doc");
+  });
+
+  it("prefers category override over global override/default", () => {
+    const effective = applyOverrides([
+      {
+        id: "g-cert",
+        workforce_role: null,
+        workforce_category: null,
+        doc_type: "certification",
+        label: "Global Cert",
+        required: true,
+        expires_required: false,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+      {
+        id: "c-cert",
+        workforce_role: null,
+        workforce_category: "driver",
+        doc_type: "certification",
+        label: "Driver Cert",
+        required: true,
+        expires_required: true,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+    ]);
+    const result = buildDocumentRequirementsReadiness({
+      people: [makePerson({ workforce_category: "driver" })],
+      documents: [{ id: "tax", user_id: "1", doc_type: "tax_form", status: "accepted", expires_at: null, uploaded_at: "2024-01-01" }],
+      requirements: effective,
+    });
+    expect(result.readinessItems[0].missingDocTypes).toContain("certification");
+  });
+
+  it("prefers role override over category/global/default", () => {
+    const effective = applyOverrides([
+      {
+        id: "cat-license",
+        workforce_role: null,
+        workforce_category: "mechanic",
+        doc_type: "drivers_license",
+        label: "Mechanic License",
+        required: true,
+        expires_required: true,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+      {
+        id: "role-license",
+        workforce_role: "technician",
+        workforce_category: null,
+        doc_type: "drivers_license",
+        label: "Technician License",
+        required: true,
+        expires_required: false,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+    ]);
+    const picked = effective.find((rule) => rule.workforceRole === "technician" && rule.docType === "drivers_license");
+    expect(picked?.expiresRequired).toBe(false);
+  });
+
+  it("ignores inactive overrides and keeps defaults", () => {
+    const effective = applyOverrides([
+      {
+        id: "inactive-global-tax",
+        workforce_role: null,
+        workforce_category: null,
+        doc_type: "tax_form",
+        label: "Ignored",
+        required: true,
+        expires_required: true,
+        warning_days: 5,
+        priority: 10,
+        is_active: false,
+      },
+    ]);
+    const globalTax = effective.find((rule) => rule.key === "default:active:tax_form");
+    expect(globalTax?.expiresRequired).toBe(false);
+  });
+
+  it("ignores override rows with unsupported doc_type", () => {
+    const effective = applyOverrides([
+      {
+        id: "bad-type",
+        workforce_role: null,
+        workforce_category: null,
+        doc_type: "passport",
+        label: "Passport",
+        required: true,
+        expires_required: true,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+    ]);
+    expect(effective.some((rule) => rule.label === "Passport")).toBe(false);
+  });
+
+  it("keeps readiness priority unchanged with overrides", () => {
+    const effective = applyOverrides([
+      {
+        id: "driver-cert",
+        workforce_role: null,
+        workforce_category: "driver",
+        doc_type: "certification",
+        label: "Driver Certification",
+        required: true,
+        expires_required: false,
+        warning_days: 30,
+        priority: 1,
+        is_active: true,
+      },
+    ]);
+    const result = buildDocumentRequirementsReadiness({
+      people: [makePerson({ workforce_category: "driver" })],
+      documents: [{ id: "cert", user_id: "1", doc_type: "certification", status: "pending", expires_at: null, uploaded_at: "2024-01-01" }],
+      requirements: effective,
+    });
+    expect(result.readinessItems[0].readiness).toBe("missing_required");
   });
 });


### PR DESCRIPTION
### Motivation
- Allow shop-level overrides from `public.workforce_document_requirements` to overlay code defaults when computing workforce document readiness. 
- Preserve existing B1 behavior when no overrides exist and keep the read-path owner/admin and shop-scoped.

### Description
- Load active override rows for the authenticated `shop_id` in `GET /api/workforce/document-requirements/readiness` and pass them into the readiness builder; access guard remains `requireShopScopedApiAccess({ allowRoles: ["owner","admin"] })`. (changed: `app/api/workforce/document-requirements/readiness/route.ts`)
- Implement `buildEffectiveDocumentRequirements(defaults, overrides)` to merge code defaults with active DB overrides, filter to supported doc types, and produce deterministic, deduped RequirementRules using precedence (role > category > global > default) and tie-breakers (precedence rank, `priority`, `doc_type`, `id/key`). (added to `features/shared/lib/workforce/documentRequirementsDefaults.ts`)
- B2.2 inactive behavior: `is_active = false` rows are ignored (defaults stay in effect); no disable-marker behavior added. This is documented in comments and covered by tests.
- Tests extended to cover read-path/merge behavior and precedence: no-overrides fallback, global/category/role override precedence, inactive ignored, unsupported `doc_type` ignored, and readiness priority preserved. (changed: `tests/workforce-document-readiness.test.ts`)
- No migrations, no write/edit endpoints, no upload/signed URL changes, and response shape for the readiness API is preserved.

### Testing
- Ran unit tests: `npx vitest run tests/workforce-document-readiness.test.ts` — all tests passed (25/25). 
- Type-check: `npx tsc --noEmit` — succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f23314a2c8328ad819c2c4e5648f3)