### PR TITLE
Portal: Customer approve work_order_quote_lines and materialize into work_order_lines (Phase 5C)

### DIFF
--- a/app/api/work-orders/quotes/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval-decision/route.ts
@@ -1,0 +1,150 @@
+import "server-only";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { createClient } from "@supabase/supabase-js";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  applyWorkOrderQuoteLineDecision,
+  type QuoteApprovalDecision,
+} from "@/features/work-orders/server/workOrderQuoteLineApproval";
+
+export const runtime = "nodejs";
+
+type DB = Database;
+type RouteContext = { params: Promise<{ id: string }> };
+type Body = {
+  decision?: QuoteApprovalDecision;
+  lineIds?: string[];
+  workOrderId?: string | null;
+  declineRemaining?: boolean;
+};
+
+function safeTrim(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function serviceSupabase() {
+  return createClient<DB>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  const routeSupabase = createRouteHandlerClient<DB>({ cookies });
+  const { id } = await ctx.params;
+  const routeQuoteLineId = safeTrim(id);
+
+  const {
+    data: { user },
+    error: userErr,
+  } = await routeSupabase.auth.getUser();
+
+  if (userErr || !user) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as Body | null;
+  const decision = body?.decision;
+  const workOrderId = safeTrim(body?.workOrderId);
+  const requestedLineIds = Array.isArray(body?.lineIds) ? body.lineIds.map(safeTrim).filter(Boolean) : [];
+  const quoteLineIds = [...new Set([routeQuoteLineId, ...requestedLineIds].filter(Boolean))];
+
+  if (!workOrderId || quoteLineIds.length === 0 || (decision !== "approve" && decision !== "decline" && decision !== "defer")) {
+    return NextResponse.json({ ok: false, error: "Missing workOrderId, quote line id, or decision" }, { status: 400 });
+  }
+
+  const { data: customer, error: customerErr } = await routeSupabase
+    .from("customers")
+    .select("id")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (customerErr) {
+    return NextResponse.json({ ok: false, error: customerErr.message }, { status: 400 });
+  }
+
+  if (!customer?.id) {
+    return NextResponse.json({ ok: false, error: "Customer profile not found" }, { status: 403 });
+  }
+
+  const { data: workOrder, error: workOrderErr } = await routeSupabase
+    .from("work_orders")
+    .select("id, shop_id, customer_id")
+    .eq("id", workOrderId)
+    .eq("customer_id", customer.id)
+    .maybeSingle();
+
+  if (workOrderErr) {
+    return NextResponse.json({ ok: false, error: workOrderErr.message }, { status: 400 });
+  }
+
+  if (!workOrder?.id || !workOrder.shop_id || workOrder.customer_id !== customer.id) {
+    return NextResponse.json({ ok: false, error: "Quote not found" }, { status: 404 });
+  }
+
+  const supabaseAdmin = serviceSupabase();
+  const result = await applyWorkOrderQuoteLineDecision({
+    supabase: supabaseAdmin,
+    quoteLineIds,
+    workOrderId: workOrder.id,
+    shopId: workOrder.shop_id,
+    customerId: customer.id,
+    actorUserId: user.id,
+    decision,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, error: result.error ?? "Unable to update quote decision" }, { status: 400 });
+  }
+
+  if (body?.declineRemaining && decision === "approve") {
+    const { data: remaining, error: remainingErr } = await supabaseAdmin
+      .from("work_order_quote_lines")
+      .select("id, status")
+      .eq("shop_id", workOrder.shop_id)
+      .eq("work_order_id", workOrder.id);
+
+    if (remainingErr) {
+      return NextResponse.json({ ok: false, error: remainingErr.message }, { status: 400 });
+    }
+
+    const selectedIds = new Set(quoteLineIds);
+    const remainingIds = (remaining ?? [])
+      .filter((line) => !selectedIds.has(line.id) && safeTrim(line.status).toLowerCase() === "sent")
+      .map((line) => line.id)
+      .filter(Boolean);
+    if (remainingIds.length > 0) {
+      const declineResult = await applyWorkOrderQuoteLineDecision({
+        supabase: supabaseAdmin,
+        quoteLineIds: remainingIds,
+        workOrderId: workOrder.id,
+        shopId: workOrder.shop_id,
+        customerId: customer.id,
+        actorUserId: user.id,
+        decision: "decline",
+      });
+
+      if (!declineResult.ok) {
+        return NextResponse.json({ ok: false, error: declineResult.error ?? "Unable to decline remaining quote lines" }, { status: 400 });
+      }
+
+      return NextResponse.json({
+        ok: true,
+        quoteLineIds,
+        workOrderLineIds: result.workOrderLineIds,
+        declinedRemainingQuoteLineIds: remainingIds,
+        approvalState: declineResult.approvalState,
+      });
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    quoteLineIds,
+    workOrderLineIds: result.workOrderLineIds,
+    approvalState: result.approvalState,
+  });
+}

--- a/app/api/work-orders/quotes/[id]/authorize/route.ts
+++ b/app/api/work-orders/quotes/[id]/authorize/route.ts
@@ -3,15 +3,13 @@ import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database, TablesInsert } from "@shared/types/types/supabase";
+import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { applyWorkOrderQuoteLineDecision } from "@/features/work-orders/server/workOrderQuoteLineApproval";
 
 export const runtime = "nodejs";
 
 type DB = Database;
-type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
-
-const NON_CONVERTIBLE_STATUSES = new Set(["declined", "deferred", "rejected", "cancelled"]);
 
 export async function POST(req: NextRequest) {
   const supabase = createRouteHandlerClient<DB>({ cookies });
@@ -42,18 +40,15 @@ export async function POST(req: NextRequest) {
 
     // Extract `[id]` from the pathname .../quotes/<id>/authorize
     const segments = req.nextUrl.pathname.split("/").filter(Boolean);
-    const id = segments[segments.length - 2]; // the segment before "authorize"
+    const id = segments[segments.length - 2];
 
     if (!id) {
       return NextResponse.json({ error: "Missing quote line id" }, { status: 400 });
     }
 
-    // 1) Load the quote line we’re authorizing
     const { data: q, error: qErr } = await supabase
       .from("work_order_quote_lines")
-      .select(
-        "id, shop_id, work_order_id, work_order_line_id, status, vehicle_id, description, job_type, est_labor_hours, ai_complaint, ai_cause, ai_correction",
-      )
+      .select("id, shop_id, work_order_id, work_order_line_id")
       .eq("id", id)
       .single();
 
@@ -68,83 +63,26 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    if ((q.status && NON_CONVERTIBLE_STATUSES.has(q.status)) ?? false) {
-      return NextResponse.json(
-        { error: `Quote line cannot be authorized from status '${q.status}'` },
-        { status: 409 },
-      );
+    const result = await applyWorkOrderQuoteLineDecision({
+      supabase,
+      quoteLineIds: [q.id],
+      workOrderId: q.work_order_id,
+      shopId: q.shop_id,
+      customerId: null,
+      actorUserId: user.id,
+      decision: "approve",
+    });
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error ?? "Failed to authorize quote line" }, { status: 400 });
     }
 
