### PR TITLE
Deterministic supplier / PO suggestions for part request items

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -31,6 +31,10 @@ import {
   buildDeterministicStockSuggestions,
   type DeterministicStockSuggestion,
 } from "@/features/parts/lib/parts/deterministicStockMatcher";
+import {
+  buildDeterministicSupplierSuggestions,
+  type DeterministicSupplierSuggestion,
+} from "@/features/parts/lib/parts/deterministicSupplierMatcher";
 
 type DB = Database;
 
@@ -193,6 +197,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const [locations, setLocations] = useState<LocationRow[]>([]);
   const [defaultLocationId, setDefaultLocationId] = useState<string>("");
   const [stockSuggestionsByItemId, setStockSuggestionsByItemId] = useState<Record<string, DeterministicStockSuggestion[]>>({});
+  const [supplierSuggestionsByItemId, setSupplierSuggestionsByItemId] = useState<Record<string, DeterministicSupplierSuggestion[]>>({});
 
   const [pos, setPOs] = useState<PurchaseOrderRow[]>([]);
   const [suppliers, setSuppliers] = useState<SupplierRow[]>([]);
@@ -344,6 +349,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setSuppliers([]);
       setSelectedPo("");
       setStockSuggestionsByItemId({});
+      setSupplierSuggestionsByItemId({});
       setLoading(false);
       return;
     }
@@ -454,6 +460,17 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
             .eq("shop_id", shopId)
             .limit(2000),
         ]);
+      const poIds = ((poRows ?? []) as PurchaseOrderRow[]).map((po) => String(po.id));
+      let poLineRows: DB["public"]["Tables"]["purchase_order_lines"]["Row"][] = [];
+      if (poIds.length > 0) {
+        const { data: lineRows } = await supabase
+          .from("purchase_order_lines")
+          .select("po_id, part_id, description, unit_cost, created_at")
+          .in("po_id", poIds)
+          .order("created_at", { ascending: false })
+          .limit(2000);
+        poLineRows = ((lineRows ?? []) as unknown) as DB["public"]["Tables"]["purchase_order_lines"]["Row"][];
+      }
 
       const partRows = (ps ?? []) as PartRow[];
       setParts(partRows);
@@ -487,10 +504,18 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setSuppliers((supRows ?? []) as SupplierRow[]);
 
       const suggestions: Record<string, DeterministicStockSuggestion[]> = {};
