### PR TITLE
Phase 5D-5B: learn menu repair items from approved quote lines

### DIFF
--- a/db/sql/2026-06-02_phase5d5b_menu_repair_quote_line_learning.sql
+++ b/db/sql/2026-06-02_phase5d5b_menu_repair_quote_line_learning.sql
@@ -1,0 +1,50 @@
+-- Phase 5D-5B: trace menu repair learning/pricing snapshots back to canonical quote lines.
+-- Additive and nullable only; no destructive or uniqueness constraints are introduced.
+
+do $$
+begin
+  if to_regclass('public.menu_repair_items') is not null then
+    alter table public.menu_repair_items
+      add column if not exists source_quote_line_id uuid;
+
+    comment on column public.menu_repair_items.source_quote_line_id is
+      'Canonical work_order_quote_lines row most recently used to learn/update this menu repair item. Nullable for legacy/manual items.';
+  else
+    raise notice 'Skipping menu_repair_items source_quote_line_id: public.menu_repair_items does not exist.';
+  end if;
+end $$;
+
+do $$
+begin
+  if to_regclass('public.menu_repair_item_pricing_snapshots') is not null then
+    alter table public.menu_repair_item_pricing_snapshots
+      add column if not exists source_quote_line_id uuid,
+      add column if not exists source_work_order_line_id uuid;
+
+    comment on column public.menu_repair_item_pricing_snapshots.source_quote_line_id is
+      'Canonical work_order_quote_lines row whose approved/materialized pricing created this snapshot, when applicable.';
+    comment on column public.menu_repair_item_pricing_snapshots.source_work_order_line_id is
+      'Materialized work_order_lines row associated with this pricing snapshot, when applicable.';
+  else
+    raise notice 'Skipping menu_repair_item_pricing_snapshots trace columns: public.menu_repair_item_pricing_snapshots does not exist.';
+  end if;
+end $$;
+
+do $$
+begin
+  if to_regclass('public.menu_repair_items') is not null then
+    create index if not exists idx_menu_repair_items_shop_source_quote_line
+      on public.menu_repair_items (shop_id, source_quote_line_id)
+      where source_quote_line_id is not null;
+  end if;
+
+  if to_regclass('public.menu_repair_item_pricing_snapshots') is not null then
+    create index if not exists idx_menu_repair_pricing_snapshots_shop_source_quote_line
+      on public.menu_repair_item_pricing_snapshots (shop_id, source_quote_line_id)
+      where source_quote_line_id is not null;
+
+    create index if not exists idx_menu_repair_pricing_snapshots_shop_source_wol
+      on public.menu_repair_item_pricing_snapshots (shop_id, source_work_order_line_id)
+      where source_work_order_line_id is not null;
+  end if;
+end $$;

