### PR TITLE
Phase 3A: neutralize legacy LockedFeature paywall UX

### DIFF
--- a/features/shared/components/ui/LockedFeature.tsx
+++ b/features/shared/components/ui/LockedFeature.tsx
@@ -1,25 +1,75 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { LockIcon } from "lucide-react";
+import { AlertCircleIcon, LockIcon, WrenchIcon } from "lucide-react";
 import clsx from "clsx";
 
+type LockedFeatureReason =
+  | "setup_required"
+  | "permission_required"
+  | "usage_limit"
+  | "temporary_unavailable";
+
 interface LockedFeatureProps {
-  reason?: string;
+  /**
+   * Neutral access state for setup, permission, usage, or temporary availability.
+   * This component is no longer a pricing/feature-gate paywall.
+   */
+  reason?: LockedFeatureReason;
+  /**
+   * Optional CTA for setup-only flows.
+   * Maintained as explicit opt-in to avoid module/plan purchase messaging.
+   */
+  showSetupButton?: boolean;
+  setupHref?: string;
+  className?: string;
+
+  /**
+   * Backward-compatibility props from legacy feature tax UX.
+   * Intentionally ignored for rendering paywall copy/routes.
+   */
   showUpgradeButton?: boolean;
   showTryNowButton?: boolean;
   featureId?: string;
-  className?: string;
+  plan?: string;
+  addOnAvailable?: boolean;
 }
 
+const REASON_COPY: Record<
+  LockedFeatureReason,
+  { title: string; body: string; icon: typeof LockIcon }
+> = {
+  setup_required: {
+    title: "Setup required",
+    body: "This workflow needs a setup step before it can run.",
+    icon: WrenchIcon,
+  },
+  permission_required: {
+    title: "Permission required",
+    body: "Your role does not include this action. Ask an owner or admin for access.",
+    icon: LockIcon,
+  },
+  usage_limit: {
+    title: "Usage limit reached",
+    body: "You’ve reached your current shop-size or usage limit. Contact support if your operation has grown.",
+    icon: AlertCircleIcon,
+  },
+  temporary_unavailable: {
+    title: "Temporarily unavailable",
+    body: "This workflow is temporarily unavailable. Try again shortly.",
+    icon: AlertCircleIcon,
+  },
+};
+
 export default function LockedFeature({
-  reason = "This feature is not available on your current plan.",
-  showUpgradeButton = true,
-  showTryNowButton = false,
-  featureId,
+  reason = "permission_required",
+  showSetupButton = false,
+  setupHref = "/settings",
   className,
 }: LockedFeatureProps) {
   const router = useRouter();
+  const copy = REASON_COPY[reason];
+  const Icon = copy.icon;
 
   return (
     <div
@@ -31,33 +81,23 @@ export default function LockedFeature({
       )}
     >
       <div className="flex items-center gap-2 text-[color:var(--accent-copper-light,#fdba74)]">
-        <LockIcon className="h-5 w-5" />
-        <span className="text-lg font-semibold">Feature Locked</span>
+        <Icon className="h-5 w-5" />
+        <span className="text-lg font-semibold">{copy.title}</span>
       </div>
 
-      <p className="max-w-md text-sm text-neutral-300">{reason}</p>
+      <p className="max-w-md text-sm text-neutral-300">{copy.body}</p>
 
-      <div className="flex flex-wrap justify-center gap-3 mt-1">
-        {showUpgradeButton && (
+      {showSetupButton && reason === "setup_required" ? (
+        <div className="mt-1 flex flex-wrap justify-center gap-3">
           <button
             type="button"
-            onClick={() => router.push("/onboarding/plan")}
+            onClick={() => router.push(setupHref)}
             className="rounded-full border border-[rgba(184,115,51,0.45)] bg-[rgba(184,115,51,0.10)] px-5 py-2 text-sm font-semibold text-amber-100 transition hover:bg-[rgba(184,115,51,0.16)]"
           >
-            Upgrade Plan
+            Review setup
           </button>
-        )}
-
-        {showTryNowButton && featureId && (
-          <button
-            type="button"
-            onClick={() => router.push(`/pay-per-use/${featureId}`)}
-            className="rounded-full border border-white/10 bg-black/30 px-5 py-2 text-sm font-semibold text-neutral-200 transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-black/40"
-          >
-            Try Now
-          </button>
-        )}
-      </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- An audit found `LockedFeature` still embodied legacy plan/paywall language and routes which risked latent reintroduction of a feature-tax UX despite not being actively used. 
- The goal is to neutralize paywall semantics in the UI while preserving all backend, billing, seat-limit, and route/API behavior.

### Description
- Reworked `features/shared/components/ui/LockedFeature.tsx` to replace paywall copy with neutral access/prerequisite variants and kept the export name for compatibility. 
- Introduced explicit reason variants `setup_required`, `permission_required`, `usage_limit`, and `temporary_unavailable` with corresponding title/body/icon copy and an opt-in `showSetupButton` + `setupHref` CTA for setup flows. 
- Removed all paywall wording, purchase routing, and `pay-per-use`/`/onboarding/plan` navigation from rendering while retaining legacy props (`featureId`, `showUpgradeButton`, `showTryNowButton`, `plan`, `addOnAvailable`) for backward compatibility but intentionally not using them for paywall messaging. 
- Preserved visual styling consistent with the existing dark/glass theme and added inline comments that the component is no longer a pricing/feature-gate paywall.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript build validation passed. 
- Searched for legacy paywall strings with ripgrep; an initial run failed due to a malformed `.gitignore` glob (repo env issue), then `rg --no-ignore --no-ignore-files -n "Feature Locked|Upgrade Plan|pay-per-use|not available on your current plan" features/shared/components/ui/LockedFeature.tsx app features` returned no matches in the targeted files. 
- Only `features/shared/components/ui/LockedFeature.tsx` was modified and no automated tests failed during validation.

Files changed:
- `features/shared/components/ui/LockedFeature.tsx`

UX copy changes summary:
- Removed/neutralized: "Feature Locked", "This feature is not available on your current plan.", "Upgrade Plan", "Try Now", `/onboarding/plan`, and `/pay-per-use/*` from this component. 
- Added neutral variants and default texts for `setup_required`, `permission_required`, `usage_limit`, and `temporary_unavailable`.

Confirmations:
- No backend, Stripe, DB plan storage, seat-limit enforcement, plan normalization, webhook, or route/API access behavior was changed. 
- No pay-per-feature or purchase CTA remains in `LockedFeature`; the only CTA available is the optional `Review setup` for `setup_required` flows. 
- Inline comments were added to clarify this component is no longer a pricing/feature-gate surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1266e3e2688328a85a025a17f03652)