### PR TITLE
Route lead_hand and foreman to operations defaults

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -44,6 +44,11 @@ export default function DashboardEntryPage() {
         return;
       }
 
+      if (role === "lead_hand" || role === "foreman") {
+        router.replace("/dashboard/operations");
+        return;
+      }
+
       const stored = window.localStorage.getItem(DASHBOARD_LAST_VIEW_KEY);
       const view: DashboardView = isDashboardView(stored) ? stored : "operations";
 

--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -394,7 +394,7 @@ export default function MobileHome() {
     );
   }
 
-  if (profile && (role === "manager" || role === "owner" || role === "admin")) {
+  if (profile && (role === "manager" || role === "owner" || role === "admin" || role === "foreman")) {
     return (
       <main className="min-h-screen bg-black text-white">
         <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -9,6 +9,7 @@ export type MobileRole = Extract<
   | "advisor"
   | "mechanic"
   | "lead_hand"
+  | "foreman"
   | "parts"
   | "driver"
   | "dispatcher"


### PR DESCRIPTION
### Motivation
- Prevent lead_hand and foreman from being sent to stale/localStorage-backed performance views on desktop by giving them explicit desktop landing behavior. 
- Keep existing mobile/desktop UX stable: preserve `lead_hand` mobile entry and give `foreman` a safe initial mobile experience by inheriting the manager mobile home.

### Description
- Added an explicit desktop routing guard in `app/dashboard/page.tsx` so `lead_hand` and `foreman` are routed to `/dashboard/operations` while preserving the `admin` → `/dashboard/admin` special-case and the existing localStorage logic for other roles. (file: `app/dashboard/page.tsx`)
- Updated mobile home rendering in `app/mobile/page.tsx` so `foreman` is treated like managers and renders `MobileManagerHome`, while `lead_hand` continues to render `MobileLeadHome`. (file: `app/mobile/page.tsx`)
- Extended the `MobileRole` union in `features/mobile/config/mobile-tiles.ts` to include `foreman` to satisfy TypeScript type checking without changing any tile role arrays. (file: `features/mobile/config/mobile-tiles.ts`)
- No widget visibility, widget registry role arrays, nav/RoleHub tiles, RLS, RBAC, create-user, assignment logic, admin/workforce allowlists, or new pages/components were changed. 

### Testing
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `pnpm typecheck` (which runs `tsc --noEmit`) and it completed successfully. 
- Result: TypeScript checks passed and the patch is type-safe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a0d9ef3c8328a6471f03dda9ba4c)