### PR TITLE
Fix shop user seat count query

### DIFF
--- a/features/shared/lib/server/shop-seat-limit.ts
+++ b/features/shared/lib/server/shop-seat-limit.ts
@@ -49,14 +49,16 @@ export async function getShopSeatLimitSnapshot(
     stripeStatus: shop?.stripe_subscription_status ?? null,
   });
 
+  // `profiles` is the app's provisioned-user table for shop access.
+  // It does not currently have an `is_active` flag; deleted users are removed
+  // from this table and pending invite candidates are not inserted here yet.
   const { count: activeUsers, error: countErr } = await admin
     .from("profiles")
     .select("id", { count: "exact", head: true })
-    .eq("shop_id", shopId)
-    .eq("is_active", true);
+    .eq("shop_id", shopId);
 
   if (countErr) {
-    throw new Error(`Failed to count active shop users: ${countErr.message}`);
+    throw new Error(`Failed to count shop users: ${countErr.message}`);
   }
 
   return {


### PR DESCRIPTION
### Motivation
- The owner/admin create-user flow was failing with “Failed to count active shop users” because the seat-limit helper queried `profiles` with a non-existent `.is_active` filter, causing the route to return HTTP 400 before provisioning users.

### Description
- Remove the unsupported `.eq("is_active", true)` filter and adjust the error message in `getShopSeatLimitSnapshot` so the active-user count is correctly performed as `.eq("shop_id", shopId)` and add a short comment documenting that `profiles` represents provisioned app users (file: `features/shared/lib/server/shop-seat-limit.ts`).

### Testing
- Ran TypeScript validation with `npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2c34057883288248177a869e39c0)