--- a/features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine.ts
+++ b/features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine.ts
@@ -1,0 +1,717 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@shared/types/types/supabase";
+import { getShopPricingValidDays } from "@/features/menu-repair-items/server/getShopPricingValidDays";
+
+type DB = Database;
+
+type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
+type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
+type MenuRepairItemInsert = DB["public"]["Tables"]["menu_repair_items"]["Insert"];
+type MenuRepairItemUpdate = DB["public"]["Tables"]["menu_repair_items"]["Update"];
+type PricingSnapshotInsert = DB["public"]["Tables"]["menu_repair_item_pricing_snapshots"]["Insert"];
+type PricingPartInsert = DB["public"]["Tables"]["menu_repair_item_pricing_parts"]["Insert"];
+
+type QuoteLineLite = Pick<
+  QuoteLineRow,
+  | "id"
+  | "shop_id"
+  | "work_order_id"
+  | "work_order_line_id"
+  | "vehicle_id"
+  | "description"
+  | "ai_complaint"
+  | "ai_cause"
+  | "ai_correction"
+  | "notes"
+  | "labor_hours"
+  | "est_labor_hours"
+  | "labor_total"
+  | "parts_total"
+  | "subtotal"
+  | "tax_total"
+  | "grand_total"
+  | "metadata"
+  | "sent_to_customer_at"
+  | "approved_at"
+  | "created_at"
+>;
+
+type WorkOrderLineLite = Pick<
+  WorkOrderLineRow,
+  | "id"
+  | "shop_id"
+  | "work_order_id"
+  | "vehicle_id"
+  | "description"
+  | "complaint"
+  | "cause"
+  | "correction"
+  | "notes"
+  | "labor_time"
+  | "price_estimate"
+>;
+
+type WorkOrderLite = Pick<
+  WorkOrderRow,
+  | "id"
+  | "shop_id"
+  | "vehicle_id"
+  | "vehicle_year"
+  | "vehicle_make"
+  | "vehicle_model"
+  | "vehicle_engine"
+  | "vehicle_drivetrain"
+  | "vehicle_transmission"
+  | "vehicle_fuel_type"
+>;
+
+type VehicleLite = Pick<
+  VehicleRow,
+  | "id"
+  | "shop_id"
+  | "year"
+  | "make"
+  | "model"
+  | "engine"
+  | "engine_family"
+  | "engine_type"
+  | "drivetrain"
+  | "transmission"
+  | "transmission_type"
+  | "fuel_type"
+  | "submodel"
+>;
+
+type PartRequestItemLite = Pick<
+  PartRequestItemRow,
+  | "id"
+  | "shop_id"
+  | "work_order_id"
+  | "quote_line_id"
+  | "work_order_line_id"
+  | "description"
+  | "qty"
+  | "qty_requested"
+  | "quoted_price"
+  | "unit_price"
+  | "unit_cost"
+  | "vendor"
+>;
+
+type MenuRepairItemLite = Pick<
+  DB["public"]["Tables"]["menu_repair_items"]["Row"],
+  | "id"
+  | "shop_id"
+  | "usage_count"
+  | "active_pricing_snapshot_id"
+  | "source_quote_line_id"
+>;
+
+type LearnedPart = {
+  id?: string;
+  name: string;
+  qty: number;
+  unitCost: number | null;
+  unitSell: number | null;
+  quotedPrice: number | null;
+  vendor: string | null;
+  partNumber: string | null;
+  supplierPartNumber: string | null;
+  notes: string | null;
+};
+
+export type UpsertMenuRepairItemFromQuoteLineResult = {
+  ok: true;
+  menuRepairItemId: string;
+  pricingSnapshotId: string | null;
+  updated: boolean;
+  templateKey: string;
+  partsLearned: number;
+};
+
+function safeTrim(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function numOrNull(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim()) {
+    const parsed = Number(v);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function nonNegative(v: unknown): number | null {
+  const n = numOrNull(v);
+  if (n == null) return null;
+  return n < 0 ? 0 : n;
+}
+
+function positiveQty(v: unknown): number {
+  const n = nonNegative(v);
+  return n && n > 0 ? n : 1;
+}
+
+function compactKeyPart(v: unknown): string {
+  return (
+    safeTrim(v)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "na"
+  );
+}
+
+function metadataRecord(metadata: Json | null): Record<string, Json> {
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as Record<string, Json>)
+    : {};
+}
+
+function buildTemplateKey(args: {
+  shopId: string;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  submodel: string | null;
+  engine: string | null;
+  drivetrain: string | null;
+  transmission: string | null;
+  title: string;
+  complaint: string | null;
+  description: string | null;
+}): string {
+  return [
+    args.shopId,
+    args.year ?? "na",
+    compactKeyPart(args.make),
+    compactKeyPart(args.model),
+    compactKeyPart(args.submodel),
+    compactKeyPart(args.engine),
+    compactKeyPart(args.drivetrain),
+    compactKeyPart(args.transmission),
+    compactKeyPart(args.title || args.complaint || args.description || "repair"),
+  ].join("::");
+}
+
+function partFromMetadata(raw: unknown): LearnedPart | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  const name =
+    safeTrim(record.name) ||
+    safeTrim(record.description) ||
+    safeTrim(record.part_name) ||
+    safeTrim(record.label);
+  if (!name) return null;
+
+  return {
+    name,
+    qty: positiveQty(record.qty ?? record.quantity),
+    unitCost: nonNegative(record.unitCost ?? record.unit_cost ?? record.cost),
+    unitSell: nonNegative(record.unitPrice ?? record.unit_price ?? record.price ?? record.sell),
+    quotedPrice: nonNegative(record.quotedPrice ?? record.quoted_price),
+    vendor: safeTrim(record.vendor ?? record.supplier ?? record.supplier_name) || null,
+    partNumber: safeTrim(record.partNumber ?? record.part_number ?? record.sku) || null,
+    supplierPartNumber: safeTrim(record.supplierPartNumber ?? record.supplier_part_number) || null,
+    notes: safeTrim(record.notes) || null,
+  };
+}
+
+function metadataParts(line: QuoteLineLite): LearnedPart[] {
+  const parts = metadataRecord(line.metadata).parts;
+  if (!Array.isArray(parts)) return [];
+  return parts.map(partFromMetadata).filter((part): part is LearnedPart => part !== null);
+}
+
+function partsFromRequestItems(items: PartRequestItemLite[]): LearnedPart[] {
+  return items
+    .map<LearnedPart | null>((item) => {
+      const name = safeTrim(item.description);
+      if (!name) return null;
+      return {
+        id: item.id,
+        name,
+        qty: positiveQty(item.qty_requested ?? item.qty),
+        unitCost: nonNegative(item.unit_cost),
+        unitSell: nonNegative(item.quoted_price ?? item.unit_price),
+        quotedPrice: nonNegative(item.quoted_price),
+        vendor: safeTrim(item.vendor) || null,
+        partNumber: null,
+        supplierPartNumber: null,
+        notes: null,
+      };
+    })
+    .filter((part): part is LearnedPart => part !== null);
+}
+
+function partsTotal(parts: LearnedPart[]): number | null {
+  if (parts.length === 0) return 0;
+  let total = 0;
+  let hasAny = false;
+  for (const part of parts) {
+    const unitSell = part.quotedPrice ?? part.unitSell;
+    if (unitSell == null) continue;
+    total += unitSell * part.qty;
+    hasAny = true;
+  }
+  return hasAny ? total : null;
+}
+
+function partsCostTotal(parts: LearnedPart[]): number | null {
+  if (parts.length === 0) return 0;
+  let total = 0;
+  let hasAny = false;
+  for (const part of parts) {
+    if (part.unitCost == null) continue;
+    total += part.unitCost * part.qty;
+    hasAny = true;
+  }
+  return hasAny ? total : null;
+}
+
+function isoAddDays(date: Date, days: number): string {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+async function loadLinkedPartRequestItems(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+  quoteLineId: string;
+  workOrderLineId: string;
+}): Promise<PartRequestItemLite[]> {
+  const { supabase, shopId, workOrderId, quoteLineId, workOrderLineId } = args;
+  const { data, error } = await supabase
+    .from("part_request_items")
+    .select(
+      "id, shop_id, work_order_id, quote_line_id, work_order_line_id, description, qty, qty_requested, quoted_price, unit_price, unit_cost, vendor",
+    )
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .or(`quote_line_id.eq.${quoteLineId},work_order_line_id.eq.${workOrderLineId}`)
+    .returns<PartRequestItemLite[]>();
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+async function createQuoteLinePricingSnapshot(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  menuRepairItemId: string;
+  activePricingSnapshotId: string | null;
+  quoteLine: QuoteLineLite;
+  workOrderLineId: string;
+  actorUserId: string | null;
+  pricingValidDays: number;
+  laborTotal: number | null;
+  partSellTotal: number | null;
+  partCostTotal: number | null;
+  grandTotal: number | null;
+  parts: LearnedPart[];
+}): Promise<string> {
+  const {
+    supabase,
+    shopId,
+    menuRepairItemId,
+    activePricingSnapshotId,
+    quoteLine,
+    workOrderLineId,
+    actorUserId,
+    pricingValidDays,
+    laborTotal,
+    partSellTotal,
+    partCostTotal,
+    grandTotal,
+    parts,
+  } = args;
+
+  const quotedAt = new Date(
+    quoteLine.approved_at ?? quoteLine.sent_to_customer_at ?? quoteLine.created_at ?? Date.now(),
+  );
+  const quotedAtIso = Number.isNaN(quotedAt.getTime()) ? new Date().toISOString() : quotedAt.toISOString();
+  const validUntil = isoAddDays(new Date(quotedAtIso), pricingValidDays);
+  const totalSell =
+    grandTotal ??
+    numOrNull(quoteLine.subtotal) ??
+    ((laborTotal ?? 0) + (partSellTotal ?? 0) || null);
+
+  const snapshotPayload: PricingSnapshotInsert = {
+    menu_repair_item_id: menuRepairItemId,
+    shop_id: shopId,
+    supplier_name: null,
+    quote_source: "approved_quote_line",
+    quote_reference: quoteLine.id,
+    quoted_at: quotedAtIso,
+    valid_until: validUntil,
+    pricing_valid_days: pricingValidDays,
+    total_cost: partCostTotal,
+    total_sell: totalSell,
+    currency: "CAD",
+    status: "fresh",
+    uploaded_by: actorUserId,
+    source_quote_line_id: quoteLine.id,
+    source_work_order_line_id: workOrderLineId,
+  };
+
+  const { data: existingSnapshot, error: existingSnapshotErr } = await supabase
+    .from("menu_repair_item_pricing_snapshots")
+    .select("id")
+    .eq("shop_id", shopId)
+    .eq("menu_repair_item_id", menuRepairItemId)
+    .eq("source_quote_line_id", quoteLine.id)
+    .eq("source_work_order_line_id", workOrderLineId)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<{ id: string }>();
+
+  if (existingSnapshotErr) throw existingSnapshotErr;
+
+  let snapshotId = existingSnapshot?.id ?? null;
+  if (snapshotId) {
+    const { error: updateSnapshotErr } = await supabase
+      .from("menu_repair_item_pricing_snapshots")
+      .update(snapshotPayload)
+      .eq("shop_id", shopId)
+      .eq("id", snapshotId);
+    if (updateSnapshotErr) throw updateSnapshotErr;
+
+    const { error: deletePartsErr } = await supabase
+      .from("menu_repair_item_pricing_parts")
+      .delete()
+      .eq("pricing_snapshot_id", snapshotId);
+    if (deletePartsErr) throw deletePartsErr;
+  } else {
+    const { data: snapshot, error: snapshotErr } = await supabase
+      .from("menu_repair_item_pricing_snapshots")
+      .insert(snapshotPayload)
+      .select("id")
+      .single();
+
+    if (snapshotErr) throw snapshotErr;
+    if (!snapshot?.id) throw new Error("Failed to create quote-line pricing snapshot");
+    snapshotId = snapshot.id;
+  }
+
+  if (!snapshotId) throw new Error("Failed to resolve quote-line pricing snapshot");
+
+  const pricingParts: PricingPartInsert[] = parts.map((part) => ({
+    pricing_snapshot_id: snapshotId,
+    menu_repair_item_part_id: null,
+    part_name: part.name,
+    quoted_part_number: part.partNumber,
+    supplier_part_number: part.supplierPartNumber,
+    qty: part.qty,
+    unit_cost: part.unitCost,
+    unit_sell: part.quotedPrice ?? part.unitSell,
+    notes:
+      [part.vendor ? `Vendor: ${part.vendor}` : null, part.notes]
+        .filter((note): note is string => Boolean(note))
+        .join("; ") || null,
+  }));
+
+  if (pricingParts.length > 0) {
+    const { error: partsErr } = await supabase
+      .from("menu_repair_item_pricing_parts")
+      .insert(pricingParts);
+    if (partsErr) throw partsErr;
+  }
+
+  const { error: repairUpdateErr } = await supabase
+    .from("menu_repair_items")
+    .update({
+      active_pricing_snapshot_id: snapshotId,
+      last_pricing_refresh_at: quotedAtIso,
+      last_pricing_source: "approved_quote_line",
+      pricing_status: "fresh",
+      pricing_valid_days: pricingValidDays,
+    })
+    .eq("shop_id", shopId)
+    .eq("id", menuRepairItemId);
+
+  if (repairUpdateErr) throw repairUpdateErr;
+
+  if (activePricingSnapshotId && activePricingSnapshotId !== snapshotId) {
+    await supabase
+      .from("menu_repair_item_pricing_snapshots")
+      .update({ status: "superseded" })
+      .eq("shop_id", shopId)
+      .eq("id", activePricingSnapshotId);
+  }
+
+  return snapshotId;
+}
+
+export async function upsertMenuRepairItemFromQuoteLine(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+  quoteLineId: string;
+  workOrderLineId: string;
+  actorUserId?: string | null;
+}): Promise<UpsertMenuRepairItemFromQuoteLineResult> {
+  const { supabase, shopId, workOrderId, quoteLineId, workOrderLineId, actorUserId = null } = args;
+
+  const { data: quoteLine, error: quoteErr } = await supabase
+    .from("work_order_quote_lines")
+    .select("*")
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .eq("id", quoteLineId)
+    .maybeSingle<QuoteLineLite>();
+  if (quoteErr) throw quoteErr;
+  if (!quoteLine?.id) throw new Error("Quote line not found for shop/work order");
+
+  const { data: workOrderLine, error: lineErr } = await supabase
+    .from("work_order_lines")
+    .select(
+      "id, shop_id, work_order_id, vehicle_id, description, complaint, cause, correction, notes, labor_time, price_estimate",
+    )
+    .eq("shop_id", shopId)
+    .eq("work_order_id", workOrderId)
+    .eq("id", workOrderLineId)
+    .maybeSingle<WorkOrderLineLite>();
+  if (lineErr) throw lineErr;
+  if (!workOrderLine?.id) throw new Error("Materialized work order line not found for shop/work order");
+
+  const { data: workOrder, error: workOrderErr } = await supabase
+    .from("work_orders")
+    .select(
+      "id, shop_id, vehicle_id, vehicle_year, vehicle_make, vehicle_model, vehicle_engine, vehicle_drivetrain, vehicle_transmission, vehicle_fuel_type",
+    )
+    .eq("shop_id", shopId)
+    .eq("id", workOrderId)
+    .maybeSingle<WorkOrderLite>();
+  if (workOrderErr) throw workOrderErr;
+  if (!workOrder?.id) throw new Error("Work order not found for shop");
+
+  const vehicleId = quoteLine.vehicle_id ?? workOrderLine.vehicle_id ?? workOrder.vehicle_id;
+  let vehicle: VehicleLite | null = null;
+  if (vehicleId) {
+    const { data: vehicleRow, error: vehicleErr } = await supabase
+      .from("vehicles")
+      .select(
+        "id, shop_id, year, make, model, engine, engine_family, engine_type, drivetrain, transmission, transmission_type, fuel_type, submodel",
+      )
+      .eq("id", vehicleId)
+      .eq("shop_id", shopId)
+      .maybeSingle<VehicleLite>();
+    if (vehicleErr) throw vehicleErr;
+    vehicle = vehicleRow ?? null;
+  }
+
+  const { data: shop, error: shopErr } = await supabase
+    .from("shops")
+    .select("labor_rate")
+    .eq("id", shopId)
+    .maybeSingle();
+  if (shopErr) throw shopErr;
+
+  const requestItems = await loadLinkedPartRequestItems({
+    supabase,
+    shopId,
+    workOrderId,
+    quoteLineId,
+    workOrderLineId,
+  });
+  const learnedParts = requestItems.length > 0 ? partsFromRequestItems(requestItems) : metadataParts(quoteLine);
+  const learnedPartsTotal = partsTotal(learnedParts);
+  const learnedPartsCostTotal = partsCostTotal(learnedParts);
+
+  const vehicleYear =
+    numOrNull(vehicle?.year) ?? numOrNull(workOrder.vehicle_year);
+  const vehicleMake = safeTrim(vehicle?.make) || safeTrim(workOrder.vehicle_make) || null;
+  const vehicleModel = safeTrim(vehicle?.model) || safeTrim(workOrder.vehicle_model) || null;
+  const vehicleSubmodel = safeTrim(vehicle?.submodel) || null;
+  const engine =
+    safeTrim(vehicle?.engine) ||
+    safeTrim(vehicle?.engine_family) ||
+    safeTrim(vehicle?.engine_type) ||
+    safeTrim(workOrder.vehicle_engine) ||
+    null;
+  const drivetrain = safeTrim(vehicle?.drivetrain) || safeTrim(workOrder.vehicle_drivetrain) || null;
+  const transmission =
+    safeTrim(vehicle?.transmission) ||
+    safeTrim(vehicle?.transmission_type) ||
+    safeTrim(workOrder.vehicle_transmission) ||
+    null;
+  const fuelType = safeTrim(vehicle?.fuel_type) || safeTrim(workOrder.vehicle_fuel_type) || null;
+
+  const name = safeTrim(quoteLine.description) || safeTrim(workOrderLine.description) || "Repair item";
+  const complaint =
+    safeTrim(quoteLine.ai_complaint) ||
+    safeTrim(workOrderLine.complaint) ||
+    safeTrim(quoteLine.notes) ||
+    null;
+  const cause = safeTrim(quoteLine.ai_cause) || safeTrim(workOrderLine.cause) || null;
+  const correction = safeTrim(quoteLine.ai_correction) || safeTrim(workOrderLine.correction) || null;
+  const notes = safeTrim(quoteLine.notes) || safeTrim(workOrderLine.notes) || null;
+  const laborHours = nonNegative(quoteLine.labor_hours ?? quoteLine.est_labor_hours ?? workOrderLine.labor_time);
+  const laborTotal = nonNegative(quoteLine.labor_total);
+  const laborRate =
+    laborHours && laborTotal != null && laborHours > 0
+      ? laborTotal / laborHours
+      : nonNegative((shop as { labor_rate?: unknown } | null)?.labor_rate);
+  const quotePartsTotal = nonNegative(quoteLine.parts_total) ?? learnedPartsTotal;
+  const grandTotal =
+    nonNegative(quoteLine.grand_total) ??
+    nonNegative(quoteLine.subtotal) ??
+    nonNegative(workOrderLine.price_estimate) ??
+    ((laborTotal ?? 0) + (quotePartsTotal ?? 0) || null);
+
+  const templateKey = buildTemplateKey({
+    shopId,
+    year: vehicleYear,
+    make: vehicleMake,
+    model: vehicleModel,
+    submodel: vehicleSubmodel,
+    engine,
+    drivetrain,
+    transmission,
+    title: name,
+    complaint,
+    description: workOrderLine.description,
+  });
+
+  const partsJson = learnedParts.map((part) => ({
+    name: part.name,
+    qty: part.qty,
+    unit_cost: part.unitCost,
+    unit_price: part.unitSell,
+    quoted_price: part.quotedPrice,
+    vendor: part.vendor,
+    part_number: part.partNumber,
+    supplier_part_number: part.supplierPartNumber,
+    source_part_request_item_id: part.id ?? null,
+  })) as unknown as MenuRepairItemInsert["parts"];
+
+  const now = new Date().toISOString();
+  const existingResult = await supabase
+    .from("menu_repair_items")
+    .select("id, shop_id, usage_count, active_pricing_snapshot_id, source_quote_line_id")
+    .eq("shop_id", shopId)
+    .eq("template_key", templateKey)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<MenuRepairItemLite>();
+  if (existingResult.error) throw existingResult.error;
+
+  let menuRepairItemId: string;
+  let activePricingSnapshotId: string | null = null;
+  let updated = false;
+
+  if (existingResult.data?.id) {
+    const existing = existingResult.data;
+    const usageCount =
+      existing.source_quote_line_id === quoteLine.id
+        ? existing.usage_count ?? 0
+        : (existing.usage_count ?? 0) + 1;
+    const updatePayload: MenuRepairItemUpdate = {
+      source_quote_line_id: quoteLine.id,
+      source_work_order_id: workOrderId,
+      source_work_order_line_id: workOrderLineId,
+      name,
+      complaint,
+      cause,
+      correction,
+      notes,
+      vehicle_year: vehicleYear,
+      vehicle_make: vehicleMake,
+      vehicle_model: vehicleModel,
+      engine,
+      drivetrain,
+      transmission,
+      fuel_type: fuelType,
+      labor_hours: laborHours,
+      labor_rate: laborRate,
+      price_estimate: grandTotal,
+      parts: partsJson as unknown as MenuRepairItemUpdate["parts"],
+      usage_count: usageCount,
+      is_active: true,
+      last_pricing_refresh_at: now,
+      last_pricing_source: "approved_quote_line",
+      pricing_status: "fresh",
+      updated_at: now,
+    };
+
+    const { error: updateErr } = await supabase
+      .from("menu_repair_items")
+      .update(updatePayload)
+      .eq("shop_id", shopId)
+      .eq("id", existing.id);
+    if (updateErr) throw updateErr;
+
+    menuRepairItemId = existing.id;
+    activePricingSnapshotId = existing.active_pricing_snapshot_id;
+    updated = true;
+  } else {
+    const insertPayload: MenuRepairItemInsert = {
+      shop_id: shopId,
+      source_quote_line_id: quoteLine.id,
+      source_work_order_id: workOrderId,
+      source_work_order_line_id: workOrderLineId,
+      name,
+      complaint,
+      cause,
+      correction,
+      notes,
+      vehicle_year: vehicleYear,
+      vehicle_make: vehicleMake,
+      vehicle_model: vehicleModel,
+      engine,
+      drivetrain,
+      transmission,
+      fuel_type: fuelType,
+      labor_hours: laborHours,
+      labor_rate: laborRate,
+      price_estimate: grandTotal,
+      parts: partsJson,
+      template_key: templateKey,
+      usage_count: 1,
+      is_active: true,
+      last_pricing_refresh_at: now,
+      last_pricing_source: "approved_quote_line",
+      pricing_status: "fresh",
+    };
+
+    const { data: inserted, error: insertErr } = await supabase
+      .from("menu_repair_items")
+      .insert(insertPayload)
+      .select("id")
+      .single();
+    if (insertErr) throw insertErr;
+    if (!inserted?.id) throw new Error("Failed to create menu repair item");
+    menuRepairItemId = inserted.id;
+  }
+
+  const pricingValidDays = await getShopPricingValidDays({ supabase, shopId, fallback: 30 });
+  const pricingSnapshotId = await createQuoteLinePricingSnapshot({
+    supabase,
+    shopId,
+    menuRepairItemId,
+    activePricingSnapshotId,
+    quoteLine,
+    workOrderLineId,
+    actorUserId,
+    pricingValidDays,
+    laborTotal,
+    partSellTotal: quotePartsTotal,
+    partCostTotal: learnedPartsCostTotal,
+    grandTotal,
+    parts: learnedParts,
+  });
+
+  return {
+    ok: true,
+    menuRepairItemId,
+    pricingSnapshotId,
+    updated,
+    templateKey,
+    partsLearned: learnedParts.length,
+  };
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -7105,6 +7105,8 @@ export type Database = {
           quote_source: string
           quoted_at: string
           shop_id: string
+          source_quote_line_id: string | null
+          source_work_order_line_id: string | null
           status: string
           supplier_id: string | null
           supplier_name: string | null
@@ -7125,6 +7127,8 @@ export type Database = {
           quote_source?: string
           quoted_at?: string
           shop_id: string
+          source_quote_line_id?: string | null
+          source_work_order_line_id?: string | null
           status?: string
           supplier_id?: string | null
           supplier_name?: string | null
@@ -7145,6 +7149,8 @@ export type Database = {
           quote_source?: string
           quoted_at?: string
           shop_id?: string
+          source_quote_line_id?: string | null
+          source_work_order_line_id?: string | null
           status?: string
           supplier_id?: string | null
           supplier_name?: string | null
@@ -7208,6 +7214,7 @@ export type Database = {
           pricing_status: string | null
           pricing_valid_days: number | null
           shop_id: string
+          source_quote_line_id: string | null
           source_work_order_id: string | null
           source_work_order_line_id: string | null
           tags: string[]
@@ -7241,6 +7248,7 @@ export type Database = {
           pricing_status?: string | null
           pricing_valid_days?: number | null
           shop_id: string
+          source_quote_line_id?: string | null
           source_work_order_id?: string | null
           source_work_order_line_id?: string | null
           tags?: string[]
@@ -7274,6 +7282,7 @@ export type Database = {
           pricing_status?: string | null
           pricing_valid_days?: number | null
           shop_id?: string
+          source_quote_line_id?: string | null
           source_work_order_id?: string | null
           source_work_order_line_id?: string | null
           tags?: string[]

--- a/features/work-orders/server/workOrderQuoteLineApproval.ts
+++ b/features/work-orders/server/workOrderQuoteLineApproval.ts
@@ -6,12 +6,23 @@ import {
   relinkQuoteLinePartsToWorkOrderLine,
   type RelinkQuoteLinePartsResult,
 } from "@/features/parts/server/relinkQuoteLinePartsToWorkOrderLine";
+import {
+  upsertMenuRepairItemFromQuoteLine,
+  type UpsertMenuRepairItemFromQuoteLineResult,
+} from "@/features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine";
 
 type DB = Database;
 type Json = DB["public"]["Tables"]["work_order_quote_lines"]["Row"]["metadata"];
 type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
 type WorkOrderUpdate = DB["public"]["Tables"]["work_orders"]["Update"];
+
+export type QuoteLineLearningResult = {
+  quoteLineId: string;
+  workOrderLineId: string;
+  result: UpsertMenuRepairItemFromQuoteLineResult | null;
+  error: string | null;
+};
 
 export type QuoteApprovalDecision = "approve" | "decline" | "defer";
 
@@ -367,6 +378,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   workOrderLineIds: string[];
   approvalState: string | null;
   partRelink: RelinkQuoteLinePartsResult;
+  menuRepairLearning: QuoteLineLearningResult[];
   error?: string;
 }> {
   const {
@@ -385,6 +397,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
       workOrderLineIds: [],
       approvalState: null,
       partRelink: emptyPartRelinkResult(),
+      menuRepairLearning: [],
       error: "No quote line ids supplied",
     };
   }
@@ -402,6 +415,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
       workOrderLineIds: [],
       approvalState: null,
       partRelink: emptyPartRelinkResult(),
+      menuRepairLearning: [],
       error: loadErr.message,
     };
   if ((rows?.length ?? 0) !== ids.length) {
@@ -410,6 +424,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
       workOrderLineIds: [],
       approvalState: null,
       partRelink: emptyPartRelinkResult(),
+      menuRepairLearning: [],
       error: "One or more quote lines were not found for this work order",
     };
   }
@@ -417,6 +432,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   const now = new Date().toISOString();
   const workOrderLineIds: string[] = [];
   const partRelink = emptyPartRelinkResult();
+  const menuRepairLearning: QuoteLineLearningResult[] = [];
 
   for (const line of (rows ?? []) as QuoteLineRow[]) {
     const status = safeTrim(line.status).toLowerCase();
@@ -426,6 +442,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
         workOrderLineIds,
         approvalState: null,
         partRelink,
+        menuRepairLearning,
         error: `Quote line cannot be approved from status '${line.status}'`,
       };
     }
@@ -441,6 +458,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
         workOrderLineIds,
         approvalState: null,
         partRelink,
+        menuRepairLearning,
         error: "Quote line has not been sent to the customer",
       };
     }
@@ -459,6 +477,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
           workOrderLineIds,
           approvalState: null,
           partRelink,
+          menuRepairLearning,
           error: materialized.error.message,
         };
       materializedLineId = materialized.id;
