### PR TITLE
Add same-shop duplicate vehicle detection & safe selection (VIN Phase 2)

### DIFF
--- a/app/api/vehicles/duplicate-check/route.ts
+++ b/app/api/vehicles/duplicate-check/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+
+type Body = {
+  vin?: string | null;
+  licensePlate?: string | null;
+  license_plate?: string | null;
+  unitNumber?: string | null;
+  unit_number?: string | null;
+  customerId?: string | null;
+  customer_id?: string | null;
+  vehicleId?: string | null;
+  vehicle_id?: string | null;
+};
+
+type VehicleDuplicateMatch = {
+  id: string;
+  customer_id: string | null;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  vin: string | null;
+  license_plate: string | null;
+  unit_number: string | null;
+  customer_display_name: string | null;
+  same_customer: boolean | null;
+  match_type: "vin" | "license_plate" | "unit_number";
+};
+
+type VehicleQueryRow = Omit<VehicleDuplicateMatch, "customer_display_name" | "same_customer" | "match_type"> & {
+  customers?:
+    | {
+        business_name?: string | null;
+        name?: string | null;
+        first_name?: string | null;
+        last_name?: string | null;
+        email?: string | null;
+        phone?: string | null;
+        phone_number?: string | null;
+      }
+    | null;
+};
+
+function cleanText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizePlate(value: unknown): string | null {
+  return cleanText(value)?.toUpperCase() ?? null;
+}
+
+function customerName(customer: VehicleQueryRow["customers"]): string | null {
+  if (!customer) return null;
+  const business = customer.business_name?.trim();
+  if (business) return business;
+  const name = customer.name?.trim();
+  if (name) return name;
+  const person = [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim();
+  if (person) return person;
+  return customer.email ?? customer.phone ?? customer.phone_number ?? null;
+}
+
+export async function POST(req: Request) {
+  const supabase = await createServerSupabaseRSC();
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user?.id) {
+    return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  }
+
+  const byUserId = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  const byId = byUserId.data?.shop_id
+    ? null
+    : await supabase.from("profiles").select("shop_id").eq("id", user.id).maybeSingle();
+
+  const portalCustomer = byUserId.data?.shop_id || byId?.data?.shop_id
+    ? null
+    : await supabase
+        .from("customers")
+        .select("id, shop_id")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+  const shopId = byUserId.data?.shop_id ?? byId?.data?.shop_id ?? portalCustomer?.data?.shop_id ?? null;
+
+  if (!shopId) {
+    return NextResponse.json({ error: "Your profile isn’t linked to a shop yet." }, { status: 403 });
+  }
+
+  const requestedCustomerId = cleanText(body.customerId ?? body.customer_id);
+  const customerId = portalCustomer?.data?.id ?? requestedCustomerId;
+  const vehicleId = cleanText(body.vehicleId ?? body.vehicle_id);
+  const vinInput = cleanText(body.vin);
+  const vin = vinInput ? normalizeVinInput(vinInput).vin || vinInput.toUpperCase() : null;
+  const licensePlate = normalizePlate(body.licensePlate ?? body.license_plate);
+  const unitNumber = cleanText(body.unitNumber ?? body.unit_number);
+
+  if (!vin && !licensePlate && !unitNumber) {
+    return NextResponse.json({ matches: [], hasVinMatch: false, hasSameCustomerMatch: false, hasDifferentCustomerMatch: false });
+  }
+
+  async function findMatches(matchType: "vin" | "license_plate" | "unit_number", value: string) {
+    let query = supabase
+      .from("vehicles")
+      .select(
+        "id, customer_id, year, make, model, vin, license_plate, unit_number, customers(business_name, name, first_name, last_name, email, phone, phone_number)",
+      )
+      .eq("shop_id", shopId);
+
+    if (vehicleId) query = query.neq("id", vehicleId);
+
+    if (matchType === "vin") {
+      query = query.eq("vin", value);
+    } else if (matchType === "license_plate") {
+      query = query.ilike("license_plate", value);
+    } else {
+      query = query.ilike("unit_number", value);
+    }
+
+    const { data, error } = await query.limit(20);
+    if (error) throw error;
+
+    return ((data ?? []) as VehicleQueryRow[]).map((row): VehicleDuplicateMatch => ({
+      id: row.id,
+      customer_id: row.customer_id,
+      year: row.year,
+      make: row.make,
+      model: row.model,
+      vin: row.vin,
+      license_plate: row.license_plate,
+      unit_number: row.unit_number,
+      customer_display_name: customerName(row.customers),
+      same_customer: customerId ? row.customer_id === customerId : null,
+      match_type: matchType,
+    }));
+  }
+
+  try {
+    const matchesById = new Map<string, VehicleDuplicateMatch>();
+    const ordered: VehicleDuplicateMatch[] = [];
+
+    for (const [matchType, value] of [
+      ["vin", vin],
+      ["license_plate", licensePlate],
+      ["unit_number", unitNumber],
+    ] as const) {
+      if (!value) continue;
+      const rows = await findMatches(matchType, value);
+      for (const row of rows) {
+        if (!matchesById.has(row.id)) {
+          matchesById.set(row.id, row);
+          ordered.push(row);
+        }
+      }
+    }
+
+    return NextResponse.json({
+      matches: ordered,
+      hasVinMatch: ordered.some((row) => row.match_type === "vin"),
+      hasSameCustomerMatch: ordered.some((row) => row.same_customer === true),
+      hasDifferentCustomerMatch: ordered.some((row) => row.same_customer === false),
+    });
+  } catch (err) {
+    console.error("[vehicles.duplicate-check]", err);
+    return NextResponse.json({ error: "Failed to check duplicate vehicles." }, { status: 500 });
+  }
+}

