### PR TITLE
Secure VIN endpoints and add VIN normalization

### DIFF
--- a/app/api/ocr/registration/route.ts
+++ b/app/api/ocr/registration/route.ts
@@ -1,5 +1,7 @@
 // app/api/ocr/registration/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
@@ -8,12 +10,16 @@ export const runtime = "nodejs";
 
 const client = getOpenAIClient();
 
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+]);
+
 /* ----------------------------- helpers ----------------------------- */
-function normalizeVin(raw?: string | null): string | null {
-  if (!raw) return null;
-  const cleaned = raw.replace(/[^a-zA-Z0-9]/g, "").toUpperCase().replace(/[IOQ]/g, "");
-  return cleaned.length === 17 ? cleaned : cleaned || null;
-}
 function clean(v: unknown): string | null {
   if (typeof v === "string") {
     const t = v.trim();
@@ -53,7 +59,7 @@ function coerceFields(obj: unknown): Partial<Fields> {
     obj && typeof obj === "object" && k in obj ? clean((obj as Record<string, unknown>)[k]) : null;
 
   return {
-    vin: normalizeVin(get("vin")),
+    vin: normalizeVinInput(get("vin")).vin || null,
     plate: get("plate"),
     year: get("year"),
     make: get("make"),
@@ -74,6 +80,24 @@ function coerceFields(obj: unknown): Partial<Fields> {
 /* ------------------------------ handler ---------------------------- */
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createServerSupabaseRSC();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    const userId = userData.user?.id ?? null;
+
+    if (userError || !userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("id", userId)
+      .maybeSingle();
+
+    if (profileError || !profile?.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const ctype = req.headers.get("content-type") || "";
 
     let imageUrl: string | undefined;
@@ -84,6 +108,12 @@ export async function POST(req: NextRequest) {
       const file = form.get("file") as File | null;
       if (!file) {
         return NextResponse.json({ error: "Missing 'file' in form-data." }, { status: 400 });
+      }
+      if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+        return NextResponse.json({ error: "Unsupported image type" }, { status: 415 });
+      }
+      if (file.size > MAX_IMAGE_BYTES) {
+        return NextResponse.json({ error: "Image must be 8 MB or smaller" }, { status: 413 });
       }
       const buf = Buffer.from(await file.arrayBuffer());
       const base64 = buf.toString("base64");

--- a/app/api/vehicle/ensure/route.ts
+++ b/app/api/vehicle/ensure/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import type { Database } from "@shared/types/types/supabase";
 
 type Body = {
@@ -20,10 +21,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const rawVin = (body.vin || "").trim().toUpperCase();
-  if (rawVin.length !== 17) {
-    return NextResponse.json({ error: "VIN must be 17 characters" }, { status: 400 });
+  const vinCheck = normalizeVinInput(body.vin);
+  if (!vinCheck.isValid) {
+    return NextResponse.json(
+      { error: vinCheck.message, reason: vinCheck.reason },
+      { status: 400 },
+    );
   }
+  const rawVin = vinCheck.vin;
 
   // get the signed-in user + shop_id
   const { data: u } = await supabase.auth.getUser();
@@ -37,6 +42,9 @@ export async function POST(req: Request) {
     .maybeSingle();
 
   const shopId = profile?.shop_id ?? null;
+  if (!shopId) {
+    return NextResponse.json({ error: "Your profile isn’t linked to a shop yet." }, { status: 403 });
+  }
 
   // ensure placeholder customer in this shop (re-uses your "Walk-in Customer" pattern)
   async function ensureWalkInCustomer(): Promise<Database["public"]["Tables"]["customers"]["Row"]> {
@@ -59,11 +67,12 @@ export async function POST(req: Request) {
     return created;
   }
 
-  // Try to find vehicle by VIN within this shop (or globally if shop not present).
+  // Try to find vehicle by VIN within this shop.
   const vehQ = supabase
     .from("vehicles")
     .select("*")
     .eq("vin", rawVin)
+    .eq("shop_id", shopId)
     .order("created_at", { ascending: false })
     .limit(1);
   const { data: foundVeh } = await vehQ;

--- a/app/api/vin/extract-from-image/route.ts
+++ b/app/api/vin/extract-from-image/route.ts
@@ -1,21 +1,75 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
 const openai = getOpenAIClient();
 
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+]);
+
 function findVinLike(text: string): string | null {
-  const match = text.toUpperCase().match(/[A-HJ-NPR-Z0-9]{17}/);
-  return match ? match[0] : null;
+  const direct = normalizeVinInput(text);
+  if (direct.isValid) return direct.vin;
+
+  const candidates = text
+    .toUpperCase()
+    .match(/[A-Z0-9][A-Z0-9\s\-_.:/\\|]{15,}[A-Z0-9]/g);
+
+  for (const candidate of candidates ?? []) {
+    const normalized = normalizeVinInput(candidate);
+    if (normalized.isValid) return normalized.vin;
+  }
+
+  return null;
 }
 
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createServerSupabaseRSC();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    const userId = userData.user?.id ?? null;
+
+    if (userError || !userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("id", userId)
+      .maybeSingle();
+
+    if (profileError || !profile?.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const formData = await req.formData();
     const file = formData.get("image") as File | null;
 
     if (!file) {
       return NextResponse.json({ error: "No image provided" }, { status: 400 });
+    }
+
+    if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+      return NextResponse.json(
+        { error: "Unsupported image type" },
+        { status: 415 },
+      );
+    }
+
+    if (file.size > MAX_IMAGE_BYTES) {
+      return NextResponse.json(
+        { error: "Image must be 8 MB or smaller" },
+        { status: 413 },
+      );
     }
 
     const bytes = Buffer.from(await file.arrayBuffer());

--- a/app/api/vin/route.ts
+++ b/app/api/vin/route.ts
@@ -1,5 +1,7 @@
 // app/api/vin/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 
 type VpicRow = {
   ModelYear?: string;
@@ -24,6 +26,24 @@ type VpicResponse = {
 
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createServerSupabaseRSC();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    const userId = userData.user?.id ?? null;
+
+    if (userError || !userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("id", userId)
+      .maybeSingle();
+
+    if (profileError || !profile?.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const contentType = req.headers.get("content-type") || "";
 
     let vin: string | null = null;
@@ -41,12 +61,15 @@ export async function POST(req: NextRequest) {
       // const u = form.get("user_id"); // not used currently
     }
 
-    if (!vin || vin.length !== 17) {
+    const vinCheck = normalizeVinInput(vin);
+    if (!vinCheck.isValid) {
       return NextResponse.json(
-        { error: "Invalid VIN: must be a 17-character VIN." },
+        { error: vinCheck.message, reason: vinCheck.reason },
         { status: 400 },
       );
     }
+
+    vin = vinCheck.vin;
 
     const url =
       "https://vpic.nhtsa.dot.gov/api/vehicles/DecodeVinValuesExtended/" +

--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import ModalShell from "@/features/shared/components/ModalShell";
 import VinCaptureModalContent from "@/features/vehicles/components/VinCaptureModal";
 import { decodeVin } from "@/features/shared/lib/vin/decodeVin";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 
 // Optional: tame TS around experimental BarcodeDetector
@@ -61,8 +62,7 @@ type DecodeVinResponseExtended = DecodeVinResponse & {
 };
 
 function isLikelyVin(s: string) {
-  const vin = s.replace(/[^A-Z0-9]/gi, "").toUpperCase();
-  return vin.length === 17 && !/[IOQ]/.test(vin);
+  return normalizeVinInput(s).isValid;
 }
 
 /** Scanner pane used in scanSlot */
@@ -111,10 +111,10 @@ function ScannerPane({
               if (codes?.length) {
                 for (const c of codes) {
                   const raw = String(c.rawValue ?? "");
-                  const cleaned = raw.replace(/[^A-Z0-9]/gi, "").toUpperCase();
-                  if (isLikelyVin(cleaned)) {
+                  const cleaned = normalizeVinInput(raw);
+                  if (cleaned.isValid) {
                     lockedRef.current = true;
-                    onFoundVin(cleaned);
+                    onFoundVin(cleaned.vin);
                     return;
                   }
                 }
@@ -214,8 +214,9 @@ function ScannerPane({
               }
 
               const data = (await res.json()) as { vin?: string | null };
-              const vin = data?.vin?.toString().toUpperCase() ?? "";
-              if (!vin || !isLikelyVin(vin)) {
+              const extractedVin = normalizeVinInput(data?.vin);
+              const vin = extractedVin.vin;
+              if (!extractedVin.isValid || !isLikelyVin(vin)) {
                 alert(
                   "No clear VIN found in the photo. Please retake or type it manually.",
                 );
@@ -305,10 +306,15 @@ export default function VinCaptureModal({
 
   const handleFoundVin = useCallback(
     async (vin: string) => {
+      const normalizedVin = normalizeVinInput(vin);
+      if (!normalizedVin.isValid) {
+        alert(normalizedVin.message);
+        return;
+      }
       if (isDecoding) return; // prevent double fires
       setIsDecoding(true);
       try {
-        const resp = await decodeVin(vin, userId);
+        const resp = await decodeVin(normalizedVin.vin, userId);
         if (resp?.error) {
           alert(resp.error);
           return;
@@ -318,7 +324,7 @@ export default function VinCaptureModal({
 
         // hydrate shared draft
         setVehicleDraft({
-          vin,
+          vin: normalizedVin.vin,
           year: resp.year ?? null,
           make: resp.make ?? null,
           model: resp.model ?? null,
@@ -327,7 +333,7 @@ export default function VinCaptureModal({
         });
 
         const detail: VinDecodedDetail = {
-          vin,
+          vin: normalizedVin.vin,
           year: resp.year ?? null,
           make: resp.make ?? null,
           model: resp.model ?? null,
@@ -349,7 +355,7 @@ export default function VinCaptureModal({
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              vin,
+              vin: normalizedVin.vin,
               year: resp.year ?? undefined,
               make: resp.make ?? undefined,
               model: resp.model ?? undefined,

--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -8,6 +8,7 @@ import type {
   SessionVehicle as VehicleInfo,
 } from "@inspections/lib/inspection/types";
 import { normalizeCustomerForIntake } from "@inspections/lib/customerNormalization";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 
 /** Local, narrow shapes (avoid exporting DB row types in props) */
 type CustomerRow = {
@@ -417,7 +418,8 @@ export default function CustomerVehicleForm({
 
   const safeSetVehicle = useCallback(
     (field: keyof VehicleInfo, value: string | null | undefined) => {
-      onVehicleChange(field, value ?? null);
+      const nextValue = field === "vin" ? normalizeVinInput(value).vin || null : value ?? null;
+      onVehicleChange(field, nextValue);
     },
     [onVehicleChange],
   );

--- a/features/shared/lib/vin/decodeVin.ts
+++ b/features/shared/lib/vin/decodeVin.ts
@@ -1,3 +1,5 @@
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+
 export type DecodedVin = {
   year?: string | null;
   make?: string | null;
@@ -19,10 +21,15 @@ export async function decodeVin(
   vin: string,
   userId: string,
 ): Promise<DecodedVin> {
+  const normalizedVin = normalizeVinInput(vin);
+  if (!normalizedVin.isValid) {
+    return { error: normalizedVin.message };
+  }
+
   const res = await fetch("/api/vin", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ vin, user_id: userId }),
+    body: JSON.stringify({ vin: normalizedVin.vin, user_id: userId }),
   });
 
   if (!res.ok) {

--- a/features/shared/lib/vin/normalizeVin.ts
+++ b/features/shared/lib/vin/normalizeVin.ts
@@ -1,0 +1,73 @@
+export type VinValidationReason =
+  | "valid"
+  | "empty"
+  | "invalid_character"
+  | "forbidden_character"
+  | "invalid_length";
+
+export type NormalizedVinResult = {
+  vin: string;
+  isValid: boolean;
+  reason: VinValidationReason;
+  message: string;
+};
+
+const VIN_LENGTH = 17;
+const VIN_SEPARATORS = /[\s\-_.:/\\|]+/g;
+const VIN_ALLOWED_CHARS = /^[A-Z0-9]*$/;
+const VIN_FORBIDDEN_CHARS = /[IOQ]/;
+
+export function normalizeVinInput(input: unknown): NormalizedVinResult {
+  const normalized = String(input ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(VIN_SEPARATORS, "");
+
+  if (!normalized) {
+    return {
+      vin: normalized,
+      isValid: false,
+      reason: "empty",
+      message: "VIN is required.",
+    };
+  }
+
+  if (!VIN_ALLOWED_CHARS.test(normalized)) {
+    return {
+      vin: normalized,
+      isValid: false,
+      reason: "invalid_character",
+      message: "VIN can only contain letters and numbers.",
+    };
+  }
+
+  if (VIN_FORBIDDEN_CHARS.test(normalized)) {
+    return {
+      vin: normalized,
+      isValid: false,
+      reason: "forbidden_character",
+      message: "VIN cannot contain I, O, or Q.",
+    };
+  }
+
+  if (normalized.length !== VIN_LENGTH) {
+    return {
+      vin: normalized,
+      isValid: false,
+      reason: "invalid_length",
+      message: "VIN must be exactly 17 characters.",
+    };
+  }
+
+  return {
+    vin: normalized,
+    isValid: true,
+    reason: "valid",
+    message: "VIN is valid.",
+  };
+}
+
+export function normalizeVinOrNull(input: unknown): string | null {
+  const result = normalizeVinInput(input);
+  return result.isValid ? result.vin : null;
+}

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -27,6 +27,7 @@ import type {
   SessionVehicle,
 } from "@/features/inspections/lib/inspection/types";
 import { normalizeCustomerForIntake } from "@/features/inspections/lib/customerNormalization";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 
 // 👇 inspection modal, client-only
 const InspectionModal = dynamic(
@@ -209,6 +210,19 @@ const INTAKE_DISMISS_KEY = "pfq.create.intake.dismiss.v1";
 const strOrNull = (v: string | null | undefined) => {
   const t = (v ?? "").trim();
   return t ? t : null;
+};
+
+const normalizedVinOrNull = (v: string | null | undefined) => {
+  const raw = strOrNull(v);
+  if (!raw) return null;
+  return normalizeVinInput(raw).vin || null;
+};
+
+const validVinOrNull = (v: string | null | undefined) => {
+  const raw = strOrNull(v);
+  if (!raw) return null;
+  const normalized = normalizeVinInput(raw);
+  return normalized.isValid ? normalized.vin : null;
 };
 
 const normalizeEmail = (v: string | null | undefined): string | null => {
@@ -492,8 +506,9 @@ export default function CreateWorkOrderPage() {
   // ✅ allow extra vehicle fields to flow through from the form
   const onVehicleChange = useCallback(
     (field: keyof VehicleWithExtra, value: string | null) => {
-      setVehicle((v) => ({ ...v, [field]: value }));
-      cvDraft.setVehicleField(field, value);
+      const nextValue = field === "vin" ? normalizedVinOrNull(value) : value;
+      setVehicle((v) => ({ ...v, [field]: nextValue }));
+      cvDraft.setVehicleField(field, nextValue);
     },
     [cvDraft, setVehicle],
   );
@@ -763,7 +778,7 @@ useEffect(() => {
     shopId: string,
   ) => ({
     customer_id: customerIdIn,
-    vin: strOrNull(v.vin),
+    vin: validVinOrNull(v.vin),
     year: numOrNull(v.year),
     make: strOrNull(v.make),
     model: strOrNull(v.model),
@@ -791,7 +806,7 @@ useEffect(() => {
       customer_id: customerIdIn,
     };
 
-    const vin = strOrNull(v.vin);
+    const vin = validVinOrNull(v.vin);
     if (vin !== null) patch.vin = vin;
 
     const yr = numOrNull(v.year);
@@ -1205,7 +1220,7 @@ useEffect(() => {
     }
 
     const orParts = [
-      vehicle.vin ? `vin.eq.${vehicle.vin}` : "",
+      validVinOrNull(vehicle.vin) ? `vin.eq.${validVinOrNull(vehicle.vin)}` : "",
       vehicle.license_plate ? `license_plate.eq.${vehicle.license_plate}` : "",
     ].filter(Boolean);
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated or cross-shop VIN lookups and OCR usage by enforcing auth and shop scoping on VIN-related endpoints.
- Provide a single shared VIN normalization/validation helper to ensure consistent VIN handling across server and client flows. 
- Preserve existing vehicle creation UX for now while making backend VIN handling safer and deterministic. 

### Description
- Added a shared VIN helper `normalizeVinInput` in `features/shared/lib/vin/normalizeVin.ts` that trims, uppercases, strips separators, rejects `I`, `O`, `Q`, enforces 17 characters, and returns a normalized VIN plus validation reason/message. 
- Secured server VIN routes by requiring authenticated shop-scoped profiles via `createServerSupabaseRSC` and applying the shared VIN validation in `app/api/vin/route.ts`, `app/api/vin/extract-from-image/route.ts`, and `app/api/ocr/registration/route.ts`. 
- Added image type and size guards (allowed MIME types + 8 MB limit) to image-based VIN/OCR endpoints in `app/api/vin/extract-from-image/route.ts` and `app/api/ocr/registration/route.ts`. 
- Made `app/api/vehicle/ensure/route.ts` explicitly shop-scoped by validating the VIN with the helper and looking up vehicles with both `vin` and `shop_id` (no DB unique index added). 
- Wired the normalization helper into client/server flows by updating `features/shared/lib/vin/decodeVin.ts`, `app/vehicle/VinCaptureModal.tsx`, the Work Order create flow `features/work-orders/app/work-orders/create/page.tsx`, and `features/inspections/components/inspection/CustomerVehicleForm.tsx` to normalize and validate VINs before use. 

### Testing
- Ran targeted ESLint against the changed files with `npx eslint <files>` and resolved issues; lint check completed successfully. 
- Type-checked the repo with `npx tsc --noEmit` and the typecheck passed without errors. 
- Verified no whitespace or diff issues with `git diff --check` which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4353fa248328b52bc205eec1d495)