### PR TITLE
Phase 5D-4: invoice fallback for approved quote-line parts

### DIFF
--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -16,6 +16,45 @@ type Args = {
   kind: ReviewKind;
 };
 
+const BILLABLE_PART_REQUEST_ITEM_STATUSES = new Set([
+  "quoted",
+  "approved",
+  "reserved",
+  "picking",
+  "picked",
+  "ordered",
+  "partially_received",
+  "received",
+  "fulfilled",
+  "consumed",
+]);
+
+function numericValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function partRequestItemHasBillablePrice(row: Record<string, unknown>): boolean {
+  const quotedPrice = numericValue(row.quoted_price);
+  const unitPrice = numericValue(row.unit_price);
+  const unitCost = numericValue(row.unit_cost);
+  const price = quotedPrice ?? unitPrice ?? unitCost;
+  return price != null && price > 0;
+}
+
+function partRequestItemQuantity(row: Record<string, unknown>): number {
+  return (
+    numericValue(row.qty) ??
+    numericValue(row.qty_requested) ??
+    numericValue(row.qty_approved) ??
+    0
+  );
+}
+
 export async function reviewWorkOrder({
   supabase,
   workOrderId,
@@ -44,6 +83,32 @@ export async function reviewWorkOrder({
       qty > 0 && unitCost !== null && Number.isFinite(unitCost) && unitCost > 0;
     const billableByQtyFallback = qty > 0 && unitCost === null;
     if (lineId && (billableByQtyAndUnitCost || billableByQtyFallback)) {
+      hasBillablePartsByLine.set(lineId, true);
+    }
+  }
+
+  const { data: linkedPartRequestRows } = await supabase
+    .from("part_request_items")
+    .select("work_order_line_id, quote_line_id, status, approved, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost")
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .not("work_order_line_id", "is", null);
+
+  for (const row of linkedPartRequestRows ?? []) {
+    const record = row as Record<string, unknown>;
+    const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
+    const quoteLineId = typeof row.quote_line_id === "string" ? row.quote_line_id : "";
+    const status = String(row.status ?? "").trim().toLowerCase();
+    const statusIsBillable = BILLABLE_PART_REQUEST_ITEM_STATUSES.has(status);
+    const approved = row.approved === true;
+
+    if (
+      lineId &&
+      quoteLineId &&
+      (statusIsBillable || approved) &&
+      partRequestItemQuantity(record) > 0 &&
+      partRequestItemHasBillablePrice(record)
+    ) {
       hasBillablePartsByLine.set(lineId, true);
     }
   }

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -19,10 +19,6 @@ type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type InvoiceRow = DB["public"]["Tables"]["invoices"]["Row"];
-type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
-type PartRow = DB["public"]["Tables"]["parts"]["Row"];
-type WorkOrderPartAllocRow =
-  DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
 type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
 
 type PdfRgb = ReturnType<typeof rgb>;
@@ -137,21 +133,6 @@ type PdfCtx = {
   doc: PDFDocument;
   page: ReturnType<PDFDocument["addPage"]>;
   y: number;
-};
-
-// Optional line linkage if your schema has work_order_line_id
-type BilledPartRow = Pick<
-  WorkOrderPartRow,
-  "part_id" | "quantity" | "unit_price" | "total_price"
-> & {
-  work_order_line_id?: string | null;
-};
-
-type AllocPartRow = Pick<
-  WorkOrderPartAllocRow,
-  "part_id" | "qty" | "unit_cost"
-> & {
-  work_order_line_id?: string | null;
 };
 
 export async function GET(
@@ -401,123 +382,18 @@ export async function GET(
     >
   >;
 
-  // Parts: Prefer billed parts, fallback to allocations
-  const { data: wop } = await supabase
-    .from("work_order_parts")
-    .select("part_id,quantity,unit_price,total_price,work_order_line_id")
-    .eq("work_order_id", workOrderId);
-
-  const billedParts = (Array.isArray(wop) ? wop : []) as BilledPartRow[];
-
-  let allocParts: Array<{
-    part_id: string;
-    qty: number;
-    unit_cost: number;
-    work_order_line_id?: string | null;
-  }> = [];
-
-  if (billedParts.length === 0) {
-    const { data: alloc } = await supabase
-      .from("work_order_part_allocations")
-      .select("part_id,qty,unit_cost,work_order_line_id")
-      .eq("work_order_id", workOrderId);
-
-    const allocRows = (Array.isArray(alloc) ? alloc : []) as AllocPartRow[];
-
-    allocParts = allocRows
-      .filter((r) => typeof r.part_id === "string" && r.part_id.length > 0)
-      .map((r) => ({
-        part_id: r.part_id as string,
-        qty: safeMoney(r.qty),
-        unit_cost: safeMoney(r.unit_cost),
-        work_order_line_id:
-          typeof r.work_order_line_id === "string" ? r.work_order_line_id : null,
-      }));
-  }
-
-  const partIds = Array.from(
-    new Set(
-      [
-        ...billedParts
-          .map((r) => r.part_id)
-          .filter((id): id is string => typeof id === "string" && id.length > 0),
-        ...allocParts.map((r) => r.part_id),
-      ].filter(Boolean),
-    ),
-  );
-
-  let partsMap = new Map<
-    string,
-    Pick<PartRow, "id" | "name" | "part_number" | "sku" | "unit">
-  >();
-
-  if (partIds.length > 0) {
-    const { data: parts } = await supabase
-      .from("parts")
-      .select("id,name,part_number,sku,unit")
-      .in("id", partIds);
-
-    const arr = (Array.isArray(parts) ? parts : []) as Array<
-      Pick<PartRow, "id" | "name" | "part_number" | "sku" | "unit">
-    >;
-
-    partsMap = new Map(arr.map((p) => [p.id, p]));
-  }
-
-  const partRowsFromBilled: PartDisplayRow[] = billedParts.map((r) => {
-    const p = r.part_id ? partsMap.get(r.part_id) : undefined;
-
-    const qty =
-      typeof r.quantity === "number" ? r.quantity : Number(r.quantity);
-    const unitPrice = safeMoney(r.unit_price);
-    const totalPrice = safeMoney(r.total_price);
-
-    const lineId =
-      typeof r.work_order_line_id === "string" && r.work_order_line_id.length > 0
-        ? r.work_order_line_id
-        : undefined;
-
-    return {
-      name: (p?.name ?? "Part").trim() || "Part",
-      partNumber: (p?.part_number ?? "").trim() || undefined,
-      sku: (p?.sku ?? "").trim() || undefined,
-      unit: (p?.unit ?? "").trim() || undefined,
-      qty: Number.isFinite(qty) ? qty : 0,
-      unitPrice,
-      totalPrice:
-        totalPrice > 0
-          ? totalPrice
-          : Math.max(0, (Number.isFinite(qty) ? qty : 0) * unitPrice),
-      lineId,
-    };
-  });
-
-  const partRowsFromAlloc: PartDisplayRow[] = allocParts.map((r) => {
-    const p = partsMap.get(r.part_id);
-
-    const qty = safeMoney(r.qty);
-    const unitCost = safeMoney(r.unit_cost);
-    const total = Math.max(0, qty * unitCost);
-
-    const lineId =
-      typeof r.work_order_line_id === "string" && r.work_order_line_id.length > 0
-        ? r.work_order_line_id
-        : undefined;
-
-    return {
-      name: (p?.name ?? "Part").trim() || "Part",
-      partNumber: (p?.part_number ?? "").trim() || undefined,
-      sku: (p?.sku ?? "").trim() || undefined,
-      unit: (p?.unit ?? "").trim() || undefined,
-      qty,
-      unitPrice: unitCost,
-      totalPrice: total,
-      lineId,
-    };
-  });
-
-  const allPartRows: PartDisplayRow[] =
-    partRowsFromBilled.length > 0 ? partRowsFromBilled : partRowsFromAlloc;
+  // Parts: the shared invoice snapshot applies allocation → staged work_order_parts →
+  // approved quote-line part_request_items priority and exposes the exact visible rows.
+  const allPartRows: PartDisplayRow[] = snapshot.parts.map((part) => ({
+    name: part.name,
+    partNumber: part.partNumber,
+    sku: part.sku,
+    unit: part.unit,
+    qty: part.qty,
+    unitPrice: part.unitPrice,
+    totalPrice: part.totalPrice,
+    lineId: part.lineId,
+  }));
 
   const partsByLineId = new Map<string, PartDisplayRow[]>();
   const unassignedParts: PartDisplayRow[] = [];

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 type DB = Database;
 
@@ -13,7 +14,8 @@ type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type WorkOrderQuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
-import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
+type PartRequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
 
 export type InvoiceSnapshotPart = {
   id: string;
@@ -25,6 +27,8 @@ export type InvoiceSnapshotPart = {
   sku?: string;
   partNumber?: string;
   unit?: string;
+  vendor?: string;
+  source?: "work_order_part_allocation" | "work_order_part" | "quote_line_part_request";
 };
 
 export type InvoiceSnapshotLine = Pick<
@@ -143,6 +147,93 @@ function normalizeCurrencyFromCountry(country: unknown): "CAD" | "USD" {
 
 function isNonEmptyString(v: unknown): v is string {
   return typeof v === "string" && v.trim().length > 0;
+}
+
+const BILLABLE_PART_REQUEST_ITEM_STATUSES = new Set([
+  "quoted",
+  "approved",
+  "reserved",
+  "picking",
+  "picked",
+  "ordered",
+  "partially_received",
+  "received",
+  "fulfilled",
+  "consumed",
+]);
+
+const NON_BILLABLE_QUOTE_LINE_STATUSES = new Set([
+  "declined",
+  "deferred",
+  "rejected",
+  "cancelled",
+  "canceled",
+]);
+
+function itemUnitPrice(item: Pick<PartRequestItemRow, "quoted_price" | "unit_price" | "unit_cost">): number {
+  // Phase 5D quote sync treats quoted_price as the unit sell price, then falls back
+  // to unit_price and unit_cost. Preserve that unit-price interpretation here.
+  return safeNumberOrNull(item.quoted_price) ?? safeNumberOrNull(item.unit_price) ?? safeNumberOrNull(item.unit_cost) ?? 0;
+}
+
+function itemQuantity(item: Pick<PartRequestItemRow, "qty" | "qty_requested" | "qty_approved">): number {
+  const qty = safeNumber(item.qty);
+  const requested = safeNumber(item.qty_requested);
+  const approved = safeNumber(item.qty_approved);
+  const resolved = qty > 0 ? qty : requested > 0 ? requested : approved;
+  return resolved > 0 ? resolved : 1;
+}
+
+function quoteLineIsInvoiceFallbackEligible(
+  quote: Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id"> | undefined,
+  lineId: string,
+): boolean {
+  if (!quote?.work_order_line_id || quote.work_order_line_id !== lineId) return false;
+  const status = String(quote.status ?? "").trim().toLowerCase();
+  return !NON_BILLABLE_QUOTE_LINE_STATUSES.has(status);
+}
+
+function partRequestItemIsInvoiceFallbackEligible(
+  item: Pick<
+    PartRequestItemRow,
+    | "shop_id"
+    | "work_order_id"
+    | "work_order_line_id"
+    | "quote_line_id"
+    | "request_id"
+    | "status"
+    | "approved"
+    | "qty"
+    | "qty_requested"
+    | "qty_approved"
+  >,
+  args: {
+    shopId: string;
+    workOrderId: string;
+    workOrderLineId: string;
+    requestQuoteLineIdByRequestId: Map<string, string>;
+    quoteLineById: Map<string, Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id">>;
+  },
+): boolean {
+  if (item.shop_id !== args.shopId) return false;
+  if (item.work_order_id !== args.workOrderId) return false;
+  if (item.work_order_line_id !== args.workOrderLineId) return false;
+
+  const status = String(item.status ?? "").trim().toLowerCase();
+  const statusIsBillable = BILLABLE_PART_REQUEST_ITEM_STATUSES.has(status);
+  if (!statusIsBillable && item.approved !== true) return false;
+  if (itemQuantity(item) <= 0) return false;
+
+  const quoteLineId =
+    (isNonEmptyString(item.quote_line_id) ? item.quote_line_id.trim() : "") ||
+    args.requestQuoteLineIdByRequestId.get(item.request_id) ||
+    "";
+  if (!quoteLineId) return false;
+
+  return quoteLineIsInvoiceFallbackEligible(
+    args.quoteLineById.get(quoteLineId),
+    args.workOrderLineId,
+  );
 }
 
 export async function getInvoiceSnapshotForWorkOrder(args: {
@@ -279,6 +370,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const { data: linesRaw } = await supabase
     .from("work_order_lines")
     .select("id, line_no, description, complaint, cause, correction, labor_time")
+    .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .order("line_no", { ascending: true })
     .returns<InvoiceSnapshotLine[]>();
@@ -287,14 +379,15 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
 
   const { data: allocRaw } = await supabase
     .from("work_order_part_allocations")
-    .select("id, work_order_line_id, part_id, qty, unit_cost, created_at")
+    .select("id, shop_id, work_order_id, work_order_line_id, part_id, qty, unit_cost, source_request_item_id, created_at")
+    .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .order("created_at", { ascending: true })
     .returns<
       Array<
         Pick<
           AllocationRow,
-          "id" | "work_order_line_id" | "part_id" | "qty" | "unit_cost" | "created_at"
+          "id" | "shop_id" | "work_order_id" | "work_order_line_id" | "part_id" | "qty" | "unit_cost" | "source_request_item_id" | "created_at"
         >
       >
     >();
@@ -302,11 +395,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const allocs = Array.isArray(allocRaw) ? allocRaw : [];
   const { data: stagedPartsRaw } = await supabase
     .from("work_order_parts")
-    .select("id, work_order_line_id, quantity, unit_price, total_price")
+    .select("id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price")
+    .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .returns<
       Array<
-        Pick<WorkOrderPartRow, "id" | "work_order_line_id" | "quantity" | "unit_price" | "total_price">
+        Pick<WorkOrderPartRow, "id" | "shop_id" | "work_order_line_id" | "part_id" | "quantity" | "unit_price" | "total_price">
       >
     >();
   const stagedParts = Array.isArray(stagedPartsRaw) ? stagedPartsRaw : [];
@@ -314,17 +408,139 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const { data: quoteRaw } = await supabase
     .from("work_order_quote_lines")
     .select("id, work_order_line_id, status, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, grand_total")
+    .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .returns<Array<Pick<WorkOrderQuoteLineRow, "id" | "work_order_line_id" | "status" | "labor_hours" | "est_labor_hours" | "labor_total" | "parts_total" | "subtotal" | "grand_total">>>();
   const activeQuotes = (Array.isArray(quoteRaw) ? quoteRaw : []).filter((q) => {
     const s = String(q.status ?? "").toLowerCase();
-    return s !== "converted" && s !== "declined";
+    return s !== "converted" && !NON_BILLABLE_QUOTE_LINE_STATUSES.has(s);
   });
+
+  const quoteLines = Array.isArray(quoteRaw) ? quoteRaw : [];
+  const quoteLineById = new Map<
+    string,
+    Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id">
+  >();
+  for (const q of quoteLines) {
+    if (isNonEmptyString(q.id)) {
+      quoteLineById.set(q.id, {
+        status: q.status,
+        work_order_line_id: q.work_order_line_id,
+      });
+    }
+  }
+
+  const { data: requestItemsRaw } = await supabase
+    .from("part_request_items")
+    .select("id, request_id, shop_id, work_order_id, work_order_line_id, quote_line_id, description, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost, status, approved, part_id, vendor")
+    .eq("shop_id", workOrder.shop_id)
+    .eq("work_order_id", workOrderId)
+    .not("work_order_line_id", "is", null)
+    .returns<
+      Array<
+        Pick<
+          PartRequestItemRow,
+          | "id"
+          | "request_id"
+          | "shop_id"
+          | "work_order_id"
+          | "work_order_line_id"
+          | "quote_line_id"
+          | "description"
+          | "qty"
+          | "qty_requested"
+          | "qty_approved"
+          | "quoted_price"
+          | "unit_price"
+          | "unit_cost"
+          | "status"
+          | "approved"
+          | "part_id"
+          | "vendor"
+        >
+      >
+    >();
+
+  const requestItems = Array.isArray(requestItemsRaw) ? requestItemsRaw : [];
+  const requestIdsNeedingQuoteLink = Array.from(
+    new Set(
+      requestItems
+        .filter((item) => !isNonEmptyString(item.quote_line_id))
+        .map((item) => item.request_id)
+        .filter(isNonEmptyString),
+    ),
+  );
+
+  const requestQuoteLineIdByRequestId = new Map<string, string>();
+  if (requestIdsNeedingQuoteLink.length > 0) {
+    const { data: requestRows } = await supabase
+      .from("part_requests")
+      .select("id, shop_id, work_order_id, quote_line_id")
+      .eq("shop_id", workOrder.shop_id)
+      .eq("work_order_id", workOrderId)
+      .in("id", requestIdsNeedingQuoteLink)
+      .returns<
+        Array<Pick<PartRequestRow, "id" | "shop_id" | "work_order_id" | "quote_line_id">>
+      >();
+
+    for (const request of Array.isArray(requestRows) ? requestRows : []) {
+      if (
+        request.shop_id === workOrder.shop_id &&
+        request.work_order_id === workOrderId &&
+        isNonEmptyString(request.id) &&
+        isNonEmptyString(request.quote_line_id)
+      ) {
+        requestQuoteLineIdByRequestId.set(request.id, request.quote_line_id.trim());
+      }
+    }
+  }
+
+  const byLineStaged = new Map<string, typeof stagedParts>();
+  for (const part of stagedParts) {
+    if (!part.work_order_line_id) continue;
+    byLineStaged.set(part.work_order_line_id, [
+      ...(byLineStaged.get(part.work_order_line_id) ?? []),
+      part,
+    ]);
+  }
+  const byLineAlloc = new Map<string, typeof allocs>();
+  for (const alloc of allocs) {
+    if (!alloc.work_order_line_id) continue;
+    byLineAlloc.set(alloc.work_order_line_id, [
+      ...(byLineAlloc.get(alloc.work_order_line_id) ?? []),
+      alloc,
+    ]);
+  }
+
+  const fallbackRequestItems = requestItems.filter((item) => {
+    const lineId = isNonEmptyString(item.work_order_line_id) ? item.work_order_line_id.trim() : "";
+    if (!lineId) return false;
+
+    return partRequestItemIsInvoiceFallbackEligible(item, {
+      shopId: workOrder.shop_id,
+      workOrderId,
+      workOrderLineId: lineId,
+      requestQuoteLineIdByRequestId,
+      quoteLineById,
+    });
+  });
+
+  const byLineFallbackRequestItems = new Map<string, typeof fallbackRequestItems>();
+  for (const item of fallbackRequestItems) {
+    if (!item.work_order_line_id) continue;
+    byLineFallbackRequestItems.set(item.work_order_line_id, [
+      ...(byLineFallbackRequestItems.get(item.work_order_line_id) ?? []),
+      item,
+    ]);
+  }
 
   const partIds = Array.from(
     new Set(
-      allocs
-        .map((a) => a.part_id)
+      [
+        ...allocs.map((a) => a.part_id),
+        ...stagedParts.map((part) => part.part_id),
+        ...fallbackRequestItems.map((item) => item.part_id),
+      ]
         .filter(isNonEmptyString)
         .map((id) => id.trim()),
     ),
@@ -339,6 +555,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     const { data: partRows } = await supabase
       .from("parts")
       .select("id, name, sku, part_number, unit")
+      .eq("shop_id", workOrder.shop_id)
       .in("id", partIds)
       .returns<Array<Pick<PartRow, "id" | "name" | "sku" | "part_number" | "unit">>>();
 
@@ -347,7 +564,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     }
   }
 
-  const parts: InvoiceSnapshotPart[] = allocs.map((a) => {
+  const allocationParts: InvoiceSnapshotPart[] = allocs.map((a) => {
     const p = isNonEmptyString(a.part_id) ? partsMap.get(a.part_id) : undefined;
     const qtyRaw = safeNumber(a.qty);
     const qty = qtyRaw > 0 ? qtyRaw : 1;
@@ -366,8 +583,93 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       sku: (p?.sku ?? "").trim() || undefined,
       partNumber: (p?.part_number ?? "").trim() || undefined,
       unit: (p?.unit ?? "").trim() || undefined,
+      source: "work_order_part_allocation",
     };
   });
+
+  const stagedInvoiceParts: InvoiceSnapshotPart[] = stagedParts.map((part) => {
+    const p = isNonEmptyString(part.part_id) ? partsMap.get(part.part_id) : undefined;
+    const qtyRaw = safeNumber(part.quantity);
+    const qty = qtyRaw > 0 ? qtyRaw : 1;
+    const totalRaw = safeNumber(part.total_price);
+    const unitPrice = safeNumber(part.unit_price);
+    const totalPrice = totalRaw > 0 ? totalRaw : Math.max(0, qty * unitPrice);
+    const lineId = isNonEmptyString(part.work_order_line_id)
+      ? part.work_order_line_id.trim()
+      : undefined;
+
+    return {
+      id: String(part.id),
+      lineId,
+      name: (p?.name ?? "Part").trim() || "Part",
+      qty,
+      unitPrice,
+      totalPrice,
+      sku: (p?.sku ?? "").trim() || undefined,
+      partNumber: (p?.part_number ?? "").trim() || undefined,
+      unit: (p?.unit ?? "").trim() || undefined,
+      source: "work_order_part",
+    };
+  });
+
+  const requestItemInvoiceParts: InvoiceSnapshotPart[] = fallbackRequestItems.map((item) => {
+    const p = isNonEmptyString(item.part_id) ? partsMap.get(item.part_id) : undefined;
+    const qty = itemQuantity(item);
+    const unitPrice = itemUnitPrice(item);
+    const lineId = isNonEmptyString(item.work_order_line_id)
+      ? item.work_order_line_id.trim()
+      : undefined;
+    const name =
+      (item.description ?? "").trim() ||
+      (p?.name ?? "").trim() ||
+      "Part";
+
+    return {
+      id: String(item.id),
+      lineId,
+      name,
+      qty,
+      unitPrice,
+      totalPrice: Math.max(0, qty * unitPrice),
+      sku: (p?.sku ?? "").trim() || undefined,
+      partNumber: (p?.part_number ?? "").trim() || undefined,
+      unit: (p?.unit ?? "").trim() || undefined,
+      vendor: (item.vendor ?? "").trim() || undefined,
+      source: "quote_line_part_request",
+    };
+  });
+
+  const stagedPartsByLineForDisplay = new Map<string, InvoiceSnapshotPart[]>();
+  for (const part of stagedInvoiceParts) {
+    if (!part.lineId) continue;
+    stagedPartsByLineForDisplay.set(part.lineId, [
+      ...(stagedPartsByLineForDisplay.get(part.lineId) ?? []),
+      part,
+    ]);
+  }
+
+  const fallbackPartsByLineForDisplay = new Map<string, InvoiceSnapshotPart[]>();
+  for (const part of requestItemInvoiceParts) {
+    if (!part.lineId) continue;
+    fallbackPartsByLineForDisplay.set(part.lineId, [
+      ...(fallbackPartsByLineForDisplay.get(part.lineId) ?? []),
+      part,
+    ]);
+  }
+
+  const parts: InvoiceSnapshotPart[] = [...allocationParts];
+  for (const line of lines) {
+    const lineAllocations = byLineAlloc.get(line.id) ?? [];
+    if (lineAllocations.length > 0) continue;
+
+    const lineStaged = stagedPartsByLineForDisplay.get(line.id) ?? [];
+    if (lineStaged.length > 0) {
+      parts.push(...lineStaged);
+      continue;
+    }
+
+    parts.push(...(fallbackPartsByLineForDisplay.get(line.id) ?? []));
+  }
 
   const currency =
     normalizeInvoiceCurrency(invoice?.currency) ??
@@ -384,21 +686,11 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const woParts = positiveOrNull(workOrder.parts_total);
   const woInvoiceTotal = positiveOrNull(workOrder.invoice_total);
 
-  const partsTotalFromAlloc =
+  const partsTotalFromSnapshotParts =
     parts.length > 0
       ? parts.reduce((acc, p) => acc + safeNumber(p.totalPrice), 0)
       : null;
 
-  const byLineStaged = new Map<string, typeof stagedParts>();
-  for (const part of stagedParts) {
-    if (!part.work_order_line_id) continue;
-    byLineStaged.set(part.work_order_line_id, [...(byLineStaged.get(part.work_order_line_id) ?? []), part]);
-  }
-  const byLineAlloc = new Map<string, typeof allocs>();
-  for (const alloc of allocs) {
-    if (!alloc.work_order_line_id) continue;
-    byLineAlloc.set(alloc.work_order_line_id, [...(byLineAlloc.get(alloc.work_order_line_id) ?? []), alloc]);
-  }
   const byLineQuote = new Map<string, typeof activeQuotes[number]>();
   for (const q of activeQuotes) {
     if (!q.work_order_line_id) continue;
@@ -408,19 +700,33 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   let resolvedLabor = 0;
   let resolvedParts = 0;
   for (const line of lines) {
+    const lineAllocations = byLineAlloc.get(line.id) ?? [];
+    const lineStaged = byLineStaged.get(line.id) ?? [];
+    const lineFallbackParts = fallbackPartsByLineForDisplay.get(line.id) ?? [];
+    const stagedPricingParts =
+      lineAllocations.length > 0
+        ? []
+        : lineStaged.length > 0
+          ? lineStaged
+          : lineFallbackParts.map((part) => ({
+              quantity: part.qty,
+              unit_price: part.unitPrice,
+              total_price: part.totalPrice,
+            }));
+
     const resolved = resolveWorkOrderLinePricing({
       line,
       quote: byLineQuote.get(line.id) ?? null,
       shopLaborRate: safeNumberOrNull(shop?.labor_rate),
-      stagedParts: byLineStaged.get(line.id) ?? [],
-      allocatedParts: byLineAlloc.get(line.id) ?? [],
+      stagedParts: stagedPricingParts,
+      allocatedParts: lineAllocations,
     });
     resolvedLabor += resolved.laborTotal;
     resolvedParts += resolved.partsTotal;
   }
 
   const laborCost = invLabor ?? (resolvedLabor > 0 ? resolvedLabor : woLabor) ?? null;
-  const partsCost = invParts ?? (resolvedParts > 0 ? resolvedParts : partsTotalFromAlloc ?? woParts) ?? null;
+  const partsCost = invParts ?? (resolvedParts > 0 ? resolvedParts : partsTotalFromSnapshotParts ?? woParts) ?? null;
 
   const subtotal =
     invSubtotal ??

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -75,8 +75,6 @@ type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
-type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
-type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
 
 type InvoiceLinePayload = {
@@ -187,14 +185,13 @@ type PdfLinePart = {
   total: number;
 };
 
-// ✅ Your DB types for work_order_parts do NOT have qty/line_total/description.
-// Use quantity/total_price and pull names from parts table.
-// work_order_line_id is treated as optional (in case your DB has it but types are stale).
-type AllocationWithLine = Pick<
-  AllocationRow,
-  "id" | "part_id" | "qty" | "unit_cost"
-> & {
-  work_order_line_id?: string | null;
+type SnapshotPart = {
+  lineId?: string;
+  name?: string;
+  qty?: number;
+  unitPrice?: number;
+  totalPrice?: number;
+  partNumber?: string;
 };
 
 type InspectionPdfInfo = {
@@ -405,12 +402,32 @@ export default function InvoicePreviewPageClient({
 
       if (cancelled) return;
       setInvoiceId(invoiceRow?.id ?? null);
+      const snapshotPartsByLine = new Map<string, PdfLinePart[]>();
       try {
         const snapshotRes = await fetch(`/api/work-orders/${workOrderId}/invoice`, { method: "GET" });
         const snapshotJson = (await snapshotRes.json().catch(() => null)) as
-          | { snapshot?: { total?: number | null } }
+          | { snapshot?: { total?: number | null; parts?: SnapshotPart[] } }
           | null;
         const snapshotTotal = snapshotJson?.snapshot?.total;
+        for (const part of snapshotJson?.snapshot?.parts ?? []) {
+          const lineId = typeof part.lineId === "string" ? part.lineId.trim() : "";
+          if (!lineId) continue;
+          const qty = numOrUndef(part.qty) ?? 1;
+          const unitPrice = safeMoney(part.unitPrice);
+          const total = safeMoney(part.totalPrice);
+          const baseName = trimOrUndef(part.name) ?? "Part";
+          const partNumber = trimOrUndef(part.partNumber);
+          const pretty = partNumber ? `${baseName} (${partNumber})` : baseName;
+          snapshotPartsByLine.set(lineId, [
+            ...(snapshotPartsByLine.get(lineId) ?? []),
+            {
+              qty: qty > 0 ? qty : 1,
+              name: pretty,
+              unit_price: unitPrice,
+              total: total > 0 ? total : Math.max(0, (qty > 0 ? qty : 1) * unitPrice),
+            },
+          ]);
+        }
         if (!snapshotRes.ok) {
           setSnapshotWarning("Using locally derived totals; canonical invoice snapshot is unavailable.");
           setCanonicalInvoiceTotal(0);
@@ -572,75 +589,7 @@ export default function InvoicePreviewPageClient({
         if (wolErr || !Array.isArray(wol) || wol.length === 0) {
           setFLines([]);
         } else {
-          // 2) load allocated parts for this work order
-          const { data: allocRaw } = await supabase
-            .from("work_order_part_allocations")
-            .select("id, work_order_line_id, part_id, qty, unit_cost")
-            .eq("work_order_id", workOrderId);
-
-          const wop = (Array.isArray(allocRaw) ? allocRaw : []) as AllocationWithLine[];
-
-          // 3) join to parts table for names + part_number
-          const partIds = Array.from(
-            new Set(
-              wop
-                .map((p) => p.part_id)
-                .filter((id): id is string => typeof id === "string" && id.trim().length > 0),
-            ),
-          );
-
-          let partsById = new Map<string, Pick<PartRow, "id" | "name" | "part_number">>();
-
-          if (partIds.length > 0) {
-            const { data: parts } = await supabase
-              .from("parts")
-              .select("id, name, part_number")
-              .in("id", partIds);
-
-            const arr = (Array.isArray(parts) ? parts : []) as Array<
-              Pick<PartRow, "id" | "name" | "part_number">
-            >;
-
-            partsById = new Map(
-              arr
-                .filter(
-                  (p) =>
-                    typeof p.id === "string" &&
-                    p.id.length > 0 &&
-                    typeof p.name === "string",
-                )
-                .map((p) => [p.id, p]),
-            );
-          }
-
-          const perLine = new Map<string, PdfLinePart[]>();
-
-          for (const p of wop) {
-            const lidRaw = p.work_order_line_id;
-            const lid = typeof lidRaw === "string" && lidRaw.trim().length > 0 ? lidRaw.trim() : "";
-            if (!lid) continue;
-
-            const qty = Number(p.qty ?? 1);
-            const unit = safeMoney(p.unit_cost);
-            const total = Math.max(0, (Number.isFinite(qty) ? qty : 0) * unit);
-
-            const partMeta = typeof p.part_id === "string" ? partsById.get(p.part_id) : undefined;
-
-            const baseName = (partMeta?.name ?? "").trim() || "Part";
-            const pretty =
-              partMeta?.part_number && partMeta.part_number.trim().length > 0
-                ? `${baseName} (${partMeta.part_number.trim()})`
-                : baseName;
-
-            const arr = perLine.get(lid) ?? [];
-            arr.push({
-              qty: Number.isFinite(qty) && qty > 0 ? qty : 1,
-              name: pretty,
-              unit_price: Number.isFinite(unit) ? unit : 0,
-              total: Number.isFinite(total) ? total : 0,
-            });
-            perLine.set(lid, arr);
-          }
+          const perLine = snapshotPartsByLine;
 
           const mapped: Array<RepairLine & { lineId?: string; parts?: PdfLinePart[] }> = wol.map(
             (
@@ -831,8 +780,6 @@ export default function InvoicePreviewPageClient({
     effectiveVehicleInfo,
     effectiveLines,
     workOrderId,
-    derivedLaborTotal,
-    derivedPartsTotal,
     derivedInvoiceTotal,
     canonicalInvoiceTotal,
     onSent,


### PR DESCRIPTION
### Motivation
- Ensure invoice snapshot always includes approved/materialized quote-line parts even when allocation or staged work_order_parts are not present to avoid missed billed parts at invoice time. 
- Prevent duplicate counting when quote-line totals and allocations/staged parts coexist and preserve shop/work_order/work_order_line scoping.
- Preserve existing pricing behavior from quote sync (quoted_price → unit_price → unit_cost) and expose fallback rows with sufficient transparency for PDFs/portal. 

### Description
- Added a safe invoice snapshot fallback in `features/invoices/server/getInvoiceSnapshot.ts` that collects parts in priority order: `work_order_part_allocations` → staged `work_order_parts` → linked `part_request_items` (quote-line items) when allocation/staged rows are missing, and merges them into `InvoiceSnapshot.parts`. 
- Implemented helper logic and guards: `partRequestItemIsInvoiceFallbackEligible`, `itemUnitPrice`, `itemQuantity`, and status sets to only include billable item statuses and exclude declined/deferred/rejected/cancelled quote lines; pricing uses `quoted_price` as unit sell price then falls back to `unit_price` and `unit_cost`. 
- Updated consumers to use the canonical snapshot: `app/api/work-orders/[id]/invoice-pdf/route.ts` now renders parts from the shared snapshot parts rows, and `features/work-orders/components/InvoicePreviewPageClient.tsx` hydrates line parts from the snapshot for consistent display. 
- Extended invoice review helper `app/api/work-orders/[id]/_lib/reviewWorkOrder.ts` to consider linked quote-line part_request_items as satisfying billable-parts checks when allocations are not yet present while keeping the same shop/work order/line scoping and avoiding double-counting.
- Made the change idempotent and non-breaking: fallback only runs when allocations/staged rows for a line are absent; Phase 5D-5 (menu/YMM reuse) was intentionally not implemented in this PR. 

### Testing
- Ran ESLint on the touched files: `npx eslint features/invoices/server/getInvoiceSnapshot.ts app/api/work-orders/[id]/invoice-pdf/route.ts features/work-orders/components/InvoicePreviewPageClient.tsx app/api/work-orders/[id]/invoice/route.ts app/api/invoices/send/route.ts app/work-orders/invoice/[id]/page.tsx app/api/work-orders/[id]/_lib/reviewWorkOrder.ts` which completed with a single non-blocking warning. 
- Type-check: `npx tsc --noEmit` completed successfully with no type errors. 
- Verified repo hygiene: `git diff --check` produced no issues and `git status --short` shows the committed changes. 
- Commit message used: `launch cleanup phase 5d4 invoice quoted parts fallback`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f065d1a00832888fac84a758ecdd5)