### PR TITLE
Phase 2B: expand DB plan constraints for legacy + complete_* vocabulary

### DIFF
--- a/db/sql/2026-05-24_phase2b_complete_plan_constraint_expansion.sql
+++ b/db/sql/2026-05-24_phase2b_complete_plan_constraint_expansion.sql
@@ -1,0 +1,166 @@
+-- Phase 2B: expand DB plan constraints to support dual-vocabulary plan keys.
+--
+-- This is a transition migration only:
+-- - keeps legacy canonical keys (starter/pro/unlimited)
+-- - allows future complete_* keys for forward compatibility
+-- - does not backfill data
+-- - does not change runtime write paths
+
+BEGIN;
+
+-- 1) Expand enum-backed plan vocabulary used by public.profiles.plan.
+--    Keep this additive so existing values remain valid.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+      AND t.typname = 'plan_t'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public'
+        AND t.typname = 'plan_t'
+        AND e.enumlabel = 'complete_10'
+    ) THEN
+      ALTER TYPE public.plan_t ADD VALUE 'complete_10';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public'
+        AND t.typname = 'plan_t'
+        AND e.enumlabel = 'complete_50'
+    ) THEN
+      ALTER TYPE public.plan_t ADD VALUE 'complete_50';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public'
+        AND t.typname = 'plan_t'
+        AND e.enumlabel = 'complete_100'
+    ) THEN
+      ALTER TYPE public.plan_t ADD VALUE 'complete_100';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'public'
+        AND t.typname = 'plan_t'
+        AND e.enumlabel = 'complete_unlimited'
+    ) THEN
+      ALTER TYPE public.plan_t ADD VALUE 'complete_unlimited';
+    END IF;
+  END IF;
+END
+$$;
+
+-- 2) public.shops.plan check: expand accepted values for dual-vocabulary transition.
+ALTER TABLE public.shops
+  DROP CONSTRAINT IF EXISTS shops_plan_check;
+
+ALTER TABLE public.shops
+  ADD CONSTRAINT shops_plan_check
+  CHECK (
+    plan IS NULL
+    OR plan = ANY (
+      ARRAY[
+        'starter'::text,
+        'pro'::text,
+        'unlimited'::text,
+        'complete_10'::text,
+        'complete_50'::text,
+        'complete_100'::text,
+        'complete_unlimited'::text
+      ]
+    )
+  ) NOT VALID;
+
+ALTER TABLE public.shops
+  VALIDATE CONSTRAINT shops_plan_check;
+
+COMMENT ON CONSTRAINT shops_plan_check ON public.shops
+IS 'Phase 2B dual-vocabulary transition: accepts legacy (starter/pro/unlimited) and future complete_* keys.';
+
+-- 3) public.profiles.plan check (if present): normalize to same dual-vocabulary acceptance.
+--    profiles.plan remains enum-backed; this preserves compatibility with environments
+--    that may still include a text check constraint.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_plan_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_plan_check
+  CHECK (
+    plan IS NULL
+    OR plan::text = ANY (
+      ARRAY[
+        'starter'::text,
+        'pro'::text,
+        'unlimited'::text,
+        'complete_10'::text,
+        'complete_50'::text,
+        'complete_100'::text,
+        'complete_unlimited'::text
+      ]
+    )
+  ) NOT VALID;
+
+ALTER TABLE public.profiles
+  VALIDATE CONSTRAINT profiles_plan_check;
+
+COMMENT ON CONSTRAINT profiles_plan_check ON public.profiles
+IS 'Phase 2B dual-vocabulary transition: accepts legacy (starter/pro/unlimited) and future complete_* keys.';
+
+-- 4) Expand DB-level seat-cap helper for complete_* aliases.
+create or replace function public.plan_user_limit(p_plan text, p_stripe_subscription_status text default null)
+returns integer
+language plpgsql
+stable
+as $$
+declare
+  v_plan text := lower(trim(coalesce(p_plan, '')));
+  v_status text := lower(trim(coalesce(p_stripe_subscription_status, '')));
+begin
+  if v_plan in ('pro_plus', 'unlimited', 'complete_unlimited') then
+    return 2147483647;
+  end if;
+
+  if v_plan in ('complete_100') then
+    return 100;
+  end if;
+
+  if v_plan in ('pro', 'pro50', 'complete_50') then
+    return 50;
+  end if;
+
+  if v_plan in ('starter', 'starter10', 'free', 'diy', 'complete_10') then
+    return 10;
+  end if;
+
+  if v_status = 'trialing' then
+    return 10;
+  end if;
+
+  return 10;
+end;
+$$;
+
+comment on function public.plan_user_limit(text, text)
+is 'Phase 2B dual-vocabulary seat cap resolver: legacy + complete_* aliases with trial fallback=10.';
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Allow the database to accept both the existing legacy plan keys and the new `complete_*` keys so runtime and storage remain compatible during the dual-vocabulary transition. 
- Make this change as a safe, additive migration only, without backfilling or changing runtime write paths or checkout/webhook behavior. 

### Description
- Added a single migration file `db/sql/2026-05-24_phase2b_complete_plan_constraint_expansion.sql` which is explicitly scoped to be transition-only and non-destructive. 
- Expanded `public.plan_t` (enum used by `public.profiles.plan`) additively to include `complete_10`, `complete_50`, `complete_100`, and `complete_unlimited` with existence guards so the migration is safe to re-run. 
- Replaced the `shops_plan_check` and `profiles_plan_check` constraints using a drop-and-recreate pattern so both `public.shops.plan` and `public.profiles.plan` accept legacy (`starter`, `pro`, `unlimited`) and future (`complete_10`, `complete_50`, `complete_100`, `complete_unlimited`) values, while preserving `NULL` allowance; comments were added explaining the dual-vocabulary intent. 
- Updated the DB helper `public.plan_user_limit(text, text)` inside the migration so it resolves complete aliases as: `starter|starter10|free|diy|complete_10 => 10`, `pro|pro50|complete_50 => 50`, `complete_100 => 100`, and `unlimited|pro_plus|complete_unlimited => 2147483647` (trial/default fallback remains 10). 

### Testing
- Ran TypeScript validation: `npx tsc --noEmit` — succeeded. 
- Ran targeted unit tests: `npx vitest run tests/plan-normalization-complete-aliases.test.ts` — all tests passed. 
- Ran additional safety tests: `npx vitest run tests/stripe-webhook-hardening.test.ts` and `npx vitest run tests/stripe-api-version-unification.test.ts` — both test suites passed. 
- No application code was modified and no data backfill or destructive updates were performed by the migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123f7954148328991f2d0ad0119182)