### PR TITLE
Sync linked part_request_items during free-text PO receiving

### DIFF
--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -56,6 +56,7 @@ if (typeof window !== "undefined") {
 type DB = Database;
 type PurchaseOrder = DB["public"]["Tables"]["purchase_orders"]["Row"];
 type PurchaseOrderLine = DB["public"]["Tables"]["purchase_order_lines"]["Row"];
+type PurchaseOrderLineWithRequestItem = PurchaseOrderLine & { part_request_item_id?: string | null };
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type SupplierRow = DB["public"]["Tables"]["suppliers"]["Row"];
@@ -193,7 +194,7 @@ export default function PoReceivePage(): JSX.Element {
 
         const poRow = (poRes.data as PurchaseOrder | null) ?? null;
         setPo(poRow);
-        setLines((lineRes.data ?? []) as PurchaseOrderLine[]);
+        setLines((lineRes.data ?? []) as PurchaseOrderLineWithRequestItem[]);
         const locRows = (locRes.data ?? []) as StockLoc[];
         setLocs(locRows);
 
@@ -287,7 +288,7 @@ export default function PoReceivePage(): JSX.Element {
     ]);
 
     if (!poRes.error) setPo((poRes.data as PurchaseOrder | null) ?? null);
-    if (!lineRes.error) setLines((lineRes.data ?? []) as PurchaseOrderLine[]);
+    if (!lineRes.error) setLines((lineRes.data ?? []) as PurchaseOrderLineWithRequestItem[]);
   };
 
   const cleanupScannerHandlers = () => {
@@ -359,7 +360,7 @@ export default function PoReceivePage(): JSX.Element {
     window.dispatchEvent(new CustomEvent("parts:received"));
   };
 
-  const receiveFreeTextLine = async (line: PurchaseOrderLine) => {
+  const receiveFreeTextLine = async (line: PurchaseOrderLineWithRequestItem) => {
     setErr(null);
     setResult(null);
 
@@ -390,6 +391,43 @@ export default function PoReceivePage(): JSX.Element {
     if (error) {
       setErr(error.message);
       return;
+    }
+
+    const requestItemId = String(line.part_request_item_id ?? "");
+    if (requestItemId) {
+      const { data: requestItem, error: requestItemError } = await supabase
+        .from("part_request_items")
+        .select("id, qty, qty_approved, qty_received, status")
+        .eq("id", requestItemId)
+        .maybeSingle();
+
+      if (requestItemError) {
+        setErr(requestItemError.message);
+        return;
+      }
+
+      if (requestItem) {
+        const targetQtyRaw = n(requestItem.qty_approved) > 0 ? n(requestItem.qty_approved) : n(requestItem.qty);
+        const targetQty = Math.max(0, targetQtyRaw);
+        const currentQtyReceived = n(requestItem.qty_received);
+        const nextQtyReceived = Math.min(targetQty, currentQtyReceived + receiveQty);
+
+        let nextStatus = requestItem.status;
+        if (nextQtyReceived > 0) {
+          if (nextQtyReceived < targetQty) nextStatus = "partially_received";
+          else nextStatus = "received";
+        }
+
+        const { error: syncError } = await supabase
+          .from("part_request_items")
+          .update({ qty_received: nextQtyReceived, status: nextStatus })
+          .eq("id", requestItem.id);
+
+        if (syncError) {
+          setErr(syncError.message);
+          return;
+        }
+      }
     }
 
     setFreeTextQtyByLineId((prev) => ({ ...prev, [lineId]: Math.max(0, rem - receiveQty) }));


### PR DESCRIPTION
### Motivation
- Ensure deterministic sync of request-item state when a free-text/non-inventory PO line (no `part_id`) is received so UI and business logic reflect actual received quantities. 
- The free-text receive path previously updated only `purchase_order_lines.received_qty` and left linked `part_request_items` out-of-sync for request-created PO lines.
- Keep behavior minimal and non-breaking: do not touch stock-linked receive flow, inventory movement, RPCs, or DB migrations.

### Description
- Added a narrow local type `PurchaseOrderLineWithRequestItem` and used it to read optional `part_request_item_id` on PO lines in `app/parts/po/[id]/receive/page.tsx` only. 
- After the existing update to `purchase_order_lines.received_qty` in the free-text receive flow, the code now checks `part_request_item_id` and, when present, loads the linked `part_request_items` row and updates it.
- Request-item update logic: compute `targetQty = qty_approved > 0 ? qty_approved : qty`, cap `qty_received` to `targetQty`, derive status as: leave unchanged if `nextQtyReceived <= 0`, `partially_received` if `0 < nextQtyReceived < targetQty`, and `received` if `nextQtyReceived >= targetQty`; then persist `qty_received` and `status`.
- Safety constraints preserved: capped receives so PO line does not exceed ordered qty, capped request-item `qty_received` to `targetQty`, no stock movements created, no location required, no calls to `receive_part_request_item` or changes to `receive_po_part_and_allocate`.
- File changed: `app/parts/po/[id]/receive/page.tsx` (single-file change).

### Testing
- Ran type checks: `npx tsc --noEmit` — succeeded.
- Ran workspace type check: `pnpm typecheck` — succeeded.
- No automated unit tests were modified; change is limited to the free-text receive UI path and validated by successful TypeScript validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122253939c8328a3be3f363ff6892d)