### PR TITLE
Phase 5E-2: allow pre-approval quoting for quote-line-originated part request items

### DIFF
--- a/app/api/parts/requests/items/[itemId]/quote-save/route.ts
+++ b/app/api/parts/requests/items/[itemId]/quote-save/route.ts
@@ -1,0 +1,294 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
+
+type DB = Database;
+type PartRequestItemUpdate = DB["public"]["Tables"]["part_request_items"]["Update"];
+
+type Body = {
+  quoteLineId?: string | null;
+  description?: string | null;
+  qty?: number | string | null;
+  quotedPrice?: number | string | null;
+  vendorId?: string | null;
+  vendor?: string | null;
+  partId?: string | null;
+  notes?: string | null;
+};
+
+const BLOCKED_ITEM_STATUSES = new Set(["cancelled", "rejected", "declined"]);
+
+function isUuid(v: unknown): v is string {
+  if (typeof v !== "string") return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v.trim());
+}
+
+function cleanString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function nullableUuid(value: unknown, label: string): string | null {
+  const cleaned = cleanString(value);
+  if (!cleaned) return null;
+  if (!isUuid(cleaned)) throw new Error(`${label} must be a valid UUID.`);
+  return cleaned;
+}
+
+function numberOrNull(value: unknown, label: string): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${label} must be a number.`);
+  return parsed;
+}
+
+function nonNegativeCounter(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ itemId: string }> },
+) {
+  const { itemId: rawItemId } = await ctx.params;
+  const itemId = cleanString(rawItemId);
+
+  if (!itemId || !isUuid(itemId)) {
+    return NextResponse.json({ ok: false, error: "Invalid itemId" }, { status: 400 });
+  }
+
+  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const {
+    data: { user },
+    error: userErr,
+  } = await supabase.auth.getUser();
+
+  if (userErr) return NextResponse.json({ ok: false, error: userErr.message }, { status: 401 });
+  if (!user) return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
+
+  const body = (await req.json().catch(() => null)) as Body | null;
+  if (!body) {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    return NextResponse.json({ ok: false, error: profileError.message }, { status: 500 });
+  }
+
+  const shopId = cleanString(profile?.shop_id);
+  if (!shopId) {
+    return NextResponse.json({ ok: false, error: "Missing shop context" }, { status: 403 });
+  }
+
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", { p_shop_id: shopId });
+  if (contextError) {
+    return NextResponse.json({ ok: false, error: contextError.message }, { status: 403 });
+  }
+
+  const { data: item, error: itemError } = await supabase
+    .from("part_request_items")
+    .select("id, request_id, shop_id, work_order_id, quote_line_id, work_order_line_id, status, qty_received, qty_consumed, qty_reserved, qty_picked")
+    .eq("id", itemId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (itemError) {
+    return NextResponse.json({ ok: false, error: itemError.message }, { status: 500 });
+  }
+  if (!item) {
+    return NextResponse.json({ ok: false, error: "Request item not found" }, { status: 404 });
+  }
+
+  const itemQuoteLineId = cleanString(item.quote_line_id);
+  if (!itemQuoteLineId) {
+    return NextResponse.json({ ok: false, error: "This item is not linked to a quote line" }, { status: 400 });
+  }
+
+  let bodyQuoteLineId: string | null;
+  let partId: string | null;
+  let vendorId: string | null;
+  let qty: number | null;
+  let quotedPrice: number | null;
+  try {
+    bodyQuoteLineId = nullableUuid(body.quoteLineId, "quoteLineId");
+    partId = nullableUuid(body.partId, "partId");
+    vendorId = nullableUuid(body.vendorId, "vendorId");
+    qty = numberOrNull(body.qty, "qty");
+    quotedPrice = numberOrNull(body.quotedPrice, "quotedPrice");
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : "Invalid body" },
+      { status: 400 },
+    );
+  }
+
+  if (bodyQuoteLineId && bodyQuoteLineId !== itemQuoteLineId) {
+    return NextResponse.json({ ok: false, error: "Quote line mismatch" }, { status: 403 });
+  }
+
+  if (cleanString(item.work_order_line_id)) {
+    return NextResponse.json(
+      { ok: false, error: "This item is already materialized to a work order line; use the normal allocation flow." },
+      { status: 409 },
+    );
+  }
+
+  const normalizedStatus = cleanString(item.status)?.toLowerCase() ?? "";
+  if (BLOCKED_ITEM_STATUSES.has(normalizedStatus)) {
+    return NextResponse.json(
+      { ok: false, error: "Cancelled or rejected request items cannot be quoted." },
+      { status: 409 },
+    );
+  }
+
+  if (
+    nonNegativeCounter(item.qty_received) > 0 ||
+    nonNegativeCounter(item.qty_consumed) > 0 ||
+    nonNegativeCounter(item.qty_reserved) > 0 ||
+    nonNegativeCounter(item.qty_picked) > 0
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Cannot change quote-only pricing after inventory activity exists." },
+      { status: 409 },
+    );
+  }
+
+  const { data: parentRequest, error: requestError } = await supabase
+    .from("part_requests")
+    .select("id, shop_id, work_order_id, quote_line_id, status")
+    .eq("id", item.request_id)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (requestError) {
+    return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
+  }
+  if (!parentRequest) {
+    return NextResponse.json({ ok: false, error: "Parent request not found" }, { status: 404 });
+  }
+  if (cleanString(parentRequest.quote_line_id) && cleanString(parentRequest.quote_line_id) !== itemQuoteLineId) {
+    return NextResponse.json({ ok: false, error: "Parent request quote line mismatch" }, { status: 403 });
+  }
+
+  const { data: quoteLine, error: quoteLineError } = await supabase
+    .from("work_order_quote_lines")
+    .select("id, shop_id, work_order_id, work_order_line_id, approved_at, declined_at, status, stage")
+    .eq("id", itemQuoteLineId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (quoteLineError) {
+    return NextResponse.json({ ok: false, error: quoteLineError.message }, { status: 500 });
+  }
+  if (!quoteLine) {
+    return NextResponse.json({ ok: false, error: "Quote line not found" }, { status: 404 });
+  }
+  if (cleanString(quoteLine.work_order_id) !== cleanString(item.work_order_id)) {
+    return NextResponse.json({ ok: false, error: "Quote line work order mismatch" }, { status: 403 });
+  }
+  if (cleanString(quoteLine.work_order_line_id) || quoteLine.approved_at) {
+    return NextResponse.json(
+      { ok: false, error: "Quote line is already approved/materialized; use the normal allocation flow." },
+      { status: 409 },
+    );
+  }
+  if (quoteLine.declined_at || ["cancelled", "rejected", "declined"].includes((cleanString(quoteLine.status) ?? "").toLowerCase())) {
+    return NextResponse.json({ ok: false, error: "Declined or cancelled quote lines cannot be quoted." }, { status: 409 });
+  }
+
+  if (partId) {
+    const { data: part, error: partError } = await supabase
+      .from("parts")
+      .select("id")
+      .eq("id", partId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (partError) {
+      return NextResponse.json({ ok: false, error: partError.message }, { status: 500 });
+    }
+    if (!part) {
+      return NextResponse.json({ ok: false, error: "Selected part is not available in this shop" }, { status: 403 });
+    }
+  }
+
+  if (vendorId) {
+    const { data: supplier, error: supplierError } = await supabase
+      .from("suppliers")
+      .select("id")
+      .eq("id", vendorId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (supplierError) {
+      return NextResponse.json({ ok: false, error: supplierError.message }, { status: 500 });
+    }
+    if (!supplier) {
+      return NextResponse.json({ ok: false, error: "Selected supplier is not available in this shop" }, { status: 403 });
+    }
+  }
+
+  const nextQty = qty == null ? null : Math.max(1, Math.floor(qty));
+  if (quotedPrice != null && quotedPrice < 0) {
+    return NextResponse.json({ ok: false, error: "quotedPrice must be zero or greater" }, { status: 400 });
+  }
+  if (nextQty != null && nextQty <= 0) {
+    return NextResponse.json({ ok: false, error: "qty must be greater than zero" }, { status: 400 });
+  }
+
+  const description = cleanString(body.description) ?? cleanString(body.notes);
+  const vendor = cleanString(body.vendor);
+  const quoteComplete = Boolean(partId) && quotedPrice != null && quotedPrice >= 0 && (nextQty ?? 0) > 0;
+
+  const update: PartRequestItemUpdate = {
+    updated_at: new Date().toISOString(),
+    work_order_line_id: null,
+    ...(description ? { description } : {}),
+    ...(nextQty != null ? { qty: nextQty, qty_requested: nextQty } : {}),
+    ...(quotedPrice != null ? { quoted_price: quotedPrice, unit_price: quotedPrice } : {}),
+    ...(vendorId !== null ? { vendor_id: vendorId } : {}),
+    ...(vendor !== null ? { vendor } : {}),
+    ...(partId !== null ? { part_id: partId } : {}),
+    status: (quoteComplete ? "quoted" : "requested") as PartRequestItemUpdate["status"],
+  };
+
+  const { data: updatedItem, error: updateError } = await supabase
+    .from("part_request_items")
+    .update(update)
+    .eq("id", itemId)
+    .eq("shop_id", shopId)
+    .eq("request_id", item.request_id)
+    .eq("quote_line_id", itemQuoteLineId)
+    .is("work_order_line_id", null)
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
+  }
+  if (!updatedItem) {
+    return NextResponse.json({ ok: false, error: "Quote save did not apply" }, { status: 409 });
+  }
+
+  const sync = await syncQuoteLinePartsStatus(supabase, {
+    shopId,
+    quoteLineId: itemQuoteLineId,
+  });
+
+  return NextResponse.json(
+    {
+      ok: sync.ok,
+      item: updatedItem,
+      sync,
+      notice: "Quote saved. Allocation will unlock after customer approval.",
+      error: sync.ok ? undefined : sync.error,
+    },
+    { status: sync.ok ? 200 : 500 },
+  );
+}

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1042,6 +1042,122 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     }
   }
 
+
+  async function savePreApprovalQuote(reqId: string, itemId: string): Promise<void> {
+    const target = requests.find((r) => r.req.id === reqId);
+    const it = target?.items.find((x) => String(x.id) === String(itemId));
+    if (!target || !it) return;
+
+    const quoteLineId = it.quote_line_id ?? target.req.quote_line_id ?? null;
+    if (!quoteLineId) {
+      toast.error("This item is not linked to a quote line.");
+      return;
+    }
+    if (isUuid(it.work_order_line_id)) {
+      toast.error("This item is already linked to a work order line. Use the normal allocation flow.");
+      return;
+    }
+
+    const normalizedStatus = String(it.status ?? "").toLowerCase();
+    if (["cancelled", "rejected", "declined"].includes(normalizedStatus)) {
+      toast.error("Cancelled or rejected items cannot be quoted.");
+      return;
+    }
+
+    const qty = Math.max(1, Math.floor(toNum(it.ui_qty, 1)));
+    const price = it.ui_price;
+    if (price == null || !Number.isFinite(price) || price < 0) {
+      toast.error("Enter a quoted unit price of 0 or greater.");
+      return;
+    }
+
+    const partId = it.ui_part_id || it.part_id || null;
+    if (partId && !isUuid(partId)) {
+      toast.error("Invalid part id (must be a UUID).");
+      return;
+    }
+
+    const vendorId = String(it.ui_supplier_id ?? "").trim();
+    const validVendorId = vendorId && !vendorId.startsWith("__new__:") ? vendorId : null;
+    if (validVendorId && !isUuid(validVendorId)) {
+      toast.error("Invalid supplier id (must be a UUID).");
+      return;
+    }
+
+    setSavingItemId(itemId);
+    try {
+      const res = await fetch(`/api/parts/requests/items/${itemId}/quote-save`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          quoteLineId,
+          description: String(it.description ?? "").trim(),
+          qty,
+          quotedPrice: price,
+          partId,
+          vendorId: validVendorId,
+        }),
+      });
+
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; notice?: string; item?: ItemRow }
+        | null;
+
+      if (!res.ok || !body?.ok || !body.item) {
+        toast.error(body?.error || "Could not save quote.");
+        return;
+      }
+
+      const updated = body.item;
+      const nextItems = target.items.map((x) =>
+        String(x.id) === String(itemId)
+          ? ({
+              ...x,
+              ...updated,
+              ui_part_id: updated.part_id ?? partId ?? null,
+              ui_qty: toNum(updated.qty, qty),
+              ui_price:
+                updated.quoted_price == null
+                  ? price
+                  : toNum(updated.quoted_price, price),
+              ui_supplier_id: updated.vendor_id ?? validVendorId ?? x.ui_supplier_id,
+            } as UiItem)
+          : x,
+      );
+
+      setRequests((prev) =>
+        prev.map((r) =>
+          r.req.id === reqId
+            ? {
+                ...r,
+                items: r.items.map((x) =>
+                  String(x.id) === String(itemId)
+                    ? ({
+                        ...x,
+                        ...updated,
+                        ui_part_id: updated.part_id ?? partId ?? null,
+                        ui_qty: toNum(updated.qty, qty),
+                        ui_price:
+                          updated.quoted_price == null
+                            ? price
+                            : toNum(updated.quoted_price, price),
+                        ui_supplier_id: updated.vendor_id ?? validVendorId ?? x.ui_supplier_id,
+                      } as UiItem)
+                    : x,
+                ),
+              }
+            : r,
+        ),
+      );
+
+      await syncRequestQuotedState(reqId, nextItems, target.req.status);
+      window.dispatchEvent(new Event("parts-request:submitted"));
+      toast.success(body.notice || "Quote saved. Allocation will unlock after customer approval.");
+    } finally {
+      setSavingItemId(null);
+    }
+  }
+
   async function addAndAttach(reqId: string, itemId: string): Promise<void> {
     const target = requests.find((r) => r.req.id === reqId);
     const it = target?.items.find((x) => x.id === itemId);
@@ -1522,6 +1638,14 @@ if (!lineId || !isUuid(lineId)) {
                                   qtyApproved: (it as { qty_approved?: unknown }).qty_approved,
                                   qtyReceived: (it as { qty_received?: unknown }).qty_received,
                                 });
+                                const itemHasQuoteLineOrigin = !!it.quote_line_id || hasQuoteLineOrigin;
+                                const isQuoteOnlyPreApprovalItem =
+                                  itemHasQuoteLineOrigin && !isUuid(it.work_order_line_id);
+                                const quoteSaveDisabled =
+                                  rowBusy ||
+                                  it.ui_price == null ||
+                                  !Number.isFinite(it.ui_price) ||
+                                  it.ui_price < 0;
 
                                 return (
                                   <tr
@@ -1603,7 +1727,7 @@ if (!lineId || !isUuid(lineId)) {
                                                 : "Use this stock part"}
                                             </button>
                                             {topSuggestion.part_id === it.ui_part_id ? (
-                                              <div className="mt-1 text-neutral-500">Selected for review. Click <span className="text-neutral-300">Add</span> to run the normal attach flow.</div>
+                                              <div className="mt-1 text-neutral-500">Selected for review. Click <span className="text-neutral-300">{isQuoteOnlyPreApprovalItem ? "Save Quote" : "Add"}</span> to run the normal {isQuoteOnlyPreApprovalItem ? "pre-approval quote" : "attach"} flow.</div>
                                             ) : null}
                                           </div>
                                         ) : hasAttachedPart && topSuggestion ? (
@@ -1671,27 +1795,40 @@ if (!lineId || !isUuid(lineId)) {
                                             ) : null}
                                           </div>
                                         ) : null}
-                                        {approved > 0 ? (
+                                        {approved > 0 || isQuoteOnlyPreApprovalItem ? (
                                           <div className="text-[11px] text-neutral-500">
                                             State{" "}
                                             <span className="text-neutral-200">
-                                              {itemFlowLabel(itemState)}
-                                            </span>{" "}
-                                            <span className="text-neutral-600">·</span>{" "}
-                                            Approved{" "}
-                                            <span className="text-neutral-200">
-                                              {approved}
-                                            </span>{" "}
-                                            <span className="text-neutral-600">·</span>{" "}
-                                            Received{" "}
-                                            <span className="text-neutral-200">
-                                              {received}
-                                            </span>{" "}
-                                            <span className="text-neutral-600">·</span>{" "}
-                                            Remaining{" "}
-                                            <span className="text-neutral-200">
-                                              {remaining}
+                                              {isQuoteOnlyPreApprovalItem && String(it.status ?? "").toLowerCase() === "quoted"
+                                                ? "Quoted"
+                                                : itemFlowLabel(itemState)}
                                             </span>
+                                            {isQuoteOnlyPreApprovalItem ? (
+                                              <>
+                                                <span className="text-neutral-600"> · </span>
+                                                <span className="text-[rgba(242,210,187,0.94)]">
+                                                  Waiting for customer approval before allocation
+                                                </span>
+                                              </>
+                                            ) : (
+                                              <>
+                                                <span className="text-neutral-600"> · </span>
+                                                Approved{" "}
+                                                <span className="text-neutral-200">
+                                                  {approved}
+                                                </span>{" "}
+                                                <span className="text-neutral-600">·</span>{" "}
+                                                Received{" "}
+                                                <span className="text-neutral-200">
+                                                  {received}
+                                                </span>{" "}
+                                                <span className="text-neutral-600">·</span>{" "}
+                                                Remaining{" "}
+                                                <span className="text-neutral-200">
+                                                  {remaining}
+                                                </span>
+                                              </>
+                                            )}
                                             {trustMeta ? (
                                               <span className={`ml-2 inline-flex rounded-full border px-2 py-0.5 ${trustBadgeTone(trustMeta.level)}`}>
                                                 {trustLevelLabel(trustMeta.level)}
@@ -1897,20 +2034,40 @@ if (!lineId || !isUuid(lineId)) {
                                         <button
                                           className={`${btnCopper} py-1.5 text-xs`}
                                           onClick={() =>
-                                            void addAndAttach(r.req.id, String(it.id))
+                                            isQuoteOnlyPreApprovalItem
+                                              ? void savePreApprovalQuote(r.req.id, String(it.id))
+                                              : void addAndAttach(r.req.id, String(it.id))
                                           }
-                                          disabled={rowBusy || !it.ui_part_id || !canMaterializeToLine}
+                                          disabled={
+                                            isQuoteOnlyPreApprovalItem
+                                              ? quoteSaveDisabled
+                                              : rowBusy || !it.ui_part_id || !canMaterializeToLine
+                                          }
                                           title={
-                                            !canMaterializeToLine
-                                              ? hasQuoteLineOrigin
-                                                ? "Quote-originated parts are not allocated until approval creates a work order line link"
-                                                : "Missing work order line link"
-                                              : undefined
+                                            isQuoteOnlyPreApprovalItem
+                                              ? "Save quote pricing now. Allocation unlocks after customer approval."
+                                              : !canMaterializeToLine
+                                                ? hasQuoteLineOrigin
+                                                  ? "Quote-originated parts are not allocated until approval creates a work order line link"
+                                                  : "Missing work order line link"
+                                                : undefined
                                           }
                                           type="button"
                                         >
-                                          {rowBusy ? "Saving…" : "Add"}
+                                          {rowBusy
+                                            ? "Saving…"
+                                            : isQuoteOnlyPreApprovalItem
+                                              ? "Save Quote"
+                                              : "Add"}
                                         </button>
+
+                                        {isQuoteOnlyPreApprovalItem ? (
+                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-[rgba(242,210,187,0.94)]">
+                                            {String(it.status ?? "").toLowerCase() === "quoted"
+                                              ? "Quote saved. Allocation will unlock after customer approval."
+                                              : "Waiting for customer approval before allocation"}
+                                          </div>
+                                        ) : null}
 
                                         <button
                                           className={btnGhost}


### PR DESCRIPTION
### Motivation
- Quote-originated part request items were blocked from being priced by parts staff before customer approval because the UI/API required a materialized `work_order_line_id`. The change enables quoting prior to approval while preserving allocation restrictions. 
- Keep inventory allocation/reservation and normal materialization flows unchanged until the quote is approved and a `work_order_line_id` exists.

### Description
- Add a new quote-only save API at `app/api/parts/requests/items/[itemId]/quote-save/route.ts` that: validates the caller and derives `shop_id` from the current profile, ensures the item is linked to a `quote_line_id`, prevents updates if the item is already materialized or has inventory activity, validates optional `part_id`/`vendor_id` scoped to the shop, writes editable quote fields (`description`, `qty`, `quoted_price`/`unit_price`, `vendor_id`, `part_id`) and sets `status` to `quoted` only when pricing is complete, and calls `syncQuoteLinePartsStatus` after save to update quote-line totals/stage/status.
- Update UI in `app/parts/requests/[id]/page.tsx` to allow pre-approval quote saves: add `savePreApprovalQuote` handler, show a `Save Quote` action for quote-line-originated items without a `work_order_line_id`, surface the message `Quote saved. Allocation will unlock after customer approval.`, and disable allocation/reserve/attach behavior for these rows until materialization.
- Keep the existing `Add`/allocation path for items that are materialized or manually linked to a work order line; do not call allocation RPCs from the quote-save flow and do not change invoice or allocation logic.
- Enforce strict shop scoping and safe validations across API and UI: checks include profile-derived `shop_id`, `part_request_items.shop_id`, parent `part_requests.shop_id`, matching `quote_line_id`, blocked statuses (`cancelled`, `rejected`, `declined`), and prevention of quote edits after inventory activity (`qty_received`, `qty_consumed`, `qty_reserved`, `qty_picked`).

### Testing
- Ran ESLint on touched files with `npx eslint app/parts/requests/[id]/page.tsx app/parts/requests/[id]/request-detail-components.tsx app/api/parts/requests/items/[itemId]/quote-line-sync/route.ts app/api/parts/requests/items/[itemId]/quote-save/route.ts features/parts/server/syncQuoteLinePartsStatus.ts app/api/parts/requests/create/route.ts features/parts/lib/requests/setPartRequestItemStatus.ts` and the linting passed.
- Ran type check with `npx tsc --noEmit` and it passed without errors.
- Ran repository checks `git diff --check` and `git status --short` to confirm no leftover whitespace or unexpected state; checks passed.
- Verified `syncQuoteLinePartsStatus` is invoked after a successful pre-approval quote save so quote-line totals/status/stage update correctly (fully quoted -> `quoted`/`ready_to_send`, partial -> `pending_parts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1a9e03c08328a5a8f91a42d848a7)