### PR TITLE
Wire customers page into guided onboarding

### DIFF
--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -6,6 +6,8 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
+import { CustomerOnboardingSetupCard } from "@/features/customers/components/CustomerOnboardingSetupCard";
+import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 type DB = Database;
@@ -371,6 +373,11 @@ export default function CustomerProfilePage(): JSX.Element {
     if (forcedCustomerId) return forcedCustomerId;
     return looksLikeUuid(rawId) ? rawId : null;
   }, [forcedCustomerId, rawId]);
+
+  const guidedCustomerOnboarding = useMemo(() => {
+    const parsed = parseGuidedOnboardingQuery(new URLSearchParams(sp.toString()));
+    return parsed?.onboardingStep === "customers" ? parsed : null;
+  }, [sp]);
 
   // ------------------ State ------------------
   const [loading, setLoading] = useState<boolean>(true);
@@ -1183,6 +1190,18 @@ export default function CustomerProfilePage(): JSX.Element {
     return (
       <PageShell>
         <TopBar rightLabel="Customers" onBack={() => router.back()} />
+
+        {guidedCustomerOnboarding ? (
+          <div className="mb-4">
+            <CustomerOnboardingSetupCard
+              guidedQuery={guidedCustomerOnboarding}
+              onCreateCustomer={() => {
+                setCreateCustomerError(null);
+                setCreateCustomerOpen(true);
+              }}
+            />
+          </div>
+        ) : null}
 
         <div className={`${CARD_BASE} p-4`}>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">

--- a/features/customers/components/CustomerOnboardingSetupCard.tsx
+++ b/features/customers/components/CustomerOnboardingSetupCard.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery;
+  onCreateCustomer: () => void;
+};
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Customer setup step completed manually.",
+};
+
+export function CustomerOnboardingSetupCard({ guidedQuery, onCreateCustomer }: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/customers/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "complete"
+              ? { summary: COMPLETE_SUMMARY }
+              : { skippedReason: "No customer import during onboarding." },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the customers onboarding step.");
+      }
+      router.push(guidedQuery.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the customers onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Customer setup/import"
+      description="Guided onboarding brought you here because Customers owns customer setup and import."
+    >
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Customers</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Set up your customer list</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>This is where customer setup/import will live.</p>
+              <p>For now, you can create customers manually or mark this onboarding step complete.</p>
+              <p>CSV import will be added here next.</p>
+            </div>
+            {error ? (
+              <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div>
+            ) : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <button
+              type="button"
+              onClick={onCreateCustomer}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+            >
+              + Create customer
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("complete")}
+              disabled={disabled}
+              className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55"
+            >
+              {busyAction === "complete" ? "Marking complete…" : "Mark customers step complete"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("skip")}
+              disabled={disabled}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip customers"}
+            </button>
+            <Link
+              href={guidedQuery.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
+++ b/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import React, { useEffect, useRef, type ReactNode } from "react";
 
 type Props = {
   active: boolean;
@@ -16,7 +16,9 @@ export function OnboardingHighlightFrame({ active, highlightKey, title, descript
   useEffect(() => {
     if (!active) return;
     const timer = window.setTimeout(() => {
-      ref.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (typeof ref.current?.scrollIntoView === "function") {
+        ref.current.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
     }, 150);
     return () => window.clearTimeout(timer);
   }, [active, highlightKey]);

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -47,7 +47,7 @@ export const GUIDED_ONBOARDING_STEPS = [
     label: "Customers",
     question: "Do you want to bring in your customer list now?",
     destinationPath: "/customers",
-    highlightKey: "customers-import",
+    highlightKey: "customer-import",
     description: "Route to Customers so existing customer import/setup tools stay the source of truth.",
     implementationStatus: "placeholder",
   },

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CustomerOnboardingSetupCard } from "@/features/customers/components/CustomerOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "customers",
+  highlight: "customer-import",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+describe("CustomerOnboardingSetupCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains the placeholder customer import ownership and opens manual creation", async () => {
+    const onCreateCustomer = vi.fn();
+    render(<CustomerOnboardingSetupCard guidedQuery={guidedQuery} onCreateCustomer={onCreateCustomer} />);
+
+    expect(screen.getByText("This is where customer setup/import will live.")).toBeInTheDocument();
+    expect(screen.getByText("For now, you can create customers manually or mark this onboarding step complete.")).toBeInTheDocument();
+    expect(screen.getByText("CSV import will be added here next.")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /create customer/i }));
+    expect(onCreateCustomer).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the customers guided step complete and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CustomerOnboardingSetupCard guidedQuery={guidedQuery} onCreateCustomer={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark customers step complete/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/customers/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Customer setup step completed manually.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the customers guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CustomerOnboardingSetupCard guidedQuery={guidedQuery} onCreateCustomer={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip customers/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/customers/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "No customer import during onboarding." }),
+      }),
+    );
+  });
+});