@@ -487,6 +506,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
         workOrderLineIds,
         approvalState: null,
         partRelink,
+        menuRepairLearning,
         error: updateErr.message,
       };
 
@@ -505,6 +525,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
           workOrderLineIds,
           approvalState: null,
           partRelink,
+          menuRepairLearning,
           error: relink.error.message,
         };
       mergePartRelinkResult(partRelink, relink.result);
@@ -520,6 +541,38 @@ export async function applyWorkOrderQuoteLineDecision(params: {
             conflicts: relink.result.conflicts,
           },
         );
+      }
+
+      try {
+        const learningResult = await upsertMenuRepairItemFromQuoteLine({
+          supabase,
+          shopId,
+          workOrderId,
+          quoteLineId: line.id,
+          workOrderLineId: materializedLineId,
+          actorUserId,
+        });
+        menuRepairLearning.push({
+          quoteLineId: line.id,
+          workOrderLineId: materializedLineId,
+          result: learningResult,
+          error: null,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown menu repair learning error";
+        menuRepairLearning.push({
+          quoteLineId: line.id,
+          workOrderLineId: materializedLineId,
+          result: null,
+          error: message,
+        });
+        console.warn("[quote-line-approval] menu repair learning skipped after approved quote line", {
+          shopId,
+          workOrderId,
+          quoteLineId: line.id,
+          workOrderLineId: materializedLineId,
+          error: message,
+        });
       }
     }
   }
