### PR TITLE
Fix created-user auth session lifecycle and add login resolution + diagnostics

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -36,7 +36,9 @@ function logCreateUserStep(
     profileId?: string | null;
     normalizedUsername?: string | null;
     syntheticAuthEmail?: string | null;
+    contactEmail?: string | null;
     hasContactEmail?: boolean;
+    emailConfirmed?: boolean | null;
   } = {},
 ): void {
   console.info("[admin/create-user]", { step, ...details });
@@ -52,7 +54,9 @@ function logCreateUserError(
     profileId?: string | null;
     normalizedUsername?: string | null;
     syntheticAuthEmail?: string | null;
+    contactEmail?: string | null;
     hasContactEmail?: boolean;
+    emailConfirmed?: boolean | null;
     error?: string | null;
   } = {},
 ): void {
@@ -168,6 +172,7 @@ export async function POST(req: Request) {
       role: canonicalRole,
       normalizedUsername: username,
       syntheticAuthEmail: syntheticEmail,
+      contactEmail,
       hasContactEmail: Boolean(contactEmail),
     });
 
@@ -208,7 +213,9 @@ export async function POST(req: Request) {
       authUserId: newUserId,
       normalizedUsername: username,
       syntheticAuthEmail: syntheticEmail,
+      contactEmail,
       hasContactEmail: Boolean(contactEmail),
+      emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
     });
 
     // upsert profile for the new user
@@ -288,7 +295,9 @@ export async function POST(req: Request) {
       profileId: newUserId,
       normalizedUsername: username,
       syntheticAuthEmail: syntheticEmail,
+      contactEmail,
       hasContactEmail: Boolean(contactEmail),
+      emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
     });
 
     return NextResponse.json({

--- a/app/api/admin/diagnostics/user-auth/route.ts
+++ b/app/api/admin/diagnostics/user-auth/route.ts
@@ -1,0 +1,106 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  buildShopUserAuthEmail,
+  getAuthIdentifierStrategy,
+  normalizeLoginUsername,
+} from "@/features/users/lib/username";
+
+type Body = { identifier?: string | null };
+type AuthUserSummary = {
+  id: string;
+  email?: string | null;
+  email_confirmed_at?: string | null;
+  confirmed_at?: string | null;
+};
+
+async function findAuthUserByEmail(
+  supabase: ReturnType<typeof createAdminSupabase>,
+  email: string,
+): Promise<AuthUserSummary | null> {
+  for (let page = 1; page <= 20; page += 1) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage: 1000 });
+    if (error) throw error;
+    const found = data.users.find((user) => user.email?.toLowerCase() === email.toLowerCase());
+    if (found) return found;
+    if (data.users.length < 1000) return null;
+  }
+  return null;
+}
+
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageUsers",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) {
+    return NextResponse.json({ error: "Admin profile is missing shop scope." }, { status: 403 });
+  }
+
+  const { identifier = "" } = (await req.json().catch(() => ({}))) as Body;
+  const strategy = getAuthIdentifierStrategy(identifier ?? "");
+  const normalizedUsername = normalizeLoginUsername(identifier ?? "");
+  const supabase = createAdminSupabase();
+
+  let profileQuery = supabase
+    .from("profiles")
+    .select("id, username, email, shop_id, role, completed_onboarding")
+    .eq("shop_id", shopId)
+    .limit(2);
+
+  if (strategy.inputKind === "email") {
+    profileQuery = profileQuery.ilike("email", strategy.authEmail);
+  } else {
+    profileQuery = profileQuery.ilike("username", normalizedUsername);
+  }
+
+  const { data: profiles, error: profileError } = await profileQuery;
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 500 });
+  }
+
+  const profile = (profiles ?? []).length === 1 ? profiles?.[0] : null;
+  const expectedAuthEmail = profile?.username
+    ? buildShopUserAuthEmail(profile.username)
+    : strategy.authEmail;
+  const authUser = await findAuthUserByEmail(supabase, expectedAuthEmail);
+
+  return NextResponse.json({
+    inputKind: strategy.inputKind,
+    expectedAuthEmail,
+    profileMatchCount: profiles?.length ?? 0,
+    profile: profile
+      ? {
+          id: profile.id,
+          username: profile.username,
+          contactEmail: profile.email,
+          shopId: profile.shop_id,
+          role: profile.role,
+          completedOnboarding: profile.completed_onboarding,
+        }
+      : null,
+    authUser: authUser
+      ? {
+          exists: true,
+          id: authUser.id,
+          emailMatchesExpected: authUser.email?.toLowerCase() === expectedAuthEmail.toLowerCase(),
+          profileIdMatchesAuthUserId: profile?.id === authUser.id,
+          profileShopMatchesAdminShop: profile?.shop_id === shopId,
+          emailConfirmed: Boolean(authUser.email_confirmed_at ?? authUser.confirmed_at),
+        }
+      : {
+          exists: false,
+          emailMatchesExpected: false,
+          profileIdMatchesAuthUserId: false,
+          profileShopMatchesAdminShop: profile?.shop_id === shopId,
+          emailConfirmed: false,
+        },
+  });
+}

