### PR TITLE
Replace People app role free-text field with canonical role select

### DIFF
--- a/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PersonDetailClient.tsx
@@ -92,6 +92,22 @@ const EMPTY_CERT: CertificationDraft = {
   notes: "",
 };
 
+const APP_ROLE_OPTIONS = [
+  { value: "owner", label: "Owner" },
+  { value: "admin", label: "Admin" },
+  { value: "manager", label: "Manager" },
+  { value: "foreman", label: "Foreman" },
+  { value: "lead_hand", label: "Lead Hand" },
+  { value: "advisor", label: "Advisor" },
+  { value: "service", label: "Service" },
+  { value: "dispatcher", label: "Dispatcher" },
+  { value: "parts", label: "Parts" },
+  { value: "mechanic", label: "Mechanic / Technician" },
+  { value: "fleet_manager", label: "Fleet Manager" },
+  { value: "driver", label: "Driver" },
+  { value: "customer", label: "Customer" },
+] as const;
+
 function certPosture(cert: Certification) {
   if (cert.status === "revoked") return "Revoked";
   if (cert.status === "pending") return "Pending";
@@ -369,10 +385,24 @@ export default function PersonDetailClient({ personId, from }: { personId: strin
           <AdminField label="Phone" className="flex-1">
             <input className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm" value={detail.phone ?? ""} onChange={(e) => setDetail((prev) => prev ? { ...prev, phone: e.target.value } : prev)} />
           </AdminField>
-          <AdminField label="Role" className="w-full md:w-64">
-            <input className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm" value={detail.role ?? ""} onChange={(e) => setDetail((prev) => prev ? { ...prev, role: e.target.value } : prev)} />
+          <AdminField label="App role" className="w-full md:w-64">
+            <select
+              className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm"
+              value={detail.role ?? ""}
+              onChange={(e) => setDetail((prev) => (prev ? { ...prev, role: e.target.value || null } : prev))}
+            >
+              <option value="">Unassigned</option>
+              {APP_ROLE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </AdminField>
         </AdminToolbar>
+        <div className="px-4 pb-4 text-xs text-neutral-400">
+          App role controls access and permissions. Workforce role/title is managed separately.
+        </div>
       </AdminPanel>
 
       <AdminPanel>


### PR DESCRIPTION
### Motivation
- The People detail UI used a free-text app role input which allows typos and conflicts with hardened server-side role canonicalization and validation. 
- Product requires owners/admins to be able to promote/demote users using a constrained set of canonical roles (e.g., `mechanic` → `lead_hand` → `foreman` → `manager`).

### Description
- Replaced the free-text Role input with a constrained `<select>` in `features/dashboard/app/dashboard/admin/PersonDetailClient.tsx` and labeled the field `App role`.
- Added a local `APP_ROLE_OPTIONS` constant containing the exact canonical values and user-friendly labels: `owner`, `admin`, `manager`, `foreman`, `lead_hand`, `advisor`, `service`, `dispatcher`, `parts`, `mechanic`, `fleet_manager`, `driver`, and `customer` (labels: Owner, Admin, Manager, Foreman, Lead Hand, Advisor, Service, Dispatcher, Parts, Mechanic / Technician, Fleet Manager, Driver, Customer).
- Kept stored/sent values canonical (each `<option value>` is the canonical role string) and preserved the existing save flow that sends `role` through the existing `PUT /api/admin/people/[id]` payload so server-side canonicalization/validation remains authoritative.
- Preserved workforce title separation and added helper copy: “App role controls access and permissions. Workforce role/title is managed separately.”; no changes to workforce_profile behavior, APIs, RLS, DB schema, create-user, dashboards, or assignment logic.

### Testing
- Ran `npx tsc --noEmit` which completed without errors.
- Ran `pnpm typecheck` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b0df4c7c832892f216349f660aed)