### PR TITLE
Add owner/admin APIs for workforce document requirement overrides (B2.3)

### DIFF
--- a/app/api/workforce/document-requirements/[id]/route.ts
+++ b/app/api/workforce/document-requirements/[id]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  isActiveOverrideConflict,
+  validateDocumentRequirementPayload,
+} from "@/features/shared/lib/workforce/documentRequirementOverrideValidation";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, context: Ctx) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const { id } = await context.params;
+  const body = await req.json().catch(() => null);
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = validateDocumentRequirementPayload(body, "patch") as Record<string, unknown>;
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const { data: existing, error: findError } = await admin
+    .from("workforce_document_requirements")
+    .select("id,shop_id,is_active")
+    .eq("id", id)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+
+  if (findError) return NextResponse.json({ error: findError.message }, { status: 500 });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const updatePayload = { ...payload, updated_by: access.profile.id ?? null };
+
+  const { data, error } = await admin
+    .from("workforce_document_requirements")
+    .update(updatePayload)
+    .eq("id", id)
+    .eq("shop_id", access.profile.shop_id)
+    .select("*")
+    .single();
+
+  if (isActiveOverrideConflict(error)) {
+    return NextResponse.json(
+      {
+        error: "Active override already exists for this role/category/doc_type scope",
+        code: "ACTIVE_OVERRIDE_CONFLICT",
+        conflict_key: {
+          workforce_role: (payload.workforce_role as string | null | undefined) ?? null,
+          workforce_category: (payload.workforce_category as string | null | undefined) ?? null,
+          doc_type: (payload.doc_type as string | undefined) ?? undefined,
+        },
+      },
+      { status: 409 }
+    );
+  }
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const action = existing.is_active && payload.is_active === false
+    ? "workforce.document_requirement.override.disabled"
+    : "workforce.document_requirement.override.updated";
+
+  void admin.from("audit_logs").insert({
+    actor_id: access.profile.id ?? null,
+    action,
+    target: id,
+    metadata: { shop_id: access.profile.shop_id },
+  });
+
+  return NextResponse.json(data);
+}

--- a/app/api/workforce/document-requirements/route.ts
+++ b/app/api/workforce/document-requirements/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  DEFAULT_DOCUMENT_REQUIREMENTS,
+  buildEffectiveDocumentRequirements,
+} from "@/features/shared/lib/workforce/documentRequirementsDefaults";
+import {
+  isActiveOverrideConflict,
+  validateDocumentRequirementPayload,
+} from "@/features/shared/lib/workforce/documentRequirementOverrideValidation";
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const admin = createAdminSupabase();
+  const { data: overrides, error } = await admin
+    .from("workforce_document_requirements")
+    .select("*")
+    .eq("shop_id", access.profile.shop_id)
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: true });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    defaults: DEFAULT_DOCUMENT_REQUIREMENTS,
+    overrides: overrides ?? [],
+    effective: buildEffectiveDocumentRequirements(DEFAULT_DOCUMENT_REQUIREMENTS, overrides ?? []),
+    generatedAt: new Date().toISOString(),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const body = await req.json().catch(() => null);
+  let payload: Record<string, unknown>;
+  try {
+    payload = validateDocumentRequirementPayload(body, "create") as Record<string, unknown>;
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const insertPayload: Record<string, unknown> = {
+    ...payload,
+    shop_id: access.profile.shop_id,
+    created_by: access.profile.id ?? null,
+    updated_by: access.profile.id ?? null,
+  };
+
+  const { data, error } = await admin
+    .from("workforce_document_requirements")
+    .insert(insertPayload)
+    .select("*")
+    .single();
+
+  if (isActiveOverrideConflict(error)) {
+    return NextResponse.json(
+      {
+        error: "Active override already exists for this role/category/doc_type scope",
+        code: "ACTIVE_OVERRIDE_CONFLICT",
+        conflict_key: {
+          workforce_role: (insertPayload.workforce_role as string | null | undefined) ?? null,
+          workforce_category: (insertPayload.workforce_category as string | null | undefined) ?? null,
+          doc_type: insertPayload.doc_type as string,
+        },
+      },
+      { status: 409 }
+    );
+  }
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  void admin.from("audit_logs").insert({
+    actor_id: access.profile.id ?? null,
+    action: "workforce.document_requirement.override.created",
+    target: data.id,
+    metadata: { shop_id: access.profile.shop_id },
+  });
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts
+++ b/features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isActiveOverrideConflict, validateDocumentRequirementPayload } from "./documentRequirementOverrideValidation";
+
+describe("document requirement override validation", () => {
+  it("rejects invalid doc_type", () => {
+    expect(() => validateDocumentRequirementPayload({ doc_type: "bad", label: "x" }, "create")).toThrow("doc_type is invalid");
+  });
+
+  it("rejects invalid statuses", () => {
+    expect(() =>
+      validateDocumentRequirementPayload({ doc_type: "other", label: "x", accept_statuses: ["bad"] }, "create")
+    ).toThrow("accept_statuses contains invalid value");
+  });
+
+  it("rejects missing label", () => {
+    expect(() => validateDocumentRequirementPayload({ doc_type: "other" }, "create")).toThrow("label is required");
+  });
+
+  it("rejects client shop_id", () => {
+    expect(() => validateDocumentRequirementPayload({ doc_type: "other", label: "x", shop_id: "a" }, "create")).toThrow(
+      "shop_id is not allowed"
+    );
+  });
+
+  it("allows patch disable", () => {
+    const parsed = validateDocumentRequirementPayload({ is_active: false }, "patch");
+    expect(parsed).toEqual({ is_active: false });
+  });
+
+  it("detects unique conflict", () => {
+    expect(
+      isActiveOverrideConflict({ code: "23505", message: "duplicate key value violates unique constraint workforce_document_requirements_active" })
+    ).toBe(true);
+  });
+});

