### PR TITLE
Fix dashboard shop context hydration

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import {
   DASHBOARD_LAST_VIEW_KEY,
@@ -19,22 +18,36 @@ export default function DashboardEntryPage() {
   const router = useRouter();
 
   useEffect(() => {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createBrowserSupabase();
 
     (async () => {
       const {
-        data: { session },
-      } = await supabase.auth.getSession();
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
 
-      const uid = session?.user?.id;
+      const uid = user?.id;
       let role = "unknown";
 
       if (uid) {
-        const { data: profile } = await supabase
+        const { data: profile, error: profileError } = await supabase
           .from("profiles")
-          .select("role")
+          .select("id,email,role,shop_id")
           .eq("id", uid)
           .maybeSingle();
+
+        console.info("[DashboardEntry] profile resolved", {
+          authUserId: uid,
+          authEmail: user?.email ?? null,
+          profileId: profile?.id ?? null,
+          profileEmail: profile?.email ?? null,
+          role: profile?.role ?? null,
+          shopIdPresent: Boolean(profile?.shop_id),
+          authError: authError?.message ?? null,
+          profileError: profileError
+            ? { message: profileError.message, code: profileError.code }
+            : null,
+        });
 
         role = canonicalizeRole(profile?.role);
       }

--- a/features/dashboard/server/dashboard-shell-data.ts
+++ b/features/dashboard/server/dashboard-shell-data.ts
@@ -1,40 +1,187 @@
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
-export type DashboardIdentity = {
-  userId: string | null;
-  shopId: string | null;
-  role: string | null;
-  fullName: string | null;
-};
+type DashboardSupabaseClient = SupabaseClient<Database>;
 
-export async function getDashboardIdentity(): Promise<DashboardIdentity> {
-  const supabase = createServerComponentClient<Database>({ cookies });
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
+type DashboardProfile = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "email" | "full_name" | "role" | "shop_id"
+>;
 
-  const userId = session?.user?.id ?? null;
-  if (!userId) {
-    return { userId: null, shopId: null, role: null, fullName: null };
-  }
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("full_name, role, shop_id")
-    .eq("id", userId)
-    .maybeSingle();
-
+function errorSummary(error: { message?: string; code?: string | null } | null | undefined) {
+  if (!error) return null;
   return {
-    userId,
-    shopId: profile?.shop_id ?? null,
-    role: profile?.role ?? null,
-    fullName: profile?.full_name ?? null,
+    message: error.message ?? "Unknown error",
+    code: error.code ?? null,
   };
 }
 
-export function createDashboardServerClient() {
-  return createServerComponentClient<Database>({ cookies });
+export type DashboardIdentity = {
+  userId: string | null;
+  authEmail: string | null;
+  profileId: string | null;
+  profileEmail: string | null;
+  shopId: string | null;
+  role: string | null;
+  fullName: string | null;
+  diagnostics: {
+    authUserError: ReturnType<typeof errorSummary>;
+    profileExists: boolean;
+    profileError: ReturnType<typeof errorSummary>;
+    shopIdPresent: boolean;
+    shopLookupAttempted: boolean;
+    shopLookupFound: boolean;
+    shopQueryError: ReturnType<typeof errorSummary>;
+    setCurrentShopIdCalled: boolean;
+    setCurrentShopIdError: ReturnType<typeof errorSummary>;
+  };
+};
+
+export async function getDashboardIdentity(): Promise<DashboardIdentity> {
+  const supabase = createDashboardServerClient();
+  const {
+    data: { user },
+    error: authUserError,
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    const identity: DashboardIdentity = {
+      userId: null,
+      authEmail: null,
+      profileId: null,
+      profileEmail: null,
+      shopId: null,
+      role: null,
+      fullName: null,
+      diagnostics: {
+        authUserError: errorSummary(authUserError),
+        profileExists: false,
+        profileError: null,
+        shopIdPresent: false,
+        shopLookupAttempted: false,
+        shopLookupFound: false,
+        shopQueryError: null,
+        setCurrentShopIdCalled: false,
+        setCurrentShopIdError: null,
+      },
+    };
+
+    console.info("[Dashboard][Identity] no authenticated user", identity.diagnostics);
+    return identity;
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id,email,full_name,role,shop_id")
+    .eq("id", user.id)
+    .maybeSingle<DashboardProfile>();
+
+  let shopLookupAttempted = false;
+  let shopLookupFound = false;
+  let shopQueryError: ReturnType<typeof errorSummary> = null;
+  let setCurrentShopIdCalled = false;
+  let setCurrentShopIdError: ReturnType<typeof errorSummary> = null;
+
+  if (profile?.shop_id) {
+    setCurrentShopIdCalled = true;
+    const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+      p_shop_id: profile.shop_id,
+    });
+    setCurrentShopIdError = errorSummary(contextError);
+
+    shopLookupAttempted = true;
+    const { data: shop, error: shopError } = await supabase
+      .from("shops")
+      .select("id")
+      .eq("id", profile.shop_id)
+      .maybeSingle();
+    shopLookupFound = Boolean(shop?.id);
+    shopQueryError = errorSummary(shopError);
+  }
+
+  const identity: DashboardIdentity = {
+    userId: user.id,
+    authEmail: user.email ?? null,
+    profileId: profile?.id ?? null,
+    profileEmail: profile?.email ?? null,
+    shopId: profile?.shop_id ?? null,
+    role: profile?.role ?? null,
+    fullName: profile?.full_name ?? null,
+    diagnostics: {
+      authUserError: errorSummary(authUserError),
+      profileExists: Boolean(profile),
+      profileError: errorSummary(profileError),
+      shopIdPresent: Boolean(profile?.shop_id),
+      shopLookupAttempted,
+      shopLookupFound,
+      shopQueryError,
+      setCurrentShopIdCalled,
+      setCurrentShopIdError,
+    },
+  };
+
+  console.info("[Dashboard][Identity] resolved shop context", {
+    authUserId: identity.userId,
+    authEmail: identity.authEmail,
+    profileId: identity.profileId,
+    profileEmail: identity.profileEmail,
+    role: identity.role,
+    shopIdPresent: identity.diagnostics.shopIdPresent,
+    shopId: identity.shopId,
+    shopQueryError: identity.diagnostics.shopQueryError,
+    setCurrentShopIdCalled: identity.diagnostics.setCurrentShopIdCalled,
+    setCurrentShopIdError: identity.diagnostics.setCurrentShopIdError,
+    profileError: identity.diagnostics.profileError,
+  });
+
+  return identity;
+}
+
+export function createDashboardServerClient(): DashboardSupabaseClient {
+  return createServerSupabaseRSC() as DashboardSupabaseClient;
+}
+
+export async function ensureDashboardShopContext(
+  supabase: DashboardSupabaseClient,
+  identity: DashboardIdentity,
+  source: string,
+): Promise<ReturnType<typeof errorSummary>> {
+  if (!identity.shopId) return null;
+
+  const { error } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: identity.shopId,
+  });
+  const summary = errorSummary(error);
+
+  console.info(`[Dashboard][${source}] set_current_shop_id`, {
+    authUserId: identity.userId,
+    authEmail: identity.authEmail,
+    profileId: identity.profileId,
+    profileEmail: identity.profileEmail,
+    role: identity.role,
+    shopIdPresent: Boolean(identity.shopId),
+    shopId: identity.shopId,
+    setCurrentShopIdCalled: true,
+    setCurrentShopIdError: summary,
+  });
+
+  return summary;
+}
+
+export function getMissingShopContextWarning(identity: DashboardIdentity): string {
+  if (!identity.userId) return "Dashboard shop context unavailable: no authenticated user session.";
+  if (identity.diagnostics.profileError) {
+    return `Dashboard shop context unavailable: profile query failed (${identity.diagnostics.profileError.code ?? "no-code"}: ${identity.diagnostics.profileError.message}).`;
+  }
+  if (!identity.diagnostics.profileExists) return "Dashboard shop context unavailable: no profile row found for the authenticated user.";
+  if (!identity.diagnostics.shopIdPresent) return "Dashboard shop context unavailable: profile is missing shop_id.";
+  if (identity.diagnostics.shopQueryError) {
+    return `Dashboard shop context warning: shop lookup failed (${identity.diagnostics.shopQueryError.code ?? "no-code"}: ${identity.diagnostics.shopQueryError.message}).`;
+  }
+  if (identity.diagnostics.setCurrentShopIdError) {
+    return `Dashboard shop context warning: set_current_shop_id failed (${identity.diagnostics.setCurrentShopIdError.code ?? "no-code"}: ${identity.diagnostics.setCurrentShopIdError.message}).`;
+  }
+  return "Dashboard shop context unavailable: profile shop_id could not be resolved.";
 }

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -1,6 +1,11 @@
 import { endOfDay, startOfDay, startOfMonth } from "date-fns";
 
-import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
+import {
+  createDashboardServerClient,
+  ensureDashboardShopContext,
+  getDashboardIdentity,
+  getMissingShopContextWarning,
+} from "@/features/dashboard/server/dashboard-shell-data";
 
 const OPEN_PART_STATUSES = ["requested", "quoted", "approved"] as const;
 const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
@@ -119,11 +124,17 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   };
 
   if (!identity.shopId) {
-    payload.sectionErrors.push("No shop context found for this user.");
+    payload.sectionErrors.push(getMissingShopContextWarning(identity));
     return payload;
   }
 
   const supabase = createDashboardServerClient();
+  const contextError = await ensureDashboardShopContext(supabase, identity, "Operations");
+  if (contextError) {
+    payload.sectionErrors.push(
+      `Shop context RPC failed (${contextError.code ?? "no-code"}: ${contextError.message}); dashboard data may be limited by RLS.`,
+    );
+  }
   const todayStart = startOfDay(new Date()).toISOString();
   const todayEnd = endOfDay(new Date()).toISOString();
   const monthStart = startOfMonth(new Date()).toISOString();
@@ -228,8 +239,11 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
         shopId: identity.shopId,
         userId: identity.userId,
         partsByJobError: partsByJobResult.error?.message,
+        partsByJobCode: partsByJobResult.error?.code,
         partsByWorkOrderError: partsByWorkOrderResult.error?.message,
+        partsByWorkOrderCode: partsByWorkOrderResult.error?.code,
         partsByOwnerError: partsByOwnerResult.error?.message,
+        partsByOwnerCode: partsByOwnerResult.error?.code,
       });
     }
 
@@ -248,6 +262,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
         shopId: identity.shopId,
         userId: identity.userId,
         error: shopPartsResult.error.message,
+        code: shopPartsResult.error.code,
       });
     } else {
       partsRows = shopPartsResult.data ?? [];
@@ -286,6 +301,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       shopId: identity.shopId,
       userId: identity.userId,
       error: boardResult.error.message,
+      code: boardResult.error.code,
     });
     payload.sectionErrors.push("Live work signal is temporarily unavailable.");
   } else {
@@ -339,6 +355,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       shopId: identity.shopId,
       userId: identity.userId,
       error: approvalsResult.error.message,
+      code: approvalsResult.error.code,
     });
     payload.sectionErrors.push("Approvals signal is temporarily unavailable.");
   } else {
@@ -417,6 +434,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       shopId: identity.shopId,
       userId: identity.userId,
       error: bookingsTodayResult.error.message,
+      code: bookingsTodayResult.error.code,
     });
     payload.sectionErrors.push("Daily summary signal is temporarily unavailable.");
   }