--- a/app/fleet/units/new/page.tsx
+++ b/app/fleet/units/new/page.tsx
@@ -6,6 +6,7 @@ import PageShell from "@/features/shared/components/PageShell";
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 type DB = Database;
 type FleetRow = DB["public"]["Tables"]["fleets"]["Row"];
@@ -115,12 +116,38 @@ export default function FleetUnitNewPage(): JSX.Element {
         if (!trimmed) {
           throw new Error("Enter an existing Vehicle ID or switch to New vehicle.");
         }
-        vehicleId = trimmed;
+        const { data: existingVehicle, error: existingVehicleError } = await supabase
+          .from("vehicles")
+          .select("id")
+          .eq("id", trimmed)
+          .eq("shop_id", creatorShopId)
+          .maybeSingle();
+
+        if (existingVehicleError || !existingVehicle) {
+          throw new Error("Existing vehicle was not found in this shop.");
+        }
+
+        vehicleId = existingVehicle.id;
       } else {
         // create new vehicle
         if (!unitNumber.trim() && !vin.trim() && !plate.trim()) {
           throw new Error(
             "Provide at least a unit number, VIN, or plate for the new vehicle.",
+          );
+        }
+
+        const duplicateCheck = await checkVehicleDuplicates({
+          vin,
+          licensePlate: plate,
+          unitNumber,
+        });
+
+        const duplicate = duplicateCheck.matches[0] ?? null;
+        if (duplicate) {
+          setExistingVehicleId(duplicate.id);
+          setMode("existing_vehicle");
+          throw new Error(
+            "Vehicle already exists. Use existing vehicle to link this fleet unit instead of creating a duplicate.",
           );
         }
 

--- a/app/portal/vehicles/page.tsx
+++ b/app/portal/vehicles/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 /** Minimal shapes (keep lint happy, no `any`, no big supabase types) */
 type VehicleRow = {
@@ -22,6 +23,7 @@ type VehicleRow = {
 type CustomerRow = {
   id: string;
   user_id: string;
+  shop_id: string | null;
   first_name?: string | null;
   last_name?: string | null;
 };
@@ -227,8 +229,38 @@ export default function PortalVehiclesPage() {
       return;
     }
 
+    if (!customer.shop_id) {
+      setError("Contact shop/admin to move vehicle.");
+      setSaving(false);
+      return;
+    }
+
+    const duplicateCheck = await checkVehicleDuplicates({
+      vin: form.vin,
+      licensePlate: form.license_plate,
+      customerId: customer.id,
+      vehicleId: editingId,
+    });
+
+    const differentCustomerVin = duplicateCheck.matches.find(
+      (match) => match.match_type === "vin" && match.same_customer === false,
+    );
+    if (differentCustomerVin) {
+      setError("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      setSaving(false);
+      return;
+    }
+
+    const sameCustomerMatch = duplicateCheck.matches.find((match) => match.same_customer === true);
+    if (sameCustomerMatch) {
+      setError("Vehicle already exists. Use existing vehicle or contact shop to update it.");
+      setSaving(false);
+      return;
+    }
+
     const payload = {
       customer_id: customer.id,
+      shop_id: customer.shop_id,
       year: toYear(form.year),
       make: form.make.trim(),
       model: form.model.trim(),

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
+import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 type DB = Database;
 
@@ -1043,10 +1044,34 @@ export default function CustomerProfilePage(): JSX.Element {
     if (typeof vehDraft["drivetrain"] === "string")
       updateRecord["drivetrain"] = vehDraft["drivetrain"] || null;
 
-       const { error } = await supabase
+    const duplicateCheck = await checkVehicleDuplicates({
+      vin: typeof updateRecord["vin"] === "string" ? updateRecord["vin"] : null,
+      licensePlate:
+        typeof updateRecord["license_plate"] === "string" ? updateRecord["license_plate"] : null,
+      unitNumber: typeof updateRecord["unit_number"] === "string" ? updateRecord["unit_number"] : null,
+      customerId: customer?.id ?? null,
+      vehicleId: selectedVehicle.id,
+    });
+
+    const blockingMatch = duplicateCheck.matches.find(
+      (match) => match.match_type === "vin" && match.same_customer === false,
+    );
+    if (blockingMatch) {
+      setViewError("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      return;
+    }
+
+    const sameCustomerMatch = duplicateCheck.matches.find((match) => match.same_customer === true);
+    if (sameCustomerMatch) {
+      setViewError("Vehicle already exists for this customer. Open/edit the existing vehicle instead.");
+      return;
+    }
+
+    const { error } = await supabase
       .from("vehicles")
       .update(updateRecord as DB["public"]["Tables"]["vehicles"]["Update"])
-      .eq("id", selectedVehicle.id);
+      .eq("id", selectedVehicle.id)
+      .eq("shop_id", customer?.shop_id ?? "");
 
     if (error) {
       setViewError(error.message);
@@ -1055,7 +1080,7 @@ export default function CustomerProfilePage(): JSX.Element {
 
     setEditVehicleOpen(false);
     if (customer?.id) await fetchCustomerFile(customer.id);
-  }, [customer?.id, fetchCustomerFile, selectedVehicle, supabase, vehDraft]);
+  }, [customer, fetchCustomerFile, selectedVehicle, supabase, vehDraft]);
 
   // ------------------ Add Vehicle ------------------
   const [newVeh, setNewVeh] = useState<Record<string, unknown>>({
@@ -1083,6 +1108,7 @@ export default function CustomerProfilePage(): JSX.Element {
 
     const insertRecord: Record<string, unknown> = {
       customer_id: customer.id,
+      shop_id: customer.shop_id,
       year: typeof newVeh["year"] === "number" ? newVeh["year"] : null,
       make: typeof newVeh["make"] === "string" ? (newVeh["make"] as string) || null : null,
       model: typeof newVeh["model"] === "string" ? (newVeh["model"] as string) || null : null,
@@ -1110,6 +1136,30 @@ export default function CustomerProfilePage(): JSX.Element {
     if (typeof newVeh["fuel_type"] === "string") insertRecord["fuel_type"] = newVeh["fuel_type"] || null;
     if (typeof newVeh["drivetrain"] === "string") insertRecord["drivetrain"] = newVeh["drivetrain"] || null;
 
+    const duplicateCheck = await checkVehicleDuplicates({
+      vin: typeof insertRecord["vin"] === "string" ? insertRecord["vin"] : null,
+      licensePlate:
+        typeof insertRecord["license_plate"] === "string" ? insertRecord["license_plate"] : null,
+      unitNumber: typeof insertRecord["unit_number"] === "string" ? insertRecord["unit_number"] : null,
+      customerId: customer.id,
+    });
+
+    const blockingMatch = duplicateCheck.matches.find(
+      (match) => match.match_type === "vin" && match.same_customer === false,
+    );
+    if (blockingMatch) {
+      setViewError("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      return;
+    }
+
+    const sameCustomerMatch = duplicateCheck.matches.find((match) => match.same_customer === true);
+    if (sameCustomerMatch) {
+      setViewError("Vehicle already exists for this customer. Open/edit the existing vehicle instead.");
+      setSelectedVehicleId(sameCustomerMatch.id);
+      setAddVehicleOpen(false);
+      return;
+    }
+
     const { data, error } = await supabase
       .from("vehicles")
       .insert(insertRecord as DB["public"]["Tables"]["vehicles"]["Insert"])
@@ -1126,7 +1176,7 @@ export default function CustomerProfilePage(): JSX.Element {
 
     const newId = (data as Pick<Vehicle, "id"> | null)?.id ?? null;
     if (newId) setSelectedVehicleId(newId);
-  }, [customer?.id, fetchCustomerFile, newVeh, supabase]);
+  }, [customer, fetchCustomerFile, newVeh, supabase]);
 
   // ------------------ DIRECTORY MODE ------------------
   if (isDirectoryMode || sp.get("mode") === "search") {

--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@inspections/lib/inspection/types";
 import { normalizeCustomerForIntake } from "@inspections/lib/customerNormalization";
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+import { checkVehicleDuplicates, type VehicleDuplicateMatch } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 /** Local, narrow shapes (avoid exporting DB row types in props) */
 type CustomerRow = {
@@ -388,6 +389,7 @@ export default function CustomerVehicleForm({
   workOrderExists = false,
   shopId,
   selectedCustomerId = null,
+  selectedVehicleId = null,
   handlers,
 }: Props) {
   const supabase = useMemo(() => createClientComponentClient<Database>(), []);
@@ -404,6 +406,8 @@ export default function CustomerVehicleForm({
   const [currentCustomerId, setCurrentCustomerId] = useState<string | null>(
     selectedCustomerId,
   );
+  const [duplicateMatches, setDuplicateMatches] = useState<VehicleDuplicateMatch[]>([]);
+  const [duplicateWarning, setDuplicateWarning] = useState<string | null>(null);
 
   useEffect(() => {
     setCurrentCustomerId(selectedCustomerId);
@@ -423,6 +427,53 @@ export default function CustomerVehicleForm({
     },
     [onVehicleChange],
   );
+
+  useEffect(() => {
+    const vin = vehicle.vin?.trim();
+    const plate = vehicle.license_plate?.trim();
+    const unit = vehicle.unit_number?.trim();
+
+    if (!shopId || (!vin && !plate && !unit)) {
+      setDuplicateMatches([]);
+      setDuplicateWarning(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = window.setTimeout(async () => {
+      try {
+        const result = await checkVehicleDuplicates({
+          vin,
+          licensePlate: plate,
+          unitNumber: unit,
+          customerId: currentCustomerId,
+          vehicleId: selectedVehicleId,
+        });
+        if (cancelled) return;
+        setDuplicateMatches(result.matches);
+        const differentCustomerVin = result.matches.find(
+          (match) => match.match_type === "vin" && match.same_customer === false,
+        );
+        if (differentCustomerVin) {
+          setDuplicateWarning("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+        } else if (result.matches.some((match) => match.same_customer === true)) {
+          setDuplicateWarning("Vehicle already exists. Use existing vehicle instead of creating a duplicate.");
+        } else {
+          setDuplicateWarning(null);
+        }
+      } catch {
+        if (!cancelled) {
+          setDuplicateMatches([]);
+          setDuplicateWarning(null);
+        }
+      }
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [currentCustomerId, selectedVehicleId, shopId, vehicle.license_plate, vehicle.unit_number, vehicle.vin]);
 
   async function handlePickedCustomer(c: CustomerRow) {
     const applyCustomer = (picked: CustomerRow) => {
@@ -498,6 +549,13 @@ export default function CustomerVehicleForm({
 
   const handleSaveClick = async () => {
     try {
+      const differentCustomerVin = duplicateMatches.find(
+        (match) => match.match_type === "vin" && match.same_customer === false,
+      );
+      if (differentCustomerVin) {
+        throw new Error("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      }
+
       if (onSave) await onSave();
 
       // After save: fire-and-forget rule generation for this YMM (+ engine)
@@ -715,6 +773,28 @@ export default function CustomerVehicleForm({
               Use unit # or plate to pull an existing vehicle for this customer.
             </span>
           </div>
+
+          {duplicateWarning && (
+            <div className="rounded-xl border border-amber-400/40 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">
+              <div className="font-semibold">Vehicle already exists</div>
+              <div className="mt-1">{duplicateWarning}</div>
+              {duplicateMatches.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {duplicateMatches.slice(0, 3).map((match) => (
+                    <button
+                      key={match.id}
+                      type="button"
+                      className="block text-left text-[11px] text-amber-50 underline decoration-amber-300/50 underline-offset-2"
+                      onClick={() => onVehicleSelected?.(match.id)}
+                    >
+                      Use existing vehicle: {[match.year, match.make, match.model].filter(Boolean).join(" ") || match.vin || match.license_plate || match.unit_number || match.id}
+                      {match.customer_display_name ? ` · ${match.customer_display_name}` : ""}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {/* Unit # + autocomplete */}

--- a/features/shared/lib/vehicles/duplicateCheck.ts
+++ b/features/shared/lib/vehicles/duplicateCheck.ts
@@ -1,0 +1,53 @@
+export type VehicleDuplicateMatch = {
+  id: string;
+  customer_id: string | null;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  vin: string | null;
+  license_plate: string | null;
+  unit_number: string | null;
+  customer_display_name: string | null;
+  same_customer: boolean | null;
+  match_type: "vin" | "license_plate" | "unit_number";
+};
+
+export type VehicleDuplicateCheckRequest = {
+  vin?: string | null;
+  licensePlate?: string | null;
+  unitNumber?: string | null;
+  customerId?: string | null;
+  vehicleId?: string | null;
+};
+
+export type VehicleDuplicateCheckResponse = {
+  matches: VehicleDuplicateMatch[];
+  hasVinMatch: boolean;
+  hasSameCustomerMatch: boolean;
+  hasDifferentCustomerMatch: boolean;
+};
+
+export async function checkVehicleDuplicates(
+  input: VehicleDuplicateCheckRequest,
+): Promise<VehicleDuplicateCheckResponse> {
+  const res = await fetch("/api/vehicles/duplicate-check", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  const payload = (await res.json().catch(() => ({}))) as Partial<VehicleDuplicateCheckResponse> & {
+    error?: string;
+  };
+
+  if (!res.ok) {
+    throw new Error(payload.error ?? "Failed to check for duplicate vehicles.");
+  }
+
+  return {
+    matches: payload.matches ?? [],
+    hasVinMatch: Boolean(payload.hasVinMatch),
+    hasSameCustomerMatch: Boolean(payload.hasSameCustomerMatch),
+    hasDifferentCustomerMatch: Boolean(payload.hasDifferentCustomerMatch),
+  };
+}

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -28,6 +28,7 @@ import type {
 } from "@/features/inspections/lib/inspection/types";
 import { normalizeCustomerForIntake } from "@/features/inspections/lib/customerNormalization";
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 // 👇 inspection modal, client-only
 const InspectionModal = dynamic(
@@ -1195,8 +1196,65 @@ useEffect(() => {
     cust: CustomerRow,
     shopId: string,
   ): Promise<VehicleRow> {
+    const duplicateCheck = await checkVehicleDuplicates({
+      vin: vehicle.vin,
+      licensePlate: vehicle.license_plate,
+      unitNumber: vehicle.unit_number,
+      customerId: cust.id,
+      vehicleId,
+    });
+
+    const differentCustomerVin = duplicateCheck.matches.find(
+      (match) => match.match_type === "vin" && match.same_customer === false,
+    );
+    if (differentCustomerVin) {
+      throw new Error(
+        "This VIN is already assigned to another customer. Contact shop/admin to move vehicle.",
+      );
+    }
+
+    const sameCustomerMatch = duplicateCheck.matches.find(
+      (match) => match.same_customer === true,
+    );
+    if (!vehicleId && sameCustomerMatch) {
+      const label = [sameCustomerMatch.year, sameCustomerMatch.make, sameCustomerMatch.model]
+        .filter(Boolean)
+        .join(" ") || sameCustomerMatch.vin || sameCustomerMatch.license_plate || "vehicle";
+      const useExisting = window.confirm(
+        `Vehicle already exists: ${label}. Use existing vehicle?`,
+      );
+      if (!useExisting) {
+        throw new Error("Cancel/change VIN before creating another vehicle.");
+      }
+      const { data: existing, error: existingErr } = await supabase
+        .from("vehicles")
+        .select("*")
+        .eq("id", sameCustomerMatch.id)
+        .eq("shop_id", shopId)
+        .single();
+      if (existingErr || !existing) {
+        throw new Error(existingErr?.message ?? "Failed to load existing vehicle.");
+      }
+      setVehicleId(existing.id);
+      return existing as VehicleRow;
+    }
+
     // If an explicit vehicleId is set, patch update that vehicle (instead of just returning it)
     if (vehicleId) {
+      const { data: currentVehicle, error: currentErr } = await supabase
+        .from("vehicles")
+        .select("id, customer_id")
+        .eq("id", vehicleId)
+        .eq("shop_id", shopId)
+        .single();
+
+      if (currentErr) throw currentErr;
+      if (currentVehicle?.customer_id && currentVehicle.customer_id !== cust.id) {
+        throw new Error(
+          "Use existing vehicle is selected, but it belongs to another customer. Contact shop/admin to move vehicle.",
+        );
+      }
+
       const patch = buildVehiclePatch(vehicle, cust.id);
 
       const { data: updated, error: updErr } = await supabase


### PR DESCRIPTION
### Motivation

- Prevent silent duplicate vehicle creation or implicit reassignment when VIN/plate/unit are entered across the app by detecting same-shop duplicates early and surfacing a safe choice to the user.
- Provide a single, reusable duplicate-check surface so multiple flows (work order create, customer detail, portal, fleet) can behave consistently without adding a DB unique index yet.
- Keep launch risk low by blocking or surfacing explicit, warned overrides rather than building a merge/transfer workflow in this PR.

### Description

- Added a same-shop duplicate-check API endpoint at `app/api/vehicles/duplicate-check/route.ts` that authenticates the user, resolves `profile.shop_id` (with portal-customer fallback), normalizes VIN/plate/unit inputs, excludes an edited `vehicleId`, and returns safe match fields (`id`, `customer_id`, `year/make/model`, `vin`, `license_plate`, `unit_number`, `customer_display_name`, `same_customer`, `match_type`).
- Added a client helper and TypeScript types at `features/shared/lib/vehicles/duplicateCheck.ts` for calling the new API (`checkVehicleDuplicates`) and normalizing the response.
- Updated Work Order Create (`features/work-orders/app/work-orders/create/page.tsx`) to run the duplicate check in `ensureVehicleRow`, block different-customer VIN matches, offer an explicit `Use existing vehicle` confirmation when a same-customer match exists, and avoid silently reassigning vehicles to other customers.
- Added duplicate-check and simple UX to shared Customer/Vehicle form (`features/inspections/components/inspection/CustomerVehicleForm.tsx`) to show a “Vehicle already exists” warning, list up to three matches, and allow selecting an existing vehicle; updated customer detail add/edit flows (`features/customers/app/customers/[id]/page.tsx`) and portal (`app/portal/vehicles/page.tsx`) to run the check before insert/update, block cross-customer VINs, and select/point to same-customer matches; updated fleet unit creation (`app/fleet/units/new/page.tsx`) to detect duplicates and switch to existing-vehicle mode instead of creating duplicates.
- Preserved scope and safety: no DB unique index added, shop scoping enforced, portal inserts/updates now include `shop_id` where safe, and all changes avoid broad architecture rewrites or unrelated flows.

### Testing

- Ran lint and static checks with `npx eslint app/api/vehicles/duplicate-check/route.ts features/shared/lib/vehicles/duplicateCheck.ts features/work-orders/app/work-orders/create/page.tsx features/inspections/components/inspection/CustomerVehicleForm.tsx 'features/customers/app/customers/[id]/page.tsx' app/portal/vehicles/page.tsx app/fleet/units/new/page.tsx app/api/vehicle/ensure/route.ts` which completed (warnings handled).
- Type-checked the codebase with `npx tsc --noEmit` which passed without errors.
- Ran repository checks `git diff --check` and `git status --short` to verify no trailing issues and staged changes, both returned clean results for the PR changes.
- Manual smoke flows exercised locally: VIN capture → duplicate prompt in work order create, customer add/edit and portal vehicle add/update blocks, and fleet unit new switches to existing-vehicle mode (observed expected warnings and selection behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4708efe48328a14793fd2b72a9c7)