### PR TITLE
Align create-user role handling with canonical lead_hand and foreman roles

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -12,6 +12,7 @@ import {
   normalizeProvisioningUsername,
   withShopUsernameSuffix,
 } from "@/features/users/lib/username";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 type Body = {
   username: string;
@@ -37,8 +38,19 @@ export async function POST(req: Request) {
     const password = (raw.password ?? "").trim();
     const full_name = (raw.full_name ?? null) || null;
     const requestedRole = (raw.role ?? null) || null;
+    const canonicalRole = canonicalizeRole(requestedRole);
     const phone = (raw.phone ?? null) || null;
     const inputEmail = (raw.email ?? "").trim().toLowerCase();
+
+    if (canonicalRole === "unknown") {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid role. Allowed roles: owner, admin, manager, foreman, lead_hand, advisor, service, dispatcher, parts, mechanic, fleet_manager, driver, customer.",
+        },
+        { status: 400 }
+      );
+    }
 
     if (!password) {
       return NextResponse.json({ error: "Temporary password is required." }, { status: 400 });
@@ -118,7 +130,7 @@ export async function POST(req: Request) {
       email_confirm: true,
       user_metadata: {
         full_name,
-        role: requestedRole,
+        role: canonicalRole,
         shop_id: effectiveShopId, // force caller's shop
         phone,
         username,
@@ -144,7 +156,7 @@ export async function POST(req: Request) {
           email,
           full_name,
           phone,
-          role: requestedRole,
+          role: canonicalRole,
           shop_id: effectiveShopId,
           shop_name: null,
           username,

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -356,19 +356,20 @@ export default function CreateUserPage(): JSX.Element {
                 <option value="owner">Owner</option>
                 <option value="admin">Admin</option>
                 <option value="manager">Manager</option>
+                <option value="foreman">Foreman</option>
+                <option value="lead_hand">Lead Hand</option>
                 <option value="advisor">Advisor</option>
-                <option value="mechanic">Mechanic</option>
+                <option value="mechanic">Mechanic / Technician</option>
                 <option value="parts">Parts</option>
                 <option value="driver">Driver</option>
                 <option value="dispatcher">Dispatcher</option>
                 <option value="fleet_manager">Fleet manager</option>
               </select>
               <p className="text-[11px] text-neutral-500">
-                Use{" "}
-                <span style={{ color: COPPER }}>
-                  driver / dispatcher / fleet manager
-                </span>{" "}
-                for Fleet Portal accounts.
+                App role controls access and permissions. Workforce title/category is managed
+                separately in the People profile. Use{" "}
+                <span style={{ color: COPPER }}>driver / dispatcher / fleet manager</span> for
+                Fleet Portal accounts.
               </p>
             </div>
 


### PR DESCRIPTION
### Motivation
- Enable the create-user flow to accept and normalize the newly-canonical `lead_hand` and `foreman` roles and their common aliases. 
- Prevent accidental provisioning of unknown or mistyped role values by performing runtime validation before creating the auth user. 
- Surface the new roles in the Owner UI while keeping HR/workforce title concerns isolated to People/Workforce.

### Description
- Added an import and runtime canonicalization using `canonicalizeRole` from `@/features/shared/lib/rbac` in `app/api/admin/create-user/route.ts`. 
- Reject unknown/unmapped roles early with a clear `400` response and message listing allowed roles before any auth or profile writes. 
- Persist the canonical role value to auth `user_metadata.role` and `profiles.role` (replacing prior usage of the raw incoming value). 
- Kept existing permission gating (`requiredCapability: "canManageUsers"`, `allowRoles: ["owner","admin"]`) and tenant scoping intact. 
- Updated `features/dashboard/app/dashboard/owner/create-user/page.tsx` role picker to add `foreman` and `lead_hand`, relabel `mechanic` to `Mechanic / Technician`, and clarify helper text that app role is separate from People/workforce title; no workforce fields were added. 
- Left `people_workforce_profiles` seeding behavior unchanged and did not modify dashboard routing, RLS, schema, assignment APIs, work-order, or inspection logic.

### Testing
- Type-checks were run with `npx tsc --noEmit` and succeeded. 
- Project typecheck via `pnpm typecheck` (which runs `tsc --noEmit`) also succeeded. 
- Files changed: `app/api/admin/create-user/route.ts` and `features/dashboard/app/dashboard/owner/create-user/page.tsx`. 
- Remaining next steps: implement dashboard routing/inheritance for `lead_hand` and `foreman`, review hardcoded RLS role references, and refresh generated Supabase types when local typegen is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109cc7065c8328a62656de5f6b369b)