+      const supplierSuggestions: Record<string, DeterministicSupplierSuggestion[]> = {};
+      const stockSummaryRows = (((stockRows ?? []) as unknown) as DB["public"]["Views"]["part_stock_summary"]["Row"][]);
+      const stockAvailableByPartId = new Map<string, number>();
+      for (const stockRow of stockSummaryRows) {
+        if (!stockRow.part_id) continue;
+        const qty = Number((stockRow as { qty_available?: number | null }).qty_available ?? stockRow.on_hand ?? 0);
+        stockAvailableByPartId.set(String(stockRow.part_id), Number.isFinite(qty) ? qty : 0);
+      }
       for (const req of uiRequests) {
         for (const item of req.items) {
           const desc = String(item.description ?? "").trim();
-          if (!desc || isUuid(item.part_id)) continue;
+          if (!desc) continue;
           const ranked = buildDeterministicStockSuggestions({
             requestedDescription: desc,
             requestedQty: toNum(item.qty, 1),
@@ -500,9 +525,44 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
             limit: 2,
           });
           if (ranked.length > 0) suggestions[String(item.id)] = ranked;
+          const hasAttachedPart = isUuid(item.part_id);
+          const topStockSuggestion = ranked[0] ?? null;
+          const selectedPartId = isUuid(item.part_id) ? item.part_id : (isUuid(item.ui_part_id) ? item.ui_part_id : null);
+          const selectedPartStock = selectedPartId ? (stockAvailableByPartId.get(String(selectedPartId)) ?? 0) : 0;
+          const shouldSuggestSupplier =
+            !hasAttachedPart ||
+            !!topStockSuggestion?.recommended_action && topStockSuggestion.recommended_action === "order_part" ||
+            (selectedPartId != null && selectedPartStock <= 0);
+          if (shouldSuggestSupplier) {
+            supplierSuggestions[String(item.id)] = buildDeterministicSupplierSuggestions({
+              requestedDescription: desc,
+              partId: selectedPartId,
+              suppliers: ((supRows ?? []) as SupplierRow[]).map((s) => ({ id: s.id, name: s.name })),
+              purchaseOrders: ((poRows ?? []) as PurchaseOrderRow[]).map((po) => ({
+                id: po.id,
+                supplier_id: po.supplier_id,
+                status: po.status,
+                created_at: po.created_at,
+              })),
+              purchaseOrderLines: poLineRows.map((line) => ({
+                po_id: line.po_id,
+                part_id: line.part_id,
+                description: line.description,
+                unit_cost: line.unit_cost,
+                created_at: line.created_at,
+              })),
+              vendorPartNumbers: (((vendorRows ?? []) as unknown) as DB["public"]["Tables"]["vendor_part_numbers"]["Row"][]).map((v) => ({
+                part_id: v.part_id,
+                supplier_id: v.supplier_id,
+                vendor_sku: v.vendor_sku,
+              })),
+              parts: partRows.map((p) => ({ id: p.id, supplier: p.supplier })),
+            });
+          }
         }
       }
       setStockSuggestionsByItemId(suggestions);
+      setSupplierSuggestionsByItemId(supplierSuggestions);
       if (
         selectedPo &&
         !(poRows ?? []).some((p) => String(p.id) === selectedPo)
@@ -517,6 +577,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setSuppliers([]);
       setSelectedPo("");
       setStockSuggestionsByItemId({});
+      setSupplierSuggestionsByItemId({});
     }
 
     setLoading(false);
@@ -1382,6 +1443,8 @@ if (!lineId || !isUuid(lineId)) {
                                   null) as string | null;
                                 const trustMeta = effectivePartId ? trustByPartId[effectivePartId] : null;
                                 const stockSuggestions = stockSuggestionsByItemId[String(it.id)] ?? [];
+                                const supplierSuggestions = supplierSuggestionsByItemId[String(it.id)] ?? [];
+                                const supplierSuggestion = supplierSuggestions[0] ?? null;
                                 const topSuggestion = stockSuggestions[0] ?? null;
                                 const hasAttachedPart = isUuid(it.part_id);
                                 const showSuggestion = !!topSuggestion && !hasAttachedPart;
