### PR TITLE
Wire vehicles step into guided onboarding

### DIFF
--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -7,6 +7,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { CustomerOnboardingSetupCard } from "@/features/customers/components/CustomerOnboardingSetupCard";
+import { VehicleOnboardingSetupCard } from "@/features/customers/components/VehicleOnboardingSetupCard";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
@@ -374,10 +375,10 @@ export default function CustomerProfilePage(): JSX.Element {
     return looksLikeUuid(rawId) ? rawId : null;
   }, [forcedCustomerId, rawId]);
 
-  const guidedCustomerOnboarding = useMemo(() => {
-    const parsed = parseGuidedOnboardingQuery(new URLSearchParams(sp.toString()));
-    return parsed?.onboardingStep === "customers" ? parsed : null;
-  }, [sp]);
+  const guidedOnboardingQuery = useMemo(() => parseGuidedOnboardingQuery(new URLSearchParams(sp.toString())), [sp]);
+
+  const guidedCustomerOnboarding = guidedOnboardingQuery?.onboardingStep === "customers" ? guidedOnboardingQuery : null;
+  const guidedVehicleOnboarding = guidedOnboardingQuery?.onboardingStep === "vehicles" ? guidedOnboardingQuery : null;
 
   // ------------------ State ------------------
   const [loading, setLoading] = useState<boolean>(true);
@@ -1203,6 +1204,18 @@ export default function CustomerProfilePage(): JSX.Element {
           </div>
         ) : null}
 
+        {guidedVehicleOnboarding ? (
+          <div className="mb-4">
+            <VehicleOnboardingSetupCard
+              guidedQuery={guidedVehicleOnboarding}
+              onOpenVehicleWorkflow={() => {
+                setCreateCustomerError(null);
+                setCreateCustomerOpen(true);
+              }}
+            />
+          </div>
+        ) : null}
+
         <div className={`${CARD_BASE} p-4`}>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div>
