### PR TITLE
Preserve mobile intent through /auth/callback routing

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -50,8 +50,12 @@ export default function AuthCallbackPage() {
 
       if (!session?.user) {
         const passthrough = new URLSearchParams();
+        const redirect = sp.get("redirect")?.trim();
+        const mode = sp.get("mode")?.trim();
         const sessionId = sp.get("session_id")?.trim();
         const flow = sp.get("flow")?.trim();
+        if (redirect) passthrough.set("redirect", redirect);
+        if (mode) passthrough.set("mode", mode);
         if (sessionId) passthrough.set("session_id", sessionId);
         if (flow) passthrough.set("flow", flow);
         const signInHref = `/sign-in${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
@@ -70,9 +74,14 @@ export default function AuthCallbackPage() {
 
       router.refresh();
 
+      const isMobileMode =
+        (sp.get("mode") || "").toLowerCase() === "mobile" ||
+        (sp.get("redirect") || "") === "/mobile";
+
       const destination = await resolvePostAuthDestination({
         supabase,
         searchParams: sp,
+        isMobileMode,
       });
 
       router.replace(destination);


### PR DESCRIPTION
### Motivation
- The auth callback was dropping `redirect=/mobile` and `mode=mobile` intent, causing sign-ins that targeted the mobile companion to land on the main dashboard instead of the mobile UI.

### Description
- Forward `redirect` and `mode` query params back to `/sign-in` when `/auth/callback` has no active session and needs a retry, and derive `isMobileMode` from the same params and pass it into `resolvePostAuthDestination` to preserve mobile routing intent in `app/auth/callback/page.tsx`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check completed successfully (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d716b7dc832896990e4e7a21acfc)