@@ -629,6 +647,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       shopId: identity.shopId,
       userId: identity.userId,
       error: invoicesMonthResult.error.message,
+      code: invoicesMonthResult.error.code,
     });
     payload.sectionErrors.push("Revenue snapshot is temporarily unavailable.");
   } else {

--- a/features/dashboard/server/getPerformanceDashboardPayload.ts
+++ b/features/dashboard/server/getPerformanceDashboardPayload.ts
@@ -1,6 +1,11 @@
 import { endOfMonth, format, startOfMonth, subMonths } from "date-fns";
 
-import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
+import {
+  createDashboardServerClient,
+  ensureDashboardShopContext,
+  getDashboardIdentity,
+  getMissingShopContextWarning,
+} from "@/features/dashboard/server/dashboard-shell-data";
 
 type TrendPoint = {
   label: string;
@@ -56,11 +61,17 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   };
 
   if (!identity.shopId) {
-    payload.sectionErrors.push("No shop context found for this user.");
+    payload.sectionErrors.push(getMissingShopContextWarning(identity));
     return payload;
   }
 
   const supabase = createDashboardServerClient();
+  const contextError = await ensureDashboardShopContext(supabase, identity, "Performance");
+  if (contextError) {
+    payload.sectionErrors.push(
+      `Shop context RPC failed (${contextError.code ?? "no-code"}: ${contextError.message}); dashboard data may be limited by RLS.`,
+    );
+  }
   const rangeStart = startOfMonth(subMonths(new Date(), 5)).toISOString();
   const rangeEnd = endOfMonth(new Date()).toISOString();
 
@@ -98,6 +109,16 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   ]);
 
   if (invoiceResult.error || expenseResult.error) {
+    console.error("[Dashboard][Performance] finance trend queries failed", {
+      shopId: identity.shopId,
+      userId: identity.userId,
+      invoiceError: invoiceResult.error
+        ? { message: invoiceResult.error.message, code: invoiceResult.error.code }
+        : null,
+      expenseError: expenseResult.error
+        ? { message: expenseResult.error.message, code: expenseResult.error.code }
+        : null,
+    });
     payload.sectionErrors.push("Finance trend section is degraded due to invoice/expense query failures.");
   } else {
     const invoices = invoiceResult.data ?? [];
@@ -169,6 +190,16 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   }
 
   if (techProfilesResult.error || completedLinesResult.error) {
+    console.error("[Dashboard][Performance] technician performance queries failed", {
+      shopId: identity.shopId,
+      userId: identity.userId,
+      techProfilesError: techProfilesResult.error
+        ? { message: techProfilesResult.error.message, code: techProfilesResult.error.code }
+        : null,
+      completedLinesError: completedLinesResult.error
+        ? { message: completedLinesResult.error.message, code: completedLinesResult.error.code }
+        : null,
+    });
     payload.sectionErrors.push("Technician performance section is degraded due to work-order line query failures.");
   } else {
     const techs = techProfilesResult.data ?? [];
@@ -196,6 +227,12 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   }
 
   if (comebackRiskResult.error) {
+    console.error("[Dashboard][Performance] business signals query failed", {
+      shopId: identity.shopId,
+      userId: identity.userId,
+      error: comebackRiskResult.error.message,
+      code: comebackRiskResult.error.code,
+    });
     payload.sectionErrors.push("Business signals section is degraded due to board risk query failures.");
   } else {
     const riskRows = comebackRiskResult.data ?? [];

--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   TILES,
   canShowTileForEmail,
@@ -57,10 +56,7 @@ function getCanonicalActiveTile(pathname: string, tiles: Tile[]): Tile | null {
 }
 
 export default function RoleSidebar() {
-  const supabase = useMemo(
-    () => createClientComponentClient<Database>(),
-    [],
-  );
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const pathname = usePathname();
 
@@ -72,17 +68,50 @@ export default function RoleSidebar() {
   useEffect(() => {
     (async () => {
       const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      const uid = session?.user?.id;
-      setUserEmail(session?.user?.email ?? null);
-      if (!uid) return;
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+      const uid = user?.id;
+      setUserEmail(user?.email ?? null);
+      if (!uid) {
+        console.info("[RoleSidebar] no authenticated user", {
+          authError: authError?.message ?? null,
+        });
+        return;
+      }
 
-      const { data: profile } = await supabase
+      const { data: profile, error: profileError } = await supabase
         .from("profiles")
-        .select("role")
+        .select("id,email,role,shop_id")
         .eq("id", uid)
-        .single();
+        .maybeSingle();
+
+      console.info("[RoleSidebar] profile resolved", {
+        authUserId: uid,
+        authEmail: user?.email ?? null,
+        profileId: profile?.id ?? null,
+        profileEmail: profile?.email ?? null,
+        role: profile?.role ?? null,
+        shopIdPresent: Boolean(profile?.shop_id),
+        profileError: profileError
+          ? { message: profileError.message, code: profileError.code }
+          : null,
+      });
+
+      if (profile?.shop_id) {
+        const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+          p_shop_id: profile.shop_id,
+        });
+        console.info("[RoleSidebar] set_current_shop_id", {
+          authUserId: uid,
+          profileId: profile?.id ?? null,
+          shopIdPresent: true,
+          setCurrentShopIdCalled: true,
+          setCurrentShopIdError: contextError
+            ? { message: contextError.message, code: contextError.code }
+            : null,
+        });
+      }
 
       setRole(normalizeRole(profile?.role ?? null));
     })();


### PR DESCRIPTION
### Motivation

- The dashboard was showing a misleading "No shop context found for this user." warning despite valid `profiles.shop_id`, caused by mismatched session/auth paths between dashboard server code and other middleware/client code. 
- Dashboard queries rely on `current_shop_id()` and must have `set_current_shop_id` called with the same authenticated session to avoid RLS blocking shop-scoped queries. 
- Add safe, minimal diagnostics to reveal whether the profile, shop lookup, or the RPC call are the reason for missing shop context. 

### Description

- Standardize dashboard identity resolution to the shared SSR Supabase client and `auth.getUser()` so server-side dashboard payloads see the same session/cookies as middleware and route handlers, and record safe diagnostics (auth id/email, profile id/email, role, shop_id presence, shop lookup/RPC outcomes). (files changed: `features/dashboard/server/dashboard-shell-data.ts`)
- Attempt and log `set_current_shop_id` before running shop-scoped dashboard queries and surface an accurate warning message instead of the generic copy when shop context is missing or RPC/shop lookup failed. (files changed: `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/dashboard/server/getPerformanceDashboardPayload.ts`)
- Move client-side sidebar and dashboard-entry profile lookups to the shared browser Supabase client and use `auth.getUser()` with added non-sensitive console diagnostics and a client `set_current_shop_id` call when a profile `shop_id` exists, so owner/admin navigation hydrates correctly (no more perpetual "Loading navigation…"). (files changed: `features/shared/components/RoleSidebar.tsx`, `app/dashboard/page.tsx`)
- Add clearer diagnostic logging for key dashboard query failures (messages and error codes) to help future debugging while avoiding sensitive data in logs. (files changed: `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/dashboard/server/getPerformanceDashboardPayload.ts`)

### Testing

- Ran `npx eslint features/dashboard/server/dashboard-shell-data.ts features/dashboard/server/getOperationsDashboardPayload.ts features/dashboard/server/getPerformanceDashboardPayload.ts features/shared/components/RoleSidebar.tsx app/dashboard/page.tsx` and it completed without lint errors. (pass)
- Ran `npx tsc --noEmit` and TypeScript compiled with no emit errors. (pass)
- Ran `git diff --check` to ensure no leftover whitespace/merge artifacts and it reported no problems. (pass)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20dd77d8008328bfe5e7e37d2dd429)