### PR TITLE
Phase 5D-1: link part_requests/part_request_items to work_order_quote_lines (nullable quote_line_id)

### DIFF
--- a/app/api/work-orders/quotes/add/route.ts
+++ b/app/api/work-orders/quotes/add/route.ts
@@ -11,6 +11,9 @@ type PartRequestItemInsert = DB["public"]["Tables"]["part_request_items"]["Inser
 type QuotePart = {
   description?: string;
   name?: string;
+  partNumber?: string | null;
+  part_number?: string | null;
+  sku?: string | null;
   qty?: number;
   cost?: number | null;
   unitCost?: number | null;
@@ -72,6 +75,7 @@ function normalizeTitle(value: unknown): string {
 
 function cleanParts(parts: QuotePart[] | undefined): Array<{
   description: string;
+  partNumber: string | null;
   qty: number;
   unitCost: number | null;
   unitPrice: number | null;
@@ -83,6 +87,8 @@ function cleanParts(parts: QuotePart[] | undefined): Array<{
       const qty = Math.max(1, Number(part.qty) || 1);
       return {
         description,
+        partNumber:
+          safeTrim(part.partNumber) || safeTrim(part.part_number) || safeTrim(part.sku) || null,
         qty,
         unitCost: finiteNumber(part.unitCost) ?? finiteNumber(part.cost),
         unitPrice: finiteNumber(part.unitPrice),
@@ -109,6 +115,70 @@ function identityFor(item: QuoteItem): string | null {
   const parts = [inspectionId, sourceLineId, sectionKey, itemKey, normalizedTitle].filter(Boolean);
   return parts.length > 0 ? parts.join(":") : null;
 }
+
+function normalizePartRequestItemIdentity(input: {
+  description?: string | null;
+  partNumber?: string | null;
+}): string {
+  const normalizedDescription = normalizeTitle(input.description);
+  const normalizedPartNumber = safeTrim(input.partNumber).toUpperCase().replace(/\s+/g, "");
+  return [normalizedPartNumber, normalizedDescription].filter(Boolean).join("|");
+}
+
+async function getOrCreatePartRequestForQuoteLine(
+  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  input: {
+    shopId: string;
+    workOrderId: string;
+    quoteLineId: string;
+    requestedBy: string;
+    notes: string | null;
+  },
+): Promise<{ id: string; created: boolean; error?: string }> {
+  const { data: existing, error: existingError } = await supabase
+    .from("part_requests")
+    .select("id")
+    .eq("shop_id", input.shopId)
+    .eq("work_order_id", input.workOrderId)
+    .eq("quote_line_id", input.quoteLineId)
+    .limit(1);
+
+  if (existingError) {
+    return { id: "", created: false, error: existingError.message };
+  }
+
+  const reusable = existing?.[0];
+  if (reusable?.id) {
+    return { id: reusable.id, created: false };
+  }
+
+  const requestPayload: PartRequestInsert = {
+    shop_id: input.shopId,
+    work_order_id: input.workOrderId,
+    quote_line_id: input.quoteLineId,
+    job_id: null,
+    requested_by: input.requestedBy,
+    notes: input.notes,
+    status: "requested",
+  };
+
+  const { data: partRequest, error: requestError } = await supabase
+    .from("part_requests")
+    .insert(requestPayload)
+    .select("id")
+    .single();
+
+  if (requestError || !partRequest) {
+    return {
+      id: "",
+      created: false,
+      error: requestError?.message ?? "Failed to create part request",
+    };
+  }
+
+  return { id: partRequest.id, created: true };
+}
+
 
 export async function POST(req: Request) {
   const supabase = createRouteHandlerClient<DB>({ cookies });
@@ -218,6 +288,7 @@ export async function POST(req: Request) {
         (findingIdentity ? existingByIdentity.get(findingIdentity) : undefined);
 
       if (existing) {
+        sourceItemsById.set(existing.id, item);
         itemResults.push({
           requestedId,
           id: existing.id,
@@ -314,54 +385,75 @@ export async function POST(req: Request) {
       });
     }
 
-    for (const insertedRow of inserted) {
-      const source = sourceItemsById.get(insertedRow.id);
+    for (const quoteLineId of itemResults.map((item) => item.id)) {
+      const source = sourceItemsById.get(quoteLineId);
       const parts = cleanParts(source?.parts);
       if (!source || parts.length === 0) continue;
 
       const sourceNote = safeTrim(source.notes) || safeTrim(source.complaint);
       const requestNotes = [
         sourceNote,
-        `Quote line: ${insertedRow.id}`,
+        `Quote line: ${quoteLineId}`,
         source.sourceInspectionId ? `Inspection: ${source.sourceInspectionId}` : "",
       ]
         .filter(Boolean)
         .join("\n");
 
-      const requestPayload: PartRequestInsert = {
-        shop_id: wo.shop_id,
-        work_order_id: workOrderId,
-        job_id: null,
-        requested_by: suggestedBy,
+      const partRequest = await getOrCreatePartRequestForQuoteLine(supabase, {
+        shopId: wo.shop_id,
+        workOrderId,
+        quoteLineId,
+        requestedBy: suggestedBy,
         notes: requestNotes || null,
-        status: "requested",
-      };
+      });
 
-      const { data: partRequest, error: requestError } = await supabase
-        .from("part_requests")
-        .insert(requestPayload)
-        .select("id")
-        .single();
-
-      if (requestError || !partRequest) {
+      if (partRequest.error || !partRequest.id) {
         return NextResponse.json(
-          { error: requestError?.message ?? "Failed to create part request" },
+          { error: partRequest.error ?? "Failed to create part request" },
           { status: 500 },
         );
       }
 
-      const partRows: PartRequestItemInsert[] = parts.map((part) => ({
-        request_id: partRequest.id,
-        shop_id: wo.shop_id,
-        work_order_id: workOrderId,
-        work_order_line_id: null,
-        description: part.description,
-        qty: part.qty,
-        qty_requested: part.qty,
-        unit_cost: part.unitCost,
-        unit_price: part.unitPrice,
-        status: "requested",
-      }));
+      const { data: existingItems, error: existingItemsError } = await supabase
+        .from("part_request_items")
+        .select("id, description")
+        .eq("request_id", partRequest.id)
+        .eq("quote_line_id", quoteLineId);
+
+      if (existingItemsError) {
+        return NextResponse.json({ error: existingItemsError.message }, { status: 500 });
+      }
+
+      const existingItemIdentities = new Set(
+        (existingItems ?? []).map((item) =>
+          normalizePartRequestItemIdentity({ description: item.description }),
+        ),
+      );
+
+      const partRows: PartRequestItemInsert[] = [];
+      for (const part of parts) {
+        const itemIdentity = normalizePartRequestItemIdentity({
+          description: part.description,
+        });
+        if (itemIdentity && existingItemIdentities.has(itemIdentity)) continue;
+        if (itemIdentity) existingItemIdentities.add(itemIdentity);
+
+        partRows.push({
+          request_id: partRequest.id,
+          shop_id: wo.shop_id,
+          work_order_id: workOrderId,
+          quote_line_id: quoteLineId,
+          work_order_line_id: null,
+          description: part.description,
+          qty: part.qty,
+          qty_requested: part.qty,
+          unit_cost: part.unitCost,
+          unit_price: part.unitPrice,
+          status: "requested",
+        });
+      }
+
+      if (partRows.length === 0) continue;
 
       const { error: itemError } = await supabase
         .from("part_request_items")
@@ -380,7 +472,7 @@ export async function POST(req: Request) {
       skippedDuplicateCount: itemResults.filter((item) => !item.created).length,
       followUps: [
         "Add a database unique constraint for inspection finding identity when production data can be backfilled safely.",
-        "Add quote_line_id linkage to part_request_items or part_requests so parts can relate to pre-approval quote lines without notes metadata.",
+        "Phase 5D-2 should relink quote-originated part_request_items to approved/materialized work_order_lines and invoice materialization.",
       ],
     });
   } catch (err) {

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -670,7 +670,8 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     if (!target) return;
 
     const resolvedLineId = getEffectiveWorkOrderLineId(target.req, target.items);
-    if (!resolvedLineId || !isUuid(resolvedLineId)) {
+    const quoteLineId = target.req.quote_line_id ?? null;
+    if ((!resolvedLineId || !isUuid(resolvedLineId)) && !quoteLineId) {
       toast.error("This parts request is not attached to a valid work order line yet.");
       return;
     }
@@ -685,6 +686,9 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       const insertPayload: DB["public"]["Tables"]["part_request_items"]["Insert"] =
         {
           request_id: target.req.id,
+          shop_id: target.req.shop_id ?? undefined,
+          work_order_id: target.req.work_order_id ?? undefined,
+          quote_line_id: target.req.quote_line_id ?? undefined,
           work_order_line_id: safeLineId,
           description: lineText ? `(${lineText})` : "",
           qty: 1,
@@ -1049,6 +1053,12 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     }
 
     let lineId = getEffectiveWorkOrderLineId(target.req, target.items);
+    const durableLineId = resolveWorkOrderLineId(target.req, target.items);
+    const isPreApprovalQuoteItem = !!it.quote_line_id && !durableLineId;
+    if (isPreApprovalQuoteItem) {
+      toast.error("Quote-originated parts can be priced or assigned to POs before approval, but stock allocation waits for approval.");
+      return;
+    }
 
 // 🔥 Fallback: auto-pick first available line
 if ((!lineId || !isUuid(lineId)) && lineById.size > 0) {
@@ -1318,8 +1328,11 @@ if (!lineId || !isUuid(lineId)) {
                 });
 
                 const linkedLineId = resolveWorkOrderLineId(r.req, r.items);
+                const quoteLineId = r.req.quote_line_id ?? null;
+                const hasQuoteLineOrigin = !!quoteLineId;
                 const lineId = getEffectiveWorkOrderLineId(r.req, r.items);
                 const hasValidLineId = !!lineId && isUuid(lineId);
+                const canMaterializeToLine = hasValidLineId && (!hasQuoteLineOrigin || !!linkedLineId);
                 const isFallbackLinked =
                   !linkedLineId && !!lineId && isUuid(lineId);
                 const jobText =
@@ -1346,6 +1359,12 @@ if (!lineId || !isUuid(lineId)) {
                               : "—"}
                             <span className="mx-2 text-neutral-600">·</span>
                             Line: {hasValidLineId ? lineId.slice(0, 8) : "Not linked"}
+                            {hasQuoteLineOrigin ? (
+                              <>
+                                <span className="mx-2 text-neutral-600">·</span>
+                                Quote line: {quoteLineId.slice(0, 8)}
+                              </>
+                            ) : null}
                           </div>
 
                           {jobText ? (
@@ -1360,7 +1379,9 @@ if (!lineId || !isUuid(lineId)) {
                             </div>
                           ) : !hasValidLineId ? (
                             <div className="mt-1 text-xs text-[rgba(242,210,187,0.94)]">
-                              This request is not linked to a valid work order line yet.
+                              {hasQuoteLineOrigin
+                                ? "Quote-originated request: work order line linkage is deferred until approval."
+                                : "This request is not linked to a valid work order line yet."}
                             </div>
                           ) : null}
                         </div>
@@ -1384,7 +1405,7 @@ if (!lineId || !isUuid(lineId)) {
                             className={btnGhost}
                             onClick={() => void addRow(r.req.id)}
                             disabled={busy}
-                            title={!hasValidLineId ? "Missing work order line link" : undefined}
+                            title={!hasValidLineId && !hasQuoteLineOrigin ? "Missing work order line link" : undefined}
                             type="button"
                           >
                             {busy ? "Working…" : "＋ Add part row"}
@@ -1858,8 +1879,14 @@ if (!lineId || !isUuid(lineId)) {
                                           onClick={() =>
                                             void addAndAttach(r.req.id, String(it.id))
                                           }
-                                          disabled={rowBusy || !it.ui_part_id}
-                                          title={!hasValidLineId ? "Missing work order line link" : undefined}
+                                          disabled={rowBusy || !it.ui_part_id || !canMaterializeToLine}
+                                          title={
+                                            !canMaterializeToLine
+                                              ? hasQuoteLineOrigin
+                                                ? "Quote-originated parts are not allocated until approval creates a work order line link"
+                                                : "Missing work order line link"
+                                              : undefined
+                                          }
                                           type="button"
                                         >
                                           {rowBusy ? "Saving…" : "Add"}

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -22,6 +22,7 @@ type WoBucket = {
   status: BucketStatus;
   requests: PartRequest[];
   itemsCount: number;
+  quoteOriginCount: number;
   completeCount: number;
   completionPct: number;
   latestAt: string | null;
@@ -278,6 +279,7 @@ export default function PartsRequestsPage(): JSX.Element {
           status: "pending",
           requests: [],
           itemsCount: 0,
+          quoteOriginCount: 0,
           completeCount: 0,
           completionPct: 0,
           latestAt: null,
@@ -286,6 +288,7 @@ export default function PartsRequestsPage(): JSX.Element {
       }
 
       byWo[workOrderId].requests.push(r);
+      if (r.quote_line_id) byWo[workOrderId].quoteOriginCount += 1;
 
       const itemsCount = itemsCountByRequest[r.id] ?? 0;
       const completeCount = completeCountByRequest[r.id] ?? 0;
@@ -549,6 +552,12 @@ export default function PartsRequestsPage(): JSX.Element {
                       {b.requests.length} request
                       {b.requests.length === 1 ? "" : "s"} · {b.itemsCount} item
                       {b.itemsCount === 1 ? "" : "s"}
+                      {b.quoteOriginCount > 0 ? (
+                        <>
+                          <span className="mx-2 text-neutral-600">·</span>
+                          {b.quoteOriginCount} quote-originated
+                        </>
+                      ) : null}
                       {b.itemsCount > 0 ? (
                         <>
                           <span className="mx-2 text-neutral-600">·</span>

--- a/db/sql/2026-06-02_phase5d1_quote_line_part_request_linkage.sql
+++ b/db/sql/2026-06-02_phase5d1_quote_line_part_request_linkage.sql
@@ -1,0 +1,57 @@
+-- Phase 5D-1: durable quote-line linkage for canonical parts requests.
+-- Adds nullable quote_line_id links from canonical part_requests / part_request_items
+-- to work_order_quote_lines without backfilling or constraining existing rows.
+
+alter table public.part_requests
+  add column if not exists quote_line_id uuid;
+
+alter table public.part_request_items
+  add column if not exists quote_line_id uuid;
+
+comment on column public.part_requests.quote_line_id is
+  'Canonical pre-approval work_order_quote_lines row that originated this parts request, when applicable. Nullable for existing/manual requests.';
+
+comment on column public.part_request_items.quote_line_id is
+  'Canonical pre-approval work_order_quote_lines row that originated this parts request item, when applicable. Nullable for existing/manual items.';
+
+do $$
+begin
+  if to_regclass('public.work_order_quote_lines') is null then
+    raise notice 'Skipping quote_line_id foreign keys: public.work_order_quote_lines does not exist.';
+  else
+    if not exists (
+      select 1
+      from pg_constraint
+      where conname = 'part_requests_quote_line_id_fkey'
+        and conrelid = 'public.part_requests'::regclass
+    ) then
+      alter table public.part_requests
+        add constraint part_requests_quote_line_id_fkey
+        foreign key (quote_line_id)
+        references public.work_order_quote_lines(id)
+        on delete set null;
+    end if;
+
+    if not exists (
+      select 1
+      from pg_constraint
+      where conname = 'part_request_items_quote_line_id_fkey'
+        and conrelid = 'public.part_request_items'::regclass
+    ) then
+      alter table public.part_request_items
+        add constraint part_request_items_quote_line_id_fkey
+        foreign key (quote_line_id)
+        references public.work_order_quote_lines(id)
+        on delete set null;
+    end if;
+  end if;
+end $$;
+
+create index if not exists idx_part_requests_shop_quote_line
+  on public.part_requests (shop_id, quote_line_id);
+
+create index if not exists idx_part_request_items_shop_quote_line
+  on public.part_request_items (shop_id, quote_line_id);
+
+create index if not exists idx_part_request_items_work_order_quote_line
+  on public.part_request_items (work_order_id, quote_line_id);

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -8575,6 +8575,7 @@ export type Database = {
           qty_requested: number
           qty_reserved: number
           quoted_price: number | null
+          quote_line_id: string | null
           request_id: string
           shop_id: string | null
           status: Database["public"]["Enums"]["part_request_item_status"]
@@ -8604,6 +8605,7 @@ export type Database = {
           qty_requested?: number
           qty_reserved?: number
           quoted_price?: number | null
+          quote_line_id?: string | null
           request_id: string
           shop_id?: string | null
           status?: Database["public"]["Enums"]["part_request_item_status"]
@@ -8633,6 +8635,7 @@ export type Database = {
           qty_requested?: number
           qty_reserved?: number
           quoted_price?: number | null
+          quote_line_id?: string | null
           request_id?: string
           shop_id?: string | null
           status?: Database["public"]["Enums"]["part_request_item_status"]
@@ -8657,6 +8660,13 @@ export type Database = {
             columns: ["po_id"]
             isOneToOne: false
             referencedRelation: "purchase_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_request_items_quote_line_id_fkey"
+            columns: ["quote_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_quote_lines"
             referencedColumns: ["id"]
           },
           {
@@ -8746,6 +8756,7 @@ export type Database = {
           id: string
           job_id: string | null
           notes: string | null
+          quote_line_id: string | null
           requested_by: string | null
           shop_id: string
           status: Database["public"]["Enums"]["part_request_status"]
@@ -8757,6 +8768,7 @@ export type Database = {
           id?: string
           job_id?: string | null
           notes?: string | null
+          quote_line_id?: string | null
           requested_by?: string | null
           shop_id: string
           status?: Database["public"]["Enums"]["part_request_status"]
@@ -8768,12 +8780,20 @@ export type Database = {
           id?: string
           job_id?: string | null
           notes?: string | null
+          quote_line_id?: string | null
           requested_by?: string | null
           shop_id?: string
           status?: Database["public"]["Enums"]["part_request_status"]
           work_order_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "part_requests_quote_line_id_fkey"
+            columns: ["quote_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_quote_lines"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "part_requests_job_id_fkey"
             columns: ["job_id"]

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -6198,6 +6198,7 @@ export type Database = {
           qty_requested: number
           qty_reserved: number
           quoted_price: number | null
+          quote_line_id: string | null
           request_id: string
           shop_id: string | null
           status: Database["public"]["Enums"]["part_request_item_status"]
@@ -6227,6 +6228,7 @@ export type Database = {
           qty_requested?: number
           qty_reserved?: number
           quoted_price?: number | null
+          quote_line_id?: string | null
           request_id: string
           shop_id?: string | null
           status?: Database["public"]["Enums"]["part_request_item_status"]
@@ -6256,6 +6258,7 @@ export type Database = {
           qty_requested?: number
           qty_reserved?: number
           quoted_price?: number | null
+          quote_line_id?: string | null
           request_id?: string
           shop_id?: string | null
           status?: Database["public"]["Enums"]["part_request_item_status"]
@@ -6280,6 +6283,13 @@ export type Database = {
             columns: ["po_id"]
             isOneToOne: false
             referencedRelation: "purchase_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_request_items_quote_line_id_fkey"
+            columns: ["quote_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_quote_lines"
             referencedColumns: ["id"]
           },
           {
@@ -6369,6 +6379,7 @@ export type Database = {
           id: string
           job_id: string | null
           notes: string | null
+          quote_line_id: string | null
           requested_by: string | null
           shop_id: string
           status: Database["public"]["Enums"]["part_request_status"]
@@ -6380,6 +6391,7 @@ export type Database = {
           id?: string
           job_id?: string | null
           notes?: string | null
+          quote_line_id?: string | null
           requested_by?: string | null
           shop_id: string
           status?: Database["public"]["Enums"]["part_request_status"]
@@ -6391,12 +6403,20 @@ export type Database = {
           id?: string
           job_id?: string | null
           notes?: string | null
+          quote_line_id?: string | null
           requested_by?: string | null
           shop_id?: string
           status?: Database["public"]["Enums"]["part_request_status"]
           work_order_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "part_requests_quote_line_id_fkey"
+            columns: ["quote_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_quote_lines"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "part_requests_job_id_fkey"
             columns: ["job_id"]


### PR DESCRIPTION
### Motivation
- Prevent quoted parts from being lost after customer approval by adding a durable linkage from canonical quote lines to canonical part requests/items so pre-approval quote-originated parts remain traceable.
- Make quote→parts creation idempotent so repeated inspection/quote submits do not create duplicate request headers or items.
- Keep the change non-breaking and reversible-friendly by adding nullable columns and indexes only, without backfills or enforcement on existing rows.

### Description
- Add SQL migration `db/sql/2026-06-02_phase5d1_quote_line_part_request_linkage.sql` that adds nullable `quote_line_id uuid` columns to `public.part_requests` and `public.part_request_items`, comments, FK constraints (to `public.work_order_quote_lines(id)` when present), and the indexes: `idx_part_requests_shop_quote_line`, `idx_part_request_items_shop_quote_line`, and `idx_part_request_items_work_order_quote_line`.
- Persist quote linkage during quote creation in `app/api/work-orders/quotes/add/route.ts` by setting `part_requests.quote_line_id` and `part_request_items.quote_line_id` for quote-originated requests, and stop relying on notes as the machine-readable linkage.
- Implement idempotency helpers and logic in the quote route: `getOrCreatePartRequestForQuoteLine` reuses an existing `part_requests` row for `shop_id + work_order_id + quote_line_id` and `normalizePartRequestItemIdentity` + checks skip duplicate part_request_items for the same `quote_line_id`.
- Update parts request UI (`app/parts/requests/page.tsx` and `app/parts/requests/[id]/page.tsx`) to surface quote-originated requests, allow pre-approval quote requests to exist without a materialized `work_order_line_id`, and block stock-allocation/materialization actions for quote-originated items until a durable work-order-line linkage exists (approval/materialization is intentionally deferred to 5D-2).
- Regenerated/updated committed Supabase generated types to include nullable `quote_line_id` in both `shared/types/types/supabase.ts` and `features/shared/types/types/supabase.ts` so TypeScript usages reflect the new fields.
- Safety notes: all new columns are nullable, FKs set `ON DELETE SET NULL`, no backfill performed, and no pre-approval stock allocation/reservation behavior was added.
- Remaining for Phase 5D-2: relink quote-originated `part_request_items` to materialized `work_order_lines` after customer approval and use the durable `quote_line_id` during invoice/materialization so approved quoted parts are reliably included in invoices.

### Testing
- Ran ESLint against the touched route and UI files: `npx eslint app/api/work-orders/quotes/add/route.ts app/parts/requests/page.tsx app/parts/requests/[id]/page.tsx` and targeted file linting; result: succeeded.
- Type-checked the repo: `npx tsc --noEmit`; result: succeeded.
- Verified working tree and staged commit: `git status --short`; commit created: `launch cleanup phase 5d1 link parts requests to quote lines`.
- Files changed (high level): `app/api/work-orders/quotes/add/route.ts`, `app/parts/requests/page.tsx`, `app/parts/requests/[id]/page.tsx`, `db/sql/2026-06-02_phase5d1_quote_line_part_request_linkage.sql`, and regenerated Supabase types in `shared/types/types/supabase.ts` and `features/shared/types/types/supabase.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efb2c7e6c8328bbe8e531088a97bd)