### PR TITLE
Fix username auth provisioning

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -33,6 +33,10 @@ function logCreateUserStep(
     targetShopId?: string | null;
     role?: string | null;
     authUserId?: string | null;
+    profileId?: string | null;
+    normalizedUsername?: string | null;
+    syntheticAuthEmail?: string | null;
+    hasContactEmail?: boolean;
   } = {},
 ): void {
   console.info("[admin/create-user]", { step, ...details });
@@ -45,6 +49,10 @@ function logCreateUserError(
     targetShopId?: string | null;
     role?: string | null;
     authUserId?: string | null;
+    profileId?: string | null;
+    normalizedUsername?: string | null;
+    syntheticAuthEmail?: string | null;
+    hasContactEmail?: boolean;
     error?: string | null;
   } = {},
 ): void {
@@ -55,7 +63,7 @@ export async function POST(req: Request) {
   try {
     const raw = (await req.json()) as Partial<Body>;
 
-    const password = (raw.password ?? "").trim();
+    const password = raw.password ?? "";
     const full_name = (raw.full_name ?? null) || null;
     const requestedRole = (raw.role ?? null) || null;
     const canonicalRole = canonicalizeRole(requestedRole);
@@ -148,20 +156,24 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: msg }, { status: 400 });
     }
 
-    // Username-only auth still signs in as username@local.profix-internal.
-    // We enforce a shop namespace in username normalization so this backing identity remains collision-safe.
+    // Staff username auth is primary: Supabase Auth uses the same synthetic email
+    // that username sign-in derives from the normalized username. Real email remains
+    // a profile/contact field only.
     const syntheticEmail = buildShopUserAuthEmail(username);
-    const email = inputEmail || syntheticEmail;
+    const contactEmail = inputEmail || null;
 
     logCreateUserStep("creating_auth_user", {
       adminId: access.profile.id,
       targetShopId: effectiveShopId,
       role: canonicalRole,
+      normalizedUsername: username,
+      syntheticAuthEmail: syntheticEmail,
+      hasContactEmail: Boolean(contactEmail),
     });
 
     // create auth user with service client
     const { data: created, error: createErr } = await serviceSupabase.auth.admin.createUser({
-      email,
+      email: syntheticEmail,
       password,
       email_confirm: true,
       user_metadata: {
@@ -170,6 +182,7 @@ export async function POST(req: Request) {
         shop_id: effectiveShopId, // force caller's shop
         phone,
         username,
+        contact_email: contactEmail,
       },
     });
 
@@ -193,6 +206,9 @@ export async function POST(req: Request) {
       targetShopId: effectiveShopId,
       role: canonicalRole,
       authUserId: newUserId,
+      normalizedUsername: username,
+      syntheticAuthEmail: syntheticEmail,
+      hasContactEmail: Boolean(contactEmail),
     });
 
     // upsert profile for the new user
