### PR TITLE
Harden role update APIs: canonicalize roles, sync auth metadata, block self-change

### DIFF
--- a/app/api/admin/people/[id]/route.ts
+++ b/app/api/admin/people/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 type Ctx = { params: { id: string } };
 type ActionSeverity = "blocking" | "warning" | "informational";
@@ -232,14 +233,49 @@ export async function PUT(req: NextRequest, context: unknown) {
   if (!body) return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
 
   const { full_name, phone, role, completed_onboarding, workforce_profile } = body as PersonUpdatePayload;
+  const roleProvided = role !== undefined;
+  const canonicalRole = roleProvided ? canonicalizeRole(role) : null;
+
+  if (roleProvided && canonicalRole === "unknown") {
+    return NextResponse.json({ error: "Invalid role value" }, { status: 400 });
+  }
+
+  if (roleProvided && params.id === access.profile.id) {
+    return NextResponse.json({ error: "You cannot change your own role" }, { status: 403 });
+  }
+
+  if (
+    roleProvided &&
+    canonicalRole !== null &&
+    (canonicalRole === "owner" || canonicalRole === "admin") &&
+    access.canonicalRole !== "owner"
+  ) {
+    return NextResponse.json({ error: "Only owners can assign owner/admin roles" }, { status: 403 });
+  }
+
+  const { data: currentProfile, error: currentProfileErr } = await admin
+    .from("profiles")
+    .select("role")
+    .eq("id", params.id)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+
+  if (currentProfileErr) return NextResponse.json({ error: currentProfileErr.message }, { status: 500 });
 
   const { error: pErr } = await admin
     .from("profiles")
-    .update({ full_name, phone, role, completed_onboarding })
+    .update({ full_name, phone, role: canonicalRole ?? undefined, completed_onboarding })
     .eq("id", params.id)
     .eq("shop_id", access.profile.shop_id);
 
   if (pErr) return NextResponse.json({ error: pErr.message }, { status: 500 });
+
+  if (roleProvided && canonicalRole !== null) {
+    const { error: authErr } = await admin.auth.admin.updateUserById(params.id, {
+      user_metadata: { role: canonicalRole },
+    });
+    if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
+  }
 
   if (workforce_profile) {
     const { error: wErr } = await admin.from("people_workforce_profiles").upsert(
@@ -267,6 +303,9 @@ export async function PUT(req: NextRequest, context: unknown) {
       person_id: params.id,
       updated_workforce: Boolean(workforce_profile),
       employment_status: workforce_profile?.employment_status ?? null,
+      role_changed: roleProvided && canonicalRole !== null && canonicalRole !== (currentProfile?.role ?? null),
+      previous_role: currentProfile?.role ?? null,
+      new_role: roleProvided ? canonicalRole : null,
     },
   });
 

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 type DB = Database;
 
@@ -33,11 +34,11 @@ async function assertTargetInSameShop(
 type PutBody = {
   full_name?: string | null;
   phone?: string | null;
-  role?: DB["public"]["Enums"]["user_role_enum"] | null;
+  role?: string | null;
 };
 
 type RouteContext = { params: { id: string } };
-const ADMIN_LEVEL_ROLES = new Set<NonNullable<PutBody["role"]>>(["owner", "admin"]);
+const ADMIN_LEVEL_ROLES = new Set(["owner", "admin"]);
 
 export async function PUT(req: NextRequest, context: unknown) {
   const { params } = context as RouteContext;
@@ -70,16 +71,27 @@ export async function PUT(req: NextRequest, context: unknown) {
     return NextResponse.json({ error: check.message }, { status: 403 });
   }
 
+  const roleProvided = body.role !== undefined;
+  const canonicalRole = roleProvided ? canonicalizeRole(body.role) : null;
+
+  if (roleProvided && canonicalRole === "unknown") {
+    return NextResponse.json({ error: "Invalid role value" }, { status: 400 });
+  }
+
+  if (roleProvided && id === access.profile.id) {
+    return NextResponse.json({ error: "You cannot change your own role" }, { status: 403 });
+  }
+
   const update: Partial<DB["public"]["Tables"]["profiles"]["Update"]> = {
     ...(body.full_name !== undefined ? { full_name: body.full_name } : {}),
     ...(body.phone !== undefined ? { phone: body.phone } : {}),
-    ...(body.role !== undefined ? { role: body.role } : {}),
+    ...(body.role !== undefined ? { role: canonicalRole } : {}),
   };
 
   if (
-    body.role !== undefined &&
-    body.role !== null &&
-    ADMIN_LEVEL_ROLES.has(body.role) &&
+    roleProvided &&
+    canonicalRole !== null &&
+    ADMIN_LEVEL_ROLES.has(canonicalRole) &&
     access.canonicalRole !== "owner"
   ) {
     return NextResponse.json({ error: "Only owners can assign owner/admin roles" }, { status: 403 });
@@ -89,6 +101,15 @@ export async function PUT(req: NextRequest, context: unknown) {
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (roleProvided && canonicalRole !== null) {
+    const { error: authErr } = await admin.auth.admin.updateUserById(id, {
+      user_metadata: { role: canonicalRole },
+    });
+    if (authErr) {
+      return NextResponse.json({ error: authErr.message }, { status: 500 });
+    }
   }
 
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
### Motivation
- An audit found unsafe existing-user role changes via the People and Users admin APIs that used free-text roles, didn't canonicalize or sync auth metadata, and allowed self-demotion; this PR tightens those flows so owner/admin can safely promote/demote users.

### Description
- Canonicalized incoming `role` using `canonicalizeRole`, rejected unknown/mapped-to-`unknown` roles with `400`, and persist the canonical value to `profiles.role` instead of raw input.
- Synced role changes to auth metadata by calling `admin.auth.admin.updateUserById(..., { user_metadata: { role: canonicalRole } })` when a canonical role is provided, and preserved existing owner/admin + `canManageUsers` and same-shop checks.
- Added a self role-change guard that returns `403` if an actor attempts to change their own app role, and enforced owner-only assignment for `owner`/`admin` in both routes (preserving the existing restriction in `/api/admin/users/[id]` and adding it to `/api/admin/people/[id]`).
- Kept workforce profile updates separate and unchanged, preserved `people.profile.updated` audit logging and extended its metadata with `role_changed`, `previous_role`, and `new_role` fields; changed files: `app/api/admin/people/[id]/route.ts` and `app/api/admin/users/[id]/route.ts` (no UI/RLS/schema/create-user/assignment changes).`

### Testing
- Ran `npx tsc --noEmit` and it completed successfully.
- Ran `pnpm typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ae2ec2708328b8d457a992c96292)