### PR TITLE
Clarify WorkOrderBoard and operations copy semantics

### DIFF
--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -397,14 +397,14 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       targetKind: approvalTargetKind,
     },
     {
-      label: isTechnicianScoped ? "My waiting parts" : "Waiting parts",
+      label: isTechnicianScoped ? "My open parts requests" : "Open parts requests",
       value: String(payload.topSummary.waitingParts),
       tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
       href: waitingPartsTargetHref,
       targetKind: waitingPartsTargetKind,
     },
     {
-      label: isTechnicianScoped ? "My blocked jobs" : "On hold / blocked",
+      label: isTechnicianScoped ? "My blocked jobs (parts/on hold)" : "Blocked jobs (parts/on hold)",
       value: String(payload.topSummary.blockedJobs),
       tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default",
       href: blockedTargetHref,
@@ -432,7 +432,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           targetKind: approvalTargetKind,
         },
         {
-          label: "My parts delays",
+          label: "My open parts requests",
           value: String(payload.topSummary.waitingParts),
           tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
           href: waitingPartsTargetHref,
@@ -450,7 +450,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           targetKind: approvalTargetKind,
         },
         {
-          label: "Parts waiting",
+          label: "Open parts requests",
           value: String(payload.topSummary.waitingParts),
           tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
           href: waitingPartsTargetHref,
@@ -499,8 +499,8 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       ? {
           label: isTechnicianScoped ? "My blocked jobs need action" : "Blocked jobs climbing",
           detail: isTechnicianScoped
-            ? `${payload.topSummary.blockedJobs} of your assigned jobs are currently blocked.`
-            : `${payload.topSummary.blockedJobs} jobs currently in blocked stages.`,
+            ? `${payload.topSummary.blockedJobs} of your assigned jobs are waiting parts or on hold.`
+            : `${payload.topSummary.blockedJobs} jobs are currently waiting parts or on hold.`,
           tone: "critical",
           href: blockedTargetHref,
           targetKind: blockedTargetKind,

--- a/features/shared/components/workboard/WorkOrderBoard.tsx
+++ b/features/shared/components/workboard/WorkOrderBoard.tsx
@@ -159,7 +159,7 @@ export default function WorkOrderBoard(props: {
                 Active: <span className="text-white">{activeCount}</span>
               </div>
               <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-                Stalled: <span className="text-white">{stalledCount}</span>
+                Needs attention: <span className="text-white">{stalledCount}</span>
               </div>
               <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
                 Waiters: <span className="text-white">{waiterCount}</span>

--- a/features/shared/components/workboard/WorkOrderBoardCard.tsx
+++ b/features/shared/components/workboard/WorkOrderBoardCard.tsx
@@ -168,7 +168,7 @@ export default function WorkOrderBoardCard(props: {
             Open {row.jobs_open ?? 0}
           </span>
           <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-semibold text-neutral-200">
-            Blocked {row.jobs_blocked ?? 0}
+            Blocked (parts/on hold) {row.jobs_blocked ?? 0}
           </span>
           <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-semibold text-neutral-200">
             Waiting parts {row.jobs_waiting_parts ?? 0}


### PR DESCRIPTION
### Motivation
- Audit found semantic drift between labels and the underlying counts/stages (e.g., "Stalled" included awaiting_approval + waiting_parts + on_hold; "Waiting parts" displayed a parts-requests queue count; technician load uses `assigned_tech_id` only). 
- Change intent is a minimal, display/copy-only clarification so UI copy accurately reflects current semantics without touching queries, filters, stage derivation, or DB artifacts.

### Description
- Updated board header chip copy in `features/shared/components/workboard/WorkOrderBoard.tsx` from `Stalled` to `Needs attention` so the label matches the mixed-stage grouping (awaiting_approval + waiting_parts + on_hold). 
- Clarified per-card blocked metric in `features/shared/components/workboard/WorkOrderBoardCard.tsx` from `Blocked {n}` to `Blocked (parts/on hold) {n}` to indicate the metric represents waiting_parts + on_hold. 
- Adjusted operations payload labels in `features/dashboard/server/getOperationsDashboardPayload.ts` to reflect that the value is sourced from part_requests counts and blocked-stage counts by renaming: `Waiting parts` → `Open parts requests` (and scoped `My waiting parts` → `My open parts requests`) and `On hold / blocked` → `Blocked jobs (parts/on hold)` (and scoped `My blocked jobs` → `My blocked jobs (parts/on hold)`). 
- Clarified blocked alert text to explicitly say jobs are "waiting parts or on hold" so messaging aligns with the computed `blockedJobs` definition.
- No code paths, queries, filters, stage derivation, mutation logic, DB views/RPCs, schema, or migrations were changed; only labels and helper text were updated in the listed files.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which passed. 
- Verified only the intended files were modified: `features/shared/components/workboard/WorkOrderBoard.tsx`, `features/shared/components/workboard/WorkOrderBoardCard.tsx`, and `features/dashboard/server/getOperationsDashboardPayload.ts`.
- Confirmed no query/filter/count/stage derivation, mutation, schema, view, RPC, or route logic changes were made.
- Remaining semantic drift requiring a future data-logic pass: technician load still only reflects `assigned_tech_id` (bridge/multi-assignment not represented) and `On-hold revenue` remains limited to `on_hold` stage only; both were intentionally left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105f809038832883818f32636a3f8f)