### PR TITLE
Idempotent inspection import via deterministic source keys and dedupe

### DIFF
--- a/app/api/work-orders/import-from-inspection/route.ts
+++ b/app/api/work-orders/import-from-inspection/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
     // Ensure requester can see the WO (RLS enforced).
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
-      .select("id, shop_id")
+      .select("id, shop_id, vehicle_id")
       .eq("id", workOrderId)
       .maybeSingle<{ id: string; shop_id: string | null }>();
 
@@ -54,6 +54,30 @@ export async function POST(req: Request) {
     }
     if (!wo) {
       return NextResponse.json({ error: "Work order not found." }, { status: 404 });
+    }
+
+    const { data: inspection, error: inspectionErr } = await supabase
+      .from("inspections")
+      .select("id, shop_id")
+      .eq("id", inspectionId)
+      .maybeSingle<{ id: string; shop_id: string | null }>();
+
+    if (inspectionErr) {
+      return NextResponse.json(
+        { error: `Failed to load inspection: ${inspectionErr.message}` },
+        { status: 400 },
+      );
+    }
+
+    if (!inspection) {
+      return NextResponse.json({ error: "Inspection not found." }, { status: 404 });
+    }
+
+    if (!inspection.shop_id || inspection.shop_id !== wo.shop_id) {
+      return NextResponse.json(
+        { error: "Inspection does not belong to this work order's shop." },
+        { status: 403 },
+      );
     }
 
     const res = await insertPrioritizedJobsFromInspection({
@@ -73,6 +97,8 @@ export async function POST(req: Request) {
       ok: true,
       insertedCount: res.insertedCount,
       partsRequestsCount: res.partsRequestsCount,
+      skippedCount: res.skippedCount,
+      skippedPartsRequestsCount: res.skippedPartsRequestsCount,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
+++ b/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
@@ -1,12 +1,6 @@
-// features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
-// SERVER-SAFE canonical import-from-inspection implementation.
-// - Uses a SupabaseClient passed in from the API route (no browser client)
-// - Batch inserts work_order_lines
-// - Optionally creates parts_requests
-// - Uses AI labor estimate (estimateLabor)
-
 import "server-only";
 
+import crypto from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { estimateLabor } from "@ai/lib/ai/estimateLabor";
@@ -18,11 +12,22 @@ type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
 type WorkOrderLineInsert = DB["public"]["Tables"]["work_order_lines"]["Insert"];
 type PartsRequestInsert = DB["public"]["Tables"]["parts_requests"]["Insert"];
 
+type WorkOrderLineSourceInsert = WorkOrderLineInsert & {
+  source_inspection_id: string;
+  source_inspection_item_key: string;
+};
+
+type PartsRequestSourceInsert = PartsRequestInsert & {
+  source_inspection_id: string;
+  source_inspection_item_key: string;
+};
+
 type InspectionResult = {
   sections: Array<{
     title: string;
     items: Array<{
       name: string;
+      label?: string;
       value?: string;
       unit?: string;
       notes?: string;
@@ -42,8 +47,38 @@ export type ImportFromInspectionArgs = {
 };
 
 export type ImportFromInspectionResult =
-  | { ok: true; insertedCount: number; partsRequestsCount: number }
+  | {
+      ok: true;
+      insertedCount: number;
+      partsRequestsCount: number;
+      skippedCount: number;
+      skippedPartsRequestsCount: number;
+    }
   | { ok: false; error: string };
+
+function normalizeSourceComponent(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function buildInspectionSourceKey(args: {
+  inspectionId: string;
+  sectionIndex: number;
+  itemIndex: number;
+  sectionTitle?: string;
+  itemName?: string;
+  itemLabel?: string;
+  unit?: string;
+}): string {
+  const normalizedSectionTitle = normalizeSourceComponent(args.sectionTitle);
+  const normalizedItemName = normalizeSourceComponent(args.itemName || args.itemLabel);
+  const normalizedUnit = normalizeSourceComponent(args.unit);
+  const raw = `${args.inspectionId}|${args.sectionIndex}|${args.itemIndex}|${normalizedSectionTitle}|${normalizedItemName}|${normalizedUnit}`;
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+function normalizePartName(value: string | null | undefined): string {
+  return normalizeSourceComponent(value);
+}
 
 export async function insertPrioritizedJobsFromInspection(
   args: ImportFromInspectionArgs,
@@ -57,7 +92,6 @@ export async function insertPrioritizedJobsFromInspection(
     autoGenerateParts = true,
   } = args;
 
-  // 1) Load inspection
   const { data: inspection, error: inspErr } = await supabase
     .from("inspections")
     .select("*")
@@ -77,7 +111,6 @@ export async function insertPrioritizedJobsFromInspection(
 
   const shopId = inspection.shop_id;
 
-  // Some generated supabase types don't include `result` on inspections.Row.
   const result = (inspection as unknown as { result?: unknown })?.result as
     | InspectionResult
     | undefined;
@@ -86,7 +119,6 @@ export async function insertPrioritizedJobsFromInspection(
     return { ok: false, error: "Invalid inspection format: missing sections." };
   }
 
-  // 2) Build jobs
   const diagnosisKeywords = ["check engine", "diagnose", "misfire", "no start"];
   const maintenanceKeywords = ["oil", "fluid", "filter", "belt", "coolant"];
   const autoPartsKeywords = [
@@ -99,14 +131,16 @@ export async function insertPrioritizedJobsFromInspection(
     "belt",
   ];
 
-  const allJobs: WorkOrderLineInsert[] = [];
+  const allJobs: WorkOrderLineSourceInsert[] = [];
   const jobItemMap: Array<{
     originalItem: InspectionResult["sections"][number]["items"][number];
+    sourceKey: string;
   }> = [];
 
-  for (const section of result.sections) {
-    for (const item of section.items) {
-      const nameLower = (item.name ?? "").toLowerCase();
+  for (const [sectionIndex, section] of result.sections.entries()) {
+    for (const [itemIndex, item] of section.items.entries()) {
+      const itemName = item.name || item.label || "";
+      const nameLower = itemName.toLowerCase();
       let jobType: WorkOrderLineInsert["job_type"] = "repair";
 
       if (diagnosisKeywords.some((k) => nameLower.includes(k))) jobType = "diagnosis";
@@ -118,14 +152,24 @@ export async function insertPrioritizedJobsFromInspection(
 
       if (!shouldInclude) continue;
 
-      const laborTime = normalizeLaborHoursInput(await estimateLabor(item.name, jobType), true);
+      const sourceKey = buildInspectionSourceKey({
+        inspectionId,
+        sectionIndex,
+        itemIndex,
+        sectionTitle: section.title,
+        itemName: item.name,
+        itemLabel: item.label,
+        unit: item.unit,
+      });
+
+      const laborTime = normalizeLaborHoursInput(await estimateLabor(itemName, jobType), true);
 
       const complaintParts: string[] = [];
-      if (item.name) complaintParts.push(item.name);
+      if (itemName) complaintParts.push(itemName);
       if (item.value) complaintParts.push(`(${item.value}${item.unit || ""})`);
       if (item.notes) complaintParts.push(`- ${item.notes}`);
 
-      const job: WorkOrderLineInsert = {
+      const job: WorkOrderLineSourceInsert = {
         shop_id: shopId,
         work_order_id: workOrderId,
         vehicle_id: vehicleId,
@@ -137,22 +181,66 @@ export async function insertPrioritizedJobsFromInspection(
         hold_reason: null,
         assigned_tech_id: null,
         labor_time: laborTime,
+        source_inspection_id: inspectionId,
+        source_inspection_item_key: sourceKey,
       };
 
       allJobs.push(job);
-      jobItemMap.push({ originalItem: item });
+      jobItemMap.push({ originalItem: item, sourceKey });
     }
   }
 
   if (allJobs.length === 0) {
-    return { ok: true, insertedCount: 0, partsRequestsCount: 0 };
+    return { ok: true, insertedCount: 0, partsRequestsCount: 0, skippedCount: 0, skippedPartsRequestsCount: 0 };
   }
 
-  // 3) Insert jobs (batch)
+  const sourceKeys = allJobs.map((job) => job.source_inspection_item_key);
+
+  const { data: existingActiveLines, error: existingLinesErr } = await supabase
+    .from("work_order_lines")
+    .select("id, source_inspection_item_key")
+    .eq("work_order_id", workOrderId)
+    .eq("source_inspection_id", inspectionId)
+    .in("source_inspection_item_key", sourceKeys)
+    .is("voided_at", null)
+    .returns<Array<{ id: string; source_inspection_item_key: string | null }>>();
+
+  if (existingLinesErr) {
+    return {
+      ok: false,
+      error: `Error checking existing inspection lines: ${existingLinesErr.message}`,
+    };
+  }
+
+  const existingKeySet = new Set(
+    (existingActiveLines ?? [])
+      .map((row) => row.source_inspection_item_key)
+      .filter((key): key is string => Boolean(key)),
+  );
+
+  const jobsToInsert: WorkOrderLineSourceInsert[] = [];
+  const jobItemMapToInsert: Array<{
+    originalItem: InspectionResult["sections"][number]["items"][number];
+    sourceKey: string;
+  }> = [];
+
+  for (let i = 0; i < allJobs.length; i++) {
+    const sourceKey = allJobs[i].source_inspection_item_key;
+    if (existingKeySet.has(sourceKey)) continue;
+    jobsToInsert.push(allJobs[i]);
+    jobItemMapToInsert.push(jobItemMap[i]);
+  }
+
+  const skippedCount = allJobs.length - jobsToInsert.length;
+
+  if (jobsToInsert.length === 0) {
+    return { ok: true, insertedCount: 0, partsRequestsCount: 0, skippedCount, skippedPartsRequestsCount: 0 };
+  }
+
   const insertedJobsRes = await supabase
     .from("work_order_lines")
-    .insert(allJobs)
-    .select("id, complaint");
+    .insert(jobsToInsert)
+    .select("id, complaint, source_inspection_item_key");
 
   if (insertedJobsRes.error) {
     return {
@@ -163,24 +251,26 @@ export async function insertPrioritizedJobsFromInspection(
 
   const insertedJobs = insertedJobsRes.data ?? [];
   let partsRequestsCount = 0;
+  let skippedPartsRequestsCount = 0;
 
-  // 4) Optional parts_requests
   if (autoGenerateParts && insertedJobs.length > 0) {
-    const partsRequests: PartsRequestInsert[] = [];
+    const partsCandidates: PartsRequestSourceInsert[] = [];
 
     for (let i = 0; i < insertedJobs.length; i++) {
       const { complaint, id: jobId } = insertedJobs[i];
-      const originalItem = jobItemMap[i]?.originalItem;
+      const originalItem = jobItemMapToInsert[i]?.originalItem;
+      const sourceKey = jobItemMapToInsert[i]?.sourceKey;
 
       const lower = (complaint ?? "").toLowerCase();
-      if (!originalItem?.name) continue;
+      const partName = originalItem?.name || originalItem?.label;
+      if (!partName || !sourceKey) continue;
 
       if (autoPartsKeywords.some((k) => lower.includes(k))) {
-        partsRequests.push({
+        partsCandidates.push({
           id: crypto.randomUUID(),
           job_id: jobId,
           work_order_id: workOrderId,
-          part_name: originalItem.name,
+          part_name: partName,
           quantity: 1,
           urgency: "medium",
           notes: "Auto-generated from inspection",
@@ -190,19 +280,57 @@ export async function insertPrioritizedJobsFromInspection(
           viewed_at: null,
           fulfilled_at: null,
           archived: false,
+          source_inspection_id: inspectionId,
+          source_inspection_item_key: sourceKey,
         });
       }
     }
 
-    if (partsRequests.length > 0) {
-      const { error: partsErr } = await supabase
-        .from("parts_requests")
-        .insert(partsRequests);
+    if (partsCandidates.length > 0) {
+      const sourceKeysForParts = [...new Set(partsCandidates.map((row) => row.source_inspection_item_key))];
 
-      if (!partsErr) {
-        partsRequestsCount = partsRequests.length;
+      const { data: existingParts, error: existingPartsErr } = await supabase
+        .from("parts_requests")
+        .select("source_inspection_item_key, part_name")
+        .eq("work_order_id", workOrderId)
+        .eq("source_inspection_id", inspectionId)
+        .in("source_inspection_item_key", sourceKeysForParts)
+        .returns<Array<{ source_inspection_item_key: string | null; part_name: string | null }>>();
+
+      if (existingPartsErr) {
+        return {
+          ok: false,
+          error: `Error checking existing parts requests: ${existingPartsErr.message}`,
+        };
       }
-      // non-fatal if parts insert fails
+
+      const existingPartSet = new Set(
+        (existingParts ?? [])
+          .filter((row) => row.source_inspection_item_key)
+          .map(
+            (row) =>
+              `${row.source_inspection_item_key}|${normalizePartName(row.part_name)}`,
+          ),
+      );
+
+      const partsToInsert = partsCandidates.filter((row) => {
+        const dedupeKey = `${row.source_inspection_item_key}|${normalizePartName(row.part_name)}`;
+        if (existingPartSet.has(dedupeKey)) return false;
+        existingPartSet.add(dedupeKey);
+        return true;
+      });
+
+      skippedPartsRequestsCount = partsCandidates.length - partsToInsert.length;
+
+      if (partsToInsert.length > 0) {
+        const { error: partsErr } = await supabase
+          .from("parts_requests")
+          .insert(partsToInsert);
+
+        if (!partsErr) {
+          partsRequestsCount = partsToInsert.length;
+        }
+      }
     }
   }
 
@@ -210,5 +338,7 @@ export async function insertPrioritizedJobsFromInspection(
     ok: true,
     insertedCount: insertedJobs.length,
     partsRequestsCount,
+    skippedCount,
+    skippedPartsRequestsCount,
   };
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate `work_order_lines` and `parts_requests` when the same inspection is imported multiple times by introducing durable source linkage per inspection item. 
- Use a deterministic, content-stable key derived from the saved inspection JSON to reliably identify identical inspection items across repeated imports. 
- Keep existing import behavior and integrations intact while adding an idempotent layer that can be applied without changing generated Supabase types or broader app flows. 

### Description
- Added deterministic source-key logic in `insertPrioritizedJobsFromInspection` using `node:crypto` with `sha256` over `inspectionId|sectionIndex|itemIndex|normalizedSectionTitle|normalizedItemName|normalizedUnit` implemented in `buildInspectionSourceKey` and `normalizeSourceComponent`. 
- Attach durable linkage by setting `source_inspection_id` and `source_inspection_item_key` on inserted `work_order_lines` and on auto-generated `parts_requests` using local narrow types `WorkOrderLineSourceInsert` and `PartsRequestSourceInsert`. 
- Implement pre-insert dedupe for lines by querying existing active (non-voided) rows via `.eq('work_order_id', ...)`, `.eq('source_inspection_id', ...)`, `.in('source_inspection_item_key', ...)`, `.is('voided_at', null)` and skip inserting items whose source keys already exist. 
- Implement parts-request dedupe by collecting `partsCandidates`, querying `parts_requests` for the same `work_order_id`+`source_inspection_id`+`source_inspection_item_key`, and deduping by a composed key of `source_inspection_item_key|normalized(part_name)` before inserting only missing requests. 
- Route validation: preserved auth and RLS and added explicit inspection existence and ownership check in `app/api/work-orders/import-from-inspection/route.ts` to ensure `inspection.shop_id === work_order.shop_id`. 
- Response shape preserved and extended non-breakingly to include `skippedCount` and `skippedPartsRequestsCount`. 
- Did not modify generated Supabase types; used local type extensions to add the new source columns to insert payloads to avoid committing generated type changes while typegen remains environment-constrained. 

Files changed: `app/api/work-orders/import-from-inspection/route.ts`, `features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts`.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `pnpm typecheck` (project `tsc --noEmit`) and it completed successfully. 

Remaining risks / follow-ups (not part of automated tests): add DB-side uniqueness/transactional migration or an RPC to eliminate read/insert race windows; confirm generated Supabase types include new columns in CI/dev environments and update typegen if/when available; consider optional stricter vehicle compatibility checks if schema/data guarantee is required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcf045e5c832892afd420b6ca946a)