### PR TITLE
Flatten dormant feature-tax matrix to compatibility-only all-enabled state

### DIFF
--- a/features/shared/lib/plan/features.ts
+++ b/features/shared/lib/plan/features.ts
@@ -1,4 +1,6 @@
-// Types for access control by plan
+// Compatibility-only feature matrix.
+// Complete plans include all core platform features and this file must not be
+// used for paid feature gating. Use usage/seat-limit primitives for scale limits.
 export type FeatureAccess = {
   starter: boolean;
   pro: boolean;
@@ -25,73 +27,73 @@ export type Feature = {
   access: FeatureAccess;
 };
 
-// Full feature config list
+// Full feature config list retained for compatibility.
 export const features: Feature[] = [
   {
     key: "ai_diagnosis",
     title: "AI Diagnosis",
     description:
       "Use image and text to identify mechanical problems automatically.",
-    access: { starter: false, pro: true, unlimited: true, addOnAvailable: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "inspection_flow",
     title: "Inspection Flow",
     description:
       "Voice-guided inspections, summary review, and quote generation.",
-    access: { starter: false, pro: true, unlimited: true, addOnAvailable: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "photo_to_quote",
     title: "Photo to Quote",
     description: "Take photos and let the AI generate repair quotes.",
-    access: { starter: false, pro: true, unlimited: true, addOnAvailable: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "work_orders",
     title: "Work Orders",
     description: "Create, track, and complete work orders in real time.",
-    access: { starter: false, pro: true, unlimited: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "chatbot",
     title: "AI Chatbot",
     description:
       "Talk to an AI mechanic assistant for help diagnosing and learning.",
-    access: { starter: false, pro: true, unlimited: true, addOnAvailable: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "smart_scheduling",
     title: "Smart Scheduling",
     description:
       "Optimize your shop’s schedule with AI-based job priority logic.",
-    access: { starter: false, pro: true, unlimited: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "customer_portal",
     title: "Customer Portal",
     description: "Let customers view quotes, photos, and approve work online.",
-    access: { starter: false, pro: true, unlimited: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "voice_input",
     title: "Voice Input",
     description:
       "Add repairs, inspections, and job notes hands-free using voice.",
-    access: { starter: false, pro: true, unlimited: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "parts_lookup",
     title: "Parts Lookup",
     description:
       "Search and price parts in real time through connected suppliers.",
-    access: { starter: false, pro: true, unlimited: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
   {
     key: "deferred_work_tracking",
     title: "Deferred Tracking",
     description: "Automatically track declined work for follow-up.",
-    access: { starter: false, pro: true, unlimited: true },
+    access: { starter: true, pro: true, unlimited: true, addOnAvailable: false },
   },
 ];
 

--- a/tests/plan-feature-matrix-compat.test.ts
+++ b/tests/plan-feature-matrix-compat.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { featureMap } from "@/features/shared/lib/plan/features";
+
+describe("plan feature matrix compatibility", () => {
+  it("enables work_orders for starter", () => {
+    expect(featureMap.work_orders.access.starter).toBe(true);
+  });
+
+  it("enables inspection_flow for starter", () => {
+    expect(featureMap.inspection_flow.access.starter).toBe(true);
+  });
+
+  it("enables customer_portal for starter", () => {
+    expect(featureMap.customer_portal.access.starter).toBe(true);
+  });
+
+  it("enables smart_scheduling for starter", () => {
+    expect(featureMap.smart_scheduling.access.starter).toBe(true);
+  });
+
+  it("does not imply purchasable add-ons", () => {
+    for (const feature of Object.values(featureMap)) {
+      expect(feature.access.addOnAvailable ?? false).toBe(false);
+    }
+  });
+
+  it("keeps unknown feature access safe/false", () => {
+    const unknownFeature = (featureMap as Record<string, unknown>)[
+      "unknown_feature"
+    ];
+    expect(unknownFeature).toBeUndefined();
+    expect(Boolean(unknownFeature)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Remove latent ‘‘feature-tax’’ semantics from the legacy plan matrix so it cannot be re-used to gate core product functionality. 
- Preserve API/typing compatibility for any consumers that import this file while aligning with the business rule that Complete plans include all core features. 
- Keep the change small and non-breaking so no billing, DB, seat-limit, webhook, or permission behavior is affected.

### Description
- Updated `features/shared/lib/plan/features.ts` to set every core feature access to `starter: true`, `pro: true`, `unlimited: true` and `addOnAvailable: false`, and added a top-level compatibility comment explaining the matrix is retained only for compatibility and must not be used for paid gating. 
- Retained the original `FeatureKey`, `FeatureAccess`, and `Feature` types and the `featureMap` export to avoid breaking imports. 
- Added a targeted test file `tests/plan-feature-matrix-compat.test.ts` that asserts starter plan access for key features, ensures `addOnAvailable` does not imply purchasable add-ons, and verifies unknown features remain safe/false. 
- Files changed: `features/shared/lib/plan/features.ts` and `tests/plan-feature-matrix-compat.test.ts`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully. 
- Ran unit tests with `npx vitest run tests/plan-feature-matrix-compat.test.ts`, which passed (1 file, 6 tests). 
- Performed a targeted search for legacy strings/flags with `rg --no-ignore --no-ignore-files -n "addOnAvailable|Feature Locked|Upgrade Plan|pay-per-use|not available on your current plan"`, which shows the updated `addOnAvailable` usage in `features.ts` and no remaining paywall copy in the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144db77d6c8328b51becd157f08c65)