### PR TITLE
dashboard: expose floor-safe ops widgets to lead_hand and foreman

### DIFF
--- a/features/dashboard/widgets/modules/AdvisorQueueWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/AdvisorQueueWidgetModule.tsx
@@ -5,7 +5,7 @@ export const advisorQueueWidgetModule: DashboardWidgetModule = {
   id: "advisor_queue",
   title: "Advisor Queue",
   description: "Queue and approvals workload",
-  roles: ["owner", "admin", "manager", "advisor"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   defaultW: 4,
   defaultH: 4,
   minW: 3,

--- a/features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/ApprovalRiskWidgetModule.tsx
@@ -5,7 +5,7 @@ export const approvalRiskWidgetModule: DashboardWidgetModule = {
   id: "approval_risk",
   title: "Approval Risk",
   description: "Work awaiting decision",
-  roles: ["owner", "admin", "manager", "advisor"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   defaultW: 4,
   defaultH: 4,
   minW: 3,

--- a/features/dashboard/widgets/modules/BookingsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/BookingsWidgetModule.tsx
@@ -5,7 +5,7 @@ export const bookingsWidgetModule: DashboardWidgetModule = {
   id: "bookings",
   title: "Bookings",
   description: "Upcoming appointment activity",
-  roles: ["owner", "admin", "manager", "advisor"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   defaultW: 4,
   defaultH: 4,
   minW: 3,

--- a/features/dashboard/widgets/modules/DailySummaryWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/DailySummaryWidgetModule.tsx
@@ -5,7 +5,7 @@ export const dailySummaryWidgetModule: DashboardWidgetModule = {
   id: "daily_summary",
   title: "Daily Summary",
   description: "Role-aware operational snapshot",
-  roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts", "mechanic", "tech", "technician"],
   defaultW: 4,
   defaultH: 3,
   minW: 3,

--- a/features/dashboard/widgets/modules/LiveShopLoadWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/LiveShopLoadWidgetModule.tsx
@@ -5,7 +5,7 @@ export const liveShopLoadWidgetModule: DashboardWidgetModule = {
   id: "live_shop_load",
   title: "Live Shop Load",
   description: "Real-time active jobs, tech capacity, and utilization",
-  roles: ["owner", "admin", "manager", "advisor", "parts"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts"],
   defaultW: 4,
   defaultH: 4,
   minW: 4,

--- a/features/dashboard/widgets/modules/SuggestedActionsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/SuggestedActionsWidgetModule.tsx
@@ -5,7 +5,7 @@ export const suggestedActionsWidgetModule: DashboardWidgetModule = {
   id: "suggested_actions",
   title: "Suggested Actions",
   description: "Highest-value next steps",
-  roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts", "mechanic", "tech", "technician"],
   defaultW: 4,
   defaultH: 3,
   minW: 3,

--- a/features/dashboard/widgets/modules/TechLoadWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/TechLoadWidgetModule.tsx
@@ -5,7 +5,7 @@ export const techLoadWidgetModule: DashboardWidgetModule = {
   id: "tech_load",
   title: "Technician Load",
   description: "Current active jobs and load balance",
-  roles: ["owner", "admin", "manager", "advisor", "parts"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts"],
   defaultW: 4,
   defaultH: 4,
   minW: 3,

--- a/features/dashboard/widgets/modules/TechnicianPerformanceWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/TechnicianPerformanceWidgetModule.tsx
@@ -5,7 +5,7 @@ export const technicianPerformanceWidgetModule: DashboardWidgetModule = {
   id: "tech_performance",
   title: "Technician Performance",
   description: "Completed jobs and average duration today",
-  roles: ["owner", "admin", "manager", "advisor", "parts"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts"],
   defaultW: 4,
   defaultH: 3,
   minW: 3,

--- a/features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/WaitingPartsWidgetModule.tsx
@@ -5,7 +5,7 @@ export const waitingPartsWidgetModule: DashboardWidgetModule = {
   id: "waiting_parts",
   title: "Waiting Parts",
   description: "Blocked by parts availability",
-  roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts", "mechanic", "tech", "technician"],
   defaultW: 4,
   defaultH: 4,
   minW: 3,

--- a/features/dashboard/widgets/modules/WorkOrderBoardWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/WorkOrderBoardWidgetModule.tsx
@@ -5,7 +5,7 @@ export const workOrderBoardWidgetModule: DashboardWidgetModule = {
   id: "work_order_board",
   title: "Work Order Board",
   description: "Live workboard snapshot",
-  roles: ["owner", "admin", "manager", "advisor", "parts", "mechanic", "tech", "technician"],
+  roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman", "parts", "mechanic", "tech", "technician"],
   defaultW: 8,
   defaultH: 5,
   minW: 5,


### PR DESCRIPTION
### Motivation
- Lead hand and foreman desktop routing lands them on `/dashboard/operations` but many operational widgets were excluded by module `roles` arrays, causing empty/missing operational dashboards. 
- Provide a minimal, non-breaking discoverability fix so floor roles can see operational widgets they need without changing routing, RBAC, RLS, or widget behavior. 

### Description
- Added `lead_hand` and `foreman` to the `roles` arrays of 10 floor/operations-safe widget modules: `work_order_board`, `daily_summary`, `suggested_actions`, `live_shop_load`, `tech_load`, `waiting_parts`, `approval_risk`, `advisor_queue`, `bookings`, and `tech_performance` by editing their module files under `features/dashboard/widgets/modules/`. 
- Kept the patch minimal and local: no changes to `features/dashboard/lib/widget-registry.tsx`, routing, nav/RoleHub, mobile tiles, RLS/page allowlists, widget queries/content/labels/behavior, dashboard layout, RBAC, create-user/assignment logic, or work-order mutation logic. 
- Intentionally left higher-sensitivity widgets unchanged (for example `revenue_watch`, `reports_performance`, `optimization_opportunities`, `shop_pulse`, and ambiguous AI/risk widgets like `ai_mission_control`, `ai_operations_observability`, `comeback_risk`) to avoid exposing admin/financial/uncertain surfaces in this pass. 

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `pnpm typecheck` (project `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a37f3edc8328988d5b33342415ef)