### PR TITLE
Wire deterministic stock suggestions into existing attach confirmation flow

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1383,6 +1383,8 @@ if (!lineId || !isUuid(lineId)) {
                                 const trustMeta = effectivePartId ? trustByPartId[effectivePartId] : null;
                                 const stockSuggestions = stockSuggestionsByItemId[String(it.id)] ?? [];
                                 const topSuggestion = stockSuggestions[0] ?? null;
+                                const hasAttachedPart = isUuid(it.part_id);
+                                const showSuggestion = !!topSuggestion && !hasAttachedPart;
                                 const canReceive =
                                   !!effectivePartId &&
                                   approved > 0 &&
@@ -1462,23 +1464,30 @@ if (!lineId || !isUuid(lineId)) {
 
 
 
-                                        {topSuggestion ? (
+                                        {showSuggestion && topSuggestion ? (
                                           <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-300">
                                             Possible stock match: <span className="text-neutral-100">{topSuggestion.name}</span>
                                             {topSuggestion.sku_or_part_number ? <span className="text-neutral-500"> · {topSuggestion.sku_or_part_number}</span> : null}
                                             <span className="text-neutral-500"> · {topSuggestion.qty_available} available</span>
-                                            <span className="text-neutral-500"> · {topSuggestion.confidence}</span>
-                                            <div className="mt-1 text-neutral-500">{topSuggestion.reasons.slice(0, 3).join(" · ")} · action: {topSuggestion.recommended_action}</div>
-                                            {topSuggestion.part_id !== it.ui_part_id ? (
-                                              <button
-                                                type="button"
-                                                className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
-                                                onClick={() => updateItem(r.req.id, String(it.id), { ui_part_id: topSuggestion.part_id })}
-                                                disabled={rowBusy}
-                                              >
-                                                {topSuggestion.recommended_action === "allocate_from_stock" ? "Attach stock part" : "Review match"}
-                                              </button>
+                                            <span className="text-neutral-500"> · confidence {topSuggestion.confidence}</span>
+                                            <div className="mt-1 text-neutral-500">{topSuggestion.reasons.slice(0, 3).join(" · ")} · recommended: {topSuggestion.recommended_action}</div>
+                                            <button
+                                              type="button"
+                                              className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
+                                              onClick={() => updateItem(r.req.id, String(it.id), { ui_part_id: topSuggestion.part_id })}
+                                              disabled={rowBusy || topSuggestion.part_id === it.ui_part_id}
+                                            >
+                                              {topSuggestion.qty_available <= 0 || topSuggestion.confidence === "low"
+                                                ? "Review match"
+                                                : "Use this stock part"}
+                                            </button>
+                                            {topSuggestion.part_id === it.ui_part_id ? (
+                                              <div className="mt-1 text-neutral-500">Selected for review. Click <span className="text-neutral-300">Add</span> to run the normal attach flow.</div>
                                             ) : null}
+                                          </div>
+                                        ) : hasAttachedPart && topSuggestion ? (
+                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-500">
+                                            Stock suggestion available as an alternative, but this row already has an attached part.
                                           </div>
                                         ) : null}
                                         {approved > 0 ? (


### PR DESCRIPTION
### Motivation
- Deterministic stock suggestions should remain advisory and not persist or allocate automatically, while enabling a safe path for the user to accept a suggested stock part for a request item.
- Reuse the existing manual attach flow to avoid duplicating Supabase mutation or allocation logic and preserve current validation/behavior.
- Provide a clearer UI action that sets selection state and defers persistence to the existing confirmation step.

### Description
- Updated the suggestions UI in `app/parts/requests/[id]/page.tsx` to set the selector state (`ui_part_id`) via the existing `updateItem` call when a suggestion is chosen and to surface context text guiding the user to click the existing `Add` button to persist.
- Added guard logic so suggestions are hidden or shown as alternatives when the request item already has a persisted `part_id`, and adapted the suggestion CTA to read `"Use this stock part"` or `"Review match"` depending on `qty_available` and confidence.
- Reused the existing `addAndAttach` attach path to persist `part_request_items.part_id`, which already performs validation and (when appropriate) calls the allocation RPC `upsert_part_allocation_from_request_item`; no new update/mutation path was introduced.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build check passed.
- Ran `pnpm typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123a9c3eec83289d5222c5e3ba6fd1)