### PR TITLE
Harden customer portal access behind invite evidence

### DIFF
--- a/app/portal/auth/confirm/page.tsx
+++ b/app/portal/auth/confirm/page.tsx
@@ -10,6 +10,8 @@ const COPPER = "#C57A4A";
 
 type CustomersRow = Database["public"]["Tables"]["customers"]["Row"];
 type CustomersInsert = Database["public"]["Tables"]["customers"]["Insert"];
+type CustomerPortalInviteRow =
+  Database["public"]["Tables"]["customer_portal_invites"]["Row"];
 
 /**
  * Portal Confirm
@@ -62,31 +64,53 @@ export default function PortalConfirmPage() {
         }
 
         // -------------------------------------------------------------------
-        // Ensure this authed user has a portal customer profile.
-        // Try to attach to an existing customer row by email first (so we
-        // keep the shop_id + history from the work order), otherwise create.
+        // Require invite context evidence before linking customer portal data.
+        // Without this, generic email confirmation can expose customer data.
         // -------------------------------------------------------------------
         try {
           const email = session.user.email ?? null;
           if (email) {
+            const normalizedEmail = email.toLowerCase();
+            const { data: inviteRows, error: inviteErr } = await supabase
+              .from("customer_portal_invites")
+              .select("id, customer_id, email")
+              .eq("email", normalizedEmail)
+              .limit(5);
+
+            const hasInviteContext =
+              !inviteErr && Array.isArray(inviteRows) && inviteRows.length > 0;
+
+            if (!hasInviteContext) {
+              router.replace("/portal");
+              return;
+            }
+
             const { data: existing, error: findErr } = await supabase
               .from("customers")
               .select("id, shop_id, user_id")
-              .eq("email", email.toLowerCase())
+              .eq("email", normalizedEmail)
               .limit(1);
 
             if (!findErr && existing && existing.length > 0) {
               const row = existing[0] as CustomersRow;
-              if (!row.user_id) {
+              const inviteCustomerIds = (inviteRows as Pick<
+                CustomerPortalInviteRow,
+                "customer_id"
+              >[]).map((row) => row.customer_id);
+              const hasMatchingInviteCustomer = inviteCustomerIds.includes(
+                row.id,
+              );
+
+              if (!row.user_id && hasMatchingInviteCustomer) {
                 await supabase
                   .from("customers")
                   .update({ user_id: session.user.id })
                   .eq("id", row.id);
               }
-            } else {
+            } else if (inviteRows.some((r) => !!r.customer_id)) {
               const insertPayload: CustomersInsert = {
                 user_id: session.user.id,
-                email: email.toLowerCase(),
+                email: normalizedEmail,
               };
               await supabase
                 .from("customers")

--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -9,6 +9,8 @@ import { PortalActionCard, PortalEmptyState, PortalPageHeader, PortalPrimaryButt
 
 type DB = Database;
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
+type CustomerPortalInviteRow =
+  DB["public"]["Tables"]["customer_portal_invites"]["Row"];
 type BookingRow = DB["public"]["Tables"]["bookings"]["Row"];
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 
@@ -22,6 +24,7 @@ export default function PortalHomePage() {
   const [vehiclesCount, setVehiclesCount] = useState<number | null>(null);
   const [nextBookingAt, setNextBookingAt] = useState<string | null>(null);
   const [activeWo, setActiveWo] = useState<Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state"> | null>(null);
+  const [requiresInvite, setRequiresInvite] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -33,6 +36,7 @@ export default function PortalHomePage() {
       if (!mounted) return;
 
       if (userErr || !user) {
+        setRequiresInvite(false);
         setVehiclesCount(null);
         setNextBookingAt(null);
         setActiveWo(null);
@@ -44,12 +48,47 @@ export default function PortalHomePage() {
       if (!mounted) return;
 
       if (custErr || !cust?.id) {
+        setRequiresInvite(true);
         setVehiclesCount(null);
         setNextBookingAt(null);
         setActiveWo(null);
         setLoading(false);
         return;
       }
+
+      const normalizedUserEmail = (user.email ?? "").trim().toLowerCase();
+      const { data: inviteEvidence, error: inviteErr } = await supabase
+        .from("customer_portal_invites")
+        .select("id, customer_id, email")
+        .eq("customer_id", cust.id)
+        .limit(10);
+      if (!mounted) return;
+
+      const hasInviteEvidence =
+        !inviteErr &&
+        Array.isArray(inviteEvidence) &&
+        inviteEvidence.some((row) => {
+          const invite = row as Pick<
+            CustomerPortalInviteRow,
+            "id" | "customer_id" | "email"
+          >;
+          return (
+            invite.customer_id === cust.id &&
+            normalizedUserEmail.length > 0 &&
+            invite.email.trim().toLowerCase() === normalizedUserEmail
+          );
+        });
+
+      if (!hasInviteEvidence) {
+        setRequiresInvite(true);
+        setVehiclesCount(null);
+        setNextBookingAt(null);
+        setActiveWo(null);
+        setLoading(false);
+        return;
+      }
+
+      setRequiresInvite(false);
 
       const { count: vCount } = await supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("customer_id", cust.id);
       const nowIso = new Date().toISOString();
@@ -69,6 +108,18 @@ export default function PortalHomePage() {
 
   if (loading) {
     return <div className="space-y-5 text-white"><PortalPageHeader eyebrow="Customer portal" title="What needs your attention today?" subtitle="Loading your latest status and activity." /></div>;
+  }
+
+  if (requiresInvite) {
+    return (
+      <div className="space-y-5 text-white">
+        <PortalPageHeader
+          eyebrow="Customer portal"
+          title="Portal invite required"
+          subtitle="Open the invite link sent by the shop, or ask the shop to resend your portal invite."
+        />
+      </div>
+    );
   }
 
   const hasInvoice = !!activeWo && !!activeWo.invoice_sent_at && (activeWo.status === "ready_to_invoice" || activeWo.status === "invoiced");


### PR DESCRIPTION
### Motivation
- An audit showed the portal confirmation flow could auto-link by email and cause `customers.user_id` to exist without an invite, allowing live portal work data to render prematurely. This change prevents that exposure by requiring invite evidence before showing live customer data. 

### Description
- Add a conservative guard to `app/portal/page.tsx` that requires an authenticated session, a linked `customers` row (`user_id = auth.uid()`), and invite evidence in `customer_portal_invites` matching the linked `customer_id` and normalized session email, and short-circuit live data queries when the check fails. 
- Render a safe invite-required state with the exact message: "Portal invite required" and "Open the invite link sent by the shop, or ask the shop to resend your portal invite." instead of loading vehicles/bookings/work_orders/board. 
- Harden `app/portal/auth/confirm/page.tsx` to detect invite context by checking `customer_portal_invites` for the session email before attempting to link or upsert a `customers.user_id`, and redirect to `/portal` (invite-required state) when no invite context exists. 
- Added local types for `customer_portal_invites` rows and introduced `requiresInvite` state; no RLS, property portal, fleet portal, mobile routing, QR flow, or DB schema changes were made. 
- Files changed: `app/portal/page.tsx`, `app/portal/auth/confirm/page.tsx`.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `pnpm typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ab627be483288f18de66dbc4acdd)