### PR TITLE
Phase 5D-3: relink quote parts after approval

### DIFF
--- a/app/api/work-orders/quotes/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval-decision/route.ts
@@ -43,17 +43,31 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
   } = await routeSupabase.auth.getUser();
 
   if (userErr || !user) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { ok: false, error: "Unauthorized" },
+      { status: 401 },
+    );
   }
 
   const body = (await req.json().catch(() => null)) as Body | null;
   const decision = body?.decision;
   const workOrderId = safeTrim(body?.workOrderId);
-  const requestedLineIds = Array.isArray(body?.lineIds) ? body.lineIds.map(safeTrim).filter(Boolean) : [];
-  const quoteLineIds = [...new Set([routeQuoteLineId, ...requestedLineIds].filter(Boolean))];
+  const requestedLineIds = Array.isArray(body?.lineIds)
+    ? body.lineIds.map(safeTrim).filter(Boolean)
+    : [];
+  const quoteLineIds = [
+    ...new Set([routeQuoteLineId, ...requestedLineIds].filter(Boolean)),
+  ];
 
-  if (!workOrderId || quoteLineIds.length === 0 || (decision !== "approve" && decision !== "decline" && decision !== "defer")) {
-    return NextResponse.json({ ok: false, error: "Missing workOrderId, quote line id, or decision" }, { status: 400 });
+  if (
+    !workOrderId ||
+    quoteLineIds.length === 0 ||
+    (decision !== "approve" && decision !== "decline" && decision !== "defer")
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Missing workOrderId, quote line id, or decision" },
+      { status: 400 },
+    );
   }
 
   const { data: customer, error: customerErr } = await routeSupabase
@@ -63,11 +77,17 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     .maybeSingle();
 
   if (customerErr) {
-    return NextResponse.json({ ok: false, error: customerErr.message }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: customerErr.message },
+      { status: 400 },
+    );
   }
 
   if (!customer?.id) {
-    return NextResponse.json({ ok: false, error: "Customer profile not found" }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: "Customer profile not found" },
+      { status: 403 },
+    );
   }
 
   const { data: workOrder, error: workOrderErr } = await routeSupabase
@@ -78,11 +98,21 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     .maybeSingle();
 
   if (workOrderErr) {
-    return NextResponse.json({ ok: false, error: workOrderErr.message }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: workOrderErr.message },
+      { status: 400 },
+    );
   }
 
-  if (!workOrder?.id || !workOrder.shop_id || workOrder.customer_id !== customer.id) {
-    return NextResponse.json({ ok: false, error: "Quote not found" }, { status: 404 });
+  if (
+    !workOrder?.id ||
+    !workOrder.shop_id ||
+    workOrder.customer_id !== customer.id
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Quote not found" },
+      { status: 404 },
+    );
   }
 
   const supabaseAdmin = serviceSupabase();
@@ -97,7 +127,10 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
   });
 
   if (!result.ok) {
-    return NextResponse.json({ ok: false, error: result.error ?? "Unable to update quote decision" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: result.error ?? "Unable to update quote decision" },
+      { status: 400 },
+    );
   }
 
   if (body?.declineRemaining && decision === "approve") {
@@ -108,12 +141,19 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
       .eq("work_order_id", workOrder.id);
 
     if (remainingErr) {
-      return NextResponse.json({ ok: false, error: remainingErr.message }, { status: 400 });
+      return NextResponse.json(
+        { ok: false, error: remainingErr.message },
+        { status: 400 },
+      );
     }
 
     const selectedIds = new Set(quoteLineIds);
     const remainingIds = (remaining ?? [])
-      .filter((line) => !selectedIds.has(line.id) && safeTrim(line.status).toLowerCase() === "sent")
+      .filter(
+        (line) =>
+          !selectedIds.has(line.id) &&
+          safeTrim(line.status).toLowerCase() === "sent",
+      )
       .map((line) => line.id)
       .filter(Boolean);
     if (remainingIds.length > 0) {
@@ -128,7 +168,14 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
       });
 
       if (!declineResult.ok) {
-        return NextResponse.json({ ok: false, error: declineResult.error ?? "Unable to decline remaining quote lines" }, { status: 400 });
+        return NextResponse.json(
+          {
+            ok: false,
+            error:
+              declineResult.error ?? "Unable to decline remaining quote lines",
+          },
+          { status: 400 },
+        );
       }
 
       return NextResponse.json({
@@ -137,6 +184,7 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
         workOrderLineIds: result.workOrderLineIds,
         declinedRemainingQuoteLineIds: remainingIds,
         approvalState: declineResult.approvalState,
+        partRelink: result.partRelink,
       });
     }
   }
