### PR TITLE
Phase 5A: route inspection findings into canonical quote lines

### DIFF
--- a/app/api/work-orders/quotes/add/route.ts
+++ b/app/api/work-orders/quotes/add/route.ts
@@ -1,114 +1,393 @@
-import "server-only";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database, Json } from "@shared/types/types/supabase";
 
 type DB = Database;
 type QuoteInsert = DB["public"]["Tables"]["work_order_quote_lines"]["Insert"];
+type PartRequestInsert = DB["public"]["Tables"]["part_requests"]["Insert"];
+type PartRequestItemInsert = DB["public"]["Tables"]["part_request_items"]["Insert"];
+
+type QuotePart = {
+  description?: string;
+  name?: string;
+  qty?: number;
+  cost?: number | null;
+  unitCost?: number | null;
+  unitPrice?: number | null;
+  notes?: string | null;
+};
+
+type QuoteItem = {
+  id?: string | null;
+  description: string;
+  title?: string | null;
+  jobType?: "diagnosis" | "repair" | "maintenance" | "inspection" | "tech-suggested";
+  estLaborHours?: number | null;
+  laborHours?: number | null;
+  laborRate?: number | null;
+  partsTotal?: number | null;
+  laborTotal?: number | null;
+  subtotal?: number | null;
+  taxTotal?: number | null;
+  grandTotal?: number | null;
+  notes?: string | null;
+  complaint?: string | null;
+  aiComplaint?: string | null;
+  aiCause?: string | null;
+  aiCorrection?: string | null;
+  status?: string | null;
+  stage?: string | null;
+  source?: "inspection" | string | null;
+  sourceInspectionId?: string | null;
+  sourceWorkOrderLineId?: string | null;
+  sourceSectionKey?: string | null;
+  sourceSectionTitle?: string | null;
+  sourceItemKey?: string | null;
+  sourceFindingTitle?: string | null;
+  normalizedFindingTitle?: string | null;
+  findingIdentity?: string | null;
+  photoUrls?: string[];
+  parts?: QuotePart[];
+  metadata?: Record<string, Json | undefined> | null;
+};
+
+type Body = {
+  workOrderId: string;
+  vehicleId?: string | null;
+  items: QuoteItem[];
+};
+
+function safeTrim(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeTitle(value: unknown): string {
+  return safeTrim(value).toLowerCase().replace(/\s+/g, " ");
+}
+
+function cleanParts(parts: QuotePart[] | undefined): Array<{
+  description: string;
+  qty: number;
+  unitCost: number | null;
+  unitPrice: number | null;
+  notes: string | null;
+}> {
+  return (parts ?? [])
+    .map((part) => {
+      const description = safeTrim(part.description) || safeTrim(part.name);
+      const qty = Math.max(1, Number(part.qty) || 1);
+      return {
+        description,
+        qty,
+        unitCost: finiteNumber(part.unitCost) ?? finiteNumber(part.cost),
+        unitPrice: finiteNumber(part.unitPrice),
+        notes: safeTrim(part.notes) || null,
+      };
+    })
+    .filter((part) => part.description.length > 0);
+}
+
+function identityFor(item: QuoteItem): string | null {
+  const explicit = safeTrim(item.findingIdentity);
+  if (explicit) return explicit;
+
+  const inspectionId = safeTrim(item.sourceInspectionId);
+  const sourceLineId = safeTrim(item.sourceWorkOrderLineId);
+  const sectionKey = safeTrim(item.sourceSectionKey);
+  const itemKey = safeTrim(item.sourceItemKey);
+  const normalizedTitle =
+    normalizeTitle(item.normalizedFindingTitle) ||
+    normalizeTitle(item.sourceFindingTitle) ||
+    normalizeTitle(item.title) ||
+    normalizeTitle(item.description);
+
+  const parts = [inspectionId, sourceLineId, sectionKey, itemKey, normalizedTitle].filter(Boolean);
+  return parts.length > 0 ? parts.join(":") : null;
+}
 
 export async function POST(req: Request) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createRouteHandlerClient<DB>({ cookies });
 
   try {
-    const body = (await req.json()) as {
-      workOrderId: string;
-      vehicleId?: string | null;
-      items: Array<{
-        description: string;
-        jobType?: "diagnosis" | "repair" | "maintenance" | "tech-suggested";
-        estLaborHours?: number;
-        notes?: string;
-        aiComplaint?: string;
-        aiCause?: string;
-        aiCorrection?: string;
-      }>;
-    };
+    const body = (await req.json().catch(() => null)) as Body | null;
+    const workOrderId = safeTrim(body?.workOrderId);
+    const items = Array.isArray(body?.items) ? body.items : [];
 
-    const { workOrderId, vehicleId, items } = body;
-
-    if (!workOrderId || !Array.isArray(items) || items.length === 0) {
+    if (!workOrderId || items.length === 0) {
       return NextResponse.json(
         { error: "Missing workOrderId or items" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // Get current user
     const {
       data: { user },
+      error: userError,
     } = await supabase.auth.getUser();
-    const suggested_by = user?.id ?? null;
 
-    // Load work order → for shop_id
+    if (userError) {
+      return NextResponse.json({ error: userError.message }, { status: 401 });
+    }
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
-      .select("shop_id")
+      .select("id, shop_id, vehicle_id")
       .eq("id", workOrderId)
       .maybeSingle();
 
     if (woErr) {
       return NextResponse.json(
         { error: `Failed to load work order: ${woErr.message}` },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
     if (!wo?.shop_id) {
       return NextResponse.json(
         { error: "Work order has no shop_id; cannot create quote lines." },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // Build rows fully typed
-    const rows: QuoteInsert[] = items.map((i) => ({
-      work_order_id: workOrderId,
-      work_order_line_id: null,
-      shop_id: wo.shop_id,
+    const vehicleId = safeTrim(body?.vehicleId) || wo.vehicle_id || null;
+    const suggestedBy = user.id;
 
-      vehicle_id: vehicleId ?? null,
-      suggested_by,
-      description: i.description,
-      job_type: i.jobType ?? "tech-suggested",
-      est_labor_hours: i.estLaborHours ?? null,
-      notes: i.notes ?? null,
-      status: "pending_parts",
-      ai_complaint: i.aiComplaint ?? null,
-      ai_cause: i.aiCause ?? null,
-      ai_correction: i.aiCorrection ?? null,
+    const requestedIds = items.map((item) => safeTrim(item.id)).filter(Boolean);
+    const identities = items.map(identityFor).filter((value): value is string => Boolean(value));
 
-      // NEW fields ― now fully typed, no @ts-ignore
-      stage: "advisor_pending",
-      qty: 1,
+    const existingById = new Map<string, { id: string }>();
+    if (requestedIds.length > 0) {
+      const { data, error } = await supabase
+        .from("work_order_quote_lines")
+        .select("id")
+        .eq("shop_id", wo.shop_id)
+        .eq("work_order_id", workOrderId)
+        .in("id", requestedIds);
 
-      labor_hours: null,
-      parts_total: null,
-      labor_total: null,
-      subtotal: null,
-      tax_total: null,
-      grand_total: null,
-      metadata: null,
-      group_id: null,
-      sent_to_customer_at: null,
-      approved_at: null,
-      declined_at: null,
-    }));
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
 
-    const { error } = await supabase
-      .from("work_order_quote_lines")
-      .insert(rows);
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
+      for (const row of data ?? []) existingById.set(row.id, row);
     }
 
-    return NextResponse.json({ ok: true });
+    const existingByIdentity = new Map<string, { id: string }>();
+    for (const identity of identities) {
+      const { data, error } = await supabase
+        .from("work_order_quote_lines")
+        .select("id")
+        .eq("shop_id", wo.shop_id)
+        .eq("work_order_id", workOrderId)
+        .contains("metadata", { inspection_finding_identity: identity })
+        .limit(1);
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      const existing = data?.[0];
+      if (existing) existingByIdentity.set(identity, existing);
+    }
+
+    const rows: QuoteInsert[] = [];
+    const pendingSources: QuoteItem[] = [];
+    const sourceItemsById = new Map<string, QuoteItem>();
+    const itemResults: Array<{
+      requestedId: string | null;
+      id: string;
+      created: boolean;
+      findingIdentity: string | null;
+    }> = [];
+
+    for (const item of items) {
+      const description = safeTrim(item.description) || safeTrim(item.title);
+      if (!description) continue;
+
+      const requestedId = safeTrim(item.id) || null;
+      const findingIdentity = identityFor(item);
+      const existing =
+        (requestedId ? existingById.get(requestedId) : undefined) ??
+        (findingIdentity ? existingByIdentity.get(findingIdentity) : undefined);
+
+      if (existing) {
+        itemResults.push({
+          requestedId,
+          id: existing.id,
+          created: false,
+          findingIdentity,
+        });
+        continue;
+      }
+
+      const parts = cleanParts(item.parts);
+      const partsTotal =
+        finiteNumber(item.partsTotal) ??
+        parts.reduce((sum, part) => sum + (part.unitCost ?? 0) * part.qty, 0);
+      const laborHours = finiteNumber(item.laborHours) ?? finiteNumber(item.estLaborHours);
+      const laborTotal = finiteNumber(item.laborTotal);
+      const subtotal = finiteNumber(item.subtotal) ?? partsTotal + (laborTotal ?? 0);
+      const grandTotal = finiteNumber(item.grandTotal) ?? subtotal + (finiteNumber(item.taxTotal) ?? 0);
+      const normalizedFindingTitle =
+        normalizeTitle(item.normalizedFindingTitle) ||
+        normalizeTitle(item.sourceFindingTitle) ||
+        normalizeTitle(description);
+
+      const metadata: Record<string, Json | undefined> = {
+        ...(item.metadata ?? {}),
+        source: item.source ?? "inspection",
+        source_inspection_id: safeTrim(item.sourceInspectionId) || undefined,
+        source_work_order_line_id: safeTrim(item.sourceWorkOrderLineId) || undefined,
+        source_section_key: safeTrim(item.sourceSectionKey) || undefined,
+        source_section_title: safeTrim(item.sourceSectionTitle) || undefined,
+        source_item_key: safeTrim(item.sourceItemKey) || undefined,
+        source_finding_title: safeTrim(item.sourceFindingTitle) || description,
+        source_finding_title_normalized: normalizedFindingTitle || undefined,
+        inspection_finding_identity: findingIdentity ?? undefined,
+        photo_urls: Array.isArray(item.photoUrls) ? item.photoUrls : [],
+        parts,
+        labor_rate: finiteNumber(item.laborRate) ?? undefined,
+      };
+
+      const row: QuoteInsert = {
+        ...(requestedId ? { id: requestedId } : {}),
+        work_order_id: workOrderId,
+        work_order_line_id: null,
+        shop_id: wo.shop_id,
+        vehicle_id: vehicleId,
+        suggested_by: suggestedBy,
+        description,
+        job_type: item.jobType ?? "tech-suggested",
+        est_labor_hours: finiteNumber(item.estLaborHours) ?? laborHours,
+        notes: safeTrim(item.notes) || safeTrim(item.complaint) || null,
+        status: safeTrim(item.status) || "pending_parts",
+        ai_complaint: safeTrim(item.aiComplaint) || safeTrim(item.complaint) || null,
+        ai_cause: safeTrim(item.aiCause) || null,
+        ai_correction: safeTrim(item.aiCorrection) || null,
+        stage: safeTrim(item.stage) || "advisor_pending",
+        qty: 1,
+        labor_hours: laborHours,
+        parts_total: partsTotal,
+        labor_total: laborTotal,
+        subtotal,
+        tax_total: finiteNumber(item.taxTotal),
+        grand_total: grandTotal,
+        metadata: metadata as Json,
+        group_id: null,
+        sent_to_customer_at: null,
+        approved_at: null,
+        declined_at: null,
+      };
+
+      rows.push(row);
+      pendingSources.push(item);
+    }
+
+    let inserted: Array<{ id: string }> = [];
+    if (rows.length > 0) {
+      const { data, error } = await supabase
+        .from("work_order_quote_lines")
+        .insert(rows)
+        .select("id");
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      inserted = data ?? [];
+      inserted.forEach((row, index) => {
+        const source = pendingSources.find((item) => safeTrim(item.id) === row.id) ?? pendingSources[index];
+        if (source) sourceItemsById.set(row.id, source);
+        itemResults.push({
+          requestedId: safeTrim(source?.id) || null,
+          id: row.id,
+          created: true,
+          findingIdentity: source ? identityFor(source) : null,
+        });
+      });
+    }
+
+    for (const insertedRow of inserted) {
+      const source = sourceItemsById.get(insertedRow.id);
+      const parts = cleanParts(source?.parts);
+      if (!source || parts.length === 0) continue;
+
+      const sourceNote = safeTrim(source.notes) || safeTrim(source.complaint);
+      const requestNotes = [
+        sourceNote,
+        `Quote line: ${insertedRow.id}`,
+        source.sourceInspectionId ? `Inspection: ${source.sourceInspectionId}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      const requestPayload: PartRequestInsert = {
+        shop_id: wo.shop_id,
+        work_order_id: workOrderId,
+        job_id: null,
+        requested_by: suggestedBy,
+        notes: requestNotes || null,
+        status: "requested",
+      };
+
+      const { data: partRequest, error: requestError } = await supabase
+        .from("part_requests")
+        .insert(requestPayload)
+        .select("id")
+        .single();
+
+      if (requestError || !partRequest) {
+        return NextResponse.json(
+          { error: requestError?.message ?? "Failed to create part request" },
+          { status: 500 },
+        );
+      }
+
+      const partRows: PartRequestItemInsert[] = parts.map((part) => ({
+        request_id: partRequest.id,
+        shop_id: wo.shop_id,
+        work_order_id: workOrderId,
+        work_order_line_id: null,
+        description: part.description,
+        qty: part.qty,
+        qty_requested: part.qty,
+        unit_cost: part.unitCost,
+        unit_price: part.unitPrice,
+        status: "requested",
+      }));
+
+      const { error: itemError } = await supabase
+        .from("part_request_items")
+        .insert(partRows);
+
+      if (itemError) {
+        return NextResponse.json({ error: itemError.message }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      ids: itemResults.map((item) => item.id),
+      items: itemResults,
+      createdCount: itemResults.filter((item) => item.created).length,
+      skippedDuplicateCount: itemResults.filter((item) => !item.created).length,
+      followUps: [
+        "Add a database unique constraint for inspection finding identity when production data can be backfilled safely.",
+        "Add quote_line_id linkage to part_request_items or part_requests so parts can relate to pre-approval quote lines without notes metadata.",
+      ],
+    });
   } catch (err) {
     console.error("[quotes/add] error:", err);
     return NextResponse.json(
       { error: "Failed to add quote items" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/features/inspections/lib/inspection/addWorkOrderLine.ts
+++ b/features/inspections/lib/inspection/addWorkOrderLine.ts
@@ -12,7 +12,7 @@ export type AISuggestion = {
    * IMPORTANT:
    * When this suggestion originates from an inspection item,
    * set this to the inspection item's notes (e.g. "Air governor leaking").
-   * We'll pass it through as the WO line complaint.
+   * We'll pass it through as the quote-line complaint.
    */
   notes?: string;
 
@@ -26,14 +26,7 @@ type JobType =
   | "repair"
   | "tech-suggested";
 
-type WorkOrderLineWorkflowStatus =
-  | "awaiting"
-  | "assigned"
-  | "in_progress"
-  | "on_hold"
-  | "completed"
-  | "ready_to_invoice"
-  | "invoiced";
+type QuoteLineWorkflowStatus = "pending_parts" | "advisor_pending" | "quoted";
 
 function safeTrim(x: unknown): string {
   return typeof x === "string" ? x.trim() : "";
@@ -45,16 +38,17 @@ export async function addWorkOrderLineFromSuggestion(args: {
   section?: string;
 
   /**
-   * Work order line workflow status.
-   * Do NOT pass inspection statuses like fail/recommend here.
+   * Legacy callers may still pass work-order workflow statuses. Inspection
+   * suggestions now create pre-approval quote lines, so the server normalizes
+   * this path to a quote-line status.
    */
-  status?: WorkOrderLineWorkflowStatus;
+  status?: QuoteLineWorkflowStatus | string;
 
   suggestion: AISuggestion;
   source?: "inspection";
 
-  /** mark AI-added items clearly for UI rules like “not punchable until approved” */
-  jobType?: JobType; // default set server-side if omitted
+  /** mark AI-added quote items clearly for advisor review */
+  jobType?: JobType;
 
   /**
    * Optional explicit complaint.
@@ -67,25 +61,82 @@ export async function addWorkOrderLineFromSuggestion(args: {
       ? safeTrim(args.complaint)
       : safeTrim(args.suggestion?.notes);
 
-  const payload = {
-    ...args,
-    status: args.status ?? "awaiting",
-    // complaint becomes the inspection "notes" unless caller explicitly overrides it
-    complaint: derivedComplaint || null,
-  };
+  const laborHours =
+    typeof args.suggestion?.laborHours === "number" &&
+    Number.isFinite(args.suggestion.laborHours)
+      ? args.suggestion.laborHours
+      : null;
 
-  const res = await fetch("/api/work-orders/add-line", {
+  const parts = (args.suggestion?.parts ?? []).map((part) => ({
+    description: part.name,
+    qty: part.qty ?? 1,
+    cost: part.cost ?? null,
+    notes: part.notes ?? null,
+  }));
+
+  const partsTotal = parts.reduce(
+    (sum, part) => sum + (typeof part.cost === "number" ? part.cost * part.qty : 0),
+    0,
+  );
+  const laborRate =
+    typeof args.suggestion?.laborRate === "number" &&
+    Number.isFinite(args.suggestion.laborRate)
+      ? args.suggestion.laborRate
+      : null;
+  const laborTotal = laborHours != null && laborRate != null ? laborHours * laborRate : null;
+  const subtotal = partsTotal + (laborTotal ?? 0);
+
+  const res = await fetch("/api/work-orders/quotes/add", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
+    body: JSON.stringify({
+      workOrderId: args.workOrderId,
+      items: [
+        {
+          description: args.description,
+          source: args.source ?? "inspection",
+          sourceSectionTitle: args.section ?? null,
+          status: "pending_parts",
+          stage: "advisor_pending",
+          complaint: derivedComplaint || null,
+          notes: derivedComplaint || null,
+          aiComplaint: derivedComplaint || null,
+          aiCorrection: args.suggestion?.summary ?? null,
+          jobType: args.jobType ?? "tech-suggested",
+          estLaborHours: laborHours,
+          laborHours,
+          laborRate,
+          partsTotal,
+          laborTotal,
+          subtotal,
+          grandTotal:
+            typeof args.suggestion?.price === "number" &&
+            Number.isFinite(args.suggestion.price)
+              ? args.suggestion.price
+              : subtotal,
+          parts,
+          metadata: {
+            helper: "addWorkOrderLineFromSuggestion",
+            helper_behavior: "creates_work_order_quote_lines_not_work_order_lines",
+          },
+        },
+      ],
+    }),
   });
 
   if (!res.ok) {
     const j = (await res.json().catch(() => null)) as
       | { error?: string }
       | null;
-    throw new Error(j?.error || "Failed to add work order line");
+    throw new Error(j?.error || "Failed to add quote line");
   }
 
-  return (await res.json()) as { id: string };
+  const json = (await res.json()) as { ids?: string[]; items?: Array<{ id: string }> };
+  const id = json.ids?.[0] ?? json.items?.[0]?.id;
+
+  if (!id) {
+    throw new Error("Quote line created without an id");
+  }
+
+  return { id };
 }

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -12,7 +12,6 @@ import type {
   InspectionItemStatus,
   InspectionSession,
   QuoteLineItem,
-  VoiceMeta,
 } from "@inspections/lib/inspection/types";
 
 import PageShell from "@/features/shared/components/PageShell";
@@ -24,7 +23,6 @@ import PhotoThumbnail from "@inspections/components/inspection/PhotoThumbnail";
 import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import { deriveEventsFromFindings } from "@/features/shared/lib/decisionEvents";
 import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
-import { addWorkOrderLineFromSuggestion } from "@inspections/lib/inspection/addWorkOrderLine";
 import { cn } from "@shared/lib/utils";
 
 type FindingRow = {
@@ -571,7 +569,7 @@ export default function InspectionFindingsPage(): JSX.Element {
     const actionable = findings.filter((row) => {
       const item = row.item as InspectionItem & {
         estimateSubmitted?: boolean;
-        estimateWorkOrderLineId?: string | null;
+        estimateQuoteLineId?: string | null;
       };
 
       const status = String(item.status ?? "").toLowerCase();
@@ -582,8 +580,8 @@ export default function InspectionFindingsPage(): JSX.Element {
 
       if (
         item.estimateSubmitted === true &&
-        typeof item.estimateWorkOrderLineId === "string" &&
-        item.estimateWorkOrderLineId.trim().length > 0
+        typeof item.estimateQuoteLineId === "string" &&
+        item.estimateQuoteLineId.trim().length > 0
       ) {
         return true;
       }
@@ -600,6 +598,45 @@ export default function InspectionFindingsPage(): JSX.Element {
 
     try {
       let nextSession: InspectionSession = { ...session };
+      const nowIso = new Date().toISOString();
+      const quotePayloadItems: Array<{
+        id: string;
+        description: string;
+        title: string;
+        jobType: "repair";
+        status: "pending_parts";
+        stage: "advisor_pending";
+        source: "inspection";
+        sourceInspectionId: string | null;
+        sourceWorkOrderLineId: string | null;
+        sourceSectionKey: string;
+        sourceSectionTitle: string;
+        sourceItemKey: string;
+        sourceFindingTitle: string;
+        normalizedFindingTitle: string;
+        findingIdentity: string;
+        notes: string | null;
+        complaint: string | null;
+        aiComplaint: string | null;
+        aiCause: string | null;
+        aiCorrection: string | null;
+        estLaborHours: number | null;
+        laborHours: number | null;
+        laborRate: number | null;
+        partsTotal: number;
+        laborTotal: number | null;
+        subtotal: number;
+        grandTotal: number;
+        photoUrls: string[];
+        parts: Array<{
+          description: string;
+          name: string;
+          qty: number;
+          cost?: number | null;
+        }>;
+        metadata: Record<string, unknown>;
+      }> = [];
+      const quoteIdByFindingKey = new Map<string, string>();
 
       for (const row of findings) {
         const item = row.item;
@@ -627,26 +664,27 @@ export default function InspectionFindingsPage(): JSX.Element {
         const manualLaborHours =
           typeof itemExt.laborHours === "number" ? itemExt.laborHours : null;
 
-        const existingLineId =
-          typeof itemExt.estimateWorkOrderLineId === "string" &&
-          itemExt.estimateWorkOrderLineId.trim().length > 0
-            ? itemExt.estimateWorkOrderLineId.trim()
-            : null;
-
         const existingQuoteId =
           typeof itemExt.estimateQuoteLineId === "string" &&
           itemExt.estimateQuoteLineId.trim().length > 0
             ? itemExt.estimateQuoteLineId.trim()
             : null;
 
-        const alreadySubmitted = itemExt.estimateSubmitted === true;
-
-        if (alreadySubmitted && !existingLineId) {
+        if (itemExt.estimateSubmitted === true && existingQuoteId) {
           continue;
         }
 
         const quoteId = existingQuoteId ?? uuidv4();
-        const nowIso = new Date().toISOString();
+        const sourceSectionKey = String(row.sectionIndex);
+        const sourceItemKey = String(row.itemIndex);
+        const normalizedFindingTitle = norm(desc).replace(/\s+/g, " ");
+        const findingIdentity = [
+          resolvedInspectionId || "inspection-draft",
+          resolvedWorkOrderLineId || "inspection-line",
+          sourceSectionKey,
+          sourceItemKey,
+          normalizedFindingTitle,
+        ].join(":");
 
         const quoteAlreadyExists = (nextSession.quote ?? []).some(
           (line) => line.id === quoteId,
@@ -713,11 +751,11 @@ export default function InspectionFindingsPage(): JSX.Element {
 
         const partsTotal =
           mergedParts.reduce(
-            (sum, p) => sum + (typeof p.cost === "number" ? p.cost : 0),
+            (sum, p) => sum + (typeof p.cost === "number" ? p.cost * p.qty : 0),
             0,
           ) ?? 0;
-
-        const price = Math.max(0, partsTotal + laborRate * laborTime);
+        const laborTotal = laborRate * laborTime;
+        const price = Math.max(0, partsTotal + laborTotal);
 
         nextSession = updateQuoteLineInSession(nextSession, quoteId, {
           price,
@@ -731,148 +769,106 @@ export default function InspectionFindingsPage(): JSX.Element {
           aiState: "done",
         });
 
-        const cleanParts = manualParts
-          .map((p) => ({
-            description: String(p.description ?? "").trim(),
-            qty: Number(p.qty ?? 0),
-          }))
-          .filter((p) => p.description.length > 0 && p.qty > 0);
-
-        if (existingLineId) {
-          const updateRes = await fetch(
-            "/api/work-orders/lines/update-from-inspection",
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                workOrderId: resolvedWorkOrderId,
-                workOrderLineId: existingLineId,
-                laborHours: laborTime,
-                complaint: note || null,
-                notes: note || null,
-                aiSummary: suggestion.summary ?? null,
-              }),
-            },
-          );
-
-          if (!updateRes.ok) {
-            const body = (await updateRes.json().catch(() => null)) as unknown;
-            console.error("Update WO line error", body);
-            throw new Error("Could not update existing estimate line");
-          }
-
-          if (cleanParts.length > 0) {
-            const res = await fetch("/api/parts/requests/create", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                workOrderId: resolvedWorkOrderId,
-                jobId: existingLineId,
-                notes: note || null,
-                items: cleanParts,
-              }),
-            });
-
-            if (!res.ok) {
-              const body = (await res.json().catch(() => null)) as unknown;
-              console.error("Parts request error", body);
-              throw new Error("Estimate updated, but parts request failed");
-            }
-          }
-
-          nextSession = {
-            ...nextSession,
-            sections: nextSession.sections.map((sec, sIdx) => {
-              if (sIdx !== row.sectionIndex) return sec;
-              return {
-                ...sec,
-                items: (sec.items ?? []).map((it, iIdx) =>
-                  iIdx === row.itemIndex
-                    ? {
-                        ...it,
-                        estimateSubmitted: true,
-                        estimateSubmittedAt:
-                          itemExt.estimateSubmittedAt ?? nowIso,
-                        estimateLastUpdatedAt: nowIso,
-                        estimateWorkOrderLineId: existingLineId,
-                        estimateQuoteLineId: quoteId,
-                      }
-                    : it,
-                ),
-              };
-            }),
-          };
-
-          continue;
-        }
-
-        const created = await addWorkOrderLineFromSuggestion({
-          workOrderId: resolvedWorkOrderId,
+        quotePayloadItems.push({
+          id: quoteId,
           description: desc,
-          section: row.sectionTitle,
-          status: "awaiting",
-          complaint: note || null,
-          suggestion: {
-            ...suggestion,
-            parts: mergedParts,
-            laborHours: laborTime,
-            notes: note || undefined,
-          },
-          source: "inspection",
+          title: desc,
           jobType: "repair",
+          status: "pending_parts",
+          stage: "advisor_pending",
+          source: "inspection",
+          sourceInspectionId: resolvedInspectionId || null,
+          sourceWorkOrderLineId: resolvedWorkOrderLineId || null,
+          sourceSectionKey,
+          sourceSectionTitle: row.sectionTitle,
+          sourceItemKey,
+          sourceFindingTitle: desc,
+          normalizedFindingTitle,
+          findingIdentity,
+          notes: note || null,
+          complaint: note || null,
+          aiComplaint: note || null,
+          aiCause: suggestion.summary ?? null,
+          aiCorrection: suggestion.summary ?? null,
+          estLaborHours: laborTime,
+          laborHours: laborTime,
+          laborRate,
+          partsTotal,
+          laborTotal,
+          subtotal: price,
+          grandTotal: price,
+          photoUrls: item.photoUrls ?? [],
+          parts: mergedParts.map((part) => ({
+            description: part.name,
+            name: part.name,
+            qty: part.qty,
+            cost: part.cost ?? null,
+          })),
+          metadata: {
+            inspection_status: status,
+            technician_notes: note,
+            manual_parts: manualParts,
+            source_value: itemExt.value ?? null,
+          },
+        });
+        quoteIdByFindingKey.set(findingKey(row.sectionIndex, row.itemIndex), quoteId);
+      }
+
+      if (quotePayloadItems.length > 0) {
+        const quoteRes = await fetch("/api/work-orders/quotes/add", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workOrderId: resolvedWorkOrderId,
+            vehicleId:
+              typeof (nextSession.vehicle as unknown as { id?: unknown } | null | undefined)
+                ?.id === "string"
+                ? (nextSession.vehicle as unknown as { id: string }).id
+                : null,
+            items: quotePayloadItems,
+          }),
         });
 
-        const createdId = (created as unknown as { id?: unknown })?.id;
-        const createdJobId =
-          createdId && String(createdId).trim().length > 0
-            ? String(createdId).trim()
-            : null;
+        const quoteJson = (await quoteRes.json().catch(() => null)) as
+          | {
+              error?: string;
+              items?: Array<{
+                requestedId?: string | null;
+                id: string;
+                created: boolean;
+              }>;
+            }
+          | null;
 
-        if (cleanParts.length > 0 && createdJobId) {
-          const res = await fetch("/api/parts/requests/create", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              workOrderId: resolvedWorkOrderId,
-              jobId: createdJobId,
-              notes: note || null,
-              items: cleanParts,
-            }),
-          });
+        if (!quoteRes.ok) {
+          throw new Error(quoteJson?.error || "Failed to send findings to quote review");
+        }
 
-          if (!res.ok) {
-            const body = (await res.json().catch(() => null)) as unknown;
-            console.error("Parts request error", body);
-            throw new Error("Line added, but parts request failed");
-          }
+        const canonicalQuoteIds = new Map<string, string>();
+        for (const result of quoteJson?.items ?? []) {
+          if (result.requestedId) canonicalQuoteIds.set(result.requestedId, result.id);
         }
 
         nextSession = {
           ...nextSession,
-          voiceMeta: {
-            ...(nextSession.voiceMeta ??
-              ({ linesAddedToWorkOrder: 0 } as VoiceMeta)),
-            linesAddedToWorkOrder:
-              (nextSession.voiceMeta?.linesAddedToWorkOrder ?? 0) + 1,
-          },
-          sections: nextSession.sections.map((sec, sIdx) => {
-            if (sIdx !== row.sectionIndex) return sec;
-            return {
-              ...sec,
-              items: (sec.items ?? []).map((it, iIdx) =>
-                iIdx === row.itemIndex
-                  ? {
-                      ...it,
-                      estimateSubmitted: true,
-                      estimateSubmittedAt: nowIso,
-                      estimateLastUpdatedAt: nowIso,
-                      estimateWorkOrderLineId: createdJobId,
-                      estimateQuoteLineId: quoteId,
-                    }
-                  : it,
-              ),
-            };
-          }),
+          sections: nextSession.sections.map((sec, sIdx) => ({
+            ...sec,
+            items: (sec.items ?? []).map((it, iIdx) => {
+              const localQuoteId = quoteIdByFindingKey.get(findingKey(sIdx, iIdx));
+              if (!localQuoteId) return it;
+              return {
+                ...it,
+                estimateSubmitted: true,
+                estimateSubmittedAt:
+                  (it as InspectionItem & { estimateSubmittedAt?: string | null })
+                    .estimateSubmittedAt ?? nowIso,
+                estimateLastUpdatedAt: nowIso,
+                estimateWorkOrderLineId: null,
+                estimateQuoteLineId:
+                  canonicalQuoteIds.get(localQuoteId) ?? localQuoteId,
+              };
+            }),
+          })),
         };
       }
 
@@ -962,8 +958,8 @@ export default function InspectionFindingsPage(): JSX.Element {
       );
 
       window.dispatchEvent(new CustomEvent("inspection:close"));
-      toast.success("Inspection findings submitted.");
-      router.back();
+      toast.success("Findings sent to quote review.");
+      router.push(`/work-orders/${resolvedWorkOrderId}/quote-review`);
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unable to submit findings";
@@ -989,7 +985,7 @@ export default function InspectionFindingsPage(): JSX.Element {
   return (
     <PageShell
       title="Inspection findings"
-      description="Review failed and recommended findings before final submission."
+      description="Review failed and recommended findings before sending them to advisor quote review."
     >
       <div className="mx-auto max-w-5xl space-y-4">
         <DecisionEventFeed events={decisionEvents} compact maxVisible={5} />
@@ -1209,7 +1205,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                   </button>
                 </div>
                 <div className="mt-2 text-[11px] text-neutral-500">
-                  Action needed: mark reviewed so this recommendation can move to approval.
+                  Action needed: mark reviewed so this recommendation can move to quote review.
                 </div>
               </div>
             );
@@ -1234,7 +1230,7 @@ export default function InspectionFindingsPage(): JSX.Element {
               Back
             </Button>
             <Button type="button" onClick={handleSubmitReviewed} isLoading={busy}>
-              {busy ? "Submitting…" : "Submit reviewed findings"}
+              {busy ? "Sending…" : "Send to Quote Review"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Prevent inspection findings from immediately creating punchable `work_order_lines` by routing reviewed findings into canonical `work_order_quote_lines` so advisor/customer approval remains the gating step.
- Implement the first half of the canonical lifecycle (inspection reviewed findings → canonical quote lines + canonical part requests) without changing customer portal, invoice materialization, or Phase 5B behaviors.

### Description
- Added a bulk-capable quote API at `app/api/work-orders/quotes/add/route.ts` that accepts extended inspection payloads, preserves inspection source identity in `metadata`, enforces strict `shop_id`/`work_order_id` scoping, and creates canonical `part_requests` + `part_request_items` for newly inserted quote lines.
- Implemented app-level duplicate prevention by checking requested quote-line ids and `metadata.inspection_finding_identity` before inserting; the API returns created/skipped items and follow-up notes about DB constraints.
- Updated the inspection findings submit flow (`features/inspections/lib/inspection/findings/page.tsx`) to build a bulk quote payload (preserving labor/parts/photos/notes/source identity), call the new quote API, mark items as `estimateSubmitted` with `estimateQuoteLineId`, and route the user to the work-order quote review surface after submission.
- Reworked the inspection helper to stop calling the legacy add-work-order-line route and instead call the quote API (`features/inspections/lib/inspection/addWorkOrderLine.ts`), creating pre-approval quote lines rather than punchable jobs, and updated UI copy/buttons to "Send to Quote Review".
- Parts creation now uses canonical `part_requests` / `part_request_items`; where schema lacks a direct `quote_line_id` link, the quote-line id is included in the part request `notes` for traceability and a follow-up is documented.
- Kept review/edit/photo/labor/parts behavior intact and did not implement customer approval materialization in this PR.

### Testing
- Ran lint on touched files with `npx eslint app/api/work-orders/quotes/add/route.ts features/inspections/lib/inspection/findings/page.tsx features/inspections/lib/inspection/addWorkOrderLine.ts` and addressed issues; lint completed successfully.
- Ran type-checking with `npx tsc --noEmit` and fixed type errors; type-check completed successfully.
- Verified local repository status with `git status --short` after committing changes.

Notes / follow-ups (documented in PR): add a DB unique constraint for `inspection_finding_identity` after safe backfill, and consider adding a direct `quote_line_id` FK on parts tables to avoid relying on notes metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e562b54e48328b85f6ac7d7e29c02)