### PR TITLE
Refine guided onboarding entry question

### DIFF
--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { answerExistingSystemGate, guardedJsonError, requireGuidedOwnerAdminAccess } from "@/features/onboarding-v2/guided/server";
+
+type Context = { params: Promise<{ sessionId: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const access = await requireGuidedOwnerAdminAccess();
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId } = await context.params;
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const answer = body.answer === "no" ? "no" : body.answer === "yes" ? "yes" : null;
+  if (!answer) return NextResponse.json({ error: "answer must be yes or no" }, { status: 400 });
+
+  try {
+    const payload = await answerExistingSystemGate({ supabase: access.supabase, shopId, sessionId, answer });
+    return NextResponse.json({ ok: true, answer, redirectTo: answer === "no" ? "/dashboard" : null, ...payload });
+  } catch (error) {
+    return guardedJsonError(error);
+  }
+}

--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -10,7 +10,7 @@ export default async function OnboardingV2SessionPage({ params }: Props) {
   const { sessionId } = await params;
 
   return (
-    <OnboardingV2Shell title="Guided Onboarding V2">
+    <OnboardingV2Shell title="Data Onboarding">
       <GuidedOnboardingWorkspace initialSessionId={sessionId} />
       <details className="rounded-2xl border border-dashed border-white/15 bg-white/[0.025] p-4 text-slate-300">
         <summary className="cursor-pointer text-sm font-semibold text-slate-200">Legacy/dev upload workspace</summary>

--- a/app/dashboard/onboarding-v2/page.tsx
+++ b/app/dashboard/onboarding-v2/page.tsx
@@ -6,7 +6,7 @@ export default async function OnboardingV2Page() {
   await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
 
   return (
-    <OnboardingV2Shell title="Guided Onboarding V2">
+    <OnboardingV2Shell title="Data Onboarding">
       <GuidedOnboardingWorkspace />
     </OnboardingV2Shell>
   );

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -23,6 +24,12 @@ function statusLabel(status: GuidedOnboardingStatus) {
   return status.replaceAll("_", " ");
 }
 
+function implementationLabel(status: "available" | "placeholder" | "future") {
+  if (status === "available") return "normal";
+  if (status === "placeholder") return "planned";
+  return "coming later";
+}
+
 function statusTone(status: GuidedOnboardingStatus) {
   if (status === "completed") return "border-emerald-500/40 bg-emerald-950/30 text-emerald-200";
   if (status === "skipped") return "border-slate-500/40 bg-slate-900/50 text-slate-300";
@@ -39,6 +46,8 @@ export function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
   const [error, setError] = useState("");
 
   const sessionId = payload?.session.id ?? initialSessionId ?? "";
+  const existingSystemAnswer = payload?.session.summary?.existingSystemImport;
+  const showExistingSystemGate = payload ? existingSystemAnswer !== "yes" && existingSystemAnswer !== "no" : false;
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -106,6 +115,27 @@ export function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
     if (next?.destinationUrl) router.push(next.destinationUrl);
   };
 
+  async function answerExistingSystem(answer: "yes" | "no") {
+    if (!sessionId) return;
+    setBusyStep(`existing-system:${answer}`);
+    setError("");
+    try {
+      const response = await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(sessionId)}/existing-system`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answer }),
+      });
+      const next = await response.json() as GuidedPayload & { error?: string; redirectTo?: string | null };
+      if (!response.ok || !next.ok) throw new Error(next.error ?? "Guided onboarding entry update failed");
+      setPayload(next);
+      if (next.redirectTo) router.push(next.redirectTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Guided onboarding entry update failed");
+    } finally {
+      setBusyStep(null);
+    }
+  }
+
   if (loading) {
     return <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-5 text-sm text-slate-300">Loading guided onboarding…</div>;
   }
@@ -123,6 +153,7 @@ export function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
 
   const currentDefinition = getGuidedOnboardingStep(currentStep.step_key);
   const currentDestination = buildGuidedOnboardingDestinationUrl({ sessionId: payload.session.id, stepKey: currentStep.step_key });
+  const currentImplementationLabel = implementationLabel(currentDefinition.implementationStatus);
 
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
@@ -137,43 +168,69 @@ export function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
 
         <div className="rounded-2xl border border-white/10 bg-[rgba(15,23,42,0.72)] p-5">
           <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Current question</div>
-          <h3 className="mt-2 text-xl font-semibold text-white">{currentDefinition.question}</h3>
-          <p className="mt-2 text-sm text-slate-300">{currentDefinition.description}</p>
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${statusTone(currentStep.status)}`}>{statusLabel(currentStep.status)}</span>
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-slate-300">{currentDefinition.implementationStatus}</span>
-          </div>
+          {showExistingSystemGate ? (
+            <>
+              <h3 className="mt-2 text-xl font-semibold text-white">Do you currently have an existing shop/system to import?</h3>
+              <p className="mt-2 text-sm text-slate-300">Choose whether ProFixIQ should guide you through existing shop data setup or let you start with an empty workspace.</p>
+              {error ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/25 p-3 text-sm text-red-100">{error}</div> : null}
+              <div className="mt-5 flex flex-wrap gap-3">
+                <button
+                  className="rounded-xl border border-[rgba(197,122,74,0.55)] bg-[linear-gradient(135deg,rgba(197,122,74,0.30),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 hover:bg-orange-400/20 disabled:opacity-50"
+                  onClick={() => void answerExistingSystem("yes")}
+                  disabled={Boolean(busyStep)}
+                >
+                  Yes, guide me through import
+                </button>
+                <button
+                  className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-50"
+                  onClick={() => void answerExistingSystem("no")}
+                  disabled={Boolean(busyStep)}
+                >
+                  No, start from empty
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <h3 className="mt-2 text-xl font-semibold text-white">{currentDefinition.question}</h3>
+              <p className="mt-2 text-sm text-slate-300">{currentDefinition.description}</p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${statusTone(currentStep.status)}`}>{statusLabel(currentStep.status)}</span>
+                <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-slate-300">{currentImplementationLabel}</span>
+              </div>
 
-          {error ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/25 p-3 text-sm text-red-100">{error}</div> : null}
+              {error ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/25 p-3 text-sm text-red-100">{error}</div> : null}
 
-          <div className="mt-5 flex flex-wrap gap-3">
-            <button
-              className="rounded-xl border border-[rgba(197,122,74,0.55)] bg-[linear-gradient(135deg,rgba(197,122,74,0.30),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 hover:bg-orange-400/20 disabled:opacity-50"
-              onClick={() => void routeStep(currentStep.step_key)}
-              disabled={Boolean(busyStep) || currentDefinition.implementationStatus === "future"}
-            >
-              Yes, route me there
-            </button>
-            <button
-              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-50"
-              onClick={() => void postStep(currentStep.step_key, "skip", { skippedReason: "User answered no" })}
-              disabled={Boolean(busyStep)}
-            >
-              No, skip this
-            </button>
-            <button
-              className="rounded-xl border border-emerald-500/30 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-50"
-              onClick={() => void postStep(currentStep.step_key, "complete", { summary: { completedFrom: "guided-control-room" } })}
-              disabled={Boolean(busyStep) || currentStep.status === "completed"}
-            >
-              Mark done
-            </button>
-            {currentStep.status === "routing" ? (
-              <Link className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-900/30" href={currentDestination}>
-                Resume step
-              </Link>
-            ) : null}
-          </div>
+              <div className="mt-5 flex flex-wrap gap-3">
+                <button
+                  className="rounded-xl border border-[rgba(197,122,74,0.55)] bg-[linear-gradient(135deg,rgba(197,122,74,0.30),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 hover:bg-orange-400/20 disabled:opacity-50"
+                  onClick={() => void routeStep(currentStep.step_key)}
+                  disabled={Boolean(busyStep) || currentDefinition.implementationStatus === "future"}
+                >
+                  Yes, route me there
+                </button>
+                <button
+                  className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-50"
+                  onClick={() => void postStep(currentStep.step_key, "skip", { skippedReason: "User answered no" })}
+                  disabled={Boolean(busyStep)}
+                >
+                  No, skip this
+                </button>
+                <button
+                  className="rounded-xl border border-emerald-500/30 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-50"
+                  onClick={() => void postStep(currentStep.step_key, "complete", { summary: { completedFrom: "guided-control-room" } })}
+                  disabled={Boolean(busyStep) || currentStep.status === "completed"}
+                >
+                  Mark done
+                </button>
+                {currentStep.status === "routing" ? (
+                  <Link className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-sm font-semibold text-sky-100 hover:bg-sky-900/30" href={currentDestination}>
+                    Continue to {currentDefinition.label}
+                  </Link>
+                ) : null}
+              </div>
+            </>
+          )}
         </div>
 
         <div className="rounded-2xl border border-white/10 bg-white/[0.035] p-5">
@@ -194,19 +251,16 @@ export function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
             const definition = getGuidedOnboardingStep(step.step_key);
             const active = step.step_key === currentStep.step_key;
             return (
-              <button
-                type="button"
+              <div
                 key={step.step_key}
-                className={`w-full rounded-xl border p-3 text-left transition ${active ? "border-[rgba(197,122,74,0.65)] bg-[rgba(197,122,74,0.14)]" : "border-white/10 bg-white/[0.03] hover:bg-white/[0.06]"}`}
-                onClick={() => void routeStep(step.step_key)}
-                disabled={Boolean(busyStep) || definition.implementationStatus === "future"}
+                className={`w-full rounded-xl border p-3 text-left transition ${active ? "border-[rgba(197,122,74,0.65)] bg-[rgba(197,122,74,0.14)]" : "border-white/10 bg-white/[0.03]"} ${definition.implementationStatus === "future" ? "opacity-75" : ""}`}
               >
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-sm font-semibold text-white">{index + 1}. {definition.label}</span>
                   <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${statusTone(step.status)}`}>{statusLabel(step.status)}</span>
                 </div>
-                <div className="mt-1 text-xs text-slate-400">{definition.implementationStatus}</div>
-              </button>
+                <div className="mt-1 text-xs text-slate-400">{implementationLabel(definition.implementationStatus)}</div>
+              </div>
             );
           })}
         </div>

--- a/features/onboarding-v2/guided/server.ts
+++ b/features/onboarding-v2/guided/server.ts
@@ -36,6 +36,10 @@ function nextActionableStep(steps: GuidedStepRow[]): GuidedOnboardingStepKey | n
   return steps.find((step) => !["completed", "skipped"].includes(step.status))?.step_key ?? null;
 }
 
