### PR TITLE
Normalize JobCard display status interpretation using shared line-status helper

### DIFF
--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -8,6 +8,7 @@ import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 import Card from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/utils";
+import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
 
 type WorkOrderLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
 type WorkOrderPartAllocation =
@@ -104,8 +105,9 @@ function statusLabelFromKey(status: string): string {
 
 function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boolean): StatusVisual {
   const raw = norm(status).replaceAll("-", "_");
+  const normalized = normalizeWorkOrderLineStatus(status);
 
-  if (isPunchedIn || raw === "in_progress" || raw === "active") {
+  if (isPunchedIn || normalized === "in_progress" || raw === "active") {
     return {
       label: "Active",
       railClass: "bg-cyan-400/90",
@@ -117,13 +119,9 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
     };
   }
 
-  if (
-    raw === "completed" ||
-    raw === "ready_to_invoice" ||
-    raw === "invoiced"
-  ) {
+  if (normalized === "completed" || normalized === "ready_to_invoice" || normalized === "invoiced") {
     return {
-      label: statusLabelFromKey(raw),
+      label: statusLabelFromKey(normalized),
       railClass: "bg-slate-400/75",
       chipClass: "border-slate-400/55 bg-slate-500/10 text-slate-200",
       orbClass: "bg-slate-300",
@@ -133,7 +131,7 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
     };
   }
 
-  if (raw === "on_hold") {
+  if (normalized === "on_hold") {
     return {
       label: "On Hold",
       railClass: "bg-amber-400/90",
@@ -145,7 +143,7 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
     };
   }
 
-  if (raw === "waiting_parts" || raw === "pending_parts") {
+  if (normalized === "waiting_parts" || raw === "pending_parts") {
     return {
       label: "Waiting Parts",
       railClass: "bg-indigo-400/90",
@@ -157,7 +155,7 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
     };
   }
 
-  if (raw === "awaiting_approval" || raw === "needs_approval") {
+  if (normalized === "awaiting_approval" || raw === "needs_approval") {
     return {
       label: "Awaiting Approval",
       railClass: "bg-amber-500/90",
@@ -169,9 +167,9 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
     };
   }
 
-  if (raw === "blocked" || raw === "declined" || raw === "critical") {
+  if (raw === "blocked" || raw === "critical" || normalized === "declined" || normalized === "deferred") {
     return {
-      label: "Blocked",
+      label: normalized === "deferred" ? "Deferred" : normalized === "declined" ? "Declined" : "Blocked",
       railClass: "bg-red-400/90",
       chipClass: "border-red-300/60 bg-red-500/12 text-red-100",
       orbClass: "bg-red-300",
@@ -181,9 +179,9 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
     };
   }
 
-  if (raw === "queued" || raw === "ready") {
+  if (raw === "queued" || raw === "ready" || normalized === "approved") {
     return {
-      label: statusLabelFromKey(raw),
+      label: normalized === "approved" ? "Ready" : statusLabelFromKey(raw),
       railClass: "bg-sky-400/90",
       chipClass: "border-sky-300/60 bg-sky-500/12 text-sky-100",
       orbClass: "bg-sky-300",
@@ -194,7 +192,7 @@ function resolveStatusVisual(status: string | null | undefined, isPunchedIn: boo
   }
 
   return {
-    label: raw ? statusLabelFromKey(raw) : "Awaiting",
+    label: normalized === "pending" ? "Awaiting" : raw ? statusLabelFromKey(raw) : "Awaiting",
     railClass: "bg-sky-500/80",
     chipClass: "border-sky-400/55 bg-sky-500/10 text-sky-100",
     orbClass: "bg-sky-300",


### PR DESCRIPTION
### Motivation
- Reduce local display drift in `JobCard` by using the shared line status normalizer so visual mapping aligns with canonical line statuses.
- Keep this change display-only to avoid any impact on persisted behavior, mutation routes, or schemas.

### Description
- Imported the shared normalizer `normalizeWorkOrderLineStatus` from `@/features/work-orders/lib/line-status` and used it inside `resolveStatusVisual` in `features/work-orders/components/JobCard.tsx` to normalize incoming status values.
- Kept `isPunchedIn` behavior unchanged so punched-in lines still show the **Active** visual and preserved legacy aliases (`active`, `queued`, `ready`, etc.) as compatibility fallbacks.
- Mapped canonical statuses so `in_progress` (or punched-in) → Active, `waiting_parts` → Waiting Parts, `completed`/`ready_to_invoice`/`invoiced` → Completed (muted slate), `declined`/`deferred` → blocked-style red with explicit labels, and `approved` surfaces into the existing queued/Ready sky styling; `pending` now falls back to the Awaiting label in the default path.
- Did not add files, routes, schema changes, or change any writes/mutations; the change is limited to display logic in `JobCard.tsx` only.

### Testing
- Ran type checks with `npx tsc --noEmit` which completed successfully.
- Ran `pnpm typecheck` which completed successfully.
- Confirmed no runtime type errors were introduced and only `features/work-orders/components/JobCard.tsx` was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1059dc4070832885264c4bc737009d)