### PR TITLE
Phase 5E-1: Canonicalize inspection import to quote-lines

### DIFF
--- a/app/api/work-orders/import-from-inspection/route.ts
+++ b/app/api/work-orders/import-from-inspection/route.ts
@@ -15,7 +15,7 @@ type DB = Database;
 type ImportBody = {
   workOrderId: string;
   inspectionId: string;
-  vehicleId: string;
+  vehicleId?: string | null;
   autoGenerateParts?: boolean;
 };
 
@@ -26,8 +26,8 @@ export async function POST(req: Request) {
     const body = (await req.json()) as Partial<ImportBody>;
     const { workOrderId, inspectionId, vehicleId, autoGenerateParts } = body;
 
-    if (!workOrderId || !inspectionId || !vehicleId) {
-      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    if (!workOrderId || !inspectionId) {
+      return NextResponse.json({ error: "Missing workOrderId or inspectionId" }, { status: 400 });
     }
 
     const {
@@ -39,12 +39,23 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Ensure requester can see the WO (RLS enforced).
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("id", user.id)
+      .maybeSingle<{ shop_id: string | null }>();
+
+    if (profileErr || !profile?.shop_id) {
+      return NextResponse.json({ error: "Profile for current user not found." }, { status: 403 });
+    }
+
+    // Ensure requester can see the WO (RLS enforced) and the WO is scoped to the current shop.
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
-      .select("id, shop_id, vehicle_id")
+      .select("id, shop_id, vehicle_id, status")
       .eq("id", workOrderId)
-      .maybeSingle<{ id: string; shop_id: string | null }>();
+      .eq("shop_id", profile.shop_id)
+      .maybeSingle<{ id: string; shop_id: string | null; vehicle_id: string | null; status: string | null }>();
 
     if (woErr) {
       return NextResponse.json(
@@ -73,6 +84,21 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Inspection not found." }, { status: 404 });
     }
 
+    if (wo.shop_id !== profile.shop_id) {
+      return NextResponse.json(
+        { error: "Work order does not belong to the current user's shop." },
+        { status: 403 },
+      );
+    }
+
+    const blockedStatuses = new Set(["cancelled", "canceled", "invoiced", "closed"]);
+    if (blockedStatuses.has((wo.status ?? "").toLowerCase())) {
+      return NextResponse.json(
+        { error: "Cannot import inspection findings into a cancelled, closed, or invoiced work order." },
+        { status: 409 },
+      );
+    }
+
     if (!inspection.shop_id || inspection.shop_id !== wo.shop_id) {
       return NextResponse.json(
         { error: "Inspection does not belong to this work order's shop." },
@@ -84,7 +110,7 @@ export async function POST(req: Request) {
       supabase,
       inspectionId,
       workOrderId,
-      vehicleId,
+      vehicleId: vehicleId || wo.vehicle_id || null,
       userId: user.id,
       autoGenerateParts: autoGenerateParts ?? true,
     });
@@ -95,10 +121,17 @@ export async function POST(req: Request) {
 
     return NextResponse.json({
       ok: true,
+      message: res.message,
+      quoteLineIds: res.quoteLineIds,
+      createdQuoteLines: res.createdQuoteLines,
+      skippedDuplicates: res.skippedDuplicates,
+      createdPartRequestIds: res.createdPartRequestIds,
       insertedCount: res.insertedCount,
       partsRequestsCount: res.partsRequestsCount,
       skippedCount: res.skippedCount,
       skippedPartsRequestsCount: res.skippedPartsRequestsCount,
+      insertedJobIds: res.insertedJobIds,
+      workOrderLineIds: res.workOrderLineIds,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/app/api/work-orders/quotes/add/route.ts
+++ b/app/api/work-orders/quotes/add/route.ts
@@ -1,185 +1,20 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database, Json } from "@shared/types/types/supabase";
-import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  createCanonicalQuoteLines,
+  safeTrim,
+  type CanonicalQuoteItem,
+} from "@/features/work-orders/lib/work-orders/canonicalQuoteLines";
 
 type DB = Database;
-type QuoteInsert = DB["public"]["Tables"]["work_order_quote_lines"]["Insert"];
-type PartRequestInsert = DB["public"]["Tables"]["part_requests"]["Insert"];
-type PartRequestItemInsert = DB["public"]["Tables"]["part_request_items"]["Insert"];
-
-type QuotePart = {
-  description?: string;
-  name?: string;
-  partNumber?: string | null;
-  part_number?: string | null;
-  sku?: string | null;
-  qty?: number;
-  cost?: number | null;
-  unitCost?: number | null;
-  unitPrice?: number | null;
-  notes?: string | null;
-};
-
-type QuoteItem = {
-  id?: string | null;
-  description: string;
-  title?: string | null;
-  jobType?: "diagnosis" | "repair" | "maintenance" | "inspection" | "tech-suggested";
-  estLaborHours?: number | null;
-  laborHours?: number | null;
-  laborRate?: number | null;
-  partsTotal?: number | null;
-  laborTotal?: number | null;
-  subtotal?: number | null;
-  taxTotal?: number | null;
-  grandTotal?: number | null;
-  notes?: string | null;
-  complaint?: string | null;
-  aiComplaint?: string | null;
-  aiCause?: string | null;
-  aiCorrection?: string | null;
-  status?: string | null;
-  stage?: string | null;
-  source?: "inspection" | string | null;
-  sourceInspectionId?: string | null;
-  sourceWorkOrderLineId?: string | null;
-  sourceSectionKey?: string | null;
-  sourceSectionTitle?: string | null;
-  sourceItemKey?: string | null;
-  sourceFindingTitle?: string | null;
-  normalizedFindingTitle?: string | null;
-  findingIdentity?: string | null;
-  photoUrls?: string[];
-  parts?: QuotePart[];
-  metadata?: Record<string, Json | undefined> | null;
-};
 
 type Body = {
   workOrderId: string;
   vehicleId?: string | null;
-  items: QuoteItem[];
+  items: CanonicalQuoteItem[];
 };
-
-function safeTrim(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function finiteNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function normalizeTitle(value: unknown): string {
-  return safeTrim(value).toLowerCase().replace(/\s+/g, " ");
-}
-
-function cleanParts(parts: QuotePart[] | undefined): Array<{
-  description: string;
-  partNumber: string | null;
-  qty: number;
-  unitCost: number | null;
-  unitPrice: number | null;
-  notes: string | null;
-}> {
-  return (parts ?? [])
-    .map((part) => {
-      const description = safeTrim(part.description) || safeTrim(part.name);
-      const qty = Math.max(1, Number(part.qty) || 1);
-      return {
-        description,
-        partNumber:
-          safeTrim(part.partNumber) || safeTrim(part.part_number) || safeTrim(part.sku) || null,
-        qty,
-        unitCost: finiteNumber(part.unitCost) ?? finiteNumber(part.cost),
-        unitPrice: finiteNumber(part.unitPrice),
-        notes: safeTrim(part.notes) || null,
-      };
-    })
-    .filter((part) => part.description.length > 0);
-}
-
-function identityFor(item: QuoteItem): string | null {
-  const explicit = safeTrim(item.findingIdentity);
-  if (explicit) return explicit;
-
-  const inspectionId = safeTrim(item.sourceInspectionId);
-  const sourceLineId = safeTrim(item.sourceWorkOrderLineId);
-  const sectionKey = safeTrim(item.sourceSectionKey);
-  const itemKey = safeTrim(item.sourceItemKey);
-  const normalizedTitle =
-    normalizeTitle(item.normalizedFindingTitle) ||
-    normalizeTitle(item.sourceFindingTitle) ||
-    normalizeTitle(item.title) ||
-    normalizeTitle(item.description);
-
-  const parts = [inspectionId, sourceLineId, sectionKey, itemKey, normalizedTitle].filter(Boolean);
-  return parts.length > 0 ? parts.join(":") : null;
-}
-
-function normalizePartRequestItemIdentity(input: {
-  description?: string | null;
-  partNumber?: string | null;
-}): string {
-  const normalizedDescription = normalizeTitle(input.description);
-  const normalizedPartNumber = safeTrim(input.partNumber).toUpperCase().replace(/\s+/g, "");
-  return [normalizedPartNumber, normalizedDescription].filter(Boolean).join("|");
-}
-
-async function getOrCreatePartRequestForQuoteLine(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
-  input: {
-    shopId: string;
-    workOrderId: string;
-    quoteLineId: string;
-    requestedBy: string;
-    notes: string | null;
-  },
-): Promise<{ id: string; created: boolean; error?: string }> {
-  const { data: existing, error: existingError } = await supabase
-    .from("part_requests")
-    .select("id")
-    .eq("shop_id", input.shopId)
-    .eq("work_order_id", input.workOrderId)
-    .eq("quote_line_id", input.quoteLineId)
-    .limit(1);
-
-  if (existingError) {
-    return { id: "", created: false, error: existingError.message };
-  }
-
-  const reusable = existing?.[0];
-  if (reusable?.id) {
-    return { id: reusable.id, created: false };
-  }
-
-  const requestPayload: PartRequestInsert = {
-    shop_id: input.shopId,
-    work_order_id: input.workOrderId,
-    quote_line_id: input.quoteLineId,
-    job_id: null,
-    requested_by: input.requestedBy,
-    notes: input.notes,
-    status: "requested",
-  };
-
-  const { data: partRequest, error: requestError } = await supabase
-    .from("part_requests")
-    .insert(requestPayload)
-    .select("id")
-    .single();
-
-  if (requestError || !partRequest) {
-    return {
-      id: "",
-      created: false,
-      error: requestError?.message ?? "Failed to create part request",
-    };
-  }
-
-  return { id: partRequest.id, created: true };
-}
-
 
 export async function POST(req: Request) {
   const supabase = createRouteHandlerClient<DB>({ cookies });
@@ -228,260 +63,29 @@ export async function POST(req: Request) {
       );
     }
 
-    const vehicleId = safeTrim(body?.vehicleId) || wo.vehicle_id || null;
-    const suggestedBy = user.id;
+    const result = await createCanonicalQuoteLines({
+      supabase,
+      shopId: wo.shop_id,
+      workOrderId,
+      vehicleId: safeTrim(body?.vehicleId) || wo.vehicle_id || null,
+      suggestedBy: user.id,
+      items,
+    });
 
-    const requestedIds = items.map((item) => safeTrim(item.id)).filter(Boolean);
-    const identities = items.map(identityFor).filter((value): value is string => Boolean(value));
-
-    const existingById = new Map<string, { id: string }>();
-    if (requestedIds.length > 0) {
-      const { data, error } = await supabase
-        .from("work_order_quote_lines")
-        .select("id")
-        .eq("shop_id", wo.shop_id)
-        .eq("work_order_id", workOrderId)
-        .in("id", requestedIds);
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      for (const row of data ?? []) existingById.set(row.id, row);
-    }
-
-    const existingByIdentity = new Map<string, { id: string }>();
-    for (const identity of identities) {
-      const { data, error } = await supabase
-        .from("work_order_quote_lines")
-        .select("id")
-        .eq("shop_id", wo.shop_id)
-        .eq("work_order_id", workOrderId)
-        .contains("metadata", { inspection_finding_identity: identity })
-        .limit(1);
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      const existing = data?.[0];
-      if (existing) existingByIdentity.set(identity, existing);
-    }
-
-    const rows: QuoteInsert[] = [];
-    const pendingSources: QuoteItem[] = [];
-    const sourceItemsById = new Map<string, QuoteItem>();
-    const itemResults: Array<{
-      requestedId: string | null;
-      id: string;
-      created: boolean;
-      findingIdentity: string | null;
-    }> = [];
-
-    for (const item of items) {
-      const description = safeTrim(item.description) || safeTrim(item.title);
-      if (!description) continue;
-
-      const requestedId = safeTrim(item.id) || null;
-      const findingIdentity = identityFor(item);
-      const existing =
-        (requestedId ? existingById.get(requestedId) : undefined) ??
-        (findingIdentity ? existingByIdentity.get(findingIdentity) : undefined);
-
-      if (existing) {
-        sourceItemsById.set(existing.id, item);
-        itemResults.push({
-          requestedId,
-          id: existing.id,
-          created: false,
-          findingIdentity,
-        });
-        continue;
-      }
-
-      const parts = cleanParts(item.parts);
-      const partsTotal =
-        finiteNumber(item.partsTotal) ??
-        parts.reduce((sum, part) => sum + (part.unitCost ?? 0) * part.qty, 0);
-      const laborHours = finiteNumber(item.laborHours) ?? finiteNumber(item.estLaborHours);
-      const laborTotal = finiteNumber(item.laborTotal);
-      const subtotal = finiteNumber(item.subtotal) ?? partsTotal + (laborTotal ?? 0);
-      const grandTotal = finiteNumber(item.grandTotal) ?? subtotal + (finiteNumber(item.taxTotal) ?? 0);
-      const normalizedFindingTitle =
-        normalizeTitle(item.normalizedFindingTitle) ||
-        normalizeTitle(item.sourceFindingTitle) ||
-        normalizeTitle(description);
-
-      const metadata: Record<string, Json | undefined> = {
-        ...(item.metadata ?? {}),
-        source: item.source ?? "inspection",
-        source_inspection_id: safeTrim(item.sourceInspectionId) || undefined,
-        source_work_order_line_id: safeTrim(item.sourceWorkOrderLineId) || undefined,
-        source_section_key: safeTrim(item.sourceSectionKey) || undefined,
-        source_section_title: safeTrim(item.sourceSectionTitle) || undefined,
-        source_item_key: safeTrim(item.sourceItemKey) || undefined,
-        source_finding_title: safeTrim(item.sourceFindingTitle) || description,
-        source_finding_title_normalized: normalizedFindingTitle || undefined,
-        inspection_finding_identity: findingIdentity ?? undefined,
-        photo_urls: Array.isArray(item.photoUrls) ? item.photoUrls : [],
-        parts,
-        labor_rate: finiteNumber(item.laborRate) ?? undefined,
-      };
-
-      const row: QuoteInsert = {
-        ...(requestedId ? { id: requestedId } : {}),
-        work_order_id: workOrderId,
-        work_order_line_id: null,
-        shop_id: wo.shop_id,
-        vehicle_id: vehicleId,
-        suggested_by: suggestedBy,
-        description,
-        job_type: item.jobType ?? "tech-suggested",
-        est_labor_hours: finiteNumber(item.estLaborHours) ?? laborHours,
-        notes: safeTrim(item.notes) || safeTrim(item.complaint) || null,
-        status: safeTrim(item.status) || "pending_parts",
-        ai_complaint: safeTrim(item.aiComplaint) || safeTrim(item.complaint) || null,
-        ai_cause: safeTrim(item.aiCause) || null,
-        ai_correction: safeTrim(item.aiCorrection) || null,
-        stage: safeTrim(item.stage) || "advisor_pending",
-        qty: 1,
-        labor_hours: laborHours,
-        parts_total: partsTotal,
-        labor_total: laborTotal,
-        subtotal,
-        tax_total: finiteNumber(item.taxTotal),
-        grand_total: grandTotal,
-        metadata: metadata as Json,
-        group_id: null,
-        sent_to_customer_at: null,
-        approved_at: null,
-        declined_at: null,
-      };
-
-      rows.push(row);
-      pendingSources.push(item);
-    }
-
-    let inserted: Array<{ id: string }> = [];
-    if (rows.length > 0) {
-      const { data, error } = await supabase
-        .from("work_order_quote_lines")
-        .insert(rows)
-        .select("id");
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      inserted = data ?? [];
-      inserted.forEach((row, index) => {
-        const source = pendingSources.find((item) => safeTrim(item.id) === row.id) ?? pendingSources[index];
-        if (source) sourceItemsById.set(row.id, source);
-        itemResults.push({
-          requestedId: safeTrim(source?.id) || null,
-          id: row.id,
-          created: true,
-          findingIdentity: source ? identityFor(source) : null,
-        });
-      });
-    }
-
-    for (const quoteLineId of itemResults.map((item) => item.id)) {
-      const source = sourceItemsById.get(quoteLineId);
-      const parts = cleanParts(source?.parts);
-      if (!source || parts.length === 0) continue;
-
-      const sourceNote = safeTrim(source.notes) || safeTrim(source.complaint);
-      const requestNotes = [
-        sourceNote,
-        `Quote line: ${quoteLineId}`,
-        source.sourceInspectionId ? `Inspection: ${source.sourceInspectionId}` : "",
-      ]
-        .filter(Boolean)
-        .join("\n");
-
-      const partRequest = await getOrCreatePartRequestForQuoteLine(supabase, {
-        shopId: wo.shop_id,
-        workOrderId,
-        quoteLineId,
-        requestedBy: suggestedBy,
-        notes: requestNotes || null,
-      });
-
-      if (partRequest.error || !partRequest.id) {
-        return NextResponse.json(
-          { error: partRequest.error ?? "Failed to create part request" },
-          { status: 500 },
-        );
-      }
-
-      const { data: existingItems, error: existingItemsError } = await supabase
-        .from("part_request_items")
-        .select("id, description")
-        .eq("request_id", partRequest.id)
-        .eq("quote_line_id", quoteLineId);
-
-      if (existingItemsError) {
-        return NextResponse.json({ error: existingItemsError.message }, { status: 500 });
-      }
-
-      const existingItemIdentities = new Set(
-        (existingItems ?? []).map((item) =>
-          normalizePartRequestItemIdentity({ description: item.description }),
-        ),
-      );
-
-      const partRows: PartRequestItemInsert[] = [];
-      for (const part of parts) {
-        const itemIdentity = normalizePartRequestItemIdentity({
-          description: part.description,
-        });
-        if (itemIdentity && existingItemIdentities.has(itemIdentity)) continue;
-        if (itemIdentity) existingItemIdentities.add(itemIdentity);
-
-        partRows.push({
-          request_id: partRequest.id,
-          shop_id: wo.shop_id,
-          work_order_id: workOrderId,
-          quote_line_id: quoteLineId,
-          work_order_line_id: null,
-          description: part.description,
-          qty: part.qty,
-          qty_requested: part.qty,
-          unit_cost: part.unitCost,
-          unit_price: part.unitPrice,
-          status: "requested",
-        });
-      }
-
-      if (partRows.length === 0) continue;
-
-      const { error: itemError } = await supabase
-        .from("part_request_items")
-        .insert(partRows);
-
-      if (itemError) {
-        return NextResponse.json({ error: itemError.message }, { status: 500 });
-      }
-
-      const syncResult = await syncQuoteLinePartsStatus(supabase, {
-        shopId: wo.shop_id,
-        quoteLineId,
-      });
-      if (!syncResult.ok) {
-        return NextResponse.json(
-          { error: syncResult.error ?? "Failed to sync quote line parts status" },
-          { status: 500 },
-        );
-      }
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 500 });
     }
 
     return NextResponse.json({
       ok: true,
-      ids: itemResults.map((item) => item.id),
-      items: itemResults,
-      createdCount: itemResults.filter((item) => item.created).length,
-      skippedDuplicateCount: itemResults.filter((item) => !item.created).length,
+      ids: result.ids,
+      items: result.items,
+      createdCount: result.createdCount,
+      skippedDuplicateCount: result.skippedDuplicateCount,
+      createdPartRequestIds: result.createdPartRequestIds,
+      partRequestIds: result.partRequestIds,
+      createdPartRequestItemCount: result.createdPartRequestItemCount,
+      skippedPartRequestItemCount: result.skippedPartRequestItemCount,
       followUps: [
         "Add a database unique constraint for inspection finding identity when production data can be backfilled safely.",
         "Phase 5D-2 should relink quote-originated part_request_items to approved/materialized work_order_lines and invoice materialization.",

--- a/features/inspections/app/inspection/summary/page.tsx
+++ b/features/inspections/app/inspection/summary/page.tsx
@@ -183,14 +183,14 @@ export default function SummaryPage() {
         }),
       });
 
-      if (!response.ok) throw new Error("Failed to add jobs to work order.");
+      if (!response.ok) throw new Error("Failed to send findings to Quote Review.");
 
       window.dispatchEvent(new CustomEvent("wo:line-added"));
-      toast.success("Jobs added to work order.");
+      toast.success("Imported findings to Quote Review.");
     } catch (e) {
       console.error(e);
       toast.error(
-        e instanceof Error ? e.message : "Failed to add jobs to work order.",
+        e instanceof Error ? e.message : "Failed to send findings to Quote Review.",
       );
     } finally {
       setIsAddingToWorkOrder(false);
@@ -535,8 +535,8 @@ export default function SummaryPage() {
               disabled={!hasFailedItems || isAddingToWorkOrder}
             >
               {isAddingToWorkOrder
-                ? "Adding to work order…"
-                : "Add failed items to work order"}
+                ? "Sending to Quote Review…"
+                : "Send to Quote Review"}
             </Button>
           )}
 

--- a/features/work-orders/lib/work-orders/canonicalQuoteLines.ts
+++ b/features/work-orders/lib/work-orders/canonicalQuoteLines.ts
@@ -1,0 +1,449 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@shared/types/types/supabase";
+import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
+
+type DB = Database;
+type QuoteInsert = DB["public"]["Tables"]["work_order_quote_lines"]["Insert"];
+type PartRequestInsert = DB["public"]["Tables"]["part_requests"]["Insert"];
+type PartRequestItemInsert = DB["public"]["Tables"]["part_request_items"]["Insert"];
+
+export type CanonicalQuotePart = {
+  description?: string;
+  name?: string;
+  partNumber?: string | null;
+  part_number?: string | null;
+  sku?: string | null;
+  qty?: number;
+  cost?: number | null;
+  unitCost?: number | null;
+  unitPrice?: number | null;
+  notes?: string | null;
+};
+
+export type CanonicalQuoteItem = {
+  id?: string | null;
+  description: string;
+  title?: string | null;
+  jobType?: "diagnosis" | "repair" | "maintenance" | "inspection" | "inspection-fail" | "tech-suggested";
+  estLaborHours?: number | null;
+  laborHours?: number | null;
+  laborRate?: number | null;
+  partsTotal?: number | null;
+  laborTotal?: number | null;
+  subtotal?: number | null;
+  taxTotal?: number | null;
+  grandTotal?: number | null;
+  notes?: string | null;
+  complaint?: string | null;
+  aiComplaint?: string | null;
+  aiCause?: string | null;
+  aiCorrection?: string | null;
+  status?: string | null;
+  stage?: string | null;
+  source?: "inspection" | string | null;
+  sourceInspectionId?: string | null;
+  sourceWorkOrderLineId?: string | null;
+  sourceSectionKey?: string | null;
+  sourceSectionTitle?: string | null;
+  sourceItemKey?: string | null;
+  sourceFindingTitle?: string | null;
+  normalizedFindingTitle?: string | null;
+  findingIdentity?: string | null;
+  photoUrls?: string[];
+  parts?: CanonicalQuotePart[];
+  metadata?: Record<string, Json | undefined> | null;
+};
+
+export type CreateCanonicalQuoteLinesInput = {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+  vehicleId?: string | null;
+  suggestedBy?: string | null;
+  items: CanonicalQuoteItem[];
+};
+
+export type CanonicalQuoteLineItemResult = {
+  requestedId: string | null;
+  id: string;
+  created: boolean;
+  findingIdentity: string | null;
+};
+
+export type CreateCanonicalQuoteLinesResult = {
+  ok: true;
+  ids: string[];
+  items: CanonicalQuoteLineItemResult[];
+  createdCount: number;
+  skippedDuplicateCount: number;
+  createdPartRequestIds: string[];
+  partRequestIds: string[];
+  createdPartRequestItemCount: number;
+  skippedPartRequestItemCount: number;
+} | { ok: false; error: string };
+
+export function safeTrim(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeTitle(value: unknown): string {
+  return safeTrim(value).toLowerCase().replace(/\s+/g, " ");
+}
+
+export function cleanParts(parts: CanonicalQuotePart[] | undefined): Array<{
+  description: string;
+  partNumber: string | null;
+  qty: number;
+  unitCost: number | null;
+  unitPrice: number | null;
+  notes: string | null;
+}> {
+  return (parts ?? [])
+    .map((part) => {
+      const description = safeTrim(part.description) || safeTrim(part.name);
+      const qty = Math.max(1, Number(part.qty) || 1);
+      return {
+        description,
+        partNumber:
+          safeTrim(part.partNumber) || safeTrim(part.part_number) || safeTrim(part.sku) || null,
+        qty,
+        unitCost: finiteNumber(part.unitCost) ?? finiteNumber(part.cost),
+        unitPrice: finiteNumber(part.unitPrice),
+        notes: safeTrim(part.notes) || null,
+      };
+    })
+    .filter((part) => part.description.length > 0);
+}
+
+export function identityFor(item: CanonicalQuoteItem): string | null {
+  const explicit = safeTrim(item.findingIdentity);
+  if (explicit) return explicit;
+
+  const inspectionId = safeTrim(item.sourceInspectionId);
+  const sourceLineId = safeTrim(item.sourceWorkOrderLineId);
+  const sectionKey = safeTrim(item.sourceSectionKey);
+  const itemKey = safeTrim(item.sourceItemKey);
+  const normalizedTitle =
+    normalizeTitle(item.normalizedFindingTitle) ||
+    normalizeTitle(item.sourceFindingTitle) ||
+    normalizeTitle(item.title) ||
+    normalizeTitle(item.description);
+
+  const parts = [inspectionId, sourceLineId, sectionKey, itemKey, normalizedTitle].filter(Boolean);
+  return parts.length > 0 ? parts.join(":") : null;
+}
+
+function normalizePartRequestItemIdentity(input: {
+  description?: string | null;
+  partNumber?: string | null;
+}): string {
+  const normalizedDescription = normalizeTitle(input.description);
+  const normalizedPartNumber = safeTrim(input.partNumber).toUpperCase().replace(/\s+/g, "");
+  return [normalizedPartNumber, normalizedDescription].filter(Boolean).join("|");
+}
+
+async function getOrCreatePartRequestForQuoteLine(
+  supabase: SupabaseClient<DB>,
+  input: {
+    shopId: string;
+    workOrderId: string;
+    quoteLineId: string;
+    requestedBy: string | null;
+    notes: string | null;
+  },
+): Promise<{ id: string; created: boolean; error?: string }> {
+  const { data: existing, error: existingError } = await supabase
+    .from("part_requests")
+    .select("id")
+    .eq("shop_id", input.shopId)
+    .eq("work_order_id", input.workOrderId)
+    .eq("quote_line_id", input.quoteLineId)
+    .limit(1);
+
+  if (existingError) {
+    return { id: "", created: false, error: existingError.message };
+  }
+
+  const reusable = existing?.[0];
+  if (reusable?.id) {
+    return { id: reusable.id, created: false };
+  }
+
+  const requestPayload: PartRequestInsert = {
+    shop_id: input.shopId,
+    work_order_id: input.workOrderId,
+    quote_line_id: input.quoteLineId,
+    job_id: null,
+    requested_by: input.requestedBy,
+    notes: input.notes,
+    status: "requested",
+  };
+
+  const { data: partRequest, error: requestError } = await supabase
+    .from("part_requests")
+    .insert(requestPayload)
+    .select("id")
+    .single();
+
+  if (requestError || !partRequest) {
+    return {
+      id: "",
+      created: false,
+      error: requestError?.message ?? "Failed to create part request",
+    };
+  }
+
+  return { id: partRequest.id, created: true };
+}
+
+export async function createCanonicalQuoteLines(
+  input: CreateCanonicalQuoteLinesInput,
+): Promise<CreateCanonicalQuoteLinesResult> {
+  const { supabase, shopId, workOrderId, vehicleId = null, suggestedBy = null, items } = input;
+
+  const requestedIds = items.map((item) => safeTrim(item.id)).filter(Boolean);
+  const identities = items.map(identityFor).filter((value): value is string => Boolean(value));
+
+  const existingById = new Map<string, { id: string }>();
+  if (requestedIds.length > 0) {
+    const { data, error } = await supabase
+      .from("work_order_quote_lines")
+      .select("id")
+      .eq("shop_id", shopId)
+      .eq("work_order_id", workOrderId)
+      .in("id", requestedIds);
+
+    if (error) return { ok: false, error: error.message };
+    for (const row of data ?? []) existingById.set(row.id, row);
+  }
+
+  const existingByIdentity = new Map<string, { id: string }>();
+  for (const identity of identities) {
+    const { data, error } = await supabase
+      .from("work_order_quote_lines")
+      .select("id")
+      .eq("shop_id", shopId)
+      .eq("work_order_id", workOrderId)
+      .contains("metadata", { inspection_finding_identity: identity })
+      .limit(1);
+
+    if (error) return { ok: false, error: error.message };
+
+    const existing = data?.[0];
+    if (existing) existingByIdentity.set(identity, existing);
+  }
+
+  const rows: QuoteInsert[] = [];
+  const pendingSources: CanonicalQuoteItem[] = [];
+  const sourceItemsById = new Map<string, CanonicalQuoteItem>();
+  const itemResults: CanonicalQuoteLineItemResult[] = [];
+  const seenNewIdentities = new Set<string>();
+
+  for (const item of items) {
+    const description = safeTrim(item.description) || safeTrim(item.title);
+    if (!description) continue;
+
+    const requestedId = safeTrim(item.id) || null;
+    const findingIdentity = identityFor(item);
+    const existing =
+      (requestedId ? existingById.get(requestedId) : undefined) ??
+      (findingIdentity ? existingByIdentity.get(findingIdentity) : undefined);
+
+    if (existing || (findingIdentity && seenNewIdentities.has(findingIdentity))) {
+      const duplicate = existing ?? (findingIdentity ? existingByIdentity.get(findingIdentity) : undefined);
+      if (duplicate) {
+        sourceItemsById.set(duplicate.id, item);
+        itemResults.push({ requestedId, id: duplicate.id, created: false, findingIdentity });
+      } else {
+        itemResults.push({ requestedId, id: "", created: false, findingIdentity });
+      }
+      continue;
+    }
+
+    if (findingIdentity) seenNewIdentities.add(findingIdentity);
+
+    const parts = cleanParts(item.parts);
+    const partsTotal =
+      finiteNumber(item.partsTotal) ??
+      parts.reduce((sum, part) => sum + (part.unitCost ?? 0) * part.qty, 0);
+    const laborHours = finiteNumber(item.laborHours) ?? finiteNumber(item.estLaborHours);
+    const laborTotal = finiteNumber(item.laborTotal);
+    const subtotal = finiteNumber(item.subtotal) ?? partsTotal + (laborTotal ?? 0);
+    const grandTotal = finiteNumber(item.grandTotal) ?? subtotal + (finiteNumber(item.taxTotal) ?? 0);
+    const normalizedFindingTitle =
+      normalizeTitle(item.normalizedFindingTitle) ||
+      normalizeTitle(item.sourceFindingTitle) ||
+      normalizeTitle(description);
+
+    const metadata: Record<string, Json | undefined> = {
+      ...(item.metadata ?? {}),
+      source: item.source ?? "inspection",
+      source_inspection_id: safeTrim(item.sourceInspectionId) || undefined,
+      source_work_order_line_id: safeTrim(item.sourceWorkOrderLineId) || undefined,
+      source_section_key: safeTrim(item.sourceSectionKey) || undefined,
+      source_section_title: safeTrim(item.sourceSectionTitle) || undefined,
+      source_item_key: safeTrim(item.sourceItemKey) || undefined,
+      source_finding_title: safeTrim(item.sourceFindingTitle) || description,
+      source_finding_title_normalized: normalizedFindingTitle || undefined,
+      inspection_finding_identity: findingIdentity ?? undefined,
+      photo_urls: Array.isArray(item.photoUrls) ? item.photoUrls : [],
+      parts,
+      labor_rate: finiteNumber(item.laborRate) ?? undefined,
+    };
+
+    const row: QuoteInsert = {
+      ...(requestedId ? { id: requestedId } : {}),
+      work_order_id: workOrderId,
+      work_order_line_id: null,
+      shop_id: shopId,
+      vehicle_id: vehicleId,
+      suggested_by: suggestedBy,
+      description,
+      job_type: item.jobType ?? "tech-suggested",
+      est_labor_hours: finiteNumber(item.estLaborHours) ?? laborHours,
+      notes: safeTrim(item.notes) || safeTrim(item.complaint) || null,
+      status: safeTrim(item.status) || "pending_parts",
+      ai_complaint: safeTrim(item.aiComplaint) || safeTrim(item.complaint) || null,
+      ai_cause: safeTrim(item.aiCause) || null,
+      ai_correction: safeTrim(item.aiCorrection) || null,
+      stage: safeTrim(item.stage) || "advisor_pending",
+      qty: 1,
+      labor_hours: laborHours,
+      parts_total: partsTotal,
+      labor_total: laborTotal,
+      subtotal,
+      tax_total: finiteNumber(item.taxTotal),
+      grand_total: grandTotal,
+      metadata: metadata as Json,
+      group_id: null,
+      sent_to_customer_at: null,
+      approved_at: null,
+      declined_at: null,
+    };
+
+    rows.push(row);
+    pendingSources.push(item);
+  }
+
+  if (rows.length > 0) {
+    const { data, error } = await supabase
+      .from("work_order_quote_lines")
+      .insert(rows)
+      .select("id");
+
+    if (error) return { ok: false, error: error.message };
+
+    (data ?? []).forEach((row, index) => {
+      const source = pendingSources.find((item) => safeTrim(item.id) === row.id) ?? pendingSources[index];
+      if (source) sourceItemsById.set(row.id, source);
+      itemResults.push({
+        requestedId: safeTrim(source?.id) || null,
+        id: row.id,
+        created: true,
+        findingIdentity: source ? identityFor(source) : null,
+      });
+    });
+  }
+
+  const createdPartRequestIds: string[] = [];
+  const partRequestIds: string[] = [];
+  let createdPartRequestItemCount = 0;
+  let skippedPartRequestItemCount = 0;
+
+  for (const quoteLineId of itemResults.map((item) => item.id).filter(Boolean)) {
+    const source = sourceItemsById.get(quoteLineId);
+    const parts = cleanParts(source?.parts);
+    if (!source || parts.length === 0) continue;
+
+    const sourceNote = safeTrim(source.notes) || safeTrim(source.complaint);
+    const requestNotes = [
+      sourceNote,
+      `Quote line: ${quoteLineId}`,
+      source.sourceInspectionId ? `Inspection: ${source.sourceInspectionId}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const partRequest = await getOrCreatePartRequestForQuoteLine(supabase, {
+      shopId,
+      workOrderId,
+      quoteLineId,
+      requestedBy: suggestedBy,
+      notes: requestNotes || null,
+    });
+
+    if (partRequest.error || !partRequest.id) {
+      return { ok: false, error: partRequest.error ?? "Failed to create part request" };
+    }
+
+    partRequestIds.push(partRequest.id);
+    if (partRequest.created) createdPartRequestIds.push(partRequest.id);
+
+    const { data: existingItems, error: existingItemsError } = await supabase
+      .from("part_request_items")
+      .select("id, description")
+      .eq("request_id", partRequest.id)
+      .eq("quote_line_id", quoteLineId);
+
+    if (existingItemsError) return { ok: false, error: existingItemsError.message };
+
+    const existingItemIdentities = new Set(
+      (existingItems ?? []).map((item) =>
+        normalizePartRequestItemIdentity({ description: item.description }),
+      ),
+    );
+
+    const partRows: PartRequestItemInsert[] = [];
+    for (const part of parts) {
+      const itemIdentity = normalizePartRequestItemIdentity({ description: part.description });
+      if (itemIdentity && existingItemIdentities.has(itemIdentity)) {
+        skippedPartRequestItemCount += 1;
+        continue;
+      }
+      if (itemIdentity) existingItemIdentities.add(itemIdentity);
+
+      partRows.push({
+        request_id: partRequest.id,
+        shop_id: shopId,
+        work_order_id: workOrderId,
+        quote_line_id: quoteLineId,
+        work_order_line_id: null,
+        description: part.description,
+        qty: part.qty,
+        qty_requested: part.qty,
+        unit_cost: part.unitCost,
+        unit_price: part.unitPrice,
+        status: "requested",
+      });
+    }
+
+    if (partRows.length > 0) {
+      const { error: itemError } = await supabase.from("part_request_items").insert(partRows);
+      if (itemError) return { ok: false, error: itemError.message };
+      createdPartRequestItemCount += partRows.length;
+    }
+
+    const syncResult = await syncQuoteLinePartsStatus(supabase, { shopId, quoteLineId });
+    if (!syncResult.ok) {
+      return { ok: false, error: syncResult.error ?? "Failed to sync quote line parts status" };
+    }
+  }
+
+  return {
+    ok: true,
+    ids: itemResults.map((item) => item.id).filter(Boolean),
+    items: itemResults,
+    createdCount: itemResults.filter((item) => item.created).length,
+    skippedDuplicateCount: itemResults.filter((item) => !item.created).length,
+    createdPartRequestIds,
+    partRequestIds: [...new Set(partRequestIds)],
+    createdPartRequestItemCount,
+    skippedPartRequestItemCount,
+  };
+}

--- a/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
+++ b/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
@@ -2,38 +2,58 @@ import "server-only";
 
 import crypto from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import type { Database, Json } from "@shared/types/types/supabase";
 import { estimateLabor } from "@ai/lib/ai/estimateLabor";
 import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import {
+  createCanonicalQuoteLines,
+  type CanonicalQuoteItem,
+  type CanonicalQuotePart,
+} from "@/features/work-orders/lib/work-orders/canonicalQuoteLines";
 
 type DB = Database;
 
 type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
-type WorkOrderLineInsert = DB["public"]["Tables"]["work_order_lines"]["Insert"];
-type PartsRequestInsert = DB["public"]["Tables"]["parts_requests"]["Insert"];
 
-type WorkOrderLineSourceInsert = WorkOrderLineInsert & {
-  source_inspection_id: string;
-  source_inspection_item_key: string;
-};
-
-type PartsRequestSourceInsert = PartsRequestInsert & {
-  source_inspection_id: string;
-  source_inspection_item_key: string;
+type InspectionItem = {
+  item?: string;
+  name?: string;
+  label?: string;
+  title?: string;
+  description?: string;
+  value?: string | number | null;
+  unit?: string | null;
+  notes?: string | null;
+  note?: string | null;
+  status?: "ok" | "fail" | "na" | "recommend" | string | null;
+  recommend?: boolean | string[] | null;
+  parts?: Array<{
+    description?: string;
+    name?: string;
+    qty?: number;
+    quantity?: number;
+    cost?: number | null;
+    unitCost?: number | null;
+    unitPrice?: number | null;
+    notes?: string | null;
+  }>;
+  laborHours?: number | null;
+  labor_hours?: number | null;
+  photoUrls?: string[];
+  photo_urls?: string[];
+  severity?: string | null;
+  recommendation?: string | null;
+  recommendationType?: string | null;
+  priority?: string | number | null;
 };
 
 type InspectionResult = {
   sections: Array<{
-    title: string;
-    items: Array<{
-      name: string;
-      label?: string;
-      value?: string;
-      unit?: string;
-      notes?: string;
-      status?: "ok" | "fail" | "na" | "recommend";
-      recommend?: boolean;
-    }>;
+    key?: string;
+    id?: string;
+    title?: string;
+    name?: string;
+    items: InspectionItem[];
   }>;
 };
 
@@ -41,7 +61,7 @@ export type ImportFromInspectionArgs = {
   supabase: SupabaseClient<DB>;
   inspectionId: string;
   workOrderId: string;
-  vehicleId: string;
+  vehicleId?: string | null;
   userId: string;
   autoGenerateParts?: boolean;
 };
@@ -50,14 +70,35 @@ export type ImportFromInspectionResult =
   | {
       ok: true;
       insertedCount: number;
-      partsRequestsCount: number;
+      quoteLineIds: string[];
+      createdQuoteLines: Array<{ id: string; findingIdentity: string | null }>;
+      skippedDuplicates: number;
       skippedCount: number;
+      partsRequestsCount: number;
+      createdPartRequestIds: string[];
       skippedPartsRequestsCount: number;
+      message: string;
+      /** @deprecated Legacy work_order_lines are no longer created by inspection import. */
+      insertedJobIds: null;
+      /** @deprecated Legacy work_order_lines are no longer created by inspection import. */
+      workOrderLineIds: null;
     }
   | { ok: false; error: string };
 
-function normalizeSourceComponent(value: string | null | undefined): string {
-  return (value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+function normalizeSourceComponent(value: string | number | null | undefined): string {
+  return String(value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeTitle(value: unknown): string {
+  return safeString(value).toLowerCase().replace(/\s+/g, " ");
 }
 
 function buildInspectionSourceKey(args: {
@@ -65,19 +106,71 @@ function buildInspectionSourceKey(args: {
   sectionIndex: number;
   itemIndex: number;
   sectionTitle?: string;
+  sectionKey?: string;
   itemName?: string;
   itemLabel?: string;
-  unit?: string;
+  unit?: string | null;
 }): string {
   const normalizedSectionTitle = normalizeSourceComponent(args.sectionTitle);
+  const normalizedSectionKey = normalizeSourceComponent(args.sectionKey);
   const normalizedItemName = normalizeSourceComponent(args.itemName || args.itemLabel);
   const normalizedUnit = normalizeSourceComponent(args.unit);
-  const raw = `${args.inspectionId}|${args.sectionIndex}|${args.itemIndex}|${normalizedSectionTitle}|${normalizedItemName}|${normalizedUnit}`;
+  const raw = `${args.inspectionId}|${args.sectionIndex}|${args.itemIndex}|${normalizedSectionKey}|${normalizedSectionTitle}|${normalizedItemName}|${normalizedUnit}`;
   return crypto.createHash("sha256").update(raw).digest("hex");
 }
 
-function normalizePartName(value: string | null | undefined): string {
-  return normalizeSourceComponent(value);
+function buildFindingIdentity(args: {
+  inspectionId: string;
+  sourceKey: string;
+  sectionKey: string;
+  normalizedTitle: string;
+  normalizedDescription: string;
+}): string {
+  return [
+    args.inspectionId,
+    args.sectionKey,
+    args.sourceKey,
+    args.normalizedTitle || args.normalizedDescription,
+    args.normalizedDescription,
+  ]
+    .filter(Boolean)
+    .join(":");
+}
+
+function itemTitle(item: InspectionItem): string {
+  return (
+    safeString(item.item) ||
+    safeString(item.name) ||
+    safeString(item.label) ||
+    safeString(item.title) ||
+    safeString(item.description)
+  );
+}
+
+function itemNotes(item: InspectionItem): string {
+  return safeString(item.notes) || safeString(item.note);
+}
+
+function itemPhotoUrls(item: InspectionItem): string[] {
+  const raw = Array.isArray(item.photoUrls) ? item.photoUrls : item.photo_urls;
+  return Array.isArray(raw) ? raw.filter((url): url is string => typeof url === "string" && url.trim().length > 0) : [];
+}
+
+function itemParts(item: InspectionItem): CanonicalQuotePart[] {
+  return (Array.isArray(item.parts) ? item.parts : [])
+    .map((part) => ({
+      description: safeString(part.description) || safeString(part.name),
+      qty: Math.max(1, Number(part.qty ?? part.quantity) || 1),
+      cost: finiteNumber(part.cost),
+      unitCost: finiteNumber(part.unitCost),
+      unitPrice: finiteNumber(part.unitPrice),
+      notes: safeString(part.notes) || null,
+    }))
+    .filter((part) => part.description.length > 0);
+}
+
+function shouldIncludeInspectionItem(item: InspectionItem, jobType: CanonicalQuoteItem["jobType"]): boolean {
+  return item.status === "fail" || item.status === "recommend" || item.recommend === true || jobType !== "repair";
 }
 
 export async function insertPrioritizedJobsFromInspection(
@@ -104,16 +197,33 @@ export async function insertPrioritizedJobsFromInspection(
   if (!inspection) {
     return { ok: false, error: "Inspection not found." };
   }
-
   if (!inspection.shop_id) {
     return { ok: false, error: "Inspection is missing shop_id." };
   }
 
-  const shopId = inspection.shop_id;
+  const { data: workOrder, error: woErr } = await supabase
+    .from("work_orders")
+    .select("id, shop_id, vehicle_id, status")
+    .eq("id", workOrderId)
+    .maybeSingle<{ id: string; shop_id: string | null; vehicle_id: string | null; status: string | null }>();
 
-  const result = (inspection as unknown as { result?: unknown })?.result as
-    | InspectionResult
-    | undefined;
+  if (woErr) {
+    return { ok: false, error: `Failed to fetch work order: ${woErr.message}` };
+  }
+  if (!workOrder) {
+    return { ok: false, error: "Work order not found." };
+  }
+  if (!workOrder.shop_id || workOrder.shop_id !== inspection.shop_id) {
+    return { ok: false, error: "Inspection and work order must belong to the same shop." };
+  }
+
+  const blockedStatuses = new Set(["cancelled", "canceled", "invoiced", "closed"]);
+  if (blockedStatuses.has((workOrder.status ?? "").toLowerCase())) {
+    return { ok: false, error: "Cannot import inspection findings into a cancelled, closed, or invoiced work order." };
+  }
+
+  const shopId = inspection.shop_id;
+  const result = (inspection as unknown as { result?: unknown })?.result as InspectionResult | undefined;
 
   if (!result?.sections || !Array.isArray(result.sections)) {
     return { ok: false, error: "Invalid inspection format: missing sections." };
@@ -121,224 +231,165 @@ export async function insertPrioritizedJobsFromInspection(
 
   const diagnosisKeywords = ["check engine", "diagnose", "misfire", "no start"];
   const maintenanceKeywords = ["oil", "fluid", "filter", "belt", "coolant"];
-  const autoPartsKeywords = [
-    "brake",
-    "pads",
-    "rotor",
-    "fluid",
-    "coolant",
-    "filter",
-    "belt",
-  ];
+  const autoPartsKeywords = ["brake", "pads", "rotor", "fluid", "coolant", "filter", "belt"];
 
-  const allJobs: WorkOrderLineSourceInsert[] = [];
-  const jobItemMap: Array<{
-    originalItem: InspectionResult["sections"][number]["items"][number];
-    sourceKey: string;
-  }> = [];
+  const quoteItems: CanonicalQuoteItem[] = [];
 
   for (const [sectionIndex, section] of result.sections.entries()) {
-    for (const [itemIndex, item] of section.items.entries()) {
-      const itemName = item.name || item.label || "";
-      const nameLower = itemName.toLowerCase();
-      let jobType: WorkOrderLineInsert["job_type"] = "repair";
+    const sectionTitle = safeString(section.title) || safeString(section.name) || `Section ${sectionIndex + 1}`;
+    const sectionKey = safeString(section.key) || safeString(section.id) || normalizeTitle(sectionTitle) || `section-${sectionIndex}`;
 
-      if (diagnosisKeywords.some((k) => nameLower.includes(k))) jobType = "diagnosis";
+    for (const [itemIndex, item] of (section.items ?? []).entries()) {
+      const title = itemTitle(item);
+      if (!title) continue;
+
+      const titleLower = title.toLowerCase();
+      let jobType: CanonicalQuoteItem["jobType"] = "repair";
+
+      if (diagnosisKeywords.some((keyword) => titleLower.includes(keyword))) jobType = "diagnosis";
       else if (item.status === "fail") jobType = "inspection-fail";
-      else if (maintenanceKeywords.some((k) => nameLower.includes(k))) jobType = "maintenance";
+      else if (maintenanceKeywords.some((keyword) => titleLower.includes(keyword))) jobType = "maintenance";
 
-      const shouldInclude =
-        item.status === "fail" || item.recommend === true || jobType !== "repair";
-
-      if (!shouldInclude) continue;
+      if (!shouldIncludeInspectionItem(item, jobType)) continue;
 
       const sourceKey = buildInspectionSourceKey({
         inspectionId,
         sectionIndex,
         itemIndex,
-        sectionTitle: section.title,
-        itemName: item.name,
+        sectionTitle,
+        sectionKey,
+        itemName: title,
         itemLabel: item.label,
         unit: item.unit,
       });
-
-      const laborTime = normalizeLaborHoursInput(await estimateLabor(itemName, jobType), true);
-
-      const complaintParts: string[] = [];
-      if (itemName) complaintParts.push(itemName);
-      if (item.value) complaintParts.push(`(${item.value}${item.unit || ""})`);
-      if (item.notes) complaintParts.push(`- ${item.notes}`);
-
-      const job: WorkOrderLineSourceInsert = {
-        shop_id: shopId,
-        work_order_id: workOrderId,
-        vehicle_id: vehicleId,
-        complaint: complaintParts.join(" "),
-        status: "in_progress",
-        job_type: jobType,
-        punched_in_at: null,
-        punched_out_at: null,
-        hold_reason: null,
-        assigned_tech_id: null,
-        labor_time: laborTime,
-        source_inspection_id: inspectionId,
-        source_inspection_item_key: sourceKey,
-      };
-
-      allJobs.push(job);
-      jobItemMap.push({ originalItem: item, sourceKey });
-    }
-  }
-
-  if (allJobs.length === 0) {
-    return { ok: true, insertedCount: 0, partsRequestsCount: 0, skippedCount: 0, skippedPartsRequestsCount: 0 };
-  }
-
-  const sourceKeys = allJobs.map((job) => job.source_inspection_item_key);
-
-  const { data: existingActiveLines, error: existingLinesErr } = await supabase
-    .from("work_order_lines")
-    .select("id, source_inspection_item_key")
-    .eq("work_order_id", workOrderId)
-    .eq("source_inspection_id", inspectionId)
-    .in("source_inspection_item_key", sourceKeys)
-    .is("voided_at", null)
-    .returns<Array<{ id: string; source_inspection_item_key: string | null }>>();
-
-  if (existingLinesErr) {
-    return {
-      ok: false,
-      error: `Error checking existing inspection lines: ${existingLinesErr.message}`,
-    };
-  }
-
-  const existingKeySet = new Set(
-    (existingActiveLines ?? [])
-      .map((row) => row.source_inspection_item_key)
-      .filter((key): key is string => Boolean(key)),
-  );
-
-  const jobsToInsert: WorkOrderLineSourceInsert[] = [];
-  const jobItemMapToInsert: Array<{
-    originalItem: InspectionResult["sections"][number]["items"][number];
-    sourceKey: string;
-  }> = [];
-
-  for (let i = 0; i < allJobs.length; i++) {
-    const sourceKey = allJobs[i].source_inspection_item_key;
-    if (existingKeySet.has(sourceKey)) continue;
-    jobsToInsert.push(allJobs[i]);
-    jobItemMapToInsert.push(jobItemMap[i]);
-  }
-
-  const skippedCount = allJobs.length - jobsToInsert.length;
-
-  if (jobsToInsert.length === 0) {
-    return { ok: true, insertedCount: 0, partsRequestsCount: 0, skippedCount, skippedPartsRequestsCount: 0 };
-  }
-
-  const insertedJobsRes = await supabase
-    .from("work_order_lines")
-    .insert(jobsToInsert)
-    .select("id, complaint, source_inspection_item_key");
-
-  if (insertedJobsRes.error) {
-    return {
-      ok: false,
-      error: `Error inserting job lines: ${insertedJobsRes.error.message}`,
-    };
-  }
-
-  const insertedJobs = insertedJobsRes.data ?? [];
-  let partsRequestsCount = 0;
-  let skippedPartsRequestsCount = 0;
-
-  if (autoGenerateParts && insertedJobs.length > 0) {
-    const partsCandidates: PartsRequestSourceInsert[] = [];
-
-    for (let i = 0; i < insertedJobs.length; i++) {
-      const { complaint, id: jobId } = insertedJobs[i];
-      const originalItem = jobItemMapToInsert[i]?.originalItem;
-      const sourceKey = jobItemMapToInsert[i]?.sourceKey;
-
-      const lower = (complaint ?? "").toLowerCase();
-      const partName = originalItem?.name || originalItem?.label;
-      if (!partName || !sourceKey) continue;
-
-      if (autoPartsKeywords.some((k) => lower.includes(k))) {
-        partsCandidates.push({
-          id: crypto.randomUUID(),
-          job_id: jobId,
-          work_order_id: workOrderId,
-          part_name: partName,
-          quantity: 1,
-          urgency: "medium",
-          notes: "Auto-generated from inspection",
-          photo_urls: [],
-          requested_by: userId,
-          created_at: new Date().toISOString(),
-          viewed_at: null,
-          fulfilled_at: null,
-          archived: false,
-          source_inspection_id: inspectionId,
-          source_inspection_item_key: sourceKey,
-        });
-      }
-    }
-
-    if (partsCandidates.length > 0) {
-      const sourceKeysForParts = [...new Set(partsCandidates.map((row) => row.source_inspection_item_key))];
-
-      const { data: existingParts, error: existingPartsErr } = await supabase
-        .from("parts_requests")
-        .select("source_inspection_item_key, part_name")
-        .eq("work_order_id", workOrderId)
-        .eq("source_inspection_id", inspectionId)
-        .in("source_inspection_item_key", sourceKeysForParts)
-        .returns<Array<{ source_inspection_item_key: string | null; part_name: string | null }>>();
-
-      if (existingPartsErr) {
-        return {
-          ok: false,
-          error: `Error checking existing parts requests: ${existingPartsErr.message}`,
-        };
-      }
-
-      const existingPartSet = new Set(
-        (existingParts ?? [])
-          .filter((row) => row.source_inspection_item_key)
-          .map(
-            (row) =>
-              `${row.source_inspection_item_key}|${normalizePartName(row.part_name)}`,
-          ),
-      );
-
-      const partsToInsert = partsCandidates.filter((row) => {
-        const dedupeKey = `${row.source_inspection_item_key}|${normalizePartName(row.part_name)}`;
-        if (existingPartSet.has(dedupeKey)) return false;
-        existingPartSet.add(dedupeKey);
-        return true;
+      const notes = itemNotes(item);
+      const value = item.value != null ? String(item.value) : "";
+      const measurement = value ? `${value}${item.unit ?? ""}` : "";
+      const descriptionParts = [title, measurement ? `(${measurement})` : "", notes ? `- ${notes}` : ""];
+      const description = descriptionParts.filter(Boolean).join(" ");
+      const normalizedFindingTitle = normalizeTitle(title);
+      const normalizedDescription = normalizeTitle(description);
+      const findingIdentity = buildFindingIdentity({
+        inspectionId,
+        sourceKey,
+        sectionKey,
+        normalizedTitle: normalizedFindingTitle,
+        normalizedDescription,
       });
 
-      skippedPartsRequestsCount = partsCandidates.length - partsToInsert.length;
+      const explicitLaborHours = finiteNumber(item.laborHours) ?? finiteNumber(item.labor_hours);
+      const laborHours = explicitLaborHours ?? normalizeLaborHoursInput(await estimateLabor(title, jobType ?? "repair"), true);
+      const parts = itemParts(item);
 
-      if (partsToInsert.length > 0) {
-        const { error: partsErr } = await supabase
-          .from("parts_requests")
-          .insert(partsToInsert);
-
-        if (!partsErr) {
-          partsRequestsCount = partsToInsert.length;
-        }
+      if (autoGenerateParts && parts.length === 0 && autoPartsKeywords.some((keyword) => description.toLowerCase().includes(keyword))) {
+        parts.push({ description: title, qty: 1, cost: null, unitCost: null, unitPrice: null, notes: "Auto-generated from inspection" });
       }
+
+      const partsTotal = parts.reduce((sum, part) => sum + (finiteNumber(part.unitCost) ?? finiteNumber(part.cost) ?? 0) * (part.qty ?? 1), 0);
+      const hasUnpricedParts = parts.some((part) => finiteNumber(part.unitPrice) == null && finiteNumber(part.unitCost) == null && finiteNumber(part.cost) == null);
+
+      const metadata: Record<string, Json | undefined> = {
+        legacy_import_route: "/api/work-orders/import-from-inspection",
+        canonicalized_phase: "5E-1",
+        shop_id: shopId,
+        work_order_id: workOrderId,
+        vehicle_id: vehicleId || workOrder.vehicle_id || undefined,
+        inspection_id: inspectionId,
+        source_inspection_item_key: sourceKey,
+        source_section_key: sectionKey,
+        source_section_title: sectionTitle,
+        source_item_title: title,
+        source_item_description: safeString(item.description) || undefined,
+        technician_notes: notes || undefined,
+        measurement: measurement || undefined,
+        inspection_status: safeString(item.status) || undefined,
+        recommend: typeof item.recommend === "boolean" ? item.recommend : undefined,
+        recommendation_metadata: {
+          severity: item.severity ?? null,
+          recommendation: item.recommendation ?? null,
+          recommendationType: item.recommendationType ?? null,
+          priority: item.priority ?? null,
+        },
+        labor_estimate_hours: laborHours,
+        parts_estimate: parts,
+        photo_urls: itemPhotoUrls(item),
+      };
+
+      quoteItems.push({
+        description,
+        title,
+        source: "inspection",
+        sourceInspectionId: inspectionId,
+        sourceSectionKey: sectionKey,
+        sourceSectionTitle: sectionTitle,
+        sourceItemKey: sourceKey,
+        sourceFindingTitle: title,
+        normalizedFindingTitle,
+        findingIdentity,
+        photoUrls: itemPhotoUrls(item),
+        jobType,
+        estLaborHours: laborHours,
+        laborHours,
+        partsTotal,
+        subtotal: partsTotal,
+        grandTotal: partsTotal,
+        notes: notes || null,
+        complaint: notes || description,
+        aiComplaint: notes || description,
+        status: parts.length > 0 && hasUnpricedParts ? "pending_parts" : "advisor_pending",
+        stage: "advisor_pending",
+        parts,
+        metadata,
+      });
     }
   }
+
+  if (quoteItems.length === 0) {
+    return {
+      ok: true,
+      insertedCount: 0,
+      quoteLineIds: [],
+      createdQuoteLines: [],
+      skippedDuplicates: 0,
+      skippedCount: 0,
+      partsRequestsCount: 0,
+      createdPartRequestIds: [],
+      skippedPartsRequestsCount: 0,
+      message: "No failed or recommended inspection findings were eligible for Quote Review.",
+      insertedJobIds: null,
+      workOrderLineIds: null,
+    };
+  }
+
+  const resultFromQuoteLines = await createCanonicalQuoteLines({
+    supabase,
+    shopId,
+    workOrderId,
+    vehicleId: vehicleId || workOrder.vehicle_id || null,
+    suggestedBy: userId,
+    items: quoteItems,
+  });
+
+  if (!resultFromQuoteLines.ok) {
+    return { ok: false, error: resultFromQuoteLines.error };
+  }
+
+  const createdQuoteLines = resultFromQuoteLines.items
+    .filter((item) => item.created)
+    .map((item) => ({ id: item.id, findingIdentity: item.findingIdentity }));
 
   return {
     ok: true,
-    insertedCount: insertedJobs.length,
-    partsRequestsCount,
-    skippedCount,
-    skippedPartsRequestsCount,
+    insertedCount: resultFromQuoteLines.createdCount,
+    quoteLineIds: resultFromQuoteLines.ids,
+    createdQuoteLines,
+    skippedDuplicates: resultFromQuoteLines.skippedDuplicateCount,
+    skippedCount: resultFromQuoteLines.skippedDuplicateCount,
+    partsRequestsCount: resultFromQuoteLines.createdPartRequestIds.length,
+    createdPartRequestIds: resultFromQuoteLines.createdPartRequestIds,
+    skippedPartsRequestsCount: resultFromQuoteLines.skippedPartRequestItemCount,
+    message: "Imported findings to Quote Review. No work order lines were created before customer approval.",
+    insertedJobIds: null,
+    workOrderLineIds: null,
   };
 }


### PR DESCRIPTION
### Motivation
- Legacy inspection import created `work_order_lines` directly which bypassed the canonical quote -> parts -> approval lifecycle and allowed punchable/pending jobs before customer approval.
- The goal is to route legacy imports into the canonical quote-line flow so findings land in Quote Review with parts requests linked to quote lines and no pre-approval job materialization.

### Description
- Added a reusable helper `createCanonicalQuoteLines` in `features/work-orders/lib/work-orders/canonicalQuoteLines.ts` that encapsulates quote-line creation, idempotent dedupe by finding identity, and creation of `part_requests` / `part_request_items` linked to `quote_line_id`.
- Replaced the duplicate logic in the quote-add endpoint by calling `createCanonicalQuoteLines` from `app/api/work-orders/quotes/add/route.ts` and adjusted the route to accept the canonical item shape (`CanonicalQuoteItem`).
- Reworked `insertPrioritizedJobsFromInspection` to build `CanonicalQuoteItem` entries from inspection findings (preserving `shop_id`, `work_order_id`, `vehicle_id`, `inspection_id`, section/item keys/titles, technician notes, labor estimates, parts estimates, photo URLs, severity/recommendation metadata) and to call `createCanonicalQuoteLines` instead of inserting `work_order_lines` directly.
- Updated the legacy import route `app/api/work-orders/import-from-inspection/route.ts` to validate current profile shop scope, block cancelled/closed/invoiced work orders, pass `vehicleId` compatibly, and return response-compatible fields including `quoteLineIds`, `createdQuoteLines`, `skippedDuplicates`, `createdPartRequestIds`, plus deprecated null `workOrderLine` fields for compatibility.
- Updated the inspection summary UI copy in `features/inspections/app/inspection/summary/page.tsx` to use Quote Review phrasing (`Send to Quote Review`, `Imported findings to Quote Review`) and adjusted to expect the new response behavior.

### Testing
- Ran `npx eslint` on changed files which completed successfully and surfaced pre-existing warnings in `features/inspections/app/inspection/summary/page.tsx` (no new lint errors).
- Ran `npx tsc --noEmit` which succeeded with no type errors.
- Ran `git diff --check` and `git status --short` to validate whitespace and staged changes with no issues.
- All automated validation steps above passed (eslint passed with warnings, typecheck passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1678b7cc8328870e911d41479a28)