### PR TITLE
Add minimal RBAC canonicalization for lead_hand and foreman

### DIFF
--- a/features/shared/lib/rbac.ts
+++ b/features/shared/lib/rbac.ts
@@ -7,6 +7,7 @@ export type CanonicalRole =
   | "parts"
   | "mechanic"
   | "lead_hand"
+  | "foreman"
   | "fleet_manager"
   | "dispatcher"
   | "driver"
@@ -25,7 +26,9 @@ const ROLE_ALIASES: Record<string, CanonicalRole> = {
   technician: "mechanic",
   lead_hand: "lead_hand",
   leadhand: "lead_hand",
+  "lead hand": "lead_hand",
   lead: "lead_hand",
+  foreman: "foreman",
   fleet_manager: "fleet_manager",
   dispatcher: "dispatcher",
   driver: "driver",
@@ -130,6 +133,14 @@ const CAPABILITY_MATRIX: RoleCapabilityMap = {
   },
   lead_hand: {
     ...NONE,
+    canManageWorkOrders: true,
+    canRunInspections: true,
+    canViewShopWideData: true,
+    canManageScheduling: true,
+  },
+  foreman: {
+    ...NONE,
+    canAuthorizeQuotes: true,
     canManageWorkOrders: true,
     canRunInspections: true,
     canViewShopWideData: true,


### PR DESCRIPTION
### Motivation
- Canonicalize two HR/app roles so `profiles.role` can represent `lead_hand` and `foreman` as first-class RBAC roles without touching schema or user creation flows. 
- Provide small, safe normalization steps (aliases) so existing inputs like `lead hand`, `lead`, `leadhand`, `tech`, and `technician` continue to resolve predictably.

### Description
- Added `foreman` to the `CanonicalRole` union and added a `foreman` entry to `ROLE_ALIASES` so `"foreman" -> "foreman"` canonicalizes correctly.  
- Added the spaced alias `"lead hand" -> "lead_hand"` and preserved existing aliases: `"lead" -> "lead_hand"`, `"leadhand" -> "lead_hand"`, `"tech" -> "mechanic"`, and `"technician" -> "mechanic"` (no other alias normalization changes).  
- Added a `foreman` capability entry in `CAPABILITY_MATRIX` with the requested capabilities and confirmed `lead_hand` capabilities are set to: `canManageWorkOrders=true`, `canManageScheduling=true`, `canViewShopWideData=true`, and `canManageUsers=false` (other capabilities remain unchanged).  
- File changed: `features/shared/lib/rbac.ts` only, and no new files were added.

### Testing
- Ran `npx tsc --noEmit` and TypeScript compilation completed successfully with exit code 0.  
- No existing RBAC unit tests were found under `features/shared/lib` to update, so no focused RBAC tests were run or modified in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107cd5cf7483289685011925766e74)