### PR TITLE
Fix shop share QR source to use slug QR endpoint

### DIFF
--- a/app/portal/shop/[slug]/PageClient.tsx
+++ b/app/portal/shop/[slug]/PageClient.tsx
@@ -71,7 +71,7 @@ export default function ShopSharePage({ slug, shopId: shopIdProp }: Props) {
         : "https://example.com";
 
   const bookingUrl = `${base}/portal/booking?shop=${encodeURIComponent(slug)}`;
-  const qrSrc = `/api/portal/qr?shop=${encodeURIComponent(slug)}`;
+  const qrSrc = `/api/portal/qr/${encodeURIComponent(slug)}`;
 
   const Card =
     "rounded-3xl border border-white/10 bg-black/25 p-4 backdrop-blur-md shadow-card sm:p-6";


### PR DESCRIPTION
### Motivation
- Fix a customer-portal QR regression where the shop share page requested `/api/portal/qr?shop=<slug>` but the API route expects a `data`/`url` param (or the separate slug endpoint), causing QR image generation to fail.

### Description
- Update `app/portal/shop/[slug]/PageClient.tsx` to set `qrSrc` to `/api/portal/qr/${encodeURIComponent(slug)}` (was `/api/portal/qr?shop=${encodeURIComponent(slug)}`), preserving the visible booking link as `${base}/portal/booking?shop=${encodeURIComponent(slug)}` and keeping slug URL-encoding, with no other behavioral, RLS, schema, invite-gating, fleet, or mobile changes.

### Testing
- Ran `npx tsc --noEmit` and `pnpm typecheck`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15be1ff65c8328915aeb55faa1b842)