### PR TITLE
Phase 5E-4: owner-configurable shop supplies auto-apply (shop defaults + per-WO overrides, UI, snapshot & PDFs)

### DIFF
--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -4,6 +4,11 @@ import type { Database } from "@shared/types/types/supabase";
 import { runPostSendPersistence, sendQuoteReadyEmail } from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  calculateShopSupplies,
+  resolveShopSuppliesOverride,
+  resolveShopSuppliesSettings,
+} from "@/features/work-orders/lib/shopSupplies";
 
 type DB = Database;
 
@@ -177,13 +182,13 @@ export async function POST(req: Request) {
 
     const { data: wo, error: woErr } = await supabaseAdmin
       .from("work_orders")
-      .select("id, customer_id, shop_id, vehicle_id, quote_url")
+      .select("id, customer_id, shop_id, vehicle_id, quote_url, shop_supplies_enabled_override, shop_supplies_amount_override")
       .eq("id", workOrderId)
       .eq("shop_id", access.profile.shop_id)
       .maybeSingle<
         Pick<
           WorkOrderRow,
-          "id" | "customer_id" | "shop_id" | "vehicle_id" | "quote_url"
+          "id" | "customer_id" | "shop_id" | "vehicle_id" | "quote_url" | "shop_supplies_enabled_override" | "shop_supplies_amount_override"
         >
       >();
 
@@ -257,14 +262,15 @@ export async function POST(req: Request) {
     let shopName = safeStr(body?.shopName).trim() || "";
     let laborRate = 0;
     let brand: Awaited<ReturnType<typeof getActiveBrandForRender>> | null = null;
+    let shopForSupplies: Pick<ShopRow, "supplies_percent" | "shop_supplies_enabled" | "shop_supplies_type" | "shop_supplies_percent" | "shop_supplies_flat_amount" | "shop_supplies_cap_amount"> | null = null;
 
     if (wo.shop_id) {
       const { data: shop, error: shopErr } = await supabaseAdmin
         .from("shops")
-        .select("name, shop_name, labor_rate")
+        .select("name, shop_name, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount")
         .eq("id", wo.shop_id)
         .maybeSingle<
-          Pick<ShopRow, "name" | "shop_name" | "labor_rate">
+          Pick<ShopRow, "name" | "shop_name" | "labor_rate" | "supplies_percent" | "shop_supplies_enabled" | "shop_supplies_type" | "shop_supplies_percent" | "shop_supplies_flat_amount" | "shop_supplies_cap_amount">
         >();
 
       if (!shopErr && shop) {
@@ -273,6 +279,7 @@ export async function POST(req: Request) {
           safeStr(shop.shop_name).trim() ||
           safeStr(shop.name).trim();
         laborRate = asNumber(shop.labor_rate) ?? 0;
+        shopForSupplies = shop;
       }
 
       brand = await getActiveBrandForRender(wo.shop_id);
@@ -367,10 +374,24 @@ export async function POST(req: Request) {
       return { description, amount } satisfies QuoteLine;
     });
 
-    const computedTotal = computed.reduce((sum, line) => sum + line.amount, 0);
+    const computedLineTotal = computed.reduce((sum, line) => sum + line.amount, 0);
+    const computedLaborPartsBase = sendableQuoteLines.reduce((sum, line) => {
+      const labor = quoteLaborTotal(line, laborRate);
+      const parts = quotePartsTotal(line);
+      return sum + labor + parts;
+    }, 0);
+    const shopSupplies = calculateShopSupplies({
+      baseAmount: computedLaborPartsBase,
+      settings: resolveShopSuppliesSettings(shopForSupplies as Parameters<typeof resolveShopSuppliesSettings>[0]),
+      override: resolveShopSuppliesOverride(wo as Parameters<typeof resolveShopSuppliesOverride>[0]),
+    });
+    const computedTotal = computedLineTotal + shopSupplies.amount;
+    const computedWithSupplies = shopSupplies.amount > 0
+      ? [...computed, { description: "Shop supplies", amount: shopSupplies.amount } satisfies QuoteLine]
+      : computed;
     sendableQuoteLineIds = sendableQuoteLines.map((line) => line.id);
 
-    if (!lines || lines.length === 0) lines = computed;
+    if (!lines || lines.length === 0) lines = computedWithSupplies;
     if (typeof quoteTotal !== "number") quoteTotal = computedTotal;
     const pdfUrl = body?.pdfUrl ?? null;
 

--- a/app/api/settings/update/route.ts
+++ b/app/api/settings/update/route.ts
@@ -27,6 +27,11 @@ const ALLOWED_FIELDS = new Set([
   // numeric settings
   "labor_rate",
   "supplies_percent",
+  "shop_supplies_enabled",
+  "shop_supplies_type",
+  "shop_supplies_percent",
+  "shop_supplies_flat_amount",
+  "shop_supplies_cap_amount",
   "diagnostic_fee",
   "tax_rate",
 
@@ -84,11 +89,15 @@ export async function POST(req: Request) {
     const numericKeys = new Set([
       "labor_rate",
       "supplies_percent",
+      "shop_supplies_percent",
+      "shop_supplies_flat_amount",
+      "shop_supplies_cap_amount",
       "diagnostic_fee",
       "tax_rate",
     ]);
 
     const booleanKeys = new Set([
+      "shop_supplies_enabled",
       "use_ai",
       "require_cause_correction",
       "require_authorization",
@@ -110,6 +119,13 @@ export async function POST(req: Request) {
         const tz = String(v ?? "").trim();
         if (!tz) continue;
         safeUpdate.timezone = tz;
+        continue;
+      }
+
+      if (k === "shop_supplies_type") {
+        const type = String(v ?? "").trim().toLowerCase();
+        if (type !== "percentage" && type !== "flat") continue;
+        safeUpdate.shop_supplies_type = type;
         continue;
       }
 

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -436,6 +436,10 @@ export async function GET(
     snapshot.partsCost != null && Number.isFinite(snapshot.partsCost)
       ? snapshot.partsCost
       : derivedPartsCost;
+  const shopSuppliesTotal =
+    snapshot.shopSuppliesTotal != null && Number.isFinite(snapshot.shopSuppliesTotal)
+      ? Math.max(0, snapshot.shopSuppliesTotal)
+      : 0;
   const discountTotal =
     snapshot.discountTotal != null && Number.isFinite(snapshot.discountTotal)
       ? Math.max(0, snapshot.discountTotal)
@@ -818,6 +822,7 @@ export async function GET(
   ctxPdf = drawText(ctxPdf, `Subtotal: ${moneyLabel(subtotal, currency)}`, { size: 11 });
   ctxPdf = drawText(ctxPdf, `Labor: ${moneyLabel(laborCost, currency)}`, { size: 11, color: C_MUTED });
   ctxPdf = drawText(ctxPdf, `Parts: ${moneyLabel(partsCost, currency)}`, { size: 11, color: C_MUTED });
+  ctxPdf = drawText(ctxPdf, `Shop supplies: ${moneyLabel(shopSuppliesTotal, currency)}`, { size: 11, color: C_MUTED });
 
   if (discountTotal > 0) {
     ctxPdf = drawText(ctxPdf, `Discount: -${moneyLabel(discountTotal, currency)}`, { size: 11, color: C_MUTED });

--- a/app/portal/invoices/[id]/page.tsx
+++ b/app/portal/invoices/[id]/page.tsx
@@ -12,6 +12,11 @@ import {
 } from "@/features/portal/server/portalAuth";
 
 import PortalInvoicePayButton from "@/features/stripe/components/PortalInvoicePayButton";
+import {
+  calculateShopSupplies,
+  resolveShopSuppliesOverride,
+  resolveShopSuppliesSettings,
+} from "@/features/work-orders/lib/shopSupplies";
 
 export const dynamic = "force-dynamic";
 
@@ -41,6 +46,8 @@ type WorkOrderForPortalInvoice = Pick<
   | "invoice_total"
   | "labor_total"
   | "parts_total"
+  | "shop_supplies_enabled_override"
+  | "shop_supplies_amount_override"
 >;
 
 type InvoiceLite = Pick<
@@ -155,6 +162,16 @@ export default async function PortalInvoicePage({
 
   let lines: PortalLine[] = [];
   let parts: PartDisplayRow[] = [];
+  let shopForSupplies: Pick<
+    ShopRow,
+    | "country"
+    | "supplies_percent"
+    | "shop_supplies_enabled"
+    | "shop_supplies_type"
+    | "shop_supplies_percent"
+    | "shop_supplies_flat_amount"
+    | "shop_supplies_cap_amount"
+  > | null = null;
 
   // ✅ declare outside try so it’s usable later
   let partsTotalFromAlloc = 0;
@@ -167,7 +184,7 @@ export default async function PortalInvoicePage({
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
       .select(
-        "id, shop_id, customer_id, status, approval_state, created_at, custom_id, invoice_sent_at, invoice_last_sent_to, invoice_pdf_url, invoice_total, labor_total, parts_total",
+        "id, shop_id, customer_id, status, approval_state, created_at, custom_id, invoice_sent_at, invoice_last_sent_to, invoice_pdf_url, invoice_total, labor_total, parts_total, shop_supplies_enabled_override, shop_supplies_amount_override",
       )
       .eq("id", workOrderId)
       .eq("customer_id", customer.id)
@@ -182,15 +199,16 @@ export default async function PortalInvoicePage({
     if (workOrder.shop_id) {
       const { data: shop, error: shopErr } = await supabase
         .from("shops")
-        .select("country")
+        .select("country, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount")
         .eq("id", workOrder.shop_id)
-        .maybeSingle<Pick<ShopRow, "country">>();
+        .maybeSingle<Pick<ShopRow, "country" | "supplies_percent" | "shop_supplies_enabled" | "shop_supplies_type" | "shop_supplies_percent" | "shop_supplies_flat_amount" | "shop_supplies_cap_amount">>();
 
       if (shopErr) {
         // eslint-disable-next-line no-console
         console.warn("[portal invoice] shops query failed:", shopErr.message);
       }
 
+      shopForSupplies = shop ?? null;
       shopCountry = (shop?.country ?? null) as string | null;
     }
 
@@ -338,9 +356,27 @@ export default async function PortalInvoicePage({
   const invTax = safeNumberOrNull(invoice?.tax_total) ?? 0;
   const invDiscount = safeNumberOrNull(invoice?.discount_total) ?? 0;
 
+  // ✅ allocations parts fallback (your priced allocations)
+  const partsCostFromAlloc =
+    Number.isFinite(partsTotalFromAlloc) && partsTotalFromAlloc > 0 ? partsTotalFromAlloc : null;
+
+  // ✅ PDF-like fallback: allocations parts + WO labor (if present)
+  const computedBaseSubtotal = (woLabor ?? 0) + (partsCostFromAlloc ?? (woParts ?? 0));
+  const shopSupplies = calculateShopSupplies({
+    baseAmount: computedBaseSubtotal,
+    settings: resolveShopSuppliesSettings(shopForSupplies as Parameters<typeof resolveShopSuppliesSettings>[0]),
+    override: resolveShopSuppliesOverride(workOrder as Parameters<typeof resolveShopSuppliesOverride>[0]),
+  });
+  const shopSuppliesTotal = shopSupplies.amount > 0 ? shopSupplies.amount : null;
+
   // ✅ derive subtotal/total from invoice components only if they’re actually present (>0)
+  const invoiceBaseSubtotal = (invLabor ?? 0) + (invParts ?? 0);
   const derivedInvoiceSubtotal =
-    invSubtotal != null ? invSubtotal : (invLabor ?? 0) + (invParts ?? 0);
+    invSubtotal != null
+      ? invSubtotal <= invoiceBaseSubtotal + 0.005
+        ? invSubtotal + shopSupplies.amount
+        : invSubtotal
+      : invoiceBaseSubtotal + shopSupplies.amount;
 
   const derivedInvoiceTotalCandidate = derivedInvoiceSubtotal + invTax - invDiscount;
 
@@ -350,22 +386,22 @@ export default async function PortalInvoicePage({
     derivedInvoiceTotalCandidate > 0;
 
   const invoiceTotalFromInvoiceRow =
-    invTotalRaw != null ? invTotalRaw : shouldUseDerivedInvoiceTotal ? derivedInvoiceTotalCandidate : null;
+    invTotalRaw != null
+      ? invSubtotal != null && invSubtotal <= invoiceBaseSubtotal + 0.005
+        ? invTotalRaw + shopSupplies.amount
+        : invTotalRaw
+      : shouldUseDerivedInvoiceTotal
+        ? derivedInvoiceTotalCandidate
+        : null;
 
-  // ✅ allocations parts fallback (your priced allocations)
-  const partsCostFromAlloc =
-    Number.isFinite(partsTotalFromAlloc) && partsTotalFromAlloc > 0 ? partsTotalFromAlloc : null;
-
-  // ✅ PDF-like fallback: allocations parts + WO labor (if present)
-  const computedFallbackTotal =
-    (woLabor ?? 0) + (partsCostFromAlloc ?? (woParts ?? 0));
+  const computedFallbackTotal = computedBaseSubtotal + shopSupplies.amount;
 
   // ✅ last-resort fallback: WO invoice_total OR WO labor+parts
   const invoiceTotalFallback =
     woInvoiceTotal != null
       ? woInvoiceTotal
       : woLabor != null || woParts != null
-        ? (woLabor ?? 0) + (woParts ?? 0)
+        ? (woLabor ?? 0) + (woParts ?? 0) + shopSupplies.amount
         : null;
 
   // ✅ total selection: invoice-first (if real), then WO invoice_total, then computed, then fallback
@@ -391,9 +427,15 @@ export default async function PortalInvoicePage({
   // 2) (labor+parts) if either present
   // 3) derive from total (subtract tax, add discount)
   const subtotal =
-    invSubtotal ??
-    ((laborCost ?? 0) + (partsCost ?? 0) > 0 ? (laborCost ?? 0) + (partsCost ?? 0) : null) ??
-    (total != null ? Math.max(0, total - invTax + invDiscount) : null);
+    invSubtotal != null
+      ? invSubtotal <= (laborCost ?? 0) + (partsCost ?? 0) + 0.005
+        ? invSubtotal + shopSupplies.amount
+        : invSubtotal
+      : (laborCost ?? 0) + (partsCost ?? 0) + shopSupplies.amount > 0
+        ? (laborCost ?? 0) + (partsCost ?? 0) + shopSupplies.amount
+        : total != null
+          ? Math.max(0, total - invTax + invDiscount)
+          : null;
 
   const discountTotal = invDiscount > 0 ? invDiscount : null;
   const taxTotal = invTax > 0 ? invTax : null;
@@ -532,6 +574,11 @@ export default async function PortalInvoicePage({
               <div className="rounded-xl border border-white/5 bg-black/40 px-3 py-2">
                 <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Parts</div>
                 <div className="mt-1 text-sm font-semibold text-neutral-100">{formatCurrency(partsCost ?? null, currency)}</div>
+              </div>
+
+              <div className="rounded-xl border border-white/5 bg-black/40 px-3 py-2">
+                <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">Shop supplies</div>
+                <div className="mt-1 text-sm font-semibold text-neutral-100">{formatCurrency(shopSuppliesTotal ?? 0, currency)}</div>
               </div>
 
               <div className="rounded-xl border border-white/5 bg-black/40 px-3 py-2">

--- a/db/sql/2026-06-02_phase5e4_shop_supplies_auto_apply.sql
+++ b/db/sql/2026-06-02_phase5e4_shop_supplies_auto_apply.sql
@@ -1,0 +1,42 @@
+-- Phase 5E-4: owner-configurable shop supplies auto-apply.
+-- Additive and nullable/defaulted to avoid breaking existing shop/work-order flows.
+
+alter table public.shops
+  add column if not exists shop_supplies_enabled boolean default false,
+  add column if not exists shop_supplies_type text default 'percentage',
+  add column if not exists shop_supplies_percent numeric,
+  add column if not exists shop_supplies_flat_amount numeric,
+  add column if not exists shop_supplies_cap_amount numeric;
+
+alter table public.work_orders
+  add column if not exists shop_supplies_enabled_override boolean,
+  add column if not exists shop_supplies_amount_override numeric;
+
+update public.shops
+set
+  shop_supplies_enabled = coalesce(shop_supplies_enabled, supplies_percent is not null and supplies_percent > 0),
+  shop_supplies_type = coalesce(shop_supplies_type, 'percentage'),
+  shop_supplies_percent = coalesce(shop_supplies_percent, supplies_percent)
+where supplies_percent is not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'shops_shop_supplies_type_check'
+      and conrelid = 'public.shops'::regclass
+  ) then
+    alter table public.shops
+      add constraint shops_shop_supplies_type_check
+      check (shop_supplies_type is null or shop_supplies_type in ('percentage', 'flat'));
+  end if;
+end $$;
+
+comment on column public.shops.shop_supplies_enabled is 'Default auto-apply flag for shop supplies on quotes/work orders.';
+comment on column public.shops.shop_supplies_type is 'Default shop supplies calculation type: percentage or flat.';
+comment on column public.shops.shop_supplies_percent is 'Default shop supplies percentage when type is percentage.';
+comment on column public.shops.shop_supplies_flat_amount is 'Default shop supplies amount when type is flat.';
+comment on column public.shops.shop_supplies_cap_amount is 'Optional cap applied to calculated shop supplies before per-work-order amount overrides.';
+comment on column public.work_orders.shop_supplies_enabled_override is 'Nullable per-work-order override for including shop supplies.';
+comment on column public.work_orders.shop_supplies_amount_override is 'Nullable per-work-order fixed shop supplies amount override.';

--- a/db/sql/schema.sql
+++ b/db/sql/schema.sql
@@ -2565,6 +2565,11 @@ CREATE TABLE IF NOT EXISTS "public"."shops" (
     "logo_url" "text",
     "labor_rate" numeric,
     "supplies_percent" numeric,
+    "shop_supplies_enabled" boolean DEFAULT false,
+    "shop_supplies_type" "text" DEFAULT 'percentage'::"text",
+    "shop_supplies_percent" numeric,
+    "shop_supplies_flat_amount" numeric,
+    "shop_supplies_cap_amount" numeric,
     "diagnostic_fee" numeric,
     "tax_rate" numeric,
     "use_ai" boolean DEFAULT false,
@@ -3189,6 +3194,8 @@ CREATE TABLE IF NOT EXISTS "public"."work_orders" (
     "labor_total" numeric,
     "parts_total" numeric,
     "invoice_total" numeric,
+    "shop_supplies_enabled_override" boolean,
+    "shop_supplies_amount_override" numeric,
     "quote" "jsonb",
     "customer_name" "text",
     "vehicle_info" "text",
@@ -3607,6 +3614,10 @@ ALTER TABLE ONLY "public"."shop_time_slots"
 ALTER TABLE ONLY "public"."shops"
     ADD CONSTRAINT "shops_name_key" UNIQUE ("name");
 
+
+
+ALTER TABLE ONLY "public"."shops"
+    ADD CONSTRAINT "shops_shop_supplies_type_check" CHECK ((("shop_supplies_type" IS NULL) OR ("shop_supplies_type" = ANY (ARRAY['percentage'::"text", 'flat'::"text"]))));
 
 
 ALTER TABLE ONLY "public"."shops"

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -247,7 +247,11 @@ export default function OwnerSettingsPage() {
 
   // Money / defaults
   const [laborRate, setLaborRate] = useState("");
+  const [suppliesEnabled, setSuppliesEnabled] = useState(false);
+  const [suppliesType, setSuppliesType] = useState<"percentage" | "flat">("percentage");
   const [suppliesPercent, setSuppliesPercent] = useState("");
+  const [suppliesFlatAmount, setSuppliesFlatAmount] = useState("");
+  const [suppliesCapAmount, setSuppliesCapAmount] = useState("");
   const [diagnosticFee, setDiagnosticFee] = useState("");
   const [taxRate, setTaxRate] = useState("");
 
@@ -542,9 +546,17 @@ try {
       setTimezone((shop.timezone as string | null) || "America/New_York");
 
       setLaborRate(typeof shop.labor_rate === "number" ? String(shop.labor_rate) : "");
+      setSuppliesEnabled(Boolean((shop as { shop_supplies_enabled?: boolean | null }).shop_supplies_enabled ?? (typeof shop.supplies_percent === "number" && shop.supplies_percent > 0)));
+      setSuppliesType((shop as { shop_supplies_type?: string | null }).shop_supplies_type === "flat" ? "flat" : "percentage");
       setSuppliesPercent(
-        typeof shop.supplies_percent === "number" ? String(shop.supplies_percent) : "",
+        typeof (shop as { shop_supplies_percent?: number | null }).shop_supplies_percent === "number"
+          ? String((shop as { shop_supplies_percent?: number }).shop_supplies_percent)
+          : typeof shop.supplies_percent === "number"
+            ? String(shop.supplies_percent)
+            : "",
       );
+      setSuppliesFlatAmount(typeof (shop as { shop_supplies_flat_amount?: number | null }).shop_supplies_flat_amount === "number" ? String((shop as { shop_supplies_flat_amount?: number }).shop_supplies_flat_amount) : "");
+      setSuppliesCapAmount(typeof (shop as { shop_supplies_cap_amount?: number | null }).shop_supplies_cap_amount === "number" ? String((shop as { shop_supplies_cap_amount?: number }).shop_supplies_cap_amount) : "");
       setDiagnosticFee(
         typeof shop.diagnostic_fee === "number" ? String(shop.diagnostic_fee) : "",
       );
@@ -693,7 +705,12 @@ try {
         logo_url: logoUrl,
 
         labor_rate: laborRate ? parseFloat(laborRate) : null,
-        supplies_percent: suppliesPercent ? parseFloat(suppliesPercent) : null,
+        supplies_percent: suppliesType === "percentage" && suppliesPercent ? parseFloat(suppliesPercent) : null,
+        shop_supplies_enabled: suppliesEnabled,
+        shop_supplies_type: suppliesType,
+        shop_supplies_percent: suppliesPercent ? parseFloat(suppliesPercent) : null,
+        shop_supplies_flat_amount: suppliesFlatAmount ? parseFloat(suppliesFlatAmount) : null,
+        shop_supplies_cap_amount: suppliesCapAmount ? parseFloat(suppliesCapAmount) : null,
         diagnostic_fee: diagnosticFee ? parseFloat(diagnosticFee) : null,
         tax_rate: taxRate ? parseFloat(taxRate) : null,
 
@@ -1351,7 +1368,11 @@ try {
             currency={currency}
             taxLabel={taxLabel}
             laborRate={laborRate}
+            suppliesEnabled={suppliesEnabled}
+            suppliesType={suppliesType}
             suppliesPercent={suppliesPercent}
+            suppliesFlatAmount={suppliesFlatAmount}
+            suppliesCapAmount={suppliesCapAmount}
             diagnosticFee={diagnosticFee}
             taxRate={taxRate}
             pricingValidDays={pricingValidDays}
@@ -1365,7 +1386,11 @@ try {
             appearanceMode={appearanceMode}
             appearanceSaving={appearanceSaving}
             onLaborRateChange={setLaborRate}
+            onSuppliesEnabledChange={setSuppliesEnabled}
+            onSuppliesTypeChange={setSuppliesType}
             onSuppliesPercentChange={setSuppliesPercent}
+            onSuppliesFlatAmountChange={setSuppliesFlatAmount}
+            onSuppliesCapAmountChange={setSuppliesCapAmount}
             onDiagnosticFeeChange={setDiagnosticFee}
             onTaxRateChange={setTaxRate}
             onPricingValidDaysChange={setPricingValidDays}

--- a/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection.tsx
@@ -9,7 +9,11 @@ type Props = {
   currency: string;
   taxLabel: string;
   laborRate: string;
+  suppliesEnabled: boolean;
+  suppliesType: "percentage" | "flat";
   suppliesPercent: string;
+  suppliesFlatAmount: string;
+  suppliesCapAmount: string;
   diagnosticFee: string;
   taxRate: string;
   pricingValidDays: number;
@@ -23,7 +27,11 @@ type Props = {
   appearanceMode: "dark" | "light" | "system";
   appearanceSaving: boolean;
   onLaborRateChange: (value: string) => void;
+  onSuppliesEnabledChange: (value: boolean) => void;
+  onSuppliesTypeChange: (value: "percentage" | "flat") => void;
   onSuppliesPercentChange: (value: string) => void;
+  onSuppliesFlatAmountChange: (value: string) => void;
+  onSuppliesCapAmountChange: (value: string) => void;
   onDiagnosticFeeChange: (value: string) => void;
   onTaxRateChange: (value: string) => void;
   onPricingValidDaysChange: (value: number) => void;
@@ -41,7 +49,11 @@ export default function OwnerSettingsOperationsSection({
   currency,
   taxLabel,
   laborRate,
+  suppliesEnabled,
+  suppliesType,
   suppliesPercent,
+  suppliesFlatAmount,
+  suppliesCapAmount,
   diagnosticFee,
   taxRate,
   pricingValidDays,
@@ -55,7 +67,11 @@ export default function OwnerSettingsOperationsSection({
   appearanceMode,
   appearanceSaving,
   onLaborRateChange,
+  onSuppliesEnabledChange,
+  onSuppliesTypeChange,
   onSuppliesPercentChange,
+  onSuppliesFlatAmountChange,
+  onSuppliesCapAmountChange,
   onDiagnosticFeeChange,
   onTaxRateChange,
   onPricingValidDaysChange,
@@ -82,11 +98,42 @@ export default function OwnerSettingsOperationsSection({
             placeholder={`Labor rate (${currency}/hr)`}
             disabled={!isUnlocked}
           />
+          <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-xs text-neutral-300 md:col-span-2">
+            <input
+              type="checkbox"
+              checked={suppliesEnabled}
+              onChange={(e) => onSuppliesEnabledChange(e.target.checked)}
+              disabled={!isUnlocked}
+              className="h-4 w-4 accent-[color:var(--brand-accent,#E39A6E)]"
+            />
+            Auto-apply shop supplies to quotes and invoices
+          </label>
+          <select
+            value={suppliesType}
+            onChange={(e) => onSuppliesTypeChange(e.target.value === "flat" ? "flat" : "percentage")}
+            disabled={!isUnlocked || !suppliesEnabled}
+            className="h-10 rounded-md border border-white/10 bg-black/40 px-3 text-sm text-white disabled:opacity-60"
+          >
+            <option value="percentage">Percentage</option>
+            <option value="flat">Flat amount</option>
+          </select>
           <Input
             value={suppliesPercent}
             onChange={(e) => onSuppliesPercentChange(e.target.value)}
             placeholder="Shop supplies (%)"
-            disabled={!isUnlocked}
+            disabled={!isUnlocked || !suppliesEnabled || suppliesType !== "percentage"}
+          />
+          <Input
+            value={suppliesFlatAmount}
+            onChange={(e) => onSuppliesFlatAmountChange(e.target.value)}
+            placeholder={`Shop supplies flat (${currency})`}
+            disabled={!isUnlocked || !suppliesEnabled || suppliesType !== "flat"}
+          />
+          <Input
+            value={suppliesCapAmount}
+            onChange={(e) => onSuppliesCapAmountChange(e.target.value)}
+            placeholder={`Optional supplies cap (${currency})`}
+            disabled={!isUnlocked || !suppliesEnabled}
           />
           <Input
             value={diagnosticFee}

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -1,6 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import {
+  calculateShopSupplies,
+  resolveShopSuppliesOverride,
+  resolveShopSuppliesSettings,
+} from "@/features/work-orders/lib/shopSupplies";
 
 type DB = Database;
 
@@ -48,6 +53,8 @@ export type InvoiceSnapshot = {
     | "labor_total"
     | "parts_total"
     | "invoice_total"
+    | "shop_supplies_enabled_override"
+    | "shop_supplies_amount_override"
     | "created_at"
   >;
   invoice: Pick<
@@ -79,6 +86,12 @@ export type InvoiceSnapshot = {
     | "province"
     | "postal_code"
     | "labor_rate"
+    | "supplies_percent"
+    | "shop_supplies_enabled"
+    | "shop_supplies_type"
+    | "shop_supplies_percent"
+    | "shop_supplies_flat_amount"
+    | "shop_supplies_cap_amount"
   > | null;
   customer: Pick<
     CustomerRow,
@@ -111,6 +124,7 @@ export type InvoiceSnapshot = {
   currency: "CAD" | "USD";
   laborCost: number | null;
   partsCost: number | null;
+  shopSuppliesTotal: number | null;
   subtotal: number | null;
   discountTotal: number | null;
   taxTotal: number | null;
@@ -260,6 +274,8 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         | "labor_total"
         | "parts_total"
         | "invoice_total"
+        | "shop_supplies_enabled_override"
+        | "shop_supplies_amount_override"
         | "created_at"
       >
     >();
@@ -299,7 +315,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const { data: shop } = await supabase
     .from("shops")
     .select(
-      "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate",
+      "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount",
     )
     .eq("id", workOrder.shop_id)
     .maybeSingle<
@@ -316,6 +332,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         | "province"
         | "postal_code"
         | "labor_rate"
+    | "supplies_percent"
+    | "shop_supplies_enabled"
+    | "shop_supplies_type"
+    | "shop_supplies_percent"
+    | "shop_supplies_flat_amount"
+    | "shop_supplies_cap_amount"
       >
     >();
 
@@ -728,14 +750,31 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const laborCost = invLabor ?? (resolvedLabor > 0 ? resolvedLabor : woLabor) ?? null;
   const partsCost = invParts ?? (resolvedParts > 0 ? resolvedParts : partsTotalFromSnapshotParts ?? woParts) ?? null;
 
+  const baseSubtotal = (laborCost ?? 0) + (partsCost ?? 0);
+  const shopSupplies = calculateShopSupplies({
+    baseAmount: baseSubtotal,
+    settings: resolveShopSuppliesSettings(shop as Parameters<typeof resolveShopSuppliesSettings>[0]),
+    override: resolveShopSuppliesOverride(workOrder as Parameters<typeof resolveShopSuppliesOverride>[0]),
+  });
+  const shopSuppliesTotal = shopSupplies.amount > 0 ? shopSupplies.amount : null;
+
   const subtotal =
-    invSubtotal ??
-    ((laborCost ?? 0) + (partsCost ?? 0) > 0 ? (laborCost ?? 0) + (partsCost ?? 0) : null);
+    invSubtotal != null
+      ? invSubtotal <= baseSubtotal + 0.005
+        ? invSubtotal + shopSupplies.amount
+        : invSubtotal
+      : baseSubtotal + shopSupplies.amount > 0
+        ? baseSubtotal + shopSupplies.amount
+        : null;
 
   const derivedTotal =
     subtotal != null ? Math.max(0, subtotal + invTax - invDiscount) : null;
+  const adjustedInvoiceTotal =
+    invTotal != null && invSubtotal != null && invSubtotal <= baseSubtotal + 0.005
+      ? invTotal + shopSupplies.amount
+      : invTotal;
 
-  const total = invTotal ?? woInvoiceTotal ?? derivedTotal ?? null;
+  const total = adjustedInvoiceTotal ?? woInvoiceTotal ?? derivedTotal ?? null;
 
   return {
     workOrder,
@@ -748,6 +787,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     currency,
     laborCost,
     partsCost,
+    shopSuppliesTotal,
     subtotal,
     discountTotal: invDiscount > 0 ? invDiscount : null,
     taxTotal: invTax > 0 ? invTax : null,

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -14,6 +14,13 @@ import {
   isProvinceCode,
   type ProvinceCode,
 } from "@/features/integrations/tax";
+import {
+  calculateShopSupplies,
+  resolveShopSuppliesOverride,
+  resolveShopSuppliesSettings,
+  shopSuppliesSummaryText,
+  shopSuppliesTaxableSubtotal,
+} from "@/features/work-orders/lib/shopSupplies";
 
 const COPPER = "#C57A4A";
 const CUSTOMER_VISIBLE_QUOTE_STATUSES = new Set(["sent", "approved", "converted", "declined", "deferred"]);
@@ -374,12 +381,18 @@ export default function QuotePageClient(): JSX.Element {
   const pendingSubtotal = pendingLines.reduce((sum, line) => sum + line.totalAmount, 0);
   const approvedSubtotal = approvedLines.reduce((sum, line) => sum + line.totalAmount, 0);
   const declinedDeferredSubtotal = declinedDeferredLines.reduce((sum, line) => sum + line.totalAmount, 0);
-  const subtotal = lines.reduce((sum, line) => sum + line.totalAmount, 0);
+  const lineSubtotal = lines.reduce((sum, line) => sum + line.totalAmount, 0);
   const laborSubtotal = lines.reduce((sum, line) => sum + line.laborAmount, 0);
   const partsSubtotal = lines.reduce((sum, line) => sum + line.partsAmount, 0);
+  const shopSupplies = calculateShopSupplies({
+    baseAmount: laborSubtotal + partsSubtotal,
+    settings: resolveShopSuppliesSettings(shop as Parameters<typeof resolveShopSuppliesSettings>[0]),
+    override: resolveShopSuppliesOverride(workOrder as Parameters<typeof resolveShopSuppliesOverride>[0]),
+  });
+  const subtotal = lineSubtotal + shopSupplies.amount;
 
   const provinceCode = getShopProvinceCode(shop);
-  const taxRes = provinceCode ? calculateTax(subtotal, provinceCode) : null;
+  const taxRes = provinceCode ? calculateTax(lineSubtotal + shopSuppliesTaxableSubtotal(shopSupplies), provinceCode) : null;
   const taxAmount = lines.some((line) => line.taxAmount > 0) ? lines.reduce((sum, line) => sum + line.taxAmount, 0) : taxRes ? getTaxAmount(taxRes) : 0;
   const grandTotal = subtotal + (lines.some((line) => line.taxAmount > 0) ? 0 : taxAmount);
   return (
@@ -457,7 +470,7 @@ export default function QuotePageClient(): JSX.Element {
             </div>
           </div>
 
-          <div className="mb-6 grid gap-4 sm:grid-cols-2">
+          <div className="mb-6 grid gap-4 sm:grid-cols-3">
             <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3">
               <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Labor total</div>
               <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(laborSubtotal)}</div>
@@ -465,6 +478,11 @@ export default function QuotePageClient(): JSX.Element {
             <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3">
               <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Parts total</div>
               <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(partsSubtotal)}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-neutral-400">Shop supplies</div>
+              <div className="mt-1 text-lg font-semibold text-white">{formatCurrency(shopSupplies.amount)}</div>
+              <div className="mt-0.5 text-[11px] text-neutral-500">{shopSuppliesSummaryText(shopSupplies)}</div>
             </div>
           </div>
 

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -15130,6 +15130,11 @@ export type Database = {
           stripe_subscription_status: string | null
           stripe_trial_end: string | null
           supplies_percent: number | null
+          shop_supplies_enabled: boolean | null
+          shop_supplies_type: string | null
+          shop_supplies_percent: number | null
+          shop_supplies_flat_amount: number | null
+          shop_supplies_cap_amount: number | null
           tax_rate: number | null
           timezone: string | null
           updated_at: string | null
@@ -15192,6 +15197,11 @@ export type Database = {
           stripe_subscription_status?: string | null
           stripe_trial_end?: string | null
           supplies_percent?: number | null
+          shop_supplies_enabled?: boolean | null
+          shop_supplies_type?: string | null
+          shop_supplies_percent?: number | null
+          shop_supplies_flat_amount?: number | null
+          shop_supplies_cap_amount?: number | null
           tax_rate?: number | null
           timezone?: string | null
           updated_at?: string | null
@@ -15254,6 +15264,11 @@ export type Database = {
           stripe_subscription_status?: string | null
           stripe_trial_end?: string | null
           supplies_percent?: number | null
+          shop_supplies_enabled?: boolean | null
+          shop_supplies_type?: string | null
+          shop_supplies_percent?: number | null
+          shop_supplies_flat_amount?: number | null
+          shop_supplies_cap_amount?: number | null
           tax_rate?: number | null
           timezone?: string | null
           updated_at?: string | null
@@ -19634,6 +19649,8 @@ export type Database = {
           invoice_pdf_url: string | null
           invoice_sent_at: string | null
           invoice_total: number | null
+          shop_supplies_enabled_override: boolean | null
+          shop_supplies_amount_override: number | null
           invoice_url: string | null
           is_waiter: boolean
           labor_total: number | null
@@ -19702,6 +19719,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           is_waiter?: boolean
           labor_total?: number | null
@@ -19770,6 +19789,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           is_waiter?: boolean
           labor_total?: number | null
@@ -20432,6 +20453,8 @@ export type Database = {
           invoice_pdf_url: string | null
           invoice_sent_at: string | null
           invoice_total: number | null
+          shop_supplies_enabled_override: boolean | null
+          shop_supplies_amount_override: number | null
           invoice_url: string | null
           shop_id: string | null
           status: string | null
@@ -20447,6 +20470,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           shop_id?: string | null
           status?: string | null
@@ -20462,6 +20487,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           shop_id?: string | null
           status?: string | null

--- a/features/work-orders/lib/shopSupplies.ts
+++ b/features/work-orders/lib/shopSupplies.ts
@@ -1,0 +1,160 @@
+import type { Json } from "@shared/types/types/supabase";
+
+export type ShopSuppliesType = "percentage" | "flat";
+
+export type ShopSuppliesSettings = {
+  enabled: boolean;
+  type: ShopSuppliesType;
+  percent: number | null;
+  flatAmount: number | null;
+  capAmount: number | null;
+};
+
+export type ShopSuppliesOverride = {
+  enabled: boolean | null;
+  amount: number | null;
+};
+
+export type ShopSuppliesCalculation = {
+  enabled: boolean;
+  type: ShopSuppliesType;
+  percent: number | null;
+  flatAmount: number | null;
+  capAmount: number | null;
+  amount: number;
+  taxableAmount: number;
+  baseAmount: number;
+  isOverrideAmount: boolean;
+};
+
+type ShopSuppliesShop = {
+  shop_supplies_enabled?: unknown;
+  shop_supplies_type?: unknown;
+  shop_supplies_percent?: unknown;
+  shop_supplies_flat_amount?: unknown;
+  shop_supplies_cap_amount?: unknown;
+  supplies_percent?: unknown;
+};
+
+type ShopSuppliesWorkOrder = {
+  shop_supplies_enabled_override?: unknown;
+  shop_supplies_amount_override?: unknown;
+};
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function nonNegativeNumber(value: unknown): number | null {
+  const parsed = finiteNumber(value);
+  return parsed == null ? null : Math.max(0, parsed);
+}
+
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function normalizeType(value: unknown): ShopSuppliesType {
+  return String(value ?? "").trim().toLowerCase() === "flat" ? "flat" : "percentage";
+}
+
+export function resolveShopSuppliesSettings(shop: ShopSuppliesShop | null | undefined): ShopSuppliesSettings {
+  const legacyPercent = nonNegativeNumber(shop?.supplies_percent);
+  const percent = nonNegativeNumber(shop?.shop_supplies_percent) ?? legacyPercent;
+  const flatAmount = nonNegativeNumber(shop?.shop_supplies_flat_amount);
+  const capAmount = nonNegativeNumber(shop?.shop_supplies_cap_amount);
+  const type = normalizeType(shop?.shop_supplies_type);
+  const explicitEnabled = booleanOrNull(shop?.shop_supplies_enabled);
+  const enabled = explicitEnabled ?? Boolean((type === "flat" ? flatAmount : percent) && (type === "flat" ? flatAmount : percent)! > 0);
+
+  return {
+    enabled,
+    type,
+    percent,
+    flatAmount,
+    capAmount,
+  };
+}
+
+export function resolveShopSuppliesOverride(workOrder: ShopSuppliesWorkOrder | null | undefined): ShopSuppliesOverride {
+  return {
+    enabled: booleanOrNull(workOrder?.shop_supplies_enabled_override),
+    amount: nonNegativeNumber(workOrder?.shop_supplies_amount_override),
+  };
+}
+
+export function calculateShopSupplies(params: {
+  baseAmount: number;
+  settings: ShopSuppliesSettings;
+  override?: ShopSuppliesOverride | null;
+}): ShopSuppliesCalculation {
+  const baseAmount = Math.max(0, finiteNumber(params.baseAmount) ?? 0);
+  const override = params.override ?? null;
+  const enabled = override?.enabled ?? params.settings.enabled;
+  const type = params.settings.type;
+  let amount = 0;
+  let isOverrideAmount = false;
+
+  if (enabled) {
+    if (override?.amount != null) {
+      amount = override.amount;
+      isOverrideAmount = true;
+    } else if (type === "flat") {
+      amount = params.settings.flatAmount ?? 0;
+    } else {
+      amount = baseAmount * ((params.settings.percent ?? 0) / 100);
+    }
+  }
+
+  if (!isOverrideAmount && params.settings.capAmount != null) {
+    amount = Math.min(amount, params.settings.capAmount);
+  }
+
+  return {
+    enabled,
+    type,
+    percent: params.settings.percent,
+    flatAmount: params.settings.flatAmount,
+    capAmount: params.settings.capAmount,
+    amount: Math.max(0, roundMoney(amount)),
+    taxableAmount: Math.max(0, roundMoney(amount)),
+    baseAmount,
+    isOverrideAmount,
+  };
+}
+
+export function roundMoney(value: number): number {
+  return Math.round((Number.isFinite(value) ? value : 0) * 100) / 100;
+}
+
+export function shopSuppliesTaxableSubtotal(calc: ShopSuppliesCalculation): number {
+  return calc.taxableAmount;
+}
+
+export function shopSuppliesSummaryText(calc: ShopSuppliesCalculation): string {
+  if (!calc.enabled) return "Disabled for this work order";
+  if (calc.isOverrideAmount) return "Advisor override";
+  if (calc.type === "flat") return "Flat shop supplies";
+  const pct = calc.percent ?? 0;
+  const cap = calc.capAmount != null ? `, capped at ${roundMoney(calc.capAmount).toFixed(2)}` : "";
+  return `${pct}% of labor + parts${cap}`;
+}
+
+export function shopSuppliesMetadata(calc: ShopSuppliesCalculation): Json {
+  return {
+    enabled: calc.enabled,
+    type: calc.type,
+    percent: calc.percent,
+    flat_amount: calc.flatAmount,
+    cap_amount: calc.capAmount,
+    amount: calc.amount,
+    taxable_amount: calc.taxableAmount,
+    base_amount: calc.baseAmount,
+    override_amount: calc.isOverrideAmount,
+  } as Json;
+}

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -10,6 +10,12 @@ import type { Database, Json } from "@shared/types/types/supabase";
 import AddJobModal from "@/features/work-orders/components/workorders/AddJobModal";
 import { formatCurrency } from "@/features/shared/lib/formatCurrency";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
+import {
+  calculateShopSupplies,
+  resolveShopSuppliesOverride,
+  resolveShopSuppliesSettings,
+  shopSuppliesSummaryText,
+} from "@/features/work-orders/lib/shopSupplies";
 
 const COPPER = "#C57A4A";
 const SEND_READY_STAGES = new Set(["advisor_pending", "ready_to_send"]);
@@ -324,6 +330,9 @@ export default function QuoteReviewView(props: {
   const [sendBlocker, setSendBlocker] = useState<string | null>(null);
   const [addJobOpen, setAddJobOpen] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string>("system");
+  const [suppliesEnabledDraft, setSuppliesEnabledDraft] = useState<boolean | null>(null);
+  const [suppliesAmountDraft, setSuppliesAmountDraft] = useState("");
+  const [savingSuppliesOverride, setSavingSuppliesOverride] = useState(false);
 
   const laborRate = useMemo(() => asNumber((shop as unknown as { labor_rate?: unknown } | null)?.labor_rate) ?? 120, [shop]);
 
@@ -351,6 +360,10 @@ export default function QuoteReviewView(props: {
     }
 
     setWo(woRow ?? null);
+    const loadedSuppliesEnabled = (woRow as { shop_supplies_enabled_override?: unknown } | null)?.shop_supplies_enabled_override;
+    setSuppliesEnabledDraft(typeof loadedSuppliesEnabled === "boolean" ? loadedSuppliesEnabled : null);
+    const loadedSuppliesAmount = (woRow as { shop_supplies_amount_override?: unknown } | null)?.shop_supplies_amount_override;
+    setSuppliesAmountDraft(typeof loadedSuppliesAmount === "number" ? String(loadedSuppliesAmount) : "");
     const shopId = woRow?.shop_id ?? null;
 
     if (shopId) {
@@ -424,12 +437,24 @@ export default function QuoteReviewView(props: {
   const quoteTotals = useMemo(() => {
     const labor = quoteLines.reduce((sum, line) => sum + quoteLineLaborTotal(line, laborRate), 0);
     const parts = quoteLines.reduce((sum, line) => sum + quoteLinePartsTotal(line), 0);
-    const total = quoteLines.reduce((sum, line) => sum + quoteLineTotal(line, laborRate), 0);
+    const linesTotal = quoteLines.reduce((sum, line) => sum + quoteLineTotal(line, laborRate), 0);
+    const baseSubtotal = labor + parts;
+    const persistedOverride = resolveShopSuppliesOverride(wo as Parameters<typeof resolveShopSuppliesOverride>[0]);
+    const draftOverride = {
+      enabled: suppliesEnabledDraft,
+      amount: suppliesAmountDraft.trim() ? asNumber(suppliesAmountDraft) : persistedOverride.amount,
+    };
+    const shopSupplies = calculateShopSupplies({
+      baseAmount: baseSubtotal,
+      settings: resolveShopSuppliesSettings(shop as Parameters<typeof resolveShopSuppliesSettings>[0]),
+      override: draftOverride,
+    });
+    const total = linesTotal + shopSupplies.amount;
     const sendable = quoteLines.filter(canSendLine).length;
     const pendingParts = quoteLines.filter((line) => safeTrim(line.status).toLowerCase() === "pending_parts").length;
     const sent = quoteLines.filter((line) => safeTrim(line.status).toLowerCase() === "sent" || Boolean(line.sent_to_customer_at)).length;
-    return { labor, parts, total, sendable, pendingParts, sent };
-  }, [laborRate, quoteLines]);
+    return { labor, parts, linesTotal, shopSupplies, total, sendable, pendingParts, sent };
+  }, [laborRate, quoteLines, shop, suppliesAmountDraft, suppliesEnabledDraft, wo]);
 
   const customerEmail = safeTrim(customer?.email ?? "");
   const customerPhone = safeTrim(customer?.phone ?? "");
@@ -483,7 +508,7 @@ export default function QuoteReviewView(props: {
           labor_total: laborTotal,
           parts_total: partsTotal,
           subtotal,
-          grand_total: asNumber(line.grand_total) ?? subtotal,
+          grand_total: subtotal,
           status: line.status,
           stage: line.stage,
           metadata,
@@ -530,6 +555,40 @@ export default function QuoteReviewView(props: {
     }
     toast.success(`Quote line marked ${statusLabel(status)}.`);
     await reload();
+  }
+
+  async function saveSuppliesOverride() {
+    if (!wo?.shop_id || savingSuppliesOverride) return;
+    const amountOverride = suppliesAmountDraft.trim() ? asNumber(suppliesAmountDraft) : null;
+    if (suppliesAmountDraft.trim() && amountOverride == null) {
+      toast.error("Enter a valid shop supplies override amount.");
+      return;
+    }
+
+    setSavingSuppliesOverride(true);
+    try {
+      const { error } = await supabase
+        .from("work_orders")
+        .update({
+          shop_supplies_enabled_override: suppliesEnabledDraft,
+          shop_supplies_amount_override: amountOverride,
+          updated_at: new Date().toISOString(),
+        } as DB["public"]["Tables"]["work_orders"]["Update"])
+        .eq("id", wo.id)
+        .eq("shop_id", wo.shop_id);
+      if (error) throw error;
+      toast.success("Shop supplies override saved.");
+      await reload();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save shop supplies override.");
+    } finally {
+      setSavingSuppliesOverride(false);
+    }
+  }
+
+  function resetSuppliesOverride() {
+    setSuppliesEnabledDraft(null);
+    setSuppliesAmountDraft("");
   }
 
   async function saveCustomerEmailInline() {
@@ -867,7 +926,33 @@ export default function QuoteReviewView(props: {
                 <div className="mt-2 flex items-center justify-between"><span>Sent</span><span className="font-semibold text-white">{quoteTotals.sent}</span></div>
                 <div className={`mt-3 flex items-center justify-between border-t ${divider} pt-3`}><span>Labor</span><span className="font-medium text-white">{fmt(quoteTotals.labor)}</span></div>
                 <div className="mt-2 flex items-center justify-between"><span>Parts</span><span className="font-medium text-white">{fmt(quoteTotals.parts)}</span></div>
+                <div className="mt-2 flex items-center justify-between"><span>Shop supplies</span><span className="font-medium text-white">{fmt(quoteTotals.shopSupplies.amount)}</span></div>
+                <div className="mt-1 text-xs text-neutral-500">{shopSuppliesSummaryText(quoteTotals.shopSupplies)}</div>
                 <div className={`mt-3 flex items-center justify-between border-t ${divider} pt-3`}><span className="font-semibold text-white">Grand total</span><span className="text-lg font-bold" style={{ color: COPPER }}>{fmt(quoteTotals.total)}</span></div>
+                <div className={`mt-4 border-t ${divider} pt-3`}>
+                  <div className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Shop supplies override</div>
+                  <select
+                    value={suppliesEnabledDraft == null ? "default" : suppliesEnabledDraft ? "on" : "off"}
+                    onChange={(e) => setSuppliesEnabledDraft(e.target.value === "default" ? null : e.target.value === "on")}
+                    className="mt-2 w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white outline-none"
+                  >
+                    <option value="default">Use shop default</option>
+                    <option value="on">Include shop supplies</option>
+                    <option value="off">Remove shop supplies</option>
+                  </select>
+                  <input
+                    value={suppliesAmountDraft}
+                    onChange={(e) => setSuppliesAmountDraft(e.target.value)}
+                    placeholder="Optional fixed override amount"
+                    className="mt-2 w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500"
+                  />
+                  <div className="mt-2 grid grid-cols-2 gap-2">
+                    <button type="button" onClick={() => void saveSuppliesOverride()} disabled={savingSuppliesOverride} className="desktop-btn-secondary rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-60">
+                      {savingSuppliesOverride ? "Saving…" : "Save override"}
+                    </button>
+                    <button type="button" onClick={resetSuppliesOverride} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-white/10">Reset draft</button>
+                  </div>
+                </div>
                 <button onClick={() => void saveAllDirty()} disabled={saving} className="desktop-btn-primary mt-4 w-full rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-60">
                   {saving ? "Saving…" : "Save changes"}
                 </button>

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -9696,6 +9696,11 @@ export type Database = {
           stripe_subscription_status: string | null
           stripe_trial_end: string | null
           supplies_percent: number | null
+          shop_supplies_enabled: boolean | null
+          shop_supplies_type: string | null
+          shop_supplies_percent: number | null
+          shop_supplies_flat_amount: number | null
+          shop_supplies_cap_amount: number | null
           tax_rate: number | null
           timezone: string | null
           updated_at: string | null
@@ -9757,6 +9762,11 @@ export type Database = {
           stripe_subscription_status?: string | null
           stripe_trial_end?: string | null
           supplies_percent?: number | null
+          shop_supplies_enabled?: boolean | null
+          shop_supplies_type?: string | null
+          shop_supplies_percent?: number | null
+          shop_supplies_flat_amount?: number | null
+          shop_supplies_cap_amount?: number | null
           tax_rate?: number | null
           timezone?: string | null
           updated_at?: string | null
@@ -9818,6 +9828,11 @@ export type Database = {
           stripe_subscription_status?: string | null
           stripe_trial_end?: string | null
           supplies_percent?: number | null
+          shop_supplies_enabled?: boolean | null
+          shop_supplies_type?: string | null
+          shop_supplies_percent?: number | null
+          shop_supplies_flat_amount?: number | null
+          shop_supplies_cap_amount?: number | null
           tax_rate?: number | null
           timezone?: string | null
           updated_at?: string | null
@@ -13327,6 +13342,8 @@ export type Database = {
           invoice_pdf_url: string | null
           invoice_sent_at: string | null
           invoice_total: number | null
+          shop_supplies_enabled_override: boolean | null
+          shop_supplies_amount_override: number | null
           invoice_url: string | null
           is_waiter: boolean
           labor_total: number | null
@@ -13393,6 +13410,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           is_waiter?: boolean
           labor_total?: number | null
@@ -13459,6 +13478,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           is_waiter?: boolean
           labor_total?: number | null
@@ -14032,6 +14053,8 @@ export type Database = {
           invoice_pdf_url: string | null
           invoice_sent_at: string | null
           invoice_total: number | null
+          shop_supplies_enabled_override: boolean | null
+          shop_supplies_amount_override: number | null
           invoice_url: string | null
           shop_id: string | null
           status: string | null
@@ -14047,6 +14070,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           shop_id?: string | null
           status?: string | null
@@ -14062,6 +14087,8 @@ export type Database = {
           invoice_pdf_url?: string | null
           invoice_sent_at?: string | null
           invoice_total?: number | null
+          shop_supplies_enabled_override?: boolean | null
+          shop_supplies_amount_override?: number | null
           invoice_url?: string | null
           shop_id?: string | null
           status?: string | null


### PR DESCRIPTION
### Motivation

- Add an owner/admin-configurable shop supplies feature that can automatically apply to canonical quotes/work orders while allowing per-work-order overrides.  
- Ensure shop supplies are visible as a separate line on quote review, customer portal quote totals, approval pages, and invoice snapshots/PDFs (do not hide inside labor/parts).  
- Preserve tenant/shop scoping and RLS behavior while keeping the change additive and non-breaking.

### Description

- Database: added migration `db/sql/2026-06-02_phase5e4_shop_supplies_auto_apply.sql` to introduce new columns on `shops` (`shop_supplies_*`) and per-work-order overrides on `work_orders` (`shop_supplies_enabled_override`, `shop_supplies_amount_override`) and included a `CHECK` for `shop_supplies_type`.  
- Library: new helper `features/work-orders/lib/shopSupplies.ts` implements settings resolution, per-work-order overrides, calculation, rounding, and summary/metadata helpers.  
- Owner settings: extended owner settings UI and settings API to expose `shop_supplies` defaults (enabled/type/percent/flat/cap); server `app/api/settings/update/route.ts` was updated to accept and validate the new fields.  
- Quote & approval flows: `features/work-orders/quote-review/QuoteReviewView.tsx` computes shop supplies (shop default + per-WO override/draft), displays shop supplies as a separate totals line, and adds a per-work-order override editor (enable/remove/override amount).  
- Customer portal: `features/portal/app/quotes/[id]/QuotePageClient.tsx` shows shop supplies as its own line and summary text.  
- Invoice snapshot & rendering: `features/invoices/server/getInvoiceSnapshot.ts` now calculates and returns `shopSuppliesTotal`; `app/api/work-orders/[id]/invoice-pdf/route.ts` and `app/portal/invoices/[id]/page.tsx` include the supplies line in totals and PDF output.  
- Back-compat: where applicable code prefers existing invoice/snapshot fields (invoice-first) and falls back to computed totals including shop supplies; preserved `shop_id` checks and `set_current_shop_id` patterns where used.  
- Misc: ESLint autofixes and small typing/formatting updates applied to changed files.

### Testing

- ESLint: ran `eslint --fix` on modified files and applied autofixes; lint pass completed (tool emitted environment warnings only).  
- Snapshot/integration checks: exercised quote review, portal quote, and invoice snapshot rendering paths in the dev workspace to verify the shop supplies line appears and per-work-order override can be saved (manual smoke checks).  
- Typecheck: a full `npx tsc --noEmit` was not executed in this session; please run `npx tsc --noEmit` in CI or locally before merging to verify type correctness across the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f23d059e88328a941655aa565cbb3)