### PR TITLE
Add Complete plan alias/display helpers (Phase 2A)

### DIFF
--- a/features/shared/lib/server/shop-seat-limit.ts
+++ b/features/shared/lib/server/shop-seat-limit.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { PLAN_LIMITS } from "@/features/stripe/lib/stripe/constants";
+import { resolveSeatLimitForPlan } from "@/features/stripe/lib/stripe/constants";
 import { normalizeCanonicalPlan, type CanonicalPlan } from "@/features/stripe/lib/stripe/plan-normalization";
 
 type SeatPlanSource = "shop.plan" | "trial-default" | "safe-default";
@@ -61,7 +61,7 @@ export async function getShopSeatLimitSnapshot(
 
   return {
     plan: resolved.plan,
-    cap: PLAN_LIMITS[resolved.plan],
+    cap: resolveSeatLimitForPlan(resolved.plan) ?? 10,
     activeUsers: typeof activeUsers === "number" ? activeUsers : 0,
     source: resolved.source,
   };

--- a/features/stripe/lib/stripe/constants.ts
+++ b/features/stripe/lib/stripe/constants.ts
@@ -1,6 +1,6 @@
 // features/stripe/lib/stripe/constants.ts
 
-import type { CanonicalPlan } from "@/features/stripe/lib/stripe/plan-normalization";
+import { normalizeCanonicalPlan, type CanonicalPlan } from "@/features/stripe/lib/stripe/plan-normalization";
 
 export const STRIPE_PLATFORM_FEE_BPS = 300; // 3.00%
 
@@ -34,3 +34,39 @@ export const PLAN_PRICING: Record<PlanKey, number> = {
   pro: 399,
   unlimited: 599,
 };
+
+const PLAN_DISPLAY_LABELS: Record<string, string> = {
+  starter: "Complete 10",
+  pro: "Complete 50",
+  unlimited: "Complete Unlimited",
+  complete_10: "Complete 10",
+  complete_50: "Complete 50",
+  complete_100: "Complete 100",
+  complete_unlimited: "Complete Unlimited",
+};
+
+const COMPLETE_PLAN_LIMITS: Record<string, number> = {
+  complete_10: 10,
+  complete_50: 50,
+  complete_100: 100,
+  complete_unlimited: Number.MAX_SAFE_INTEGER,
+};
+
+export function getPlanDisplayLabel(plan: unknown): string {
+  const normalized = String(plan ?? "").trim().toLowerCase();
+  if (!normalized) return "Complete 10";
+  if (PLAN_DISPLAY_LABELS[normalized]) return PLAN_DISPLAY_LABELS[normalized];
+
+  const canonical = normalizeCanonicalPlan(normalized);
+  if (canonical) return PLAN_DISPLAY_LABELS[canonical];
+  return normalized;
+}
+
+export function resolveSeatLimitForPlan(plan: unknown): number | null {
+  const normalized = String(plan ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (COMPLETE_PLAN_LIMITS[normalized] !== undefined) return COMPLETE_PLAN_LIMITS[normalized];
+
+  const canonical = normalizeCanonicalPlan(normalized);
+  return canonical ? PLAN_LIMITS[canonical] : null;
+}

--- a/features/stripe/lib/stripe/plan-normalization.ts
+++ b/features/stripe/lib/stripe/plan-normalization.ts
@@ -1,4 +1,6 @@
 export type CanonicalPlan = "starter" | "pro" | "unlimited";
+export type CompletePlanKey = "complete_10" | "complete_50" | "complete_100" | "complete_unlimited";
+export type KnownPlanInput = CanonicalPlan | CompletePlanKey;
 
 const CANONICAL_PLAN_SET = new Set<CanonicalPlan>(["starter", "pro", "unlimited"]);
 
@@ -9,14 +11,41 @@ const PLAN_ALIASES: Record<string, CanonicalPlan> = {
   free: "starter",
   pro: "pro",
   pro50: "pro",
+  complete_50: "pro",
   unlimited: "unlimited",
   pro_plus: "unlimited",
+  complete_unlimited: "unlimited",
+  complete_10: "starter",
+  complete10: "starter",
 };
+
+const KNOWN_PLAN_INPUTS = new Set<string>([
+  "starter",
+  "starter10",
+  "free",
+  "diy",
+  "pro",
+  "pro50",
+  "unlimited",
+  "pro_plus",
+  "complete_10",
+  "complete_50",
+  "complete_100",
+  "complete_unlimited",
+]);
 
 export function normalizeCanonicalPlan(value: unknown): CanonicalPlan | null {
   const normalized = String(value ?? "").trim().toLowerCase();
   if (!normalized) return null;
   return PLAN_ALIASES[normalized] ?? null;
+}
+
+export function isKnownPlanInput(value: unknown): value is KnownPlanInput {
+  return KNOWN_PLAN_INPUTS.has(String(value ?? "").trim().toLowerCase());
+}
+
+export function isUnsupportedCompletePlanForCheckout(value: unknown): boolean {
+  return String(value ?? "").trim().toLowerCase() === "complete_100";
 }
 
 export function isCanonicalPlan(value: unknown): value is CanonicalPlan {

--- a/tests/plan-normalization-complete-aliases.test.ts
+++ b/tests/plan-normalization-complete-aliases.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  isKnownPlanInput,
+  isUnsupportedCompletePlanForCheckout,
+  normalizeCanonicalPlan,
+} from "../features/stripe/lib/stripe/plan-normalization";
+import { getPlanDisplayLabel, resolveSeatLimitForPlan } from "../features/stripe/lib/stripe/constants";
+
+describe("plan normalization complete aliases", () => {
+  it("keeps legacy plans normalized to legacy canonical keys", () => {
+    expect(normalizeCanonicalPlan("starter")).toBe("starter");
+    expect(normalizeCanonicalPlan("pro")).toBe("pro");
+    expect(normalizeCanonicalPlan("unlimited")).toBe("unlimited");
+  });
+
+  it("normalizes complete_10/50/unlimited into storage-compatible legacy keys", () => {
+    expect(normalizeCanonicalPlan("complete_10")).toBe("starter");
+    expect(normalizeCanonicalPlan("complete_50")).toBe("pro");
+    expect(normalizeCanonicalPlan("complete_unlimited")).toBe("unlimited");
+  });
+
+  it("recognizes complete_100 but does not normalize it to a storage/checkout key", () => {
+    expect(isKnownPlanInput("complete_100")).toBe(true);
+    expect(normalizeCanonicalPlan("complete_100")).toBeNull();
+    expect(isUnsupportedCompletePlanForCheckout("complete_100")).toBe(true);
+  });
+
+  it("maps legacy and complete keys to Complete display labels", () => {
+    expect(getPlanDisplayLabel("starter")).toBe("Complete 10");
+    expect(getPlanDisplayLabel("pro")).toBe("Complete 50");
+    expect(getPlanDisplayLabel("unlimited")).toBe("Complete Unlimited");
+    expect(getPlanDisplayLabel("complete_10")).toBe("Complete 10");
+    expect(getPlanDisplayLabel("complete_50")).toBe("Complete 50");
+    expect(getPlanDisplayLabel("complete_100")).toBe("Complete 100");
+    expect(getPlanDisplayLabel("complete_unlimited")).toBe("Complete Unlimited");
+  });
+
+  it("resolves seat limits for complete aliases", () => {
+    expect(resolveSeatLimitForPlan("complete_10")).toBe(10);
+    expect(resolveSeatLimitForPlan("complete_50")).toBe(50);
+    expect(resolveSeatLimitForPlan("complete_100")).toBe(100);
+    expect(resolveSeatLimitForPlan("complete_unlimited")).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce Phase 2A app-level vocabulary so UI and helpers can use the new “Complete” plan names while preserving existing backend/storage/checkout behavior.
- Recognize new `complete_*` inputs everywhere safe to read them, but do not change persisted canonical keys, DB constraints, Stripe envs, or checkout/webhook write behavior yet.
- Ensure `complete_100` is known for display/validation but remains non-checkout/unsupported for normalization to an active storage/checkout key.

### Description
- Added alias and recognition support in `features/stripe/lib/stripe/plan-normalization.ts` including `isKnownPlanInput` and `isUnsupportedCompletePlanForCheckout` and mapped `complete_10`, `complete_50`, and `complete_unlimited` to legacy canonical keys while keeping `complete_100` non-normalizing.
- Added display label and read-side seat-limit helpers in `features/stripe/lib/stripe/constants.ts`: `getPlanDisplayLabel` maps legacy and `complete_*` values to human labels, and `resolveSeatLimitForPlan` resolves `complete_*` seat caps without changing stored plan keys.
- Swapped shop seat limit usage to the new resolver in `features/shared/lib/server/shop-seat-limit.ts` so read-side seat caps accept `complete_*` aliases while storage output remains legacy canonical keys.
- Added targeted tests `tests/plan-normalization-complete-aliases.test.ts` covering legacy normalization, `complete_*` alias normalization, `complete_100` recognition/unsupported behavior, display labels, and seat-limit resolution.

### Testing
- Ran typecheck with `npx tsc --noEmit` and it succeeded.
- Ran existing billing tests with `npx vitest run tests/stripe-webhook-hardening.test.ts` and `npx vitest run tests/stripe-api-version-unification.test.ts`, both passed.
- Ran new alias tests with `npx vitest run tests/plan-normalization-complete-aliases.test.ts` and all tests passed.
- Confirmations: no DB migrations, no Stripe/env/checkout/webhook write behavior changes, and `complete_100` remains disabled for checkout normalization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123d6f5490832891e78beaec41d103)