### PR TITLE
Add schema foundation for inspection import source linkage keys

### DIFF
--- a/db/sql/2026-05-22_work_order_inspection_import_source_keys.sql
+++ b/db/sql/2026-05-22_work_order_inspection_import_source_keys.sql
@@ -1,0 +1,78 @@
+-- Foundation schema for durable inspection-import idempotency and audit traceability.
+-- Adds nullable source linkage fields only; importer behavior changes are intentionally deferred.
+
+alter table public.work_order_lines
+  add column if not exists source_inspection_id uuid,
+  add column if not exists source_inspection_item_key text;
+
+comment on column public.work_order_lines.source_inspection_id is
+  'Identifies the inspection result that produced the imported work_order_lines row for idempotent import and audit traceability; does not replace source_intake_id/source_row_id.';
+
+comment on column public.work_order_lines.source_inspection_item_key is
+  'Deterministic key derived from the saved inspection result item for idempotent import and audit traceability; does not replace source_intake_id/source_row_id.';
+
+alter table public.parts_requests
+  add column if not exists source_inspection_id uuid,
+  add column if not exists source_inspection_item_key text;
+
+comment on column public.parts_requests.source_inspection_id is
+  'Identifies the inspection result that produced the imported parts_requests row for idempotent import and audit traceability; does not replace source_intake_id/source_row_id.';
+
+comment on column public.parts_requests.source_inspection_item_key is
+  'Deterministic key derived from the saved inspection result item for idempotent import and audit traceability; does not replace source_intake_id/source_row_id.';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'work_order_lines_source_inspection_id_fkey'
+      and conrelid = 'public.work_order_lines'::regclass
+  ) then
+    alter table public.work_order_lines
+      add constraint work_order_lines_source_inspection_id_fkey
+      foreign key (source_inspection_id)
+      references public.inspections(id)
+      on delete set null;
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'parts_requests_source_inspection_id_fkey'
+      and conrelid = 'public.parts_requests'::regclass
+  ) then
+    alter table public.parts_requests
+      add constraint parts_requests_source_inspection_id_fkey
+      foreign key (source_inspection_id)
+      references public.inspections(id)
+      on delete set null;
+  end if;
+end $$;
+
+create index if not exists idx_wol_wo_source_inspection_lookup
+  on public.work_order_lines (work_order_id, source_inspection_id, source_inspection_item_key);
+
+create index if not exists idx_parts_requests_wo_source_inspection_lookup
+  on public.parts_requests (work_order_id, source_inspection_id, source_inspection_item_key);
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'work_order_lines'
+      and column_name = 'voided_at'
+  ) then
+    execute $stmt$
+      create unique index if not exists uq_wol_active_import_source_key
+        on public.work_order_lines (work_order_id, source_inspection_id, source_inspection_item_key)
+      where source_inspection_id is not null
+        and source_inspection_item_key is not null
+        and voided_at is null
+    $stmt$;
+  else
+    raise notice 'Skipping uq_wol_active_import_source_key: public.work_order_lines.voided_at is not present.';
+  end if;
+end $$;


### PR DESCRIPTION
### Motivation
- Provide explicit nullable source linkage fields to enable deterministic, idempotent inspection imports in a future pass. 
- Create a non-invasive, additive schema foundation without changing importer logic or runtime behavior. 
- Preserve existing import identity fields and tenant boundaries by not repurposing `source_intake_id`/`source_row_id`. 

### Description
- Added a new additive SQL migration `db/sql/2026-05-22_work_order_inspection_import_source_keys.sql` that adds nullable columns `source_inspection_id uuid` and `source_inspection_item_key text` to `public.work_order_lines` and `public.parts_requests`. 
- Added column comments on all four new columns describing their idempotency/audit purpose and explicitly stating they do not replace `source_intake_id`/`source_row_id`. 
- Added defensive foreign keys (if not already present) from `work_order_lines.source_inspection_id` and `parts_requests.source_inspection_id` to `public.inspections(id)` with `ON DELETE SET NULL`. 
- Created lookup indexes `idx_wol_wo_source_inspection_lookup` and `idx_parts_requests_wo_source_inspection_lookup` on `(work_order_id, source_inspection_id, source_inspection_item_key)`, and added a guarded unique partial index `uq_wol_active_import_source_key` on `work_order_lines(work_order_id, source_inspection_id, source_inspection_item_key)` for active rows only when `voided_at` exists (otherwise the index is skipped). 
- Made migration idempotent via `IF NOT EXISTS` for columns/indexes and `DO $$` guards before adding constraints or conditional unique index. 

### Testing
- Ran `npx tsc --noEmit` and it completed successfully after restoring the pre-existing generated types file. 
- Attempted `pnpm typegen` to regenerate Supabase types but it failed due to environment package fetch (403), so no generated type files were updated or committed. 
- No automated migration run against a live DB was performed in this change; migration is defensive and additive to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcd19155c8328b3426efc9d9ceef2)