-    if (q.status === "converted" || q.work_order_line_id) {
-      return NextResponse.json({
-        ok: true,
-        alreadyConverted: true,
-        workOrderLineId: q.work_order_line_id ?? null,
-      });
-    }
-
-    const { data: workOrder, error: workOrderErr } = await supabase
-      .from("work_orders")
-      .select("id, shop_id")
-      .eq("id", q.work_order_id)
-      .maybeSingle();
-
-    if (workOrderErr) {
-      return NextResponse.json({ error: workOrderErr.message }, { status: 500 });
-    }
-
-    if (!workOrder) {
-      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
-    }
-
-    if (workOrder.shop_id !== profile.shop_id) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    // 2) Turn it into a punchable job line
-    const newLine: WorkOrderLineInsert = {
-      shop_id: q.shop_id,
-      work_order_id: q.work_order_id,
-      vehicle_id: q.vehicle_id,
-      description: q.description,
-      job_type: q.job_type ?? "repair",
-      status: "awaiting",
-      labor_time: q.est_labor_hours ?? null,
-      complaint: q.ai_complaint ?? q.description,
-      cause: q.ai_cause ?? null,
-      correction: q.ai_correction ?? null,
-    };
-
-    const { data: inserted, error: insErr } = await supabase
-      .from("work_order_lines")
-      .insert(newLine)
-      .select("id")
-      .single();
-
-    if (insErr) {
-      return NextResponse.json({ error: insErr.message }, { status: 500 });
-    }
-
-    // 3) Mark quote line as converted and point to created work order line
-    const { error: updErr } = await supabase
-      .from("work_order_quote_lines")
-      .update({
-        status: "converted",
-        work_order_line_id: inserted?.id ?? null,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", id);
-
-    if (updErr) {
-      console.error("Failed to update quote line after authorize insert", {
-        quoteLineId: id,
-        insertedWorkOrderLineId: inserted?.id ?? null,
-        error: updErr.message,
-      });
-      return NextResponse.json({ error: updErr.message }, { status: 500 });
-    }
-
-    return NextResponse.json({ ok: true, workOrderLineId: inserted?.id ?? null });
+    return NextResponse.json({
+      ok: true,
+      workOrderLineId: result.workOrderLineIds[0] ?? q.work_order_line_id ?? null,
+      workOrderLineIds: result.workOrderLineIds,
+      approvalState: result.approvalState,
+    });
   } catch {
     return NextResponse.json({ error: "Failed to authorize" }, { status: 500 });
   }

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -16,36 +16,50 @@ import {
 } from "@/features/integrations/tax";
 
 const COPPER = "#C57A4A";
+const CUSTOMER_VISIBLE_QUOTE_STATUSES = new Set(["sent", "approved", "converted", "declined", "deferred"]);
+const CUSTOMER_VISIBLE_QUOTE_STAGES = new Set(["sent", "customer_review", "customer_approved", "customer_declined", "customer_deferred"]);
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
-type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
-type PartRow = DB["public"]["Tables"]["parts"]["Row"];
-type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type QuoteLineDbRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type InspectionPhotoRow = DB["public"]["Tables"]["inspection_photos"]["Row"];
 
 type ParamsShape = Record<string, string | string[] | undefined>;
 
 type QuoteLineRow = Pick<
-  WorkOrderLineRow,
+  QuoteLineDbRow,
   | "id"
   | "description"
-  | "complaint"
-  | "labor_time"
-  | "price_estimate"
-  | "line_no"
-  | "approval_state"
+  | "ai_complaint"
+  | "ai_cause"
+  | "ai_correction"
+  | "notes"
+  | "job_type"
+  | "labor_hours"
+  | "est_labor_hours"
+  | "labor_total"
+  | "parts_total"
+  | "subtotal"
+  | "tax_total"
+  | "grand_total"
   | "status"
+  | "stage"
+  | "sent_to_customer_at"
+  | "approved_at"
+  | "declined_at"
+  | "work_order_line_id"
+  | "metadata"
   | "created_at"
   | "updated_at"
 >;
 
-type AllocationWithPart = Pick<
-  AllocationRow,
-  "id" | "work_order_line_id" | "qty" | "unit_cost"
-> & {
-  parts: Pick<PartRow, "name" | "part_number" | "sku">[] | Pick<PartRow, "name" | "part_number" | "sku"> | null;
+type QuotePartView = {
+  name: string;
+  qty: number;
+  unitCost: number;
+  total: number;
+  meta: string | null;
 };
 
 type LineView = {
@@ -53,21 +67,25 @@ type LineView = {
   lineNo: number | null;
   title: string;
   complaint: string | null;
+  cause: string | null;
+  correction: string | null;
+  notes: string | null;
   laborHours: number;
   laborAmount: number;
   partsAmount: number;
+  subtotalAmount: number;
+  taxAmount: number;
   totalAmount: number;
-  approvalState: "pending" | "approved" | "declined" | null;
+  approvalState: "pending" | "approved" | "declined" | "deferred" | null;
   status: string | null;
+  stage: string | null;
+  sentAt: string | null;
+  approvedAt: string | null;
+  declinedAt: string | null;
+  convertedWorkOrderLineId: string | null;
   createdAt: string | null;
   updatedAt: string | null;
-  parts: Array<{
-    name: string;
-    qty: number;
-    unitCost: number;
-    total: number;
-    meta: string | null;
-  }>;
+  parts: QuotePartView[];
   evidencePhotos: string[];
 };
 
@@ -83,6 +101,15 @@ function safeTrim(x: unknown): string {
 function asNumber(v: unknown): number {
   const n = typeof v === "number" ? v : Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+function nullableNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
 }
 
 function formatCurrency(value: number | null | undefined): string {
@@ -108,30 +135,57 @@ function getShopProvinceCode(shop: ShopRow | null): ProvinceCode | null {
   return isProvinceCode(raw) ? raw : null;
 }
 
-function getPartName(parts: AllocationWithPart["parts"]): string {
-  if (Array.isArray(parts)) {
-    return safeTrim(parts[0]?.name) || "Part";
-  }
-  if (parts && typeof parts === "object") {
-    return safeTrim(parts.name) || "Part";
-  }
-  return "Part";
+function quoteMetadata(line: Pick<QuoteLineRow, "metadata">): Record<string, unknown> {
+  if (!line.metadata || typeof line.metadata !== "object" || Array.isArray(line.metadata)) return {};
+  return line.metadata as Record<string, unknown>;
 }
 
-function getPartMeta(parts: AllocationWithPart["parts"]): string | null {
-  const source = Array.isArray(parts) ? parts[0] : parts;
-  if (!source || typeof source !== "object") return null;
-  const pn = safeTrim((source as { part_number?: unknown }).part_number);
-  const sku = safeTrim((source as { sku?: unknown }).sku);
+function metadataArray(metadata: Record<string, unknown>, key: string): unknown[] {
+  const value = metadata[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function getPartName(part: Record<string, unknown>): string {
+  return safeTrim(part.name) || safeTrim(part.description) || safeTrim(part.part_number) || safeTrim(part.sku) || "Part";
+}
+
+function getPartMeta(part: Record<string, unknown>): string | null {
+  const pn = safeTrim(part.part_number ?? part.partNumber);
+  const sku = safeTrim(part.sku);
   return [pn, sku].filter(Boolean).join(" • ") || null;
 }
 
-function findEvidencePhotos(
-  line: Pick<QuoteLineRow, "description" | "complaint">,
+function getQuoteParts(line: QuoteLineRow): QuotePartView[] {
+  const metadata = quoteMetadata(line);
+  return metadataArray(metadata, "parts")
+    .filter((part): part is Record<string, unknown> => Boolean(part) && typeof part === "object" && !Array.isArray(part))
+    .map((part) => {
+      const qty = asNumber(part.qty ?? part.quantity ?? 1) || 1;
+      const unitCost = asNumber(part.unitCost ?? part.unit_cost ?? part.unitPrice ?? part.unit_price);
+      const total = nullableNumber(part.total ?? part.totalCost ?? part.total_cost ?? part.totalPrice ?? part.total_price) ?? qty * unitCost;
+      return {
+        name: getPartName(part),
+        qty,
+        unitCost,
+        total,
+        meta: getPartMeta(part),
+      };
+    });
+}
+
+function getEvidencePhotos(
+  line: QuoteLineRow,
   photos: Array<Pick<InspectionPhotoRow, "image_url" | "item_name">>,
 ): string[] {
+  const metadata = quoteMetadata(line);
+  const metadataPhotos = metadataArray(metadata, "photo_urls")
+    .map((photo) => safeTrim(photo))
+    .filter(Boolean);
+
+  if (metadataPhotos.length > 0) return metadataPhotos.slice(0, 6);
   if (photos.length === 0) return [];
-  const text = [safeTrim(line.description), safeTrim(line.complaint)]
+
+  const text = [safeTrim(line.description), safeTrim(line.ai_complaint), safeTrim(line.notes)]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
@@ -145,6 +199,21 @@ function findEvidencePhotos(
     .map((photo) => safeTrim(photo.image_url))
     .filter(Boolean)
     .slice(0, 3);
+}
+
+function isCustomerVisibleQuoteLine(line: QuoteLineRow): boolean {
+  const status = safeTrim(line.status).toLowerCase();
+  const stage = safeTrim(line.stage).toLowerCase();
+  return Boolean(line.sent_to_customer_at) || CUSTOMER_VISIBLE_QUOTE_STATUSES.has(status) || CUSTOMER_VISIBLE_QUOTE_STAGES.has(stage);
+}
+
+function quoteApprovalState(line: QuoteLineRow): LineView["approvalState"] {
+  const status = safeTrim(line.status).toLowerCase();
+  const stage = safeTrim(line.stage).toLowerCase();
+  if (status === "approved" || status === "converted" || stage === "customer_approved" || line.approved_at || line.work_order_line_id) return "approved";
+  if (status === "declined" || stage === "customer_declined" || line.declined_at) return "declined";
+  if (status === "deferred" || stage === "customer_deferred") return "deferred";
+  return "pending";
 }
 
 export default function QuotePageClient(): JSX.Element {
@@ -194,7 +263,7 @@ export default function QuotePageClient(): JSX.Element {
       .eq("customer_id", customer.id)
       .maybeSingle();
 
-    if (woErr || !wo) {
+    if (woErr || !wo?.id || !wo.shop_id) {
       router.replace("/portal");
       return;
     }
@@ -204,37 +273,24 @@ export default function QuotePageClient(): JSX.Element {
     let shopRow: ShopRow | null = null;
     let laborRate = 0;
 
-    if (wo.shop_id) {
-      const { data } = await supabase.from("shops").select("*").eq("id", wo.shop_id).maybeSingle();
-      shopRow = (data ?? null) as ShopRow | null;
-      laborRate = asNumber((data as { labor_rate?: unknown } | null)?.labor_rate);
-    }
-
+    const { data: shopData } = await supabase.from("shops").select("*").eq("id", wo.shop_id).maybeSingle();
+    shopRow = (shopData ?? null) as ShopRow | null;
+    laborRate = asNumber((shopData as { labor_rate?: unknown } | null)?.labor_rate);
     setShop(shopRow);
 
-    const { data: lineRowsRaw, error: lineErr } = await supabase
-      .from("work_order_lines")
-      .select("id, description, complaint, labor_time, price_estimate, line_no, approval_state, status, created_at, updated_at")
+    const { data: quoteRowsRaw, error: quoteErr } = await supabase
+      .from("work_order_quote_lines")
+      .select(
+        "id, description, ai_complaint, ai_cause, ai_correction, notes, job_type, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, tax_total, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata, created_at, updated_at",
+      )
       .eq("work_order_id", workOrderId)
-      .order("line_no", { ascending: true });
+      .eq("shop_id", wo.shop_id)
+      .order("created_at", { ascending: true });
 
-    if (lineErr) {
+    if (quoteErr) {
       setLines([]);
       setLoading(false);
       return;
-    }
-
-    const lineRows = (lineRowsRaw ?? []) as QuoteLineRow[];
-    const lineIds = lineRows.map((l) => l.id).filter(Boolean);
-
-    let allocRows: AllocationWithPart[] = [];
-    if (lineIds.length > 0) {
-      const { data: allocs } = await supabase
-        .from("work_order_part_allocations")
-        .select("id, work_order_line_id, qty, unit_cost, parts(name, part_number, sku)")
-        .in("work_order_line_id", lineIds);
-
-      allocRows = (allocs ?? []) as AllocationWithPart[];
     }
 
     let inspectionPhotos: Array<Pick<InspectionPhotoRow, "image_url" | "item_name">> = [];
@@ -249,60 +305,46 @@ export default function QuotePageClient(): JSX.Element {
       inspectionPhotos = (photos ?? []) as Array<Pick<InspectionPhotoRow, "image_url" | "item_name">>;
     }
 
-    const byLine = new Map<string, AllocationWithPart[]>();
-    for (const a of allocRows) {
-      const lineId = safeTrim(a.work_order_line_id);
-      if (!lineId) continue;
-      const bucket = byLine.get(lineId) ?? [];
-      bucket.push(a);
-      byLine.set(lineId, bucket);
-    }
+    const mapped: LineView[] = ((quoteRowsRaw ?? []) as QuoteLineRow[])
+      .filter(isCustomerVisibleQuoteLine)
+      .map((line, index) => {
+        const parts = getQuoteParts(line);
+        const metadata = quoteMetadata(line);
+        const laborHours = nullableNumber(line.labor_hours) ?? nullableNumber(line.est_labor_hours) ?? 0;
+        const computedLabor = laborHours * (nullableNumber(metadata.labor_rate) ?? laborRate);
+        const partsAmount = nullableNumber(line.parts_total) ?? parts.reduce((sum, part) => sum + part.total, 0);
+        const laborAmount = nullableNumber(line.labor_total) ?? computedLabor;
+        const subtotalAmount = nullableNumber(line.subtotal) ?? laborAmount + partsAmount;
+        const taxAmount = nullableNumber(line.tax_total) ?? 0;
+        const totalAmount = nullableNumber(line.grand_total) ?? subtotalAmount + taxAmount;
 
-    const mapped: LineView[] = lineRows.map((line) => {
-      const allocs = byLine.get(line.id) ?? [];
-      const parts = allocs.map((a) => {
-        const qty = asNumber(a.qty);
-        const unitCost = asNumber(a.unit_cost);
         return {
-          name: getPartName(a.parts),
-          qty,
-          unitCost,
-          total: qty * unitCost,
-          meta: getPartMeta(a.parts),
+          id: line.id,
+          lineNo: index + 1,
+          title: safeTrim(line.description) || safeTrim(line.ai_complaint) || "Quote line",
+          complaint: safeTrim(line.ai_complaint) || safeTrim(line.notes) || null,
+          cause: safeTrim(line.ai_cause) || null,
+          correction: safeTrim(line.ai_correction) || null,
+          notes: safeTrim(line.notes) || null,
+          laborHours,
+          laborAmount,
+          partsAmount,
+          subtotalAmount,
+          taxAmount,
+          totalAmount,
+          approvalState: quoteApprovalState(line),
+          status: line.status,
+          stage: line.stage,
+          sentAt: line.sent_to_customer_at ?? null,
+          approvedAt: line.approved_at ?? null,
+          declinedAt: line.declined_at ?? null,
+          convertedWorkOrderLineId: line.work_order_line_id ?? null,
+          createdAt: line.created_at ?? null,
+          updatedAt: line.updated_at ?? null,
+          parts,
+          evidencePhotos: getEvidencePhotos(line, inspectionPhotos),
         };
       });
-
-      const partsAmount = parts.reduce((sum, p) => sum + p.total, 0);
-      const laborHours = asNumber(line.labor_time);
-      const computedLabor = laborHours * laborRate;
-      const explicitLineTotal =
-        typeof line.price_estimate === "number" && Number.isFinite(line.price_estimate)
-          ? line.price_estimate
-          : null;
-
-      const totalAmount = explicitLineTotal != null ? explicitLineTotal : computedLabor + partsAmount;
-      const laborAmount = Math.max(0, totalAmount - partsAmount);
-
-      return {
-        id: line.id,
-        lineNo: typeof line.line_no === "number" ? line.line_no : asNumber(line.line_no) || null,
-        title: safeTrim(line.description) || safeTrim(line.complaint) || "Line item",
-        complaint: safeTrim(line.complaint) || null,
-        laborHours,
-        laborAmount,
-        partsAmount,
-        totalAmount,
-        approvalState:
-          line.approval_state === "approved" || line.approval_state === "declined" || line.approval_state === "pending"
-            ? line.approval_state
-            : null,
-        status: line.status,
-        createdAt: line.created_at ?? null,
-        updatedAt: line.updated_at ?? null,
-        parts,
-        evidencePhotos: findEvidencePhotos(line, inspectionPhotos),
-      };
-    });
 
     setLines(mapped);
     setLoading(false);
@@ -326,14 +368,20 @@ export default function QuotePageClient(): JSX.Element {
 
   const titleLabel = workOrder.custom_id || `Work Order ${workOrder.id.slice(0, 8)}…`;
 
+  const pendingLines = lines.filter((line) => line.approvalState === "pending");
+  const approvedLines = lines.filter((line) => line.approvalState === "approved");
+  const declinedDeferredLines = lines.filter((line) => line.approvalState === "declined" || line.approvalState === "deferred");
+  const pendingSubtotal = pendingLines.reduce((sum, line) => sum + line.totalAmount, 0);
+  const approvedSubtotal = approvedLines.reduce((sum, line) => sum + line.totalAmount, 0);
+  const declinedDeferredSubtotal = declinedDeferredLines.reduce((sum, line) => sum + line.totalAmount, 0);
   const subtotal = lines.reduce((sum, line) => sum + line.totalAmount, 0);
   const laborSubtotal = lines.reduce((sum, line) => sum + line.laborAmount, 0);
   const partsSubtotal = lines.reduce((sum, line) => sum + line.partsAmount, 0);
 
   const provinceCode = getShopProvinceCode(shop);
   const taxRes = provinceCode ? calculateTax(subtotal, provinceCode) : null;
-  const taxAmount = taxRes ? getTaxAmount(taxRes) : 0;
-  const grandTotal = subtotal + taxAmount;
+  const taxAmount = lines.some((line) => line.taxAmount > 0) ? lines.reduce((sum, line) => sum + line.taxAmount, 0) : taxRes ? getTaxAmount(taxRes) : 0;
+  const grandTotal = subtotal + (lines.some((line) => line.taxAmount > 0) ? 0 : taxAmount);
   return (
     <div
       className="
@@ -377,40 +425,53 @@ export default function QuotePageClient(): JSX.Element {
               {titleLabel}
             </h1>
             <p className="text-xs text-neutral-400 sm:text-sm">
-              Review the finding, supporting photo, and price for each recommendation.
+              Review sent recommendations and choose what you want the shop to perform. Only approved items become authorized work.
             </p>
           </div>
 
           <div className="mb-6 grid gap-4 sm:grid-cols-4">
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Labor</div>
-              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(laborSubtotal)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Pending authorization</div>
+              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(pendingSubtotal)}</div>
+              <div className="mt-0.5 text-[11px] text-neutral-500">{pendingLines.length} item(s)</div>
             </div>
 
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Parts</div>
-              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(partsSubtotal)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Approved</div>
+              <div className="mt-1 text-lg font-semibold text-emerald-100">{formatCurrency(approvedSubtotal)}</div>
+              <div className="mt-0.5 text-[11px] text-neutral-500">{approvedLines.length} item(s)</div>
             </div>
 
             <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Tax</div>
-              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(taxAmount)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Declined / Deferred</div>
+              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(declinedDeferredSubtotal)}</div>
+              <div className="mt-0.5 text-[11px] text-neutral-500">{declinedDeferredLines.length} item(s)</div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Visible quote total</div>
+              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(grandTotal)}</div>
               <div className="mt-0.5 text-[11px] text-neutral-500">
-                {provinceCode ? `CA (${provinceCode})` : "Not set"}
+                Tax: {formatCurrency(taxAmount)} {provinceCode ? `(${provinceCode})` : ""}
               </div>
             </div>
+          </div>
 
-            <div className="rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Grand Total</div>
-              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(grandTotal)}</div>
-              <div className="mt-0.5 text-[11px] text-neutral-500">Requested: {formatDate(workOrder.created_at)}</div>
+          <div className="mb-6 grid gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Labor total</div>
+              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(laborSubtotal)}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Parts total</div>
+              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(partsSubtotal)}</div>
             </div>
           </div>
 
           <div className="space-y-4">
             {lines.length === 0 ? (
               <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 px-4 py-6 text-sm text-neutral-400">
-                No quote lines are available yet.
+                No customer-visible quote lines are available yet.
               </div>
             ) : (
               lines.map((line) => (
@@ -434,20 +495,41 @@ export default function QuotePageClient(): JSX.Element {
                         <StatusBadge
                           variant={
                             formatDecisionStatus({
-                              approvalState: line.approvalState,
+                              approvalState: line.approvalState === "deferred" ? "pending" : line.approvalState,
                               workStatus: line.status,
                             }).variant
                           }
                         >
-                          {
-                            formatDecisionStatus({
-                              approvalState: line.approvalState,
-                              workStatus: line.status,
-                            }).label
-                          }
+                          {line.approvalState === "deferred"
+                            ? "Deferred"
+                            : formatDecisionStatus({
+                                approvalState: line.approvalState,
+                                workStatus: line.status,
+                              }).label}
                         </StatusBadge>
                       </div>
                     </div>
+                  </div>
+
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                    {line.cause ? (
+                      <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
+                        <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Cause</div>
+                        <div className="mt-1 text-xs text-neutral-300">{line.cause}</div>
+                      </div>
+                    ) : null}
+                    {line.correction ? (
+                      <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
+                        <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Correction</div>
+                        <div className="mt-1 text-xs text-neutral-300">{line.correction}</div>
+                      </div>
+                    ) : null}
+                    {line.notes ? (
+                      <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3 sm:col-span-2">
+                        <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Advisor / technician notes</div>
+                        <div className="mt-1 text-xs text-neutral-300">{line.notes}</div>
+                      </div>
+                    ) : null}
                   </div>
 
                   <div className="mt-4 rounded-xl border border-white/10 bg-slate-950/50 p-3">
@@ -476,7 +558,7 @@ export default function QuotePageClient(): JSX.Element {
                     )}
                   </div>
 
-                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  <div className="mt-4 grid gap-3 sm:grid-cols-4">
                     <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
                       <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Labor</div>
                       <div className="mt-1 text-sm font-medium text-white">{formatCurrency(line.laborAmount)}</div>
@@ -487,6 +569,11 @@ export default function QuotePageClient(): JSX.Element {
                       <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Parts</div>
                       <div className="mt-1 text-sm font-medium text-white">{formatCurrency(line.partsAmount)}</div>
                       <div className="mt-1 text-xs text-neutral-400">{line.parts.length} item(s)</div>
+                    </div>
+
+                    <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">Tax</div>
+                      <div className="mt-1 text-sm font-medium text-white">{formatCurrency(line.taxAmount)}</div>
                     </div>
 
                     <div className="rounded-xl border border-white/10 bg-black/30 px-3 py-3">
@@ -514,6 +601,15 @@ export default function QuotePageClient(): JSX.Element {
                       ))}
                     </div>
                   ) : null}
+
+                  <div className="mt-4 grid gap-2 text-[11px] text-neutral-500 sm:grid-cols-3">
+                    <div>Status: {line.status || "—"}</div>
+                    <div>Stage: {line.stage || "—"}</div>
+                    <div>Sent: {formatDate(line.sentAt)}</div>
+                    {line.approvedAt ? <div>Approved: {formatDate(line.approvedAt)}</div> : null}
+                    {line.declinedAt ? <div>Declined: {formatDate(line.declinedAt)}</div> : null}
+                    {line.convertedWorkOrderLineId ? <div>Authorized work created</div> : null}
+                  </div>
                 </div>
               ))
             )}

--- a/features/portal/components/QuoteApprovalActions.tsx
+++ b/features/portal/components/QuoteApprovalActions.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 
 type Decision = "approve" | "decline" | "defer";
+type ApprovalState = "pending" | "approved" | "declined" | "deferred" | null;
 
 type LineLite = {
   id: string;
   description: string | null;
-  approval_state: "pending" | "approved" | "declined" | null;
+  approval_state: ApprovalState;
   status: string | null;
 };
 
@@ -19,21 +20,46 @@ type Props = {
   onChanged?: () => void | Promise<void>;
 };
 
+function decisionLabel(decision: Decision): string {
+  if (decision === "approve") return "Approve";
+  if (decision === "decline") return "Decline";
+  return "Defer";
+}
+
+function completedDecisionLabel(decision: Decision): string {
+  if (decision === "approve") return "Approved";
+  if (decision === "decline") return "Declined";
+  return "Deferred";
+}
+
+function approvalStateForDecision(decision: Decision): Exclude<ApprovalState, null> {
+  if (decision === "approve") return "approved";
+  if (decision === "decline") return "declined";
+  return "deferred";
+}
+
 export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: Props) {
-  const [loadingLineId, setLoadingLineId] = useState<string | null>(null);
+  const [loadingKey, setLoadingKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const runDecision = async (lineId: string, decision: Decision) => {
-    if (!lineId || loadingLineId) return;
+  const pendingLines = useMemo(
+    () => lines.filter((line) => (line.approval_state ?? "pending") === "pending"),
+    [lines],
+  );
 
-    setLoadingLineId(lineId);
+  const runDecision = async (lineIds: string[], decision: Decision, declineRemaining = false) => {
+    const ids = lineIds.map((id) => id.trim()).filter(Boolean);
+    if (ids.length === 0 || loadingKey) return;
+
+    const key = ids.length === 1 ? ids[0] : `${decision}-bulk`;
+    setLoadingKey(key);
     setError(null);
 
     try {
-      const res = await fetch(`/api/work-orders/lines/${lineId}/approval-decision`, {
+      const res = await fetch(`/api/work-orders/quotes/${ids[0]}/approval-decision`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ decision, workOrderId }),
+        body: JSON.stringify({ decision, lineIds: ids, workOrderId, declineRemaining }),
         cache: "no-store",
       });
 
@@ -42,7 +68,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
         | null;
 
       if (!res.ok || !json?.ok) {
-        setError(json?.error ?? "Unable to update line decision.");
+        setError(json?.error ?? "Unable to update quote decision.");
         return;
       }
 
@@ -50,7 +76,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unexpected error updating decision.");
     } finally {
-      setLoadingLineId(null);
+      setLoadingKey(null);
     }
   };
 
@@ -60,21 +86,51 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
 
   return (
     <div className="mt-6 space-y-3">
-      <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
-        Approvals
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">
+          Approvals
+        </div>
+        {pendingLines.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void runDecision(pendingLines.map((line) => line.id), "approve")}
+              disabled={!!loadingKey}
+              className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-100 transition hover:bg-emerald-500/25 disabled:opacity-50"
+            >
+              {loadingKey === "approve-bulk" ? "Saving..." : `Approve all (${pendingLines.length})`}
+            </button>
+            <button
+              type="button"
+              onClick={() => void runDecision(pendingLines.map((line) => line.id), "decline")}
+              disabled={!!loadingKey}
+              className="inline-flex items-center justify-center rounded-full border border-white/20 bg-black/45 px-4 py-1.5 text-xs font-semibold text-neutral-100 transition hover:bg-black/65 disabled:opacity-50"
+            >
+              {loadingKey === "decline-bulk" ? "Saving..." : `Decline all (${pendingLines.length})`}
+            </button>
+            <button
+              type="button"
+              onClick={() => void runDecision(pendingLines.map((line) => line.id), "defer")}
+              disabled={!!loadingKey}
+              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-transparent px-4 py-1.5 text-xs font-semibold text-neutral-200 transition hover:bg-white/5 disabled:opacity-50"
+            >
+              {loadingKey === "defer-bulk" ? "Saving..." : `Defer all (${pendingLines.length})`}
+            </button>
+          </div>
+        ) : null}
       </div>
       <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-xs text-neutral-400">
-        For each recommendation: confirm the issue, review evidence, then choose Approve or Decline.
+        Approving a quote item authorizes the shop to perform that work. Declined or deferred items stay on the quote and do not become punchable work.
       </div>
 
       <div className="space-y-2">
         {lines.map((l) => {
           const ap = l.approval_state ?? "pending";
           const decisionStatus = formatDecisionStatus({
-            approvalState: l.approval_state,
+            approvalState: ap === "deferred" ? "pending" : ap,
             workStatus: l.status,
           });
-          const isBusy = loadingLineId === l.id;
+          const isBusy = loadingKey === l.id;
 
           return (
             <div
@@ -85,42 +141,39 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
                     <div className="truncate text-sm font-semibold text-neutral-100">
-                      {l.description?.trim() || "Line item"}
+                      {l.description?.trim() || "Quote item"}
                     </div>
 
                     <StatusBadge variant={decisionStatus.variant}>
-                      {decisionStatus.label}
+                      {ap === "deferred" ? "Deferred" : decisionStatus.label}
                     </StatusBadge>
                   </div>
                 </div>
 
                 <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => void runDecision(l.id, "approve")}
-                    disabled={!!loadingLineId || ap === "approved"}
-                    className="inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-100 transition hover:bg-emerald-500/25 disabled:opacity-50"
-                  >
-                    {isBusy ? "Saving..." : ap === "approved" ? "Approved" : "Approve"}
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={() => void runDecision(l.id, "decline")}
-                    disabled={!!loadingLineId || ap === "declined"}
-                    className="inline-flex items-center justify-center rounded-full border border-white/20 bg-black/45 px-4 py-1.5 text-xs font-semibold text-neutral-100 transition hover:bg-black/65 disabled:opacity-50"
-                  >
-                    {isBusy ? "Saving..." : ap === "declined" ? "Declined" : "Decline"}
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={() => void runDecision(l.id, "defer")}
-                    disabled={!!loadingLineId || ap === "pending"}
-                    className="inline-flex items-center justify-center rounded-full border border-white/15 bg-transparent px-3 py-1.5 text-[11px] font-medium text-neutral-300 transition hover:bg-white/5 disabled:opacity-50"
-                  >
-                    {isBusy ? "Saving..." : "Defer"}
-                  </button>
+                  {(["approve", "decline", "defer"] as Decision[]).map((decision) => {
+                    const disabled =
+                      !!loadingKey ||
+                      (decision === "approve" && ap === "approved") ||
+                      (decision === "decline" && ap === "declined") ||
+                      (decision === "defer" && ap === "deferred");
+                    const isPrimaryApprove = decision === "approve";
+                    return (
+                      <button
+                        key={decision}
+                        type="button"
+                        onClick={() => void runDecision([l.id], decision)}
+                        disabled={disabled}
+                        className={
+                          isPrimaryApprove
+                            ? "inline-flex items-center justify-center rounded-full border border-emerald-400/70 bg-emerald-500/15 px-4 py-1.5 text-xs font-semibold text-emerald-100 transition hover:bg-emerald-500/25 disabled:opacity-50"
+                            : "inline-flex items-center justify-center rounded-full border border-white/20 bg-black/45 px-4 py-1.5 text-xs font-semibold text-neutral-100 transition hover:bg-black/65 disabled:opacity-50"
+                        }
+                      >
+                        {isBusy ? "Saving..." : ap === approvalStateForDecision(decision) ? completedDecisionLabel(decision) : decisionLabel(decision)}
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             </div>

--- a/features/work-orders/server/workOrderQuoteLineApproval.ts
+++ b/features/work-orders/server/workOrderQuoteLineApproval.ts
@@ -1,0 +1,325 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, TablesInsert } from "@shared/types/types/supabase";
+
+type DB = Database;
+type Json = DB["public"]["Tables"]["work_order_quote_lines"]["Row"]["metadata"];
+type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
+type WorkOrderUpdate = DB["public"]["Tables"]["work_orders"]["Update"];
+
+export type QuoteApprovalDecision = "approve" | "decline" | "defer";
+
+const APPROVABLE_STATUSES = new Set(["sent", "ready_to_send", "quoted", "approved", "converted"]);
+const NON_APPROVABLE_STATUSES = new Set(["declined", "deferred", "rejected", "cancelled"]);
+
+function safeTrim(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function asNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function quoteMetadata(line: Pick<QuoteLineRow, "metadata">): Record<string, unknown> {
+  if (!line.metadata || typeof line.metadata !== "object" || Array.isArray(line.metadata)) return {};
+  return line.metadata as Record<string, unknown>;
+}
+
+function mergeMetadata(line: QuoteLineRow, patch: Record<string, unknown>): Json {
+  return {
+    ...quoteMetadata(line),
+    ...patch,
+  } as Json;
+}
+
+function getPartsFromMetadata(line: QuoteLineRow): unknown[] {
+  const parts = quoteMetadata(line).parts;
+  return Array.isArray(parts) ? parts : [];
+}
+
+function describeParts(parts: unknown[]): string | null {
+  const labels = parts
+    .filter((part): part is Record<string, unknown> => Boolean(part) && typeof part === "object" && !Array.isArray(part))
+    .map((part) => safeTrim(part.name) || safeTrim(part.description) || safeTrim(part.part_number) || safeTrim(part.sku))
+    .filter(Boolean);
+
+  return labels.length > 0 ? labels.join(", ") : null;
+}
+
+function decisionPatch(params: {
+  line: QuoteLineRow;
+  decision: QuoteApprovalDecision;
+  actorUserId: string;
+  customerId: string | null;
+  now: string;
+  materializedWorkOrderLineId?: string | null;
+}): DB["public"]["Tables"]["work_order_quote_lines"]["Update"] {
+  const { line, decision, actorUserId, customerId, now, materializedWorkOrderLineId } = params;
+  const baseAudit = {
+    customer_decision: decision,
+    customer_decision_at: now,
+    customer_actor_user_id: actorUserId,
+    customer_id: customerId,
+  };
+
+  if (decision === "approve") {
+    return {
+      status: "converted",
+      stage: "customer_approved",
+      approved_at: line.approved_at ?? now,
+      declined_at: null,
+      work_order_line_id: materializedWorkOrderLineId ?? line.work_order_line_id,
+      metadata: mergeMetadata(line, {
+        ...baseAudit,
+        materialized_work_order_line_id: materializedWorkOrderLineId ?? line.work_order_line_id ?? null,
+      }),
+      updated_at: now,
+    };
+  }
+
+  if (decision === "decline") {
+    return {
+      status: "declined",
+      stage: "customer_declined",
+      declined_at: line.declined_at ?? now,
+      metadata: mergeMetadata(line, baseAudit),
+      updated_at: now,
+    };
+  }
+
+  return {
+    status: "deferred",
+    stage: "customer_deferred",
+    declined_at: null,
+    metadata: mergeMetadata(line, baseAudit),
+    updated_at: now,
+  };
+}
+
+async function findExistingMaterializedLine(params: {
+  supabase: SupabaseClient<DB>;
+  line: QuoteLineRow;
+}): Promise<{ id: string | null; error: Error | null }> {
+  const { supabase, line } = params;
+  if (line.work_order_line_id) return { id: line.work_order_line_id, error: null };
+
+  const externalId = `quote_line:${line.id}`;
+  const { data, error } = await supabase
+    .from("work_order_lines")
+    .select("id")
+    .eq("shop_id", line.shop_id)
+    .eq("work_order_id", line.work_order_id)
+    .or(`external_id.eq.${externalId},source_row_id.eq.${line.id}`)
+    .limit(1);
+
+  if (error) return { id: null, error: new Error(error.message) };
+  return { id: data?.[0]?.id ?? null, error: null };
+}
+
+async function materializeQuoteLine(params: {
+  supabase: SupabaseClient<DB>;
+  line: QuoteLineRow;
+  actorUserId: string;
+  now: string;
+}): Promise<{ id: string | null; error: Error | null }> {
+  const { supabase, line, actorUserId, now } = params;
+  const existing = await findExistingMaterializedLine({ supabase, line });
+  if (existing.error || existing.id) return existing;
+
+  const metadata = quoteMetadata(line);
+  const parts = getPartsFromMetadata(line);
+  const lineTotal = asNumber(line.grand_total) ?? asNumber(line.subtotal) ?? (asNumber(line.labor_total) ?? 0) + (asNumber(line.parts_total) ?? 0);
+  const laborHours = asNumber(line.labor_hours) ?? asNumber(line.est_labor_hours);
+
+  const insertLine: WorkOrderLineInsert = {
+    shop_id: line.shop_id,
+    work_order_id: line.work_order_id,
+    vehicle_id: line.vehicle_id,
+    description: safeTrim(line.description) || safeTrim(line.ai_complaint) || "Approved quote line",
+    job_type: safeTrim(line.job_type) || "repair",
+    status: "in_progress",
+    line_status: "authorized",
+    approval_state: "approved",
+    approval_at: now,
+    approval_by: actorUserId,
+    quoted_at: line.sent_to_customer_at ?? line.created_at ?? now,
+    labor_time: laborHours,
+    price_estimate: lineTotal,
+    complaint: safeTrim(line.ai_complaint) || safeTrim(line.notes) || safeTrim(line.description) || null,
+    cause: safeTrim(line.ai_cause) || null,
+    correction: safeTrim(line.ai_correction) || null,
+    notes: safeTrim(line.notes) || null,
+    parts: describeParts(parts),
+    parts_needed: parts.length > 0 ? (parts as WorkOrderLineInsert["parts_needed"]) : null,
+    external_id: `quote_line:${line.id}`,
+    source_row_id: line.id,
+    source_intake_id: safeTrim(metadata.source_inspection_id) || null,
+    intake_json: {
+      source: "work_order_quote_lines",
+      quote_line_id: line.id,
+      quote_line_metadata: metadata,
+      customer_approved_at: now,
+      customer_approved_by: actorUserId,
+      labor_total: line.labor_total,
+      parts_total: line.parts_total,
+      subtotal: line.subtotal,
+      tax_total: line.tax_total,
+      grand_total: line.grand_total,
+    } as WorkOrderLineInsert["intake_json"],
+  };
+
+  const { data: inserted, error } = await supabase
+    .from("work_order_lines")
+    .insert(insertLine)
+    .select("id")
+    .single();
+
+  if (error) return { id: null, error: new Error(error.message) };
+  return { id: inserted?.id ?? null, error: null };
+}
+
+async function rollupWorkOrderQuoteApprovalState(params: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+  now: string;
+  actorUserId: string;
+}): Promise<{ state: string | null; error: Error | null }> {
+  const { supabase, workOrderId, shopId, now, actorUserId } = params;
+  const { data, error } = await supabase
+    .from("work_order_quote_lines")
+    .select("status, stage, approved_at, declined_at, work_order_line_id, sent_to_customer_at")
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId);
+
+  if (error) return { state: null, error: new Error(error.message) };
+
+  const customerVisibleLines = (data ?? []).filter((line) => {
+    const status = safeTrim((line as { status?: unknown }).status).toLowerCase();
+    return (
+      Boolean((line as { sent_to_customer_at?: unknown }).sent_to_customer_at) ||
+      status === "sent" ||
+      status === "approved" ||
+      status === "converted" ||
+      status === "declined" ||
+      status === "deferred"
+    );
+  });
+
+  let approved = 0;
+  let declinedDeferred = 0;
+  let pending = 0;
+
+  for (const line of customerVisibleLines) {
+    const status = safeTrim((line as { status?: unknown }).status).toLowerCase();
+    const stage = safeTrim((line as { stage?: unknown }).stage).toLowerCase();
+    if (status === "approved" || status === "converted" || stage === "customer_approved" || (line as { approved_at?: unknown }).approved_at || (line as { work_order_line_id?: unknown }).work_order_line_id) {
+      approved += 1;
+    } else if (status === "declined" || status === "deferred" || stage === "customer_declined" || stage === "customer_deferred" || (line as { declined_at?: unknown }).declined_at) {
+      declinedDeferred += 1;
+    } else {
+      pending += 1;
+    }
+  }
+
+  let approvalState: WorkOrderUpdate["approval_state"] = "pending";
+  if (approved > 0 && pending === 0 && declinedDeferred === 0) approvalState = "approved";
+  else if (approved > 0) approvalState = "partial";
+  else if (approved === 0 && pending === 0 && declinedDeferred > 0) approvalState = "declined";
+
+  const patch: WorkOrderUpdate = {
+    approval_state: approvalState,
+    updated_at: now,
+  };
+
+  if (approvalState === "approved" || approvalState === "partial") {
+    patch.customer_approval_at = now;
+    patch.customer_agreed_at = now;
+    patch.customer_approved_by = actorUserId;
+  }
+
+  const { error: updateErr } = await supabase
+    .from("work_orders")
+    .update(patch)
+    .eq("id", workOrderId)
+    .eq("shop_id", shopId);
+
+  if (updateErr) return { state: null, error: new Error(updateErr.message) };
+  return { state: approvalState ?? null, error: null };
+}
+
+export async function applyWorkOrderQuoteLineDecision(params: {
+  supabase: SupabaseClient<DB>;
+  quoteLineIds: string[];
+  workOrderId: string;
+  shopId: string;
+  customerId: string | null;
+  actorUserId: string;
+  decision: QuoteApprovalDecision;
+}): Promise<{ ok: boolean; workOrderLineIds: string[]; approvalState: string | null; error?: string }> {
+  const { supabase, quoteLineIds, workOrderId, shopId, customerId, actorUserId, decision } = params;
+  const ids = [...new Set(quoteLineIds.map((id) => id.trim()).filter(Boolean))];
+  if (ids.length === 0) return { ok: false, workOrderLineIds: [], approvalState: null, error: "No quote line ids supplied" };
+
+  const { data: rows, error: loadErr } = await supabase
+    .from("work_order_quote_lines")
+    .select("*")
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .in("id", ids);
+
+  if (loadErr) return { ok: false, workOrderLineIds: [], approvalState: null, error: loadErr.message };
+  if ((rows?.length ?? 0) !== ids.length) return { ok: false, workOrderLineIds: [], approvalState: null, error: "One or more quote lines were not found for this work order" };
+
+  const now = new Date().toISOString();
+  const workOrderLineIds: string[] = [];
+
+  for (const line of (rows ?? []) as QuoteLineRow[]) {
+    const status = safeTrim(line.status).toLowerCase();
+    if (decision === "approve" && NON_APPROVABLE_STATUSES.has(status)) {
+      return { ok: false, workOrderLineIds, approvalState: null, error: `Quote line cannot be approved from status '${line.status}'` };
+    }
+
+    if (decision === "approve" && status && !APPROVABLE_STATUSES.has(status) && !line.sent_to_customer_at) {
+      return { ok: false, workOrderLineIds, approvalState: null, error: "Quote line has not been sent to the customer" };
+    }
+
+    let materializedLineId: string | null = null;
+    if (decision === "approve") {
+      const materialized = await materializeQuoteLine({ supabase, line, actorUserId, now });
+      if (materialized.error) return { ok: false, workOrderLineIds, approvalState: null, error: materialized.error.message };
+      materializedLineId = materialized.id;
+      if (materializedLineId) workOrderLineIds.push(materializedLineId);
+    }
+
+    const patch = decisionPatch({
+      line,
+      decision,
+      actorUserId,
+      customerId,
+      now,
+      materializedWorkOrderLineId: materializedLineId,
+    });
+
+    const { error: updateErr } = await supabase
+      .from("work_order_quote_lines")
+      .update(patch)
+      .eq("id", line.id)
+      .eq("shop_id", shopId)
+      .eq("work_order_id", workOrderId);
+
+    if (updateErr) return { ok: false, workOrderLineIds, approvalState: null, error: updateErr.message };
+  }
+
+  const rollup = await rollupWorkOrderQuoteApprovalState({ supabase, workOrderId, shopId, now, actorUserId });
+  if (rollup.error) return { ok: false, workOrderLineIds, approvalState: null, error: rollup.error.message };
+
+  return { ok: true, workOrderLineIds, approvalState: rollup.state };
+}


### PR DESCRIPTION
### Motivation
- Move the customer portal to operate on the canonical pre-approval records (`work_order_quote_lines`) so customers can approve/decline/defer recommendations rather than acting on punchable `work_order_lines` directly.
- Ensure only customer-approved quote lines become technician-punchable `work_order_lines` while declined/deferred items remain canonical and do not block invoicing.
- Preserve audit and metadata from quote lines when materializing work lines and avoid duplicate materialization.
- Keep legacy/manual `work_order_lines` approval behavior intact while reusing the new quote-line materialization helper for advisor authorizations.

### Description
- Portal UI: replaced the portal quote page to load customer-visible `work_order_quote_lines` scoped by `work_order_id` and `shop_id`, surface description/complaint/cause/correction/notes, parts metadata, labor/parts/tax/grand totals, evidence links, status/stage and decision timestamps, and separate pending/approved/declined+deferred rollups (`features/portal/app/quotes/[id]/QuotePageClient.tsx`).
- Approval UI/actions: updated `QuoteApprovalActions` to call a new quote-line decision API and support individual and bulk `approve`/`decline`/`defer` flows, with UI state and decision labels adjusted for deferred items (`features/portal/components/QuoteApprovalActions.tsx`).
- New portal API: added a portal-scoped route `POST /api/work-orders/quotes/[id]/approval-decision` that validates the signed-in portal customer ownership and then calls service-role logic to apply decisions and optionally decline remaining sent quote lines (`app/api/work-orders/quotes/[id]/approval-decision/route.ts`).
- Server-side materialization/rollup: added `applyWorkOrderQuoteLineDecision` and helpers in `features/work-orders/server/workOrderQuoteLineApproval.ts` to:
  - validate quote-line states and sent status before approving,
  - idempotently materialize approved `work_order_quote_lines` into `work_order_lines` while preserving `shop_id`, `work_order_id`, vehicle context, titles/notes/AI fields, labor/parts/subtotals/totals, `intake_json` metadata and audit stamps,
  - prevent duplicates by checking `work_order_line_id`, `external_id` (`quote_line:<id>`), and `source_row_id`,
  - update quote-line rows (`status`, `stage`, `approved_at`/`declined_at`, metadata) and roll up the `work_orders.approval_state` to `approved`, `partial`, `pending`, or `declined` using existing approval state strings.
- Reused materializer: updated shop-authorize route to call the same quote-line decision helper so advisor authorization reuses the new materialization logic (`app/api/work-orders/quotes/[id]/authorize/route.ts`).

### Testing
- Ran targeted ESLint on changed files (`features/portal/app/quotes/[id]/QuotePageClient.tsx`, `features/portal/components/QuoteApprovalActions.tsx`, `app/api/work-orders/quotes/[id]/approval-decision/route.ts`, `app/api/work-orders/quotes/[id]/authorize/route.ts`, `features/work-orders/server/workOrderQuoteLineApproval.ts`) and no lint errors were reported (✅).
- Ran TypeScript typecheck with `npx tsc --noEmit` and it completed successfully with no type errors (✅).
- Verified repository state with `git status --short` to confirm staged/committed edits; changes were committed as "launch cleanup phase 5c portal quote approval materializes work lines" (✅).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eda5dc30483288ce0b05621a5bf82)