### PR TITLE
Clarify technician assignment copy for primary vs collaborator semantics

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1937,14 +1937,14 @@ export default function WorkOrderIdClient(): JSX.Element {
                                     throw new Error(
                                       typeof json?.error === "string"
                                         ? json.error
-                                        : "Failed to assign technician."
+                                        : "Failed to update primary tech."
                                     );
                                   }
 
-                                  toast.success("Technician assigned.");
+                                  toast.success("Primary tech updated.");
                                   await fetchAll();
                                 } catch (e) {
-                                  const msg = e instanceof Error ? e.message : "Failed to assign technician.";
+                                  const msg = e instanceof Error ? e.message : "Failed to update primary tech.";
                                   toast.error(msg);
                                 }
                               }

--- a/features/work-orders/components/WorkOrderAssignedSummary.tsx
+++ b/features/work-orders/components/WorkOrderAssignedSummary.tsx
@@ -75,7 +75,7 @@ export function WorkOrderAssignedSummary({ workOrderId }: Props) {
   const firstTechLabel = useMemo(() => {
     if (!rows.length) return null;
     const first = rows[0];
-    const full = first.full_name || "Assigned tech";
+    const full = first.full_name || "Primary tech";
     const firstName = full.split(" ")[0] || full;
     return firstName;
   }, [rows]);
@@ -113,7 +113,7 @@ export function WorkOrderAssignedSummary({ workOrderId }: Props) {
       title={
         hasActive
           ? "At least one job line is currently punched in."
-          : "Jobs assigned to technician(s) on this work order."
+          : "Primary tech first, plus any supporting techs on this work order."
       }
     >
       {hasActive && (
@@ -125,7 +125,7 @@ export function WorkOrderAssignedSummary({ workOrderId }: Props) {
       <span>{firstTechLabel}</span>
       {extraCount > 0 && (
         <span className="text-[0.65rem] text-neutral-100/80">
-          +{extraCount} more
+          +{extraCount} collaborators
         </span>
       )}
     </span>

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -820,7 +820,7 @@ export default function FocusedJobModal(props: {
                     value={String(line.job_type ?? "—").replaceAll("_", " ")}
                   />
                   <MetaStat
-                    label="Assigned tech"
+                    label="Primary tech"
                     value={line.assigned_tech_id ? `${line.assigned_tech_id.slice(0, 8)}…` : "Unassigned"}
                   />
                   <MetaStat label="Parts count" value={String(partsCount)} />

--- a/features/work-orders/components/workorders/extras/AssignTechModal.tsx
+++ b/features/work-orders/components/workorders/extras/AssignTechModal.tsx
@@ -113,11 +113,11 @@ export default function AssignTechModal({
         // ignore
       }
 
-      toast.success("Mechanic assigned.");
+      toast.success("Primary tech updated.");
       await onAssigned?.(techId);
       onClose();
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "Failed to assign mechanic.";
+      const msg = e instanceof Error ? e.message : "Failed to update primary tech.";
       toast.error(msg);
     } finally {
       setSubmitting(false);
@@ -129,13 +129,16 @@ export default function AssignTechModal({
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={submit}
-      title="Assign mechanic"
+      title="Set primary tech"
       submitText={submitting ? "Assigning…" : "Assign"}
       size="sm"
     >
+      <p className="mb-2 text-xs text-muted-foreground">
+        Primary tech is the operational owner. Additional techs are supporting collaborators.
+      </p>
       <label className="block text-sm">
         <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Choose mechanic
+          Choose primary tech
         </span>
         <select
           className="w-full rounded border border-border/60 bg-background px-3 py-2 text-sm text-foreground dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"


### PR DESCRIPTION
### Motivation
- Clarify UI language so shop staff understand the difference between the single operational owner on a job and additional supporting technicians. 
- Fix surfaces that currently display merged assignment sets with generic wording that can imply equal ownership. 
- Keep behavior, authorization, and workload math unchanged while improving shop-floor clarity.

### Description
- Updated `features/work-orders/components/WorkOrderAssignedSummary.tsx` to use "Primary tech" as the fallback label, change the tooltip to "Primary tech first, plus any supporting techs on this work order.", and convert the count suffix from "+N more" to "+N collaborators". 
- Updated `features/work-orders/components/workorders/extras/AssignTechModal.tsx` to change the modal title to "Set primary tech", update the field label to "Choose primary tech", add a single-line helper clarifying primary vs supporting roles, and adjust success/error toasts to say "Primary tech updated"/"Failed to update primary tech". 
- Updated `features/work-orders/components/workorders/FocusedJobModal.tsx` to rename the Quick status stat label from "Assigned tech" to "Primary tech". 
- Updated `app/work-orders/[id]/Client.tsx` to align job-card assignment toasts/errors to the new "Primary tech" wording while preserving the same API call and flow.

### Testing
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `pnpm typecheck` which completed successfully. 
- Confirmed no logic, API, DB schema/view/RPC, assignment write-path, workload aggregation, punch authorization, dashboard math, or queue filtering changes were made; only UI copy and labels were modified. 
- Remaining risk: some screens still render merged technician lists without per-person role badges, so future follow-up may be needed if explicit visual role indicators are desired across all surfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1065e859388328b4a2b866f87fbd21)