### PR TITLE
Fix invalid demo seed work_order_lines status value

### DIFF
--- a/scripts/seed-demo-shop.mjs
+++ b/scripts/seed-demo-shop.mjs
@@ -497,7 +497,7 @@ async function main() {
       correction: "Recommend front brake service and rotor resurfacing.",
       approval_state: "approved",
       techId: leadTechId,
-      status: "ready",
+      status: "active",
       labor_time: 1.4,
       job_type: "inspection",
       parts_required: [{ part: "Front pad set", qty: 1 }],


### PR DESCRIPTION
### Motivation
- The demo seed failed on insert because a seeded work_order_line used an invalid status value `ready`, which violates the script's local status validation and the schema/UI allowlist.

### Description
- Edited `scripts/seed-demo-shop.mjs` to replace the invalid `status: "ready"` for the brake verification line (DEMO-WO-1001, description: "Brake pull and noise verification from inspection findings") with `status: "active"`, keeping `line_status` and `status` aligned and preserving the demo narrative.

### Testing
- Ran `npx tsc --noEmit` which passed, and attempted the dry-run `ALLOW_DEMO_SEED=true DEMO_SEED_DRY_RUN=true DEMO_OWNER_EMAIL="edwardlakin35@gmail.com" npm run seed:demo-shop` which could not proceed here due to a missing `NEXT_PUBLIC_SUPABASE_URL` environment variable; local completed-line preflight validation remains unchanged and strict.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149997c7dc8328be6fb89e9a6c6b1e)