### PR TITLE
Fix demo seed: make 'Wheel seal replacement recurrence' status schema-safe

### DIFF
--- a/scripts/seed-demo-shop.mjs
+++ b/scripts/seed-demo-shop.mjs
@@ -600,7 +600,7 @@ async function main() {
       correction: "Replace seal, clean brake assembly, road-test.",
       approval_state: "approved",
       techId: leadTechId,
-      status: "completed",
+      status: "active",
       labor_time: 2.4,
       job_type: "repair",
       parts_required: [{ part: "Axle wheel seal", qty: 1 }],


### PR DESCRIPTION
### Motivation
- Local demo seed preflight failed because the seeded work order line `Wheel seal replacement recurrence` used a completed-like status but lacked required completion/punch timestamps.
- The change preserves the recurring repair narrative without loosening validation or altering schema or runtime behavior.

### Description
- Updated `scripts/seed-demo-shop.mjs` to change the seeded line `Wheel seal replacement recurrence` from `status: "completed"` to `status: "active"`, which also yields `line_status: "active"` via the payload mapping. 
- Preserved narrative fields: `description`, `complaint`, `cause`, and `correction` and kept `approval_state` and `parts_required` unchanged. 
- Audited seeded `work_order_lines` in the seed script to ensure no other seeded lines use completed-like statuses (`completed`, `done`, `closed`, `invoiced`) without the required completion fields.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Verified the file change: `scripts/seed-demo-shop.mjs` was modified and the replacement status used is `status: "active"` (resulting `line_status: "active"`).
- Searched the seed file for completed-like statuses and confirmed there are no remaining seeded lines using `completed`, `done`, `closed`, or `invoiced` without required fields. 
- Attempted the write-mode seed command as requested and it failed with `Demo seed failed: Invalid URL` due to placeholder environment values (this is an external env issue, not a seed script failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14aa52c34c832881fdccb7f168b4f8)