### PR TITLE
Improve mobile inspection UI containment and voice correction fallback

### DIFF
--- a/features/inspections/lib/inspection/handleTranscript.ts
+++ b/features/inspections/lib/inspection/handleTranscript.ts
@@ -714,6 +714,11 @@ function mergeNotes(existing: unknown, incoming: string): string {
   return `${ex}; ${inc}`;
 }
 
+function isCorrectionSpeech(text?: string): boolean {
+  const t = norm(text ?? "");
+  return t.includes("change that") || t.includes("actually") || t.includes("undo last");
+}
+
 function inferNoteFromSpeech(params: {
   rawSpeech?: string;
   item?: string;
@@ -1125,6 +1130,17 @@ async function applySingleCommand(args: {
   }
 
   if (!target) {
+    if (isCorrectionSpeech(rawSpeech)) {
+      const sIdx = getSafeCurrentSectionIndex(session);
+      const iIdx = Math.max(
+        0,
+        Math.min(session.currentItemIndex ?? 0, (session.sections[sIdx]?.items?.length ?? 1) - 1),
+      );
+      target = { sectionIndex: sIdx, itemIndex: iIdx };
+    }
+  }
+
+  if (!target) {
     console.warn("[handleTranscript] Could not resolve target:", {
       rawSpeech,
       section,
@@ -1138,6 +1154,22 @@ async function applySingleCommand(args: {
   }
 
   const safeTarget = clampTargetToSession(session, target);
+  const speechNorm = norm(rawSpeech ?? "");
+  if (speechNorm.includes("left side") || speechNorm.includes("right side")) {
+    const wanted = speechNorm.includes("left side") ? "left" : "right";
+    const currentLabel = norm(
+      String(
+        session.sections[safeTarget.sectionIndex]?.items?.[safeTarget.itemIndex]?.item ??
+          session.sections[safeTarget.sectionIndex]?.items?.[safeTarget.itemIndex]?.name ??
+          "",
+      ),
+    ).replace(/\bleft\b|\bright\b/g, "").trim();
+    const siblingIdx = session.sections[safeTarget.sectionIndex]?.items?.findIndex((it) => {
+      const l = norm(String(it.item ?? it.name ?? ""));
+      return l.includes(wanted) && l.replace(/\bleft\b|\bright\b/g, "").trim() === currentLabel;
+    });
+    if (typeof siblingIdx === "number" && siblingIdx >= 0) safeTarget.itemIndex = siblingIdx;
+  }
 
   const itemUpdates: Partial<
     InspectionSession["sections"][number]["items"][number]

--- a/features/inspections/lib/inspection/ui/AirCornerGrid.tsx
+++ b/features/inspections/lib/inspection/ui/AirCornerGrid.tsx
@@ -221,9 +221,9 @@ export default function AirCornerGrid({
           </div>
 
           {open ? (
-            <div className="overflow-x-auto">
-              <div className="inline-block min-w-full align-middle">
-                <table className="min-w-full border-separate border-spacing-y-1">
+            <div className="overflow-x-visible">
+              <div className="min-w-0 align-middle">
+                <table className="w-full table-fixed border-separate border-spacing-y-1">
                   <thead>
                     <tr className="text-xs text-muted-foreground">
                       <th className="px-3 py-2 text-left text-[11px] font-normal uppercase tracking-[0.16em] text-slate-400">
@@ -242,7 +242,12 @@ export default function AirCornerGrid({
                     {t.rows.map((row, rowIdx) => (
                       <tr key={`${row.metric}-${rowIdx}`} className="align-middle">
                         <td className="px-3 py-2 text-sm font-semibold text-foreground">
-                          {row.metric}
+                          <span className="line-clamp-2 md:line-clamp-none">
+                            {row.metric
+                              .replace("Brake Pad / Shoe Thickness", "Pad/Shoe")
+                              .replace("Brake Drum / Rotor Thickness", "Drum/Rotor")
+                              .replace("Push Rod Travel", "Push Rod")}
+                          </span>
                         </td>
 
                         {(["Left", "Right"] as const).map((side) => {
@@ -257,10 +262,10 @@ export default function AirCornerGrid({
 
                           return (
                             <td key={side} className="px-3 py-2 text-center">
-                              <div className="relative w-full max-w-[9rem]">
+                              <div className="relative w-full max-w-none">
                                 <input
                                   defaultValue={cell.initial}
-                                  className="w-full rounded-lg border border-slate-700/70 bg-slate-950/70 px-3 py-1.5 pr-14 text-sm text-foreground placeholder:text-slate-500 focus:border-orange-400 focus:ring-2 focus:ring-orange-400"
+                                  className="h-12 w-full rounded-lg border border-slate-700/70 bg-slate-950/70 px-3 pr-14 text-base text-foreground placeholder:text-slate-500 focus:border-orange-400 focus:ring-2 focus:ring-orange-400"
                                   placeholder="Value"
                                   autoComplete="off"
                                   inputMode="decimal"

--- a/features/inspections/lib/inspection/ui/CornerGrid.tsx
+++ b/features/inspections/lib/inspection/ui/CornerGrid.tsx
@@ -200,7 +200,7 @@ export default function CornerGrid(props: CornerGridProps) {
               </div>
 
               {/* LF | spacer(body) | RF */}
-              <div className="grid grid-cols-[minmax(170px,1fr)_64px_minmax(170px,1fr)] items-start gap-3">
+              <div className="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(170px,1fr)_64px_minmax(170px,1fr)]">
                 {Stack("LF")}
                 <div className="flex h-full items-center justify-center">
                   <div className="h-[110px] w-full rounded-xl border border-white/10 bg-black/25" />
@@ -219,7 +219,7 @@ export default function CornerGrid(props: CornerGridProps) {
               </div>
 
               {/* LR | spacer(body) | RR */}
-              <div className="grid grid-cols-[minmax(170px,1fr)_64px_minmax(170px,1fr)] items-start gap-3">
+              <div className="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(170px,1fr)_64px_minmax(170px,1fr)]">
                 {Stack("LR")}
                 <div className="flex h-full items-center justify-center">
                   <div className="h-[110px] w-full rounded-xl border border-white/10 bg-black/25" />

--- a/features/inspections/lib/inspection/ui/TireCornerGrid.tsx
+++ b/features/inspections/lib/inspection/ui/TireCornerGrid.tsx
@@ -1208,7 +1208,7 @@ export default function TireGrid(props: Props) {
                   </div>
                 </div>
 
-                <div className="grid grid-cols-[minmax(170px,1fr)_minmax(320px,1.35fr)_minmax(170px,1fr)] items-start gap-4">
+                <div className="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(170px,1fr)_minmax(320px,1.35fr)_minmax(170px,1fr)] md:gap-4">
                   {TDColumn(leftTD, "Left Tread Depth", isDual)}
                   {TPCenter({ isDual, left: leftTP, right: rightTP })}
                   {TDColumn(rightTD, "Right Tread Depth", isDual)}

--- a/features/inspections/lib/inspection/ui/TireGridHydraulic.tsx
+++ b/features/inspections/lib/inspection/ui/TireGridHydraulic.tsx
@@ -1138,7 +1138,7 @@ export default function TireGridHydraulic(props: Props) {
                   </div>
                 </div>
 
-                <div className="grid grid-cols-[minmax(170px,1fr)_minmax(320px,1.35fr)_minmax(170px,1fr)] items-start gap-4">
+                <div className="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(170px,1fr)_minmax(320px,1.35fr)_minmax(170px,1fr)] md:gap-4">
                   {TDColumn(leftTD, "Left Tread Depth", isDual)}
                   {TPCenter({ isDual, left: leftTP, right: rightTP })}
                   {TDColumn(rightTD, "Right Tread Depth", isDual)}

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -2488,8 +2488,8 @@ type SmartMatchRow = {
   };
 
   const shell = isEmbed
-    ? "relative mx-auto max-w-[1100px] px-3 py-4 pb-36"
-    : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-40";
+    ? "relative mx-auto max-w-[1100px] px-3 py-4 pb-[calc(9rem+env(safe-area-inset-bottom))]"
+    : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-[calc(9.5rem+env(safe-area-inset-bottom))]";
 
   const headerCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-4 mb-3 md:mb-4`;
   const sectionCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-5 mb-4 md:mb-6`;
@@ -3150,9 +3150,9 @@ type SmartMatchRow = {
         )}
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-black/92 px-3 py-2 backdrop-blur">
-        <div className="mx-auto flex max-w-[1100px] flex-wrap items-center justify-between gap-2">
-          <div className="flex flex-wrap items-center gap-2">{actions}</div>
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-black/92 px-3 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur">
+        <div className="mx-auto flex max-w-[1100px] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-wrap sm:items-center">{actions}</div>
           <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-400">
             Draft auto-saves locally
           </div>


### PR DESCRIPTION
### Motivation

- Fix mobile overflow and visual speed issues where tire/air brake grids and sticky action controls were extending off-screen on narrow (iPhone) widths and inputs were sub‑optimal for thumb interaction.  
- Keep desktop/tablet grid behavior intact while making the mobile experience stacked, touch-friendly, and visually denser (collapse/summary behavior preserved by keeping existing data models).  
- Improve voice transcript behavior so mechanic correction phrases target the active cursor context instead of being dropped or misapplied.

### Description

- Air corner grid containment and mobile touch targets were changed in `features/inspections/lib/inspection/ui/AirCornerGrid.tsx` by removing the `overflow-x-auto` + `inline-block min-w-full` wrappers, switching to `table-fixed` full-width layout, increasing input height to ~48px (`h-12` + `text-base`) and shortening repeated labels for mobile display only (`Pad/Shoe`, `Drum/Rotor`, `Push Rod`); data keys and save behavior remain unchanged.  
- Tire/axle and hydraulic corner layouts were made responsive by switching hard 3-column minmax grids to single-column on small screens and restoring the original multi-column layout at `md+` in `TireCornerGrid.tsx`, `TireGridHydraulic.tsx`, and `CornerGrid.tsx` to eliminate off-screen pushing.  
- Sticky footer/action rail in `features/inspections/screens/GenericInspectionScreen.tsx` was updated to reserve additional bottom padding and include `env(safe-area-inset-bottom)` so Save/Finish/Findings controls never cover fields on iOS, and the action layout was made compact/responsive.  
- Voice fallback and correction improvements were added to `features/inspections/lib/inspection/handleTranscript.ts`: a small `isCorrectionSpeech` detector recognizes correction-style phrases (e.g. "change that", "actually", "undo last") and falls back to the current cursor target when target resolution fails, and left/right side retargeting maps sibling paired items when the transcript contains "left side" or "right side"; existing confidence/review-first semantics and parts/labor review behavior were not changed.  
- No database schema or autosave behavior changes were introduced; all changes are UI/UX and parsing fallbacks only.

Files changed: `features/inspections/screens/GenericInspectionScreen.tsx`, `features/inspections/lib/inspection/ui/AirCornerGrid.tsx`, `features/inspections/lib/inspection/ui/TireCornerGrid.tsx`, `features/inspections/lib/inspection/ui/TireGridHydraulic.tsx`, `features/inspections/lib/inspection/ui/CornerGrid.tsx`, `features/inspections/lib/inspection/handleTranscript.ts`.

### Testing

- Ran TypeScript compile check with `npx tsc --noEmit`, which completed successfully.  
- No automated UI/e2e tests were run as part of this patch; manual validation recommended on iPhone widths and with voice flows.  
- Note: no schema migrations were added so no DB migration tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126604c1f483289751d0e1b0b0c7c2)