### PR TITLE
Harden AssignTechModal to enforce server-side assignment policy

### DIFF
--- a/features/work-orders/components/workorders/extras/AssignTechModal.tsx
+++ b/features/work-orders/components/workorders/extras/AssignTechModal.tsx
@@ -4,9 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { toast } from "sonner";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
 
 interface Assignable {
   id: string;
@@ -79,7 +76,6 @@ export default function AssignTechModal({
 
     setSubmitting(true);
     try {
-      // Prefer API route if available
       const res = await fetch("/api/work-orders/assign-line", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -90,27 +86,8 @@ export default function AssignTechModal({
       });
 
       if (!res.ok) {
-        // ✅ Correct DB column (NOT assigned_tech_id)
-        const { error } = await supabase
-          .from("work_order_lines")
-          .update(
-            { assigned_tech_id: techId } as DB["public"]["Tables"]["work_order_lines"]["Update"],
-          )
-          .eq("id", workOrderLineId);
-
-        if (error) throw error;
-      }
-
-      // Optional: also keep join table in sync (ignore if blocked/missing)
-      try {
-        await supabase
-          .from("work_order_line_technicians")
-          .upsert(
-            { work_order_line_id: workOrderLineId, technician_id: techId },
-            { onConflict: "work_order_line_id,technician_id" },
-          );
-      } catch {
-        // ignore
+        const json = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(json?.error || "Failed to update primary tech.");
       }
 
       toast.success("Primary tech updated.");


### PR DESCRIPTION
### Motivation
- Prevent client-side bypass of centralized assignment authorization by ensuring the modal cannot write directly to the DB when the server API is unavailable or rejects the request.
- The modal previously attempted direct Supabase writes (updating `work_order_lines.assigned_tech_id` and upserting `work_order_line_technicians`) when the API returned non-OK, which could circumvent server RBAC/RLS.

### Description
- Removed the direct client-side fallback in `features/work-orders/components/workorders/extras/AssignTechModal.tsx` so the modal only posts to `POST /api/work-orders/assign-line` for assignments.
- Deleted the fallback `.from('work_order_lines').update(...)` and `.from('work_order_line_technicians').upsert(...)` logic from the modal and replaced it with parsing the API error and throwing it on non-OK responses.
- Preserved UI success flow so a successful API response still shows the success toast, calls `onAssigned`, and closes the modal.
- Preserved assignables loading behavior (API-first `/api/assignables`, then client `profiles` query fallback) unchanged.

### Testing
- Ran `npx tsc --noEmit` which completed successfully.
- Ran `pnpm typecheck` which completed successfully.
- Verified only `features/work-orders/components/workorders/extras/AssignTechModal.tsx` was changed and that assignment now only goes through `/api/work-orders/assign-line` with API errors surfaced to the user.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1090cf0f9483288366aeebd9562645)