### PR TITLE
Stabilize work-order status normalization and readiness gating

### DIFF
--- a/app/api/work-orders/[id]/mark-ready/route.ts
+++ b/app/api/work-orders/[id]/mark-ready/route.ts
@@ -5,6 +5,8 @@ import type { Database } from "@shared/types/types/supabase";
 import { buildWorkOrderCompletedEvent } from "@/features/integrations/shopreel/server/buildProFixIQStoryEvents";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
 import { syncWorkOrderToHistory } from "@/features/work-orders/server/syncWorkOrderToHistory";
+import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
 
 type DB = Database;
 
@@ -33,10 +35,8 @@ export async function POST(req: Request) {
     if (lnErr) throw lnErr;
 
     const notDone = (lines ?? []).some((l) => {
-      const normalized = String(l.status ?? "awaiting")
-        .toLowerCase()
-        .replaceAll(" ", "_");
-      return !["completed", "ready_to_invoice", "invoiced"].includes(normalized);
+      const normalized = normalizeWorkOrderLineStatus(l.status ?? "pending");
+      return !["completed", "declined", "deferred"].includes(normalized);
     });
     if (notDone) {
       return NextResponse.json({ ok: false, error: "All lines must be completed first." }, { status: 400 });
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
 
     const { error: updErr } = await supabase
       .from("work_orders")
-      .update({ status: "ready_to_invoice" })
+      .update({ status: normalizeWorkOrderStatus("ready_to_invoice") })
       .eq("id", woId);
     if (updErr) throw updErr;
 

--- a/app/api/work-orders/update-status/create/route.ts
+++ b/app/api/work-orders/update-status/create/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
 
 const supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -62,7 +63,7 @@ export async function POST(req: NextRequest) {
         vehicle_id,
         inspection_id: inspection_id ?? null,
         customer_id,
-        status: "queued",
+        status: normalizeWorkOrderStatus("new"),
         type,
         complaint: complaint ?? null,
         appointment: appointment ?? null,

--- a/app/api/work-orders/update-status/route.ts
+++ b/app/api/work-orders/update-status/route.ts
@@ -5,6 +5,7 @@ import type { Database } from "@shared/types/types/supabase";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 import { syncWorkOrderToHistory } from "@/features/work-orders/server/syncWorkOrderToHistory";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
 
 export const runtime = "nodejs";
 
@@ -69,11 +70,11 @@ export async function POST(req: NextRequest) {
 
     if (command === "punch-in") {
       updateFields = {
-        status: "in_progress",
+        status: normalizeWorkOrderStatus("in_progress"),
       };
     } else if (command === "complete") {
       const nextFields: WorkOrderUpdate = {
-        status: "completed",
+        status: normalizeWorkOrderStatus("completed"),
       };
 
       if (quote && summary) {

--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -3216,6 +3216,38 @@
     "riskLevel": "high"
   },
   {
+    "path": "app/api/payroll-time/exports/[batchId]/download/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/payroll-time/exports/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/payroll-time/periods/route.ts",
     "methods": [
       "GET"
@@ -4974,6 +5006,7 @@
   {
     "path": "app/api/work-orders/[id]/invoice/route.ts",
     "methods": [
+      "GET",
       "POST"
     ],
     "isMutating": true,
@@ -5539,5 +5572,132 @@
       "service_role_with_shop_identifier_input_or_reference"
     ],
     "riskLevel": "medium"
+  },
+  {
+    "path": "app/api/workforce/certifications-readiness/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/document-requirements/[id]/route.ts",
+    "methods": [
+      "PATCH"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/document-requirements/readiness/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/document-requirements/route.ts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/documents-readiness/[id]/signed-url/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/documents-readiness/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/overview/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
   }
 ]

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,16 +1,16 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-05-14T02:53:21.273Z
+Generated: 2026-05-21T22:05:58.096Z
 
 ## Summary
-- Total route count: **326**
-- Routes exporting GET: **93**
-- Routes exporting POST: **239**
+- Total route count: **335**
+- Routes exporting GET: **102**
+- Routes exporting POST: **240**
 - Routes exporting PUT: **6**
-- Routes exporting PATCH: **16**
+- Routes exporting PATCH: **17**
 - Routes exporting DELETE: **12**
 - Routes with service-role pattern: **19**
-- Routes using requireShopScopedApiAccess: **75**
+- Routes using requireShopScopedApiAccess: **82**
 - Routes with auth.getUser references: **147**
 
 ## High-Risk Routes
@@ -60,7 +60,7 @@ Generated: 2026-05-14T02:53:21.273Z
 - `app/api/stripe/link-user/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/vin/extract-from-image/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/vin/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/work-orders/[id]/invoice/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/work-orders/[id]/invoice/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/[id]/mark-ready/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/quotes/[id]/mark-quoted/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker
 
@@ -156,6 +156,8 @@ Generated: 2026-05-14T02:53:21.273Z
 - `app/api/payments/checkout/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/approve/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/payroll-time/exports/[batchId]/download/route.ts` | methods: GET | riskFlags: none
+- `app/api/payroll-time/exports/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/periods/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/settings/update/shop/owner-pin/set/route.ts` | methods: none | riskFlags: none
@@ -170,7 +172,7 @@ Generated: 2026-05-14T02:53:21.273Z
 - `app/api/stripe/link-user/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/vin/extract-from-image/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/vin/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/work-orders/[id]/invoice/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/work-orders/[id]/invoice/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/[id]/mark-ready/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/quotes/[id]/mark-quoted/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker
 

--- a/features/work-orders/lib/line-status.ts
+++ b/features/work-orders/lib/line-status.ts
@@ -1,11 +1,16 @@
 export const CANONICAL_WORK_ORDER_LINE_STATUSES = [
+  "pending",
+  "approved",
   "awaiting",
   "awaiting_approval",
   "in_progress",
+  "waiting_parts",
   "on_hold",
   "completed",
   "ready_to_invoice",
   "invoiced",
+  "declined",
+  "deferred",
 ] as const;
 
 export type WorkOrderLineStatus =
@@ -15,40 +20,54 @@ export const WORK_ORDER_LINE_ALLOWED_TRANSITIONS: Record<
   WorkOrderLineStatus,
   readonly WorkOrderLineStatus[]
 > = {
-  awaiting: ["awaiting_approval", "in_progress", "on_hold", "completed"],
-  awaiting_approval: ["awaiting_approval", "in_progress", "on_hold", "completed"],
-  in_progress: ["in_progress", "on_hold", "completed", "awaiting_approval"],
-  on_hold: ["on_hold", "in_progress", "completed", "awaiting_approval"],
+  pending: ["pending", "approved", "awaiting_approval", "in_progress", "waiting_parts", "declined", "deferred"],
+  approved: ["approved", "in_progress", "waiting_parts", "completed", "declined", "deferred"],
+  awaiting: ["awaiting", "awaiting_approval", "in_progress", "on_hold", "completed", "declined", "deferred"],
+  awaiting_approval: ["awaiting_approval", "approved", "in_progress", "on_hold", "completed", "declined", "deferred"],
+  in_progress: ["in_progress", "on_hold", "waiting_parts", "completed", "awaiting_approval", "declined", "deferred"],
+  waiting_parts: ["waiting_parts", "in_progress", "completed", "declined", "deferred"],
+  on_hold: ["on_hold", "in_progress", "waiting_parts", "completed", "awaiting_approval"],
   completed: ["completed", "ready_to_invoice", "invoiced"],
   ready_to_invoice: ["ready_to_invoice", "invoiced"],
   invoiced: ["invoiced"],
+  declined: ["declined"],
+  deferred: ["deferred"],
 } as const;
 
 const LEGACY_TO_CANONICAL: Record<string, WorkOrderLineStatus> = {
+  pending: "pending",
+  approved: "approved",
   awaiting: "awaiting",
   awaiting_approval: "awaiting_approval",
   active: "in_progress",
   in_progress: "in_progress",
   on_hold: "on_hold",
+  waiting_parts: "waiting_parts",
   completed: "completed",
   ready_to_invoice: "ready_to_invoice",
   invoiced: "invoiced",
   queued: "in_progress",
   paused: "on_hold",
-  declined: "on_hold",
+  declined: "declined",
+  deferred: "deferred",
   assigned: "in_progress",
   unassigned: "awaiting",
   quoted: "awaiting_approval",
 };
 
 const CANONICAL_TO_DB_ALIASES: Record<WorkOrderLineStatus, readonly string[]> = {
+  pending: ["pending"],
+  approved: ["approved"],
   awaiting: ["awaiting", "unassigned"],
   awaiting_approval: ["awaiting_approval", "quoted"],
   in_progress: ["in_progress", "active", "queued", "assigned"],
-  on_hold: ["on_hold", "paused", "declined"],
+  waiting_parts: ["waiting_parts"],
+  on_hold: ["on_hold", "paused"],
   completed: ["completed"],
   ready_to_invoice: ["ready_to_invoice"],
   invoiced: ["invoiced"],
+  declined: ["declined"],
+  deferred: ["deferred"],
 } as const;
 
 export function getWorkOrderLineStatusDbFilter(statuses: readonly WorkOrderLineStatus[]): string[] {
@@ -69,7 +88,7 @@ export function normalizeWorkOrderLineStatus(value: unknown): WorkOrderLineStatu
     .toLowerCase()
     .replaceAll(" ", "_");
 
-  return LEGACY_TO_CANONICAL[key] ?? "awaiting";
+  return LEGACY_TO_CANONICAL[key] ?? "pending";
 }
 
 export function isWorkOrderLineStatus(value: unknown): value is WorkOrderLineStatus {

--- a/features/work-orders/lib/work-order-status.ts
+++ b/features/work-orders/lib/work-order-status.ts
@@ -1,0 +1,41 @@
+export const CANONICAL_WORK_ORDER_STATUSES = [
+  "new",
+  "awaiting_inspection",
+  "awaiting_approval",
+  "approved",
+  "in_progress",
+  "waiting_parts",
+  "ready_to_invoice",
+  "invoiced",
+  "completed",
+  "cancelled",
+] as const;
+
+export type WorkOrderStatus = (typeof CANONICAL_WORK_ORDER_STATUSES)[number];
+
+const LEGACY_TO_CANONICAL: Record<string, WorkOrderStatus> = {
+  new: "new",
+  queued: "new",
+  pending: "new",
+  awaiting_inspection: "awaiting_inspection",
+  inspection: "awaiting_inspection",
+  awaiting_approval: "awaiting_approval",
+  quote_sent: "awaiting_approval",
+  approved: "approved",
+  in_progress: "in_progress",
+  active: "in_progress",
+  waiting_parts: "waiting_parts",
+  on_hold: "waiting_parts",
+  paused: "waiting_parts",
+  ready_to_invoice: "ready_to_invoice",
+  invoiced: "invoiced",
+  completed: "completed",
+  done: "completed",
+  cancelled: "cancelled",
+  canceled: "cancelled",
+};
+
+export function normalizeWorkOrderStatus(value: unknown): WorkOrderStatus {
+  const key = String(value ?? "").trim().toLowerCase().replaceAll(" ", "_");
+  return LEGACY_TO_CANONICAL[key] ?? "new";
+}


### PR DESCRIPTION
### Motivation
- Normalize and centralize work-order and work-order-line statuses to prevent status drift and make work orders a reliable central record without changing schema or business flows.
- Ensure new work orders start in a clear canonical state and that downstream actions (mark-ready, invoice) enforce safe completion gating.
- Preserve Supabase shop-scoping and existing auth patterns while remaining backward compatible with legacy status values.
- Make a small, surgical change set that enables safer integration points for inspections, quotes, parts, and invoicing.

### Description
- Added a canonical work-order status utility `features/work-orders/lib/work-order-status.ts` with legacy->canonical mapping and `normalizeWorkOrderStatus` for compatibility (`new`, `awaiting_inspection`, `awaiting_approval`, `approved`, `in_progress`, `waiting_parts`, `ready_to_invoice`, `invoiced`, `completed`, `cancelled`).
- Expanded and normalized work-order-line statuses in `features/work-orders/lib/line-status.ts` to include `pending`, `approved`, `waiting_parts`, `declined`, and `deferred`, kept legacy aliases, and adjusted allowed transitions and normalization defaults.
- Updated work order creation to use canonical initial status in `app/api/work-orders/update-status/create/route.ts` and updated status mutation behavior for `punch-in`/`complete` in `app/api/work-orders/update-status/route.ts` to write normalized statuses while preserving shop-scoped access checks and event/history sync.
- Tightened readiness gating in `app/api/work-orders/[id]/mark-ready/route.ts` to normalize line statuses and require lines to be `completed`, `declined`, or `deferred` before transitioning the work order to `ready_to_invoice`.

### Testing
- Ran `pnpm typecheck` which passed (no new TypeScript errors introduced by this change set).
- Ran `pnpm lint` and observed pre-existing ESLint/TS rules failures across the repo not introduced by this PR (lint failed for unrelated files).
- Ran `pnpm test` and observed pre-existing failing tests in onboarding/history-related suites (tests failing are outside the scope of these status normalization changes).
- Ran `pnpm build` which encountered environment/network font fetch issues during Next build and did not complete (this is an environment/runtime issue, not caused by the code changes).
- Ran `pnpm audit:api-routes` which completed successfully and refreshed the audit reports included in `docs/audits/*`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7f230f9883289128ccd35fd3b5dc)