@@ -146,5 +194,6 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     quoteLineIds,
     workOrderLineIds: result.workOrderLineIds,
     approvalState: result.approvalState,
+    partRelink: result.partRelink,
   });
 }

--- a/app/api/work-orders/quotes/[id]/authorize/route.ts
+++ b/app/api/work-orders/quotes/[id]/authorize/route.ts
@@ -30,7 +30,10 @@ export async function POST(req: NextRequest) {
       .single();
 
     if (profileErr || !profile?.shop_id) {
-      return NextResponse.json({ error: "Unable to resolve actor profile" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Unable to resolve actor profile" },
+        { status: 403 },
+      );
     }
 
     const actor = getActorCapabilities({ role: profile.role });
@@ -43,7 +46,10 @@ export async function POST(req: NextRequest) {
     const id = segments[segments.length - 2];
 
     if (!id) {
-      return NextResponse.json({ error: "Missing quote line id" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing quote line id" },
+        { status: 400 },
+      );
     }
 
     const { data: q, error: qErr } = await supabase
@@ -53,11 +59,17 @@ export async function POST(req: NextRequest) {
       .single();
 
     if (qErr || !q) {
-      return NextResponse.json({ error: "Quote line not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Quote line not found" },
+        { status: 404 },
+      );
     }
 
     if (!q.shop_id) {
-      return NextResponse.json({ error: "Quote line is missing shop_id" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Quote line is missing shop_id" },
+        { status: 400 },
+      );
     }
     if (q.shop_id !== profile.shop_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
@@ -74,14 +86,19 @@ export async function POST(req: NextRequest) {
     });
 
     if (!result.ok) {
-      return NextResponse.json({ error: result.error ?? "Failed to authorize quote line" }, { status: 400 });
+      return NextResponse.json(
+        { error: result.error ?? "Failed to authorize quote line" },
+        { status: 400 },
+      );
     }
 
     return NextResponse.json({
       ok: true,
-      workOrderLineId: result.workOrderLineIds[0] ?? q.work_order_line_id ?? null,
+      workOrderLineId:
+        result.workOrderLineIds[0] ?? q.work_order_line_id ?? null,
       workOrderLineIds: result.workOrderLineIds,
       approvalState: result.approvalState,
+      partRelink: result.partRelink,
     });
   } catch {
     return NextResponse.json({ error: "Failed to authorize" }, { status: 500 });

--- a/features/parts/server/relinkQuoteLinePartsToWorkOrderLine.ts
+++ b/features/parts/server/relinkQuoteLinePartsToWorkOrderLine.ts
@@ -1,0 +1,142 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type PartRequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
+type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
+
+type PartRelinkConflict = {
+  table: "part_requests" | "part_request_items";
+  id: string;
+  currentWorkOrderLineId: string;
+  targetWorkOrderLineId: string;
+};
+
+export type RelinkQuoteLinePartsResult = {
+  partRequestsRelinked: number;
+  partRequestItemsRelinked: number;
+  partRequestsAlreadyLinked: number;
+  partRequestItemsAlreadyLinked: number;
+  conflicts: PartRelinkConflict[];
+};
+
+export async function relinkQuoteLinePartsToWorkOrderLine(params: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+  quoteLineId: string;
+  workOrderLineId: string;
+}): Promise<{ result: RelinkQuoteLinePartsResult; error: Error | null }> {
+  const { supabase, shopId, workOrderId, quoteLineId, workOrderLineId } =
+    params;
+
+  const { data: requestRows, error: requestsLoadErr } = await supabase
+    .from("part_requests")
+    .select("id, job_id")
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .eq("quote_line_id", quoteLineId);
+
+  if (requestsLoadErr) {
+    return { result: emptyResult(), error: new Error(requestsLoadErr.message) };
+  }
+
+  const { data: itemRows, error: itemsLoadErr } = await supabase
+    .from("part_request_items")
+    .select("id, work_order_line_id")
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .eq("quote_line_id", quoteLineId);
+
+  if (itemsLoadErr) {
+    return { result: emptyResult(), error: new Error(itemsLoadErr.message) };
+  }
+
+  const result: RelinkQuoteLinePartsResult = emptyResult();
+  const requestIdsToRelink: string[] = [];
+  const itemIdsToRelink: string[] = [];
+
+  for (const row of (requestRows ?? []) as Pick<
+    PartRequestRow,
+    "id" | "job_id"
+  >[]) {
+    if (row.job_id === workOrderLineId) {
+      result.partRequestsAlreadyLinked += 1;
+    } else if (!row.job_id) {
+      requestIdsToRelink.push(row.id);
+    } else {
+      result.conflicts.push({
+        table: "part_requests",
+        id: row.id,
+        currentWorkOrderLineId: row.job_id,
+        targetWorkOrderLineId: workOrderLineId,
+      });
+    }
+  }
+
+  for (const row of (itemRows ?? []) as Pick<
+    PartRequestItemRow,
+    "id" | "work_order_line_id"
+  >[]) {
+    if (row.work_order_line_id === workOrderLineId) {
+      result.partRequestItemsAlreadyLinked += 1;
+    } else if (!row.work_order_line_id) {
+      itemIdsToRelink.push(row.id);
+    } else {
+      result.conflicts.push({
+        table: "part_request_items",
+        id: row.id,
+        currentWorkOrderLineId: row.work_order_line_id,
+        targetWorkOrderLineId: workOrderLineId,
+      });
+    }
+  }
+
+  if (requestIdsToRelink.length > 0) {
+    const { data: updatedRequests, error: requestsUpdateErr } = await supabase
+      .from("part_requests")
+      .update({ job_id: workOrderLineId })
+      .eq("shop_id", shopId)
+      .eq("work_order_id", workOrderId)
+      .eq("quote_line_id", quoteLineId)
+      .in("id", requestIdsToRelink)
+      .select("id");
+
+    if (requestsUpdateErr) {
+      return { result, error: new Error(requestsUpdateErr.message) };
+    }
+
+    result.partRequestsRelinked = updatedRequests?.length ?? 0;
+  }
+
+  if (itemIdsToRelink.length > 0) {
+    const { data: updatedItems, error: itemsUpdateErr } = await supabase
+      .from("part_request_items")
+      .update({ work_order_line_id: workOrderLineId })
+      .eq("shop_id", shopId)
+      .eq("work_order_id", workOrderId)
+      .eq("quote_line_id", quoteLineId)
+      .in("id", itemIdsToRelink)
+      .select("id");
+
+    if (itemsUpdateErr) {
+      return { result, error: new Error(itemsUpdateErr.message) };
+    }
+
+    result.partRequestItemsRelinked = updatedItems?.length ?? 0;
+  }
+
+  return { result, error: null };
+}
+
+function emptyResult(): RelinkQuoteLinePartsResult {
+  return {
+    partRequestsRelinked: 0,
+    partRequestItemsRelinked: 0,
+    partRequestsAlreadyLinked: 0,
+    partRequestItemsAlreadyLinked: 0,
+    conflicts: [],
+  };
+}

--- a/features/work-orders/server/workOrderQuoteLineApproval.ts
+++ b/features/work-orders/server/workOrderQuoteLineApproval.ts
@@ -2,6 +2,10 @@ import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database, TablesInsert } from "@shared/types/types/supabase";
+import {
+  relinkQuoteLinePartsToWorkOrderLine,
+  type RelinkQuoteLinePartsResult,
+} from "@/features/parts/server/relinkQuoteLinePartsToWorkOrderLine";
 
 type DB = Database;
 type Json = DB["public"]["Tables"]["work_order_quote_lines"]["Row"]["metadata"];
@@ -11,8 +15,40 @@ type WorkOrderUpdate = DB["public"]["Tables"]["work_orders"]["Update"];
 
 export type QuoteApprovalDecision = "approve" | "decline" | "defer";
 
-const APPROVABLE_STATUSES = new Set(["sent", "ready_to_send", "quoted", "approved", "converted"]);
-const NON_APPROVABLE_STATUSES = new Set(["declined", "deferred", "rejected", "cancelled"]);
+const APPROVABLE_STATUSES = new Set([
+  "sent",
+  "ready_to_send",
+  "quoted",
+  "approved",
+  "converted",
+]);
+const NON_APPROVABLE_STATUSES = new Set([
+  "declined",
+  "deferred",
+  "rejected",
+  "cancelled",
+]);
+
+function emptyPartRelinkResult(): RelinkQuoteLinePartsResult {
+  return {
+    partRequestsRelinked: 0,
+    partRequestItemsRelinked: 0,
+    partRequestsAlreadyLinked: 0,
+    partRequestItemsAlreadyLinked: 0,
+    conflicts: [],
+  };
+}
+
+function mergePartRelinkResult(
+  target: RelinkQuoteLinePartsResult,
+  source: RelinkQuoteLinePartsResult,
+): void {
+  target.partRequestsRelinked += source.partRequestsRelinked;
+  target.partRequestItemsRelinked += source.partRequestItemsRelinked;
+  target.partRequestsAlreadyLinked += source.partRequestsAlreadyLinked;
+  target.partRequestItemsAlreadyLinked += source.partRequestItemsAlreadyLinked;
+  target.conflicts.push(...source.conflicts);
+}
 
 function safeTrim(v: unknown): string {
   return typeof v === "string" ? v.trim() : "";
@@ -27,12 +63,22 @@ function asNumber(v: unknown): number | null {
   return null;
 }
 
-function quoteMetadata(line: Pick<QuoteLineRow, "metadata">): Record<string, unknown> {
-  if (!line.metadata || typeof line.metadata !== "object" || Array.isArray(line.metadata)) return {};
+function quoteMetadata(
+  line: Pick<QuoteLineRow, "metadata">,
+): Record<string, unknown> {
+  if (
+    !line.metadata ||
+    typeof line.metadata !== "object" ||
+    Array.isArray(line.metadata)
+  )
+    return {};
   return line.metadata as Record<string, unknown>;
 }
 
-function mergeMetadata(line: QuoteLineRow, patch: Record<string, unknown>): Json {
+function mergeMetadata(
+  line: QuoteLineRow,
+  patch: Record<string, unknown>,
+): Json {
   return {
     ...quoteMetadata(line),
     ...patch,
@@ -46,8 +92,17 @@ function getPartsFromMetadata(line: QuoteLineRow): unknown[] {
 
 function describeParts(parts: unknown[]): string | null {
   const labels = parts
-    .filter((part): part is Record<string, unknown> => Boolean(part) && typeof part === "object" && !Array.isArray(part))
-    .map((part) => safeTrim(part.name) || safeTrim(part.description) || safeTrim(part.part_number) || safeTrim(part.sku))
+    .filter(
+      (part): part is Record<string, unknown> =>
+        Boolean(part) && typeof part === "object" && !Array.isArray(part),
+    )
+    .map(
+      (part) =>
+        safeTrim(part.name) ||
+        safeTrim(part.description) ||
+        safeTrim(part.part_number) ||
+        safeTrim(part.sku),
+    )
     .filter(Boolean);
 
   return labels.length > 0 ? labels.join(", ") : null;
@@ -61,7 +116,14 @@ function decisionPatch(params: {
   now: string;
   materializedWorkOrderLineId?: string | null;
 }): DB["public"]["Tables"]["work_order_quote_lines"]["Update"] {
-  const { line, decision, actorUserId, customerId, now, materializedWorkOrderLineId } = params;
+  const {
+    line,
+    decision,
+    actorUserId,
+    customerId,
+    now,
+    materializedWorkOrderLineId,
+  } = params;
   const baseAudit = {
     customer_decision: decision,
     customer_decision_at: now,
@@ -75,10 +137,12 @@ function decisionPatch(params: {
       stage: "customer_approved",
       approved_at: line.approved_at ?? now,
       declined_at: null,
-      work_order_line_id: materializedWorkOrderLineId ?? line.work_order_line_id,
+      work_order_line_id:
+        materializedWorkOrderLineId ?? line.work_order_line_id,
       metadata: mergeMetadata(line, {
         ...baseAudit,
-        materialized_work_order_line_id: materializedWorkOrderLineId ?? line.work_order_line_id ?? null,
+        materialized_work_order_line_id:
+          materializedWorkOrderLineId ?? line.work_order_line_id ?? null,
       }),
       updated_at: now,
     };
@@ -108,7 +172,8 @@ async function findExistingMaterializedLine(params: {
   line: QuoteLineRow;
 }): Promise<{ id: string | null; error: Error | null }> {
   const { supabase, line } = params;
-  if (line.work_order_line_id) return { id: line.work_order_line_id, error: null };
+  if (line.work_order_line_id)
+    return { id: line.work_order_line_id, error: null };
 
   const externalId = `quote_line:${line.id}`;
   const { data, error } = await supabase
@@ -135,14 +200,21 @@ async function materializeQuoteLine(params: {
 
   const metadata = quoteMetadata(line);
   const parts = getPartsFromMetadata(line);
-  const lineTotal = asNumber(line.grand_total) ?? asNumber(line.subtotal) ?? (asNumber(line.labor_total) ?? 0) + (asNumber(line.parts_total) ?? 0);
-  const laborHours = asNumber(line.labor_hours) ?? asNumber(line.est_labor_hours);
+  const lineTotal =
+    asNumber(line.grand_total) ??
+    asNumber(line.subtotal) ??
+    (asNumber(line.labor_total) ?? 0) + (asNumber(line.parts_total) ?? 0);
+  const laborHours =
+    asNumber(line.labor_hours) ?? asNumber(line.est_labor_hours);
 
   const insertLine: WorkOrderLineInsert = {
     shop_id: line.shop_id,
     work_order_id: line.work_order_id,
     vehicle_id: line.vehicle_id,
-    description: safeTrim(line.description) || safeTrim(line.ai_complaint) || "Approved quote line",
+    description:
+      safeTrim(line.description) ||
+      safeTrim(line.ai_complaint) ||
+      "Approved quote line",
     job_type: safeTrim(line.job_type) || "repair",
     status: "in_progress",
     line_status: "authorized",
@@ -152,12 +224,17 @@ async function materializeQuoteLine(params: {
     quoted_at: line.sent_to_customer_at ?? line.created_at ?? now,
     labor_time: laborHours,
     price_estimate: lineTotal,
-    complaint: safeTrim(line.ai_complaint) || safeTrim(line.notes) || safeTrim(line.description) || null,
+    complaint:
+      safeTrim(line.ai_complaint) ||
+      safeTrim(line.notes) ||
+      safeTrim(line.description) ||
+      null,
     cause: safeTrim(line.ai_cause) || null,
     correction: safeTrim(line.ai_correction) || null,
     notes: safeTrim(line.notes) || null,
     parts: describeParts(parts),
-    parts_needed: parts.length > 0 ? (parts as WorkOrderLineInsert["parts_needed"]) : null,
+    parts_needed:
+      parts.length > 0 ? (parts as WorkOrderLineInsert["parts_needed"]) : null,
     external_id: `quote_line:${line.id}`,
     source_row_id: line.id,
     source_intake_id: safeTrim(metadata.source_inspection_id) || null,
@@ -195,16 +272,22 @@ async function rollupWorkOrderQuoteApprovalState(params: {
   const { supabase, workOrderId, shopId, now, actorUserId } = params;
   const { data, error } = await supabase
     .from("work_order_quote_lines")
-    .select("status, stage, approved_at, declined_at, work_order_line_id, sent_to_customer_at")
+    .select(
+      "status, stage, approved_at, declined_at, work_order_line_id, sent_to_customer_at",
+    )
     .eq("shop_id", shopId)
     .eq("work_order_id", workOrderId);
 
   if (error) return { state: null, error: new Error(error.message) };
 
   const customerVisibleLines = (data ?? []).filter((line) => {
-    const status = safeTrim((line as { status?: unknown }).status).toLowerCase();
+    const status = safeTrim(
+      (line as { status?: unknown }).status,
+    ).toLowerCase();
     return (
-      Boolean((line as { sent_to_customer_at?: unknown }).sent_to_customer_at) ||
+      Boolean(
+        (line as { sent_to_customer_at?: unknown }).sent_to_customer_at,
+      ) ||
       status === "sent" ||
       status === "approved" ||
       status === "converted" ||
@@ -218,11 +301,25 @@ async function rollupWorkOrderQuoteApprovalState(params: {
   let pending = 0;
 
   for (const line of customerVisibleLines) {
-    const status = safeTrim((line as { status?: unknown }).status).toLowerCase();
+    const status = safeTrim(
+      (line as { status?: unknown }).status,
+    ).toLowerCase();
     const stage = safeTrim((line as { stage?: unknown }).stage).toLowerCase();
-    if (status === "approved" || status === "converted" || stage === "customer_approved" || (line as { approved_at?: unknown }).approved_at || (line as { work_order_line_id?: unknown }).work_order_line_id) {
+    if (
+      status === "approved" ||
+      status === "converted" ||
+      stage === "customer_approved" ||
+      (line as { approved_at?: unknown }).approved_at ||
+      (line as { work_order_line_id?: unknown }).work_order_line_id
+    ) {
       approved += 1;
-    } else if (status === "declined" || status === "deferred" || stage === "customer_declined" || stage === "customer_deferred" || (line as { declined_at?: unknown }).declined_at) {
+    } else if (
+      status === "declined" ||
+      status === "deferred" ||
+      stage === "customer_declined" ||
+      stage === "customer_deferred" ||
+      (line as { declined_at?: unknown }).declined_at
+    ) {
       declinedDeferred += 1;
     } else {
       pending += 1;
@@ -230,9 +327,11 @@ async function rollupWorkOrderQuoteApprovalState(params: {
   }
 
   let approvalState: WorkOrderUpdate["approval_state"] = "pending";
-  if (approved > 0 && pending === 0 && declinedDeferred === 0) approvalState = "approved";
+  if (approved > 0 && pending === 0 && declinedDeferred === 0)
+    approvalState = "approved";
   else if (approved > 0) approvalState = "partial";
-  else if (approved === 0 && pending === 0 && declinedDeferred > 0) approvalState = "declined";
+  else if (approved === 0 && pending === 0 && declinedDeferred > 0)
+    approvalState = "declined";
 
   const patch: WorkOrderUpdate = {
     approval_state: approvalState,
@@ -263,10 +362,32 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   customerId: string | null;
   actorUserId: string;
   decision: QuoteApprovalDecision;
-}): Promise<{ ok: boolean; workOrderLineIds: string[]; approvalState: string | null; error?: string }> {
-  const { supabase, quoteLineIds, workOrderId, shopId, customerId, actorUserId, decision } = params;
+}): Promise<{
+  ok: boolean;
+  workOrderLineIds: string[];
+  approvalState: string | null;
+  partRelink: RelinkQuoteLinePartsResult;
+  error?: string;
+}> {
+  const {
+    supabase,
+    quoteLineIds,
+    workOrderId,
+    shopId,
+    customerId,
+    actorUserId,
+    decision,
+  } = params;
   const ids = [...new Set(quoteLineIds.map((id) => id.trim()).filter(Boolean))];
-  if (ids.length === 0) return { ok: false, workOrderLineIds: [], approvalState: null, error: "No quote line ids supplied" };
+  if (ids.length === 0) {
+    return {
+      ok: false,
+      workOrderLineIds: [],
+      approvalState: null,
+      partRelink: emptyPartRelinkResult(),
+      error: "No quote line ids supplied",
+    };
+  }
 
   const { data: rows, error: loadErr } = await supabase
     .from("work_order_quote_lines")
@@ -275,26 +396,71 @@ export async function applyWorkOrderQuoteLineDecision(params: {
     .eq("work_order_id", workOrderId)
     .in("id", ids);
 
-  if (loadErr) return { ok: false, workOrderLineIds: [], approvalState: null, error: loadErr.message };
-  if ((rows?.length ?? 0) !== ids.length) return { ok: false, workOrderLineIds: [], approvalState: null, error: "One or more quote lines were not found for this work order" };
+  if (loadErr)
+    return {
+      ok: false,
+      workOrderLineIds: [],
+      approvalState: null,
+      partRelink: emptyPartRelinkResult(),
+      error: loadErr.message,
+    };
+  if ((rows?.length ?? 0) !== ids.length) {
+    return {
+      ok: false,
+      workOrderLineIds: [],
+      approvalState: null,
+      partRelink: emptyPartRelinkResult(),
+      error: "One or more quote lines were not found for this work order",
+    };
+  }
 
   const now = new Date().toISOString();
   const workOrderLineIds: string[] = [];
+  const partRelink = emptyPartRelinkResult();
 
   for (const line of (rows ?? []) as QuoteLineRow[]) {
     const status = safeTrim(line.status).toLowerCase();
     if (decision === "approve" && NON_APPROVABLE_STATUSES.has(status)) {
-      return { ok: false, workOrderLineIds, approvalState: null, error: `Quote line cannot be approved from status '${line.status}'` };
+      return {
+        ok: false,
+        workOrderLineIds,
+        approvalState: null,
+        partRelink,
+        error: `Quote line cannot be approved from status '${line.status}'`,
+      };
     }
 
-    if (decision === "approve" && status && !APPROVABLE_STATUSES.has(status) && !line.sent_to_customer_at) {
-      return { ok: false, workOrderLineIds, approvalState: null, error: "Quote line has not been sent to the customer" };
+    if (
+      decision === "approve" &&
+      status &&
+      !APPROVABLE_STATUSES.has(status) &&
+      !line.sent_to_customer_at
+    ) {
+      return {
+        ok: false,
+        workOrderLineIds,
+        approvalState: null,
+        partRelink,
+        error: "Quote line has not been sent to the customer",
+      };
     }
 
     let materializedLineId: string | null = null;
     if (decision === "approve") {
-      const materialized = await materializeQuoteLine({ supabase, line, actorUserId, now });
-      if (materialized.error) return { ok: false, workOrderLineIds, approvalState: null, error: materialized.error.message };
+      const materialized = await materializeQuoteLine({
+        supabase,
+        line,
+        actorUserId,
+        now,
+      });
+      if (materialized.error)
+        return {
+          ok: false,
+          workOrderLineIds,
+          approvalState: null,
+          partRelink,
+          error: materialized.error.message,
+        };
       materializedLineId = materialized.id;
       if (materializedLineId) workOrderLineIds.push(materializedLineId);
     }
@@ -315,11 +481,69 @@ export async function applyWorkOrderQuoteLineDecision(params: {
       .eq("shop_id", shopId)
       .eq("work_order_id", workOrderId);
 
-    if (updateErr) return { ok: false, workOrderLineIds, approvalState: null, error: updateErr.message };
+    if (updateErr)
+      return {
+        ok: false,
+        workOrderLineIds,
+        approvalState: null,
+        partRelink,
+        error: updateErr.message,
+      };
+
+    if (decision === "approve" && materializedLineId) {
+      const relink = await relinkQuoteLinePartsToWorkOrderLine({
+        supabase,
+        shopId,
+        workOrderId,
+        quoteLineId: line.id,
+        workOrderLineId: materializedLineId,
+      });
+
+      if (relink.error)
+        return {
+          ok: false,
+          workOrderLineIds,
+          approvalState: null,
+          partRelink,
+          error: relink.error.message,
+        };
+      mergePartRelinkResult(partRelink, relink.result);
+
+      if (relink.result.conflicts.length > 0) {
+        console.warn(
+          "[quote-line-approval] linked parts conflict while relinking approved quote line",
+          {
+            shopId,
+            workOrderId,
+            quoteLineId: line.id,
+            workOrderLineId: materializedLineId,
+            conflicts: relink.result.conflicts,
+          },
+        );
+      }
+    }
   }
 
-  const rollup = await rollupWorkOrderQuoteApprovalState({ supabase, workOrderId, shopId, now, actorUserId });
-  if (rollup.error) return { ok: false, workOrderLineIds, approvalState: null, error: rollup.error.message };
+  const rollup = await rollupWorkOrderQuoteApprovalState({
+    supabase,
+    workOrderId,
+    shopId,
+    now,
+    actorUserId,
+  });
+  if (rollup.error)
+    return {
+      ok: false,
+      workOrderLineIds,
+      approvalState: null,
+      partRelink,
+      error: rollup.error.message,
+    };
 
-  return { ok: true, workOrderLineIds, approvalState: rollup.state };
+  return {
+    ok: true,
+    workOrderLineIds,
+    approvalState: rollup.state,
+    partRelink,
+  };
 }


### PR DESCRIPTION
### Motivation
- Approved quote lines that are materialized into `work_order_lines` must have their canonical parts (`part_requests` / `part_request_items`) relinked to the new work order line so technicians, allocations, and invoices can see the correct links. 
- Existing flows materialize quote lines but left `quote_line_id`-originated parts orphaned from the new `work_order_line_id`, breaking visibility and traceability. 
- This change adds a focused, conservative relink step that preserves existing status/metadata and avoids overwriting conflicting links.

### Description
- Added a new helper `relinkQuoteLinePartsToWorkOrderLine` in `features/parts/server/relinkQuoteLinePartsToWorkOrderLine.ts` that, scoped by `shopId`, `workOrderId`, and `quoteLineId`, sets `part_requests.job_id` and `part_request_items.work_order_line_id` only when those fields are currently empty and returns counts and any conflicts. 
- Integrated the relink helper into the approval/materialization path in `features/work-orders/server/workOrderQuoteLineApproval.ts` so relinking runs immediately after a quote line is materialized (and `work_order_quote_lines.work_order_line_id` is updated), and merged relink results across multiple lines. 
- API responses were extended to return relink metadata (`partRelink`) from customer approval and authorize endpoints in `app/api/work-orders/quotes/[id]/approval-decision/route.ts` and `app/api/work-orders/quotes/[id]/authorize/route.ts` so callers can observe counts and conflicts. 
- Behavior notes: relinking is idempotent (reuses existing materialized `work_order_lines`), already-linked records are counted and not rewritten, conflicting records pointing at a different line are not overwritten and are reported/logged, and all updates include `shop_id` + `work_order_id` + `quote_line_id` checks to preserve tenant scoping.

### Testing
- Ran targeted ESLint on the touched files via `npx eslint features/parts/server/relinkQuoteLinePartsToWorkOrderLine.ts features/work-orders/server/workOrderQuoteLineApproval.ts app/api/work-orders/quotes/[id]/approval-decision/route.ts app/api/work-orders/quotes/[id]/authorize/route.ts` and it completed successfully. 
- Ran TypeScript checks with `npx tsc --noEmit` and there were no type errors. 
- Verified repository status with `git status --short` to confirm the intended changes were staged/committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f04da6f1c8328a3ec3c5bf5e3adfd)