@@ -1488,6 +1551,44 @@ if (!lineId || !isUuid(lineId)) {
                                         ) : hasAttachedPart && topSuggestion ? (
                                           <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-500">
                                             Stock suggestion available as an alternative, but this row already has an attached part.
+                                          </div>
+                                        ) : null}
+                                        {supplierSuggestion ? (
+                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-300">
+                                            <div>
+                                              Suggested supplier:{" "}
+                                              <span className="text-neutral-100">
+                                                {supplierSuggestion.supplier_name ?? "Review / manual"}
+                                              </span>
+                                              <span className="text-neutral-500"> · confidence {supplierSuggestion.confidence}</span>
+                                            </div>
+                                            {supplierSuggestion.open_po_number ? (
+                                              <div className="text-neutral-500">
+                                                Open PO available: {supplierSuggestion.open_po_number}
+                                              </div>
+                                            ) : null}
+                                            {supplierSuggestion.suggested_unit_cost != null ? (
+                                              <div className="text-neutral-500">
+                                                Last cost: ${supplierSuggestion.suggested_unit_cost.toFixed(2)}
+                                              </div>
+                                            ) : null}
+                                            <div className="mt-1 flex flex-wrap gap-1">
+                                              {supplierSuggestion.reasons.slice(0, 3).map((reason) => (
+                                                <span key={reason} className="rounded-full border border-[color:var(--desktop-border)] px-2 py-0.5 text-[10px] text-neutral-400">
+                                                  {reason}
+                                                </span>
+                                              ))}
+                                            </div>
+                                            {supplierSuggestion.supplier_id ? (
+                                              <button
+                                                type="button"
+                                                className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
+                                                onClick={() => updateItem(r.req.id, String(it.id), { ui_supplier_id: supplierSuggestion.supplier_id ?? "" })}
+                                                disabled={rowBusy || it.ui_supplier_id === supplierSuggestion.supplier_id}
+                                              >
+                                                Use suggested supplier (manual PO action still required)
+                                              </button>
+                                            ) : null}
                                           </div>
                                         ) : null}
                                         {approved > 0 ? (

--- a/features/parts/lib/parts/deterministicSupplierMatcher.ts
+++ b/features/parts/lib/parts/deterministicSupplierMatcher.ts
@@ -1,0 +1,208 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type SupplierRow = Pick<Database["public"]["Tables"]["suppliers"]["Row"], "id" | "name">;
+type PurchaseOrderRow = Pick<Database["public"]["Tables"]["purchase_orders"]["Row"], "id" | "supplier_id" | "status" | "created_at">;
+type PurchaseOrderLineRow = Pick<Database["public"]["Tables"]["purchase_order_lines"]["Row"], "po_id" | "part_id" | "description" | "unit_cost" | "created_at">;
+type VendorPartNumberRow = Pick<Database["public"]["Tables"]["vendor_part_numbers"]["Row"], "part_id" | "supplier_id" | "vendor_sku">;
+type PartRow = Pick<Database["public"]["Tables"]["parts"]["Row"], "id" | "supplier">;
+
+export type DeterministicSupplierSuggestion = {
+  supplier_id: string | null;
+  supplier_name: string | null;
+  confidence: "high" | "medium" | "low";
+  reasons: string[];
+  open_po_id: string | null;
+  open_po_number: string | null;
+  suggested_unit_cost: number | null;
+  vendor_sku: string | null;
+  recommended_action:
+    | "add_to_existing_open_po"
+    | "create_new_po"
+    | "review_supplier"
+    | "keep_free_text";
+};
+
+type MatcherInput = {
+  requestedDescription: string;
+  partId?: string | null;
+  suppliers: SupplierRow[];
+  purchaseOrders: PurchaseOrderRow[];
+  purchaseOrderLines: PurchaseOrderLineRow[];
+  vendorPartNumbers?: VendorPartNumberRow[];
+  parts?: PartRow[];
+};
+
+const CLOSED_PO_STATUSES = new Set(["received", "closed", "cancelled", "canceled", "void"]);
+
+const normalize = (value: string): string =>
+  value.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
+
+function scoreDescriptionOverlap(requested: string, candidate: string): number {
+  const a = new Set(normalize(requested).split(" ").filter((token) => token.length >= 3));
+  const b = new Set(normalize(candidate).split(" ").filter((token) => token.length >= 3));
+  if (a.size === 0 || b.size === 0) return 0;
+  let hits = 0;
+  for (const token of a) if (b.has(token)) hits += 1;
+  return hits / a.size;
+}
+
+export function buildDeterministicSupplierSuggestions(input: MatcherInput): DeterministicSupplierSuggestion[] {
+  const description = String(input.requestedDescription ?? "").trim();
+  const supplierNameById = new Map(input.suppliers.map((s) => [String(s.id), String(s.name ?? "").trim()]));
+
+  type Candidate = {
+    supplierId: string;
+    score: number;
+    confidence: "high" | "medium" | "low";
+    reasons: string[];
+    vendorSku: string | null;
+    latestCost: number | null;
+    latestCostAt: string | null;
+  };
+
+  const candidates = new Map<string, Candidate>();
+
+  const getCandidate = (supplierId: string): Candidate => {
+    const id = String(supplierId);
+    const existing = candidates.get(id);
+    if (existing) return existing;
+    const created: Candidate = {
+      supplierId: id,
+      score: 0,
+      confidence: "low",
+      reasons: [],
+      vendorSku: null,
+      latestCost: null,
+      latestCostAt: null,
+    };
+    candidates.set(id, created);
+    return created;
+  };
+
+  const poById = new Map(input.purchaseOrders.map((po) => [String(po.id), po]));
+
+  const partId = input.partId ? String(input.partId) : null;
+
+  if (partId) {
+    for (const vpn of input.vendorPartNumbers ?? []) {
+      if (String(vpn.part_id) !== partId || !vpn.supplier_id) continue;
+      const c = getCandidate(String(vpn.supplier_id));
+      c.score += 90;
+      c.confidence = "high";
+      c.vendorSku = c.vendorSku ?? (vpn.vendor_sku ? String(vpn.vendor_sku) : null);
+      c.reasons.push("Vendor part number maps this part to supplier");
+    }
+
+    const historyCountBySupplier = new Map<string, number>();
+    for (const line of input.purchaseOrderLines) {
+      if (!line.part_id || String(line.part_id) !== partId) continue;
+      const po = poById.get(String(line.po_id));
+      const supplierId = po?.supplier_id ? String(po.supplier_id) : null;
+      if (!supplierId) continue;
+      const c = getCandidate(supplierId);
+      const count = (historyCountBySupplier.get(supplierId) ?? 0) + 1;
+      historyCountBySupplier.set(supplierId, count);
+      c.score += count >= 2 ? 45 : 25;
+      if (count >= 2) c.confidence = "high";
+      else if (c.confidence === "low") c.confidence = "medium";
+      c.reasons.push(count >= 2 ? "Repeated PO history for same part/supplier" : "Recent PO history for same part");
+      const cost = Number(line.unit_cost);
+      if (Number.isFinite(cost)) {
+        const createdAt = line.created_at ? String(line.created_at) : "";
+        if (!c.latestCostAt || createdAt > c.latestCostAt) {
+          c.latestCost = cost;
+          c.latestCostAt = createdAt;
+        }
+      }
+    }
+
+    const legacySupplier = input.parts?.find((p) => String(p.id) === partId)?.supplier;
+    const legacySupplierNorm = legacySupplier ? normalize(String(legacySupplier)) : "";
+    if (legacySupplierNorm) {
+      for (const [supplierId, supplierName] of supplierNameById.entries()) {
+        if (!supplierName) continue;
+        if (normalize(supplierName) === legacySupplierNorm) {
+          const c = getCandidate(supplierId);
+          c.score += 20;
+          if (c.confidence === "low") c.confidence = "medium";
+          c.reasons.push("Legacy part supplier text matches canonical supplier");
+        }
+      }
+    }
+  }
+
+  if (description.length >= 3) {
+    const supplierDescHits = new Map<string, { strong: number; weak: number }>();
+    for (const line of input.purchaseOrderLines) {
+      const po = poById.get(String(line.po_id));
+      const supplierId = po?.supplier_id ? String(po.supplier_id) : null;
+      if (!supplierId) continue;
+      const overlap = scoreDescriptionOverlap(description, String(line.description ?? ""));
+      if (overlap < 0.3) continue;
+      const bucket = supplierDescHits.get(supplierId) ?? { strong: 0, weak: 0 };
+      if (overlap >= 0.65) bucket.strong += 1;
+      else bucket.weak += 1;
+      supplierDescHits.set(supplierId, bucket);
+    }
+
+    for (const [supplierId, hits] of supplierDescHits.entries()) {
+      const c = getCandidate(supplierId);
+      if (hits.strong >= 2) {
+        c.score += 40;
+        if (c.confidence === "low") c.confidence = "medium";
+        c.reasons.push("Repeated strong description match in PO history");
+      } else if (hits.strong >= 1 || hits.weak >= 2) {
+        c.score += 20;
+        c.reasons.push("Description overlap in prior PO lines");
+      } else {
+        c.score += 10;
+        c.reasons.push("Weak description match in prior PO lines");
+      }
+    }
+  }
+
+  const ranked = Array.from(candidates.values())
+    .filter((c) => c.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map<DeterministicSupplierSuggestion>((c) => {
+      const openPo = input.purchaseOrders.find((po) => {
+        if (String(po.supplier_id ?? "") !== c.supplierId) return false;
+        return !CLOSED_PO_STATUSES.has(String(po.status ?? "open").toLowerCase());
+      });
+
+      const recommendedAction: DeterministicSupplierSuggestion["recommended_action"] = !c.supplierId
+        ? "keep_free_text"
+        : openPo
+          ? "add_to_existing_open_po"
+          : c.confidence === "high" || c.confidence === "medium"
+            ? "create_new_po"
+            : "review_supplier";
+
+      return {
+        supplier_id: c.supplierId,
+        supplier_name: supplierNameById.get(c.supplierId) || null,
+        confidence: c.confidence,
+        reasons: Array.from(new Set(c.reasons)).slice(0, 4),
+        open_po_id: openPo?.id ? String(openPo.id) : null,
+        open_po_number: openPo?.id ? String(openPo.id).slice(0, 8) : null,
+        suggested_unit_cost: c.latestCost,
+        vendor_sku: c.vendorSku,
+        recommended_action: recommendedAction,
+      };
+    });
+
+  if (ranked.length > 0) return ranked;
+
+  return [{
+    supplier_id: null,
+    supplier_name: null,
+    confidence: "low",
+    reasons: ["No supplier history match; keep manual supplier choice"],
+    open_po_id: null,
+    open_po_number: null,
+    suggested_unit_cost: null,
+    vendor_sku: null,
+    recommended_action: "keep_free_text",
+  }];
+}


### PR DESCRIPTION
### Motivation
- Provide a first deterministic, non-AI helper to advise which supplier / PO action is most appropriate for a part request item when stock is unavailable or uncertain. 
- Surface compact advisory UI in the existing request detail flow so users can review suggestions and then manually run the existing Create / Reuse PO flow. 
- Keep behavior advisory-only with no automatic PO/PO-line creation, inventory movement, or schema changes.

### Description
- Added a reusable matcher `buildDeterministicSupplierSuggestions` in `features/parts/lib/parts/deterministicSupplierMatcher.ts` that returns ranked suggestions with fields: `supplier_id`, `supplier_name`, `confidence`, `reasons`, `open_po_id`, `open_po_number`, `suggested_unit_cost`, `vendor_sku`, and `recommended_action` (one of `add_to_existing_open_po`, `create_new_po`, `review_supplier`, `keep_free_text`).
- Implemented deterministic ranking rules that use vendor part numbers, repeated PO-line history for part+supplier, recent part PO history, legacy `parts.supplier` text matching, and description overlap; latest non-null `unit_cost` is captured where available; closed/received/cancelled POs are excluded from “open” candidates.
- Integrated shop-scoped, batched loading of `purchase_order_lines` (by PO ids) into `app/parts/requests/[id]/page.tsx` and added per-item supplier suggestion generation when: no stock suggestion exists, top stock suggestion recommends ordering, or a selected/attached part has no available stock.
- Added compact advisory UI inside the item row showing: “Suggested supplier: [name]”, “Open PO available: [PO id/short]”, “Last cost: $X”, and reason chips; the suggestion CTA only preselects `ui_supplier_id` and explicitly does not create PO or PO line (user must still click existing Create/Re-use PO action).

### Testing
- Ran `npx tsc --noEmit` and it completed successfully.
- Ran `pnpm typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123d58d7808328bab8de00d0ff745a)