### PR TITLE
Link PO lines to part_request_items for idempotent PO line creation

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -41,6 +41,10 @@ type PartTrustFields = Pick<
 type LocationRow = DB["public"]["Tables"]["stock_locations"]["Row"];
 type PurchaseOrderRow = DB["public"]["Tables"]["purchase_orders"]["Row"];
 type SupplierRow = DB["public"]["Tables"]["suppliers"]["Row"];
+type PurchaseOrderLineInsert =
+  DB["public"]["Tables"]["purchase_order_lines"]["Insert"] & {
+    part_request_item_id?: string | null;
+  };
 
 type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type LineLite = Pick<WorkOrderLineRow, "id" | "complaint" | "description">;
@@ -875,32 +879,29 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     const unitCost = Number.isFinite(unitCostNum) ? Math.max(0, unitCostNum) : 0;
 
     if (qty > 0 && description) {
-      const dedupeQuery = supabase
+      const { data: existingLinkedLine, error: lineCheckErr } = await supabase
         .from("purchase_order_lines")
         .select("id")
         .eq("po_id", poId)
-        .eq("description", description)
-        .eq("qty", qty)
+        .eq("part_request_item_id", String(item.id))
         .limit(1);
 
-      const { data: existingLines, error: lineCheckErr } = partId
-        ? await dedupeQuery.eq("part_id", partId)
-        : await dedupeQuery.is("part_id", null);
-
       if (lineCheckErr) {
-        toast.warning(`PO line dedupe check skipped: ${lineCheckErr.message}`);
+        toast.warning(`PO line linkage check skipped: ${lineCheckErr.message}`);
       }
 
-      const hasExactLine = Array.isArray(existingLines) && existingLines.length > 0;
+      const hasLinkedLine =
+        Array.isArray(existingLinkedLine) && existingLinkedLine.length > 0;
 
-      if (!hasExactLine) {
+      if (!hasLinkedLine) {
         const { error: lineInsertErr } = await supabase.from("purchase_order_lines").insert({
           po_id: poId,
           description,
           qty,
           unit_cost: unitCost,
           part_id: partId,
-        } as unknown as DB["public"]["Tables"]["purchase_order_lines"]["Insert"]);
+          part_request_item_id: String(item.id),
+        } as PurchaseOrderLineInsert);
 
         if (lineInsertErr) {
           toast.warning(`PO linked, but line insert failed: ${lineInsertErr.message}`);

--- a/db/sql/2026-05-23_purchase_order_lines_part_request_item_linkage.sql
+++ b/db/sql/2026-05-23_purchase_order_lines_part_request_item_linkage.sql
@@ -1,0 +1,32 @@
+-- Adds durable linkage from PO lines back to source part_request_items for traceability + idempotency.
+
+alter table public.purchase_order_lines
+  add column if not exists part_request_item_id uuid;
+
+comment on column public.purchase_order_lines.part_request_item_id is
+  'Source part request item used to create this PO line; supports traceability and idempotent request→PO creation. inventory part_id remains optional.';
+
+do $$
+begin
+  if to_regclass('public.part_request_items') is null then
+    raise notice 'Skipping purchase_order_lines_part_request_item_id_fkey: public.part_request_items does not exist.';
+  elsif not exists (
+    select 1
+    from pg_constraint
+    where conname = 'purchase_order_lines_part_request_item_id_fkey'
+      and conrelid = 'public.purchase_order_lines'::regclass
+  ) then
+    alter table public.purchase_order_lines
+      add constraint purchase_order_lines_part_request_item_id_fkey
+      foreign key (part_request_item_id)
+      references public.part_request_items(id)
+      on delete set null;
+  end if;
+end $$;
+
+create index if not exists idx_purchase_order_lines_part_request_item_id
+  on public.purchase_order_lines (part_request_item_id);
+
+create unique index if not exists uq_purchase_order_lines_po_request_item
+  on public.purchase_order_lines (po_id, part_request_item_id)
+  where part_request_item_id is not null;


### PR DESCRIPTION
### Motivation
- Provide durable traceability and idempotent behavior for PO lines created from part request items so repeated clicks, split ordering, and future matching are reliable. 
- Replace best-effort text/qty dedupe with a source-linked guard so the app and DB can consistently recognize an already-created line. 
- Keep manual/free-text PO lines and existing receiving/work-order/inventory flows unchanged in this phase. 

### Description
- Add a defensive SQL migration `db/sql/2026-05-23_purchase_order_lines_part_request_item_linkage.sql` that: adds nullable `purchase_order_lines.part_request_item_id uuid`, comments the column, adds a guarded FK to `public.part_request_items(id) ON DELETE SET NULL` (only if the table exists), creates `idx_purchase_order_lines_part_request_item_id`, and creates a partial unique index `uq_purchase_order_lines_po_request_item` on `(po_id, part_request_item_id)` where `part_request_item_id IS NOT NULL` to enforce server-side idempotency. 
- Update the request-row Create/Re-use PO flow in `app/parts/requests/[id]/page.tsx` to stamp `part_request_item_id` when inserting PO lines and to perform a dedupe check using `po_id + part_request_item_id` before inserting, while preserving existing `description`, `qty`, `unit_cost`, and `part_id` carry-forward behavior. 
- Add a narrow local insert type `PurchaseOrderLineInsert` to avoid requiring regenerated Supabase types in this environment. 
- Scope: no changes to receiving RPCs, AI matching, work-order logic, PO page layouts, inventory allocation, or broad RLS policy changes. 

### Testing
- Attempted type generation with `pnpm typegen`, which failed in this environment due to npm registry auth (`ERR_PNPM_FETCH_403`); generated types were not committed and a local type extension was used instead. 
- Ran `npx tsc --noEmit` and it passed. 
- Ran `pnpm typecheck` (alias to `tsc --noEmit`) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11336301c88328a9881b86dd88ecf4)