### PR TITLE
Fix demo-seed owner persona overwrite detection

### DIFF
--- a/scripts/qa-demo-seed.mjs
+++ b/scripts/qa-demo-seed.mjs
@@ -162,8 +162,10 @@ async function main() {
     const ownerProfile = (profiles ?? []).find((profile) => (profile.email || "").toLowerCase() === ownerEmail);
     addCheck(checks, failures, "owner_profile_exists", Boolean(ownerProfile), { ownerEmail });
 
-    const personaNames = new Set([
+    const seededPersonaNames = new Set([
+      "Demo Owner",
       "Owner Demo",
+      "Prairie Demo Owner",
       "Admin Demo",
       "Manager Demo",
       "Advisor One",
@@ -174,11 +176,30 @@ async function main() {
       "Parts Coordinator",
       "Payroll Coordinator",
     ]);
-    const personaRoles = new Set(["owner", "admin", "manager", "advisor", "tech", "parts"]);
-    const ownerNotPersona = Boolean(ownerProfile) && !personaNames.has(ownerProfile.full_name || "") && !personaRoles.has(ownerProfile.role || "");
+
+    const overwriteSignals = [];
+    const ownerProfileEmail = (ownerProfile?.email || "").trim().toLowerCase();
+    const ownerFullName = (ownerProfile?.full_name || ownerProfile?.name || "").trim();
+    const ownerRole = (ownerProfile?.role || "").trim().toLowerCase();
+
+    if (ownerProfileEmail && ownerProfileEmail !== ownerEmail && isDemoSafeEmail(ownerProfileEmail)) {
+      overwriteSignals.push(`owner_email_replaced_with_demo_safe:${ownerProfileEmail}`);
+    }
+
+    if (ownerFullName && seededPersonaNames.has(ownerFullName)) {
+      overwriteSignals.push(`owner_name_matches_seeded_persona:${ownerFullName}`);
+    }
+
+    if (/\bdemo\b/i.test(ownerFullName) && ownerFullName.toLowerCase() !== "edward lakin") {
+      overwriteSignals.push(`owner_name_contains_demo_marker:${ownerFullName}`);
+    }
+
+    const ownerNotPersona = Boolean(ownerProfile) && overwriteSignals.length === 0;
     addCheck(checks, failures, "owner_profile_not_overwritten_to_persona", ownerNotPersona, {
-      ownerFullName: ownerProfile?.full_name ?? null,
-      ownerRole: ownerProfile?.role ?? null,
+      ownerEmail: ownerProfileEmail || null,
+      ownerFullName: ownerFullName || null,
+      ownerRole: ownerRole || null,
+      overwriteSignals,
     });
 
     addCheck(checks, failures, "portal_depth_absent_phase_1", true, {


### PR DESCRIPTION
### Motivation
- The demo-seed QA was producing a false positive when a legitimate owner profile (e.g. Edward Lakin with role `owner`) was flagged as overwritten by a demo persona. 
- The intent is to make the check only fail on clear evidence of seeded demo persona overwrites while preserving read-only QA behavior and exit-code semantics.

### Description
- Update the `owner_profile_not_overwritten_to_persona` logic in `scripts/qa-demo-seed.mjs` to stop treating role values like `owner`/`admin` as overwrite evidence. 
- Introduce explicit `overwriteSignals` detection that flags owner overwrite only when the owner email was replaced with a demo-safe email, the owner full name matches seeded demo persona names (including `Demo Owner`, `Owner Demo`, `Prairie Demo Owner`), or the name contains a demo marker. 
- Add richer check output fields: `ownerEmail`, `ownerFullName`, `ownerRole`, and `overwriteSignals` so failures include actionable details. 
- Only `scripts/qa-demo-seed.mjs` was modified and read-only behavior and exit-code behavior (`process.exit(summary.ok ? 0 : 1)`) were preserved.

### Testing
- Ran `npx tsc --noEmit` which completed successfully. 
- Attempted to run the QA script with `ALLOW_DEMO_SEED_QA=true DEMO_OWNER_EMAIL="edwardlakin35@gmail.com" npm run qa:demo-seed` but the run could not complete in this environment because required Supabase env vars (`NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) were not provided, and the script exited with the expected runtime error path. 
- Summary of results: TypeScript validation passed and the QA script behaves as intended in principle (runtime QA requires Supabase envs to fully verify in CI or a properly provisioned environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148e4d3a7483289d3603a654c701af)