### PR TITLE
Implement guided onboarding v2 foundation

### DIFF
--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { fetchGuidedSession, guardedJsonError, requireGuidedOwnerAdminAccess } from "@/features/onboarding-v2/guided/server";
+
+type Context = { params: Promise<{ sessionId: string }> };
+
+export async function GET(_: Request, context: Context) {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId } = await context.params;
+  try {
+    const payload = await fetchGuidedSession({ supabase: access.supabase, shopId, sessionId });
+    return NextResponse.json({ ok: true, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { buildGuidedOnboardingDestinationUrl } from "@/features/onboarding-v2/guided/query";
+import { assertGuidedStepKey, answerGuidedStepYes, guardedJsonError, requireGuidedOwnerAdminAccess, updateGuidedStepStatus } from "@/features/onboarding-v2/guided/server";
+
+type Context = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId, stepKey: rawStepKey } = await context.params;
+  const stepKey = assertGuidedStepKey(rawStepKey);
+  if (!stepKey) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const answer = body.answer === "no" ? "no" : body.answer === "yes" ? "yes" : null;
+  if (!answer) return NextResponse.json({ error: "answer must be yes or no" }, { status: 400 });
+
+  try {
+    const payload = answer === "yes"
+      ? await answerGuidedStepYes({ supabase: access.supabase, shopId, sessionId, stepKey })
+      : await updateGuidedStepStatus({
+          supabase: access.supabase,
+          shopId,
+          sessionId,
+          stepKey,
+          status: "skipped",
+          skippedReason: typeof body.skippedReason === "string" ? body.skippedReason : "User answered no",
+        });
+
+    const destinationUrl = answer === "yes"
+      ? buildGuidedOnboardingDestinationUrl({ sessionId, stepKey })
+      : null;
+
+    return NextResponse.json({ ok: true, answer, destinationUrl, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { assertGuidedStepKey, guardedJsonError, requireGuidedOwnerAdminAccess, updateGuidedStepStatus } from "@/features/onboarding-v2/guided/server";
+
+type Context = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId, stepKey: rawStepKey } = await context.params;
+  const stepKey = assertGuidedStepKey(rawStepKey);
+  if (!stepKey) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const summary = body.summary && typeof body.summary === "object" && !Array.isArray(body.summary) ? body.summary as Record<string, unknown> : {};
+
+  try {
+    const payload = await updateGuidedStepStatus({ supabase: access.supabase, shopId, sessionId, stepKey, status: "completed", summary });
+    return NextResponse.json({ ok: true, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { assertGuidedStepKey, guardedJsonError, requireGuidedOwnerAdminAccess, updateGuidedStepStatus } from "@/features/onboarding-v2/guided/server";
+
+type Context = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId, stepKey: rawStepKey } = await context.params;
+  const stepKey = assertGuidedStepKey(rawStepKey);
+  if (!stepKey) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+
+  try {
+    const payload = await updateGuidedStepStatus({
+      supabase: access.supabase,
+      shopId,
+      sessionId,
+      stepKey,
+      status: "skipped",
+      skippedReason: typeof body.skippedReason === "string" ? body.skippedReason : "Skipped by user",
+    });
+    return NextResponse.json({ ok: true, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { assertGuidedStepKey, guardedJsonError, parseGuidedStatusPayload, requireGuidedOwnerAdminAccess, updateGuidedStepStatus } from "@/features/onboarding-v2/guided/server";
+
+type Context = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId, stepKey: rawStepKey } = await context.params;
+  const stepKey = assertGuidedStepKey(rawStepKey);
+  if (!stepKey) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+
+  const parsed = parseGuidedStatusPayload(await request.json().catch(() => ({})));
+  if (!parsed) return NextResponse.json({ error: "Invalid guided onboarding status payload" }, { status: 400 });
+
+  try {
+    const payload = await updateGuidedStepStatus({
+      supabase: access.supabase,
+      shopId,
+      sessionId,
+      stepKey,
+      status: parsed.status,
+      summary: parsed.summary,
+      error: parsed.error,
+    });
+    return NextResponse.json({ ok: true, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { createOrResumeGuidedSession, guardedJsonError, requireGuidedOwnerAdminAccess } from "@/features/onboarding-v2/guided/server";
+
+export async function POST() {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  try {
+    const payload = await createOrResumeGuidedSession({ supabase: access.supabase, shopId, userId: access.profile.id });
+    return NextResponse.json({ ok: true, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -1,4 +1,5 @@
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { GuidedOnboardingWorkspace } from "@/features/onboarding-v2/components/GuidedOnboardingWorkspace";
 import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
 import { SessionWorkspace } from "@/features/onboarding-v2/components/SessionWorkspace";
 
@@ -9,8 +10,14 @@ export default async function OnboardingV2SessionPage({ params }: Props) {
   const { sessionId } = await params;
 
   return (
-    <OnboardingV2Shell title="Onboarding Agent Session">
-      <SessionWorkspace sessionId={sessionId} />
+    <OnboardingV2Shell title="Guided Onboarding V2">
+      <GuidedOnboardingWorkspace initialSessionId={sessionId} />
+      <details className="rounded-2xl border border-dashed border-white/15 bg-white/[0.025] p-4 text-slate-300">
+        <summary className="cursor-pointer text-sm font-semibold text-slate-200">Legacy/dev upload workspace</summary>
+        <div className="mt-4">
+          <SessionWorkspace sessionId={sessionId} />
+        </div>
+      </details>
     </OnboardingV2Shell>
   );
 }

--- a/app/dashboard/onboarding-v2/page.tsx
+++ b/app/dashboard/onboarding-v2/page.tsx
@@ -1,20 +1,13 @@
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
-import { AgentReadinessBanner } from "@/features/onboarding-v2/components/AgentReadinessBanner";
 import { OnboardingV2Shell } from "@/features/onboarding-v2/components/OnboardingV2Shell";
-import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
-import { getAgentReadinessForDashboard } from "@/features/onboarding-v2/lib/agentReadinessServer";
-import { StartOnboardingSessionCard } from "@/features/onboarding-v2/components/StartOnboardingSessionCard";
+import { GuidedOnboardingWorkspace } from "@/features/onboarding-v2/components/GuidedOnboardingWorkspace";
 
 export default async function OnboardingV2Page() {
   await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
-  const readiness = await getAgentReadinessForDashboard();
 
   return (
-    <OnboardingV2Shell title="Onboarding Agent">
-      <SafeModeVerifyOnlyBanner />
-      <AgentReadinessBanner readiness={readiness} />
-      <StartOnboardingSessionCard />
-      <div className="rounded-xl border border-dashed border-white/15 p-4 text-sm text-slate-300">Session listing coming next.</div>
+    <OnboardingV2Shell title="Guided Onboarding V2">
+      <GuidedOnboardingWorkspace />
     </OnboardingV2Shell>
   );
 }

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -6,6 +6,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import {
   buildPartTrustMeta,
   trustBadgeTone,
@@ -13,6 +14,8 @@ import {
   type PartTrustMeta,
 } from "@/features/parts/lib/trust-signals";
 import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 /* ----------------------------- Types ----------------------------- */
 
@@ -275,6 +278,9 @@ async function applyStockMoveRPC(
 
 export default function InventoryPage(): JSX.Element {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const searchParams = useSearchParams();
+  const guidedOnboarding = useMemo(() => parseGuidedOnboardingQuery(searchParams), [searchParams]);
+  const partsImportHighlightActive = guidedOnboarding?.onboardingStep === "inventory_parts" && guidedOnboarding.highlight === "parts-csv-import";
   const [shopId, setShopId] = useState<string>("");
 
   const [search, setSearch] = useState<string>("");
@@ -715,6 +721,9 @@ export default function InventoryPage(): JSX.Element {
   const runCsvImport = async () => {
     if (!shopId || !csvRows.length) return;
 
+    let importedCount = 0;
+    let stockReceiveCount = 0;
+
     // NOTE: intentionally sequential to keep it safe and predictable for now.
     for (const row of csvRows) {
       let partId: string | null = null;
@@ -746,6 +755,7 @@ export default function InventoryPage(): JSX.Element {
           console.warn("Insert failed:", row, error.message);
           continue;
         }
+        importedCount += 1;
         partId = id;
       } else {
         const patch: PartUpdate = {
@@ -755,6 +765,7 @@ export default function InventoryPage(): JSX.Element {
           price: typeof row.price === "number" ? row.price : undefined,
         };
         await supabase.from("parts").update(patch).eq("id", partId);
+        importedCount += 1;
       }
 
       if (partId && csvDefaultLoc && typeof row.qty === "number" && row.qty > 0) {
@@ -767,6 +778,7 @@ export default function InventoryPage(): JSX.Element {
             p_ref_kind: "csv_import",
             p_ref_id: null,
           });
+          stockReceiveCount += 1;
         } catch (err: unknown) {
           // eslint-disable-next-line no-console
           console.warn("Stock receive failed for row:", row, errMsg(err));
@@ -779,6 +791,20 @@ export default function InventoryPage(): JSX.Element {
     setCsvText("");
     setCsvRows([]);
     await load(shopId);
+
+    if (guidedOnboarding?.onboardingStep === "inventory_parts") {
+      await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedOnboarding.onboardingSession)}/steps/inventory_parts/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ summary: { importedCount, stockReceiveCount, source: "parts-csv-import" } }),
+        },
+      ).catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.warn("Guided onboarding completion callback failed:", errMsg(err));
+      });
+    }
   };
 
   /* ----------------------------- UI ----------------------------- */
@@ -809,6 +835,14 @@ export default function InventoryPage(): JSX.Element {
               <div className="mt-1 text-sm text-neutral-400">
                 Create parts, quick receive, and import stock from CSV.
               </div>
+              {guidedOnboarding ? (
+                <Link
+                  href={guidedOnboarding.returnTo}
+                  className="mt-3 inline-flex rounded-lg border border-[rgba(197,122,74,0.45)] bg-[rgba(197,122,74,0.12)] px-3 py-2 text-xs font-semibold text-orange-100 hover:bg-[rgba(197,122,74,0.2)]"
+                >
+                  Return to guided onboarding
+                </Link>
+              ) : null}
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
@@ -827,9 +861,16 @@ export default function InventoryPage(): JSX.Element {
                 Add Part
               </button>
 
-              <button className={btnBlue} onClick={() => setCsvOpen(true)} disabled={!shopId}>
-                CSV Import
-              </button>
+              <OnboardingHighlightFrame
+                active={Boolean(partsImportHighlightActive)}
+                highlightKey="parts-csv-import"
+                title="Import inventory parts"
+                description="Open CSV Import, review the preview, then import. ProFixIQ will mark this guided step complete only after you explicitly import."
+              >
+                <button className={btnBlue} onClick={() => setCsvOpen(true)} disabled={!shopId}>
+                  CSV Import
+                </button>
+              </OnboardingHighlightFrame>
               <select
                 className={inputBase}
                 value={trustFilter}

--- a/db/sql/2026-06-04_guided_onboarding_v2_foundation.sql
+++ b/db/sql/2026-06-04_guided_onboarding_v2_foundation.sql
@@ -1,0 +1,109 @@
+-- Guided Onboarding V2 foundation.
+-- Additive, shop-scoped tables only. Existing onboarding/auth tables are not changed.
+
+begin;
+
+create table if not exists public.guided_onboarding_sessions (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  created_by uuid null references auth.users(id) on delete set null,
+  status text not null default 'active' check (status in ('active', 'in_progress', 'completed', 'cancelled')),
+  current_step_key text null,
+  summary jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz null
+);
+
+create index if not exists guided_onboarding_sessions_shop_updated_idx
+  on public.guided_onboarding_sessions(shop_id, updated_at desc);
+
+create index if not exists guided_onboarding_sessions_shop_status_idx
+  on public.guided_onboarding_sessions(shop_id, status);
+
+create table if not exists public.guided_onboarding_steps (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.guided_onboarding_sessions(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  step_key text not null,
+  status text not null default 'not_started' check (status in (
+    'not_started',
+    'asked',
+    'skipped',
+    'routing',
+    'upload_requested',
+    'uploading',
+    'uploaded',
+    'parsing',
+    'validation_required',
+    'ready_to_import',
+    'importing',
+    'completed',
+    'failed',
+    'retry_requested'
+  )),
+  destination_path text not null,
+  highlight_key text not null,
+  skipped_reason text null,
+  summary jsonb not null default '{}'::jsonb,
+  error text null,
+  retry_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz null,
+  unique (session_id, step_key)
+);
+
+create index if not exists guided_onboarding_steps_shop_session_idx
+  on public.guided_onboarding_steps(shop_id, session_id);
+
+create index if not exists guided_onboarding_steps_shop_status_idx
+  on public.guided_onboarding_steps(shop_id, status);
+
+create table if not exists public.guided_onboarding_events (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.guided_onboarding_sessions(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  step_key text null,
+  event_type text not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists guided_onboarding_events_shop_session_idx
+  on public.guided_onboarding_events(shop_id, session_id, created_at desc);
+
+create index if not exists guided_onboarding_events_shop_step_idx
+  on public.guided_onboarding_events(shop_id, step_key, created_at desc);
+
+alter table public.guided_onboarding_sessions enable row level security;
+alter table public.guided_onboarding_steps enable row level security;
+alter table public.guided_onboarding_events enable row level security;
+
+DO $$
+DECLARE tbl text;
+BEGIN
+  FOREACH tbl IN ARRAY ARRAY[
+    'guided_onboarding_sessions',
+    'guided_onboarding_steps',
+    'guided_onboarding_events'
+  ]
+  LOOP
+    EXECUTE format('drop policy if exists service_role_manage_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy service_role_manage_%I on public.%I to service_role using (auth.role() = ''service_role'') with check (auth.role() = ''service_role'')', tbl, tbl);
+    EXECUTE format('grant all on public.%I to service_role', tbl);
+
+    EXECUTE format('drop policy if exists guided_onboarding_owner_admin_select_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy guided_onboarding_owner_admin_select_%I on public.%I for select to authenticated using (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'', ''admin'')))', tbl, tbl, tbl);
+
+    EXECUTE format('drop policy if exists guided_onboarding_owner_admin_insert_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy guided_onboarding_owner_admin_insert_%I on public.%I for insert to authenticated with check (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'', ''admin'')))', tbl, tbl, tbl);
+
+    EXECUTE format('drop policy if exists guided_onboarding_owner_admin_update_%I on public.%I', tbl, tbl);
+    EXECUTE format('create policy guided_onboarding_owner_admin_update_%I on public.%I for update to authenticated using (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'', ''admin''))) with check (shop_id = public.current_shop_id() and exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = %I.shop_id and lower(coalesce(p.role, '''')) in (''owner'', ''admin'')))', tbl, tbl, tbl, tbl);
+
+    EXECUTE format('grant select, insert, update on public.%I to authenticated', tbl);
+  END LOOP;
+END $$;
+
+commit;

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { buildGuidedOnboardingDestinationUrl } from "@/features/onboarding-v2/guided/query";
+import { GUIDED_ONBOARDING_STEPS, getGuidedOnboardingStep, type GuidedOnboardingStatus, type GuidedOnboardingStepKey } from "@/features/onboarding-v2/guided/steps";
+import type { GuidedSessionRow, GuidedStepRow } from "@/features/onboarding-v2/guided/types";
+
+type GuidedPayload = {
+  ok: boolean;
+  session: GuidedSessionRow;
+  steps: GuidedStepRow[];
+};
+
+type Props = {
+  initialSessionId?: string;
+};
+
+const terminalStatuses = new Set<GuidedOnboardingStatus>(["completed", "skipped"]);
+
+function statusLabel(status: GuidedOnboardingStatus) {
+  return status.replaceAll("_", " ");
+}
+
+function statusTone(status: GuidedOnboardingStatus) {
+  if (status === "completed") return "border-emerald-500/40 bg-emerald-950/30 text-emerald-200";
+  if (status === "skipped") return "border-slate-500/40 bg-slate-900/50 text-slate-300";
+  if (status === "failed") return "border-red-500/40 bg-red-950/35 text-red-200";
+  if (["routing", "uploading", "importing", "parsing"].includes(status)) return "border-orange-400/40 bg-orange-950/20 text-orange-100";
+  return "border-white/10 bg-white/[0.04] text-slate-300";
+}
+
+export function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
+  const router = useRouter();
+  const [payload, setPayload] = useState<GuidedPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busyStep, setBusyStep] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const sessionId = payload?.session.id ?? initialSessionId ?? "";
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = initialSessionId
+        ? await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(initialSessionId)}`)
+        : await fetch("/api/onboarding-v2/guided/sessions", { method: "POST" });
+      const next = await response.json() as GuidedPayload & { error?: string };
+      if (!response.ok || !next.ok) throw new Error(next.error ?? "Unable to load guided onboarding");
+      setPayload(next);
+      if (!initialSessionId) router.replace(`/dashboard/onboarding-v2/${next.session.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load guided onboarding");
+    } finally {
+      setLoading(false);
+    }
+  }, [initialSessionId, router]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const currentStep = useMemo(() => {
+    if (!payload) return null;
+    const keyed = payload.session.current_step_key
+      ? payload.steps.find((step) => step.step_key === payload.session.current_step_key)
+      : null;
+    return keyed ?? payload.steps.find((step) => !terminalStatuses.has(step.status)) ?? payload.steps[0] ?? null;
+  }, [payload]);
+
+  const counts = useMemo(() => {
+    const steps = payload?.steps ?? [];
+    return {
+      completed: steps.filter((step) => step.status === "completed").length,
+      skipped: steps.filter((step) => step.status === "skipped").length,
+      failed: steps.filter((step) => step.status === "failed").length,
+      total: GUIDED_ONBOARDING_STEPS.length,
+    };
+  }, [payload]);
+
+  async function postStep(stepKey: GuidedOnboardingStepKey, action: "answer" | "skip" | "complete", body: Record<string, unknown> = {}) {
+    if (!sessionId) return null;
+    setBusyStep(`${stepKey}:${action}`);
+    setError("");
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(sessionId)}/steps/${encodeURIComponent(stepKey)}/${action}`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) },
+      );
+      const next = await response.json() as GuidedPayload & { error?: string; destinationUrl?: string | null };
+      if (!response.ok || !next.ok) throw new Error(next.error ?? "Guided onboarding step update failed");
+      setPayload(next);
+      return next;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Guided onboarding step update failed");
+      return null;
+    } finally {
+      setBusyStep(null);
+    }
+  }
+
+  const routeStep = async (stepKey: GuidedOnboardingStepKey) => {
+    const next = await postStep(stepKey, "answer", { answer: "yes" });
+    if (next?.destinationUrl) router.push(next.destinationUrl);
+  };
+
+  if (loading) {
+    return <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-5 text-sm text-slate-300">Loading guided onboarding…</div>;
+  }
+
+  if (error && !payload) {
+    return (
+      <div className="rounded-2xl border border-red-500/30 bg-red-950/30 p-5 text-sm text-red-100">
+        {error}
+        <button className="ml-3 rounded-lg border border-red-300/30 px-3 py-1" onClick={() => void load()}>Retry</button>
+      </div>
+    );
+  }
+
+  if (!payload || !currentStep) return null;
+
+  const currentDefinition = getGuidedOnboardingStep(currentStep.step_key);
+  const currentDestination = buildGuidedOnboardingDestinationUrl({ sessionId: payload.session.id, stepKey: currentStep.step_key });
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <section className="space-y-4">
+        <div className="rounded-2xl border border-[rgba(197,122,74,0.35)] bg-[linear-gradient(135deg,rgba(197,122,74,0.16),rgba(15,23,42,0.78))] p-5 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
+          <div className="text-xs font-semibold uppercase tracking-[0.24em] text-orange-200/75">Guided control room</div>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Let ProFixIQ guide setup one decision at a time.</h2>
+          <p className="mt-2 max-w-2xl text-sm text-slate-300">
+            The onboarding agent does not import data here. It routes you to the real ProFixIQ page that owns each setup task, tracks your answer, and resumes when the step is done.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-[rgba(15,23,42,0.72)] p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Current question</div>
+          <h3 className="mt-2 text-xl font-semibold text-white">{currentDefinition.question}</h3>
+          <p className="mt-2 text-sm text-slate-300">{currentDefinition.description}</p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${statusTone(currentStep.status)}`}>{statusLabel(currentStep.status)}</span>
+            <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-slate-300">{currentDefinition.implementationStatus}</span>
+          </div>
+
+          {error ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/25 p-3 text-sm text-red-100">{error}</div> : null}
+
+          <div className="mt-5 flex flex-wrap gap-3">
+            <button
+              className="rounded-xl border border-[rgba(197,122,74,0.55)] bg-[linear-gradient(135deg,rgba(197,122,74,0.30),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 hover:bg-orange-400/20 disabled:opacity-50"
+              onClick={() => void routeStep(currentStep.step_key)}
+              disabled={Boolean(busyStep) || currentDefinition.implementationStatus === "future"}
+            >
+              Yes, route me there
+            </button>
+            <button
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-50"
+              onClick={() => void postStep(currentStep.step_key, "skip", { skippedReason: "User answered no" })}
+              disabled={Boolean(busyStep)}
+            >
+              No, skip this
+            </button>
+            <button
+              className="rounded-xl border border-emerald-500/30 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-50"
+              onClick={() => void postStep(currentStep.step_key, "complete", { summary: { completedFrom: "guided-control-room" } })}
+              disabled={Boolean(busyStep) || currentStep.status === "completed"}
+            >
+              Mark done
+            </button>
+            {currentStep.status === "routing" ? (
+              <Link className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-900/30" href={currentDestination}>
+                Resume step
+              </Link>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-white/[0.035] p-5">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-400">Readiness summary</h3>
+          <div className="mt-4 grid gap-3 sm:grid-cols-4">
+            <Metric label="Completed" value={counts.completed} />
+            <Metric label="Skipped" value={counts.skipped} />
+            <Metric label="Failed" value={counts.failed} />
+            <Metric label="Remaining" value={Math.max(counts.total - counts.completed - counts.skipped, 0)} />
+          </div>
+        </div>
+      </section>
+
+      <aside className="rounded-2xl border border-white/10 bg-[rgba(2,6,23,0.72)] p-4">
+        <div className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Checklist</div>
+        <div className="space-y-2">
+          {payload.steps.map((step, index) => {
+            const definition = getGuidedOnboardingStep(step.step_key);
+            const active = step.step_key === currentStep.step_key;
+            return (
+              <button
+                type="button"
+                key={step.step_key}
+                className={`w-full rounded-xl border p-3 text-left transition ${active ? "border-[rgba(197,122,74,0.65)] bg-[rgba(197,122,74,0.14)]" : "border-white/10 bg-white/[0.03] hover:bg-white/[0.06]"}`}
+                onClick={() => void routeStep(step.step_key)}
+                disabled={Boolean(busyStep) || definition.implementationStatus === "future"}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-semibold text-white">{index + 1}. {definition.label}</span>
+                  <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${statusTone(step.status)}`}>{statusLabel(step.status)}</span>
+                </div>
+                <div className="mt-1 text-xs text-slate-400">{definition.implementationStatus}</div>
+              </button>
+            );
+          })}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+      <div className="text-2xl font-semibold text-white">{value}</div>
+      <div className="text-xs uppercase tracking-[0.16em] text-slate-500">{label}</div>
+    </div>
+  );
+}

--- a/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
+++ b/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+type Props = {
+  active: boolean;
+  highlightKey: string;
+  title: string;
+  description: string;
+  children: ReactNode;
+};
+
+export function OnboardingHighlightFrame({ active, highlightKey, title, description, children }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const timer = window.setTimeout(() => {
+      ref.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 150);
+    return () => window.clearTimeout(timer);
+  }, [active, highlightKey]);
+
+  return (
+    <div
+      ref={ref}
+      data-onboarding-highlight={highlightKey}
+      className={active ? "rounded-2xl border border-[rgba(197,122,74,0.65)] bg-[rgba(197,122,74,0.08)] p-2 shadow-[0_0_0_1px_rgba(197,122,74,0.18),0_24px_80px_rgba(197,122,74,0.16)]" : undefined}
+    >
+      {active ? (
+        <div className="mb-2 rounded-xl border border-[rgba(197,122,74,0.45)] bg-[linear-gradient(135deg,rgba(197,122,74,0.22),rgba(15,23,42,0.88))] p-3 text-sm text-orange-50">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/80">Upload/setup here</div>
+          <div className="mt-1 font-semibold text-white">{title}</div>
+          <div className="mt-1 text-xs text-orange-100/80">{description}</div>
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/features/onboarding-v2/guided/query.ts
+++ b/features/onboarding-v2/guided/query.ts
@@ -1,0 +1,66 @@
+import {
+  GUIDED_ONBOARDING_SOURCE,
+  getGuidedOnboardingStep,
+  isGuidedOnboardingStepKey,
+  type GuidedOnboardingStepKey,
+} from "./steps";
+
+export type GuidedOnboardingQuery = {
+  onboardingSession: string;
+  onboardingStep: GuidedOnboardingStepKey;
+  highlight: string;
+  returnTo: string;
+  source: typeof GUIDED_ONBOARDING_SOURCE;
+};
+
+export function isSafeGuidedReturnTo(value: string | null | undefined): value is string {
+  if (!value) return false;
+  if (!value.startsWith("/")) return false;
+  if (value.startsWith("//")) return false;
+  try {
+    const parsed = new URL(value, "https://profixiq.local");
+    return parsed.origin === "https://profixiq.local" && parsed.pathname.startsWith("/");
+  } catch {
+    return false;
+  }
+}
+
+export function sanitizeGuidedReturnTo(value: string | null | undefined, fallback = "/dashboard/onboarding-v2"): string {
+  return isSafeGuidedReturnTo(value) ? value : fallback;
+}
+
+export function buildGuidedOnboardingReturnTo(sessionId: string): string {
+  return `/dashboard/onboarding-v2/${encodeURIComponent(sessionId)}`;
+}
+
+export function buildGuidedOnboardingDestinationUrl(args: {
+  sessionId: string;
+  stepKey: GuidedOnboardingStepKey;
+  returnTo?: string;
+}): string {
+  const step = getGuidedOnboardingStep(args.stepKey);
+  const params = new URLSearchParams({
+    onboardingSession: args.sessionId,
+    onboardingStep: step.stepKey,
+    highlight: step.highlightKey,
+    returnTo: sanitizeGuidedReturnTo(args.returnTo, buildGuidedOnboardingReturnTo(args.sessionId)),
+    source: GUIDED_ONBOARDING_SOURCE,
+  });
+  return `${step.destinationPath}?${params.toString()}`;
+}
+
+export function parseGuidedOnboardingQuery(params: URLSearchParams): GuidedOnboardingQuery | null {
+  const source = params.get("source");
+  const onboardingSession = params.get("onboardingSession") ?? "";
+  const onboardingStep = params.get("onboardingStep") ?? "";
+  const highlight = params.get("highlight") ?? "";
+  const returnTo = params.get("returnTo") ?? "";
+
+  if (source !== GUIDED_ONBOARDING_SOURCE) return null;
+  if (!onboardingSession) return null;
+  if (!isGuidedOnboardingStepKey(onboardingStep)) return null;
+  if (!highlight) return null;
+  if (!isSafeGuidedReturnTo(returnTo)) return null;
+
+  return { onboardingSession, onboardingStep, highlight, returnTo, source };
+}

--- a/features/onboarding-v2/guided/server.ts
+++ b/features/onboarding-v2/guided/server.ts
@@ -1,0 +1,230 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  GUIDED_ONBOARDING_STEPS,
+  getGuidedOnboardingStep,
+  isGuidedOnboardingStatus,
+  isGuidedOnboardingStepKey,
+  type GuidedOnboardingStatus,
+  type GuidedOnboardingStepKey,
+} from "./steps";
+import type { GuidedOnboardingPayload, GuidedSessionRow, GuidedStepRow, JsonObject } from "./types";
+
+type GuidedPayload = GuidedOnboardingPayload;
+
+// The generated Supabase types intentionally lag additive migrations in this repo.
+type UntypedSupabase = {
+  from: (table: string) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
+
+function asGuidedDb(supabase: unknown): UntypedSupabase {
+  return supabase as UntypedSupabase;
+}
+
+export async function requireGuidedOwnerAdminAccess() {
+  return requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+}
+
+export function assertGuidedStepKey(stepKey: string): GuidedOnboardingStepKey | null {
+  return isGuidedOnboardingStepKey(stepKey) ? stepKey : null;
+}
+
+function nextActionableStep(steps: GuidedStepRow[]): GuidedOnboardingStepKey | null {
+  return steps.find((step) => !["completed", "skipped"].includes(step.status))?.step_key ?? null;
+}
+
+async function insertGuidedEvent(db: UntypedSupabase, args: {
+  shopId: string;
+  sessionId: string;
+  stepKey?: GuidedOnboardingStepKey | null;
+  eventType: string;
+  payload?: JsonObject;
+}) {
+  await db.from("guided_onboarding_events").insert({
+    shop_id: args.shopId,
+    session_id: args.sessionId,
+    step_key: args.stepKey ?? null,
+    event_type: args.eventType,
+    payload: args.payload ?? {},
+  });
+}
+
+async function ensureSessionSteps(db: UntypedSupabase, shopId: string, sessionId: string) {
+  const rows = GUIDED_ONBOARDING_STEPS.map((step) => ({
+    session_id: sessionId,
+    shop_id: shopId,
+    step_key: step.stepKey,
+    status: "not_started",
+    destination_path: step.destinationPath,
+    highlight_key: step.highlightKey,
+    summary: {},
+  }));
+
+  await db
+    .from("guided_onboarding_steps")
+    .upsert(rows, { onConflict: "session_id,step_key", ignoreDuplicates: true });
+}
+
+export async function createOrResumeGuidedSession(args: {
+  supabase: unknown;
+  shopId: string;
+  userId: string;
+}): Promise<GuidedPayload> {
+  const db = asGuidedDb(args.supabase);
+
+  const { data: existing, error: existingError } = await db
+    .from("guided_onboarding_sessions")
+    .select("*")
+    .eq("shop_id", args.shopId)
+    .in("status", ["active", "in_progress"])
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (existingError) throw new Error(existingError.message ?? "Unable to resume guided onboarding session");
+
+  let session = existing as GuidedSessionRow | null;
+  if (!session) {
+    const id = randomUUID();
+    const { data: inserted, error } = await db
+      .from("guided_onboarding_sessions")
+      .insert({ id, shop_id: args.shopId, created_by: args.userId, status: "active", current_step_key: "customers", summary: {} })
+      .select("*")
+      .single();
+    if (error) throw new Error(error.message ?? "Unable to create guided onboarding session");
+    session = inserted as GuidedSessionRow;
+    await insertGuidedEvent(db, { shopId: args.shopId, sessionId: session.id, eventType: "session_created" });
+  }
+
+  await ensureSessionSteps(db, args.shopId, session.id);
+  return fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: session.id });
+}
+
+export async function fetchGuidedSession(args: {
+  supabase: unknown;
+  shopId: string;
+  sessionId: string;
+}): Promise<GuidedPayload> {
+  const db = asGuidedDb(args.supabase);
+  const { data: session, error: sessionError } = await db
+    .from("guided_onboarding_sessions")
+    .select("*")
+    .eq("id", args.sessionId)
+    .eq("shop_id", args.shopId)
+    .maybeSingle();
+
+  if (sessionError) throw new Error(sessionError.message ?? "Unable to fetch guided onboarding session");
+  if (!session) throw new Error("Guided onboarding session not found");
+
+  await ensureSessionSteps(db, args.shopId, args.sessionId);
+
+  const { data: steps, error: stepsError } = await db
+    .from("guided_onboarding_steps")
+    .select("*")
+    .eq("session_id", args.sessionId)
+    .eq("shop_id", args.shopId)
+    .order("created_at", { ascending: true });
+
+  if (stepsError) throw new Error(stepsError.message ?? "Unable to fetch guided onboarding steps");
+
+  const ordered = GUIDED_ONBOARDING_STEPS.map((definition) =>
+    (steps as GuidedStepRow[]).find((step) => step.step_key === definition.stepKey),
+  ).filter((step): step is GuidedStepRow => Boolean(step));
+
+  return { session: session as GuidedSessionRow, steps: ordered };
+}
+
+export async function updateGuidedStepStatus(args: {
+  supabase: unknown;
+  shopId: string;
+  sessionId: string;
+  stepKey: GuidedOnboardingStepKey;
+  status: GuidedOnboardingStatus;
+  skippedReason?: string | null;
+  summary?: JsonObject;
+  error?: string | null;
+}) {
+  const db = asGuidedDb(args.supabase);
+  const definition = getGuidedOnboardingStep(args.stepKey);
+  const current = await fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: args.sessionId });
+  const existing = current.steps.find((step) => step.step_key === args.stepKey);
+
+  const retryCount = args.status === "retry_requested" ? (existing?.retry_count ?? 0) + 1 : (existing?.retry_count ?? 0);
+  const patch = {
+    status: args.status,
+    destination_path: definition.destinationPath,
+    highlight_key: definition.highlightKey,
+    skipped_reason: args.skippedReason ?? existing?.skipped_reason ?? null,
+    summary: args.summary ?? existing?.summary ?? {},
+    error: args.error ?? (args.status === "failed" ? existing?.error ?? "Step failed" : null),
+    retry_count: retryCount,
+    completed_at: args.status === "completed" ? new Date().toISOString() : existing?.completed_at ?? null,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error } = await db
+    .from("guided_onboarding_steps")
+    .update(patch)
+    .eq("session_id", args.sessionId)
+    .eq("shop_id", args.shopId)
+    .eq("step_key", args.stepKey);
+  if (error) throw new Error(error.message ?? "Unable to update guided onboarding step");
+
+  await insertGuidedEvent(db, {
+    shopId: args.shopId,
+    sessionId: args.sessionId,
+    stepKey: args.stepKey,
+    eventType: `step_${args.status}`,
+    payload: { summary: args.summary ?? {}, error: args.error ?? null },
+  });
+
+  const refreshed = await fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: args.sessionId });
+  const currentStepKey = nextActionableStep(refreshed.steps);
+  const sessionComplete = currentStepKey === null;
+
+  const { error: sessionError } = await db
+    .from("guided_onboarding_sessions")
+    .update({
+      current_step_key: currentStepKey,
+      status: sessionComplete ? "completed" : "active",
+      completed_at: sessionComplete ? new Date().toISOString() : null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", args.sessionId)
+    .eq("shop_id", args.shopId);
+  if (sessionError) throw new Error(sessionError.message ?? "Unable to update guided onboarding session");
+
+  return fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: args.sessionId });
+}
+
+export async function answerGuidedStepYes(args: {
+  supabase: unknown;
+  shopId: string;
+  sessionId: string;
+  stepKey: GuidedOnboardingStepKey;
+}) {
+  return updateGuidedStepStatus({ ...args, status: "routing" });
+}
+
+export function guardedJsonError(error: unknown, status = 500) {
+  const message = error instanceof Error ? error.message : "Guided onboarding request failed";
+  const responseStatus = message.includes("not found") ? 404 : status;
+  return NextResponse.json({ error: message }, { status: responseStatus });
+}
+
+export function parseGuidedStatusPayload(payload: unknown): {
+  status: GuidedOnboardingStatus;
+  summary?: JsonObject;
+  error?: string | null;
+} | null {
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  const status = typeof record.status === "string" && isGuidedOnboardingStatus(record.status) ? record.status : null;
+  if (!status) return null;
+  const summary = record.summary && typeof record.summary === "object" && !Array.isArray(record.summary) ? record.summary as JsonObject : undefined;
+  const error = typeof record.error === "string" ? record.error : null;
+  return { status, summary, error };
+}

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -1,0 +1,142 @@
+export const GUIDED_ONBOARDING_SOURCE = "guided-onboarding" as const;
+
+export const GUIDED_ONBOARDING_STATUSES = [
+  "not_started",
+  "asked",
+  "skipped",
+  "routing",
+  "upload_requested",
+  "uploading",
+  "uploaded",
+  "parsing",
+  "validation_required",
+  "ready_to_import",
+  "importing",
+  "completed",
+  "failed",
+  "retry_requested",
+] as const;
+
+export type GuidedOnboardingStatus = (typeof GUIDED_ONBOARDING_STATUSES)[number];
+export type GuidedStepImplementationStatus = "available" | "placeholder" | "future";
+
+export type GuidedOnboardingStepKey =
+  | "customers"
+  | "vehicles"
+  | "staff"
+  | "labor_tax_shop_settings"
+  | "inspection_templates"
+  | "service_menu"
+  | "inventory_parts"
+  | "invoices"
+  | "service_history";
+
+export type GuidedOnboardingStepDefinition = {
+  stepKey: GuidedOnboardingStepKey;
+  label: string;
+  question: string;
+  destinationPath: string;
+  highlightKey: string;
+  description: string;
+  implementationStatus: GuidedStepImplementationStatus;
+};
+
+export const GUIDED_ONBOARDING_STEPS = [
+  {
+    stepKey: "customers",
+    label: "Customers",
+    question: "Do you want to bring in your customer list now?",
+    destinationPath: "/customers",
+    highlightKey: "customers-import",
+    description: "Route to Customers so existing customer import/setup tools stay the source of truth.",
+    implementationStatus: "placeholder",
+  },
+  {
+    stepKey: "vehicles",
+    label: "Vehicles",
+    question: "Do you want to set up customer vehicles now?",
+    destinationPath: "/customers",
+    highlightKey: "vehicles-setup",
+    description: "Use Customers for now so vehicles remain connected to customer records.",
+    implementationStatus: "placeholder",
+  },
+  {
+    stepKey: "staff",
+    label: "Staff",
+    question: "Do you want to invite or create staff accounts now?",
+    destinationPath: "/dashboard/owner/create-user",
+    highlightKey: "staff-create-user",
+    description: "Route owners/admins to the existing staff creation page; no bulk user creation happens here.",
+    implementationStatus: "placeholder",
+  },
+  {
+    stepKey: "labor_tax_shop_settings",
+    label: "Labor, tax, and shop settings",
+    question: "Do you want to review labor rates, tax, and shop settings now?",
+    destinationPath: "/dashboard/owner/settings",
+    highlightKey: "shop-settings-labor-tax",
+    description: "Guide setup through the existing owner settings surface.",
+    implementationStatus: "placeholder",
+  },
+  {
+    stepKey: "inspection_templates",
+    label: "Inspection templates",
+    question: "Do you want to configure inspection templates now?",
+    destinationPath: "/inspections/templates",
+    highlightKey: "inspection-templates-setup",
+    description: "Use the real inspection template management page.",
+    implementationStatus: "placeholder",
+  },
+  {
+    stepKey: "service_menu",
+    label: "Service menu",
+    question: "Do you want to set up your canned services or menu now?",
+    destinationPath: "/menu",
+    highlightKey: "service-menu-setup",
+    description: "Route to the service menu page where menu items are owned.",
+    implementationStatus: "placeholder",
+  },
+  {
+    stepKey: "inventory_parts",
+    label: "Inventory parts",
+    question: "Do you want to import or set up inventory parts now?",
+    destinationPath: "/parts/inventory",
+    highlightKey: "parts-csv-import",
+    description: "Highlight the existing CSV import entry point on the parts inventory page.",
+    implementationStatus: "available",
+  },
+  {
+    stepKey: "invoices",
+    label: "Invoices",
+    question: "Do you want to import historical invoices now?",
+    destinationPath: "/dashboard/onboarding-v2",
+    highlightKey: "invoices-future-import",
+    description: "Invoice import is a future guided step; the control room can record skip/future intent.",
+    implementationStatus: "future",
+  },
+  {
+    stepKey: "service_history",
+    label: "Service history",
+    question: "Do you want to review or import service history now?",
+    destinationPath: "/work-orders/history",
+    highlightKey: "service-history-setup",
+    description: "Route to work order history for historical service context.",
+    implementationStatus: "placeholder",
+  },
+] as const satisfies readonly GuidedOnboardingStepDefinition[];
+
+export const GUIDED_ONBOARDING_STEP_KEYS = GUIDED_ONBOARDING_STEPS.map((step) => step.stepKey);
+
+export function isGuidedOnboardingStepKey(value: string): value is GuidedOnboardingStepKey {
+  return (GUIDED_ONBOARDING_STEP_KEYS as readonly string[]).includes(value);
+}
+
+export function isGuidedOnboardingStatus(value: string): value is GuidedOnboardingStatus {
+  return (GUIDED_ONBOARDING_STATUSES as readonly string[]).includes(value);
+}
+
+export function getGuidedOnboardingStep(stepKey: GuidedOnboardingStepKey): GuidedOnboardingStepDefinition {
+  const step = GUIDED_ONBOARDING_STEPS.find((item) => item.stepKey === stepKey);
+  if (!step) throw new Error(`Unknown guided onboarding step: ${stepKey}`);
+  return step;
+}

--- a/features/onboarding-v2/guided/types.ts
+++ b/features/onboarding-v2/guided/types.ts
@@ -1,0 +1,37 @@
+import type { GuidedOnboardingStatus, GuidedOnboardingStepKey } from "./steps";
+
+export type JsonObject = Record<string, unknown>;
+
+export type GuidedSessionRow = {
+  id: string;
+  shop_id: string;
+  created_by: string | null;
+  status: string;
+  current_step_key: GuidedOnboardingStepKey | null;
+  summary: JsonObject;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type GuidedStepRow = {
+  id: string;
+  session_id: string;
+  shop_id: string;
+  step_key: GuidedOnboardingStepKey;
+  status: GuidedOnboardingStatus;
+  destination_path: string;
+  highlight_key: string;
+  skipped_reason: string | null;
+  summary: JsonObject;
+  error: string | null;
+  retry_count: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type GuidedOnboardingPayload = {
+  session: GuidedSessionRow;
+  steps: GuidedStepRow[];
+};

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildGuidedOnboardingDestinationUrl, parseGuidedOnboardingQuery, sanitizeGuidedReturnTo } from "@/features/onboarding-v2/guided/query";
+import { getGuidedOnboardingStep, GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
+
+describe("guided onboarding step registry", () => {
+  it("defines required routes and highlight keys", () => {
+    expect(GUIDED_ONBOARDING_STEPS.map((step) => step.stepKey)).toEqual([
+      "customers",
+      "vehicles",
+      "staff",
+      "labor_tax_shop_settings",
+      "inspection_templates",
+      "service_menu",
+      "inventory_parts",
+      "invoices",
+      "service_history",
+    ]);
+
+    expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customers-import" });
+    expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicles-setup" });
+    expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-create-user" });
+    expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings-labor-tax" });
+    expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({ destinationPath: "/inspections/templates", highlightKey: "inspection-templates-setup" });
+    expect(getGuidedOnboardingStep("service_menu")).toMatchObject({ destinationPath: "/menu", highlightKey: "service-menu-setup" });
+    expect(getGuidedOnboardingStep("inventory_parts")).toMatchObject({ destinationPath: "/parts/inventory", highlightKey: "parts-csv-import", implementationStatus: "available" });
+    expect(getGuidedOnboardingStep("invoices")).toMatchObject({ implementationStatus: "future" });
+    expect(getGuidedOnboardingStep("service_history")).toMatchObject({ destinationPath: "/work-orders/history", highlightKey: "service-history-setup" });
+  });
+});
+
+describe("guided onboarding query helpers", () => {
+  it("builds and parses inventory parts destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "inventory_parts" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/parts/inventory");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("inventory_parts");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("parts-csv-import");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+
+    expect(parseGuidedOnboardingQuery(parsedUrl.searchParams)).toMatchObject({
+      onboardingSession: "session-123",
+      onboardingStep: "inventory_parts",
+      highlight: "parts-csv-import",
+      source: "guided-onboarding",
+    });
+  });
+
+  it("rejects unsafe returnTo values", () => {
+    expect(sanitizeGuidedReturnTo("https://evil.example/path", "/fallback")).toBe("/fallback");
+    expect(sanitizeGuidedReturnTo("//evil.example/path", "/fallback")).toBe("/fallback");
+    expect(sanitizeGuidedReturnTo("dashboard/onboarding-v2", "/fallback")).toBe("/fallback");
+    expect(sanitizeGuidedReturnTo("/dashboard/onboarding-v2/session-123", "/fallback")).toBe("/dashboard/onboarding-v2/session-123");
+  });
+
+  it("drops parsed guided query when returnTo is external", () => {
+    const params = new URLSearchParams({
+      onboardingSession: "session-123",
+      onboardingStep: "inventory_parts",
+      highlight: "parts-csv-import",
+      returnTo: "https://evil.example/steal",
+      source: "guided-onboarding",
+    });
+
+    expect(parseGuidedOnboardingQuery(params)).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the Onboarding V2 shell with a guided control room that walks owners/admins through setup one question at a time and routes them to the real app pages for each task while tracking step state.
- Provide a safe, small, durable foundation (registry, query helpers, DB tables, server APIs, UI) for incrementally wiring real-page integrations without performing any silent imports or changing auth/RLS semantics.

### Description
- Added a reusable step registry with the nine requested steps and their `stepKey`, `label`, `question`, `destinationPath`, `highlightKey`, `description`, and `implementationStatus` in `features/onboarding-v2/guided/steps.ts`.
- Implemented query helpers in `features/onboarding-v2/guided/query.ts` to build/parse guided params (`onboardingSession`, `onboardingStep`, `highlight`, `returnTo`, `source=guided-onboarding`) and added a safe `returnTo` sanitizer that rejects external and `//` URLs.
- Introduced additive DB migration `db/sql/2026-06-04_guided_onboarding_v2_foundation.sql` to create `guided_onboarding_sessions`, `guided_onboarding_steps`, and `guided_onboarding_events` with the requested status values, fields, indexes, and RLS policies for owner/admin access.
- Added server-side orchestration (`features/onboarding-v2/guided/server.ts`) and owner/admin, shop-scoped APIs under `app/api/onboarding-v2/guided/...` to create/resume sessions, fetch sessions, answer yes/no, skip, complete, and post status updates; all APIs derive `shop_id` from the authenticated profile and require owner/admin access.
- Implemented the guided control-room UI in `features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx` and wired it as the primary experience for `/dashboard/onboarding-v2` and `/dashboard/onboarding-v2/[sessionId]`, keeping the legacy upload `SessionWorkspace` behind a secondary/dev `details` section.
- Added `OnboardingHighlightFrame` UI component (`features/onboarding-v2/components/OnboardingHighlightFrame.tsx`) that scrolls active highlights into view and renders an upload/setup callout in the existing ProFixIQ theme.
- Demo integration: wired `inventory_parts` → `/parts/inventory` to honor guided query params, highlight the CSV Import entrypoint, show a return link to the guided session, and call the guided step completion API after an explicit CSV import (no importer changes beyond calling the completion endpoint) in `app/parts/inventory/page.tsx`.
- Added focused tests `tests/onboarding-v2/guided-registry-and-query.test.ts` that verify the registry, generated destination query parameters, parsing, and unsafe `returnTo` rejection.

### Testing
- Ran type check: `npx tsc --noEmit` — success.
- Ran lint on touched files: `npx eslint ...` (targeted paths) — success.
- Ran unit tests for the new helpers: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts` — success (all tests passed).
- Verified repo checks: `git diff --check` — no issues.

If deployed, the SQL migration `db/sql/2026-06-04_guided_onboarding_v2_foundation.sql` must be applied before calling the new guided APIs. Phase 1 wires only the `inventory_parts` demo integration; remaining steps remain placeholders/future and should be integrated incrementally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d69437d483288529aff81d30aed1)