### PR TITLE
Deterministic stock match suggestions for part request items

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -27,6 +27,10 @@ import {
   type PartTrustLevel,
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
+import {
+  buildDeterministicStockSuggestions,
+  type DeterministicStockSuggestion,
+} from "@/features/parts/lib/parts/deterministicStockMatcher";
 
 type DB = Database;
 
@@ -188,6 +192,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const [trustByPartId, setTrustByPartId] = useState<Record<string, PartTrustMeta>>({});
   const [locations, setLocations] = useState<LocationRow[]>([]);
   const [defaultLocationId, setDefaultLocationId] = useState<string>("");
+  const [stockSuggestionsByItemId, setStockSuggestionsByItemId] = useState<Record<string, DeterministicStockSuggestion[]>>({});
 
   const [pos, setPOs] = useState<PurchaseOrderRow[]>([]);
   const [suppliers, setSuppliers] = useState<SupplierRow[]>([]);
@@ -338,6 +343,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setPOs([]);
       setSuppliers([]);
       setSelectedPo("");
+      setStockSuggestionsByItemId({});
       setLoading(false);
       return;
     }
@@ -413,7 +419,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
     const shopId = woRow.shop_id ?? null;
     if (shopId) {
-      const [{ data: ps }, { data: locs }, { data: poRows }, { data: supRows }] =
+      const [{ data: ps }, { data: locs }, { data: poRows }, { data: supRows }, { data: stockRows }, { data: vendorRows }] =
         await Promise.all([
           supabase
             .from("parts")
@@ -438,6 +444,15 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
             .eq("shop_id", shopId)
             .order("name", { ascending: true })
             .limit(500),
+          supabase
+            .from("part_stock_summary")
+            .select("part_id, shop_id, on_hand, qty_available")
+            .eq("shop_id", shopId),
+          supabase
+            .from("vendor_part_numbers")
+            .select("id, part_id, shop_id, supplier_id, vendor_sku")
+            .eq("shop_id", shopId)
+            .limit(2000),
         ]);
 
       const partRows = (ps ?? []) as PartRow[];
@@ -471,6 +486,23 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setPOs((poRows ?? []) as PurchaseOrderRow[]);
       setSuppliers((supRows ?? []) as SupplierRow[]);
 
+      const suggestions: Record<string, DeterministicStockSuggestion[]> = {};
+      for (const req of uiRequests) {
+        for (const item of req.items) {
+          const desc = String(item.description ?? "").trim();
+          if (!desc || isUuid(item.part_id)) continue;
+          const ranked = buildDeterministicStockSuggestions({
+            requestedDescription: desc,
+            requestedQty: toNum(item.qty, 1),
+            parts: partRows,
+            stockSummaries: ((stockRows ?? []) as unknown) as DB["public"]["Views"]["part_stock_summary"]["Row"][],
+            vendorPartNumbers: ((vendorRows ?? []) as unknown) as DB["public"]["Tables"]["vendor_part_numbers"]["Row"][],
+            limit: 2,
+          });
+          if (ranked.length > 0) suggestions[String(item.id)] = ranked;
+        }
+      }
+      setStockSuggestionsByItemId(suggestions);
       if (
         selectedPo &&
         !(poRows ?? []).some((p) => String(p.id) === selectedPo)
@@ -484,6 +516,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setPOs([]);
       setSuppliers([]);
       setSelectedPo("");
+      setStockSuggestionsByItemId({});
     }
 
     setLoading(false);
@@ -1348,6 +1381,8 @@ if (!lineId || !isUuid(lineId)) {
                                   it.ui_part_id ??
                                   null) as string | null;
                                 const trustMeta = effectivePartId ? trustByPartId[effectivePartId] : null;
+                                const stockSuggestions = stockSuggestionsByItemId[String(it.id)] ?? [];
+                                const topSuggestion = stockSuggestions[0] ?? null;
                                 const canReceive =
                                   !!effectivePartId &&
                                   approved > 0 &&
@@ -1425,6 +1460,27 @@ if (!lineId || !isUuid(lineId)) {
                                           ))}
                                         </select>
 