--- a/tests/onboarding-v2/guided-entry-ui.test.tsx
+++ b/tests/onboarding-v2/guided-entry-ui.test.tsx
@@ -115,7 +115,7 @@ describe("guided onboarding entry UI", () => {
       if (url.endsWith("/steps/customers/answer")) {
         return jsonResponse({
           ...payload({ existingSystemImport: "yes", currentStepKey: "customers", statusByStep: { customers: "routing" } }),
-          destinationUrl: "/customers?onboardingSession=session-1&onboardingStep=customers&highlight=customers-import&source=guided-onboarding",
+          destinationUrl: "/customers?onboardingSession=session-1&onboardingStep=customers&highlight=customer-import&source=guided-onboarding",
         });
       }
       return jsonResponse(payload());

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -16,7 +16,7 @@ describe("guided onboarding step registry", () => {
       "service_history",
     ]);
 
-    expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customers-import" });
+    expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customer-import" });
     expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicles-setup" });
     expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-create-user" });
     expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings-labor-tax" });
@@ -29,6 +29,18 @@ describe("guided onboarding step registry", () => {
 });
 
 describe("guided onboarding query helpers", () => {
+  it("builds the exact Customers destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "customers" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/customers");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("customers");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("customer-import");
+    expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+  });
+
   it("builds and parses inventory parts destination query params", () => {
     const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "inventory_parts" });
     const parsedUrl = new URL(url, "https://app.profixiq.test");


### PR DESCRIPTION
### Motivation
- Route the guided "Customers" onboarding step to the real Customers page so the Customers feature owns import/setup and the onboarding control room only routes, highlights, and resumes.
- Provide a lightweight, onboarding-aware UI on the Customers page that explains the placeholder import UX and exposes manual creation and step controls without implementing CSV import yet.

### Description
- Added a small onboarding-aware component `CustomerOnboardingSetupCard` that reuses `OnboardingHighlightFrame`, explains that import will live on Customers, exposes a Create customer action, and offers "Mark customers step complete", "Skip customers", and "Back to Data Onboarding" buttons which call the existing guided endpoints. (`features/customers/components/CustomerOnboardingSetupCard.tsx`)
- Wired the Customers page to detect guided onboarding query params using `parseGuidedOnboardingQuery` and render the onboarding card when the step is `customers`. (`features/customers/app/customers/[id]/page.tsx`)
- Normalized the Customers highlight key to `customer-import` and updated test expectations and the destination URL that the guided workspace builds. (`features/onboarding-v2/guided/steps.ts`, tests)
- Hardened `OnboardingHighlightFrame` to guard `scrollIntoView` calls in non-browser/test environments to avoid errors during automated tests. (`features/onboarding-v2/components/OnboardingHighlightFrame.tsx`)
- Added focused tests covering the Customers query params and the new onboarding card behaviors, and adjusted existing guided-entry tests to expect the updated highlight key. (new `tests/onboarding-v2/customer-onboarding-card.test.tsx`, updated registry & entry tests)

### Testing
- Ran targeted unit tests: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/customer-onboarding-card.test.tsx tests/onboarding-v2/guided-entry-ui.test.tsx`, and all tests passed.
- Type check: ran `npx tsc --noEmit` with no errors.
- Lint: ran `npx eslint` on the touched files with no blocking findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e87a31348328a1126880a48879fb)