### PR TITLE
Payroll: export history API and secure signed downloads (Phase A1.3)

### DIFF
--- a/app/api/payroll-time/exports/[batchId]/download/route.ts
+++ b/app/api/payroll-time/exports/[batchId]/download/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { requirePayrollReviewer } from "../../../_lib/auth";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+const SIGNED_TTL_SECONDS = 300;
+
+export async function GET(_req: Request, context: { params: Promise<{ batchId: string }> }) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+
+  const supabase = createServerSupabaseRoute();
+  const { batchId } = await context.params;
+
+  const { data: batch, error: batchErr } = await supabase
+    .from("payroll_export_batches")
+    .select(
+      "id, shop_id, period_id, provider_type, file_sha256, file_size_bytes, storage_bucket, storage_path, download_count",
+    )
+    .eq("id", batchId)
+    .eq("shop_id", auth.me.shop_id)
+    .maybeSingle();
+
+  if (batchErr || !batch) {
+    return NextResponse.json({ error: "Export batch not found" }, { status: 404 });
+  }
+
+  if (!batch.storage_bucket || !batch.storage_path) {
+    return NextResponse.json({ error: "Export artifact unavailable" }, { status: 409 });
+  }
+
+  if (!batch.storage_path.startsWith(`${auth.me.shop_id}/`)) {
+    return NextResponse.json({ error: "Invalid artifact path" }, { status: 400 });
+  }
+
+  const { data: signed, error: signedErr } = await supabase.storage
+    .from(batch.storage_bucket)
+    .createSignedUrl(batch.storage_path, SIGNED_TTL_SECONDS);
+
+  if (signedErr || !signed?.signedUrl) {
+    return NextResponse.json({ error: "Failed to prepare download" }, { status: 500 });
+  }
+
+  const now = new Date().toISOString();
+  void supabase
+    .from("payroll_export_batches")
+    .update({
+      download_count: Number(batch.download_count ?? 0) + 1,
+      last_downloaded_at: now,
+      last_downloaded_by: auth.me.id,
+      updated_at: now,
+    })
+    .eq("id", batch.id)
+    .eq("shop_id", auth.me.shop_id);
+
+  void supabase.from("audit_logs").insert({
+    shop_id: auth.me.shop_id,
+    actor_id: auth.me.id,
+    action: "payroll.export.downloaded",
+    target_table: "payroll_export_batches",
+    target_id: batch.id,
+    metadata: {
+      shop_id: auth.me.shop_id,
+      period_id: batch.period_id,
+      batch_id: batch.id,
+      provider_type: batch.provider_type,
+      file_sha256: batch.file_sha256,
+      file_size_bytes: batch.file_size_bytes,
+    },
+  });
+
+  return NextResponse.json({ signedUrl: signed.signedUrl, expiresIn: SIGNED_TTL_SECONDS });
+}

--- a/app/api/payroll-time/exports/route.ts
+++ b/app/api/payroll-time/exports/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { requirePayrollReviewer } from "../_lib/auth";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+const DEFAULT_LIMIT = 20;
+
+export async function GET(req: Request) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+
+  const supabase = createServerSupabaseRoute();
+  const { searchParams } = new URL(req.url);
+  const periodId = searchParams.get("period_id")?.trim() ?? "";
+
+  let query = supabase
+    .from("payroll_export_batches")
+    .select(
+      "id, period_id, provider_type, status, handoff_status, row_count, exported_at, exported_by, file_size_bytes, file_sha256, provider_template_version, download_count, last_downloaded_at, created_at",
+    )
+    .eq("shop_id", auth.me.shop_id)
+    .order("exported_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (periodId) {
+    query = query.eq("period_id", periodId);
+  } else {
+    query = query.limit(DEFAULT_LIMIT);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    return NextResponse.json({ error: "Failed to load export history" }, { status: 500 });
+  }
+
+  return NextResponse.json({ batches: data ?? [] });
+}

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -51,11 +51,37 @@ type Exception = {
   resolved: boolean;
 };
 
