### PR TITLE
Fix Supabase env initialization regression

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,11 +33,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = createServerSupabaseRSC();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
   const hdrs = await headers();
   const pathname = hdrs.get("x-next-pathname") ?? "";
 
@@ -45,6 +40,7 @@ export default async function RootLayout({
     pathname === "/" ||
     pathname.startsWith("/signup") ||
     pathname.startsWith("/sign-in") ||
+    pathname.startsWith("/mobile/sign-in") ||
     pathname.startsWith("/forgot-password") ||
     pathname.startsWith("/auth/reset") ||
     pathname.startsWith("/auth/set-password") ||
@@ -52,9 +48,22 @@ export default async function RootLayout({
     pathname.startsWith("/compare-plans") ||
     pathname.startsWith("/subscribe") ||
     pathname.startsWith("/demo") ||
-    pathname.startsWith("/onboarding");
+    pathname.startsWith("/onboarding") ||
+    pathname.startsWith("/portal/auth/") ||
+    pathname.startsWith("/portal/confirm");
 
   const useAppShell = !isPublicRoute;
+
+  const session = useAppShell
+    ? (await createServerSupabaseRSC().auth.getSession()).data.session
+    : null;
+
+  const appContent = (
+    <VoiceProvider>
+      <BrandThemeBoot />
+      {useAppShell ? <AppShell>{children}</AppShell> : children}
+    </VoiceProvider>
+  );
 
   return (
     <html
@@ -74,26 +83,26 @@ export default async function RootLayout({
             "var(--app-shell-bg, radial-gradient(circle at top, rgba(59,130,246,0.12), transparent 56%), radial-gradient(circle at bottom, rgba(15,23,42,0.96), #020617 70%))",
         }}
       >
-        <Providers initialSession={session ?? null}>
-          <VoiceProvider>
-            <BrandThemeBoot />
-            {useAppShell ? <AppShell>{children}</AppShell> : children}
-          </VoiceProvider>
+        {useAppShell ? (
+          <Providers initialSession={session}>{appContent}</Providers>
+        ) : (
+          appContent
+        )}
 
-          <Toaster
-            position="bottom-center"
-            theme="dark"
-            richColors
-            toastOptions={{
-              style: {
-                background:
-                  "var(--theme-header-bg, radial-gradient(circle at top, rgba(15,23,42,0.96), #020617 70%))",
-                border: "1px solid var(--theme-card-border, rgba(148, 163, 184, 0.5))",
-                color: "var(--theme-text-primary, #e5e7eb)",
-              },
-            }}
-          />
-        </Providers>
+        <Toaster
+          position="bottom-center"
+          theme="dark"
+          richColors
+          toastOptions={{
+            style: {
+              background:
+                "var(--theme-header-bg, radial-gradient(circle at top, rgba(15,23,42,0.96), #020617 70%))",
+              border:
+                "1px solid var(--theme-card-border, rgba(148, 163, 184, 0.5))",
+              color: "var(--theme-text-primary, #e5e7eb)",
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,9 +2,8 @@
 
 import { useMemo } from "react";
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Session } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function Providers({
   children,
@@ -13,9 +12,12 @@ export default function Providers({
   children: React.ReactNode;
   initialSession: Session | null;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   return (
-    <SessionContextProvider supabaseClient={supabase} initialSession={initialSession}>
+    <SessionContextProvider
+      supabaseClient={supabase}
+      initialSession={initialSession}
+    >
       {children}
     </SessionContextProvider>
   );

--- a/features/shared/lib/supabase/admin.ts
+++ b/features/shared/lib/supabase/admin.ts
@@ -2,16 +2,33 @@
 import "server-only";
 
 import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  readSupabaseServerEnv,
+  readSupabaseServiceRoleKey,
+} from "./server-env";
+
+let adminClient: SupabaseClient<Database> | null = null;
+
+function createSupabaseAdminClient(): SupabaseClient<Database> {
+  const { supabaseUrl } = readSupabaseServerEnv();
+  return createClient<Database>(supabaseUrl, readSupabaseServiceRoleKey(), {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
 
 /**
  * Service-role client (server-only).
  * NEVER import from client components.
  */
-export const supabaseAdmin = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  {
-    auth: { persistSession: false, autoRefreshToken: false },
+export const supabaseAdmin = new Proxy({} as SupabaseClient<Database>, {
+  get(_target, property, receiver) {
+    adminClient ??= createSupabaseAdminClient();
+    return Reflect.get(adminClient, property, receiver);
   },
-);
+  set(_target, property, value, receiver) {
+    adminClient ??= createSupabaseAdminClient();
+    return Reflect.set(adminClient, property, value, receiver);
+  },
+});

--- a/features/shared/lib/supabase/client.ts
+++ b/features/shared/lib/supabase/client.ts
@@ -2,23 +2,27 @@
 "use client";
 
 import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { readSupabasePublicEnv } from "./public-env";
 
-let _client: ReturnType<typeof createBrowserClient<Database>> | null = null;
+type BrowserSupabaseClient = SupabaseClient<Database>;
 
-function mustBrowserEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY") {
-  const value = process.env[name];
-  if (!value) throw new Error(`Missing env: ${name}`);
-  return value;
-}
+let _client: BrowserSupabaseClient | null = null;
 
-export function createBrowserSupabase() {
+export function createBrowserSupabase(): BrowserSupabaseClient {
   if (_client) return _client;
-  _client = createBrowserClient<Database>(
-    mustBrowserEnv("NEXT_PUBLIC_SUPABASE_URL"),
-    mustBrowserEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
-  );
+
+  const { supabaseUrl, supabaseAnonKey } = readSupabasePublicEnv("browser");
+  _client = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
   return _client;
 }
 
-export const supabaseBrowser = createBrowserSupabase();
+export const supabaseBrowser = new Proxy({} as BrowserSupabaseClient, {
+  get(_target, property, receiver) {
+    return Reflect.get(createBrowserSupabase(), property, receiver);
+  },
+  set(_target, property, value, receiver) {
+    return Reflect.set(createBrowserSupabase(), property, value, receiver);
+  },
+});

--- a/features/shared/lib/supabase/public-env.ts
+++ b/features/shared/lib/supabase/public-env.ts
@@ -1,0 +1,53 @@
+type SupabasePublicEnvContext = "browser" | "server" | "middleware" | "unknown";
+
+type SupabasePublicEnv = {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+};
+
+function normalizeSupabaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function logSupabasePublicEnvDiagnostics(
+  context: SupabasePublicEnvContext,
+  event: "missing" | "present",
+): void {
+  console.info("[supabase/public-env]", {
+    context,
+    event,
+    hasNextPublicSupabaseUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+    hasNextPublicSupabaseAnonKey: Boolean(
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    ),
+    // These are intentionally diagnostics only. Do not read these fallbacks for
+    // app clients because this project standardizes on NEXT_PUBLIC_* keys.
+    hasLegacySupabaseUrl: Boolean(process.env.SUPABASE_URL),
+    hasLegacySupabaseAnonKey: Boolean(process.env.SUPABASE_ANON_KEY),
+  });
+}
+
+export function readSupabasePublicEnv(
+  context: SupabasePublicEnvContext = "unknown",
+): SupabasePublicEnv {
+  const rawUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const rawAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabaseUrl = rawUrl ? normalizeSupabaseUrl(rawUrl) : "";
+  const supabaseAnonKey = rawAnonKey?.trim() ?? "";
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    logSupabasePublicEnvDiagnostics(context, "missing");
+    if (!supabaseUrl) throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL");
+    throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  }
+
+  logSupabasePublicEnvDiagnostics(context, "present");
+  return { supabaseUrl, supabaseAnonKey };
+}
+
+export function hasSupabasePublicEnv(): boolean {
+  return Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() &&
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim(),
+  );
+}

--- a/features/shared/lib/supabase/server-env.ts
+++ b/features/shared/lib/supabase/server-env.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { readSupabasePublicEnv } from "./public-env";
+
+export function readSupabaseServerEnv() {
+  return readSupabasePublicEnv("server");
+}
+
+export function readSupabaseServiceRoleKey(): string {
+  const value = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim() ?? "";
+  if (!value) {
+    console.info("[supabase/server-env]", {
+      event: "missing_service_role",
+      hasSupabaseServiceRoleKey: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY),
+    });
+    throw new Error("Missing env: SUPABASE_SERVICE_ROLE_KEY");
+  }
+
+  console.info("[supabase/server-env]", {
+    event: "present_service_role",
+    hasSupabaseServiceRoleKey: true,
+  });
+  return value;
+}

--- a/features/shared/lib/supabase/server.ts
+++ b/features/shared/lib/supabase/server.ts
@@ -6,31 +6,10 @@ import { createServerClient } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { Database } from "@shared/types/types/supabase";
-
-function mustSupabaseUrl() {
-  const value =
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
-  if (!value)
-    throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL");
-  return value;
-}
-
-function mustSupabaseAnonKey() {
-  const value =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
-  if (!value) {
-    throw new Error(
-      "Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY",
-    );
-  }
-  return value;
-}
-
-function mustEnv(name: "SUPABASE_SERVICE_ROLE_KEY") {
-  const value = process.env[name];
-  if (!value) throw new Error(`Missing env: ${name}`);
-  return value;
-}
+import {
+  readSupabaseServerEnv,
+  readSupabaseServiceRoleKey,
+} from "./server-env";
 
 function createCookieBackedServerClient() {
   const cookieStore = cookies() as unknown as {
@@ -42,27 +21,25 @@ function createCookieBackedServerClient() {
     ) => void;
   };
 
-  return createServerClient<Database>(
-    mustSupabaseUrl(),
-    mustSupabaseAnonKey(),
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
-            });
-          } catch {
-            // Server Components cannot set cookies. Middleware/route handlers that
-            // can write cookies refresh the session before RSC reads it.
-          }
-        },
+  const { supabaseUrl, supabaseAnonKey } = readSupabaseServerEnv();
+
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options);
+          });
+        } catch {
+          // Server Components cannot set cookies. Middleware/route handlers that
+          // can write cookies refresh the session before RSC reads it.
+        }
       },
     },
-  );
+  });
 }
 
 /**
@@ -86,37 +63,35 @@ export function createServerSupabaseApi(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  return createServerClient<Database>(
-    mustSupabaseUrl(),
-    mustSupabaseAnonKey(),
-    {
-      cookies: {
-        getAll() {
-          return Object.entries(req.cookies).map(([name, value]) => ({
-            name,
-            value: value ?? "",
-          }));
-        },
-        setAll(cookiesToSet) {
-          const existing = res.getHeader("Set-Cookie");
-          const nextCookies = cookiesToSet.map(({ name, value, options }) => {
-            const parts = [`${name}=${encodeURIComponent(value)}`, "Path=/"];
-            if (options?.maxAge) parts.push(`Max-Age=${options.maxAge}`);
-            if (options?.sameSite) parts.push(`SameSite=${options.sameSite}`);
-            if (options?.secure) parts.push("Secure");
-            if (options?.httpOnly) parts.push("HttpOnly");
-            return parts.join("; ");
-          });
-          const previous = Array.isArray(existing)
-            ? existing
-            : existing
-              ? [String(existing)]
-              : [];
-          res.setHeader("Set-Cookie", [...previous, ...nextCookies]);
-        },
+  const { supabaseUrl, supabaseAnonKey } = readSupabaseServerEnv();
+
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return Object.entries(req.cookies).map(([name, value]) => ({
+          name,
+          value: value ?? "",
+        }));
+      },
+      setAll(cookiesToSet) {
+        const existing = res.getHeader("Set-Cookie");
+        const nextCookies = cookiesToSet.map(({ name, value, options }) => {
+          const parts = [`${name}=${encodeURIComponent(value)}`, "Path=/"];
+          if (options?.maxAge) parts.push(`Max-Age=${options.maxAge}`);
+          if (options?.sameSite) parts.push(`SameSite=${options.sameSite}`);
+          if (options?.secure) parts.push("Secure");
+          if (options?.httpOnly) parts.push("HttpOnly");
+          return parts.join("; ");
+        });
+        const previous = Array.isArray(existing)
+          ? existing
+          : existing
+            ? [String(existing)]
+            : [];
+        res.setHeader("Set-Cookie", [...previous, ...nextCookies]);
       },
     },
-  );
+  });
 }
 
 /**
@@ -124,11 +99,9 @@ export function createServerSupabaseApi(
  * Never import this into client components.
  */
 export function createAdminSupabase() {
-  return createClient<Database>(
-    mustSupabaseUrl(),
-    mustEnv("SUPABASE_SERVICE_ROLE_KEY"),
-    {
-      auth: { persistSession: false, autoRefreshToken: false },
-    },
-  );
+  const { supabaseUrl } = readSupabaseServerEnv();
+
+  return createClient<Database>(supabaseUrl, readSupabaseServiceRoleKey(), {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,10 @@ import { createServerClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import {
+  hasSupabasePublicEnv,
+  readSupabasePublicEnv,
+} from "@/features/shared/lib/supabase/public-env";
 
 function isAssetPath(p: string) {
   return (
@@ -31,26 +35,10 @@ function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
   return normalized === "owner" || normalized === "admin";
 }
 
-function readSupabaseServerEnv() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
-  const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
-
-  if (!url)
-    throw new Error("Missing env: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL");
-  if (!anonKey) {
-    throw new Error(
-      "Missing env: NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY",
-    );
-  }
-
-  return { url, anonKey };
-}
-
 function createMiddlewareSupabase(req: NextRequest, res: NextResponse) {
-  const { url, anonKey } = readSupabaseServerEnv();
+  const { supabaseUrl, supabaseAnonKey } = readSupabasePublicEnv("middleware");
 
-  return createServerClient<Database>(url, anonKey, {
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
       getAll() {
         return req.cookies.getAll();
@@ -115,6 +103,8 @@ async function resolvePortalModeServer(
 
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-next-pathname", pathname);
 
   if (isAssetPath(pathname) || pathname.startsWith("/api")) {
     return NextResponse.next();
@@ -124,21 +114,7 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  const res = NextResponse.next({ request: req });
-  const supabase = createMiddlewareSupabase(req, res);
-
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
-
-  if (userError && userError.message !== "Auth session missing!") {
-    console.info("[auth/middleware-get-user]", {
-      pathname,
-      userId: null,
-      error: userError.message,
-    });
-  }
+  const res = NextResponse.next({ request: { headers: requestHeaders } });
 
   const isPortal = pathname === "/portal" || pathname.startsWith("/portal/");
   const isPortalAuthPage = pathname.startsWith("/portal/auth/");
@@ -161,6 +137,32 @@ export async function middleware(req: NextRequest) {
     pathname.startsWith("/demo") ||
     isPortalAuthPage ||
     isLegacyPortalConfirm;
+
+  if (isPublic && !hasSupabasePublicEnv()) {
+    console.info("[auth/middleware-public-skip]", {
+      pathname,
+      hasNextPublicSupabaseUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+      hasNextPublicSupabaseAnonKey: Boolean(
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      ),
+    });
+    return res;
+  }
+
+  const supabase = createMiddlewareSupabase(req, res);
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError && userError.message !== "Auth session missing!") {
+    console.info("[auth/middleware-get-user]", {
+      pathname,
+      userId: null,
+      error: userError.message,
+    });
+  }
 
   let completed = false;
   let needsShopBoostIntake = false;


### PR DESCRIPTION
### Motivation
- Landing page was crashing with `Missing env: NEXT_PUBLIC_SUPABASE_URL` because Supabase env validation and client creation were happening at module-import / layout render time even for public routes. 
- The recent auth/session refactor introduced eager env checks, mixed legacy `SUPABASE_*` fallbacks, and a middleware/layout header forwarding gap that prevented the layout from avoiding session init on public pages. 

### Description
- Centralized public env reads into `features/shared/lib/supabase/public-env.ts` which trims the URL, removes trailing slashes, and emits boolean-only diagnostics about env presence. 
- Added `features/shared/lib/supabase/server-env.ts` to expose server-only helpers and the service-role key check under `server-only`. 
- Made the browser Supabase client (`features/shared/lib/supabase/client.ts`) and admin singleton (`features/shared/lib/supabase/admin.ts`) lazy so importing them does not validate env or construct clients until actually used. 
- Updated server helpers (`features/shared/lib/supabase/server.ts`) to use the centralized server env helper and removed eager fallback validation that caused public pages to crash. 
- Prevent RootLayout from initializing Supabase on public routes by checking `x-next-pathname` first and only fetching server session for protected routes, and render the session-backed provider only when needed. 
- Updated `middleware.ts` to forward `x-next-pathname`, to use the centralized public env helper for middleware Supabase, and to skip middleware Supabase initialization for public routes when `NEXT_PUBLIC_*` keys are absent. 
- Replaced the `@supabase/auth-helpers-nextjs` client creation in the provider with the new lazy `createBrowserSupabase` so the client path reads only `NEXT_PUBLIC_*` keys. 
- Preserved the created-user / synthetic-email auth flow and server/admin route behavior (no functional change to create-user or resolve-login flows). 

### Testing
- Ran `npx eslint features/shared/lib/supabase/client.ts features/shared/lib/supabase/server.ts middleware.ts app/layout.tsx app/auth/callback/page.tsx app/api/auth/resolve-login/route.ts app/api/admin/create-user/route.ts app/api/admin/diagnostics/user-auth/route.ts`; ESLint completed but reported that the two server/client files are ignored by repo ignore rules (warnings only). 
- Ran `npx tsc --noEmit` and TypeScript checked successfully with no errors. 
- Ran `git diff --check` and it reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a0ce77e48328aec415f5fba9ff3b)