### PR TITLE
Fix Workforce Required Document Matrix B2.4-B conflict error mapping

### DIFF
--- a/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
@@ -306,8 +306,15 @@ export default function WorkforceDocumentsClient() {
   };
 
   const mapApiError = (status: number, payload: unknown): string => {
+    const serverCode = isRecord(payload) ? safeString(payload.code) : "";
     const serverError = isRecord(payload) ? safeString(payload.error) : "";
-    if (status === 409 && serverError === "ACTIVE_OVERRIDE_CONFLICT") return "An active override already exists for this role/category/doc type scope.";
+    const serverMessage = isRecord(payload) ? safeString(payload.message) : "";
+    const conflictText = `${serverError} ${serverMessage}`.toLowerCase();
+    const isActiveOverrideConflict =
+      serverCode === "ACTIVE_OVERRIDE_CONFLICT" ||
+      serverError === "ACTIVE_OVERRIDE_CONFLICT" ||
+      (status === 409 && conflictText.includes("active override already exists"));
+    if (isActiveOverrideConflict) return "An active override already exists for this role/category/doc type scope.";
     if (status === 401 || status === 403) return "You do not have permission to manage requirements.";
     if (status === 400) return serverError || "Validation failed. Please review your input.";
     return serverError || "Network or server error while saving override.";


### PR DESCRIPTION
### Motivation
- The UI was only treating `payload.error === "ACTIVE_OVERRIDE_CONFLICT"` as a conflict, but the API may return `code: "ACTIVE_OVERRIDE_CONFLICT"` or a 409 with a human-readable message, causing true conflicts to miss the friendly copy.

### Description
- Updated `mapApiError` in `features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx` to also consider `payload.code === "ACTIVE_OVERRIDE_CONFLICT"`, `payload.error === "ACTIVE_OVERRIDE_CONFLICT"`, or `status === 409` with `error`/`message` text that includes "Active override already exists", and return the existing friendly conflict string.
- Preserved existing behavior for showing `conflict_key` details and did not change any API, validation, permissions/scoping, upload/signed URL, or readiness scoring logic.

### Testing
- Ran `npx tsc --noEmit` which succeeded, and ran `npx vitest run features/shared/lib/workforce/documentRequirementOverrideValidation.test.ts` and `npx vitest run tests/workforce-document-readiness.test.ts`, both of which passed; the mapping now recognizes 409/`code`/`error` variants as conflicts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f52f8c2e083289f9eefea33d87a41)