### PR TITLE
Launch cleanup (Phase 4C): treat business display names as business_name in Work Order Create

### DIFF
--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -7,6 +7,7 @@ import type {
   SessionCustomer as CustomerInfo,
   SessionVehicle as VehicleInfo,
 } from "@inspections/lib/inspection/types";
+import { normalizeCustomerForIntake } from "@inspections/lib/customerNormalization";
 
 /** Local, narrow shapes (avoid exporting DB row types in props) */
 type CustomerRow = {
@@ -79,33 +80,8 @@ type Handlers = {
   onVehicleSelected?: (vehicleId: string) => void;
 };
 
-/* Small helper to split a single "name" into first/last */
-function splitNamefallback(
-  n?: string | null,
-): { first: string | null; last: string | null } {
-  const s = (n ?? "").trim();
-  if (!s) return { first: null, last: null };
-  const parts = s.split(/\s+/);
-  if (parts.length === 1) return { first: parts[0], last: null };
-  return { first: parts.slice(0, -1).join(" "), last: parts.at(-1) ?? null };
-}
-
 function hydrateCustomerFields(c: CustomerRow): CustomerInfo {
-  const hasBusiness = Boolean(c.business_name?.trim());
-  const fallback = hasBusiness ? { first: null, last: null } : splitNamefallback(c.name);
-
-  return {
-    business_name: c.business_name ?? null,
-    name: c.name ?? null,
-    first_name: c.first_name ?? fallback.first,
-    last_name: c.last_name ?? fallback.last,
-    phone: c.phone ?? c.phone_number ?? null,
-    email: c.email ?? null,
-    address: c.address ?? null,
-    city: c.city ?? null,
-    province: c.province ?? null,
-    postal_code: c.postal_code ?? null,
-  };
+  return normalizeCustomerForIntake(c);
 }
 
 function hydrateVehicleFields(v: VehicleRow): VehicleInfo {
@@ -184,8 +160,13 @@ function CustomerAutocomplete({
           .limit(12);
 
         if (error) throw error;
-        if (thisReq === reqCounter.current)
-          setRows((data ?? []) as CustomerRow[]);
+        if (thisReq === reqCounter.current) {
+          const deduped = new Map<string, CustomerRow>();
+          for (const row of (data ?? []) as CustomerRow[]) {
+            if (!deduped.has(row.id)) deduped.set(row.id, row);
+          }
+          setRows(Array.from(deduped.values()));
+        }
       } catch {
         if (thisReq === reqCounter.current) setRows([]);
       } finally {
@@ -222,12 +203,16 @@ function CustomerAutocomplete({
             <div className="px-3 py-2 text-xs text-white/60">Searching…</div>
           )}
           {rows.map((c) => {
-            const contact = [c.first_name, c.last_name].filter(Boolean).join(" ");
-            const top = c.business_name || contact || c.name || "Unnamed";
+            const normalized = hydrateCustomerFields(c);
+            const contact = [normalized.first_name, normalized.last_name]
+              .filter(Boolean)
+              .join(" ");
+            const top =
+              normalized.business_name || contact || normalized.name || "Unnamed";
             const sub =
-              c.business_name && contact
+              normalized.business_name && contact
                 ? contact
-                : [c.phone, c.email].filter(Boolean).join(" · ");
+                : [normalized.phone, normalized.email].filter(Boolean).join(" · ");
             return (
               <button
                 key={c.id}

--- a/features/inspections/lib/customerNormalization.ts
+++ b/features/inspections/lib/customerNormalization.ts
@@ -1,0 +1,120 @@
+import type { SessionCustomer } from "./inspection/types";
+
+export type NormalizableCustomer = Partial<SessionCustomer> & {
+  business_name?: string | null;
+  contact_first_name?: string | null;
+  contact_last_name?: string | null;
+  display_name?: string | null;
+  full_name?: string | null;
+  phone_number?: string | null;
+  street?: string | null;
+};
+
+const BUSINESS_NAME_INDICATORS = [
+  "Ltd",
+  "Ltd.",
+  "Inc",
+  "Inc.",
+  "LLC",
+  "Corp",
+  "Corporation",
+  "Co.",
+  "Company",
+  "Services",
+  "Logistics",
+  "Fleet",
+  "Transport",
+  "Trucking",
+  "Diesel",
+  "Municipal",
+  "Enterprises",
+  "Industries",
+  "Group",
+] as const;
+
+function textOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function splitPersonNameFallback(name: string | null | undefined): {
+  first_name: string | null;
+  last_name: string | null;
+} {
+  const clean = textOrNull(name);
+  if (!clean) return { first_name: null, last_name: null };
+  const parts = clean.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return { first_name: parts[0], last_name: null };
+  return {
+    first_name: parts.slice(0, -1).join(" "),
+    last_name: parts.at(-1) ?? null,
+  };
+}
+
+export function looksLikeBusinessName(name: string | null | undefined): boolean {
+  const clean = textOrNull(name);
+  if (!clean) return false;
+
+  return BUSINESS_NAME_INDICATORS.some((indicator) => {
+    const escaped = indicator.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(^|\\W)${escaped}(\\W|$)`, "i").test(clean);
+  });
+}
+
+export function normalizeCustomerForIntake(
+  customer: NormalizableCustomer,
+): SessionCustomer {
+  const businessName = textOrNull(customer.business_name);
+  const explicitFirstName =
+    textOrNull(customer.first_name) ?? textOrNull(customer.contact_first_name);
+  const explicitLastName =
+    textOrNull(customer.last_name) ?? textOrNull(customer.contact_last_name);
+  const fallbackName =
+    textOrNull(customer.name) ??
+    textOrNull(customer.display_name) ??
+    textOrNull(customer.full_name);
+
+  if (businessName) {
+    return {
+      business_name: businessName,
+      name: fallbackName,
+      first_name: explicitFirstName,
+      last_name: explicitLastName,
+      phone: textOrNull(customer.phone) ?? textOrNull(customer.phone_number),
+      email: textOrNull(customer.email),
+      address: textOrNull(customer.address) ?? textOrNull(customer.street),
+      city: textOrNull(customer.city),
+      province: textOrNull(customer.province),
+      postal_code: textOrNull(customer.postal_code),
+    };
+  }
+
+  if (looksLikeBusinessName(fallbackName)) {
+    return {
+      business_name: fallbackName,
+      name: fallbackName,
+      first_name: explicitFirstName,
+      last_name: explicitLastName,
+      phone: textOrNull(customer.phone) ?? textOrNull(customer.phone_number),
+      email: textOrNull(customer.email),
+      address: textOrNull(customer.address) ?? textOrNull(customer.street),
+      city: textOrNull(customer.city),
+      province: textOrNull(customer.province),
+      postal_code: textOrNull(customer.postal_code),
+    };
+  }
+
+  const personFallback = splitPersonNameFallback(fallbackName);
+
+  return {
+    business_name: null,
+    name: fallbackName,
+    first_name: explicitFirstName ?? personFallback.first_name,
+    last_name: explicitLastName ?? personFallback.last_name,
+    phone: textOrNull(customer.phone) ?? textOrNull(customer.phone_number),
+    email: textOrNull(customer.email),
+    address: textOrNull(customer.address) ?? textOrNull(customer.street),
+    city: textOrNull(customer.city),
+    province: textOrNull(customer.province),
+    postal_code: textOrNull(customer.postal_code),
+  };
+}

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -26,6 +26,7 @@ import type {
   SessionCustomer,
   SessionVehicle,
 } from "@/features/inspections/lib/inspection/types";
+import { normalizeCustomerForIntake } from "@/features/inspections/lib/customerNormalization";
 
 // 👇 inspection modal, client-only
 const InspectionModal = dynamic(
@@ -268,20 +269,6 @@ function buildBookingNotesBlock(booking: BookingConversionRow): string {
   if (windowLabel) lines.push(`Scheduled: ${windowLabel}`);
   if (booking.notes?.trim()) lines.push(`Appointment notes: ${booking.notes.trim()}`);
   return lines.join("\n");
-}
-
-function splitPersonNameFallback(name: string | null | undefined): {
-  first_name: string | null;
-  last_name: string | null;
-} {
-  const clean = strOrNull(name);
-  if (!clean) return { first_name: null, last_name: null };
-  const parts = clean.split(/\s+/).filter(Boolean);
-  if (parts.length === 1) return { first_name: parts[0], last_name: null };
-  return {
-    first_name: parts.slice(0, -1).join(" "),
-    last_name: parts.at(-1) ?? null,
-  };
 }
 
 function hydrateVehicleFromRow(row: VehicleRow): VehicleWithExtra {
@@ -848,25 +835,25 @@ useEffect(() => {
   };
 
   const hydrateCustomerFromRow = useCallback(
-    (row: CustomerRowWithBusiness): CustomerWithBusiness => {
-      const businessName = strOrNull(row.business_name ?? null);
-      const personFallback = businessName
-        ? { first_name: null, last_name: null }
-        : splitPersonNameFallback(getStrField(row, "name"));
-
-      return {
-        name: businessName ? getStrField(row, "name") : getStrField(row, "name"),
-        first_name: row.first_name ?? personFallback.first_name,
-        last_name: row.last_name ?? personFallback.last_name,
-        phone: getStrField(row, "phone") ?? getStrField(row, "phone_number"),
-        email: row.email ?? null,
-        address: getStrField(row, "address") ?? getStrField(row, "street"),
+    (row: CustomerRowWithBusiness): CustomerWithBusiness =>
+      normalizeCustomerForIntake({
+        business_name: row.business_name ?? null,
+        name: getStrField(row, "name"),
+        display_name: getStrField(row, "display_name"),
+        full_name: getStrField(row, "full_name"),
+        first_name: getStrField(row, "first_name"),
+        last_name: getStrField(row, "last_name"),
+        contact_first_name: getStrField(row, "contact_first_name"),
+        contact_last_name: getStrField(row, "contact_last_name"),
+        phone: getStrField(row, "phone"),
+        phone_number: getStrField(row, "phone_number"),
+        email: getStrField(row, "email"),
+        address: getStrField(row, "address"),
+        street: getStrField(row, "street"),
         city: getStrField(row, "city"),
         province: getStrField(row, "province"),
         postal_code: getStrField(row, "postal_code"),
-        business_name: businessName,
-      };
-    },
+      }),
     [],
   );
 


### PR DESCRIPTION
### Motivation
- Demo shop data stores company names in `name` while `business_name`, `first_name`, and `last_name` are null, which caused business names like "North Ridge Logistics Ltd." to be split into person `first_name`/`last_name` during Work Order Create.
- The goal is to update the customer normalization used by the customer picker, query-param hydration, and handoff flows so obvious business/company display names are treated as `business_name` (not split), while preserving explicit contact first/last values and existing selected-customer handoffs.

### Description
- Added a shared normalization helper `normalizeCustomerForIntake` in `features/inspections/lib/customerNormalization.ts` that: detects business-like names using a configurable indicators list (e.g. `Ltd`, `Inc`, `LLC`, `Company`, `Services`, `Logistics`, `Municipal`, `Group`, etc.), prefers explicit `business_name` when present, and only splits `name` into person `first_name`/`last_name` when it does not look like a business.
- Replaced ad-hoc fallback logic with the new helper in the Work Order Create hydration (`features/work-orders/app/work-orders/create/page.tsx`) so query-param/customerId hydration uses the same normalization.
- Updated the customer picker/search and selection handling in `features/inspections/components/inspection/CustomerVehicleForm.tsx` to use the helper when rendering suggestions and when applying a picked customer, and to avoid splitting business display names; suggestion rows are deduped by `customer.id` before rendering.
- Kept existing selected-customer handoff (`selectedCustomerId` / `onCustomerSelected`) behavior intact so Save & Continue continues to preserve the selected customer rather than creating duplicates.
- Files changed: `features/inspections/lib/customerNormalization.ts` (new), `features/inspections/components/inspection/CustomerVehicleForm.tsx` (updated), `features/work-orders/app/work-orders/create/page.tsx` (updated).

### Testing
- Ran lint on touched files with `npx eslint features/work-orders/app/work-orders/create/page.tsx features/inspections/components/inspection/CustomerVehicleForm.tsx features/inspections/lib/customerNormalization.ts` and it completed (no blocking errors for the changes made).
- Ran typecheck with `npx tsc --noEmit` which succeeded with no type errors.
- Verified working-tree status with `git status --short` to confirm the intended files were staged/committed as part of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eea85d444832887aefd91a78e748b)