### PR TITLE
Fix Phase 1 pricing blocker by removing Complete 100 checkout plan key

### DIFF
--- a/features/shared/components/ui/PricingSection.tsx
+++ b/features/shared/components/ui/PricingSection.tsx
@@ -23,8 +23,9 @@ export type PricingSectionProps = {
   onStartFree: () => void;
 };
 
-type PricingPlan = {
+type CheckoutPricingPlan = {
   key: PlanKey;
+  checkoutEnabled: true;
   title: string;
   desc: string;
   priceLabel: string;
@@ -34,6 +35,21 @@ type PricingPlan = {
   featured: boolean;
   badge?: string;
 };
+
+type ContactPricingPlan = {
+  key: string;
+  checkoutEnabled: false;
+  title: string;
+  desc: string;
+  priceLabel: string;
+  subLabel: string;
+  features: string[];
+  cta: string;
+  featured: boolean;
+  badge?: string;
+};
+
+type PricingPlan = CheckoutPricingPlan | ContactPricingPlan;
 
 /* -------------------------------------------------------------------------- */
 /* Component                                                                  */
@@ -50,6 +66,7 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
     () => [
       {
         key: "starter",
+        checkoutEnabled: true,
         title: "Complete 10",
         desc: "One complete shop operating system for smaller teams. Full platform access with pricing sized for up to 10 active users.",
         priceLabel: "$299 / month",
@@ -67,6 +84,7 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
       },
       {
         key: "pro",
+        checkoutEnabled: true,
         title: "Complete 50",
         desc: "One complete shop operating system for growing shops. Full platform access with pricing sized for up to 50 active users.",
         priceLabel: "$399 / month",
@@ -84,7 +102,8 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
         cta: "Start free trial",
       },
       {
-        key: "pro",
+        key: "complete-100",
+        checkoutEnabled: false,
         title: "Complete 100",
         desc: "Complete platform for high-capacity shops scaling toward 100 active users. Launching for self-serve soon.",
         priceLabel: "Talk to us",
@@ -102,6 +121,7 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
       },
       {
         key: "unlimited",
+        checkoutEnabled: true,
         title: "Complete Unlimited",
         desc: "One complete shop operating system for larger operations with unlimited active users per location.",
         priceLabel: "$599 / month / location",
@@ -195,14 +215,14 @@ const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) =>
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
         {plans.map((p) => {
-          const isBusy = busyKey === p.key;
+          const isBusy = p.checkoutEnabled ? busyKey === p.key : false;
 
           return (
             <button
               key={`${p.key}-${p.title}`}
               type="button"
-              onClick={() => (p.title === "Complete 100" ? (window.location.href = "/#contact") : void handlePlanClick(p.key))}
-              disabled={Boolean(busyKey) || p.title === "Complete 100"}
+              onClick={() => (p.checkoutEnabled ? void handlePlanClick(p.key) : (window.location.href = "/#contact"))}
+              disabled={Boolean(busyKey) || !p.checkoutEnabled}
               className={[
                 "group relative text-left",
                 "rounded-3xl border bg-black/35 p-6 backdrop-blur-xl transition",


### PR DESCRIPTION
### Motivation
- Prevent a contact-only pricing card (Complete 100) from carrying an active backend checkout plan key during Phase 1 by encoding checkout behavior in the frontend data shape.
- Make click/checkout behavior robust and data-driven instead of inferring behavior from the human-facing title string.

### Description
- Introduced a discriminated pricing-plan shape so cards are either checkout-enabled (`checkoutEnabled: true` with `key: PlanKey`) or contact-only (`checkoutEnabled: false` with a non-checkout `key`).
- Converted Complete 100 to a contact-only card (`checkoutEnabled: false`) and changed its internal key to a non-checkout identifier so it carries no backend `planKey` used by checkout.
- Updated click handling and busy-state logic to branch on the explicit `checkoutEnabled` flag instead of comparing `p.title` to strings like "Complete 100".
- Exact files changed: `features/shared/components/ui/PricingSection.tsx`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check passed.
- Ran `npx vitest run tests/stripe-api-version-unification.test.ts` and the test suite passed (1 file, 2 tests).
- Validation confirms: Complete 100 has no backend plan key, the click handler uses `checkoutEnabled` not title string, and checkout mappings for Complete 10/50/Unlimited remain `starter`/`pro`/`unlimited` respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123961f93c8328aea52cbd88bcfbcb)