+
+
+                                        {topSuggestion ? (
+                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-300">
+                                            Possible stock match: <span className="text-neutral-100">{topSuggestion.name}</span>
+                                            {topSuggestion.sku_or_part_number ? <span className="text-neutral-500"> · {topSuggestion.sku_or_part_number}</span> : null}
+                                            <span className="text-neutral-500"> · {topSuggestion.qty_available} available</span>
+                                            <span className="text-neutral-500"> · {topSuggestion.confidence}</span>
+                                            <div className="mt-1 text-neutral-500">{topSuggestion.reasons.slice(0, 3).join(" · ")} · action: {topSuggestion.recommended_action}</div>
+                                            {topSuggestion.part_id !== it.ui_part_id ? (
+                                              <button
+                                                type="button"
+                                                className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
+                                                onClick={() => updateItem(r.req.id, String(it.id), { ui_part_id: topSuggestion.part_id })}
+                                                disabled={rowBusy}
+                                              >
+                                                {topSuggestion.recommended_action === "allocate_from_stock" ? "Attach stock part" : "Review match"}
+                                              </button>
+                                            ) : null}
+                                          </div>
+                                        ) : null}
                                         {approved > 0 ? (
                                           <div className="text-[11px] text-neutral-500">
                                             State{" "}

--- a/features/parts/lib/parts/deterministicStockMatcher.ts
+++ b/features/parts/lib/parts/deterministicStockMatcher.ts
@@ -1,0 +1,183 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type PartRow = Pick<
+  Database["public"]["Tables"]["parts"]["Row"],
+  "id" | "name" | "sku" | "part_number"
+>;
+
+type VendorPartNumberRow =
+  Database["public"]["Tables"]["vendor_part_numbers"]["Row"];
+
+type PartStockSummaryRow = Database["public"]["Views"]["part_stock_summary"]["Row"];
+
+export type StockMatchConfidence = "high" | "medium" | "low";
+export type StockMatchAction = "allocate_from_stock" | "review_match" | "order_part";
+
+export type StockMatchReason =
+  | "exact sku match"
+  | "exact part number match"
+  | "exact normalized name match"
+  | "vendor SKU match"
+  | "token match"
+  | "description match"
+  | "in stock"
+  | "no stock available";
+
+export type DeterministicStockSuggestion = {
+  part_id: string;
+  name: string;
+  sku_or_part_number: string | null;
+  description: string | null;
+  qty_available: number;
+  confidence: StockMatchConfidence;
+  reasons: StockMatchReason[];
+  recommended_action: StockMatchAction;
+};
+
+type MatcherArgs = {
+  requestedDescription: string;
+  requestedQty?: number | null;
+  parts: PartRow[];
+  vendorPartNumbers?: VendorPartNumberRow[];
+  stockSummaries?: PartStockSummaryRow[];
+  limit?: number;
+};
+
+const STOP_TOKENS = new Set(["the", "and", "for", "with", "from", "rear", "front"]);
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function tokenize(value: string): string[] {
+  return Array.from(new Set(normalize(value).split(" ").filter((t) => t.length >= 2 && !STOP_TOKENS.has(t))));
+}
+
+function overlapScore(requestTokens: string[], candidateTokens: string[]): number {
+  if (!requestTokens.length || !candidateTokens.length) return 0;
+  const set = new Set(candidateTokens);
+  let hits = 0;
+  for (const token of requestTokens) if (set.has(token)) hits += 1;
+  return hits / requestTokens.length;
+}
+
+export function buildDeterministicStockSuggestions(args: MatcherArgs): DeterministicStockSuggestion[] {
+  const text = (args.requestedDescription ?? "").trim();
+  if (text.length < 2) return [];
+
+  const requestedQty = Math.max(1, Math.floor(Number(args.requestedQty ?? 1) || 1));
+  const requestedNorm = normalize(text);
+  const requestedTokens = tokenize(text);
+  const requestedTight = requestedNorm.replace(/\s+/g, "");
+  const limit = Math.min(5, Math.max(1, args.limit ?? 3));
+
+  const vendorByPart = new Map<string, string[]>();
+  for (const row of args.vendorPartNumbers ?? []) {
+    const list = vendorByPart.get(row.part_id) ?? [];
+    list.push(row.vendor_sku);
+    vendorByPart.set(row.part_id, list);
+  }
+
+  const stockByPart = new Map<string, number>();
+  for (const stock of args.stockSummaries ?? []) {
+    if (!stock.part_id) continue;
+    const qty = Number((stock as { qty_available?: number | null }).qty_available ?? stock.on_hand ?? 0);
+    stockByPart.set(stock.part_id, Number.isFinite(qty) ? qty : 0);
+  }
+
+  const scored = args.parts.map((part) => {
+    const reasons: StockMatchReason[] = [];
+    const name = String(part.name ?? "").trim();
+    const sku = String(part.sku ?? "").trim();
+    const pn = String(part.part_number ?? "").trim();
+    const partKeys = [sku, pn, ...((vendorByPart.get(part.id) ?? []).map((v) => v.trim()))].filter(Boolean);
+    const candidateText = `${name} ${sku} ${pn}`.trim();
+    const candidateNorm = normalize(candidateText);
+    const candidateTokens = tokenize(candidateText);
+    const qtyAvailable = stockByPart.get(part.id) ?? 0;
+
+    let score = 0;
+    let confidence: StockMatchConfidence = "low";
+
+    const exactKey = partKeys.find((key) => normalize(key).replace(/\s+/g, "") === requestedTight);
+    if (exactKey) {
+      if (sku && normalize(sku).replace(/\s+/g, "") === requestedTight) reasons.push("exact sku match");
+      else if (pn && normalize(pn).replace(/\s+/g, "") === requestedTight) reasons.push("exact part number match");
+      else reasons.push("vendor SKU match");
+      score += 120;
+      confidence = "high";
+    }
+
+    if (name && normalize(name) === requestedNorm) {
+      reasons.push("exact normalized name match");
+      score += 100;
+      confidence = "high";
+    }
+
+    const overlap = overlapScore(requestedTokens, candidateTokens);
+    if (overlap >= 0.75) {
+      reasons.push("token match");
+      score += 50;
+      if (confidence !== "high") confidence = "medium";
+    } else if (overlap >= 0.4) {
+      reasons.push("token match");
+      score += 30;
+      if (confidence === "low") confidence = "medium";
+    } else if (overlap > 0) {
+      reasons.push("token match");
+      score += 10;
+    }
+
+    if (candidateNorm.includes(requestedNorm) || requestedNorm.includes(candidateNorm)) {
+      reasons.push("description match");
+      score += 20;
+      if (confidence === "low" && overlap >= 0.3) confidence = "medium";
+    }
+
+    if (qtyAvailable > 0) {
+      reasons.push("in stock");
+      score += Math.min(15, qtyAvailable);
+    } else {
+      reasons.push("no stock available");
+    }
+
+    let recommended_action: StockMatchAction = "order_part";
+    if (qtyAvailable > 0 && confidence === "high") recommended_action = "allocate_from_stock";
+    else if (confidence === "medium" || (confidence === "high" && qtyAvailable <= 0)) recommended_action = "review_match";
+
+    if (requestedQty > qtyAvailable && qtyAvailable > 0 && recommended_action === "allocate_from_stock") {
+      recommended_action = "review_match";
+    }
+
+    return {
+      part_id: part.id,
+      name: name || sku || pn || part.id,
+      sku_or_part_number: sku || pn || null,
+      description: candidateText || null,
+      qty_available: qtyAvailable,
+      confidence,
+      reasons,
+      recommended_action,
+      score,
+    };
+  });
+
+  const highCountByKey = new Map<string, number>();
+  for (const row of scored.filter((r) => r.confidence === "high")) {
+    const key = normalize(`${row.name} ${row.sku_or_part_number ?? ""}`);
+    highCountByKey.set(key, (highCountByKey.get(key) ?? 0) + 1);
+  }
+
+  return scored
+    .filter((row) => row.score > 0)
+    .map((row) => {
+      const key = normalize(`${row.name} ${row.sku_or_part_number ?? ""}`);
+      if (row.confidence === "high" && (highCountByKey.get(key) ?? 0) > 1) {
+        return { ...row, confidence: "medium" as const, recommended_action: "review_match" as const };
+      }
+      return row;
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ score: _score, ...rest }) => rest);
+}


### PR DESCRIPTION
### Motivation
- Provide explainable, deterministic stock-match suggestions for free-text part request items so users see likely in‑shop matches before ordering. 
- Start with a non-AI, non-destructive layer: advisory suggestions only, no auto-allocation, no PO/receiving changes, and no schema changes. 

### Description
- Added a reusable matcher `buildDeterministicStockSuggestions(...)` in `features/parts/lib/parts/deterministicStockMatcher.ts` that accepts `requestedDescription`, optional `requestedQty`, `parts`, `vendor_part_numbers`, and `part_stock_summary` rows and returns ranked suggestions with `part_id`, `name`, `sku_or_part_number`, `description`, `qty_available`, `confidence` (`high|medium|low`), `reasons` (labels such as `exact sku match`, `vendor SKU match`, `token match`, `description match`, `in stock`, `no stock available`) and `recommended_action` (`allocate_from_stock|review_match|order_part`).
- Integrated suggestions into the parts request detail UI at `app/parts/requests/[id]/page.tsx` by:
  - batching reads to fetch `parts`, `part_stock_summary` (`part_id`, `on_hand`, `qty_available`) and `vendor_part_numbers` during page load, avoiding per-item inventory queries; 
  - computing per-item suggestions for free-text request items and storing keyed results in `stockSuggestionsByItemId` state; and
  - rendering a compact advisory block under the part selector showing the top suggestion, qty available, confidence, brief reasons, and an optional small action button that only sets the `ui_part_id` in the UI (does not persist/allocate or create PO/receive).
- Matching/ranking heuristics (deterministic only): exact SKU/part number/vendor SKU or exact normalized name => `high` confidence; strong token overlap / phrase matches => `medium`; weak token overlap => `low`; stock availability affects recommended action (in-stock + high => `allocate_from_stock`, medium/uncertain => `review_match`, out-of-stock => `order_part`).
- Kept all safety boundaries: no AI, no auto-attach persistence, no inventory movement, no PO creation, no schema changes, and no changes to receiving or invoice/cost rollup flows.

### Testing
- Type-checks passed: ran `npx tsc --noEmit` and `pnpm typecheck`, both succeeded with no type errors.
- No automated behavior tests were added in this pass; changes are limited to a deterministic helper and UI advisory rendering only. Please run functional QA in a dev shop to validate suggestion quality and UI appearance before wider rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1238903fb0832889c68c87edaa69d3)