### PR TITLE
Fix demo seed failure for completed work_order_lines constraint

### DIFF
--- a/scripts/seed-demo-shop.mjs
+++ b/scripts/seed-demo-shop.mjs
@@ -153,6 +153,25 @@ function opError(operation, details, error) {
   return new Error(`${operation} failed (${details}): ${message}`);
 }
 
+const COMPLETED_LINE_STATUSES = new Set(["completed", "done", "closed", "invoiced"]);
+
+function normalizeLineStatus(status) {
+  return typeof status === "string" ? status.trim().toLowerCase() : "";
+}
+
+function validateWorkOrderLineCompletedConstraint(line) {
+  const normalizedStatus = normalizeLineStatus(line.line_status ?? line.status);
+  if (!COMPLETED_LINE_STATUSES.has(normalizedStatus)) return;
+
+  const requiredCompletedFields = ["assigned_tech_id", "punched_in_at", "punched_out_at", "completed_at"];
+  const missing = requiredCompletedFields.filter((field) => !line[field]);
+  if (missing.length > 0) {
+    throw new Error(
+      `work_order_line_preflight failed: description=\"${line.description}\" status=${normalizedStatus} missing completed fields: ${missing.join(", ")}`,
+    );
+  }
+}
+
 async function upsertByNaturalKey({ supabase, table, match, payload, select = "id" }) {
   const query = supabase.from(table).select(select).limit(1);
   for (const [key, value] of Object.entries(match)) query.eq(key, value);
@@ -442,35 +461,39 @@ async function main() {
   }
 
   const lines = [
-    ["DEMO-WO-1003", "Approved steering link replacement", "approved", leadTechId, "completed"],
+    ["DEMO-WO-1003", "Approved steering link replacement", "approved", leadTechId, "active"],
     ["DEMO-WO-1003", "Recommended shock absorbers (deferred)", "declined", leadTechId, "awaiting"],
     ["DEMO-WO-1004", "ABS wheel speed sensor backorder", "pending", tech1Id, "on_hold"],
-    ["DEMO-WO-1002", "Pressure test and leak trace", null, tech1Id, "in_progress"],
-    ["DEMO-WO-1007", "Wheel seal replacement recurrence", "approved", leadTechId, "completed"],
+    ["DEMO-WO-1002", "Pressure test and leak trace", null, tech1Id, "active"],
+    ["DEMO-WO-1007", "Wheel seal replacement recurrence", "approved", leadTechId, "active"],
   ];
 
   for (const [woNumber, description, approval_state, techId, status] of lines) {
+    const linePayload = {
+      shop_id: shopId,
+      work_order_id: workOrderIds[woNumber],
+      user_id: managerId,
+      assigned_to: techId,
+      assigned_tech_id: techId,
+      description,
+      complaint: description,
+      cause: "Demo seeded narrative cause",
+      correction: "Demo seeded narrative correction",
+      line_status: status,
+      status,
+      job_type: "repair",
+      approval_state,
+      labor_time: 1.5,
+      parts_required: [{ part: "Demo Part", qty: 1 }],
+    };
+
+    validateWorkOrderLineCompletedConstraint(linePayload);
+
     await upsertByNaturalKey({
       supabase,
       table: "work_order_lines",
       match: { shop_id: shopId, work_order_id: workOrderIds[woNumber], description },
-      payload: {
-        shop_id: shopId,
-        work_order_id: workOrderIds[woNumber],
-        user_id: managerId,
-        assigned_to: techId,
-        assigned_tech_id: techId,
-        description,
-        complaint: description,
-        cause: "Demo seeded narrative cause",
-        correction: "Demo seeded narrative correction",
-        line_status: status,
-        status,
-        job_type: "repair",
-        approval_state,
-        labor_time: 1.5,
-        parts_required: [{ part: "Demo Part", qty: 1 }],
-      },
+      payload: linePayload,
     });
   }
 
@@ -525,6 +548,7 @@ async function main() {
   console.log(`work_order_count: ${counts.work_orders}`);
   console.log(`inspection_count: ${counts.inspections}`);
   console.log("vehicle_customer_consistency: passed");
+  console.log("work_order_line_constraint_validation: passed");
   console.log("notable_moments: awaiting approval quote split, parts bottleneck, recurring TR-101 repair, completed municipal inspection");
   console.log("portal_seed: skipped (schema/flow ambiguity; follow-up in Phase 2)");
   console.log(`safe_domain_check_non_demo_emails: ${unsafeEmails?.length ?? 0}`);


### PR DESCRIPTION
### Motivation
- The demo seed failed when inserting `work_order_lines` because some lines were marked completed without the punch-out/completion metadata the DB requires, causing a check-constraint violation. 
- The intent is to make Phase 1 seeding safe (dry-run and write mode) without changing schema or weakening constraints.

### Description
- Added defensive preflight validation in `scripts/seed-demo-shop.mjs` that treats `completed`-like statuses (`completed`, `done`, `closed`, `invoiced`) as requiring completion fields and throws a clear error before any DB operation via `validateWorkOrderLineCompletedConstraint`.
- Normalized the seeded line payloads to use demo-safe non-completed statuses (`active`, `awaiting`, `on_hold`) so narrative lines like "Approved steering link replacement" no longer trigger the completed check unless full completion metadata is provided.
- Centralized the work order line payload into `linePayload` before upsert and run the new validation on that payload (preserves idempotent `upsertByNaturalKey` behavior and allows repair on re-runs).
- Added summary output `work_order_line_constraint_validation: passed` so dry-run and write-mode both report validation status.
- Files changed: `scripts/seed-demo-shop.mjs`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it succeeded.
- Dry-run seed: ran `ALLOW_DEMO_SEED=true DEMO_SEED_DRY_RUN=true DEMO_OWNER_EMAIL="edwardlakin35@gmail.com" npm run seed:demo-shop`, which aborted early with a missing-env error `Missing required env var: NEXT_PUBLIC_SUPABASE_URL`, so the full networked dry-run could not complete here; the script still enforces the new line validation during dry-run when env is present.
- Root cause: seed created lines with a completed-like `status` while omitting punch/completion fields required by DB constraints.
- Constraint fields enforced by the new validation: `assigned_tech_id`, `punched_in_at`, `punched_out_at`, `completed_at`.
- Fix summary: seeded lines no longer use completed statuses by default and preflight validation prevents accidental insertion of incomplete completed lines; idempotent upserts will repair previously partially seeded rows to the new payload on re-run.
- Confirmation: current seed payloads contain no completed work_order_lines that would violate the required punch-out/completion fields (completed statuses were changed to `active`/`awaiting`/`on_hold`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147d62e0e483289f4d3df47549e29b)