### PR TITLE
Persist payroll CSV artifact to private storage and save batch metadata

### DIFF
--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -1,4 +1,5 @@
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { createHash } from "crypto";
 
 export type PayrollPeriodStatus = "draft" | "open" | "approved" | "exported";
 
@@ -535,18 +536,60 @@ export async function exportPeriod(params: { shopId: string; periodId: string; a
     if (rowsErr) throw new Error(rowsErr.message);
   }
 
+  const csvHeaders = ["user_id", "employee_external_id", "regular_hours", "overtime_hours", "unpaid_break_hours", "total_hours"];
+  const csvLines = [
+    csvHeaders.join(","),
+    ...rows.map((r) => [r.user_id, r.employee_external_id ?? "", r.regular_hours, r.overtime_hours, r.unpaid_break_hours, r.total_hours].join(",")),
+  ];
+  const csv = csvLines.join("\n");
+
+  const storageBucket = "payroll-exports";
+  const storagePath = `${shopId}/${periodId}/${batch.id}.csv`;
+  const fileSizeBytes = Buffer.byteLength(csv, "utf8");
+  const fileSha256 = createHash("sha256").update(csv, "utf8").digest("hex");
+
+  const { error: uploadErr } = await admin.storage
+    .from(storageBucket)
+    .upload(storagePath, csv, { contentType: "text/csv; charset=utf-8", upsert: false });
+
+  if (uploadErr) {
+    await admin
+      .from("payroll_export_batches")
+      .update({ handoff_status: "failed", updated_at: new Date().toISOString() })
+      .eq("id", batch.id)
+      .eq("shop_id", shopId);
+    throw new Error(`Failed to persist payroll export artifact: ${uploadErr.message}`);
+  }
+
+  const { error: batchMetaErr } = await admin
+    .from("payroll_export_batches")
+    .update({
+      storage_bucket: storageBucket,
+      storage_path: storagePath,
+      file_size_bytes: fileSizeBytes,
+      file_sha256: fileSha256,
+      provider_template_version: "generic-v1",
+      handoff_status: "generated",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", batch.id)
+    .eq("shop_id", shopId);
+
+  if (batchMetaErr) {
+    await admin
+      .from("payroll_export_batches")
+      .update({ handoff_status: "failed", updated_at: new Date().toISOString() })
+      .eq("id", batch.id)
+      .eq("shop_id", shopId);
+    throw new Error(`Failed to save payroll export artifact metadata: ${batchMetaErr.message}`);
+  }
+
   const now = new Date().toISOString();
   await admin
     .from("payroll_pay_periods")
     .update({ status: "exported", exported_at: now, exported_by: actorId, locked_at: now, updated_at: now })
     .eq("id", periodId)
     .eq("shop_id", shopId);
-
-  const csvHeaders = ["user_id", "employee_external_id", "regular_hours", "overtime_hours", "unpaid_break_hours", "total_hours"];
-  const csvLines = [
-    csvHeaders.join(","),
-    ...rows.map((r) => [r.user_id, r.employee_external_id ?? "", r.regular_hours, r.overtime_hours, r.unpaid_break_hours, r.total_hours].join(",")),
-  ];
 
   void admin.from("audit_logs").insert({
     shop_id: shopId,
@@ -560,8 +603,11 @@ export async function exportPeriod(params: { shopId: string; periodId: string; a
       batch_id: batch.id,
       provider_type: providerType,
       row_count: rows.length,
+      has_artifact: true,
+      file_sha256: fileSha256,
+      file_size_bytes: fileSizeBytes,
     },
   });
 
-  return { batchId: batch.id, rowCount: rows.length, csv: csvLines.join("\n") };
+  return { batchId: batch.id, rowCount: rows.length, csv };
 }


### PR DESCRIPTION
### Motivation
- Save the generated payroll CSV as a private artifact during export so artifacts are durable and auditable. 
- Record artifact integrity/metadata on the existing `payroll_export_batches` row to support later handoff and verification.
- Preserve the current inline CSV response and existing export/approval flows while preventing a period from being marked exported if artifact persistence fails.

### Description
- Added CSV upload to private Supabase Storage bucket `payroll-exports` and metadata persistence in `exportPeriod` using the existing admin client, with storage path convention ` {shop_id}/{period_id}/{batch_id}.csv` (bucket passed separately and not repeated in path). (file changed: `features/payroll-time/server/payrollTime.ts`).
- Calculated `file_size_bytes` from the CSV bytes and `file_sha256` using Node `crypto.createHash('sha256')`, and saved `storage_bucket`, `storage_path`, `file_size_bytes`, `file_sha256`, `provider_template_version: "generic-v1"`, and `handoff_status: "generated"` on `payroll_export_batches` after upload.
- Failure behavior: if upload or metadata update fails, the batch row is updated to `handoff_status = "failed"` and an error is thrown, and the period is not marked as exported (period status update occurs only after artifact+metadata succeed); existing batch/row snapshots may remain but are explicitly marked failed in those error paths.
- Kept the CSV header/columns unchanged (`user_id, employee_external_id, regular_hours, overtime_hours, unpaid_break_hours, total_hours`) and preserved the export return shape (`{ batchId, rowCount, csv }`) without returning storage paths or URLs to clients; audit log `payroll.export.generated` metadata now includes `has_artifact`, `file_sha256`, and `file_size_bytes` (no public URLs logged).

### Testing
- Ran type-checking: `npx tsc --noEmit`, which completed successfully.
- No additional automated payroll-specific tests were present/targeted in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f76310ba08328a004e7167abdcf6f)