### PR TITLE
DB migration: normalize public.profiles.role and add canonical role check

### DIFF
--- a/db/sql/2026-05-22_normalize_profile_roles_for_floor_leads.sql
+++ b/db/sql/2026-05-22_normalize_profile_roles_for_floor_leads.sql
@@ -1,0 +1,123 @@
+-- Normalize public.profiles.role into a canonical RBAC allowlist.
+-- NOTE: profiles.role is the app access/RBAC role.
+-- Workforce role/title semantics remain in public.people_workforce_profiles.
+
+-- 1) Backfill known legacy aliases (idempotent and non-destructive).
+update public.profiles
+set role = case lower(btrim(role))
+  when 'tech' then 'mechanic'
+  when 'technician' then 'mechanic'
+  when 'lead' then 'lead_hand'
+  when 'leadhand' then 'lead_hand'
+  when 'lead hand' then 'lead_hand'
+  else role
+end
+where role is not null
+  and lower(btrim(role)) in ('tech', 'technician', 'lead', 'leadhand', 'lead hand');
+
+-- 2) Remove conflicting legacy checks before adding canonical guardrail.
+alter table public.profiles drop constraint if exists profiles_role_check;
+alter table public.profiles drop constraint if exists profiles_role_chk;
+alter table public.profiles drop constraint if exists profiles_role_canonical_check;
+
+-- 3) Ensure no remaining non-canonical values block the new check.
+do $$
+declare
+  v_unknown_count bigint;
+begin
+  select count(*)
+  into v_unknown_count
+  from public.profiles
+  where role is not null
+    and lower(btrim(role)) not in (
+      'owner',
+      'admin',
+      'manager',
+      'foreman',
+      'lead_hand',
+      'advisor',
+      'service',
+      'dispatcher',
+      'parts',
+      'mechanic',
+      'fleet_manager',
+      'driver',
+      'customer',
+      'unknown'
+    );
+
+  if v_unknown_count > 0 then
+    raise notice 'Normalizing % non-canonical public.profiles.role values to unknown to satisfy canonical role check.', v_unknown_count;
+
+    update public.profiles
+    set role = 'unknown'
+    where role is not null
+      and lower(btrim(role)) not in (
+        'owner',
+        'admin',
+        'manager',
+        'foreman',
+        'lead_hand',
+        'advisor',
+        'service',
+        'dispatcher',
+        'parts',
+        'mechanic',
+        'fleet_manager',
+        'driver',
+        'customer',
+        'unknown'
+      );
+  end if;
+end $$;
+
+-- 4) Add canonical guardrail.
+alter table public.profiles
+  add constraint profiles_role_canonical_check
+  check (
+    role is null
+    or role = any (
+      array[
+        'owner'::text,
+        'admin'::text,
+        'manager'::text,
+        'foreman'::text,
+        'lead_hand'::text,
+        'advisor'::text,
+        'service'::text,
+        'dispatcher'::text,
+        'parts'::text,
+        'mechanic'::text,
+        'fleet_manager'::text,
+        'driver'::text,
+        'customer'::text,
+        'unknown'::text
+      ]
+    )
+  );
+
+comment on column public.profiles.role is
+  'Application access/RBAC role. Workforce role/title remains in public.people_workforce_profiles.';
+
+-- 5) Keep public.user_role_enum compatible where present.
+do $$
+begin
+  if exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where n.nspname = 'public'
+      and t.typname = 'user_role_enum'
+  ) then
+    alter type public.user_role_enum add value if not exists 'foreman';
+    alter type public.user_role_enum add value if not exists 'lead_hand';
+    alter type public.user_role_enum add value if not exists 'service';
+    alter type public.user_role_enum add value if not exists 'dispatcher';
+    alter type public.user_role_enum add value if not exists 'fleet_manager';
+    alter type public.user_role_enum add value if not exists 'driver';
+    alter type public.user_role_enum add value if not exists 'unknown';
+    alter type public.user_role_enum add value if not exists 'mechanic';
+  else
+    raise notice 'public.user_role_enum does not exist; skipping enum value alignment.';
+  end if;
+end $$;


### PR DESCRIPTION
### Motivation
- The DB schema contained conflicting legacy CHECK constraints and a text `profiles.role` which blocks newly recognized RBAC roles like `lead_hand` and `foreman`.
- The intent is to provide a safe, idempotent, migration-only foundation so the database accepts canonical role values while preserving existing app behavior.
- Backfilling legacy aliases avoids application failures when new RBAC values are introduced downstream.

### Description
- Added migration `db/sql/2026-05-22_normalize_profile_roles_for_floor_leads.sql` which performs all changes idempotently and without modifying application code.
- Backfill mappings applied using `lower(btrim(role))`: `tech` -> `mechanic`, `technician` -> `mechanic`, `lead` -> `lead_hand`, `leadhand` -> `lead_hand`, and `lead hand` -> `lead_hand`, updating only non-null, mapped values.
- Drop conflicting legacy checks using `ALTER TABLE ... DROP CONSTRAINT IF EXISTS` for `profiles_role_check` and `profiles_role_chk` and any pre-existing `profiles_role_canonical_check` before re-adding the canonical guardrail.
- Add `profiles_role_canonical_check` CHECK that allows `NULL` or any of: `owner, admin, manager, foreman, lead_hand, advisor, service, dispatcher, parts, mechanic, fleet_manager, driver, customer, unknown`.
- Normalize remaining non-canonical non-null roles to `'unknown'` only when required to satisfy the new check and emit a `NOTICE` with the affected row count to be non-destructive and observable.
- Where present, align `public.user_role_enum` defensively using `ALTER TYPE ... ADD VALUE IF NOT EXISTS` for `foreman, lead_hand, service, dispatcher, fleet_manager, driver, unknown, mechanic` and otherwise skip and emit a notice.
- Add a comment on `public.profiles.role` clarifying it is the application access/RBAC role while workforce title semantics remain in `people_workforce_profiles`.
- No application code, create-user UI/API, dashboard, RLS, RBAC logic files, workforce profile/title behavior, or assignment logic were changed in this migration pass.

### Testing
- Ran `npx tsc --noEmit` which completed successfully and did not introduce TypeScript errors.
- Attempted project `pnpm typegen` which failed due to registry/auth environment error (`ERR_PNPM_FETCH_403`), so generated Supabase types were not updated and remain unchanged.
- The migration file is written defensively and is safe to run multiple times (`UPDATE`, `DROP CONSTRAINT IF EXISTS`, `ADD VALUE IF NOT EXISTS`, and idempotent `DO` blocks are used).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109825ddf08328810bf2aa62b5d3b8)