### PR TITLE
Route condition-language voice input away from measurement grids

### DIFF
--- a/features/inspections/lib/inspection/handleTranscript.ts
+++ b/features/inspections/lib/inspection/handleTranscript.ts
@@ -223,6 +223,12 @@ function stripStatusForMatch(text: string): string {
   return stripStatusWords(text);
 }
 
+function hasConditionFindingLanguage(text: string): boolean {
+  const t = norm(text);
+  if (!t) return false;
+  return /\b(fail|failed|recommend|recommended|rec|bulge|rim|crack|cracked|lug|loose)\b/.test(t);
+}
+
 function scoreLabel(args: {
   label: string;
   hintTokens: string[];
@@ -393,6 +399,10 @@ function scoreLabel(args: {
       if (isGridLikeLabel(label)) score += 60;
       if (isPlainPushrodLabel(label)) score -= 25;
     }
+  }
+
+  if ((mode === "measurement" || mode === "update_value") && hasConditionFindingLanguage(rawSpeech)) {
+    if (isGridLikeLabel(label)) score -= 50;
   }
 
   return score;


### PR DESCRIPTION
### Motivation
- Measurement grids should remain focused on numeric capture while condition/finding intent is handled by lower/detail inspection items, so voice input must not accidentally route condition-language utterances into numeric grid cells. 
- Existing transcript scoring sometimes favored grid labels even when the user spoke finding/condition terms (e.g., “fail”, “recommend”, “bulge”), which risks overwriting measurements or misrouting intent. 

### Description
- Added `hasConditionFindingLanguage()` to `features/inspections/lib/inspection/handleTranscript.ts` to detect condition/finding terms in raw speech. 
- Adjusted `scoreLabel()` in `handleTranscript.ts` so that in `measurement` / `update_value` modes grid-like labels receive a negative score when condition/finding language is present, reducing the likelihood that condition-oriented speech updates measurement cells. 
- Audit summary: per-measurement status controls are currently rendered by `features/inspections/lib/inspection/ui/TireCornerGrid.tsx` and `features/inspections/lib/inspection/ui/TireGridHydraulic.tsx` (they use `StatusButtons` / per-row status blocks), while `AirCornerGrid.tsx` / `CornerGrid.tsx` focus on numeric pads/rotor cells; no UI files were modified in this change. 
- No database schema changes were made and all existing numeric input autosave/value update code paths were preserved; this change only adjusts transcript-to-target scoring. 
- TODOs: remove per-measurement `OK/FAIL/REC/N/A` controls and add compact group-level notes across tire/air/hydraulic/battery grids in a follow-up patch (targets: `TireCornerGrid.tsx`, `TireGridHydraulic.tsx`, `AirCornerGrid.tsx`, plus shared `StatusButtons` usage). 

### Testing
- Ran type-checking with `npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126d71349c8328b64f80be75afce62)