### PR TITLE
Harden payroll-time export with server-side approval and blocking gates

### DIFF
--- a/app/api/payroll-time/export/route.ts
+++ b/app/api/payroll-time/export/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { exportPeriod } from "@/features/payroll-time/server/payrollTime";
+import { exportPeriod, PayrollExportError } from "@/features/payroll-time/server/payrollTime";
 import { requirePayrollReviewer } from "../_lib/auth";
 
 export async function POST(req: Request) {
@@ -18,9 +18,13 @@ export async function POST(req: Request) {
     });
     return NextResponse.json({ ok: true, ...result });
   } catch (error) {
+    if (error instanceof PayrollExportError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Export failed" },
-      { status: 400 },
+      { status: 500 },
     );
   }
 }

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -14,6 +14,16 @@ export type PayrollException = {
 
 const MINUTES_IN_HOUR = 60;
 
+export class PayrollExportError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "PayrollExportError";
+    this.status = status;
+  }
+}
+
 function startOfUtcDay(dateIso: string): Date {
   const d = new Date(dateIso);
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
@@ -435,6 +445,34 @@ export async function exportPeriod(params: { shopId: string; periodId: string; a
   const { shopId, periodId, actorId } = params;
   const providerType = params.providerType ?? "csv";
 
+  const { data: period, error: periodErr } = await admin
+    .from("payroll_pay_periods")
+    .select("id, status")
+    .eq("id", periodId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (periodErr) throw new Error(periodErr.message);
+  if (!period?.id) {
+    throw new PayrollExportError("Payroll period not found.", 404);
+  }
+  if (period.status !== "approved") {
+    throw new PayrollExportError("Payroll period must be approved before export.", 409);
+  }
+
+  const { count: unresolvedBlockingCount, error: blockingErr } = await admin
+    .from("payroll_time_exceptions")
+    .select("id", { count: "exact", head: true })
+    .eq("shop_id", shopId)
+    .eq("period_id", periodId)
+    .eq("severity", "blocking")
+    .eq("resolved", false);
+
+  if (blockingErr) throw new Error(blockingErr.message);
+  if ((unresolvedBlockingCount ?? 0) > 0) {
+    throw new PayrollExportError("Resolve blocking payroll exceptions before export.", 409);
+  }
+
   const { data: entries, error: entriesErr } = await admin
     .from("payroll_time_entries")
     .select("user_id, regular_minutes, overtime_minutes, unpaid_break_minutes, worked_minutes")
@@ -509,6 +547,21 @@ export async function exportPeriod(params: { shopId: string; periodId: string; a
     csvHeaders.join(","),
     ...rows.map((r) => [r.user_id, r.employee_external_id ?? "", r.regular_hours, r.overtime_hours, r.unpaid_break_hours, r.total_hours].join(",")),
   ];
+
+  void admin.from("audit_logs").insert({
+    shop_id: shopId,
+    actor_id: actorId,
+    action: "payroll.export.generated",
+    target_table: "payroll_export_batches",
+    target_id: batch.id,
+    metadata: {
+      shop_id: shopId,
+      period_id: periodId,
+      batch_id: batch.id,
+      provider_type: providerType,
+      row_count: rows.length,
+    },
+  });
 
   return { batchId: batch.id, rowCount: rows.length, csv: csvLines.join("\n") };
 }


### PR DESCRIPTION
### Motivation
- Enforce server-side export integrity for Payroll Connect A0 by preventing UI-only bypasses and ensuring exports only run for the correct shop and approved periods.
- Prevent stale/manual bypass by re-checking unresolved blocking payroll exceptions at export time.
- Provide non-blocking audit traceability for generated exports while preserving existing snapshot/export behavior and response contract.

### Description
- Added a small typed error `PayrollExportError` and used it to return meaningful HTTP status hints for export failures (404/409) without introducing a new error framework. (files: `features/payroll-time/server/payrollTime.ts`, `app/api/payroll-time/export/route.ts`)
- Inside `exportPeriod` we now load and confirm the period belongs to the authenticated `shop_id` and reject if not found or if `status !== "approved"` with the message: "Payroll period must be approved before export." (preserves existing re-export behavior in A0).
- Before generating the export we query unresolved blocking exceptions for the `shop_id`+`period_id` and reject export with: "Resolve blocking payroll exceptions before export." if any are present.
- Preserved all existing snapshot behavior (inserts into `payroll_export_batches`, `payroll_export_rows`, period status update to `exported` + lock, and CSV generation) and kept the response shape unchanged; added best-effort, non-blocking `audit_logs` insert with `action: "payroll.export.generated"` and metadata. The export route now maps `PayrollExportError` to proper HTTP statuses and returns 500 for unexpected failures.

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f652320908328accc0da9c48c7efa)