### PR TITLE
Harden quote authorization route idempotency

### DIFF
--- a/app/api/work-orders/quotes/[id]/authorize/route.ts
+++ b/app/api/work-orders/quotes/[id]/authorize/route.ts
@@ -11,6 +11,8 @@ export const runtime = "nodejs";
 type DB = Database;
 type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
 
+const NON_CONVERTIBLE_STATUSES = new Set(["declined", "deferred", "rejected", "cancelled"]);
+
 export async function POST(req: NextRequest) {
   const supabase = createRouteHandlerClient<DB>({ cookies });
 
@@ -49,7 +51,9 @@ export async function POST(req: NextRequest) {
     // 1) Load the quote line we’re authorizing
     const { data: q, error: qErr } = await supabase
       .from("work_order_quote_lines")
-      .select("*")
+      .select(
+        "id, shop_id, work_order_id, work_order_line_id, status, vehicle_id, description, job_type, est_labor_hours, ai_complaint, ai_cause, ai_correction",
+      )
       .eq("id", id)
       .single();
 
@@ -61,6 +65,39 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Quote line is missing shop_id" }, { status: 400 });
     }
     if (q.shop_id !== profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if ((q.status && NON_CONVERTIBLE_STATUSES.has(q.status)) ?? false) {
+      return NextResponse.json(
+        { error: `Quote line cannot be authorized from status '${q.status}'` },
+        { status: 409 },
+      );
+    }
+
+    if (q.status === "converted" || q.work_order_line_id) {
+      return NextResponse.json({
+        ok: true,
+        alreadyConverted: true,
+        workOrderLineId: q.work_order_line_id ?? null,
+      });
+    }
+
+    const { data: workOrder, error: workOrderErr } = await supabase
+      .from("work_orders")
+      .select("id, shop_id")
+      .eq("id", q.work_order_id)
+      .maybeSingle();
+
+    if (workOrderErr) {
+      return NextResponse.json({ error: workOrderErr.message }, { status: 500 });
+    }
+
+    if (!workOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+    }
+
+    if (workOrder.shop_id !== profile.shop_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -88,17 +125,26 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: insErr.message }, { status: 500 });
     }
 
-    // 3) Mark quote line as converted
+    // 3) Mark quote line as converted and point to created work order line
     const { error: updErr } = await supabase
       .from("work_order_quote_lines")
-      .update({ status: "converted", updated_at: new Date().toISOString() })
+      .update({
+        status: "converted",
+        work_order_line_id: inserted?.id ?? null,
+        updated_at: new Date().toISOString(),
+      })
       .eq("id", id);
 
     if (updErr) {
+      console.error("Failed to update quote line after authorize insert", {
+        quoteLineId: id,
+        insertedWorkOrderLineId: inserted?.id ?? null,
+        error: updErr.message,
+      });
       return NextResponse.json({ error: updErr.message }, { status: 500 });
     }
 
-    return NextResponse.json({ ok: true, jobLineId: inserted?.id ?? null });
+    return NextResponse.json({ ok: true, workOrderLineId: inserted?.id ?? null });
   } catch {
     return NextResponse.json({ error: "Failed to authorize" }, { status: 500 });
   }


### PR DESCRIPTION
### Motivation
- Prevent duplicate active `work_order_lines` being created by repeated submits to the quote authorize endpoint. 
- Ensure the authorize handler is idempotent and respects quote terminal states that must not be converted. 
- Enforce that the target `work_order` belongs to the same shop as the acting profile to preserve tenant isolation. 

### Description
- Load explicit quote fields via `SELECT id, shop_id, work_order_id, work_order_line_id, status, vehicle_id, description, job_type, est_labor_hours, ai_complaint, ai_cause, ai_correction` before conversion checks. 
- Block conversion and return `409` for terminal statuses in the set `declined`, `deferred`, `rejected`, `cancelled` via `NON_CONVERTIBLE_STATUSES`. 
- If `quote.status === "converted"` OR `quote.work_order_line_id` is set, return `{ ok: true, alreadyConverted: true, workOrderLineId }` and do not insert a new line. 
- Verify the `work_orders` row exists and its `shop_id` matches the actor `profile.shop_id` before inserting the `work_order_lines` row, returning `404`/`403` as appropriate. 
- Preserve the existing `work_order_lines` insert shape (copied AI fields, `status`, `labor_time`, etc.) and then update the quote to set `status: "converted"`, `work_order_line_id`, and `updated_at` on success. 
- Add contextual `console.error` logging when the quote update fails after an insert to aid debugging, and preserve existing auth/role/shop checks and all external flows (no parts/menu/inspection/AI behavior added). 

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `pnpm typecheck` (which runs `tsc --noEmit`) and it completed successfully. 

Remaining risk: the insert + quote update is still non-atomic by design in this patch, so if the quote update fails after a successful insert a `work_order_lines` row may exist without the `work_order_quote_lines.work_order_line_id` linkage and will require reconciliation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc91765f48328b870b5ad73ac8808)