--- a/app/api/auth/resolve-login/route.ts
+++ b/app/api/auth/resolve-login/route.ts
@@ -1,0 +1,76 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  buildShopUserAuthEmail,
+  getAuthIdentifierStrategy,
+  normalizeLoginUsername,
+} from "@/features/users/lib/username";
+
+type Body = { identifier?: string | null };
+
+export async function POST(req: Request) {
+  const { identifier = "" } = (await req.json().catch(() => ({}))) as Body;
+  const strategy = getAuthIdentifierStrategy(identifier ?? "");
+
+  if (strategy.inputKind !== "email") {
+    return NextResponse.json({
+      inputKind: strategy.inputKind,
+      authEmail: strategy.authEmail,
+      resolvedBy: "username",
+    });
+  }
+
+  const contactEmail = strategy.authEmail;
+  const supabase = createAdminSupabase();
+
+  const { data: profiles, error } = await supabase
+    .from("profiles")
+    .select("id, username, shop_id")
+    .ilike("email", contactEmail)
+    .not("username", "is", null)
+    .limit(2);
+
+  if (error) {
+    console.info("[auth/resolve-login]", {
+      inputKind: strategy.inputKind,
+      resolved: false,
+      error: error.message,
+    });
+    return NextResponse.json({ inputKind: strategy.inputKind, authEmail: strategy.authEmail });
+  }
+
+  if ((profiles ?? []).length === 1) {
+    const username = normalizeLoginUsername(profiles?.[0]?.username ?? "");
+    if (username) {
+      const authEmail = buildShopUserAuthEmail(username);
+      console.info("[auth/resolve-login]", {
+        inputKind: strategy.inputKind,
+        resolved: true,
+        resolvedBy: "unique_contact_email_profile",
+        profileId: profiles?.[0]?.id ?? null,
+        profileShopId: profiles?.[0]?.shop_id ?? null,
+        normalizedAuthEmail: authEmail,
+      });
+      return NextResponse.json({
+        inputKind: strategy.inputKind,
+        authEmail,
+        resolvedBy: "unique_contact_email_profile",
+      });
+    }
+  }
+
+  console.info("[auth/resolve-login]", {
+    inputKind: strategy.inputKind,
+    resolved: false,
+    reason: (profiles ?? []).length > 1 ? "ambiguous_contact_email" : "no_staff_contact_profile",
+  });
+
+  return NextResponse.json({
+    inputKind: strategy.inputKind,
+    authEmail: strategy.authEmail,
+    resolvedBy: "email_auth_identity",
+  });
+}

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { EmailOtpType } from "@supabase/supabase-js";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
 