--- a/features/shared/lib/workforce/documentRequirementOverrideValidation.ts
+++ b/features/shared/lib/workforce/documentRequirementOverrideValidation.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+export const REQUIRED_DOC_TYPES = ["drivers_license", "certification", "tax_form", "other"] as const;
+const ACCEPT_STATUSES = ["active", "approved", "accepted"] as const;
+const REVIEW_STATUSES = ["received", "pending", "review", "needs_review"] as const;
+
+type Mode = "create" | "patch";
+
+const allowedFields = new Set([
+  "workforce_role",
+  "workforce_category",
+  "doc_type",
+  "label",
+  "is_required",
+  "expires_required",
+  "expires_warning_days",
+  "accept_statuses",
+  "review_statuses",
+  "priority",
+  "is_active",
+]);
+
+const normalizeNullableString = (value: unknown) => {
+  if (value === null || value === undefined) return null;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized.length ? normalized : null;
+};
+
+const normalizeStatuses = (value: unknown, allowed: readonly string[], field: string) => {
+  if (!Array.isArray(value) || value.length === 0) throw new Error(`${field} must be a non-empty array`);
+  const normalized = Array.from(new Set(value.map((entry) => String(entry).trim().toLowerCase()).filter(Boolean)));
+  if (!normalized.length) throw new Error(`${field} must be a non-empty array`);
+  for (const status of normalized) {
+    if (!allowed.includes(status)) throw new Error(`${field} contains invalid value: ${status}`);
+  }
+  return normalized;
+};
+
+export function validateDocumentRequirementPayload(payload: unknown, mode: Mode) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Body must be a JSON object");
+  }
+
+  const input = payload as Record<string, unknown>;
+
+  if ("shop_id" in input) throw new Error("shop_id is not allowed");
+
+  const unknownFields = Object.keys(input).filter((key) => !allowedFields.has(key));
+  if (unknownFields.length) throw new Error(`Unknown fields: ${unknownFields.join(", ")}`);
+
+  if (mode === "patch" && Object.keys(input).length === 0) throw new Error("At least one field is required");
+
+  const output: Record<string, unknown> = {};
+
+  if ("workforce_role" in input) output.workforce_role = normalizeNullableString(input.workforce_role);
+  if ("workforce_category" in input) output.workforce_category = normalizeNullableString(input.workforce_category);
+
+  if (mode === "create" || "doc_type" in input) {
+    const result = z.enum(REQUIRED_DOC_TYPES).safeParse(String(input.doc_type ?? "").trim().toLowerCase());
+    if (!result.success) throw new Error("doc_type is invalid");
+    output.doc_type = result.data;
+  }
+
+  if (mode === "create" || "label" in input) {
+    const label = String(input.label ?? "").trim();
+    if (!label) throw new Error("label is required");
+    output.label = label;
+  }
+
+  if ("is_required" in input) output.required = Boolean(input.is_required);
+  if ("expires_required" in input) output.expires_required = Boolean(input.expires_required);
+
+  if ("expires_warning_days" in input) {
+    const n = Number(input.expires_warning_days);
+    if (!Number.isInteger(n) || n < 0 || n > 365) throw new Error("expires_warning_days must be an integer between 0 and 365");
+    output.warning_days = n;
+  }
+
+  if ("priority" in input) {
+    const n = Number(input.priority);
+    if (!Number.isInteger(n) || n < 0 || n > 1000) throw new Error("priority must be an integer between 0 and 1000");
+    output.priority = n;
+  }
+
+  if ("is_active" in input) output.is_active = Boolean(input.is_active);
+  if ("accept_statuses" in input) output.accept_statuses = normalizeStatuses(input.accept_statuses, ACCEPT_STATUSES, "accept_statuses");
+  if ("review_statuses" in input) output.review_statuses = normalizeStatuses(input.review_statuses, REVIEW_STATUSES, "review_statuses");
+
+  if (mode === "create") {
+    if (!("required" in output)) output.required = true;
+    if (!("expires_required" in output)) output.expires_required = false;
+    if (!("warning_days" in output)) output.warning_days = 30;
+    if (!("priority" in output)) output.priority = 0;
+    if (!("is_active" in output)) output.is_active = true;
+    if (!("accept_statuses" in output)) output.accept_statuses = ["active", "approved", "accepted"];
+    if (!("review_statuses" in output)) output.review_statuses = ["received", "pending", "review", "needs_review"];
+  }
+
+  return output;
+}
+
+export function isActiveOverrideConflict(error: { code?: string; message?: string } | null | undefined) {
+  const msg = String(error?.message ?? "").toLowerCase();
+  return error?.code === "23505" && msg.includes("workforce_document_requirements") && msg.includes("active");
+}


