### PR TITLE
JobCard: Expose Delete / Void action to trigger parent modal

### DIFF
--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type JSX } from "react";
+import { useEffect, useMemo, useState, type JSX, type MouseEvent } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { ChevronDown, ChevronUp, CircleAlert, CircleCheck, Wrench } from "lucide-react";
 
@@ -362,8 +362,12 @@ export function JobCard({
   const isBlocked = norm(line.status) === "on_hold" || norm(line.status) === "blocked";
   const waitingApproval = norm(line.approval_state) === "pending";
 
-  void canDelete;
-  void onDelete;
+  const showDeleteAction = canDelete === true && typeof onDelete === "function";
+
+  const handleDeleteActionClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onDelete?.();
+  };
 
   return (
     <div
@@ -456,6 +460,17 @@ export function JobCard({
                 {onAddPart ? (
                   <Button type="button" variant="secondary" size="sm" onClick={onAddPart}>
                     Add Part
+                  </Button>
+                ) : null}
+
+                {showDeleteAction ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleDeleteActionClick}
+                  >
+                    Delete / Void
                   </Button>
                 ) : null}
 


### PR DESCRIPTION
### Motivation
- Restore the parent-controlled delete/void flow by surfacing an in-card action so the existing modal and API can be reached from the job card without duplicating safety logic.

### Description
- Modified `features/work-orders/components/JobCard.tsx` to remove the `void canDelete; void onDelete;` no-ops and add a conditional `Delete / Void` button that appears when `canDelete === true` and `typeof onDelete === 'function'`, and implemented `handleDeleteActionClick` which calls `event.stopPropagation()` then `onDelete()` so the card’s `onOpen` behavior is preserved; no new files or routes were added and no modal/API logic was duplicated.

### Testing
- Ran `pnpm typecheck` (succeeded), `pnpm lint` (failed due to pre-existing repository lint issues outside this file), `pnpm test` (failed due to pre-existing failing tests unrelated to this change), and `pnpm build` (failed due to environment/font fetch issue during Next.js build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc28a4b308328a8e8973452eb98eb)