+
+
+type ExportBatch = {
+  id: string;
+  period_id: string;
+  provider_type: string | null;
+  status: string | null;
+  handoff_status: string | null;
+  row_count: number | null;
+  exported_at: string | null;
+  exported_by: string | null;
+  file_size_bytes: number | null;
+  file_sha256: string | null;
+  provider_template_version: string | null;
+  download_count: number | null;
+  last_downloaded_at: string | null;
+  created_at: string | null;
+};
 function fmtHours(minutes: number | null | undefined) {
   return ((minutes ?? 0) / 60).toFixed(2);
 }
 
+function fmtFileSize(bytes: number | null | undefined) {
+  if (!bytes || bytes <= 0) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
 export default function PayrollTimeClient() {
+
   const [periods, setPeriods] = useState<Period[]>([]);
   const [activePeriodId, setActivePeriodId] = useState<string | null>(null);
   const [entries, setEntries] = useState<Entry[]>([]);
@@ -64,6 +90,9 @@ export default function PayrollTimeClient() {
   const [error, setError] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [csvPreview, setCsvPreview] = useState<string | null>(null);
+  const [exportHistory, setExportHistory] = useState<ExportBatch[]>([]);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [downloadingBatchId, setDownloadingBatchId] = useState<string | null>(null);
   const [employeeSearch, setEmployeeSearch] = useState("");
   const [exceptionSeverityFilter, setExceptionSeverityFilter] = useState<"all" | "blocking" | "warning">("all");
   const searchParams = useSearchParams();
@@ -133,6 +162,10 @@ export default function PayrollTimeClient() {
     if (workforceSeverity) setExceptionSeverityFilter(workforceSeverity);
   }, [workforceSeverity]);
 
+  useEffect(() => {
+    void loadExportHistory(activePeriodId);
+  }, [activePeriodId]);
+
   async function runAction(path: string, actionName: string, payload: Record<string, unknown>) {
     setBusyAction(actionName);
     setError(null);
@@ -171,6 +204,44 @@ export default function PayrollTimeClient() {
     });
     if (result?.csv) setCsvPreview(String(result.csv));
     await load(activePeriodId);
+  }
+
+  async function loadExportHistory(periodId?: string | null) {
+    const targetPeriodId = periodId ?? activePeriodId;
+    if (!targetPeriodId) {
+      setExportHistory([]);
+      return;
+    }
+
+    const res = await fetch(`/api/payroll-time/exports?period_id=${targetPeriodId}`, { cache: "no-store" });
+    const body = await res.json().catch(() => null);
+
+    if (!res.ok) {
+      setHistoryError(body?.error ?? "Failed to load export history");
+      setExportHistory([]);
+      return;
+    }
+
+    setHistoryError(null);
+    setExportHistory((body?.batches ?? []) as ExportBatch[]);
+  }
+
+  async function handleDownload(batchId: string) {
+    setDownloadingBatchId(batchId);
+    setHistoryError(null);
+
+    const res = await fetch(`/api/payroll-time/exports/${batchId}/download`, { cache: "no-store" });
+    const body = await res.json().catch(() => null);
+
+    if (!res.ok || !body?.signedUrl) {
+      setHistoryError(body?.error ?? "Download unavailable. Please try again.");
+      setDownloadingBatchId(null);
+      return;
+    }
+
+    window.open(String(body.signedUrl), "_blank", "noopener,noreferrer");
+    setDownloadingBatchId(null);
+    await loadExportHistory(activePeriodId);
   }
 
   return (
@@ -373,6 +444,54 @@ export default function PayrollTimeClient() {
                     <td className="px-4 py-2.5">{item.work_date ?? "—"}</td>
                     <td className="px-4 py-2.5">{item.message}</td>
                     <td className="px-4 py-2.5">{item.resolved ? "resolved" : "open"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </AdminPanel>
+
+
+      <AdminPanel>
+        <AdminPanelTitle title="Export History" description="Read-only export snapshots for this payroll period with secure download links." />
+        {historyError ? <p className="px-4 pb-4 text-xs text-amber-300">{historyError}</p> : null}
+        {exportHistory.length === 0 ? (
+          <AdminEmptyState title="No export batches yet" body="Run an export to create a period snapshot artifact." />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400">
+                <tr>
+                  <th className="px-4 py-2.5 text-left">Provider / Template</th>
+                  <th className="px-4 py-2.5 text-left">Status</th>
+                  <th className="px-4 py-2.5 text-right">Rows</th>
+                  <th className="px-4 py-2.5 text-left">Exported</th>
+                  <th className="px-4 py-2.5 text-left">File size</th>
+                  <th className="px-4 py-2.5 text-right">Downloads</th>
+                  <th className="px-4 py-2.5 text-left">Checksum</th>
+                  <th className="px-4 py-2.5 text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {exportHistory.map((batch) => (
+                  <tr key={batch.id} className="text-neutral-200">
+                    <td className="px-4 py-2.5">{batch.provider_type ?? "csv"} / {batch.provider_template_version ?? "—"}</td>
+                    <td className="px-4 py-2.5">{batch.status ?? "—"} / {batch.handoff_status ?? "—"}</td>
+                    <td className="px-4 py-2.5 text-right">{batch.row_count ?? 0}</td>
+                    <td className="px-4 py-2.5">{batch.exported_at ? new Date(batch.exported_at).toLocaleString() : "—"}</td>
+                    <td className="px-4 py-2.5">{fmtFileSize(batch.file_size_bytes)}</td>
+                    <td className="px-4 py-2.5 text-right">{batch.download_count ?? 0}</td>
+                    <td className="px-4 py-2.5 font-mono text-xs text-neutral-400">{batch.file_sha256 ? `${batch.file_sha256.slice(0, 12)}…` : "—"}</td>
+                    <td className="px-4 py-2.5 text-right">
+                      <button
+                        className="rounded-lg border border-sky-500/40 bg-sky-500/10 px-3 py-1.5 text-xs uppercase tracking-[0.12em] text-sky-200 disabled:opacity-50"
+                        onClick={() => void handleDownload(batch.id)}
+                        disabled={downloadingBatchId !== null}
+                      >
+                        {downloadingBatchId === batch.id ? "Preparing…" : "Download"}
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
### Motivation
- Provide read-only export history and secure signed downloads for payroll reviewers without changing existing export generation, storage model, or approval flows.
- Reuse the existing `payroll_export_batches` table as the history source and keep artifacts private by issuing short-lived signed URLs.

### Description
- Added `GET /api/payroll-time/exports` which returns recent or period-scoped export batch metadata (safe fields only) and is gated by `requirePayrollReviewer` and `shop_id` scoping; it does not return `storage_path`, `storage_bucket`, or CSV contents.
- Added `GET /api/payroll-time/exports/[batchId]/download` which validates batch ownership and artifact presence, enforces `storage_path` prefix safety (`${shopId}/...`), issues a signed URL with TTL `300` seconds, increments `download_count`/`last_downloaded_*` (best-effort), and writes a best-effort audit log (`action: payroll.export.downloaded`).
- Updated the existing `PayrollTimeClient` UI to add an Export History panel for the active period that lists provider/template, status/handoff status, row count, exported time, file size, download count, and a short checksum, and provides a per-row Download button that calls the signed download endpoint and opens the returned `signedUrl`.
- Files changed: `app/api/payroll-time/exports/route.ts`, `app/api/payroll-time/exports/[batchId]/download/route.ts`, and `features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it passed (only an unrelated npm env warning was emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7a61e5e48328b2b929431487eb37)