@@ -537,6 +590,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
       workOrderLineIds,
       approvalState: null,
       partRelink,
+      menuRepairLearning,
       error: rollup.error.message,
     };
 
@@ -545,5 +599,6 @@ export async function applyWorkOrderQuoteLineDecision(params: {
     workOrderLineIds,
     approvalState: rollup.state,
     partRelink,
+    menuRepairLearning,
   };
 }


### PR DESCRIPTION
### Motivation

- Fill the learning gap where approved/materialized `work_order_quote_lines` were not used to update the shop-scoped menu repair learning/pricing system.
- Preserve the canonical quote-line lifecycle while adding traceability and learning from quote-line data and linked `part_request_items` without changing reuse/invoice behavior.

### Description

- Additive DB migration: created `db/sql/2026-06-02_phase5d5b_menu_repair_quote_line_learning.sql` which adds nullable `source_quote_line_id` to `menu_repair_items` and `source_quote_line_id`/`source_work_order_line_id` to `menu_repair_item_pricing_snapshots`, and adds guarded indexes scoped by `shop_id`. (non-destructive, nullable)
- New quote-line learning helper: `features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine.ts` that loads the `work_order_quote_lines`, the materialized `work_order_lines`, `work_orders` + vehicle YMM/profile, and linked `part_request_items` (scoped by `shop_id`/`work_order_id`/`quote_line_id` or `work_order_line_id`); it builds a stable `template_key` (shop + vehicle fields + normalized title/complaint/description) and upserts a shop-scoped `menu_repair_items` row, setting `source_quote_line_id`, `source_work_order_id`, `source_work_order_line_id`, labor/price estimates, `parts` JSON (from linked part request items or quote metadata), usage count and pricing status fields.
- Pricing snapshot creation/update: quote-line-specific snapshot logic creates or updates a snapshot in `menu_repair_item_pricing_snapshots` with `quoted_at`, `valid_until` (based on `getShopPricingValidDays`, default 30), `pricing_valid_days`, `total_sell`/`total_cost` and sets `source_quote_line_id` and `source_work_order_line_id`; it also populates `menu_repair_item_pricing_parts` rows from learned part data and idempotently replaces parts for repeated runs.
- Wire into approval flow (best-effort): `features/work-orders/server/workOrderQuoteLineApproval.ts` now calls `upsertMenuRepairItemFromQuoteLine` after a quote-line is materialized and `relinkQuoteLinePartsToWorkOrderLine` runs, and collects per-line learning metadata; learning errors are logged and do not block the approval flow.
- Idempotency and scoping: matching/upsert uses `shop_id + template_key` (not solely source ids) so repeated approvals update the same learned repair; every read/write includes `shop_id` checks to avoid cross-shop leakage.
- Types: updated generated Supabase types in `features/shared/types/types/supabase.ts` to include the new trace fields for code safety.

Files changed/added (key):
- `db/sql/2026-06-02_phase5d5b_menu_repair_quote_line_learning.sql` (new migration)
- `features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine.ts` (new helper)
- `features/work-orders/server/workOrderQuoteLineApproval.ts` (call learning helper & return metadata)
- `features/shared/types/types/supabase.ts` (updated generated types)

### Testing

- Ran TypeScript checks with `npx tsc --noEmit --pretty false` (succeeded).
- Ran lint on touched files with `npx eslint features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine.ts features/work-orders/server/workOrderQuoteLineApproval.ts` (succeeded).
- Verified repository file checks with `git diff --check` and `git status --short` as part of the flow (no outstanding errors reported by the automated checks).

If any further runtime validation or DB backfill is desired (e.g., backfilling `source_quote_line_id` for existing rows), a follow-up migration/backfill can be provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0db85f3883288a1e3483916b25a3)