+function mergeSummary(summary: JsonObject | null | undefined, patch: JsonObject): JsonObject {
+  return { ...(summary ?? {}), ...patch };
+}
+
 async function insertGuidedEvent(db: UntypedSupabase, args: {
   shopId: string;
   sessionId: string;
@@ -91,7 +95,7 @@ export async function createOrResumeGuidedSession(args: {
     const id = randomUUID();
     const { data: inserted, error } = await db
       .from("guided_onboarding_sessions")
-      .insert({ id, shop_id: args.shopId, created_by: args.userId, status: "active", current_step_key: "customers", summary: {} })
+      .insert({ id, shop_id: args.shopId, created_by: args.userId, status: "active", current_step_key: null, summary: {} })
       .select("*")
       .single();
     if (error) throw new Error(error.message ?? "Unable to create guided onboarding session");
@@ -135,6 +139,92 @@ export async function fetchGuidedSession(args: {
   ).filter((step): step is GuidedStepRow => Boolean(step));
 
   return { session: session as GuidedSessionRow, steps: ordered };
+}
+
+export async function answerExistingSystemGate(args: {
+  supabase: unknown;
+  shopId: string;
+  sessionId: string;
+  answer: "yes" | "no";
+}) {
+  const db = asGuidedDb(args.supabase);
+  const current = await fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: args.sessionId });
+  const now = new Date().toISOString();
+
+  if (args.answer === "no") {
+    const { error: stepsError } = await db
+      .from("guided_onboarding_steps")
+      .update({
+        status: "skipped",
+        skipped_reason: "starting empty",
+        completed_at: now,
+        updated_at: now,
+      })
+      .eq("session_id", args.sessionId)
+      .eq("shop_id", args.shopId);
+    if (stepsError) throw new Error(stepsError.message ?? "Unable to skip guided onboarding steps");
+
+    const { error: sessionError } = await db
+      .from("guided_onboarding_sessions")
+      .update({
+        current_step_key: null,
+        status: "completed",
+        summary: mergeSummary(current.session.summary, { existingSystemImport: "no", skippedReason: "starting empty" }),
+        completed_at: now,
+        updated_at: now,
+      })
+      .eq("id", args.sessionId)
+      .eq("shop_id", args.shopId);
+    if (sessionError) throw new Error(sessionError.message ?? "Unable to complete guided onboarding session");
+
+    await insertGuidedEvent(db, {
+      shopId: args.shopId,
+      sessionId: args.sessionId,
+      eventType: "existing_system_gate_no",
+      payload: { skippedReason: "starting empty" },
+    });
+
+    return fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: args.sessionId });
+  }
+
+  const firstStepKey = GUIDED_ONBOARDING_STEPS[0]?.stepKey ?? null;
+  if (!firstStepKey) throw new Error("No guided onboarding steps configured");
+  const firstStep = getGuidedOnboardingStep(firstStepKey);
+
+  const { error: stepError } = await db
+    .from("guided_onboarding_steps")
+    .update({
+      status: "asked",
+      destination_path: firstStep.destinationPath,
+      highlight_key: firstStep.highlightKey,
+      updated_at: now,
+    })
+    .eq("session_id", args.sessionId)
+    .eq("shop_id", args.shopId)
+    .eq("step_key", firstStepKey);
+  if (stepError) throw new Error(stepError.message ?? "Unable to activate guided onboarding first step");
+
+  const { error: sessionError } = await db
+    .from("guided_onboarding_sessions")
+    .update({
+      current_step_key: firstStepKey,
+      status: "active",
+      summary: mergeSummary(current.session.summary, { existingSystemImport: "yes" }),
+      completed_at: null,
+      updated_at: now,
+    })
+    .eq("id", args.sessionId)
+    .eq("shop_id", args.shopId);
+  if (sessionError) throw new Error(sessionError.message ?? "Unable to start guided onboarding steps");
+
+  await insertGuidedEvent(db, {
+    shopId: args.shopId,
+    sessionId: args.sessionId,
+    eventType: "existing_system_gate_yes",
+    payload: {},
+  });
+
+  return fetchGuidedSession({ supabase: args.supabase, shopId: args.shopId, sessionId: args.sessionId });
 }
 
 export async function updateGuidedStepStatus(args: {

--- a/tests/onboarding-v2/guided-entry-ui.test.tsx
+++ b/tests/onboarding-v2/guided-entry-ui.test.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GuidedOnboardingWorkspace } from "@/features/onboarding-v2/components/GuidedOnboardingWorkspace";
+import { GUIDED_ONBOARDING_STEPS, type GuidedOnboardingStatus } from "@/features/onboarding-v2/guided/steps";
+import type { GuidedOnboardingPayload, GuidedSessionRow, GuidedStepRow } from "@/features/onboarding-v2/guided/types";
+
+const router = { push: vi.fn(), replace: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+function payload(options: {
+  existingSystemImport?: "yes" | "no";
+  currentStepKey?: GuidedSessionRow["current_step_key"];
+  statusByStep?: Partial<Record<GuidedStepRow["step_key"], GuidedOnboardingStatus>>;
+  sessionStatus?: string;
+} = {}): GuidedOnboardingPayload & { ok: true; destinationUrl?: string | null; redirectTo?: string | null } {
+  const now = "2026-06-04T00:00:00.000Z";
+  return {
+    ok: true,
+    session: {
+      id: "session-1",
+      shop_id: "shop-1",
+      created_by: "user-1",
+      status: options.sessionStatus ?? "active",
+      current_step_key: options.currentStepKey ?? null,
+      summary: options.existingSystemImport ? { existingSystemImport: options.existingSystemImport } : {},
+      created_at: now,
+      updated_at: now,
+      completed_at: options.sessionStatus === "completed" ? now : null,
+    },
+    steps: GUIDED_ONBOARDING_STEPS.map((step) => ({
+      id: `${step.stepKey}-row`,
+      session_id: "session-1",
+      shop_id: "shop-1",
+      step_key: step.stepKey,
+      status: options.statusByStep?.[step.stepKey] ?? "not_started",
+      destination_path: step.destinationPath,
+      highlight_key: step.highlightKey,
+      skipped_reason: null,
+      summary: {},
+      error: null,
+      retry_count: 0,
+      created_at: now,
+      updated_at: now,
+      completed_at: null,
+    })),
+  };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  };
+}
+
+describe("guided onboarding entry UI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the existing-system gate before Customers on a new session", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(payload())));
+
+    render(<GuidedOnboardingWorkspace />);
+
+    expect(await screen.findByRole("heading", { name: /do you currently have an existing shop\/system to import\?/i })).toBeInTheDocument();
+    expect(screen.queryByText(/do you want to bring in your customer list now\?/i)).not.toBeInTheDocument();
+    expect(router.replace).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-1");
+  });
+
+  it("answering NO skips guided import and returns to dashboard", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/existing-system")) {
+        return jsonResponse({ ...payload({ existingSystemImport: "no", sessionStatus: "completed", statusByStep: Object.fromEntries(GUIDED_ONBOARDING_STEPS.map((step) => [step.stepKey, "skipped"])) }), redirectTo: "/dashboard" });
+      }
+      return jsonResponse(payload());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GuidedOnboardingWorkspace />);
+    await userEvent.click(await screen.findByRole("button", { name: /no, start from empty/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard"));
+    expect(fetchMock).toHaveBeenCalledWith("/api/onboarding-v2/guided/sessions/session-1/existing-system", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("answering YES activates Customers as asked instead of routing", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/existing-system")) {
+        return jsonResponse(payload({ existingSystemImport: "yes", currentStepKey: "customers", statusByStep: { customers: "asked" } }));
+      }
+      return jsonResponse(payload());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GuidedOnboardingWorkspace />);
+    await userEvent.click(await screen.findByRole("button", { name: /yes, guide me through import/i }));
+
+    expect(await screen.findByRole("heading", { name: /do you want to bring in your customer list now\?/i })).toBeInTheDocument();
+    expect(screen.getAllByText("asked").length).toBeGreaterThan(0);
+    expect(screen.queryByText("routing")).not.toBeInTheDocument();
+  });
+
+  it("sets Customers to routing only after the explicit route action", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/existing-system")) {
+        return jsonResponse(payload({ existingSystemImport: "yes", currentStepKey: "customers", statusByStep: { customers: "asked" } }));
+      }
+      if (url.endsWith("/steps/customers/answer")) {
+        return jsonResponse({
+          ...payload({ existingSystemImport: "yes", currentStepKey: "customers", statusByStep: { customers: "routing" } }),
+          destinationUrl: "/customers?onboardingSession=session-1&onboardingStep=customers&highlight=customers-import&source=guided-onboarding",
+        });
+      }
+      return jsonResponse(payload());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GuidedOnboardingWorkspace />);
+    await userEvent.click(await screen.findByRole("button", { name: /yes, guide me through import/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /yes, route me there/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith(expect.stringContaining("/customers?onboardingSession=session-1")));
+    await waitFor(() => expect(screen.getAllByText("routing").length).toBeGreaterThan(0));
+    expect(screen.getByRole("link", { name: /continue to customers/i })).toBeInTheDocument();
+  });
+
+  it("does not expose V2 in the user-facing page title", () => {
+    const indexPage = readFileSync("app/dashboard/onboarding-v2/page.tsx", "utf8");
+    const sessionPage = readFileSync("app/dashboard/onboarding-v2/[sessionId]/page.tsx", "utf8");
+
+    expect(indexPage).toContain('title="Data Onboarding"');
+    expect(sessionPage).toContain('title="Data Onboarding"');
+    expect(indexPage).not.toContain("Guided Onboarding V2");
+    expect(sessionPage).not.toContain("Guided Onboarding V2");
+  });
+});