@@ -19,7 +18,7 @@ const OTP_TYPES = new Set<EmailOtpType>([
 export default function AuthCallbackPage() {
   const router = useRouter();
   const sp = useSearchParams();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const ran = useRef(false);
 
   useEffect(() => {

--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -1,13 +1,10 @@
-// app/api/auth/signout/route.ts
+// app/auth/signout/route.ts
 import { NextResponse, NextRequest } from "next/server";
-import { cookies as nextCookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export async function GET(req: NextRequest) {
-  const supabase = createRouteHandlerClient<Database>({ cookies: nextCookies });
+  const supabase = createServerSupabaseRoute();
   await supabase.auth.signOut();
 
-  // send them home (adjust if you want a different landing page)
   return NextResponse.redirect(new URL("/", req.url));
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,9 +4,7 @@ import Script from "next/script";
 import Providers from "./providers";
 import AppShell from "@/features/shared/components/AppShell";
 import { headers } from "next/headers";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { VoiceProvider } from "@/features/shared/voice/VoiceProvider";
 import BrandThemeBoot from "@/features/branding/components/BrandThemeBoot";
 
@@ -35,7 +33,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = createServerComponentClient<Database>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/app/mobile/sign-in/page.tsx
+++ b/app/mobile/sign-in/page.tsx
@@ -6,17 +6,13 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { getAuthIdentifierStrategy } from "@/features/users/lib/username";
-
-type DB = Database;
-
 
 export default function MobileSignInPage() {
   const router = useRouter();
   const sp = useSearchParams();
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
 
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
@@ -59,15 +55,40 @@ export default function MobileSignInPage() {
     setLoading(true);
     setError("");
 
-    const authIdentifier = getAuthIdentifierStrategy(identifier);
+    const initialAuthIdentifier = getAuthIdentifierStrategy(identifier);
+    let authEmail = initialAuthIdentifier.authEmail;
+
+    try {
+      const resolveRes = await fetch("/api/auth/resolve-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier }),
+      });
+      const resolvePayload = (await resolveRes.json().catch(() => null)) as
+        | { authEmail?: string }
+        | null;
+      if (resolveRes.ok && resolvePayload?.authEmail) authEmail = resolvePayload.authEmail;
+    } catch {
+      // Fall back to local username/email normalization.
+    }
+
     console.info("[auth/sign-in]", {
-      inputKind: authIdentifier.inputKind,
-      normalizedAuthEmail: authIdentifier.authEmail,
+      inputKind: initialAuthIdentifier.inputKind,
+      normalizedAuthEmail: authEmail,
     });
 
-    const { error: signInErr } = await supabase.auth.signInWithPassword({
-      email: authIdentifier.authEmail,
+    const { data: signInData, error: signInErr } = await supabase.auth.signInWithPassword({
+      email: authEmail,
       password,
+    });
+
+    console.info("[auth/sign-in-result]", {
+      inputKind: initialAuthIdentifier.inputKind,
+      normalizedAuthEmail: authEmail,
+      userId: signInData.user?.id ?? null,
+      hasAccessToken: Boolean(signInData.session?.access_token),
+      errorCode: signInErr?.status ?? null,
+      errorMessage: signInErr?.message ?? null,
     });
 
     if (signInErr) {
@@ -75,8 +96,6 @@ export default function MobileSignInPage() {
       setLoading(false);
       return;
     }
-
-    await supabase.auth.refreshSession();
 
     const { data: u } = await supabase.auth.getUser();
     if (!u.user) {

--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -4,8 +4,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import AuthShell from "@/features/auth/components/AuthShell";
 import { getAuthIdentifierStrategy } from "@/features/users/lib/username";
 
@@ -27,7 +26,7 @@ function isAllowedRedirectForMode(path: string) {
 export default function PortalSignInPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [portalType, setPortalType] = useState<PortalType>("customer");
   const [identifier, setIdentifier] = useState<string>(""); // ✅ email OR username
@@ -60,15 +59,40 @@ export default function PortalSignInPage() {
     setLoading(true);
     setError("");
 
-    const authIdentifier = getAuthIdentifierStrategy(identifier);
+    const initialAuthIdentifier = getAuthIdentifierStrategy(identifier);
+    let authEmail = initialAuthIdentifier.authEmail;
+
+    try {
+      const resolveRes = await fetch("/api/auth/resolve-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier }),
+      });
+      const resolvePayload = (await resolveRes.json().catch(() => null)) as
+        | { authEmail?: string }
+        | null;
+      if (resolveRes.ok && resolvePayload?.authEmail) authEmail = resolvePayload.authEmail;
+    } catch {
+      // Fall back to local username/email normalization.
+    }
+
     console.info("[auth/sign-in]", {
-      inputKind: authIdentifier.inputKind,
-      normalizedAuthEmail: authIdentifier.authEmail,
+      inputKind: initialAuthIdentifier.inputKind,
+      normalizedAuthEmail: authEmail,
     });
 
-    const { error: signInError } = await supabase.auth.signInWithPassword({
-      email: authIdentifier.authEmail,
+    const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
+      email: authEmail,
       password,
+    });
+
+    console.info("[auth/sign-in-result]", {
+      inputKind: initialAuthIdentifier.inputKind,
+      normalizedAuthEmail: authEmail,
+      userId: signInData.user?.id ?? null,
+      hasAccessToken: Boolean(signInData.session?.access_token),
+      errorCode: signInError?.status ?? null,
+      errorMessage: signInError?.message ?? null,
     });
 
     if (signInError) {

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import AuthShell from "@/features/auth/components/AuthShell";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
 import { getAuthIdentifierStrategy } from "@/features/users/lib/username";
@@ -14,7 +13,7 @@ type Mode = "sign-in" | "sign-up";
 export default function AuthPage() {
   const router = useRouter();
   const sp = useSearchParams();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const [mode, setMode] = useState<Mode>("sign-in");
   const [identifier, setIdentifier] = useState("");
@@ -97,15 +96,46 @@ export default function AuthPage() {
     setError("");
     setNotice("");
 
-    const authIdentifier = getAuthIdentifierStrategy(identifier);
+    const initialAuthIdentifier = getAuthIdentifierStrategy(identifier);
+    let authEmail = initialAuthIdentifier.authEmail;
+
+    try {
+      const resolveRes = await fetch("/api/auth/resolve-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier }),
+      });
+      const resolvePayload = (await resolveRes.json().catch(() => null)) as
+        | { authEmail?: string; inputKind?: "email" | "username" }
+        | null;
+      if (resolveRes.ok && resolvePayload?.authEmail) {
+        authEmail = resolvePayload.authEmail;
+      }
+    } catch (resolveErr) {
+      console.info("[auth/sign-in-resolve]", {
+        inputKind: initialAuthIdentifier.inputKind,
+        resolved: false,
+        error: resolveErr instanceof Error ? resolveErr.message : "resolve failed",
+      });
+    }
+
     console.info("[auth/sign-in]", {
-      inputKind: authIdentifier.inputKind,
-      normalizedAuthEmail: authIdentifier.authEmail,
+      inputKind: initialAuthIdentifier.inputKind,
+      normalizedAuthEmail: authEmail,
     });
 
-    const { error: signInErr } = await supabase.auth.signInWithPassword({
-      email: authIdentifier.authEmail,
+    const { data: signInData, error: signInErr } = await supabase.auth.signInWithPassword({
+      email: authEmail,
       password,
+    });
+
+    console.info("[auth/sign-in-result]", {
+      inputKind: initialAuthIdentifier.inputKind,
+      normalizedAuthEmail: authEmail,
+      userId: signInData.user?.id ?? null,
+      hasAccessToken: Boolean(signInData.session?.access_token),
+      errorCode: signInErr?.status ?? null,
+      errorMessage: signInErr?.message ?? null,
     });
 
     if (signInErr) {
@@ -113,8 +143,6 @@ export default function AuthPage() {
       setLoading(false);
       return;
     }
-
-    await supabase.auth.refreshSession();
 
     const { data: u } = await supabase.auth.getUser();
     if (!u.user) {

--- a/features/auth/lib/postAuthRouting.ts
+++ b/features/auth/lib/postAuthRouting.ts
@@ -74,11 +74,20 @@ export async function resolvePostAuthDestination(args: {
 
   if (!user) return "/sign-in";
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from("profiles")
     .select("completed_onboarding, must_change_password, role, shop_id")
     .eq("id", user.id)
     .maybeSingle();
+
+  console.info("[auth/post-login-routing]", {
+    userId: user.id,
+    profileExists: Boolean(profile),
+    profileShopId: profile?.shop_id ?? null,
+    profileRole: profile?.role ?? null,
+    completedOnboarding: profile?.completed_onboarding ?? null,
+    profileError: profileError?.message ?? null,
+  });
 
   if (profile?.must_change_password) {
     return "/auth/set-password";

--- a/features/shared/lib/supabase/client.ts
+++ b/features/shared/lib/supabase/client.ts
@@ -1,15 +1,23 @@
 // src/features/shared/lib/supabase/client.ts
 "use client";
 
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "@shared/types/types/supabase";
 
-let _client: ReturnType<typeof createClientComponentClient<Database>> | null =
-  null;
+let _client: ReturnType<typeof createBrowserClient<Database>> | null = null;
+
+function mustBrowserEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY") {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env: ${name}`);
+  return value;
+}
 
 export function createBrowserSupabase() {
   if (_client) return _client;
-  _client = createClientComponentClient<Database>();
+  _client = createBrowserClient<Database>(
+    mustBrowserEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    mustBrowserEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+  );
   return _client;
 }
 

--- a/features/shared/lib/supabase/server.ts
+++ b/features/shared/lib/supabase/server.ts
@@ -2,29 +2,58 @@
 import "server-only";
 
 import { cookies } from "next/headers";
-import {
-  createServerComponentClient,
-  createRouteHandlerClient,
-  createPagesServerClient,
-} from "@supabase/auth-helpers-nextjs";
+import { createServerClient } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { Database } from "@shared/types/types/supabase";
+
+function mustEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY" | "SUPABASE_SERVICE_ROLE_KEY") {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env: ${name}`);
+  return value;
+}
+
+function createCookieBackedServerClient() {
+  const cookieStore = cookies() as unknown as {
+    getAll: () => { name: string; value: string }[];
+    set: (name: string, value: string, options?: Record<string, unknown>) => void;
+  };
+
+  return createServerClient<Database>(
+    mustEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    mustEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+            });
+          } catch {
+            // Server Components cannot set cookies. Middleware/route handlers that
+            // can write cookies refresh the session before RSC reads it.
+          }
+        },
+      },
+    },
+  );
+}
 
 /**
  * App Router – Server Components (RSC)
  */
 export function createServerSupabaseRSC() {
-  const cookieStore = cookies();
-  return createServerComponentClient<Database>({ cookies: () => cookieStore });
+  return createCookieBackedServerClient();
 }
 
 /**
  * App Router – Route Handlers (app/api/*)
  */
 export function createServerSupabaseRoute() {
-  const cookieStore = cookies();
-  return createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+  return createCookieBackedServerClient();
 }
 
 /**
@@ -34,7 +63,33 @@ export function createServerSupabaseApi(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  return createPagesServerClient<Database>({ req, res });
+  return createServerClient<Database>(
+    mustEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    mustEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    {
+      cookies: {
+        getAll() {
+          return Object.entries(req.cookies).map(([name, value]) => ({
+            name,
+            value: value ?? "",
+          }));
+        },
+        setAll(cookiesToSet) {
+          const existing = res.getHeader("Set-Cookie");
+          const nextCookies = cookiesToSet.map(({ name, value, options }) => {
+            const parts = [`${name}=${encodeURIComponent(value)}`, "Path=/"];
+            if (options?.maxAge) parts.push(`Max-Age=${options.maxAge}`);
+            if (options?.sameSite) parts.push(`SameSite=${options.sameSite}`);
+            if (options?.secure) parts.push("Secure");
+            if (options?.httpOnly) parts.push("HttpOnly");
+            return parts.join("; ");
+          });
+          const previous = Array.isArray(existing) ? existing : existing ? [String(existing)] : [];
+          res.setHeader("Set-Cookie", [...previous, ...nextCookies]);
+        },
+      },
+    },
+  );
 }
 
 /**
@@ -42,13 +97,11 @@ export function createServerSupabaseApi(
  * Never import this into client components.
  */
 export function createAdminSupabase() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!url) throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL");
-  if (!key) throw new Error("Missing env: SUPABASE_SERVICE_ROLE_KEY");
-
-  return createClient<Database>(url, key, {
-    auth: { persistSession: false },
-  });
+  return createClient<Database>(
+    mustEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    mustEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: { persistSession: false, autoRefreshToken: false },
+    },
+  );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { createMiddlewareClient } from "@supabase/auth-helpers-nextjs";
+import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 
@@ -12,13 +13,6 @@ function isAssetPath(p: string) {
     p.endsWith(".svg") ||
     /\.(png|jpg|jpeg|gif|webp|ico|css|js|map)$/i.test(p)
   );
-}
-
-function withSupabaseCookies(from: NextResponse, to: NextResponse) {
-  for (const cookie of from.cookies.getAll()) {
-    to.cookies.set(cookie);
-  }
-  return to;
 }
 
 function safeRedirectPath(v: string | null): string | null {
@@ -35,8 +29,50 @@ function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
   return normalized === "owner" || normalized === "admin";
 }
 
+function createMiddlewareSupabase(req: NextRequest, res: NextResponse) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url) throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL");
+  if (!anonKey) throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY");
+
+  return createServerClient<Database>(url, anonKey, {
+    cookies: {
+      getAll() {
+        return req.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          req.cookies.set(name, value);
+          res.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+}
+
+function logMiddlewareAuthDiagnostics(args: {
+  pathname: string;
+  userId: string | null;
+  profile?: {
+    shop_id?: string | null;
+    role?: string | null;
+    completed_onboarding?: boolean | null;
+  } | null;
+  profileError?: string | null;
+}) {
+  console.info("[auth/middleware-post-login]", {
+    pathname: args.pathname,
+    userId: args.userId,
+    profileExists: Boolean(args.profile),
+    profileShopId: args.profile?.shop_id ?? null,
+    profileRole: args.profile?.role ?? null,
+    completedOnboarding: args.profile?.completed_onboarding ?? null,
+    profileError: args.profileError ?? null,
+  });
+}
+
 async function resolvePortalModeServer(
-  supabase: ReturnType<typeof createMiddlewareClient<Database>>,
+  supabase: SupabaseClient<Database>,
   userId: string,
 ): Promise<PortalMode> {
   try {
@@ -73,12 +109,21 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  const res = NextResponse.next();
-  const supabase = createMiddlewareClient<Database>({ req, res });
+  const res = NextResponse.next({ request: req });
+  const supabase = createMiddlewareSupabase(req, res);
 
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError && userError.message !== "Auth session missing!") {
+    console.info("[auth/middleware-get-user]", {
+      pathname,
+      userId: null,
+      error: userError.message,
+    });
+  }
 
   const isPortal = pathname === "/portal" || pathname.startsWith("/portal/");
   const isPortalAuthPage = pathname.startsWith("/portal/auth/");
@@ -104,14 +149,21 @@ export async function middleware(req: NextRequest) {
 
   let completed = false;
   let needsShopBoostIntake = false;
-  if (session?.user && !isPortal) {
+  if (user && !isPortal) {
     try {
-      const { data: profile } = await supabase
+      const { data: profile, error: profileError } = await supabase
         .from("profiles")
         .select("completed_onboarding, shop_id, role")
-        .eq("id", session.user.id)
+        .eq("id", user.id)
         .limit(1)
         .maybeSingle();
+
+      logMiddlewareAuthDiagnostics({
+        pathname,
+        userId: user.id,
+        profile,
+        profileError: profileError?.message ?? null,
+      });
 
       completed = !!profile?.completed_onboarding || !!profile?.shop_id;
 
@@ -126,13 +178,19 @@ export async function middleware(req: NextRequest) {
 
         needsShopBoostIntake = !intake?.id;
       }
-    } catch {
+    } catch (err) {
+      logMiddlewareAuthDiagnostics({
+        pathname,
+        userId: user.id,
+        profile: null,
+        profileError: err instanceof Error ? err.message : "profile lookup failed",
+      });
       completed = false;
       needsShopBoostIntake = false;
     }
   }
 
-  if (pathname === "/" && session?.user) {
+  if (pathname === "/" && user) {
     const target = new URL(
       !completed
         ? "/onboarding"
@@ -141,7 +199,7 @@ export async function middleware(req: NextRequest) {
           : "/dashboard",
       req.url,
     );
-    return withSupabaseCookies(res, NextResponse.redirect(target));
+    return NextResponse.redirect(target, { headers: res.headers });
   }
 
   if (isPublic) {
@@ -153,7 +211,7 @@ export async function middleware(req: NextRequest) {
       pathname.startsWith("/sign-in") || pathname.startsWith("/signup");
     const isMobileSignIn = pathname.startsWith("/mobile/sign-in");
 
-    if (session?.user && (isMainSignIn || isMobileSignIn)) {
+    if (user && (isMainSignIn || isMobileSignIn)) {
       const to =
         redirectParam ??
         (isMobileSignIn
@@ -167,15 +225,15 @@ export async function middleware(req: NextRequest) {
               : "/dashboard");
 
       const target = new URL(to, req.url);
-      return withSupabaseCookies(res, NextResponse.redirect(target));
+      return NextResponse.redirect(target, { headers: res.headers });
     }
 
     if (
       isPortal &&
-      session?.user &&
+      user &&
       (isPortalAuthPage || isLegacyPortalConfirm)
     ) {
-      const mode = await resolvePortalModeServer(supabase, session.user.id);
+      const mode = await resolvePortalModeServer(supabase, user.id);
 
       let to = redirectParam ?? (mode === "fleet" ? "/portal/fleet" : "/portal");
 
@@ -191,17 +249,17 @@ export async function middleware(req: NextRequest) {
       }
 
       const target = new URL(to, req.url);
-      return withSupabaseCookies(res, NextResponse.redirect(target));
+      return NextResponse.redirect(target, { headers: res.headers });
     }
 
     return res;
   }
 
-  if (!session?.user) {
+  if (!user) {
     if (isPortal) {
       const login = new URL("/portal/auth/sign-in", req.url);
       login.searchParams.set("redirect", pathname + search);
-      return withSupabaseCookies(res, NextResponse.redirect(login));
+      return NextResponse.redirect(login, { headers: res.headers });
     }
 
     const isMobileRoute = pathname.startsWith("/mobile");
@@ -209,29 +267,29 @@ export async function middleware(req: NextRequest) {
     const login = new URL(loginPath, req.url);
     login.searchParams.set("redirect", pathname + search);
 
-    return withSupabaseCookies(res, NextResponse.redirect(login));
+    return NextResponse.redirect(login, { headers: res.headers });
   }
 
   if (isPortal) {
-    const mode = await resolvePortalModeServer(supabase, session.user.id);
+    const mode = await resolvePortalModeServer(supabase, user.id);
 
     const isFleetPortalPath =
       pathname === "/portal/fleet" || pathname.startsWith("/portal/fleet/");
 
     if (mode === "fleet" && !isFleetPortalPath) {
       const target = new URL("/portal/fleet", req.url);
-      return withSupabaseCookies(res, NextResponse.redirect(target));
+      return NextResponse.redirect(target, { headers: res.headers });
     }
 
     if (mode === "customer" && isFleetPortalPath) {
       const target = new URL("/portal", req.url);
-      return withSupabaseCookies(res, NextResponse.redirect(target));
+      return NextResponse.redirect(target, { headers: res.headers });
     }
   }
 
   if (!isPortal && !completed && !pathname.startsWith("/onboarding")) {
     const target = new URL("/onboarding", req.url);
-    return withSupabaseCookies(res, NextResponse.redirect(target));
+    return NextResponse.redirect(target, { headers: res.headers });
   }
 
   return res;
@@ -244,7 +302,6 @@ export const config = {
     "/subscribe",
     "/confirm",
     "/signup",
-    "/sign-in",
     "/forgot-password",
     "/auth/reset",
     "/auth/set-password",

--- a/tests/user-auth-normalization.test.ts
+++ b/tests/user-auth-normalization.test.ts
@@ -260,4 +260,75 @@ describe("shop user auth normalization", () => {
       buildShopUserAuthEmail(secondShopUsername),
     );
   });
+
+  it("resolves a unique staff contact email to the username synthetic auth email", async () => {
+    const { POST } = await import("../app/api/auth/resolve-login/route");
+    const adminClient = {
+      from: vi.fn((table: string) => {
+        expect(table).toBe("profiles");
+        return {
+          select: () => ({
+            ilike: () => ({
+              not: () => ({
+                limit: async () => ({
+                  data: [
+                    {
+                      id: "created-user-1",
+                      username: "downtowndiessamtech",
+                      shop_id: "shop-1",
+                    },
+                  ],
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }),
+    };
+    mocks.createAdminSupabase.mockReturnValue(adminClient);
+
+    const response = await POST(jsonRequest({ identifier: " Sam.Tech@Example.COM " }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual(expect.objectContaining({
+      inputKind: "email",
+      authEmail: "downtowndiessamtech@local.profix-internal",
+      resolvedBy: "unique_contact_email_profile",
+    }));
+  });
+
+  it("does not resolve ambiguous contact emails across profiles", async () => {
+    const { POST } = await import("../app/api/auth/resolve-login/route");
+    const adminClient = {
+      from: vi.fn(() => ({
+        select: () => ({
+          ilike: () => ({
+            not: () => ({
+              limit: async () => ({
+                data: [
+                  { id: "user-1", username: "shoponeuser", shop_id: "shop-1" },
+                  { id: "user-2", username: "shoptwouser", shop_id: "shop-2" },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      })),
+    };
+    mocks.createAdminSupabase.mockReturnValue(adminClient);
+
+    const response = await POST(jsonRequest({ identifier: "shared@example.com" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual(expect.objectContaining({
+      inputKind: "email",
+      authEmail: "shared@example.com",
+      resolvedBy: "email_auth_identity",
+    }));
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Users created under the username-normalization flow could not sign in due to server-side helpers calling `/auth/v1/user` with the anon JWT and/or mismatched auth-email identities for staff (synthetic username auth email vs contact email). 
- The change ensures server-side flows use cookie-backed SSR clients so server calls use the real session cookies rather than an anon token. 
- Also add safe diagnostics and a safe resolver so staff can sign in with contact email when it uniquely maps to a synthetic username auth identity. 

### Description
- Replace legacy `@supabase/auth-helpers-nextjs` server/middleware/browser helpers with cookie-aware `@supabase/ssr` clients and a cookie-backed server client to avoid anon JWT `bad_jwt` calls from node helpers. 
- Add server-side login identifier resolver at `POST /api/auth/resolve-login` that maps a unique staff contact email to the synthetic username auth email when safe, falling back to normal email auth on ambiguity. 
- Add admin-scoped diagnostics at `POST /api/admin/diagnostics/user-auth` and extensive, safe sign-in/post-login/create-user logging (no passwords/tokens) to help verify profile ↔ auth-user alignment. 
- Update provisioning flow to record `contactEmail` and surface `emailConfirmed` diagnostics, and extend `tests/user-auth-normalization.test.ts` to cover contact-email resolution and ambiguity handling. 

### Testing
- Ran `npx vitest run tests/user-auth-normalization.test.ts` and all added/related tests passed (10/10). 
- Ran ESLint over touched files and then with `--no-ignore` on SSR helpers; ESLint reported only ignore-related warnings for some helper files and no blocking errors. 
- Ran `npx tsc --noEmit` and TypeScript type check succeeded. 
- Ran `git diff --check` and there were no outstanding check failures. 

Commit: `729afef`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2087ca6f6083288a84541b794b07f1)