### PR TITLE
Wire staff step into guided onboarding

### DIFF
--- a/features/dashboard/app/dashboard/owner/create-user/StaffOnboardingSetupCard.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/StaffOnboardingSetupCard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import {
+  GUIDED_ONBOARDING_SOURCE,
+} from "@/features/onboarding-v2/guided/steps";
+import {
+  isSafeGuidedReturnTo,
+  parseGuidedOnboardingQuery,
+  type GuidedOnboardingQuery,
+} from "@/features/onboarding-v2/guided/query";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery;
+  onUseCreateUserForm: () => void;
+};
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Staff setup step completed manually.",
+};
+
+export function getStaffGuidedOnboardingQuery(params: URLSearchParams): GuidedOnboardingQuery | null {
+  const parsed = parseGuidedOnboardingQuery(params);
+  if (parsed?.onboardingStep === "staff") return parsed;
+
+  const onboardingSession = params.get("onboardingSession") ?? "";
+  const onboardingStep = params.get("onboardingStep") ?? "";
+  const highlight = params.get("highlight") ?? "";
+  const returnTo = params.get("returnTo") ?? "";
+
+  if (!onboardingSession) return null;
+  if (onboardingStep !== "staff") return null;
+  if (!highlight) return null;
+  if (!isSafeGuidedReturnTo(returnTo)) return null;
+
+  return {
+    onboardingSession,
+    onboardingStep: "staff",
+    highlight,
+    returnTo,
+    source: GUIDED_ONBOARDING_SOURCE,
+  };
+}
+
+export function StaffOnboardingSetupCard({ guidedQuery, onUseCreateUserForm }: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/staff/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "complete"
+              ? { summary: COMPLETE_SUMMARY }
+              : { skippedReason: "No staff setup during onboarding." },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the staff onboarding step.");
+      }
+      router.push(guidedQuery.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the staff onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Staff setup"
+      description="Guided onboarding brought you here because controlled staff account setup belongs on the owner/admin create-user surface."
+    >
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Staff</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Set up staff, technicians, and advisors</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>This is where staff setup lives.</p>
+              <p>For now, add users manually so roles, usernames, passwords, and shop assignment stay controlled.</p>
+              <p>Bulk staff import will stage candidates first in a future phase and will not create login accounts without approval.</p>
+            </div>
+            {error ? (
+              <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div>
+            ) : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <button
+              type="button"
+              onClick={onUseCreateUserForm}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+            >
+              Use create-user form
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("complete")}
+              disabled={disabled}
+              className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55"
+            >
+              {busyAction === "complete" ? "Marking complete…" : "Mark staff step complete"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("skip")}
+              disabled={disabled}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip staff"}
+            </button>
+            <Link
+              href={guidedQuery.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -2,11 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import UsersList from "@/features/admin/components/UsersList";
 import InviteCandidatesList from "@/features/admin/components/InviteCandidatesList";
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
+import { StaffOnboardingSetupCard, getStaffGuidedOnboardingQuery } from "./StaffOnboardingSetupCard";
 import type { Database } from "@shared/types/types/supabase";
 import {
   buildShopUsernameNamespace,
@@ -34,6 +35,8 @@ const INPUT_CLASS =
 
 export default function CreateUserPage(): JSX.Element {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const guidedStaffOnboarding = getStaffGuidedOnboardingQuery(new URLSearchParams(searchParams.toString()));
   const [form, setForm] = useState<CreatePayload>({
     username: "",
     password: "",
@@ -246,10 +249,21 @@ export default function CreateUserPage(): JSX.Element {
       title="Create User (Access Provisioning)"
       description="Provision account access, assign the initial role, and link the person to your shop. Complete workforce/profile setup in People."
     >
+      {guidedStaffOnboarding ? (
+        <div className="mb-4">
+          <StaffOnboardingSetupCard
+            guidedQuery={guidedStaffOnboarding}
+            onUseCreateUserForm={() => {
+              document.getElementById("staff-create-user-form")?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }}
+          />
+        </div>
+      ) : null}
+
       {/* top 2-column content */}
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         {/* LEFT: create user */}
-        <div className={`space-y-4 ${PANEL_CLASS}`}>
+        <div id="staff-create-user-form" className={`space-y-4 ${PANEL_CLASS}`}>
           <div className="space-y-1">
             <h2 className="text-lg font-semibold text-white">New team member</h2>
             <p className="text-sm text-neutral-400">

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -63,9 +63,9 @@ export const GUIDED_ONBOARDING_STEPS = [
   {
     stepKey: "staff",
     label: "Staff",
-    question: "Do you want to invite or create staff accounts now?",
+    question: "Do you want to set up your staff, technicians, or advisors now?",
     destinationPath: "/dashboard/owner/create-user",
-    highlightKey: "staff-create-user",
+    highlightKey: "staff-import",
     description: "Route owners/admins to the existing staff creation page; no bulk user creation happens here.",
     implementationStatus: "placeholder",
   },

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -18,7 +18,7 @@ describe("guided onboarding step registry", () => {
 
     expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customer-import" });
     expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicle-import" });
-    expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-create-user" });
+    expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-import" });
     expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings-labor-tax" });
     expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({ destinationPath: "/inspections/templates", highlightKey: "inspection-templates-setup" });
     expect(getGuidedOnboardingStep("service_menu")).toMatchObject({ destinationPath: "/menu", highlightKey: "service-menu-setup" });
@@ -56,6 +56,26 @@ describe("guided onboarding query helpers", () => {
       onboardingSession: "session-123",
       onboardingStep: "vehicles",
       highlight: "vehicle-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+  });
+
+  it("builds the exact Staff destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "staff" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/dashboard/owner/create-user");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("staff");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("staff-import");
+    expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+
+    expect(parseGuidedOnboardingQuery(parsedUrl.searchParams)).toMatchObject({
+      onboardingSession: "session-123",
+      onboardingStep: "staff",
+      highlight: "staff-import",
       returnTo: "/dashboard/onboarding-v2/session-123",
       source: "guided-onboarding",
     });

--- a/tests/onboarding-v2/staff-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/staff-onboarding-card.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  StaffOnboardingSetupCard,
+  getStaffGuidedOnboardingQuery,
+} from "@/features/dashboard/app/dashboard/owner/create-user/StaffOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "staff",
+  highlight: "staff-import",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+function StaffCardFromParams({ params }: { params: URLSearchParams }) {
+  const query = getStaffGuidedOnboardingQuery(params);
+  return query ? <StaffOnboardingSetupCard guidedQuery={query} onUseCreateUserForm={vi.fn()} /> : null;
+}
+
+describe("StaffOnboardingSetupCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders only in staff onboarding mode", () => {
+    const onboardingParams = new URLSearchParams({
+      onboardingSession: "session-123",
+      onboardingStep: "staff",
+      highlight: "staff-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+    const normalParams = new URLSearchParams();
+
+    const { rerender } = render(<StaffCardFromParams params={normalParams} />);
+    expect(screen.queryByText("This is where staff setup lives.")).not.toBeInTheDocument();
+
+    rerender(<StaffCardFromParams params={onboardingParams} />);
+    expect(screen.getByText("This is where staff setup lives.")).toBeInTheDocument();
+  });
+
+  it("explains manual controlled staff setup and opens the create-user form", async () => {
+    const onUseCreateUserForm = vi.fn();
+    render(<StaffOnboardingSetupCard guidedQuery={guidedQuery} onUseCreateUserForm={onUseCreateUserForm} />);
+
+    expect(screen.getByText("This is where staff setup lives.")).toBeInTheDocument();
+    expect(
+      screen.getByText("For now, add users manually so roles, usernames, passwords, and shop assignment stay controlled."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Bulk staff import will stage candidates first in a future phase and will not create login accounts without approval."),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /use create-user form/i }));
+    expect(onUseCreateUserForm).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the staff guided step complete and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<StaffOnboardingSetupCard guidedQuery={guidedQuery} onUseCreateUserForm={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark staff step complete/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/staff/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Staff setup step completed manually.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the staff guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<StaffOnboardingSetupCard guidedQuery={guidedQuery} onUseCreateUserForm={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip staff/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/staff/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "No staff setup during onboarding." }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Route the Staff guided onboarding step into the existing, controlled create-user surface so owners/admins can set up staff where account provisioning already lives while preserving tenant and auth guardrails.
- Provide a low-risk onboarding-aware card that explains manual setup and prevents any silent or bulk creation of auth users during onboarding.

### Description
- Update the guided registry so the Staff step asks “Do you want to set up your staff, technicians, or advisors now?” and uses `destinationPath: /dashboard/owner/create-user` with `highlight=staff-import` (`features/onboarding-v2/guided/steps.ts`).
- Add `StaffOnboardingSetupCard` and `getStaffGuidedOnboardingQuery` under `features/dashboard/app/dashboard/owner/create-user/` to render an onboarding-only highlighted card that explains manual setup, links to the existing create-user form, and posts complete/skip to the guided endpoints.
- Wire the owner create-user page to parse onboarding params and conditionally render the Staff onboarding card (scrolls to the existing form when CTA is used) without changing create-user behavior or server-side auth logic (`features/dashboard/app/dashboard/owner/create-user/page.tsx`).
- Add and update tests to cover the Staff destination/query, onboarding-only rendering of the card, and that complete/skip post to the correct guided endpoints and route back to `returnTo` (`tests/onboarding-v2/guided-registry-and-query.test.ts` and new `tests/onboarding-v2/staff-onboarding-card.test.tsx`).

### Testing
- Ran focused unit tests: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/customer-onboarding-card.test.tsx tests/onboarding-v2/vehicle-onboarding-card.test.tsx tests/onboarding-v2/staff-onboarding-card.test.tsx`, and all tests passed (4 files, 17 tests total).
- Typecheck and lint: ran `npx tsc --noEmit` and `npx eslint` on touched files and fixed issues; both succeeded with no errors reported.
- Performed `git diff --check` to validate whitespace/patch cleanliness with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ee83d378832882ffbb228432d5ff)