### PR DESCRIPTION
### Motivation

- Avoid exposing internal "V2" branding in production and ensure the onboarding flow asks the initial gate question so users aren't stranded mid-flow.
- Provide a clear yes/no entry gate to choose between importing an existing shop/system or starting empty so Customers isn't prematurely set to `routing`.
- Keep changes small and non-breaking while preserving existing step routing and import pages.

### Description

- Rename the user-facing page title from `"Guided Onboarding V2"` to `"Data Onboarding"` on both the index and session pages (`app/dashboard/onboarding-v2/page.tsx`, `app/dashboard/onboarding-v2/[sessionId]/page.tsx`).
- Add an existing-system gate UI with buttons `Yes, guide me through import` and `No, start from empty` to the guided control room and only reveal the Customers question after a `yes` answer (`features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx`).
- Implement a scoped API route to handle the gate (`app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts`) and server helpers to mark all steps skipped and complete the session when the user selects `no`, or to set the first step to `asked` when the user selects `yes` (`features/onboarding-v2/guided/server.ts`).
- Ensure Customers is not set to `routing` until the user explicitly performs the route action, update the UX to show a clear "Continue to Customers" action, and surface friendly implementation labels (`normal`, `planned`, `coming later`) instead of raw implementation tokens (`features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx`, `features/onboarding-v2/guided/steps.ts`).
- Add unit tests covering the new entry gate and behaviors (`tests/onboarding-v2/guided-entry-ui.test.tsx`).

### Testing

- Ran linting: `npx eslint features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx features/onboarding-v2/guided/server.ts app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts app/dashboard/onboarding-v2/page.tsx app/dashboard/onboarding-v2/[sessionId]/page.tsx tests/onboarding-v2/guided-entry-ui.test.tsx` — succeeded.
- Typecheck: `npx tsc --noEmit` — succeeded.
- Unit tests: `npx vitest run tests/onboarding-v2/guided-entry-ui.test.tsx tests/onboarding-v2/guided-registry-and-query.test.ts` — all tests passed.
- Performed `git diff --check` to validate patch hygiene — no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e0e7eb8c8328b0aeda1d600b8553)