@@ -1588,6 +1601,16 @@ export default function CustomerProfilePage(): JSX.Element {
             </div>
 
             {/* Vehicles */}
+            {guidedVehicleOnboarding ? (
+              <div className="mb-4">
+                <VehicleOnboardingSetupCard
+                  guidedQuery={guidedVehicleOnboarding}
+                  workflowCtaLabel="+ Add vehicle"
+                  onOpenVehicleWorkflow={() => setAddVehicleOpen(true)}
+                />
+              </div>
+            ) : null}
+
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>

--- a/features/customers/components/VehicleOnboardingSetupCard.tsx
+++ b/features/customers/components/VehicleOnboardingSetupCard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery;
+  onOpenVehicleWorkflow: () => void;
+  workflowCtaLabel?: string;
+};
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Vehicle setup step completed manually.",
+};
+
+export function VehicleOnboardingSetupCard({
+  guidedQuery,
+  onOpenVehicleWorkflow,
+  workflowCtaLabel = "Create/select a customer",
+}: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "complete"
+              ? { summary: COMPLETE_SUMMARY }
+              : { skippedReason: "No vehicle import during onboarding." },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the vehicles onboarding step.");
+      }
+      router.push(guidedQuery.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the vehicles onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Vehicle setup/import"
+      description="Guided onboarding brought you here because vehicle setup belongs in the customer file workflow."
+    >
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Vehicles</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Do you want to bring in your vehicle list now?</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>This is where vehicle setup/import will live.</p>
+              <p>Vehicles are tied to customer files, so this step helps you prepare vehicle records in the real workflow.</p>
+              <p>For now, you can create vehicles manually from customer files or mark this onboarding step complete.</p>
+              <p>CSV import will be added here next.</p>
+            </div>
+            {error ? (
+              <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div>
+            ) : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <button
+              type="button"
+              onClick={onOpenVehicleWorkflow}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+            >
+              {workflowCtaLabel}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("complete")}
+              disabled={disabled}
+              className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55"
+            >
+              {busyAction === "complete" ? "Marking complete…" : "Mark vehicles step complete"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("skip")}
+              disabled={disabled}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip vehicles"}
+            </button>
+            <Link
+              href={guidedQuery.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -54,10 +54,10 @@ export const GUIDED_ONBOARDING_STEPS = [
   {
     stepKey: "vehicles",
     label: "Vehicles",
-    question: "Do you want to set up customer vehicles now?",
+    question: "Do you want to bring in your vehicle list now?",
     destinationPath: "/customers",
-    highlightKey: "vehicles-setup",
-    description: "Use Customers for now so vehicles remain connected to customer records.",
+    highlightKey: "vehicle-import",
+    description: "Use Customers for now because vehicles are managed from customer files today.",
     implementationStatus: "placeholder",
   },
   {

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -17,7 +17,7 @@ describe("guided onboarding step registry", () => {
     ]);
 
     expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customer-import" });
-    expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicles-setup" });
+    expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicle-import" });
     expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-create-user" });
     expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings-labor-tax" });
     expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({ destinationPath: "/inspections/templates", highlightKey: "inspection-templates-setup" });
@@ -39,6 +39,26 @@ describe("guided onboarding query helpers", () => {
     expect(parsedUrl.searchParams.get("highlight")).toBe("customer-import");
     expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
     expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+  });
+
+  it("builds the exact Vehicles destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "vehicles" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/customers");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("vehicles");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("vehicle-import");
+    expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+
+    expect(parseGuidedOnboardingQuery(parsedUrl.searchParams)).toMatchObject({
+      onboardingSession: "session-123",
+      onboardingStep: "vehicles",
+      highlight: "vehicle-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
   });
 
   it("builds and parses inventory parts destination query params", () => {

--- a/tests/onboarding-v2/vehicle-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/vehicle-onboarding-card.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VehicleOnboardingSetupCard } from "@/features/customers/components/VehicleOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "vehicles",
+  highlight: "vehicle-import",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+describe("VehicleOnboardingSetupCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains vehicle setup ownership and opens the customer vehicle workflow", async () => {
+    const onOpenVehicleWorkflow = vi.fn();
+    render(<VehicleOnboardingSetupCard guidedQuery={guidedQuery} onOpenVehicleWorkflow={onOpenVehicleWorkflow} />);
+
+    expect(screen.getByText("This is where vehicle setup/import will live.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Vehicles are tied to customer files, so this step helps you prepare vehicle records in the real workflow."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("For now, you can create vehicles manually from customer files or mark this onboarding step complete."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("CSV import will be added here next.")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /create\/select a customer/i }));
+    expect(onOpenVehicleWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the vehicles guided step complete and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VehicleOnboardingSetupCard guidedQuery={guidedQuery} onOpenVehicleWorkflow={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark vehicles step complete/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/vehicles/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Vehicle setup step completed manually.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the vehicles guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VehicleOnboardingSetupCard guidedQuery={guidedQuery} onOpenVehicleWorkflow={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip vehicles/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/vehicles/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "No vehicle import during onboarding." }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Continue Guided Onboarding V2 by adding a low-risk Vehicles step that routes users to the real app surface where vehicles are managed, not a fake onboarding workspace.
- Keep the pattern used by Customers so vehicles remain tied to customer files and the onboarding agent never owns import UI or creates vehicle records silently.

### Description

- Update the guided registry so the `vehicles` step routes to `/customers` with the highlight key `vehicle-import` and updated question/description in `features/onboarding-v2/guided/steps.ts`.
- Add `VehicleOnboardingSetupCard` at `features/customers/components/VehicleOnboardingSetupCard.tsx` that reuses `OnboardingHighlightFrame`, provides the requested copy, and supports `Mark vehicles step complete`, `Skip vehicles`, `Back to Data Onboarding`, and a workflow CTA to open the existing customer/vehicle flow.
- Wire the new card into the real Customers surface in `features/customers/app/customers/[id]/page.tsx`, parsing the guided onboarding query once and rendering the Vehicles card only when `onboardingStep === 'vehicles'` in both directory and customer-vehicle areas without changing normal behavior.
- Add focused tests: update `tests/onboarding-v2/guided-registry-and-query.test.ts` and add `tests/onboarding-v2/vehicle-onboarding-card.test.tsx` to assert destination params and card behaviors, and keep existing customer onboarding tests unchanged.

### Testing

- Ran unit tests with `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/vehicle-onboarding-card.test.tsx tests/onboarding-v2/customer-onboarding-card.test.tsx`, and all tests passed.
- Ran linting with `npx eslint` on touched files and `npx tsc --noEmit`, both of which completed without errors.
- Verified repository hygiene with `git diff --check`, which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ec9a60ac83288a96f133d233e01a)