### PR TITLE
Stabilize Work Order command feed and add dashboard entry route

### DIFF
--- a/app/dashboard/work-orders/page.tsx
+++ b/app/dashboard/work-orders/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DashboardWorkOrdersPage() {
+  redirect("/work-orders/view");
+}

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,6 +1,6 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-05-21T22:05:58.096Z
+Generated: 2026-05-21T22:17:42.743Z
 
 ## Summary
 - Total route count: **335**

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -7,6 +7,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { toast } from "sonner";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
 
 import { WorkOrderAssignedSummary } from "@/features/work-orders/components/WorkOrderAssignedSummary";
 import StatusPickerModal, {
@@ -726,7 +727,7 @@ export default function WorkOrdersView(): JSX.Element {
               Work Orders
             </h1>
             <p className="mt-2 text-sm text-neutral-300">
-              Advisor view with full actions. Same workflow logic, updated board-style layout.
+              Live repair jobs across inspection, approval, parts, technician work, and invoicing.
             </p>
 
             {!loading && !err ? (
@@ -874,6 +875,18 @@ export default function WorkOrdersView(): JSX.Element {
             const reviewedOk = Boolean(review?.ok);
             const issueCount = review?.issues?.length ?? 0;
             const techRollup = techRollupByWo[r.id] ?? "awaiting";
+            const canonicalStatus = normalizeWorkOrderStatus(r.status);
+            const nextAction =
+              canonicalStatus === "new" ? (r.assigned_tech ? "Start inspection" : "Assign technician") :
+              canonicalStatus === "awaiting_inspection" ? "Open inspection" :
+              canonicalStatus === "awaiting_approval" ? "Review approval" :
+              canonicalStatus === "approved" ? (r.assigned_tech ? "Start work" : "Schedule work") :
+              canonicalStatus === "in_progress" ? "Continue work" :
+              canonicalStatus === "waiting_parts" ? "Check parts" :
+              canonicalStatus === "ready_to_invoice" ? "Create invoice" :
+              canonicalStatus === "invoiced" ? "Review invoice" :
+              canonicalStatus === "completed" ? "View record" : "View cancelled";
+            const staleDays = Math.max(0, Math.floor((Date.now() - new Date(r.updated_at ?? r.created_at ?? Date.now()).getTime()) / 86400000));
 
             const accent = stageAccent(r.status);
             const priority = priorityLabel(r.priority);
@@ -908,7 +921,7 @@ export default function WorkOrdersView(): JSX.Element {
                       <span
                         className={`rounded-full border px-2 py-0.5 text-[11px] font-bold ${accent.badge}`}
                       >
-                        {(r.status ?? "awaiting").replaceAll("_", " ")}
+                        {normalizeWorkOrderStatus(r.status).replaceAll("_", " ")}
                       </span>
 
                       <span
@@ -983,6 +996,19 @@ export default function WorkOrdersView(): JSX.Element {
 
                 <div className="mt-4 flex min-h-[30px] items-center">
                   <WorkOrderAssignedSummary workOrderId={r.id} />
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+                  {canonicalStatus === "awaiting_approval" ? <span className="rounded-full border border-blue-400/50 bg-blue-500/10 px-2 py-0.5 text-blue-100">Needs approval</span> : null}
+                  {canonicalStatus === "waiting_parts" || techRollup === "on_hold" ? <span className="rounded-full border border-sky-400/45 bg-sky-500/10 px-2 py-0.5 text-sky-100">Waiting parts</span> : null}
+                  {!r.assigned_tech ? <span className="rounded-full border border-amber-400/50 bg-amber-500/10 px-2 py-0.5 text-amber-100">No technician assigned</span> : null}
+                  {!r.inspection_id ? <span className="rounded-full border border-indigo-400/45 bg-indigo-500/10 px-2 py-0.5 text-indigo-100">Inspection pending</span> : null}
+                  {canonicalStatus === "ready_to_invoice" ? <span className="rounded-full border border-emerald-400/60 bg-emerald-500/10 px-2 py-0.5 text-emerald-100">Ready to invoice</span> : null}
+                  {staleDays >= 3 ? <span className="rounded-full border border-red-400/45 bg-red-500/10 px-2 py-0.5 text-red-100">Stale {staleDays}d</span> : null}
+                </div>
+
+                <div className="mt-3 text-xs text-neutral-300">
+                  Next action: <span className="font-semibold text-white">{nextAction}</span>
                 </div>
 
                 <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
### Motivation
- Make the Work Orders surface a reliable operational command feed that uses the new canonical status normalization and makes next actions / attention states obvious for advisors/managers without changing business logic or RLS.
- Surface lightweight triage indicators (approval, parts, tech assignment, inspection, stale) and next-action guidance so teams can prioritize work quickly.
- Preserve existing links and dashboard compatibility by adding a non-breaking dashboard entry route rather than creating a parallel page.

### Description
- Updated the advisor-facing Work Orders board to use `normalizeWorkOrderStatus` for canonical lifecycle labels and to display normalized status on each card. (file: `features/work-orders/app/work-orders/view/page.tsx`).
- Added operational attention chips per card (Needs approval, Waiting parts, No technician assigned, Inspection pending, Ready to invoice, Stale Xd) and a small next-action helper to recommend the next step based on canonical state. (file: `features/work-orders/app/work-orders/view/page.tsx`).
- Adjusted feed header copy to emphasize the page as a live operational command surface and kept all existing actions/links intact. (file: `features/work-orders/app/work-orders/view/page.tsx`).
- Added a safe dashboard entry route that redirects `/dashboard/work-orders` → `/work-orders/view` to preserve CTAs and widget compatibility. (file: `app/dashboard/work-orders/page.tsx`).
- Regenerated API route audit artifacts via `pnpm audit:api-routes` (updated `docs/audits/api-route-boundary-inventory.md`).
- No database/schema changes, no RLS or service-role changes, and no large architectural rewrites were introduced.

### Testing
- Ran `pnpm typecheck` and it passed with no new type errors.
- Ran `pnpm lint` which failed due to pre-existing repository lint problems (report shows 14 errors / 407 warnings) and no new lint regressions were introduced by this patch.
- Ran `pnpm test` which failed due to pre-existing test failures in the onboarding history suite (the failing tests are outside the scope of this UI patch).
- Ran `pnpm build` which did not complete in this environment because the build is blocked by Google Fonts network fetch errors for `Inter` and `Black Ops One` (environment/network issue, not changes in this patch).
- Ran `pnpm audit:api-routes` which completed and regenerated `docs/audits/api-route-boundary-inventory.md` and `.json` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f83b3a01083288dae591337294d80)