### PR TITLE
Patch allowRoles for operational AI endpoints and quote approval (add foreman/lead_hand)

### DIFF
--- a/app/api/dashboard/ai-recommendations/route.ts
+++ b/app/api/dashboard/ai-recommendations/route.ts
@@ -12,7 +12,7 @@ function parseBooleanFilter(value: string | null): "all" | boolean {
 export async function GET(request: Request) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
 
   if (!access.ok) return access.response;

--- a/app/api/quotes/send-for-approval/route.ts
+++ b/app/api/quotes/send-for-approval/route.ts
@@ -29,7 +29,7 @@ function toStringArray(x: unknown): string[] | null {
 export async function POST(req: Request) {
   const access = await requireShopScopedApiAccess({
     requiredCapabilities: ["canManageWorkOrders", "canAuthorizeQuotes"],
-    allowRoles: ["owner", "admin", "manager", "advisor", "service"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "service", "foreman"],
   });
 
   if (!access.ok) {

--- a/app/api/work-orders/[id]/ai-review/route.ts
+++ b/app/api/work-orders/[id]/ai-review/route.ts
@@ -35,7 +35,7 @@ async function getShopScopedWorkOrder(input: {
 export async function POST(req: Request) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
   if (!access.ok) return access.response;
 

--- a/app/api/work-orders/[id]/ai/advisor-draft/route.ts
+++ b/app/api/work-orders/[id]/ai/advisor-draft/route.ts
@@ -90,7 +90,7 @@ function selectPrimaryRecommendation<T extends { status: string; created_at: str
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
   if (!access.ok) return access.response;
 
@@ -182,7 +182,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
 export async function POST(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
   if (!access.ok) return access.response;
 

--- a/app/api/work-orders/[id]/ai/closeout-gate-preview/route.ts
+++ b/app/api/work-orders/[id]/ai/closeout-gate-preview/route.ts
@@ -5,7 +5,7 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
   if (!access.ok) return access.response;
 

--- a/app/api/work-orders/[id]/ai/freshness/route.ts
+++ b/app/api/work-orders/[id]/ai/freshness/route.ts
@@ -5,7 +5,7 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
   if (!access.ok) return access.response;
 

--- a/app/api/work-orders/[id]/ai/recommendations/route.ts
+++ b/app/api/work-orders/[id]/ai/recommendations/route.ts
@@ -86,7 +86,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
 export async function POST(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageWorkOrders",
-    allowRoles: ["owner", "admin", "manager", "advisor"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
   });
   if (!access.ok) return access.response;
 

--- a/app/api/work-orders/ai/indicators/route.ts
+++ b/app/api/work-orders/ai/indicators/route.ts
@@ -16,7 +16,7 @@ function parseWorkOrderIds(body: unknown): string[] {
 
 export async function POST(req: Request) {
   const access = await requireShopScopedApiAccess({
-    allowRoles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand"],
+    allowRoles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman"],
     requiredCapability: "canManageWorkOrders",
   });
   if (!access.ok) return access.response;


### PR DESCRIPTION
### Motivation
- An access audit found several operational AI and quote endpoints with stale explicit `allowRoles` arrays that omitted canonical roles `lead_hand` and/or `foreman`, causing inconsistent app-layer gating relative to existing RBAC capabilities, so a minimal, non-breaking fix was required without touching RLS, schema, or business logic.

### Description
- Updated `allowRoles` on operational work-order AI endpoints gated by `requiredCapability: "canManageWorkOrders"` to include both `lead_hand` and `foreman` in the existing allowlists (targets: `app/api/work-orders/ai/indicators/route.ts`, `app/api/work-orders/[id]/ai-review/route.ts`, `app/api/work-orders/[id]/ai/advisor-draft/route.ts`, `app/api/work-orders/[id]/ai/freshness/route.ts`, `app/api/work-orders/[id]/ai/closeout-gate-preview/route.ts`, `app/api/work-orders/[id]/ai/recommendations/route.ts`, and `app/api/dashboard/ai-recommendations/route.ts`).
- Updated the quote send-for-approval endpoint (`app/api/quotes/send-for-approval/route.ts`) to add `foreman` to the `allowRoles` while keeping `lead_hand` excluded, preserving the `requiredCapabilities: ["canManageWorkOrders", "canAuthorizeQuotes"]` gate.
- Made the smallest safe edits by changing only role allowlists where capability checks already existed and avoided removing allowlists or altering any request/response/business logic, RLS, schema, routing, prompts, or model calls.
- All edits were limited to the listed API route files and preserved existing multi-tenant and shop-scoped checks.

### Testing
- Ran `npx tsc --noEmit` and `pnpm typecheck`, and both completed successfully.
- Verified the patch only changed allowlists and confirmed `lead_hand` was not granted quote authorization while `foreman` was added only where `canAuthorizeQuotes` already gates the endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b65c1b8c832889c18daa714db26d)