### PR TITLE
Fix labor breakdown fallback totals in work order displays

### DIFF
--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -30,6 +30,7 @@ type ReviewFlags = {
 };
 
 type PricingSummary = {
+  laborHours?: number | null;
   laborTotal?: number | null;
   partsTotal?: number | null;
   lineTotal?: number | null;
@@ -523,7 +524,12 @@ export function JobCard({
                   <MetaTile label="Assigned Tech" value={assignedTech} />
                   <MetaTile
                     label="Labor"
-                    value={formatLaborSummary(line.labor_time, Number(pricing?.laborTotal ?? 0))}
+                    value={formatLaborSummary(
+                      Number.isFinite(Number(pricing?.laborHours))
+                        ? Number(pricing?.laborHours)
+                        : line.labor_time,
+                      Number(pricing?.laborTotal ?? 0),
+                    )}
                   />
                   <MetaTile
                     label="Parts"

--- a/features/work-orders/lib/display/linePresentation.test.ts
+++ b/features/work-orders/lib/display/linePresentation.test.ts
@@ -5,6 +5,7 @@ import {
   resolvePartsBottleneckDisplay,
   resolvePrimaryTechDisplay,
 } from "./linePresentation";
+import { resolveWorkOrderLinePricing } from "../pricing/resolveWorkOrderLinePricing";
 
 describe("linePresentation", () => {
   it("returns Unassigned when tech is missing or non-tech profile", () => {
@@ -29,6 +30,30 @@ describe("linePresentation", () => {
   it("formats labor summary with non-zero labor dollars", () => {
     expect(formatLaborSummary(2.2, 319)).toContain("2.2h");
     expect(formatLaborSummary(2.2, 319)).toContain("$319.00");
+  });
+
+  it("resolves labor total from line total when parts and labor time are present", () => {
+    const pricing = resolveWorkOrderLinePricing({
+      line: { labor_time: 2.2, price_estimate: 844 },
+      shopLaborRate: null,
+      stagedParts: [{ quantity: 1, unit_price: 525, total_price: 525 }],
+    });
+    expect(pricing.laborHours).toBe(2.2);
+    expect(pricing.partsTotal).toBe(525);
+    expect(pricing.laborTotal).toBe(319);
+    expect(pricing.lineTotal).toBe(844);
+    expect(formatLaborSummary(pricing.laborHours, pricing.laborTotal)).toContain("$319.00");
+  });
+
+  it("does not collapse to zero labor when line total exists without parts", () => {
+    const pricing = resolveWorkOrderLinePricing({
+      line: { labor_time: 0.6, price_estimate: 87 },
+      shopLaborRate: null,
+    });
+    expect(pricing.laborHours).toBe(0.6);
+    expect(pricing.partsTotal).toBe(0);
+    expect(pricing.laborTotal).toBe(87);
+    expect(formatLaborSummary(pricing.laborHours, pricing.laborTotal)).toContain("$87.00");
   });
 
   it("formats parts summary with requested estimate", () => {

--- a/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
+++ b/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
@@ -84,7 +84,13 @@ export function resolveWorkOrderLinePricing(args: {
   const lineTotal = toNum(quote?.grand_total) ?? toNum(quote?.subtotal) ?? toNum(line.price_estimate) ?? (laborHours * laborRate) + partsTotal;
   const computedLaborTotal = laborHours * laborRate;
   const inferredLaborFromLineTotal = Math.max(0, lineTotal - partsTotal);
-  const laborTotal = quotedLaborTotal ?? (computedLaborTotal > 0 ? computedLaborTotal : inferredLaborFromLineTotal);
+  const quotedLaborTotalIsUsable = quotedLaborTotal != null && quotedLaborTotal > 0;
+  const computedLaborTotalIsUsable = computedLaborTotal > 0;
+  const laborTotal = quotedLaborTotalIsUsable
+    ? quotedLaborTotal
+    : computedLaborTotalIsUsable
+      ? computedLaborTotal
+      : inferredLaborFromLineTotal;
 
   return { laborHours, laborRate, laborTotal, partsCount, partsTotal, lineTotal };
 }


### PR DESCRIPTION
### Motivation
- Labor breakdown tiles were showing `$0.00` when `quote.labor_total` was present but zero, even though invoice-grade totals or computed rates could produce a valid labor amount.
- The display code also relied on raw `line.labor_time` in `JobCard` instead of the resolved pricing contract, causing contract drift between resolver and UI.

### Description
- Updated resolver precedence in `resolveWorkOrderLinePricing` so a quoted `labor_total` is only authoritative when it is `> 0`; otherwise it falls back to computed `laborHours * laborRate` or inferred `lineTotal - partsTotal` (whichever is available). (file: `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts`)
- Made `JobCard` consume resolved pricing hours and amounts by adding `laborHours` to the `PricingSummary` contract and using `pricing.laborHours` + `pricing.laborTotal` in the labor tile. (file: `features/work-orders/components/JobCard.tsx`)
- Added tests that exercise the resolver/display contract to ensure labor totals are derived as expected: a 2.2h line with `price_estimate=844` and parts `525` yields labor `319`, and a 0.6h line with `price_estimate=87` and no parts yields labor `87`. (file: `features/work-orders/lib/display/linePresentation.test.ts`)

### Testing
- Ran TypeScript check with `npx tsc --noEmit` and it passed successfully.
- Ran targeted tests with `npx vitest run features/work-orders/lib/display/linePresentation.test.ts` and they passed (7 tests, all green), including the new resolver/display cases.

Files changed: `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts`, `features/work-orders/components/JobCard.tsx`, `features/work-orders/lib/display/linePresentation.test.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a1f8845083288027b8da1ac1d2e2)