### PR TITLE
Add lead_hand/foreman discoverability to safe desktop operations nav

### DIFF
--- a/features/shared/components/RoleHubTiles/tiles.ts
+++ b/features/shared/components/RoleHubTiles/tiles.ts
@@ -4,7 +4,9 @@ export type Role =
   | "manager"
   | "advisor"
   | "mechanic"
-  | "parts";
+  | "parts"
+  | "lead_hand"
+  | "foreman";
 
 export type Scope =
   | "work_orders"
@@ -33,21 +35,21 @@ export const TILES: Tile[] = [
     title: "Create Work Order",
     subtitle: "Start a new job",
     cta: "+",
-    roles: ["advisor", "manager", "owner", "admin"],
+    roles: ["advisor", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["work_orders", "all"],
   },
   {
     href: "/work-orders/view",
     title: "View Work Orders",
     subtitle: "Browse & manage",
-    roles: ["advisor", "manager", "owner", "admin"],
+    roles: ["advisor", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["work_orders", "all"],
   },
   {
     href: "/work-orders/queue",
     title: "Job Queue",
     subtitle: "Active & in-progress",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["work_orders", "all"],
   },
   {
@@ -68,7 +70,7 @@ export const TILES: Tile[] = [
     href: "/work-orders/history",
     title: "History",
     subtitle: "Completed Work Orders & Invoices",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman"],
     scopes: ["work_orders", "all"],
   },
   // NEW: Billing (Ready to invoice)
@@ -205,14 +207,14 @@ export const TILES: Tile[] = [
     href: "/dashboard/appointments",
     title: "Scheduling",
     subtitle: "Calendar & bookings",
-    roles: ["owner", "admin", "manager", "advisor"],
+    roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
     scopes: ["management", "all"],
   },
   {
     href: "/dashboard/appointments",
     title: "Appointments",
     subtitle: "Customer bookings calendar",
-    roles: ["owner", "admin", "manager", "advisor"],
+    roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
     scopes: ["management", "all"],
   },
   {
@@ -313,7 +315,7 @@ export const TILES: Tile[] = [
     href: "/tech/queue",
     title: "Tech Job Queue",
     subtitle: "My assigned work",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["tech", "all"],
   },
 ];

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -7,7 +7,9 @@ export type Role =
   | "parts"
   | "dispatcher"
   | "driver"
-  | "fleet_manager";
+  | "fleet_manager"
+  | "lead_hand"
+  | "foreman";
 
 export type Scope =
   | "work_orders"
@@ -59,7 +61,7 @@ export const TILES: Tile[] = [
     href: "/tech/queue",
     title: "Tech Job Queue",
     subtitle: "My assigned work",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["tech", "all"],
     section: "Tech",
   },
@@ -67,7 +69,7 @@ export const TILES: Tile[] = [
     href: "/parts/requests?mine=1",
     title: "My Parts Requests",
     subtitle: "Requests involving me",
-    roles: ["mechanic", "manager", "owner", "admin"],
+    roles: ["mechanic", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["parts", "tech", "all"],
     section: "Tech",
   },
@@ -96,7 +98,7 @@ export const TILES: Tile[] = [
     title: "Create Work Order",
     subtitle: "Start a new job",
     cta: "+",
-    roles: ["advisor", "manager", "owner", "admin"],
+    roles: ["advisor", "manager", "owner", "admin", "lead_hand", "foreman"],
     scopes: ["work_orders", "all"],
     section: "Operations",
   },
@@ -136,7 +138,7 @@ export const TILES: Tile[] = [
     href: "/work-orders/history",
     title: "History",
     subtitle: "Completed work",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman"],
     scopes: ["work_orders", "all"],
     section: "Operations",
   },

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -8,6 +8,8 @@ export type UserRole =
   | "dispatcher"
   | "driver"
   | "fleet_manager"
+  | "lead_hand"
+  | "foreman"
   | "agent_admin"
   // legacy / generic roles still used in some places
   | "service"
@@ -54,7 +56,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/work-orders/view": {
     title: () => "View Work Orders",
     icon: "📋",
-    roles: ["owner", "admin", "manager", "advisor", "service"],
+    roles: ["owner", "admin", "manager", "advisor", "service", "lead_hand", "foreman"],
   },
   "/work-orders/create": {
     title: () => "New Work Order",
@@ -64,7 +66,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/work-orders/queue": {
     title: () => "Job Queue",
     icon: "🧰",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
   },
   "/work-orders/quote-review": {
     title: () => "Quote Review",
@@ -74,7 +76,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/work-orders/history": {
     title: () => "History",
     icon: "📜",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman"],
   },
   "/billing": {
     title: () => "Billing",
@@ -86,7 +88,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     title: (href) => `WO #${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
     icon: "🔧",
     persist: { keyParams: ["id"] },
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
   },
 
   "/work-orders/view/[id]": {
@@ -121,19 +123,19 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/inspections": {
     title: () => "Inspections",
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
   },
 
   // Runtime screens
   "/inspections/run": {
     title: () => "Run Inspection",
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
   },
   "/inspections/fill": {
     title: () => "Inspection",
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
   },
 
   // Inspection templates (tiles.ts uses /inspections/templates for this)
@@ -188,7 +190,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
       return `Inspection – ${nice}`;
     },
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
   },
 
   // Maintenance templates (if you still expose them directly)
@@ -426,7 +428,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/tech/queue": {
     title: () => "Tech Job Queue",
     icon: "🧰",
-    roles: ["owner", "admin", "manager", "mechanic", "tech"],
+    roles: ["owner", "admin", "manager", "mechanic", "tech", "lead_hand", "foreman"],
   },
   "/tech/performance": {
     title: () => "My Performance",

--- a/tests/owner-sidebar-nav.test.ts
+++ b/tests/owner-sidebar-nav.test.ts
@@ -74,6 +74,8 @@ describe("owner sidebar IA", () => {
       dispatcher: [],
       driver: [],
       fleet_manager: [],
+      lead_hand: [],
+      foreman: [],
       manager: [],
       owner: [],
     };


### PR DESCRIPTION
### Motivation
- Lead Hand and Foreman roles exist in RBAC and routing but were missing from desktop nav/tile and route-meta role arrays, blocking discoverability of operational links for those users.  
- Apply the smallest, safe change to surface operational links for these roles without altering page-level gates, RLS, routing, widgets, mobile, or admin/workforce surfaces.

### Description
- Added `lead_hand` and `foreman` to local role unions/types used by desktop nav/tile/route-meta systems in `features/shared/config/tiles.ts`, `features/shared/components/RoleHubTiles/tiles.ts`, and `features/shared/lib/routeMeta.ts`.  
- Updated desktop tile availability (RoleHub and shared tiles) to include `lead_hand` and `foreman` only for safe operational links, specifically: ` /tech/queue`, `/parts/requests?mine=1`, `/work-orders/create?autostart=1`, `/work-orders/view`, `/work-orders/queue`, `/work-orders/history`, and the dashboard appointments tiles used for operational scheduling.  Changes touch the three files above plus a small test fixture.  
- Added `lead_hand`/`foreman` to route metadata role arrays for operational routes to keep title/tab discovery consistent for: `/work-orders/view`, `/work-orders/queue`, `/work-orders/history`, `/work-orders/[id]`, `/inspections`, `/inspections/run`, `/inspections/fill`, `/inspections/[slug]`, and `/tech/queue`.  
- Included a minimal test fixture update in `tests/owner-sidebar-nav.test.ts` to include the new role keys so TypeScript checks remain correct.

### Testing
- Files changed: `features/shared/config/tiles.ts`, `features/shared/components/RoleHubTiles/tiles.ts`, `features/shared/lib/routeMeta.ts`, and `tests/owner-sidebar-nav.test.ts`.  
- Exact tiles/links updated for `lead_hand`: `/tech/queue`, `/parts/requests?mine=1`, `/work-orders/create?autostart=1`, `/work-orders/view`, `/work-orders/queue`, `/work-orders/history`, dashboard appointments tiles.  
- Exact tiles/links updated for `foreman`: `/tech/queue`, `/parts/requests?mine=1`, `/work-orders/create?autostart=1`, `/work-orders/view`, `/work-orders/queue`, `/work-orders/history`, dashboard appointments tiles.  
- Tiles intentionally left unchanged: billing/subscription, admin dashboard, owner settings/create-user, workforce/people pages, payroll/HR and other high-scope admin or finance/reporting tiles were not changed to avoid overexposure beyond discoverability (examples: `/billing`, `/dashboard/admin*`, `/dashboard/owner/create-user`, `/dashboard/workforce/*`).  
- Confirmations: no page-level access gates, no RLS, no dashboard routing, no widget registry/module changes, no mobile tile changes, and no RBAC/create-user/assignment logic were modified.  
- Validation commands run: `npx tsc --noEmit` and `pnpm typecheck`.  
- Result: both type checks succeeded (TypeScript compile/typecheck passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a89b7f448328b2940ce890cfa287)