### PR TITLE
Normalize shop usernames into a consistent auth email for create-user and sign-in

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -3,11 +3,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { assertShopHasAvailableSeat } from "@/features/shared/lib/server/shop-seat-limit";
 import {
+  buildShopUserAuthEmail,
   buildShopUsernameNamespace,
   normalizeProvisioningUsername,
   withShopUsernameSuffix,
@@ -25,10 +26,29 @@ type Body = {
   phone?: string | null;
 };
 
-function mustEnv(name: string): string {
-  const v = process.env[name];
-  if (!v || v.trim() === "") throw new Error(`Missing required env: ${name}`);
-  return v;
+function logCreateUserStep(
+  step: string,
+  details: {
+    adminId?: string | null;
+    targetShopId?: string | null;
+    role?: string | null;
+    authUserId?: string | null;
+  } = {},
+): void {
+  console.info("[admin/create-user]", { step, ...details });
+}
+
+function logCreateUserError(
+  step: string,
+  details: {
+    adminId?: string | null;
+    targetShopId?: string | null;
+    role?: string | null;
+    authUserId?: string | null;
+    error?: string | null;
+  } = {},
+): void {
+  console.warn("[admin/create-user]", { step, ...details });
 }
 
 export async function POST(req: Request) {
@@ -68,10 +88,14 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Profile for current user not found." }, { status: 403 });
     }
 
-    // build service client to actually create auth user
-    const url = mustEnv("NEXT_PUBLIC_SUPABASE_URL");
-    const service = mustEnv("SUPABASE_SERVICE_ROLE_KEY");
-    const serviceSupabase = createClient<Database>(url, service);
+    logCreateUserStep("access_authorized", {
+      adminId: access.profile.id,
+      targetShopId: effectiveShopId,
+      role: canonicalRole,
+    });
+
+    // Service-role client is created server-side only and is never exposed to the browser.
+    const serviceSupabase = createAdminSupabase();
 
     const { data: shop } = await serviceSupabase
       .from("shops")
@@ -98,8 +122,14 @@ export async function POST(req: Request) {
       .limit(1);
 
     if (existingErr) {
+      logCreateUserError("username_lookup_failed", {
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        role: canonicalRole,
+        error: existingErr.message,
+      });
       return NextResponse.json(
-        { error: `Failed to check existing usernames: ${existingErr.message}` },
+        { error: "Failed to check existing usernames.", code: "username_lookup_failed" },
         { status: 500 }
       );
     }
@@ -120,8 +150,14 @@ export async function POST(req: Request) {
 
     // Username-only auth still signs in as username@local.profix-internal.
     // We enforce a shop namespace in username normalization so this backing identity remains collision-safe.
-    const syntheticEmail = `${username}@local.profix-internal`;
+    const syntheticEmail = buildShopUserAuthEmail(username);
     const email = inputEmail || syntheticEmail;
+
+    logCreateUserStep("creating_auth_user", {
+      adminId: access.profile.id,
+      targetShopId: effectiveShopId,
+      role: canonicalRole,
+    });
 
     // create auth user with service client
     const { data: created, error: createErr } = await serviceSupabase.auth.admin.createUser({
@@ -138,14 +174,26 @@ export async function POST(req: Request) {
     });
 
     if (createErr || !created?.user) {
+      logCreateUserError("auth_user_create_failed", {
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        role: canonicalRole,
+        error: createErr?.message ?? "No auth user returned",
+      });
       const safeMessage = createErr?.message?.toLowerCase().includes("already been registered")
         ? "Unable to provision this username. Try the suggested shop-prefixed username."
         : (createErr?.message ?? "Failed to create user.");
 
-      return NextResponse.json({ error: safeMessage }, { status: 400 });
+      return NextResponse.json({ error: safeMessage, code: "auth_user_create_failed" }, { status: 400 });
     }
 
     const newUserId = created.user.id;
+    logCreateUserStep("auth_user_created", {
+      adminId: access.profile.id,
+      targetShopId: effectiveShopId,
+      role: canonicalRole,
+      authUserId: newUserId,
+    });
 
     // upsert profile for the new user
     const { error: profileErr } = await serviceSupabase
@@ -175,8 +223,15 @@ export async function POST(req: Request) {
           { status: 400 }
         );
       }
+      logCreateUserError("profile_upsert_failed", {
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        role: canonicalRole,
+        authUserId: newUserId,
+        error: profileErr.message,
+      });
       return NextResponse.json(
-        { error: `Profile upsert failed: ${profileErr.message}` },
+        { error: "Profile upsert failed.", code: "profile_upsert_failed" },
         { status: 400 }
       );
     }
@@ -196,11 +251,25 @@ export async function POST(req: Request) {
       );
 
     if (workforceErr) {
+      logCreateUserError("workforce_profile_seed_failed", {
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        role: canonicalRole,
+        authUserId: newUserId,
+        error: workforceErr.message,
+      });
       return NextResponse.json(
-        { error: `Workforce profile seed failed: ${workforceErr.message}` },
+        { error: "Workforce profile seed failed.", code: "workforce_profile_seed_failed" },
         { status: 400 }
       );
     }
+
+    logCreateUserStep("completed", {
+      adminId: access.profile.id,
+      targetShopId: effectiveShopId,
+      role: canonicalRole,
+      authUserId: newUserId,
+    });
 
     return NextResponse.json({
       ok: true,
@@ -214,6 +283,7 @@ export async function POST(req: Request) {
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected error.";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    logCreateUserError("unexpected_error", { error: msg });
+    return NextResponse.json({ error: msg, code: "unexpected_error" }, { status: 500 });
   }
 }

--- a/app/api/admin/reset-user-password/route.ts
+++ b/app/api/admin/reset-user-password/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { normalizeLoginUsername } from "@/features/users/lib/username";
 
 function mustEnv(name: string) {
   const v = process.env[name];
@@ -21,7 +22,9 @@ export async function POST(req: Request) {
     username?: string;
     password?: string;
   };
-  if (!username || !password) {
+  const normalizedUsername = normalizeLoginUsername(username ?? "");
+
+  if (!normalizedUsername || !password) {
     return NextResponse.json({ error: "username and password required" }, { status: 400 });
   }
 
@@ -35,7 +38,7 @@ export async function POST(req: Request) {
     .from("profiles")
     .select("id, shop_id")
     .eq("shop_id", access.profile.shop_id)
-    .ilike("username", username.toLowerCase())
+    .ilike("username", normalizedUsername)
     .maybeSingle();
 
   if (profileErr || !profile) {

--- a/app/mobile/sign-in/page.tsx
+++ b/app/mobile/sign-in/page.tsx
@@ -8,11 +8,10 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { normalizeAuthIdentifier } from "@/features/users/lib/username";
 
 type DB = Database;
 
-// same synthetic-username domain as portal sign-in
-const SHOP_USER_DOMAIN = "local.profix-internal";
 
 export default function MobileSignInPage() {
   const router = useRouter();
@@ -60,13 +59,7 @@ export default function MobileSignInPage() {
     setLoading(true);
     setError("");
 
-    const raw = identifier.trim();
-    let emailToUse = raw;
-
-    // username → synthetic email (same behavior as main sign-in)
-    if (!raw.includes("@")) {
-      emailToUse = `${raw.toLowerCase()}@${SHOP_USER_DOMAIN}`;
-    }
+    const emailToUse = normalizeAuthIdentifier(identifier);
 
     const { error: signInErr } = await supabase.auth.signInWithPassword({
       email: emailToUse,

--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -7,9 +7,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import AuthShell from "@/features/auth/components/AuthShell";
+import { normalizeAuthIdentifier } from "@/features/users/lib/username";
 
 const COPPER = "#C57A4A";
-const SHOP_USER_DOMAIN = "local.profix-internal";
 
 type PortalType = "customer" | "fleet";
 
@@ -60,13 +60,7 @@ export default function PortalSignInPage() {
     setLoading(true);
     setError("");
 
-    const raw = identifier.trim();
-    let emailToUse = raw;
-
-    // ✅ Allow username-only for shop/fleet-created accounts
-    if (!raw.includes("@")) {
-      emailToUse = `${raw.toLowerCase()}@${SHOP_USER_DOMAIN}`;
-    }
+    const emailToUse = normalizeAuthIdentifier(identifier);
 
     const { error: signInError } = await supabase.auth.signInWithPassword({
       email: emailToUse,

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -6,10 +6,10 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import AuthShell from "@/features/auth/components/AuthShell";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
+import { normalizeAuthIdentifier } from "@/features/users/lib/username";
 
 type Mode = "sign-in" | "sign-up";
 
-const SHOP_USER_DOMAIN = "local.profix-internal";
 
 export default function AuthPage() {
   const router = useRouter();
@@ -97,13 +97,7 @@ export default function AuthPage() {
     setError("");
     setNotice("");
 
-    const raw = identifier.trim();
-    let emailToUse = raw;
-
-    // Allow username-only for shop staff: username@SHOP_USER_DOMAIN
-    if (!raw.includes("@")) {
-      emailToUse = `${raw.toLowerCase()}@${SHOP_USER_DOMAIN}`;
-    }
+    const emailToUse = normalizeAuthIdentifier(identifier);
 
     const { error: signInErr } = await supabase.auth.signInWithPassword({
       email: emailToUse,

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -154,19 +154,26 @@ export default function CreateUserPage(): JSX.Element {
       });
 
       const payload = (await res.json().catch(() => null)) as
-        | { error?: string; user_id?: string; people_record_href?: string }
+        | { error?: string; user_id?: string; username?: string; email?: string; people_record_href?: string }
         | null;
 
       if (!res.ok) throw new Error(payload?.error || "Failed to create user.");
 
+      const createdUsername = payload?.username ?? body.username;
+      const createdEmail = payload?.email ?? null;
+
       // local feedback
-      setSuccess(`User "${body.username}" created.`);
+      setSuccess(
+        `User "${createdUsername}" created. They can sign in with username "${createdUsername}"${
+          createdEmail ? ` or email ${createdEmail}` : ""
+        } and the password entered here.`,
+      );
       setCreatedUserId(payload?.user_id ?? null);
       setCreatedPersonHref(payload?.people_record_href ?? null);
       setRecentUsers((prev) =>
         [
           {
-            username: body.username,
+            username: createdUsername,
             full_name: body.full_name,
             role: body.role ?? "mechanic",
           },

--- a/features/users/lib/username.ts
+++ b/features/users/lib/username.ts
@@ -1,7 +1,22 @@
 const MAX_USERNAME_LENGTH = 32;
+export const SHOP_USER_AUTH_DOMAIN = "local.profix-internal";
 
 function toAlphaNumericLower(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+export function normalizeLoginUsername(input: string): string {
+  return toAlphaNumericLower(input.trim());
+}
+
+export function buildShopUserAuthEmail(username: string): string {
+  return `${normalizeLoginUsername(username)}@${SHOP_USER_AUTH_DOMAIN}`;
+}
+
+export function normalizeAuthIdentifier(input: string): string {
+  const raw = input.trim();
+  if (raw.includes("@")) return raw.toLowerCase();
+  return buildShopUserAuthEmail(raw);
 }
 
 export function buildShopUsernameNamespace(shopName: string | null | undefined): string {

--- a/tests/user-auth-normalization.test.ts
+++ b/tests/user-auth-normalization.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildShopUserAuthEmail,
+  buildShopUsernameNamespace,
+  normalizeAuthIdentifier,
+  normalizeLoginUsername,
+  normalizeProvisioningUsername,
+} from "../features/users/lib/username";
+
+describe("shop user auth normalization", () => {
+  it("uses the same synthetic auth email for created usernames and username sign-in", () => {
+    const namespace = buildShopUsernameNamespace("Downtown Diesel");
+    const username = normalizeProvisioningUsername(" Sam Tech ", namespace);
+
+    expect(username).toBe("downtowndiessamtech");
+    expect(buildShopUserAuthEmail(username)).toBe("downtowndiessamtech@local.profix-internal");
+    expect(normalizeAuthIdentifier(username)).toBe(
+      "downtowndiessamtech@local.profix-internal",
+    );
+  });
+
+  it("normalizes username-only login exactly like backing auth email creation", () => {
+    expect(normalizeLoginUsername(" Shop.User-01 ")).toBe("shopuser01");
+    expect(normalizeAuthIdentifier(" Shop.User-01 ")).toBe("shopuser01@local.profix-internal");
+  });
+
+  it("preserves explicit email login as lower-case email auth", () => {
+    expect(normalizeAuthIdentifier(" Person@Example.COM ")).toBe("person@example.com");
+  });
+});


### PR DESCRIPTION
### Motivation
- Created users could not sign in because the admin provisioning flow and client sign-in flow used different normalization rules for usernames, producing mismatched synthetic auth emails (e.g. `username@local.profix-internal`).
- The goal is to ensure owner/admin-provisioned accounts can immediately sign in with the credentials provided, without weakening RLS or seat checks.

### Description
- Centralized username/login normalization in `features/users/lib/username.ts` with `normalizeProvisioningUsername`, `normalizeLoginUsername`, `buildShopUserAuthEmail`, and `normalizeAuthIdentifier` so both provisioning and sign-in produce the same Supabase auth email.
- Updated server provisioning in `app/api/admin/create-user/route.ts` to use the service-role client via `createAdminSupabase`, create the auth user with `serviceSupabase.auth.admin.createUser` using the supplied password, set `email_confirm: true`, include `user_metadata` (`username`, `full_name`, `role`, `shop_id`), and upsert a `profiles` row with `id` equal to the created auth user id and the correct `shop_id`, `role`, `username`, and `must_change_password` flag while preserving seat-limit checks.
- Added safe diagnostic logging in the admin create route (step names, admin id, target shop id, role, auth user id) and returned limited error codes for safer observability without logging passwords.
- Normalized client sign-in to use the shared `normalizeAuthIdentifier` in the main sign-in component and portal/mobile sign-in pages so `username` input becomes the same synthetic email used during provisioning before calling `signInWithPassword`.
- Updated admin password reset lookup (`app/api/admin/reset-user-password/route.ts`) to normalize username lookups consistently and remain shop-scoped.
- Improved UI feedback in the owner/admin create-user page to display the server-returned username/email that will actually sign in.
- Added a focused test `tests/user-auth-normalization.test.ts` covering provisioning username normalization, synthetic auth email generation, username-signin normalization, and explicit-email normalization.

### Testing
- Ran the new unit tests: `npx vitest run tests/user-auth-normalization.test.ts` and they passed (all tests green).
- Ran lint on touched files: `npx eslint app/api/admin/create-user/route.ts app/api/admin/reset-user-password/route.ts features/users/lib/username.ts features/auth/components/SignIn.tsx app/mobile/sign-in/page.tsx app/portal/auth/sign-in/PortalSignInForm.tsx features/dashboard/app/dashboard/owner/create-user/page.tsx tests/user-auth-normalization.test.ts` and it succeeded (no new lint failures).
- Type-checked the repo with `npx tsc --noEmit` and it succeeded (no type errors).
- Ran `git diff --check` to ensure no trailing whitespace/patch issues; it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2071efc894832880ffb0791c63eb46)