### PR TITLE
Improve VIN capture modal UX and decode mapping

### DIFF
--- a/app/api/vin/route.ts
+++ b/app/api/vin/route.ts
@@ -17,6 +17,10 @@ type VpicRow = {
   TransmissionStyle?: string;
   DriveType?: string;
   BodyClass?: string;
+  Manufacturer?: string;
+  GVWR?: string;
+  GrossVehicleWeightRatingFrom?: string;
+  GrossVehicleWeightRatingTo?: string;
   [key: string]: unknown;
 };
 
@@ -92,7 +96,8 @@ export async function POST(req: NextRequest) {
       year: row.ModelYear || null,
       make: row.Make || null,
       model: row.Model || null,
-      trim: row.Series || row.Trim || null,
+      trim: row.Trim || row.Series || null,
+      submodel: row.Series || row.Trim || null,
       engine:
         row.EngineModel ||
         row.EngineConfiguration ||
@@ -102,10 +107,20 @@ export async function POST(req: NextRequest) {
       // 🔽 extra structured fields you can use in the UI / DB
       engineDisplacementL: row.DisplacementL || null,
       engineCylinders: row.EngineCylinders || null,
+      engineFamily: row.EngineModel || null,
+      engineType: row.EngineConfiguration || null,
       fuelType: row.FuelTypePrimary || null,
       transmission: row.TransmissionStyle || null,
+      transmissionType: row.TransmissionStyle || null,
       driveType: row.DriveType || null,
       bodyClass: row.BodyClass || null,
+      manufacturer: row.Manufacturer || null,
+      gvwr:
+        row.GVWR ||
+        [row.GrossVehicleWeightRatingFrom, row.GrossVehicleWeightRatingTo]
+          .filter(Boolean)
+          .join(" - ") ||
+        null,
     };
 
     return NextResponse.json(result);

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -1233,7 +1233,8 @@ export default function MobileCreateWorkOrderPage() {
                 <option value="diesel">Diesel</option>
                 <option value="hybrid">Hybrid</option>
                 <option value="phev">Plug-in hybrid</option>
-                <option value="ev">Electric (BEV)</option>
+                <option value="electric">Electric (BEV)</option>
+                <option value="ev">Electric (legacy)</option>
                 <option value="other">Other</option>
               </select>
 

--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -6,11 +6,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { useRouter } from "next/navigation";
-
 import ModalShell from "@/features/shared/components/ModalShell";
 import VinCaptureModalContent from "@/features/vehicles/components/VinCaptureModal";
-import { decodeVin } from "@/features/shared/lib/vin/decodeVin";
+import { decodeVin, mapDecodedVinToVehicleSelectValues } from "@/features/shared/lib/vin/decodeVin";
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 
@@ -29,15 +27,21 @@ export type VinDecodedDetail = {
   make: string | null;
   model: string | null;
   trim: string | null;
+  submodel?: string | null;
   engine?: string | null;
+  engineFamily?: string | null;
+  engineType?: string | null;
 
   // extra fields from /api/vin
   engineDisplacementL?: string | null;
   engineCylinders?: string | null;
   fuelType?: string | null;
   transmission?: string | null;
+  transmissionType?: string | null;
   driveType?: string | null;
   bodyClass?: string | null;
+  manufacturer?: string | null;
+  gvwr?: string | null;
 };
 
 type Props = {
@@ -57,21 +61,34 @@ type DecodeVinResponseExtended = DecodeVinResponse & {
   engineCylinders?: string | null;
   fuelType?: string | null;
   transmission?: string | null;
+  transmissionType?: string | null;
   driveType?: string | null;
   bodyClass?: string | null;
+  manufacturer?: string | null;
+  gvwr?: string | null;
 };
 
 function isLikelyVin(s: string) {
   return normalizeVinInput(s).isValid;
 }
 
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
+function describeOcrError(status: number, fallback?: string | null) {
+  if (status === 413) return "Image is too large. Upload an image 8 MB or smaller, or enter the VIN manually.";
+  if (status === 415) return "Unsupported image type. Upload a JPEG, PNG, WebP, HEIC, or enter the VIN manually.";
+  return fallback || "Could not read a VIN from this image. Retake the photo, upload another, or enter it manually.";
+}
+
 /** Scanner pane used in scanSlot */
 function ScannerPane({
   onFoundVin,
+  onError,
   isBusy,
 }: {
   userId: string;
   onFoundVin: (vin: string) => void;
+  onError: (message: string) => void;
   isBusy: boolean;
 }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -126,12 +143,16 @@ function ScannerPane({
           };
           raf = requestAnimationFrame(scan);
         } else {
-          setError(
-            "Live barcode detection not supported in this browser. Use photo upload below.",
-          );
+          const message =
+            "Live barcode detection is not supported in this browser. Upload a photo or enter the VIN manually.";
+          setError(message);
+          onError(message);
         }
       } catch {
-        setError("Camera unavailable. Use photo upload below.");
+        const message =
+          "Camera unavailable. Upload a photo or enter the VIN manually.";
+        setError(message);
+        onError(message);
       }
     };
 
@@ -146,7 +167,7 @@ function ScannerPane({
         /* no-op */
       }
     };
-  }, [onFoundVin]);
+  }, [onError, onFoundVin]);
 
   return (
     <div
@@ -191,12 +212,25 @@ function ScannerPane({
         <input
           type="file"
           accept="image/*"
+          capture="environment"
           disabled={isBusy}
           className="block w-full text-xs text-neutral-300 file:mr-3 file:rounded file:border-0 file:bg-[linear-gradient(135deg,rgba(197,122,74,0.9),rgba(197,122,74,0.75))] file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-black hover:file:bg-[linear-gradient(135deg,rgba(197,122,74,1),rgba(197,122,74,0.85))] disabled:opacity-60"
           onChange={async (e) => {
             if (isBusy) return;
             const file = e.target.files?.[0];
             if (!file) return;
+
+            if (!file.type.startsWith("image/")) {
+              onError("Unsupported file type. Upload an image or enter the VIN manually.");
+              e.target.value = "";
+              return;
+            }
+
+            if (file.size > MAX_IMAGE_BYTES) {
+              onError("Image is too large. Upload an image 8 MB or smaller, or enter the VIN manually.");
+              e.target.value = "";
+              return;
+            }
 
             try {
               const formData = new FormData();
@@ -208,7 +242,10 @@ function ScannerPane({
               });
 
               if (!res.ok) {
-                alert("Could not read VIN from image. Please try again.");
+                const body = (await res.json().catch(() => ({}))) as {
+                  error?: string | null;
+                };
+                onError(describeOcrError(res.status, body.error));
                 e.target.value = "";
                 return;
               }
@@ -217,8 +254,8 @@ function ScannerPane({
               const extractedVin = normalizeVinInput(data?.vin);
               const vin = extractedVin.vin;
               if (!extractedVin.isValid || !isLikelyVin(vin)) {
-                alert(
-                  "No clear VIN found in the photo. Please retake or type it manually.",
+                onError(
+                  "No clear VIN found in the photo. Retake it, upload another photo, or type the VIN manually.",
                 );
                 e.target.value = "";
                 return;
@@ -227,8 +264,8 @@ function ScannerPane({
               onFoundVin(vin);
             } catch (err) {
               console.error(err);
-              alert(
-                "Error reading VIN from image. Please try again or enter it manually.",
+              onError(
+                "OCR failed while reading the photo. Try again, upload another photo, or enter the VIN manually.",
               );
             } finally {
               e.target.value = "";
@@ -242,7 +279,8 @@ function ScannerPane({
       </div>
 
       <div className="text-[11px] text-neutral-500">
-        We will decode with NHTSA and store it to your account.
+        We will decode with NHTSA and fill the vehicle form; you stay in control
+        of saving.
       </div>
     </div>
   );
@@ -258,6 +296,7 @@ export default function VinCaptureModal({
 }: Props) {
   const [internalOpen, setInternalOpen] = useState(false);
   const [isDecoding, setIsDecoding] = useState(false);
+  const [captureError, setCaptureError] = useState<string | null>(null);
 
   const isControlled = typeof open === "boolean";
   const isOpen = isControlled ? (open as boolean) : internalOpen;
@@ -270,7 +309,6 @@ export default function VinCaptureModal({
     [isControlled, onOpenChange],
   );
 
-  const router = useRouter();
   const setVehicleDraft = useWorkOrderDraft((s) => s.setVehicle);
 
   // Lock body scroll when modal is open
@@ -308,7 +346,7 @@ export default function VinCaptureModal({
     async (vin: string) => {
       const normalizedVin = normalizeVinInput(vin);
       if (!normalizedVin.isValid) {
-        alert(normalizedVin.message);
+        setCaptureError(normalizedVin.message);
         return;
       }
       if (isDecoding) return; // prevent double fires
@@ -316,11 +354,12 @@ export default function VinCaptureModal({
       try {
         const resp = await decodeVin(normalizedVin.vin, userId);
         if (resp?.error) {
-          alert(resp.error);
+          setCaptureError(resp.error);
           return;
         }
 
         const extended = resp as DecodeVinResponseExtended;
+        const mapped = mapDecodedVinToVehicleSelectValues(extended);
 
         // hydrate shared draft
         setVehicleDraft({
@@ -329,7 +368,14 @@ export default function VinCaptureModal({
           make: resp.make ?? null,
           model: resp.model ?? null,
           trim: resp.trim ?? null,
+          submodel: resp.submodel ?? resp.trim ?? null,
           engine: resp.engine ?? null,
+          engine_family: resp.engineFamily ?? null,
+          engine_type: resp.engineType ?? null,
+          transmission_type: resp.transmissionType ?? extended.transmission ?? null,
+          fuel_type: mapped.fuel_type ?? null,
+          drivetrain: mapped.drivetrain ?? null,
+          transmission: mapped.transmission ?? null,
         });
 
         const detail: VinDecodedDetail = {
@@ -338,13 +384,19 @@ export default function VinCaptureModal({
           make: resp.make ?? null,
           model: resp.model ?? null,
           trim: resp.trim ?? null,
+          submodel: resp.submodel ?? resp.trim ?? null,
           engine: resp.engine ?? null,
+          engineFamily: resp.engineFamily ?? null,
+          engineType: resp.engineType ?? null,
           engineDisplacementL: extended.engineDisplacementL ?? null,
           engineCylinders: extended.engineCylinders ?? null,
-          fuelType: extended.fuelType ?? null,
-          transmission: extended.transmission ?? null,
-          driveType: extended.driveType ?? null,
+          fuelType: mapped.fuel_type ?? null,
+          transmission: mapped.transmission ?? null,
+          transmissionType: resp.transmissionType ?? extended.transmission ?? null,
+          driveType: mapped.drivetrain ?? null,
           bodyClass: extended.bodyClass ?? null,
+          manufacturer: extended.manufacturer ?? null,
+          gvwr: extended.gvwr ?? null,
         };
 
         onDecodedRef.current?.(detail);
@@ -367,13 +419,13 @@ export default function VinCaptureModal({
           /* non-blocking */
         }
 
+        setCaptureError(null);
         setOpen(false);
-        router.push("/work-orders/create?source=vin");
       } finally {
         setIsDecoding(false);
       }
     },
-    [userId, setVehicleDraft, router, setOpen, isDecoding],
+    [userId, setVehicleDraft, setOpen, isDecoding],
   );
 
 
@@ -399,10 +451,19 @@ export default function VinCaptureModal({
         <VinCaptureModalContent
           action={action}
           userId={userId}
+          onManualSubmit={handleFoundVin}
+          isDecoding={isDecoding}
+          error={captureError}
+          onClearError={() => setCaptureError(null)}
+          onContinueManual={() => {
+            setCaptureError(null);
+            setOpen(false);
+          }}
           scanSlot={
             <ScannerPane
               userId={userId}
               onFoundVin={handleFoundVin}
+              onError={setCaptureError}
               isBusy={isDecoding}
             />
           }

--- a/app/work-orders/state/useCustomerVehicleDraft.ts
+++ b/app/work-orders/state/useCustomerVehicleDraft.ts
@@ -24,6 +24,14 @@ export type SessionVehicle = {
   color: string | null;
   unit_number: string | null;
   engine_hours: string | null;
+  engine?: string | null;
+  submodel?: string | null;
+  engine_family?: string | null;
+  engine_type?: string | null;
+  transmission?: string | null;
+  transmission_type?: string | null;
+  fuel_type?: string | null;
+  drivetrain?: string | null;
 };
 
 type DraftState = {
@@ -56,6 +64,14 @@ const emptyVehicle: SessionVehicle = {
   color: null,
   unit_number: null,
   engine_hours: null,
+  engine: null,
+  submodel: null,
+  engine_family: null,
+  engine_type: null,
+  transmission: null,
+  transmission_type: null,
+  fuel_type: null,
+  drivetrain: null,
 };
 
 export const useCustomerVehicleDraft = create<DraftState>()(

--- a/app/work-orders/state/useWorkOrderDraft.ts
+++ b/app/work-orders/state/useWorkOrderDraft.ts
@@ -8,7 +8,14 @@ type VehicleDraft = {
   make: string | null;
   model: string | null;
   trim: string | null;
+  submodel: string | null;
   engine: string | null;
+  engine_family: string | null;
+  engine_type: string | null;
+  transmission: string | null;
+  transmission_type: string | null;
+  fuel_type: string | null;
+  drivetrain: string | null;
   plate: string | null;
 };
 
@@ -33,7 +40,14 @@ const emptyVehicle: VehicleDraft = {
   make: null,
   model: null,
   trim: null,
+  submodel: null,
   engine: null,
+  engine_family: null,
+  engine_type: null,
+  transmission: null,
+  transmission_type: null,
+  fuel_type: null,
+  drivetrain: null,
   plate: null,
 };
 

--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -5,11 +5,18 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import type {
   SessionCustomer as CustomerInfo,
-  SessionVehicle as VehicleInfo,
+  SessionVehicle,
 } from "@inspections/lib/inspection/types";
 import { normalizeCustomerForIntake } from "@inspections/lib/customerNormalization";
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { checkVehicleDuplicates, type VehicleDuplicateMatch } from "@/features/shared/lib/vehicles/duplicateCheck";
+
+type VehicleInfo = SessionVehicle & {
+  submodel?: string | null;
+  engine_family?: string | null;
+  engine_type?: string | null;
+  transmission_type?: string | null;
+};
 
 /** Local, narrow shapes (avoid exporting DB row types in props) */
 type CustomerRow = {
@@ -41,7 +48,11 @@ type VehicleRow = {
   engine_hours?: number | null;
 
   engine?: string | null;
+  submodel?: string | null;
+  engine_family?: string | null;
+  engine_type?: string | null;
   transmission?: string | null;
+  transmission_type?: string | null;
   fuel_type?: string | null;
   drivetrain?: string | null;
 
@@ -98,7 +109,11 @@ function hydrateVehicleFields(v: VehicleRow): VehicleInfo {
     color: v.color ?? null,
     engine_hours: v.engine_hours != null ? String(v.engine_hours) : null,
     engine: v.engine ?? null,
+    submodel: v.submodel ?? null,
+    engine_family: v.engine_family ?? null,
+    engine_type: v.engine_type ?? null,
     transmission: v.transmission ?? null,
+    transmission_type: v.transmission_type ?? null,
     fuel_type: v.fuel_type ?? null,
     drivetrain: v.drivetrain ?? null,
   };
@@ -286,7 +301,7 @@ function UnitNumberAutocomplete({
         const { data, error } = await supabase
           .from("vehicles")
           .select(
-            "id, unit_number, license_plate, vin, year, make, model, mileage, color, engine_hours, engine, transmission, fuel_type, drivetrain, customer_id, created_at",
+            "id, unit_number, license_plate, vin, year, make, model, mileage, color, engine_hours, engine, submodel, engine_family, engine_type, transmission, transmission_type, fuel_type, drivetrain, customer_id, created_at",
           )
           .eq("shop_id", shopId)
           .eq("customer_id", customerId)
@@ -515,7 +530,7 @@ export default function CustomerVehicleForm({
       const { data: vehs } = await supabase
         .from("vehicles")
         .select(
-          "id, vin, year, make, model, license_plate, mileage, unit_number, color, engine_hours, engine, transmission, fuel_type, drivetrain, created_at",
+          "id, vin, year, make, model, license_plate, mileage, unit_number, color, engine_hours, engine, submodel, engine_family, engine_type, transmission, transmission_type, fuel_type, drivetrain, created_at",
         )
         .eq("customer_id", c.id)
         .eq("shop_id", shopId)
@@ -536,7 +551,11 @@ export default function CustomerVehicleForm({
         safeSetVehicle("color", fields.color);
         safeSetVehicle("engine_hours", fields.engine_hours ?? null);
         safeSetVehicle("engine", fields.engine ?? null);
+        safeSetVehicle("submodel", fields.submodel ?? null);
+        safeSetVehicle("engine_family", fields.engine_family ?? null);
+        safeSetVehicle("engine_type", fields.engine_type ?? null);
         safeSetVehicle("transmission", fields.transmission ?? null);
+        safeSetVehicle("transmission_type", fields.transmission_type ?? null);
         safeSetVehicle("fuel_type", fields.fuel_type ?? null);
         safeSetVehicle("drivetrain", fields.drivetrain ?? null);
 
@@ -827,7 +846,11 @@ export default function CustomerVehicleForm({
                   );
 
                   safeSetVehicle("engine", v.engine ?? null);
+                  safeSetVehicle("submodel", v.submodel ?? null);
+                  safeSetVehicle("engine_family", v.engine_family ?? null);
+                  safeSetVehicle("engine_type", v.engine_type ?? null);
                   safeSetVehicle("transmission", v.transmission ?? null);
+                  safeSetVehicle("transmission_type", v.transmission_type ?? null);
                   safeSetVehicle("fuel_type", v.fuel_type ?? null);
                   safeSetVehicle("drivetrain", v.drivetrain ?? null);
 
@@ -976,7 +999,8 @@ export default function CustomerVehicleForm({
                 <option value="diesel">Diesel</option>
                 <option value="hybrid">Hybrid</option>
                 <option value="phev">Plug-in hybrid</option>
-                <option value="ev">Electric (BEV)</option>
+                <option value="electric">Electric (BEV)</option>
+                <option value="ev">Electric (legacy)</option>
                 <option value="other">Other</option>
               </select>
             </div>

--- a/features/shared/lib/vin/decodeVin.ts
+++ b/features/shared/lib/vin/decodeVin.ts
@@ -5,17 +5,115 @@ export type DecodedVin = {
   make?: string | null;
   model?: string | null;
   trim?: string | null;
+  submodel?: string | null;
   engine?: string | null;
+  engineFamily?: string | null;
+  engineType?: string | null;
 
   engineDisplacementL?: string | null;
   engineCylinders?: string | null;
   fuelType?: string | null;
   transmission?: string | null;
+  transmissionType?: string | null;
   driveType?: string | null;
   bodyClass?: string | null;
+  manufacturer?: string | null;
+  gvwr?: string | null;
 
   error?: string;
 };
+
+export type VinSelectValues = {
+  fuel_type?: string | null;
+  transmission?: string | null;
+  drivetrain?: string | null;
+};
+
+function compactToken(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+export function mapFuelTypeToVehicleValue(value: unknown): string | null {
+  const normalized = compactToken(value);
+  if (!normalized) return null;
+  if (normalized.includes("diesel")) return "diesel";
+  if (normalized.includes("plug in") || normalized.includes("phev")) return "phev";
+  if (normalized.includes("hybrid")) return "hybrid";
+  if (
+    normalized.includes("electric") ||
+    normalized.includes("bev") ||
+    normalized.includes("battery")
+  ) {
+    return "electric";
+  }
+  if (
+    normalized.includes("gasoline") ||
+    normalized.includes("gas") ||
+    normalized.includes("petrol")
+  ) {
+    return "gasoline";
+  }
+  return "other";
+}
+
+export function mapTransmissionToVehicleValue(value: unknown): string | null {
+  const normalized = compactToken(value);
+  if (!normalized) return null;
+  if (normalized.includes("cvt") || normalized.includes("continuously variable")) {
+    return "cvt";
+  }
+  if (normalized.includes("dual clutch") || normalized.includes("dct")) {
+    return "dct";
+  }
+  if (normalized.includes("automatic")) return "automatic";
+  if (normalized.includes("manual")) return "manual";
+  return "other";
+}
+
+export function mapDriveTypeToVehicleValue(value: unknown): string | null {
+  const normalized = compactToken(value);
+  if (!normalized) return null;
+  if (
+    normalized.includes("all wheel") ||
+    normalized.includes("awd")
+  ) {
+    return "awd";
+  }
+  if (
+    normalized.includes("four wheel") ||
+    normalized.includes("4wd") ||
+    normalized.includes("4x4")
+  ) {
+    return "4x4";
+  }
+  if (
+    normalized.includes("front wheel") ||
+    normalized.includes("fwd")
+  ) {
+    return "fwd";
+  }
+  if (
+    normalized.includes("rear wheel") ||
+    normalized.includes("rwd")
+  ) {
+    return "rwd";
+  }
+  return "other";
+}
+
+export function mapDecodedVinToVehicleSelectValues(
+  decoded: Pick<DecodedVin, "fuelType" | "transmission" | "driveType">,
+): VinSelectValues {
+  return {
+    fuel_type: mapFuelTypeToVehicleValue(decoded.fuelType),
+    transmission: mapTransmissionToVehicleValue(decoded.transmission),
+    drivetrain: mapDriveTypeToVehicleValue(decoded.driveType),
+  };
+}
 
 export async function decodeVin(
   vin: string,

--- a/features/vehicles/components/VinCaptureModal.tsx
+++ b/features/vehicles/components/VinCaptureModal.tsx
@@ -1,13 +1,20 @@
 // features/vehicles/components/VinCaptureModal.tsx
-// SERVER COMPONENT – content only (ModalShell handles chrome)
+"use client";
 
-import type { ReactNode } from "react";
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
+
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 
 type Props = {
   action: string;
   userId: string;
   defaultVin?: string;
   scanSlot?: ReactNode;
+  onManualSubmit?: (vin: string) => void | Promise<void>;
+  isDecoding?: boolean;
+  error?: string | null;
+  onClearError?: () => void;
+  onContinueManual?: () => void;
 };
 
 export default function VinCaptureModalContent({
@@ -15,67 +22,135 @@ export default function VinCaptureModalContent({
   userId,
   defaultVin,
   scanSlot,
+  onManualSubmit,
+  isDecoding = false,
+  error,
+  onClearError,
+  onContinueManual,
 }: Props) {
+  const [manualVin, setManualVin] = useState(defaultVin ?? "");
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setManualVin(defaultVin ?? "");
+  }, [defaultVin]);
+
+  const handleManualSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onClearError?.();
+
+    const normalized = normalizeVinInput(manualVin);
+    if (!normalized.isValid) {
+      setManualError(normalized.message);
+      return;
+    }
+
+    setManualError(null);
+    await onManualSubmit?.(normalized.vin);
+  };
+
   return (
-    <div className="grid gap-6 sm:grid-cols-2">
-      {/* Manual Entry */}
-      <section className="rounded-2xl border border-[var(--metal-border-soft)] bg-black/50 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.9)]">
-        <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
-          MANUAL ENTRY
-        </h3>
-        <p className="mt-1 text-xs text-neutral-400">
-          Enter a valid 17-character VIN. No I, O, or Q.
-        </p>
-
-        <form method="post" action={action} className="mt-3 space-y-3">
-          <input type="hidden" name="user_id" value={userId} />
-
-          <label className="block text-xs text-neutral-300">
-            VIN
-            <input
-              name="vin"
-              defaultValue={defaultVin ?? ""}
-              inputMode="text"
-              autoCapitalize="characters"
-              spellCheck={false}
-              placeholder="1HGCM82633A004352"
-              className="mt-1 w-full rounded border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder-neutral-500 outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500/70"
-            />
-          </label>
-
-          <div className="flex items-center justify-between">
-            <span className="text-[11px] text-neutral-500">
-              Decoded via NHTSA vPIC
-            </span>
+    <div className="space-y-4">
+      {error ? (
+        <div className="rounded-xl border border-red-500/40 bg-red-950/30 p-3 text-sm text-red-100">
+          <div className="font-semibold">VIN capture needs attention</div>
+          <div className="mt-1 text-xs text-red-100/90">{error}</div>
+          <div className="mt-3 flex flex-wrap gap-2">
             <button
-              type="submit"
-              className="rounded-full border border-orange-500 bg-black/80 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-orange-100 hover:bg-orange-500/10"
+              type="button"
+              onClick={onClearError}
+              className="rounded-full border border-red-300/50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-red-50 hover:bg-red-400/10"
             >
-              Decode VIN
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={onContinueManual}
+              className="rounded-full border border-neutral-500/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-100 hover:bg-white/10"
+            >
+              Continue manually
             </button>
           </div>
-        </form>
-      </section>
-
-      {/* Scanner card */}
-      <section className="rounded-2xl border border-[var(--metal-border-soft)] bg-black/50 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.9)]">
-        <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
-          SCAN VIN
-        </h3>
-        <p className="mt-1 text-xs text-neutral-400">
-          Use the camera or upload a photo of the VIN label.
-        </p>
-
-        <div className="mt-3 min-h-[220px] rounded-xl border border-dashed border-neutral-700 bg-neutral-950/60 p-3">
-          {scanSlot ? (
-            scanSlot
-          ) : (
-            <div className="flex h-full items-center justify-center text-sm text-neutral-500">
-              Scanner not loaded
-            </div>
-          )}
         </div>
-      </section>
+      ) : null}
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        {/* Manual Entry */}
+        <section className="rounded-2xl border border-[var(--metal-border-soft)] bg-black/50 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.9)]">
+          <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
+            MANUAL ENTRY
+          </h3>
+          <p className="mt-1 text-xs text-neutral-400">
+            Enter a valid 17-character VIN. No I, O, or Q.
+          </p>
+
+          <form
+            method="post"
+            action={action}
+            onSubmit={handleManualSubmit}
+            className="mt-3 space-y-3"
+          >
+            <input type="hidden" name="user_id" value={userId} />
+
+            <label className="block text-xs text-neutral-300">
+              VIN
+              <input
+                name="vin"
+                value={manualVin}
+                onChange={(event) => {
+                  setManualVin(event.target.value.toUpperCase());
+                  setManualError(null);
+                  onClearError?.();
+                }}
+                inputMode="text"
+                autoCapitalize="characters"
+                spellCheck={false}
+                placeholder="1HGCM82633A004352"
+                className="mt-1 w-full rounded border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder-neutral-500 outline-none focus:border-orange-500 focus:ring-1 focus:ring-orange-500/70"
+              />
+            </label>
+
+            {manualError ? (
+              <div className="rounded border border-orange-500/40 bg-orange-950/30 px-3 py-2 text-xs text-orange-100">
+                {manualError}
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span className="text-[11px] text-neutral-500">
+                Decoded via NHTSA vPIC
+              </span>
+              <button
+                type="submit"
+                disabled={isDecoding}
+                className="rounded-full border border-orange-500 bg-black/80 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-orange-100 hover:bg-orange-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isDecoding ? "Decoding…" : "Decode VIN"}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {/* Scanner card */}
+        <section className="rounded-2xl border border-[var(--metal-border-soft)] bg-black/50 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.9)]">
+          <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
+            SCAN VIN
+          </h3>
+          <p className="mt-1 text-xs text-neutral-400">
+            Use the camera or upload a photo of the VIN label.
+          </p>
+
+          <div className="mt-3 min-h-[220px] rounded-xl border border-dashed border-neutral-700 bg-neutral-950/60 p-3">
+            {scanSlot ? (
+              scanSlot
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-neutral-500">
+                Scanner not loaded
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -71,9 +71,13 @@ type UploadSummary = { uploaded: number; failed: number };
 type CustomerWithBusiness = SessionCustomer & { business_name?: string | null };
 type VehicleWithExtra = SessionVehicle & {
   engine?: string | null;
+  submodel?: string | null;
+  engine_family?: string | null;
+  engine_type?: string | null;
   fuel_type?: string | null;
   drivetrain?: string | null;
   transmission?: string | null;
+  transmission_type?: string | null;
 };
 
 type WorkOrderWaiterRow = WorkOrderRow & { is_waiter?: boolean | null };
@@ -84,10 +88,18 @@ type VinDecoded = {
   year?: string | number | null;
   make?: string | null;
   model?: string | null;
+  trim?: string | null;
+  submodel?: string | null;
   engine?: string | null;
+  engineFamily?: string | null;
+  engineType?: string | null;
   fuelType?: string | null;
   driveType?: string | null;
   transmission?: string | null;
+  transmissionType?: string | null;
+  bodyClass?: string | null;
+  manufacturer?: string | null;
+  gvwr?: string | null;
 };
 
 type CustomerRowWithBusiness = CustomerRow & { business_name?: string | null };
@@ -298,7 +310,11 @@ function hydrateVehicleFromRow(row: VehicleRow): VehicleWithExtra {
     color: getStrField(row, "color"),
     engine_hours: row.engine_hours != null ? String(row.engine_hours) : null,
     engine: getStrField(row, "engine"),
+    submodel: getStrField(row, "submodel"),
+    engine_family: getStrField(row, "engine_family"),
+    engine_type: getStrField(row, "engine_type"),
     transmission: getStrField(row, "transmission"),
+    transmission_type: getStrField(row, "transmission_type"),
     fuel_type: getStrField(row, "fuel_type"),
     drivetrain: getStrField(row, "drivetrain"),
   };
@@ -487,7 +503,11 @@ export default function CreateWorkOrderPage() {
 
         // ✅ persist extra fields from draft too
         engine: dv.engine ?? prev.engine ?? null,
+        submodel: dv.submodel ?? prev.submodel ?? null,
+        engine_family: dv.engine_family ?? prev.engine_family ?? null,
+        engine_type: dv.engine_type ?? prev.engine_type ?? null,
         transmission: dv.transmission ?? prev.transmission ?? null,
+        transmission_type: dv.transmission_type ?? prev.transmission_type ?? null,
         fuel_type: dv.fuel_type ?? prev.fuel_type ?? null,
         drivetrain: dv.drivetrain ?? prev.drivetrain ?? null,
       }));
@@ -631,9 +651,14 @@ export default function CreateWorkOrderPage() {
 
         // ✅ extra fields from VIN draft
         engine: draft.vehicle?.engine ?? prev.engine ?? null,
+        submodel: draft.vehicle?.submodel ?? prev.submodel ?? null,
+        engine_family: draft.vehicle?.engine_family ?? prev.engine_family ?? null,
+        engine_type: draft.vehicle?.engine_type ?? prev.engine_type ?? null,
         fuel_type: draft.vehicle?.fuel_type ?? prev.fuel_type ?? null,
         drivetrain: draft.vehicle?.drivetrain ?? prev.drivetrain ?? null,
         transmission: draft.vehicle?.transmission ?? prev.transmission ?? null,
+        transmission_type:
+          draft.vehicle?.transmission_type ?? prev.transmission_type ?? null,
       }));
     }
     if (hasCust) {
@@ -791,7 +816,11 @@ useEffect(() => {
 
     // ✅ NEW
     engine: strOrNull(v.engine ?? null),
+    submodel: strOrNull(v.submodel ?? null),
+    engine_family: strOrNull(v.engine_family ?? null),
+    engine_type: strOrNull(v.engine_type ?? null),
     transmission: strOrNull(v.transmission ?? null),
+    transmission_type: strOrNull(v.transmission_type ?? null),
     fuel_type: strOrNull(v.fuel_type ?? null),
     drivetrain: strOrNull(v.drivetrain ?? null),
 
@@ -838,8 +867,20 @@ useEffect(() => {
     const engine = strOrNull(v.engine ?? null);
     if (engine !== null) patch.engine = engine;
 
+    const submodel = strOrNull(v.submodel ?? null);
+    if (submodel !== null) patch.submodel = submodel;
+
+    const engineFamily = strOrNull(v.engine_family ?? null);
+    if (engineFamily !== null) patch.engine_family = engineFamily;
+
+    const engineType = strOrNull(v.engine_type ?? null);
+    if (engineType !== null) patch.engine_type = engineType;
+
     const trans = strOrNull(v.transmission ?? null);
     if (trans !== null) patch.transmission = trans;
+
+    const transmissionType = strOrNull(v.transmission_type ?? null);
+    if (transmissionType !== null) patch.transmission_type = transmissionType;
 
     const fuel = strOrNull(v.fuel_type ?? null);
     if (fuel !== null) patch.fuel_type = fuel;
@@ -1009,7 +1050,7 @@ useEffect(() => {
           const query = supabase
             .from("vehicles")
             .select(
-              "id, vin, year, make, model, license_plate, mileage, unit_number, color, engine_hours, engine, transmission, fuel_type, drivetrain, customer_id",
+              "id, vin, year, make, model, license_plate, mileage, unit_number, color, engine_hours, engine, submodel, engine_family, engine_type, transmission, transmission_type, fuel_type, drivetrain, customer_id",
             )
             .eq("id", prefillVehicleId)
             .eq("shop_id", shopId);
@@ -1042,7 +1083,7 @@ useEffect(() => {
           const { data: vehicles } = await supabase
             .from("vehicles")
             .select(
-              "id, vin, year, make, model, license_plate, mileage, unit_number, color, engine_hours, engine, transmission, fuel_type, drivetrain, customer_id, created_at",
+              "id, vin, year, make, model, license_plate, mileage, unit_number, color, engine_hours, engine, submodel, engine_family, engine_type, transmission, transmission_type, fuel_type, drivetrain, customer_id, created_at",
             )
             .eq("shop_id", shopId)
             .eq("customer_id", effectiveCustomerId)
@@ -1399,8 +1440,17 @@ useEffect(() => {
 
           // ✅ NEW
           engine: (veh.engine as string | null) ?? vehicle.engine ?? null,
+          submodel: (veh.submodel as string | null) ?? vehicle.submodel ?? null,
+          engine_family:
+            (veh.engine_family as string | null) ?? vehicle.engine_family ?? null,
+          engine_type:
+            (veh.engine_type as string | null) ?? vehicle.engine_type ?? null,
           transmission:
             (veh.transmission as string | null) ?? vehicle.transmission ?? null,
+          transmission_type:
+            (veh.transmission_type as string | null) ??
+            vehicle.transmission_type ??
+            null,
           fuel_type:
             (veh.fuel_type as string | null) ?? vehicle.fuel_type ?? null,
           drivetrain:
@@ -2252,41 +2302,58 @@ useEffect(() => {
                   action="/api/vin"
                   onDecoded={(d: VinDecoded) => {
                     const y = yearToStrOrNull(d.year);
-
-                    draft.setVehicle({
+                    const decodedVehicle: Partial<VehicleWithExtra> = {
                       vin: d.vin,
-                      year: y,
-                      make: d.make ?? null,
-                      model: d.model ?? null,
-                      engine: d.engine ?? null,
-                      fuel_type: d.fuelType ?? null,
-                      drivetrain: d.driveType ?? null,
-                      transmission: d.transmission ?? null,
-                    });
+                    };
+
+                    if (y) decodedVehicle.year = y;
+                    if (strOrNull(d.make)) decodedVehicle.make = strOrNull(d.make);
+                    if (strOrNull(d.model)) decodedVehicle.model = strOrNull(d.model);
+                    if (strOrNull(d.engine)) decodedVehicle.engine = strOrNull(d.engine);
+                    if (strOrNull(d.submodel ?? d.trim)) {
+                      decodedVehicle.submodel = strOrNull(d.submodel ?? d.trim);
+                    }
+                    if (strOrNull(d.engineFamily)) {
+                      decodedVehicle.engine_family = strOrNull(d.engineFamily);
+                    }
+                    if (strOrNull(d.engineType)) {
+                      decodedVehicle.engine_type = strOrNull(d.engineType);
+                    }
+                    if (strOrNull(d.fuelType)) decodedVehicle.fuel_type = strOrNull(d.fuelType);
+                    if (strOrNull(d.driveType)) decodedVehicle.drivetrain = strOrNull(d.driveType);
+                    if (strOrNull(d.transmission)) {
+                      decodedVehicle.transmission = strOrNull(d.transmission);
+                    }
+                    if (strOrNull(d.transmissionType)) {
+                      decodedVehicle.transmission_type = strOrNull(d.transmissionType);
+                    }
+
+                    draft.setVehicle(decodedVehicle);
 
                     setVehicle((prev) => ({
                       ...prev,
-                      vin: d.vin || prev.vin,
-                      year: y ?? prev.year,
-                      make: d.make ?? prev.make,
-                      model: d.model ?? prev.model,
-                      engine: d.engine ?? prev.engine ?? null,
-                      fuel_type: d.fuelType ?? prev.fuel_type ?? null,
-                      drivetrain: d.driveType ?? prev.drivetrain ?? null,
-                      transmission: d.transmission ?? prev.transmission ?? null,
+                      vin: decodedVehicle.vin ?? prev.vin,
+                      year: decodedVehicle.year ?? prev.year,
+                      make: decodedVehicle.make ?? prev.make,
+                      model: decodedVehicle.model ?? prev.model,
+                      engine: decodedVehicle.engine ?? prev.engine ?? null,
+                      submodel: decodedVehicle.submodel ?? prev.submodel ?? null,
+                      engine_family:
+                        decodedVehicle.engine_family ?? prev.engine_family ?? null,
+                      engine_type:
+                        decodedVehicle.engine_type ?? prev.engine_type ?? null,
+                      fuel_type: decodedVehicle.fuel_type ?? prev.fuel_type ?? null,
+                      drivetrain: decodedVehicle.drivetrain ?? prev.drivetrain ?? null,
+                      transmission:
+                        decodedVehicle.transmission ?? prev.transmission ?? null,
+                      transmission_type:
+                        decodedVehicle.transmission_type ??
+                        prev.transmission_type ??
+                        null,
                     }));
 
                     cvDraft.bulkSet({
-                      vehicle: {
-                        vin: d.vin ?? null,
-                        year: y,
-                        make: d.make ?? null,
-                        model: d.model ?? null,
-                        engine: d.engine ?? null,
-                        fuel_type: d.fuelType ?? null,
-                        drivetrain: d.driveType ?? null,
-                        transmission: d.transmission ?? null,
-                      },
+                      vehicle: decodedVehicle,
                     });
                   }}
                 >

--- a/features/work-orders/mobile/MobileCustomerVehicleForm.tsx
+++ b/features/work-orders/mobile/MobileCustomerVehicleForm.tsx
@@ -342,7 +342,8 @@ export function MobileCustomerVehicleForm({
               <option value="diesel">Diesel</option>
               <option value="hybrid">Hybrid</option>
               <option value="phev">Plug-in hybrid</option>
-              <option value="ev">Electric (BEV)</option>
+              <option value="electric">Electric (BEV)</option>
+              <option value="ev">Electric (legacy)</option>
               <option value="other">Other</option>
             </select>
           </div>


### PR DESCRIPTION
### Motivation

- Make VIN capture usable in intake/work-order flows by decoding manual entry inline and avoiding navigation to raw JSON, and by surfacing decode/OCR/camera errors inline instead of with `alert()`.
- Ensure decoded VIN fields map cleanly to existing UI select values (fuel, transmission, drivetrain) and preserve extra decoded metadata where the app schema/drafts already support it.
- Keep behavior non-breaking: do not auto-create/select vehicles from scans alone and do not change duplicate detection or add DB unique indexes.

### Description

- Manual VIN inline decode: manual entry form now prevents default navigation, validates/normalizes client-side with `normalizeVinInput`, calls `decodeVin`, shows loading state, and invokes the existing `onDecoded`/draft update flow instead of navigating to `/api/vin` JSON (changes in `features/vehicles/components/VinCaptureModal.tsx` and `app/vehicle/VinCaptureModal.tsx`).
- Inline error UX & retry paths: replaced `alert()` usage with modal-local state and contextual messages for invalid VIN, decode failure, OCR failure, camera unavailable, unsupported scanner, invalid file type, and oversized image; added explicit actions like `Try again` and `Continue manually` (modal-local error UI and handlers in the VIN modal and scanner pane).
- Mobile photo polish & safety checks: file input keeps `accept="image/*"` and now adds `capture="environment"`, validates file type and size client-side (8 MB limit) before calling `/api/vin/extract-from-image` (scanner/photo upload changes in `app/vehicle/VinCaptureModal.tsx` and scanner slot component).
- Decode → UI normalization: added mapping helpers (`mapFuelTypeToVehicleValue`, `mapTransmissionToVehicleValue`, `mapDriveTypeToVehicleValue` and `mapDecodedVinToVehicleSelectValues`) to normalize NHTSA vPIC fields into app select values (`gasoline|diesel|hybrid|phev|electric|other`, `automatic|manual|cvt|dct|other`, `awd|4x4|fwd|rwd|other`) and applied them wherever decoded values are mapped to form/drafts (new helpers in `features/shared/lib/vin/decodeVin.ts`, used in `app/vehicle/VinCaptureModal.tsx` and create form flows).
- Preserve additional decoded metadata where supported: when present, map and persist `submodel`/`trim`, `engine`, `engine_family`, `engine_type`, and `transmission_type` into the work-order/inspection drafts and form fields without adding DB columns; the server VIN API now returns `manufacturer`, `bodyClass`, and `gvwr` when vPIC provides them (returned in response JSON from `app/api/vin/route.ts`) and these are preserved in the decode detail payload for future follow-up.
- Safe apply semantics: decoded values only overwrite form/draft fields when the decoded value is non-empty, avoiding erasing user-entered values with empty/null decode output; duplicate detection logic and creation flows were intentionally left unchanged.

### Testing

- Ran lint across touched files with `npx eslint <files>`; linter completed successfully for the modified files.
- Type-checked the repo with `npx tsc --noEmit`; typecheck succeeded with no new errors.
- Ran repository checks `git diff --check` and `git status --short`; both returned clean/expected results and changes were committed.

All automated validations above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4ce4fe688328b9320f6e6267562a)