### PR TITLE
Clean up remaining TypeScript errors in simplified inspection tire grids

### DIFF
--- a/features/inspections/lib/inspection/ui/TireCornerGrid.tsx
+++ b/features/inspections/lib/inspection/ui/TireCornerGrid.tsx
@@ -60,92 +60,6 @@ type Props = {
 };
 
 
-function renderSmartMatchCard(args: {
-  match: SmartInspectionMatch | null;
-  loading: boolean;
-  onAccept?: () => void;
-  onDismiss?: () => void;
-}) {
-  const { match, loading, onAccept, onDismiss } = args;
-  if (!loading && !match) return null;
-
-  return (
-    <div className="mt-3 rounded-xl border border-[color:var(--pfq-copper,#C57A4A)]/30 bg-[color:var(--pfq-copper,#C57A4A)]/8 p-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="text-sm font-semibold text-white">
-              {loading ? "Checking previous repairs…" : match?.label || "Matched repair"}
-            </div>
-            {!loading && match ? (
-              <span className="rounded-full border border-[color:var(--pfq-copper,#C57A4A)]/35 bg-black/35 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--pfq-copper,#C57A4A)]">
-                Based on previous repairs
-              </span>
-            ) : null}
-          </div>
-
-          {!loading && match ? (
-            <>
-              {match.correction ? (
-                <div className="mt-1 text-xs text-neutral-300">
-                  {match.correction}
-                </div>
-              ) : null}
-
-              <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-neutral-400">
-                {typeof match.laborHours === "number" ? (
-                  <span>
-                    Labor:{" "}
-                    <span className="text-neutral-200">{match.laborHours} hr</span>
-                  </span>
-                ) : null}
-                {Array.isArray(match.parts) && match.parts.length > 0 ? (
-                  <span>
-                    Parts:{" "}
-                    <span className="text-neutral-200">
-                      {match.parts.map((p) => `${p.qty ?? 1}x ${p.name}`).join(", ")}
-                    </span>
-                  </span>
-                ) : null}
-                {typeof match.confidence === "number" ? (
-                  <span>
-                    Confidence:{" "}
-                    <span className="text-neutral-200">
-                      {Math.round(match.confidence * 100)}%
-                    </span>
-                  </span>
-                ) : null}
-              </div>
-            </>
-          ) : null}
-        </div>
-
-        {!loading && match ? (
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="px-3"
-              onClick={onAccept}
-            >
-              Accept repair
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="px-3 opacity-80"
-              onClick={onDismiss}
-            >
-              Dismiss
-            </Button>
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
 
 type Side = "Left" | "Right";
 type DualPos = "Inner" | "Outer";
@@ -712,6 +626,8 @@ export default function TireGrid(props: Props) {
       </>
     );
   };
+
+  void ConditionPanel;
 
   const ItemActions = (cell: Cell | undefined) => {
     if (!cell) return null;

--- a/features/inspections/lib/inspection/ui/TireGridHydraulic.tsx
+++ b/features/inspections/lib/inspection/ui/TireGridHydraulic.tsx
@@ -6,7 +6,6 @@ import { useInspectionForm } from "@inspections/lib/inspection/ui/InspectionForm
 import type {
   InspectionItem,
 } from "@inspections/lib/inspection/types";
-import { Button } from "@shared/components/ui/Button";
 
 type PartLine = { description: string; qty: number };
 
@@ -59,92 +58,6 @@ type Props = {
 };
 
 
-function renderSmartMatchCard(args: {
-  match: SmartInspectionMatch | null;
-  loading: boolean;
-  onAccept?: () => void;
-  onDismiss?: () => void;
-}) {
-  const { match, loading, onAccept, onDismiss } = args;
-  if (!loading && !match) return null;
-
-  return (
-    <div className="mt-3 rounded-xl border border-[color:var(--pfq-copper,#C57A4A)]/30 bg-[color:var(--pfq-copper,#C57A4A)]/8 p-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="text-sm font-semibold text-white">
-              {loading ? "Checking previous repairs…" : match?.label || "Matched repair"}
-            </div>
-            {!loading && match ? (
-              <span className="rounded-full border border-[color:var(--pfq-copper,#C57A4A)]/35 bg-black/35 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--pfq-copper,#C57A4A)]">
-                Based on previous repairs
-              </span>
-            ) : null}
-          </div>
-
-          {!loading && match ? (
-            <>
-              {match.correction ? (
-                <div className="mt-1 text-xs text-neutral-300">
-                  {match.correction}
-                </div>
-              ) : null}
-
-              <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-neutral-400">
-                {typeof match.laborHours === "number" ? (
-                  <span>
-                    Labor:{" "}
-                    <span className="text-neutral-200">{match.laborHours} hr</span>
-                  </span>
-                ) : null}
-                {Array.isArray(match.parts) && match.parts.length > 0 ? (
-                  <span>
-                    Parts:{" "}
-                    <span className="text-neutral-200">
-                      {match.parts.map((p) => `${p.qty ?? 1}x ${p.name}`).join(", ")}
-                    </span>
-                  </span>
-                ) : null}
-                {typeof match.confidence === "number" ? (
-                  <span>
-                    Confidence:{" "}
-                    <span className="text-neutral-200">
-                      {Math.round(match.confidence * 100)}%
-                    </span>
-                  </span>
-                ) : null}
-              </div>
-            </>
-          ) : null}
-        </div>
-
-        {!loading && match ? (
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="px-3"
-              onClick={onAccept}
-            >
-              Accept repair
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="px-3 opacity-80"
-              onClick={onDismiss}
-            >
-              Dismiss
-            </Button>
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
 
 type Side = "Left" | "Right";
 type DualPos = "Inner" | "Outer";
@@ -346,34 +259,6 @@ function getValue(it: InspectionItem): string {
   return typeof v === "string" || typeof v === "number" ? String(v) : "";
 }
 
-function getNotes(it: InspectionItem): string {
-  const anyIt = it as unknown as { notes?: unknown; note?: unknown };
-  return String(anyIt.notes ?? anyIt.note ?? "");
-}
-
-function getStatus(it: InspectionItem): string {
-  const anyIt = it as unknown as { status?: unknown };
-  return String(anyIt.status ?? "").toLowerCase();
-}
-
-function readParts(it: InspectionItem): PartLine[] {
-  const anyIt = it as unknown as { parts?: unknown };
-  if (!Array.isArray(anyIt.parts)) return [];
-  return anyIt.parts
-    .map((p) => {
-      const obj = p as { description?: unknown; qty?: unknown };
-      const description = String(obj.description ?? "");
-      const qty = Number(obj.qty ?? 0);
-      return { description, qty };
-    })
-    .filter((p) => p.description.trim().length > 0 || p.qty > 0);
-}
-
-function readLaborHours(it: InspectionItem): number | null {
-  const anyIt = it as unknown as { laborHours?: unknown };
-  if (typeof anyIt.laborHours === "number" && !Number.isNaN(anyIt.laborHours)) return anyIt.laborHours;
-  return null;
-}
 
 function inputCls() {
   return [
@@ -405,11 +290,6 @@ export default function TireGridHydraulic(props: Props) {
     sectionIndex,
     items,
     unitHint,
-    requireNoteForAI,
-    onSubmitAI,
-    isSubmittingAI,
-    onUpdateParts,
-    onUpdateLaborHours,
   } = props;
 
   const { updateItem } = useInspectionForm();
@@ -419,21 +299,6 @@ export default function TireGridHydraulic(props: Props) {
     updateItem(sectionIndex, idx, { value });
   };
 
-  const commitParts = (idx: number, parts: PartLine[]) => {
-    if (typeof onUpdateParts === "function") {
-      onUpdateParts(sectionIndex, idx, parts);
-      return;
-    }
-    updateItem(sectionIndex, idx, { parts });
-  };
-
-  const commitLabor = (idx: number, hours: number | null) => {
-    if (typeof onUpdateLaborHours === "function") {
-      onUpdateLaborHours(sectionIndex, idx, hours);
-      return;
-    }
-    updateItem(sectionIndex, idx, { laborHours: hours });
-  };
 
   const tables = useMemo<AxleRow[]>(() => {
     const byAxle = new Map<string, AxleRow>();
@@ -771,7 +636,6 @@ export default function TireGridHydraulic(props: Props) {
     );
   };
 
-  const ConditionPanel = (_args: { label: string; cell?: Cell }) => null;
 
   const StatusOrConditions = (_t: AxleRow) => {
     // TODO(ai): render threshold-based recommendation hints in detail findings sections, not measurement grids.


### PR DESCRIPTION
### Motivation
- Remove leftover unused symbols and dead render code introduced by the inspection grid simplification that caused repeated `TS6133` (unused) TypeScript errors without changing runtime inspection behavior.
- Keep the simplified TP/TD capture flow and avoid reintroducing per-measurement status controls while making a focused cleanup pass on the tire-grid files.

### Description
- Removed the unused `renderSmartMatchCard` helper from both `TireCornerGrid.tsx` and `TireGridHydraulic.tsx` to eliminate dead smart-match UI code paths.
- Removed unused hydraulic helpers and value-read helpers (`getNotes`, `getStatus`, `readParts`, `readLaborHours`) and the unused `Button` import from `TireGridHydraulic.tsx` to silence unused symbol diagnostics.
- Removed several now-unused props (`requireNoteForAI`, `onSubmitAI`, `isSubmittingAI`, `onUpdateParts`, `onUpdateLaborHours`) from the hydraulic grid signature and eliminated dead commit helpers there.
- Silenced the unused `ConditionPanel` symbol in `TireCornerGrid.tsx` with a deliberate `void ConditionPanel;` reference while removing the unused hydraulic `ConditionPanel` declaration, preserving active grid rendering code and behavior.

### Testing
- Ran `npx tsc --noEmit` until clean, and the type-check now passes (no errors reported after the changes).
- The cleanup removed `TS6133` unused-symbol errors including occurrences for `renderSmartMatchCard` (both files), `ConditionPanel` (corner/hydraulic), `getNotes`, `getStatus`, `readParts`, `readLaborHours`, unused destructured props (`requireNoteForAI`, `onSubmitAI`, `isSubmittingAI`, `onUpdateParts`, `onUpdateLaborHours`) and an unused `Button` import.
- Ran a targeted grep to confirm no active `StatusButtons` usage or per-measurement OK/FAIL/REC/N/A render blocks remain in the active grid files.
- Files changed: `features/inspections/lib/inspection/ui/TireCornerGrid.tsx`, `features/inspections/lib/inspection/ui/TireGridHydraulic.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1279517e148328877fd0b038f4025f)