### PR TITLE
Replace direct work order status write with canonical approval flow

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1172,23 +1172,6 @@ export default function WorkOrderIdClient(): JSX.Element {
         return;
       }
 
-      const workOrderId =
-        (typeof json.workOrderId === "string" && json.workOrderId.trim().length > 0
-          ? json.workOrderId
-          : null) ?? wo?.id ?? null;
-
-      if (workOrderId) {
-        const { error: woErr } = await supabase
-          .from("work_orders")
-          .update({ status: "queued" } as DB["public"]["Tables"]["work_orders"]["Update"])
-          .eq("id", workOrderId);
-
-        if (woErr) {
-          // eslint-disable-next-line no-console
-          console.error("[approveLine] failed to update work order status", woErr);
-        }
-      }
-
       toast.success("Line approved");
       void fetchAll();
     },


### PR DESCRIPTION
### Motivation
- Centralize status transitions to the backend approval flow and remove a legacy client-side `supabase` write that directly updated `work_orders.status`.

### Description
- Removed the client-side `supabase.from('work_orders').update({ status: 'queued' })` call from `approveLine` in `app/work-orders/[id]/Client.tsx` so the existing `POST /api/work-orders/lines/[lineId]/approval-decision` route remains the canonical status writer.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc4b3d9ec8328a99d3cdbcf27e5a1)