### PR TITLE
Allow server Supabase env fallbacks

### DIFF
--- a/features/shared/lib/supabase/server.ts
+++ b/features/shared/lib/supabase/server.ts
@@ -7,7 +7,26 @@ import { createClient } from "@supabase/supabase-js";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { Database } from "@shared/types/types/supabase";
 
-function mustEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY" | "SUPABASE_SERVICE_ROLE_KEY") {
+function mustSupabaseUrl() {
+  const value =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  if (!value)
+    throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL");
+  return value;
+}
+
+function mustSupabaseAnonKey() {
+  const value =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
+  if (!value) {
+    throw new Error(
+      "Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY",
+    );
+  }
+  return value;
+}
+
+function mustEnv(name: "SUPABASE_SERVICE_ROLE_KEY") {
   const value = process.env[name];
   if (!value) throw new Error(`Missing env: ${name}`);
   return value;
@@ -16,12 +35,16 @@ function mustEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_K
 function createCookieBackedServerClient() {
   const cookieStore = cookies() as unknown as {
     getAll: () => { name: string; value: string }[];
-    set: (name: string, value: string, options?: Record<string, unknown>) => void;
+    set: (
+      name: string,
+      value: string,
+      options?: Record<string, unknown>,
+    ) => void;
   };
 
   return createServerClient<Database>(
-    mustEnv("NEXT_PUBLIC_SUPABASE_URL"),
-    mustEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    mustSupabaseUrl(),
+    mustSupabaseAnonKey(),
     {
       cookies: {
         getAll() {
@@ -64,8 +87,8 @@ export function createServerSupabaseApi(
   res: NextApiResponse,
 ) {
   return createServerClient<Database>(
-    mustEnv("NEXT_PUBLIC_SUPABASE_URL"),
-    mustEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    mustSupabaseUrl(),
+    mustSupabaseAnonKey(),
     {
       cookies: {
         getAll() {
@@ -84,7 +107,11 @@ export function createServerSupabaseApi(
             if (options?.httpOnly) parts.push("HttpOnly");
             return parts.join("; ");
           });
-          const previous = Array.isArray(existing) ? existing : existing ? [String(existing)] : [];
+          const previous = Array.isArray(existing)
+            ? existing
+            : existing
+              ? [String(existing)]
+              : [];
           res.setHeader("Set-Cookie", [...previous, ...nextCookies]);
         },
       },
@@ -98,7 +125,7 @@ export function createServerSupabaseApi(
  */
 export function createAdminSupabase() {
   return createClient<Database>(
-    mustEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    mustSupabaseUrl(),
     mustEnv("SUPABASE_SERVICE_ROLE_KEY"),
     {
       auth: { persistSession: false, autoRefreshToken: false },

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,15 +25,30 @@ function safeRedirectPath(v: string | null): string | null {
 type PortalMode = "customer" | "fleet";
 
 function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
-  const normalized = String(role ?? "").trim().toLowerCase();
+  const normalized = String(role ?? "")
+    .trim()
+    .toLowerCase();
   return normalized === "owner" || normalized === "admin";
 }
 
+function readSupabaseServerEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const anonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
+
+  if (!url)
+    throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL");
+  if (!anonKey) {
+    throw new Error(
+      "Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY",
+    );
+  }
+
+  return { url, anonKey };
+}
+
 function createMiddlewareSupabase(req: NextRequest, res: NextResponse) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url) throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL");
-  if (!anonKey) throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  const { url, anonKey } = readSupabaseServerEnv();
 
   return createServerClient<Database>(url, anonKey, {
     cookies: {
@@ -167,7 +182,11 @@ export async function middleware(req: NextRequest) {
 
       completed = !!profile?.completed_onboarding || !!profile?.shop_id;
 
-      if (profile?.completed_onboarding && profile?.shop_id && isShopBoostOrchestratedRole(profile.role)) {
+      if (
+        profile?.completed_onboarding &&
+        profile?.shop_id &&
+        isShopBoostOrchestratedRole(profile.role)
+      ) {
         const { data: intake } = await supabase
           .from("shop_boost_intakes")
           .select("id")
@@ -183,7 +202,8 @@ export async function middleware(req: NextRequest) {
         pathname,
         userId: user.id,
         profile: null,
-        profileError: err instanceof Error ? err.message : "profile lookup failed",
+        profileError:
+          err instanceof Error ? err.message : "profile lookup failed",
       });
       completed = false;
       needsShopBoostIntake = false;
@@ -228,14 +248,11 @@ export async function middleware(req: NextRequest) {
       return NextResponse.redirect(target, { headers: res.headers });
     }
 
-    if (
-      isPortal &&
-      user &&
-      (isPortalAuthPage || isLegacyPortalConfirm)
-    ) {
+    if (isPortal && user && (isPortalAuthPage || isLegacyPortalConfirm)) {
       const mode = await resolvePortalModeServer(supabase, user.id);
 
-      let to = redirectParam ?? (mode === "fleet" ? "/portal/fleet" : "/portal");
+      let to =
+        redirectParam ?? (mode === "fleet" ? "/portal/fleet" : "/portal");
 
       if (
         mode === "fleet" &&


### PR DESCRIPTION
### Motivation
- A recent sign-in/user change caused middleware and server Supabase factories to crash when `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` were not present in the environment.
- Provide a safe server-only fallback to `SUPABASE_URL` / `SUPABASE_ANON_KEY` so server code can initialize Supabase in environments that only expose non-public env names.

### Description
- Added `readSupabaseServerEnv()` in `middleware.ts` to read `NEXT_PUBLIC_*` or fallback to `SUPABASE_*` and used it for creating the middleware Supabase client.
- Replaced strict `mustEnv(...)` usage in `features/shared/lib/supabase/server.ts` with `mustSupabaseUrl()` and `mustSupabaseAnonKey()` that accept `NEXT_PUBLIC_*` or `SUPABASE_*` fallbacks, and wired those into RSC/route/pages/admin client factories.
- Kept auth/session behavior and cookie handling unchanged while avoiding hard failures when only server env names are configured.
- Small formatting/typing cleanups around cookie handling and conditional logic to satisfy linters/formatter.

### Testing
- Ran `npx prettier --check middleware.ts features/shared/lib/supabase/server.ts` and formatting was fixed with `prettier --write` (now passes).
- Ran `npx tsc --noEmit` and TypeScript typecheck passed.
- Ran `npx eslint middleware.ts` and `npx eslint --no-ignore features/shared/lib/supabase/server.ts` and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a209a0a7a048328b162ee8ca29800e4)