### PR TITLE
Phase 1: Update public pricing copy to “Complete” plans and add non-checkout Complete 100

### DIFF
--- a/app/compare-plans/page.tsx
+++ b/app/compare-plans/page.tsx
@@ -85,7 +85,7 @@ export default function ComparePlansPage() {
               className="mt-2 text-3xl text-neutral-100 sm:text-4xl"
               style={{ fontFamily: "var(--font-blackops)" }}
             >
-              Choose your plan
+              Choose your Complete plan
             </h1>
             <p className="mt-2 max-w-2xl text-sm text-neutral-400">
               Accounts are created after checkout — we don&apos;t allow sign-up without a

--- a/features/shared/components/ProFixIQLanding.tsx
+++ b/features/shared/components/ProFixIQLanding.tsx
@@ -256,11 +256,10 @@ export default function ProFixIQLanding() {
               className="mt-2 text-3xl text-neutral-100 md:text-5xl"
               style={{ fontFamily: "var(--font-blackops)" }}
             >
-              Pricing that scales with your operation
+              One complete shop operating system. No feature tax.
             </h2>
             <p className="mt-3 text-sm text-neutral-300 md:text-base">
-              Start with a free trial. Upgrade when you’re ready — no migration
-              mess later.
+              Every Complete plan includes repair ops, Workforce Command, documents/certifications, required document readiness, and Payroll Connect foundation with payroll review/export readiness.
             </p>
           </div>
 

--- a/features/shared/components/ui/PricingSection.tsx
+++ b/features/shared/components/ui/PricingSection.tsx
@@ -50,49 +50,69 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
     () => [
       {
         key: "starter",
-        title: "Starter",
-        desc: "Perfect for smaller teams getting started — technician-first inspections, quotes, approvals, and customer transparency.",
+        title: "Complete 10",
+        desc: "One complete shop operating system for smaller teams. Full platform access with pricing sized for up to 10 active users.",
         priceLabel: "$299 / month",
-        subLabel: "Up to 10 users",
+        subLabel: "Up to 10 active users",
         features: [
           "14-day free trial included",
-          "Up to 10 users (techs, advisors, parts, admin)",
-          "HD + fleet-ready inspections (works great for automotive too)",
-          "Customer portal + proof-based approvals",
-          "Internal messaging + role-based dashboards",
+          "Up to 10 active users (techs, advisors, parts, admin)",
+          "Full repair operations: work orders, inspections, approvals, parts, and invoicing",
+          "Workforce Command: scheduling + attendance",
+          "Documents/certifications + Required Document Matrix readiness",
+          "Payroll review and export readiness with provider-ready export workflows",
         ],
         featured: false,
         cta: "Start free trial",
       },
       {
         key: "pro",
-        title: "Pro",
-        desc: "Best for most HD or mixed shops — everything you need to run the shop with less screen time and faster approvals.",
+        title: "Complete 50",
+        desc: "One complete shop operating system for growing shops. Full platform access with pricing sized for up to 50 active users.",
         priceLabel: "$399 / month",
-        subLabel: "Up to 50 users",
+        subLabel: "Up to 50 active users",
         features: [
           "14-day free trial included",
-          "Up to 50 users (techs, advisors, parts, admin)",
-          "Measured diagnostic inspections + automation workflows",
-          "Customer portal + fleet programs",
+          "Up to 50 active users (techs, advisors, parts, admin)",
+          "Everything in Complete 10 + expanded implementation support",
+          "Customer + fleet portal workflows included",
           "Priority support",
+          "Payroll Connect foundation + review/export readiness",
         ],
         featured: true,
         badge: "Most popular",
         cta: "Start free trial",
       },
       {
+        key: "pro",
+        title: "Complete 100",
+        desc: "Complete platform for high-capacity shops scaling toward 100 active users. Launching for self-serve soon.",
+        priceLabel: "Talk to us",
+        subLabel: "Up to 100 active users",
+        features: [
+          "Everything in Complete plans",
+          "Sized for up to 100 active users",
+          "Implementation planning and rollout guidance",
+          "Payroll Connect foundation + provider-ready export workflows",
+          "Coming soon for self-serve checkout",
+        ],
+        featured: false,
+        badge: "Coming soon",
+        cta: "Talk to us",
+      },
+      {
         key: "unlimited",
-        title: "Unlimited",
-        desc: "Unlimited users per location — ideal for larger HD operations, fleets, municipalities, and multi-role teams.",
+        title: "Complete Unlimited",
+        desc: "One complete shop operating system for larger operations with unlimited active users per location.",
         priceLabel: "$599 / month / location",
         subLabel: "Unlimited users",
         features: [
           "14-day free trial included",
-          "Unlimited users per location",
-          "Best for fleets + high-volume operations",
-          "All inspections, portal, messaging, and automation",
-          "Priority support",
+          "Unlimited active users per location",
+          "Everything in Complete plans with enterprise-scale operations",
+          "High-volume fleet + municipality readiness",
+          "Priority support with implementation coordination",
+          "Provider-ready payroll export workflows",
         ],
         featured: false,
         cta: "Start free trial",
@@ -140,12 +160,11 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
           </div>
 
           <p className="text-sm text-neutral-200/90">
-            No feature gating. Inspections, portals, messaging, and automation are included
-            from day one.
+            Every Complete plan includes the full ProFixIQ platform. Pricing scales by shop size, not by feature access.
           </p>
 
           <p className="text-xs text-neutral-400">
-            Start your free trial today — your Founding Shop discount applies at checkout.
+            No feature tax. Repair operations, workforce scheduling + attendance, customer/fleet portals, documents/certifications, required document readiness, and Payroll Connect foundation are included.
           </p>
 
           <button
@@ -168,16 +187,22 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
       </div>
 
       {/* Plans */}
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+      <div
+        className="mt-5 rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-xs text-neutral-300"
+      >
+        SMS, payment processing, heavy AI usage, storage overages, and custom integrations may be billed separately.
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
         {plans.map((p) => {
           const isBusy = busyKey === p.key;
 
           return (
             <button
-              key={p.key}
+              key={`${p.key}-${p.title}`}
               type="button"
-              onClick={() => void handlePlanClick(p.key)}
-              disabled={Boolean(busyKey)}
+              onClick={() => (p.title === "Complete 100" ? (window.location.href = "/#contact") : void handlePlanClick(p.key))}
+              disabled={Boolean(busyKey) || p.title === "Complete 100"}
               className={[
                 "group relative text-left",
                 "rounded-3xl border bg-black/35 p-6 backdrop-blur-xl transition",
@@ -253,7 +278,7 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
                   {p.priceLabel}
                 </div>
                 <div className="mt-2 text-xs text-neutral-400">
-                  Includes <span className="text-neutral-200">14-day free trial</span> •
+                  Includes <span className="text-neutral-200">full platform access</span> •
                   Founding discount at checkout
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Align public pricing and marketing to a single, full-platform product positioning: “One complete shop operating system. No feature tax.”
- Surface plan labels sized by shop size (Complete 10 / 50 / 100 / Unlimited) while preserving existing backend checkout compatibility and avoiding any billing/schema changes in this phase.

### Description
- Replace visible plan names and descriptions in the pricing UI so `Starter` → `Complete 10`, `Pro` → `Complete 50`, and `Unlimited` → `Complete Unlimited`, and update feature lists to emphasize full-platform inclusion rather than feature gating. (Files changed: `features/shared/components/ui/PricingSection.tsx`.)
- Add a visible `Complete 100` card as a Phase 1 “Talk to us / Coming soon” option and explicitly disable checkout for that card so no new Stripe/backend plan key is introduced. (Files changed: `features/shared/components/ui/PricingSection.tsx`.)
- Add pass-through usage note: “SMS, payment processing, heavy AI usage, storage overages, and custom integrations may be billed separately,” adjust pricing grid to better accommodate the Complete set, and ensure CTAs preserve existing checkout behavior for active plans. (Files changed: `features/shared/components/ui/PricingSection.tsx`.)
- Update top-level marketing headings and supporting copy to reflect the Complete plan positioning on the landing and compare pages. (Files changed: `features/shared/components/ProFixIQLanding.tsx`, `app/compare-plans/page.tsx`.)
- Confirmations: no Stripe/backend plan keys, enums, DB constraints, subscription logic, or checkout payload behavior were changed; the active checkout mapping remains intact so the visible labels map to existing keys (`Complete 10` → `starter`, `Complete 50` → `pro`, `Complete Unlimited` → `unlimited`).

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully. ✅
- Ran the targeted Stripe test with `npx vitest run tests/stripe-api-version-unification.test.ts`, which passed (2 tests). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1226e8a9548328b9e308370c716a41)