### PR TITLE
Harden Onboarding V2 auth routing

### DIFF
--- a/app/account/shop-assignment-required/page.tsx
+++ b/app/account/shop-assignment-required/page.tsx
@@ -15,7 +15,7 @@ export default async function ShopAssignmentRequiredPage() {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("completed_onboarding, must_change_password, role, shop_id, full_name, email")
+    .select("must_change_password, role, shop_id, full_name, email")
     .eq("id", user.id)
     .maybeSingle();
 

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -1,8 +1,6 @@
 // app/api/onboarding/bootstrap-owner/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 import { OWNER_PIN_PURPOSES, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
@@ -11,8 +9,8 @@ import {
   reconcileShopBillingFromUser,
 } from "@/features/stripe/lib/server/canonical-shop-billing";
 
-type DB = Database;
 
+const OWNER_SETUP_ROLES = new Set(["owner", "admin"]);
 const NA_COUNTRIES = new Set(["US", "CA"]);
 
 function cleanStr(v: unknown): string {
@@ -28,7 +26,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const {
@@ -38,6 +36,37 @@ export async function POST(req: Request) {
 
     if (userErr || !user) {
       return NextResponse.json({ msg: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles")
+      .select("role, shop_id")
+      .eq("id", user.id)
+      .maybeSingle<{ role: string | null; shop_id: string | null }>();
+
+    if (profileErr || !profile) {
+      return NextResponse.json(
+        { msg: "Profile setup required before owner onboarding." },
+        { status: 403 },
+      );
+    }
+
+    const normalizedRole = String(profile.role ?? "")
+      .trim()
+      .toLowerCase();
+
+    if (!OWNER_SETUP_ROLES.has(normalizedRole)) {
+      return NextResponse.json(
+        { msg: "Only owner or admin accounts can create the first shop." },
+        { status: 403 },
+      );
+    }
+
+    if (profile.shop_id) {
+      return NextResponse.json(
+        { msg: "This account already has a shop assigned." },
+        { status: 409 },
+      );
     }
 
     const rawUnknown = (await req.json().catch(() => null)) as unknown;

--- a/app/dashboard/onboarding/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding/[sessionId]/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from "next/navigation";
 
-export default function LegacyDashboardOnboardingSessionRedirect() {
-  redirect("/dashboard/onboarding-v2");
+type Props = { params: Promise<{ sessionId: string }> };
+
+export default async function LegacyDashboardOnboardingSessionRedirect({
+  params,
+}: Props) {
+  const { sessionId } = await params;
+  redirect(`/dashboard/onboarding-v2/${encodeURIComponent(sessionId)}`);
 }

--- a/app/onboarding/v2/page.tsx
+++ b/app/onboarding/v2/page.tsx
@@ -16,7 +16,7 @@ export default async function OnboardingV2Page() {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("completed_onboarding, must_change_password, role, shop_id, full_name, phone, email")
+    .select("must_change_password, role, shop_id, full_name, phone, email")
     .eq("id", user.id)
     .maybeSingle();
 

--- a/features/auth/lib/postAuthRouting.ts
+++ b/features/auth/lib/postAuthRouting.ts
@@ -19,7 +19,6 @@ export const SHOP_ASSIGNMENT_REQUIRED_PATH = "/account/shop-assignment-required"
 export const PROFILE_RECOVERY_PATH = "/account/profile-recovery";
 
 export type PostAuthProfile = {
-  completed_onboarding?: boolean | null;
   must_change_password?: boolean | null;
   role?: string | null;
   shop_id?: string | null;
@@ -106,7 +105,7 @@ export async function resolvePostAuthDestination(args: {
 
   const { data: profile, error: profileError } = await supabase
     .from("profiles")
-    .select("completed_onboarding, must_change_password, role, shop_id")
+    .select("must_change_password, role, shop_id")
     .eq("id", user.id)
     .maybeSingle();
 
@@ -115,7 +114,6 @@ export async function resolvePostAuthDestination(args: {
     profileExists: Boolean(profile),
     profileShopId: profile?.shop_id ?? null,
     profileRole: profile?.role ?? null,
-    completedOnboarding: profile?.completed_onboarding ?? null,
     profileError: profileError?.message ?? null,
   });
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -57,7 +57,6 @@ function logMiddlewareAuthDiagnostics(args: {
   profile?: {
     shop_id?: string | null;
     role?: string | null;
-    completed_onboarding?: boolean | null;
   } | null;
   profileError?: string | null;
 }) {
@@ -67,7 +66,6 @@ function logMiddlewareAuthDiagnostics(args: {
     profileExists: Boolean(args.profile),
     profileShopId: args.profile?.shop_id ?? null,
     profileRole: args.profile?.role ?? null,
-    completedOnboarding: args.profile?.completed_onboarding ?? null,
     profileError: args.profileError ?? null,
   });
 }
@@ -165,7 +163,6 @@ export async function middleware(req: NextRequest) {
 
   let postAuthDestination = ONBOARDING_V2_PATH;
   let profileForRouting: {
-    completed_onboarding?: boolean | null;
     must_change_password?: boolean | null;
     role?: string | null;
     shop_id?: string | null;
@@ -174,7 +171,7 @@ export async function middleware(req: NextRequest) {
     try {
       const { data: profile, error: profileError } = await supabase
         .from("profiles")
-        .select("completed_onboarding, must_change_password, shop_id, role")
+        .select("must_change_password, shop_id, role")
         .eq("id", user.id)
         .limit(1)
         .maybeSingle();
@@ -301,6 +298,7 @@ export const config = {
     "/subscribe",
     "/confirm",
     "/signup",
+    "/sign-in",
     "/forgot-password",
     "/auth/reset",
     "/auth/set-password",


### PR DESCRIPTION
### Motivation
- Ensure onboarding routing is role/shop-driven and safe for signed-out public pages so landing, sign-in, sign-up and portal auth pages render without requiring a Supabase session/profile/shop/onboarding flag.
- Make post-login routing canonical (owner/admin vs staff) by driving decisions from `role`, `shop_id` and `must_change_password` rather than an independently read `completed_onboarding` flag.
- Prevent staff accounts from invoking owner bootstrap and preserve legacy session IDs when redirecting into the Onboarding V2 workspace.
- Note: repo-wide `@supabase/auth-helpers-nextjs` usage and legacy onboarding components remain in other areas and were not mass-migrated as part of this focused audit (listed below as an informational risk). 

### Description
- Added `/sign-in` to the middleware matcher so a signed-in user who visits the sign-in page is routed through the canonical post-auth decision path (`middleware.ts`).
- Removed `completed_onboarding` from canonical middleware/profile selects and from post-auth routing logging so routing decisions use `must_change_password`, `shop_id`, and normalized `role` instead (`middleware.ts`, `features/auth/lib/postAuthRouting.ts`, `app/onboarding/v2/page.tsx`, `app/account/shop-assignment-required/page.tsx`).
- Hardened owner bootstrap API: switched from auth-helpers client to server SSR route client and added guards so only authenticated `owner`/`admin` profiles without an assigned `shop_id` may create the first shop (`app/api/onboarding/bootstrap-owner/route.ts`).
- Preserved legacy onboarding session routing by redirecting `/dashboard/onboarding/[sessionId]` to `/dashboard/onboarding-v2/[sessionId]` with the `sessionId` encoded, instead of dropping it (`app/dashboard/onboarding/[sessionId]/page.tsx`).
- Files changed (key): `middleware.ts`, `features/auth/lib/postAuthRouting.ts`, `app/onboarding/v2/page.tsx`, `app/account/shop-assignment-required/page.tsx`, `app/api/onboarding/bootstrap-owner/route.ts`, `app/dashboard/onboarding/[sessionId]/page.tsx`.
- Informational: repo searches still show many `@supabase/auth-helpers-nextjs` imports in unrelated components and pages; those were intentionally left untouched because migrating them is outside this focused audit.

### Testing
- Ran unit tests: `npx vitest run features/auth/lib/postAuthRouting.test.ts tests/user-auth-normalization.test.ts` — all tests passed.
- Ran linting on the touched files: `npx eslint middleware.ts app/layout.tsx app/onboarding/v2/page.tsx app/account/profile-recovery/page.tsx app/account/shop-assignment-required/page.tsx features/auth/lib/postAuthRouting.ts features/auth/app/onboarding-v2/OnboardingV2OwnerSetup.tsx app/api/onboarding/bootstrap-owner/route.ts` — linter passed for modified targets.
- Ran TypeScript build check: `npx tsc --noEmit` — typecheck passed.
- Ran `git diff --check` — no whitespace/merge issues.
- Ran the requested repo searches (informational): `grep -RIn "Shop Boost needs a shop\|Finish owner onboarding\|Back to onboarding\|completed_onboarding\|auth-helpers-nextjs" app features middleware.ts` to confirm there is no remaining user-facing copy and to surface remaining `auth-helpers-nextjs` usages; results show `completed_onboarding` references in various admin surfaces and `auth-helpers-nextjs` imports across many client components (these are informational and outside this PR scope).

All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a805b6288328bd01732032d8b0a0)