### PR TITLE
Normalize legacy queued status write in quote approval webhook

### DIFF
--- a/app/api/quotes/approval-webhook/route.ts
+++ b/app/api/quotes/approval-webhook/route.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import type { Database } from "@shared/types/types/supabase";
 import { applyAndPropagateWorkOrderLineApprovalDecision } from "@/features/work-orders/server/workOrderLineApproval";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
 
 type DB = Database;
 type Json = Record<string, unknown>;
@@ -189,8 +190,8 @@ export async function POST(req: Request) {
     const approvedAt = workOrder.customer_approval_at ?? new Date().toISOString();
     const nextStatus =
       workOrder.status === "awaiting_approval" || workOrder.status === "awaiting"
-        ? "queued"
-        : (workOrder.status ?? "queued");
+        ? normalizeWorkOrderStatus("queued")
+        : normalizeWorkOrderStatus(workOrder.status ?? "queued");
 
     let woUpdateQuery = supabase
       .from("work_orders")


### PR DESCRIPTION
### Motivation
- Ensure persisted work order status uses the canonical normalization function instead of writing the legacy literal `"queued"` when a quote approval updates a work order.

### Description
- In `app/api/quotes/approval-webhook/route.ts` import `normalizeWorkOrderStatus` and replace the direct `"queued"` / raw `workOrder.status ?? "queued"` assignment with `normalizeWorkOrderStatus("queued")` and `normalizeWorkOrderStatus(workOrder.status ?? "queued")`, keeping all other webhook logic unchanged.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd20d54d88328a5d0e81476b5524a)