### PR TITLE
Fix `plan_user_limit` function overload ambiguity in DB

### DIFF
--- a/db/sql/2026-05-25_plan_user_limit_overload_disambiguation.sql
+++ b/db/sql/2026-05-25_plan_user_limit_overload_disambiguation.sql
@@ -1,0 +1,59 @@
+BEGIN;
+
+-- Resolve function-call ambiguity introduced when a 2-arg overload gained a default value
+-- while a legacy 1-arg overload may still exist in some environments.
+--
+-- Canonical behavior is preserved in the 2-arg form, but we explicitly remove its default
+-- and keep a 1-arg wrapper so both call styles remain deterministic.
+
+create or replace function public.plan_user_limit(
+  p_plan text,
+  p_stripe_subscription_status text
+)
+returns integer
+language plpgsql
+stable
+as $$
+declare
+  v_plan text := lower(trim(coalesce(p_plan, '')));
+  v_status text := lower(trim(coalesce(p_stripe_subscription_status, '')));
+begin
+  if v_plan in ('pro_plus', 'unlimited', 'complete_unlimited') then
+    return 2147483647;
+  end if;
+
+  if v_plan in ('complete_100') then
+    return 100;
+  end if;
+
+  if v_plan in ('pro', 'pro50', 'complete_50') then
+    return 50;
+  end if;
+
+  if v_plan in ('starter', 'starter10', 'free', 'diy', 'complete_10') then
+    return 10;
+  end if;
+
+  if v_status = 'trialing' then
+    return 10;
+  end if;
+
+  return 10;
+end;
+$$;
+
+create or replace function public.plan_user_limit(p_plan text)
+returns integer
+language sql
+stable
+as $$
+  select public.plan_user_limit(p_plan, null::text)
+$$;
+
+comment on function public.plan_user_limit(text, text)
+is 'Canonical seat-cap resolver (2-arg, no default) to avoid ambiguous resolution with 1-arg overloads.';
+
+comment on function public.plan_user_limit(text)
+is 'Compatibility wrapper delegating to public.plan_user_limit(text, text) with null subscription status.';
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Demo/shop insert was failing with "function public.plan_user_limit(text) is not unique" because a newer 2‑arg overload had a defaulted second parameter which made calls to the 1‑arg form ambiguous when a legacy 1‑arg overload also existed.
- The goal is to resolve the DB-side ambiguity safely without changing runtime app code, checkout/webhook behavior, plan storage, or data backfills.

### Description
- Added a focused migration `db/sql/2026-05-25_plan_user_limit_overload_disambiguation.sql` that normalizes the function shapes and documents the intent.  
- The canonical implementation is now `public.plan_user_limit(p_plan text, p_stripe_subscription_status text)` with no default second argument, preserving Phase 2B seat-cap mappings in the function body.  
- A compatibility wrapper `public.plan_user_limit(p_plan text)` was added which delegates to the canonical 2‑arg function via `select public.plan_user_limit(p_plan, null::text)`, ensuring existing 1‑arg call sites remain deterministic.  
- The migration contains comments explaining the ambiguity fix and the wrapper purpose, and preserves the seat-cap mappings: `starter/starter10/free/diy/complete_10 -> 10`, `pro/pro50/complete_50 -> 50`, `complete_100 -> 100`, `unlimited/pro_plus/complete_unlimited -> 2147483647`, and `trialing/default fallback -> 10`.

### Testing
- Ran the targeted unit tests with `npx vitest run tests/plan-normalization-complete-aliases.test.ts` and they passed.  
- Ran `npx vitest run tests/stripe-webhook-hardening.test.ts` and `npx vitest run tests/stripe-api-version-unification.test.ts` and both test files passed.  
- Attempted `npx tsc --noEmit` as required by project rules, but the `tsc` run did not complete within the session window; it was started but remained running and therefore its final result could not be observed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a146eb996ec8328a913d5cd0730ac5b)