@@ -201,7 +217,7 @@ export async function POST(req: Request) {
       .upsert(
         {
           id: newUserId,
-          email,
+          email: contactEmail,
           full_name,
           phone,
           role: canonicalRole,
@@ -269,6 +285,10 @@ export async function POST(req: Request) {
       targetShopId: effectiveShopId,
       role: canonicalRole,
       authUserId: newUserId,
+      profileId: newUserId,
+      normalizedUsername: username,
+      syntheticAuthEmail: syntheticEmail,
+      hasContactEmail: Boolean(contactEmail),
     });
 
     return NextResponse.json({
@@ -276,7 +296,8 @@ export async function POST(req: Request) {
       user_id: newUserId,
       username,
       suggested_alternate_username: withShopUsernameSuffix(username, 1),
-      email,
+      email: contactEmail,
+      auth_email: syntheticEmail,
       must_change_password: true,
       shop_id: effectiveShopId,
       people_record_href: `/dashboard/admin/people/${newUserId}?from=create-user`,

--- a/app/mobile/sign-in/page.tsx
+++ b/app/mobile/sign-in/page.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { normalizeAuthIdentifier } from "@/features/users/lib/username";
+import { getAuthIdentifierStrategy } from "@/features/users/lib/username";
 
 type DB = Database;
 
@@ -59,10 +59,14 @@ export default function MobileSignInPage() {
     setLoading(true);
     setError("");
 
-    const emailToUse = normalizeAuthIdentifier(identifier);
+    const authIdentifier = getAuthIdentifierStrategy(identifier);
+    console.info("[auth/sign-in]", {
+      inputKind: authIdentifier.inputKind,
+      normalizedAuthEmail: authIdentifier.authEmail,
+    });
 
     const { error: signInErr } = await supabase.auth.signInWithPassword({
-      email: emailToUse,
+      email: authIdentifier.authEmail,
       password,
     });
 

--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -7,7 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import AuthShell from "@/features/auth/components/AuthShell";
-import { normalizeAuthIdentifier } from "@/features/users/lib/username";
+import { getAuthIdentifierStrategy } from "@/features/users/lib/username";
 
 const COPPER = "#C57A4A";
 
@@ -60,10 +60,14 @@ export default function PortalSignInPage() {
     setLoading(true);
     setError("");
 
-    const emailToUse = normalizeAuthIdentifier(identifier);
+    const authIdentifier = getAuthIdentifierStrategy(identifier);
+    console.info("[auth/sign-in]", {
+      inputKind: authIdentifier.inputKind,
+      normalizedAuthEmail: authIdentifier.authEmail,
+    });
 
     const { error: signInError } = await supabase.auth.signInWithPassword({
-      email: emailToUse,
+      email: authIdentifier.authEmail,
       password,
     });
 

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -6,7 +6,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import AuthShell from "@/features/auth/components/AuthShell";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
-import { normalizeAuthIdentifier } from "@/features/users/lib/username";
+import { getAuthIdentifierStrategy } from "@/features/users/lib/username";
 
 type Mode = "sign-in" | "sign-up";
 
@@ -97,10 +97,14 @@ export default function AuthPage() {
     setError("");
     setNotice("");
 
-    const emailToUse = normalizeAuthIdentifier(identifier);
+    const authIdentifier = getAuthIdentifierStrategy(identifier);
+    console.info("[auth/sign-in]", {
+      inputKind: authIdentifier.inputKind,
+      normalizedAuthEmail: authIdentifier.authEmail,
+    });
 
     const { error: signInErr } = await supabase.auth.signInWithPassword({
-      email: emailToUse,
+      email: authIdentifier.authEmail,
       password,
     });
 

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -19,6 +19,7 @@ type UserRole = Database["public"]["Enums"]["user_role_enum"];
 type CreatePayload = {
   username: string;
   password: string;
+  email?: string | null;
   full_name?: string | null;
   role?: UserRole | null;
   shop_id?: string | null;
@@ -36,6 +37,7 @@ export default function CreateUserPage(): JSX.Element {
   const [form, setForm] = useState<CreatePayload>({
     username: "",
     password: "",
+    email: "",
     full_name: "",
     role: "mechanic",
     shop_id: null,
@@ -133,7 +135,8 @@ export default function CreateUserPage(): JSX.Element {
           form.username.trim(),
           buildShopUsernameNamespace(creatorShopName),
         ),
-        password: form.password.trim(),
+        password: form.password,
+        email: (form.email ?? "").trim().toLowerCase() || null,
         full_name: (form.full_name ?? "").trim() || null,
         role: form.role ?? null,
         shop_id: (form.shop_id ?? "")?.trim() || creatorShopId || null,
@@ -154,7 +157,7 @@ export default function CreateUserPage(): JSX.Element {
       });
 
       const payload = (await res.json().catch(() => null)) as
-        | { error?: string; user_id?: string; username?: string; email?: string; people_record_href?: string }
+        | { error?: string; user_id?: string; username?: string; email?: string | null; auth_email?: string; people_record_href?: string }
         | null;
 
       if (!res.ok) throw new Error(payload?.error || "Failed to create user.");
@@ -164,9 +167,9 @@ export default function CreateUserPage(): JSX.Element {
 
       // local feedback
       setSuccess(
-        `User "${createdUsername}" created. They can sign in with username "${createdUsername}"${
-          createdEmail ? ` or email ${createdEmail}` : ""
-        } and the password entered here.`,
+        `User "${createdUsername}" created. They can sign in with the exact username "${createdUsername}" and the password entered here.${
+          createdEmail ? ` Contact email saved: ${createdEmail}.` : ""
+        }`,
       );
       setCreatedUserId(payload?.user_id ?? null);
       setCreatedPersonHref(payload?.people_record_href ?? null);
@@ -186,6 +189,7 @@ export default function CreateUserPage(): JSX.Element {
         ...f,
         username: "",
         password: "",
+        email: "",
         full_name: "",
         phone: "",
         shop_id: body.shop_id ?? creatorShopId ?? null,
@@ -211,7 +215,7 @@ export default function CreateUserPage(): JSX.Element {
 
     try {
       const uname = resetUsername.trim().toLowerCase();
-      const tmp = resetPass.trim();
+      const tmp = resetPass;
 
       if (!uname || !tmp) {
         throw new Error("Username and new temporary password are required.");
@@ -312,6 +316,22 @@ export default function CreateUserPage(): JSX.Element {
                 value={form.phone ?? ""}
                 onChange={(e) => setForm({ ...form, phone: e.target.value })}
               />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs font-medium uppercase tracking-[0.14em] text-neutral-300">
+                Contact email
+              </label>
+              <input
+                className={INPUT_CLASS}
+                placeholder="technician@example.com"
+                type="email"
+                value={form.email ?? ""}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+              <p className="text-[11px] text-neutral-500">
+                Stored on the profile for contact only. Username remains the staff sign-in identity.
+              </p>
             </div>
 
             <div className="space-y-1">

--- a/features/users/lib/username.ts
+++ b/features/users/lib/username.ts
@@ -13,10 +13,21 @@ export function buildShopUserAuthEmail(username: string): string {
   return `${normalizeLoginUsername(username)}@${SHOP_USER_AUTH_DOMAIN}`;
 }
 
-export function normalizeAuthIdentifier(input: string): string {
+export function getAuthIdentifierStrategy(input: string): {
+  inputKind: "email" | "username";
+  authEmail: string;
+} {
   const raw = input.trim();
-  if (raw.includes("@")) return raw.toLowerCase();
-  return buildShopUserAuthEmail(raw);
+  const isEmail = raw.includes("@");
+
+  return {
+    inputKind: isEmail ? "email" : "username",
+    authEmail: isEmail ? raw.toLowerCase() : buildShopUserAuthEmail(raw),
+  };
+}
+
+export function normalizeAuthIdentifier(input: string): string {
+  return getAuthIdentifierStrategy(input).authEmail;
 }
 
 export function buildShopUsernameNamespace(shopName: string | null | undefined): string {

--- a/tests/user-auth-normalization.test.ts
+++ b/tests/user-auth-normalization.test.ts
@@ -1,13 +1,124 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import {
   buildShopUserAuthEmail,
   buildShopUsernameNamespace,
+  getAuthIdentifierStrategy,
   normalizeAuthIdentifier,
   normalizeLoginUsername,
   normalizeProvisioningUsername,
 } from "../features/users/lib/username";
 
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+  createAdminSupabase: vi.fn(),
+  assertShopHasAvailableSeat: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdminSupabase,
+}));
+
+vi.mock("@/features/shared/lib/server/shop-seat-limit", () => ({
+  assertShopHasAvailableSeat: mocks.assertShopHasAvailableSeat,
+}));
+
+type CreateUserPayload = {
+  email: string;
+  password: string;
+  email_confirm: boolean;
+  user_metadata?: Record<string, unknown>;
+};
+
+type ProfileUpsertPayload = {
+  id: string;
+  email?: string | null;
+  username?: string | null;
+  shop_id?: string | null;
+};
+
+type MockAdminOptions = {
+  shopId?: string;
+  adminId?: string;
+  shopName?: string;
+  sameShopProfiles?: { id: string; username: string | null }[];
+  createdUserId?: string;
+};
+
+function jsonRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/admin/create-user", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
+  const shopId = options.shopId ?? "shop-1";
+  const adminId = options.adminId ?? "admin-1";
+  const createdUserId = options.createdUserId ?? "created-user-1";
+  const createUser = vi.fn(async (_payload: CreateUserPayload) => ({
+    data: { user: { id: createdUserId } },
+    error: null,
+  }));
+  const profileUpsert = vi.fn(async (_payload: ProfileUpsertPayload) => ({ error: null }));
+  const workforceUpsert = vi.fn(async (_payload: Record<string, unknown>) => ({ error: null }));
+
+  const adminClient = {
+    auth: { admin: { createUser } },
+    from: vi.fn((table: string) => {
+      if (table === "shops") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { name: options.shopName ?? "Downtown Diesel", shop_name: null },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              ilike: () => ({
+                limit: async () => ({ data: options.sameShopProfiles ?? [], error: null }),
+              }),
+            }),
+          }),
+          upsert: profileUpsert,
+        };
+      }
+
+      if (table === "people_workforce_profiles") {
+        return { upsert: workforceUpsert };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+
+  mocks.requireShopScopedApiAccess.mockResolvedValue({
+    ok: true,
+    profile: { id: adminId, shop_id: shopId },
+  });
+  mocks.createAdminSupabase.mockReturnValue(adminClient);
+  mocks.assertShopHasAvailableSeat.mockResolvedValue(undefined);
+
+  return { createUser, profileUpsert, workforceUpsert, shopId, adminId, createdUserId };
+}
+
 describe("shop user auth normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("uses the same synthetic auth email for created usernames and username sign-in", () => {
     const namespace = buildShopUsernameNamespace("Downtown Diesel");
     const username = normalizeProvisioningUsername(" Sam Tech ", namespace);
@@ -24,7 +135,129 @@ describe("shop user auth normalization", () => {
     expect(normalizeAuthIdentifier(" Shop.User-01 ")).toBe("shopuser01@local.profix-internal");
   });
 
-  it("preserves explicit email login as lower-case email auth", () => {
+  it("preserves explicit email login as lower-case email auth for email users", () => {
     expect(normalizeAuthIdentifier(" Person@Example.COM ")).toBe("person@example.com");
+    expect(getAuthIdentifierStrategy(" Person@Example.COM ")).toEqual({
+      inputKind: "email",
+      authEmail: "person@example.com",
+    });
+  });
+
+  it("normalizes uppercase, spaces, and punctuation consistently for username auth", () => {
+    const raw = "  Sam.Tech + Night-01  ";
+
+    expect(normalizeLoginUsername(raw)).toBe("samtechnight01");
+    expect(getAuthIdentifierStrategy(raw)).toEqual({
+      inputKind: "username",
+      authEmail: "samtechnight01@local.profix-internal",
+    });
+  });
+
+  it("creates username-only staff users with a synthetic auth email", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser, profileUpsert, shopId, createdUserId } = buildCreateUserRouteMocks();
+    const password = " Temp Password 123 ";
+
+    const response = await POST(jsonRequest({
+      username: " Sam Tech ",
+      password,
+      full_name: "Sam Tech",
+      role: "mechanic",
+      shop_id: "client-supplied-shop",
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
+      email: "downtowndiessamtech@local.profix-internal",
+      password,
+      email_confirm: true,
+    }));
+    expect(profileUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: createdUserId,
+        email: null,
+        username: "downtowndiessamtech",
+        shop_id: shopId,
+      }),
+      { onConflict: "id" },
+    );
+    expect(payload).toEqual(expect.objectContaining({
+      username: "downtowndiessamtech",
+      email: null,
+      auth_email: "downtowndiessamtech@local.profix-internal",
+      shop_id: shopId,
+    }));
+  });
+
+  it("creates username plus contact email staff users with username as auth identity", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser, profileUpsert } = buildCreateUserRouteMocks();
+
+    const response = await POST(jsonRequest({
+      username: "Sam.Tech",
+      email: " Sam.Tech@Example.COM ",
+      password: "temporary-password",
+      full_name: "Sam Tech",
+      role: "advisor",
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
+      email: "downtowndiessamtech@local.profix-internal",
+      email_confirm: true,
+      user_metadata: expect.objectContaining({
+        username: "downtowndiessamtech",
+        contact_email: "sam.tech@example.com",
+      }),
+    }));
+    expect(profileUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "sam.tech@example.com",
+        username: "downtowndiessamtech",
+      }),
+      { onConflict: "id" },
+    );
+    expect(payload).toEqual(expect.objectContaining({
+      username: "downtowndiessamtech",
+      email: "sam.tech@example.com",
+      auth_email: "downtowndiessamtech@local.profix-internal",
+    }));
+  });
+
+  it("blocks duplicate usernames within the same shop before creating auth users", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser } = buildCreateUserRouteMocks({
+      sameShopProfiles: [{ id: "existing-user", username: "downtowndiessamtech" }],
+    });
+
+    const response = await POST(jsonRequest({
+      username: "Sam Tech",
+      password: "temporary-password",
+      role: "mechanic",
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("A user with this username already exists in this shop.");
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("uses the server-side shop namespace, so different shop namespaces produce different usernames and auth emails", () => {
+    const firstShopUsername = normalizeProvisioningUsername(
+      "Sam Tech",
+      buildShopUsernameNamespace("Downtown Diesel"),
+    );
+    const secondShopUsername = normalizeProvisioningUsername(
+      "Sam Tech",
+      buildShopUsernameNamespace("Uptown Fleet"),
+    );
+
+    expect(firstShopUsername).toBe("downtowndiessamtech");
+    expect(secondShopUsername).toBe("uptownfleetsamtech");
+    expect(buildShopUserAuthEmail(firstShopUsername)).not.toBe(
+      buildShopUserAuthEmail(secondShopUsername),
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Users created with a username + contact email could not sign in with their username because the create-user route was provisioning Supabase Auth under the real contact email instead of the synthetic username auth email. 
- The goal is to make username the primary staff auth identity while preserving the real contact email on profile rows and keeping tenant/shop scoping intact.

### Description
- Make staff username the canonical Supabase Auth identity by provisioning Auth with the synthetic `username@local.profix-internal` email and writing the real contact email to `profiles.email` and `user_metadata.contact_email` instead of using the contact email as the Auth email.
- Add `getAuthIdentifierStrategy()` to `features/users/lib/username.ts` (keeps `normalizeAuthIdentifier()`), and update sign-in flows in `features/auth/components/SignIn.tsx`, `app/mobile/sign-in/page.tsx`, and `app/portal/auth/sign-in/PortalSignInForm.tsx` to use it and log whether the input was treated as `email` or `username` while passing the normalized auth email to `signInWithPassword`.
- Change the owner create-user UI to accept a contact email, send the password exactly as typed, and show a success message that clearly states the normalized username users must sign in with; preserve server-side shop namespace, duplicate-username checks, seat-limit enforcement, `profiles.id === auth user id`, and RLS boundaries.
- Add focused diagnostics (no passwords) to create-user and sign-in to help debug identity normalization and return `auth_email` alongside profile contact `email` in API responses.
- Add/modify tests in `tests/user-auth-normalization.test.ts` to cover username-only provisioning, username+contact-email provisioning, normalization behavior, duplicate blocking, and cross-shop namespace differences.

### Testing
- Ran unit tests: `npx vitest run tests/user-auth-normalization.test.ts`, and the test suite for the added file passed (8/8 tests passed). 
- Ran linting: `npx eslint app/api/admin/create-user/route.ts app/api/admin/reset-user-password/route.ts features/users/lib/username.ts features/auth/components/SignIn.tsx app/mobile/sign-in/page.tsx app/portal/auth/sign-in/PortalSignInForm.tsx features/dashboard/app/dashboard/owner/create-user/page.tsx tests/user-auth-normalization.test.ts`, and lint completed with no new errors.
- Typecheck: `npx tsc --noEmit` completed successfully with no errors.
- Performed lightweight runtime validation via tests and added console diagnostics to verify normalization behavior (no passwords logged) and all checks succeeded.

Files changed: `app/api/admin/create-user/route.ts`, `features/users/lib/username.ts`, `features/auth/components/SignIn.tsx`, `app/mobile/sign-in/page.tsx`, `app/portal/auth/sign-in/PortalSignInForm.tsx`, `features/dashboard/app/dashboard/owner/create-user/page.tsx`, and `tests/user-auth-normalization.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2079143c6883289dd7b68ca52619d8)