### PR TITLE
Harden QuickBooks invoice sync shop scoping

### DIFF
--- a/app/api/integrations/quickbooks/invoice/[id]/route.ts
+++ b/app/api/integrations/quickbooks/invoice/[id]/route.ts
@@ -35,6 +35,7 @@ export async function POST(
       connection,
       invoiceId,
       user.id,
+      shop.id,
     );
 
     return NextResponse.json({

--- a/features/integrations/quickbooks/server/syncInvoice.ts
+++ b/features/integrations/quickbooks/server/syncInvoice.ts
@@ -87,6 +87,7 @@ export async function syncInvoiceToQuickBooks(
   connection: QuickBooksConnectionRow,
   invoiceId: string,
   actorId?: string,
+  expectedShopId?: string,
 ): Promise<{
   qbInvoiceId: string;
   docNumber: string | null;
@@ -100,6 +101,10 @@ export async function syncInvoiceToQuickBooks(
 
   if (invoiceError || !invoice) {
     throw new Error(invoiceError?.message || "Invoice not found.");
+  }
+
+  if (expectedShopId && invoice.shop_id !== expectedShopId) {
+    throw new Error("Invoice does not belong to the active shop.");
   }
 
   if (!invoice.customer_id) {


### PR DESCRIPTION
### Motivation
- Add a defense-in-depth tenant check to the QuickBooks invoice sync so an invoice cannot be synced to a shop's QuickBooks connection if it does not belong to that shop.

### Description
- Pass the authenticated `shop.id` from the API route into `syncInvoiceToQuickBooks` by updating the call in `app/api/integrations/quickbooks/invoice/[id]/route.ts` to include `shop.id`.
- Extend `syncInvoiceToQuickBooks` signature to accept `expectedShopId` and fail fast with an error if `invoice.shop_id !== expectedShopId` in `features/integrations/quickbooks/server/syncInvoice.ts`.
- Files changed: `app/api/integrations/quickbooks/invoice/[id]/route.ts`, `features/integrations/quickbooks/server/syncInvoice.ts`.

### Testing
- Ran TypeScript validation with `npx tsc --noEmit` and it completed successfully.
- No automated unit tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f93cd1588328b97fa0dce9668e9c)