### PR TITLE
Fix portal vehicles ESLint jsx-key build blocker

### DIFF
--- a/app/portal/vehicles/page.tsx
+++ b/app/portal/vehicles/page.tsx
@@ -415,9 +415,18 @@ export default function PortalVehiclesPage() {
               [v.year ?? "", v.make ?? "", v.model ?? ""].filter(Boolean).join(" ").trim() ||
               "Vehicle";
 
-            if (inviteRequired) {
-    return <div className="mx-auto max-w-3xl"><div className={cardClass() + " text-sm text-neutral-200"}><div className="font-semibold">Portal invite required</div><div className="mt-1">Open the invite link sent by the shop, or ask the shop to resend your portal invite.</div></div></div>;
-  }
+                    if (inviteRequired) {
+              return (
+                <div key={v.id} className="mx-auto max-w-3xl">
+                  <div className={cardClass() + " text-sm text-neutral-200"}>
+                    <div className="font-semibold">Portal invite required</div>
+                    <div className="mt-1">
+                      Open the invite link sent by the shop, or ask the shop to resend your portal invite.
+                    </div>
+                  </div>
+                </div>
+              );
+            }
 
   return (
               <div


### PR DESCRIPTION
### Motivation
- Resolve the Vercel build failure caused by `react/jsx-key` in `app/portal/vehicles/page.tsx` by ensuring every element returned from the `vehicles.map(...)` iterator has a stable key.

### Description
- Added `key={v.id}` to the invite-required card returned inside the `vehicles.map((v) => ...)` branch in `app/portal/vehicles/page.tsx`; portal guard and invite logic were not changed.

### Testing
- Ran `npx tsc --noEmit` and `pnpm typecheck`, both succeeded; `pnpm build` was attempted but failed in this environment due to external Google Fonts fetch failures (`Inter` / `Black Ops One`), which are unrelated to the JSX key fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c88af0c083288f0b08283432cded)