### PR TITLE
Allow lead_hand and foreman to see assignment controls in work-orders feed

### DIFF
--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -58,7 +58,7 @@ const ACTIVE_FLOW_STATUSES: StatusKey[] = [
 const SEEDED_DEFAULT_STATUSES: StatusKey[] = [...ACTIVE_FLOW_STATUSES, "completed"];
 const ACTIVE_LINE_EXCLUDED = new Set(["completed", "invoiced", "closed", "cancelled", "declined"]);
 
-const ASSIGN_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
+const ASSIGN_ROLES = new Set(["owner", "admin", "manager", "advisor", "lead_hand", "foreman"]);
 const STATUS_PICKER_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 
 const INPUT_DARK =


### PR DESCRIPTION
### Motivation
- Align the Work Orders feed assignment UI with current RBAC direction so users with `lead_hand` and `foreman` roles see the same assignment controls as other assignment-capable roles already supported elsewhere.

### Description
- Add `lead_hand` and `foreman` to the hardcoded `ASSIGN_ROLES` set in `features/work-orders/app/work-orders/view/page.tsx`, keeping the change minimal and local to that file and preserving all existing assignment behavior.

### Testing
- Ran `npx tsc --noEmit` and `pnpm typecheck`, both completed successfully; no other files, APIs, DB/schema, mobile, dashboard, or assignment logic were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a108e563ab883288b7dc76ab0da70be)