### PR DESCRIPTION
### Motivation
- Provide owner/admin write APIs to manage shop-scoped workforce document requirement overrides so shops can create, update, and disable overrides introduced in B2.1/B2.2.
- Preserve existing B2.2 read behavior and defaults while keeping shop scoping strictly tied to the authenticated profile.

### Description
- Added `GET /api/workforce/document-requirements` returning `{ defaults, overrides, effective, generatedAt }` where `defaults` are code-level defaults, `overrides` include both active and inactive rows for the authenticated shop, and `effective` is computed with existing B2.2 logic. (file: `app/api/workforce/document-requirements/route.ts`).
- Added `POST /api/workforce/document-requirements` that validates/normalizes payloads server-side, rejects client `shop_id`, sets `shop_id`, `created_by`, and `updated_by` from the authenticated profile, returns `201` on success, and returns structured `409` with `code: "ACTIVE_OVERRIDE_CONFLICT"` when unique active-scope constraint is violated. (file: `app/api/workforce/document-requirements/route.ts`).
- Added `PATCH /api/workforce/document-requirements/[id]` supporting partial updates of allowed fields only, rejecting empty/unknown payloads, verifying the row belongs to the actor's shop, setting `updated_by`, returning `404` when not found, returning `409` on active-override uniqueness conflicts, and supporting soft-disable via `is_active=false`. (file: `app/api/workforce/document-requirements/[id]/route.ts`).
- Introduced shared validation/normalization helper `features/shared/lib/workforce/documentRequirementOverrideValidation.ts` implementing whitelist checks, normalization, bounds checks, status vocabulary checks, unknown-field and `shop_id` rejection, and a helper to detect unique-constraint conflicts.
- Added non-blocking audit inserts for create/update/disable events and unit tests for the validation helper. No UI, migration, manager access, upload/signed-URL, or readiness behavior changes were made.

### Testing
- Ran the validation unit tests with `npx vitest run features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts` and all tests passed (6 tests).
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully.
- No end-to-end route integration tests were added in this change; validation logic is covered by the new unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2941cc6c8328a7f138d85f7c3a02)