### PR TITLE
Strict boolean validation for workforce document requirement overrides

### DIFF
--- a/features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts
+++ b/features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts
@@ -27,6 +27,38 @@ describe("document requirement override validation", () => {
     expect(parsed).toEqual({ is_active: false });
   });
 
+  it("rejects create is_required string", () => {
+    expect(() =>
+      validateDocumentRequirementPayload({ doc_type: "other", label: "x", is_required: "false" }, "create")
+    ).toThrow("is_required must be a boolean");
+  });
+
+  it("rejects create expires_required string", () => {
+    expect(() =>
+      validateDocumentRequirementPayload({ doc_type: "other", label: "x", expires_required: "true" }, "create")
+    ).toThrow("expires_required must be a boolean");
+  });
+
+  it("rejects create is_active number", () => {
+    expect(() => validateDocumentRequirementPayload({ doc_type: "other", label: "x", is_active: 1 }, "create")).toThrow(
+      "is_active must be a boolean"
+    );
+  });
+
+  it("rejects patch is_active string", () => {
+    expect(() => validateDocumentRequirementPayload({ is_active: "false" }, "patch")).toThrow("is_active must be a boolean");
+  });
+
+  it("accepts patch is_required false", () => {
+    const parsed = validateDocumentRequirementPayload({ is_required: false }, "patch");
+    expect(parsed).toEqual({ required: false });
+  });
+
+  it("accepts patch expires_required false", () => {
+    const parsed = validateDocumentRequirementPayload({ expires_required: false }, "patch");
+    expect(parsed).toEqual({ expires_required: false });
+  });
+
   it("detects unique conflict", () => {
     expect(
       isActiveOverrideConflict({ code: "23505", message: "duplicate key value violates unique constraint workforce_document_requirements_active" })

--- a/features/shared/lib/workforce/documentRequirementOverrideValidation.ts
+++ b/features/shared/lib/workforce/documentRequirementOverrideValidation.ts
@@ -36,6 +36,11 @@ const normalizeStatuses = (value: unknown, allowed: readonly string[], field: st
   return normalized;
 };
 
+const parseBooleanField = (value: unknown, field: string) => {
+  if (typeof value !== "boolean") throw new Error(`${field} must be a boolean`);
+  return value;
+};
+
 export function validateDocumentRequirementPayload(payload: unknown, mode: Mode) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("Body must be a JSON object");
@@ -67,8 +72,8 @@ export function validateDocumentRequirementPayload(payload: unknown, mode: Mode)
     output.label = label;
   }
 
-  if ("is_required" in input) output.required = Boolean(input.is_required);
-  if ("expires_required" in input) output.expires_required = Boolean(input.expires_required);
+  if ("is_required" in input) output.required = parseBooleanField(input.is_required, "is_required");
+  if ("expires_required" in input) output.expires_required = parseBooleanField(input.expires_required, "expires_required");
 
   if ("expires_warning_days" in input) {
     const n = Number(input.expires_warning_days);
@@ -82,7 +87,7 @@ export function validateDocumentRequirementPayload(payload: unknown, mode: Mode)
     output.priority = n;
   }
 
-  if ("is_active" in input) output.is_active = Boolean(input.is_active);
+  if ("is_active" in input) output.is_active = parseBooleanField(input.is_active, "is_active");
   if ("accept_statuses" in input) output.accept_statuses = normalizeStatuses(input.accept_statuses, ACCEPT_STATUSES, "accept_statuses");
   if ("review_statuses" in input) output.review_statuses = normalizeStatuses(input.review_statuses, REVIEW_STATUSES, "review_statuses");
 


### PR DESCRIPTION
### Motivation
- Validation currently coerced boolean-like values with `Boolean(...)`, causing strings like `"false"` to become `true` and blocking the API review. 
- The fields affected are `is_required`, `expires_required`, and `is_active`, which must accept only real booleans and preserve `false` semantics. 

### Description
- Added a `parseBooleanField(value, field)` helper that throws if `typeof value !== "boolean"` and used it for `is_required`, `expires_required`, and `is_active` instead of `Boolean(...)` to enforce strict boolean types and produce field-specific errors like `is_active must be a boolean`.
- Preserved existing output mapping (`is_required` -> `required`) and default behavior for `create` mode, ensuring valid `false` values remain allowed and returned unchanged.
- Files changed: `features/shared/lib/workforce/documentRequirementOverrideValidation.ts` and `features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts`.

### Testing
- Ran unit tests: `npx vitest run features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts`, all tests passed (12/12).
- Ran TypeScript checks: `npx tsc --noEmit`, which completed successfully.
- Added tests to assert rejecting invalid boolean types on `create` and `patch` and to assert accepting `false` values on `patch`; all new and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f301aeadc832885786195014144d6)