### PR TITLE
Wire settings step into guided onboarding

### DIFF
--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { toast } from "sonner";
 
@@ -24,6 +24,11 @@ import OwnerSettingsBusinessSection from "@/features/dashboard/components/owner-
 import OwnerSettingsOperationsSection from "@/features/dashboard/components/owner-settings/OwnerSettingsOperationsSection";
 import OwnerSettingsSchedulingSection from "@/features/dashboard/components/owner-settings/OwnerSettingsSchedulingSection";
 import OwnerSettingsSidebar from "@/features/dashboard/components/owner-settings/OwnerSettingsSidebar";
+import {
+  SettingsOnboardingSetupCard,
+  getSettingsGuidedOnboardingQuery,
+} from "@/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
 import { OwnerSettingsPanel, OwnerSettingsSectionIntro, OwnerSettingsStat } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSummaryCard";
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
@@ -187,7 +192,12 @@ function locationName(s: { shop_name?: string | null; name?: string | null }) {
 
 export default function OwnerSettingsPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const settingsGuidedOnboarding = useMemo(
+    () => getSettingsGuidedOnboardingQuery(new URLSearchParams(searchParams.toString())),
+    [searchParams],
+  );
 
   const [loading, setLoading] = useState(true);
 
@@ -1269,7 +1279,17 @@ try {
 
   const seatLimitLabel = seatsLimit == null ? "Unlimited" : `${seatsUsed}/${seatsLimit}`;
 
-    return (
+  const focusOperationsDefaults = () => {
+    const target = document.getElementById("operations-defaults");
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (!target.hasAttribute("tabindex")) {
+      target.setAttribute("tabindex", "-1");
+    }
+    target.focus({ preventScroll: true });
+  };
+
+  return (
     <div className="mx-auto flex max-w-7xl flex-col gap-5 p-5 text-foreground lg:p-6">
       <OwnerSettingsHeader
         isUnlocked={isUnlocked}
@@ -1278,6 +1298,13 @@ try {
         onLock={() => void lockOwnerSettings()}
         onSave={handleSave}
       />
+
+      {settingsGuidedOnboarding ? (
+        <SettingsOnboardingSetupCard
+          guidedQuery={settingsGuidedOnboarding}
+          onFocusSettingsArea={focusOperationsDefaults}
+        />
+      ) : null}
 
       <OwnerSettingsPanel
         tone="passive"
@@ -1363,45 +1390,94 @@ try {
             onLogoUpload={handleLogoUpload}
             onGenerateLogo={handleGenerateLogo}
           />
-          <OwnerSettingsOperationsSection
-            isUnlocked={isUnlocked}
-            currency={currency}
-            taxLabel={taxLabel}
-            laborRate={laborRate}
-            suppliesEnabled={suppliesEnabled}
-            suppliesType={suppliesType}
-            suppliesPercent={suppliesPercent}
-            suppliesFlatAmount={suppliesFlatAmount}
-            suppliesCapAmount={suppliesCapAmount}
-            diagnosticFee={diagnosticFee}
-            taxRate={taxRate}
-            pricingValidDays={pricingValidDays}
-            pricingValidDaysLoading={pricingValidDaysLoading}
-            pricingValidDaysSaving={pricingValidDaysSaving}
-            useAi={useAi}
-            requireCauseCorrection={requireCauseCorrection}
-            requireAuthorization={requireAuthorization}
-            autoGeneratePdf={autoGeneratePdf}
-            autoSendQuoteEmail={autoSendQuoteEmail}
-            appearanceMode={appearanceMode}
-            appearanceSaving={appearanceSaving}
-            onLaborRateChange={setLaborRate}
-            onSuppliesEnabledChange={setSuppliesEnabled}
-            onSuppliesTypeChange={setSuppliesType}
-            onSuppliesPercentChange={setSuppliesPercent}
-            onSuppliesFlatAmountChange={setSuppliesFlatAmount}
-            onSuppliesCapAmountChange={setSuppliesCapAmount}
-            onDiagnosticFeeChange={setDiagnosticFee}
-            onTaxRateChange={setTaxRate}
-            onPricingValidDaysChange={setPricingValidDays}
-            onSavePricingValidDays={savePricingValidDays}
-            onUseAiChange={setUseAi}
-            onRequireCauseCorrectionChange={setRequireCauseCorrection}
-            onRequireAuthorizationChange={setRequireAuthorization}
-            onAutoGeneratePdfChange={setAutoGeneratePdf}
-            onAutoSendQuoteEmailChange={setAutoSendQuoteEmail}
-            onAppearanceModeChange={(value) => void saveAppearanceMode(value)}
-          />
+          {settingsGuidedOnboarding ? (
+            <OnboardingHighlightFrame
+              active
+              highlightKey="shop-settings"
+              title="Operations and pricing defaults"
+              description="Review these existing settings before marking the guided setup step complete."
+            >
+              <OwnerSettingsOperationsSection
+                isUnlocked={isUnlocked}
+                currency={currency}
+                taxLabel={taxLabel}
+                laborRate={laborRate}
+                suppliesEnabled={suppliesEnabled}
+                suppliesType={suppliesType}
+                suppliesPercent={suppliesPercent}
+                suppliesFlatAmount={suppliesFlatAmount}
+                suppliesCapAmount={suppliesCapAmount}
+                diagnosticFee={diagnosticFee}
+                taxRate={taxRate}
+                pricingValidDays={pricingValidDays}
+                pricingValidDaysLoading={pricingValidDaysLoading}
+                pricingValidDaysSaving={pricingValidDaysSaving}
+                useAi={useAi}
+                requireCauseCorrection={requireCauseCorrection}
+                requireAuthorization={requireAuthorization}
+                autoGeneratePdf={autoGeneratePdf}
+                autoSendQuoteEmail={autoSendQuoteEmail}
+                appearanceMode={appearanceMode}
+                appearanceSaving={appearanceSaving}
+                onLaborRateChange={setLaborRate}
+                onSuppliesEnabledChange={setSuppliesEnabled}
+                onSuppliesTypeChange={setSuppliesType}
+                onSuppliesPercentChange={setSuppliesPercent}
+                onSuppliesFlatAmountChange={setSuppliesFlatAmount}
+                onSuppliesCapAmountChange={setSuppliesCapAmount}
+                onDiagnosticFeeChange={setDiagnosticFee}
+                onTaxRateChange={setTaxRate}
+                onPricingValidDaysChange={setPricingValidDays}
+                onSavePricingValidDays={savePricingValidDays}
+                onUseAiChange={setUseAi}
+                onRequireCauseCorrectionChange={setRequireCauseCorrection}
+                onRequireAuthorizationChange={setRequireAuthorization}
+                onAutoGeneratePdfChange={setAutoGeneratePdf}
+                onAutoSendQuoteEmailChange={setAutoSendQuoteEmail}
+                onAppearanceModeChange={(value) => void saveAppearanceMode(value)}
+              />
+            </OnboardingHighlightFrame>
+          ) : (
+            <OwnerSettingsOperationsSection
+              isUnlocked={isUnlocked}
+              currency={currency}
+              taxLabel={taxLabel}
+              laborRate={laborRate}
+              suppliesEnabled={suppliesEnabled}
+              suppliesType={suppliesType}
+              suppliesPercent={suppliesPercent}
+              suppliesFlatAmount={suppliesFlatAmount}
+              suppliesCapAmount={suppliesCapAmount}
+              diagnosticFee={diagnosticFee}
+              taxRate={taxRate}
+              pricingValidDays={pricingValidDays}
+              pricingValidDaysLoading={pricingValidDaysLoading}
+              pricingValidDaysSaving={pricingValidDaysSaving}
+              useAi={useAi}
+              requireCauseCorrection={requireCauseCorrection}
+              requireAuthorization={requireAuthorization}
+              autoGeneratePdf={autoGeneratePdf}
+              autoSendQuoteEmail={autoSendQuoteEmail}
+              appearanceMode={appearanceMode}
+              appearanceSaving={appearanceSaving}
+              onLaborRateChange={setLaborRate}
+              onSuppliesEnabledChange={setSuppliesEnabled}
+              onSuppliesTypeChange={setSuppliesType}
+              onSuppliesPercentChange={setSuppliesPercent}
+              onSuppliesFlatAmountChange={setSuppliesFlatAmount}
+              onSuppliesCapAmountChange={setSuppliesCapAmount}
+              onDiagnosticFeeChange={setDiagnosticFee}
+              onTaxRateChange={setTaxRate}
+              onPricingValidDaysChange={setPricingValidDays}
+              onSavePricingValidDays={savePricingValidDays}
+              onUseAiChange={setUseAi}
+              onRequireCauseCorrectionChange={setRequireCauseCorrection}
+              onRequireAuthorizationChange={setRequireAuthorization}
+              onAutoGeneratePdfChange={setAutoGeneratePdf}
+              onAutoSendQuoteEmailChange={setAutoSendQuoteEmail}
+              onAppearanceModeChange={(value) => void saveAppearanceMode(value)}
+            />
+          )}
           <BrandStudioSummaryCard />
 
           <OwnerSettingsSectionIntro

--- a/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard.tsx
+++ b/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import { GUIDED_ONBOARDING_SOURCE } from "@/features/onboarding-v2/guided/steps";
+import {
+  isSafeGuidedReturnTo,
+  parseGuidedOnboardingQuery,
+  type GuidedOnboardingQuery,
+} from "@/features/onboarding-v2/guided/query";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery;
+  onFocusSettingsArea?: () => void;
+};
+
+const STEP_KEY = "labor_tax_shop_settings" as const;
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Labor, tax, and shop settings reviewed.",
+};
+
+const SKIP_REASON = "Labor, tax, and shop settings skipped during onboarding.";
+
+export function getSettingsGuidedOnboardingQuery(params: URLSearchParams): GuidedOnboardingQuery | null {
+  const parsed = parseGuidedOnboardingQuery(params);
+  if (parsed?.onboardingStep === STEP_KEY) return parsed;
+
+  const onboardingSession = params.get("onboardingSession") ?? "";
+  const onboardingStep = params.get("onboardingStep") ?? "";
+  const highlight = params.get("highlight") ?? "";
+  const returnTo = params.get("returnTo") ?? "";
+
+  if (!onboardingSession) return null;
+  if (onboardingStep !== STEP_KEY) return null;
+  if (!highlight) return null;
+  if (!isSafeGuidedReturnTo(returnTo)) return null;
+
+  return {
+    onboardingSession,
+    onboardingStep: STEP_KEY,
+    highlight,
+    returnTo,
+    source: GUIDED_ONBOARDING_SOURCE,
+  };
+}
+
+export function SettingsOnboardingSetupCard({ guidedQuery, onFocusSettingsArea }: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/${STEP_KEY}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "complete"
+              ? { summary: COMPLETE_SUMMARY }
+              : { skippedReason: SKIP_REASON },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the settings onboarding step.");
+      }
+      router.push(guidedQuery.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the settings onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Labor, tax, and shop settings"
+      description="Guided onboarding brought you here because operational defaults belong on the owner/admin settings surface."
+    >
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Settings</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Review labor, tax, and shop settings</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>This is where labor, tax, supplies, diagnostic fees, authorization defaults, and shop operations settings live.</p>
+              <p>Review these settings now so quotes, totals, invoices, and work orders calculate correctly.</p>
+            </div>
+            {error ? (
+              <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div>
+            ) : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <button
+              type="button"
+              onClick={onFocusSettingsArea}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+            >
+              Review operations defaults
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("complete")}
+              disabled={disabled}
+              className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55"
+            >
+              {busyAction === "complete" ? "Marking reviewed…" : "Mark settings reviewed"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("skip")}
+              disabled={disabled}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip settings for now"}
+            </button>
+            <Link
+              href={guidedQuery.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -72,9 +72,9 @@ export const GUIDED_ONBOARDING_STEPS = [
   {
     stepKey: "labor_tax_shop_settings",
     label: "Labor, tax, and shop settings",
-    question: "Do you want to review labor rates, tax, and shop settings now?",
+    question: "Do you want to review your labor, tax, and shop settings now?",
     destinationPath: "/dashboard/owner/settings",
-    highlightKey: "shop-settings-labor-tax",
+    highlightKey: "shop-settings",
     description: "Guide setup through the existing owner settings surface.",
     implementationStatus: "placeholder",
   },

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -19,7 +19,7 @@ describe("guided onboarding step registry", () => {
     expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customer-import" });
     expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicle-import" });
     expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-import" });
-    expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings-labor-tax" });
+    expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings" });
     expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({ destinationPath: "/inspections/templates", highlightKey: "inspection-templates-setup" });
     expect(getGuidedOnboardingStep("service_menu")).toMatchObject({ destinationPath: "/menu", highlightKey: "service-menu-setup" });
     expect(getGuidedOnboardingStep("inventory_parts")).toMatchObject({ destinationPath: "/parts/inventory", highlightKey: "parts-csv-import", implementationStatus: "available" });
@@ -76,6 +76,27 @@ describe("guided onboarding query helpers", () => {
       onboardingSession: "session-123",
       onboardingStep: "staff",
       highlight: "staff-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+  });
+
+
+  it("builds the exact Labor/tax/shop settings destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "labor_tax_shop_settings" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/dashboard/owner/settings");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("labor_tax_shop_settings");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("shop-settings");
+    expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+
+    expect(parseGuidedOnboardingQuery(parsedUrl.searchParams)).toMatchObject({
+      onboardingSession: "session-123",
+      onboardingStep: "labor_tax_shop_settings",
+      highlight: "shop-settings",
       returnTo: "/dashboard/onboarding-v2/session-123",
       source: "guided-onboarding",
     });

--- a/tests/onboarding-v2/settings-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/settings-onboarding-card.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  SettingsOnboardingSetupCard,
+  getSettingsGuidedOnboardingQuery,
+} from "@/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "labor_tax_shop_settings",
+  highlight: "shop-settings",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+function SettingsCardFromParams({ params }: { params: URLSearchParams }) {
+  const query = getSettingsGuidedOnboardingQuery(params);
+  return query ? <SettingsOnboardingSetupCard guidedQuery={query} onFocusSettingsArea={vi.fn()} /> : null;
+}
+
+describe("SettingsOnboardingSetupCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders only in labor/tax/shop settings onboarding mode", () => {
+    const onboardingParams = new URLSearchParams({
+      onboardingSession: "session-123",
+      onboardingStep: "labor_tax_shop_settings",
+      highlight: "shop-settings",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+    const normalParams = new URLSearchParams();
+
+    const { rerender } = render(<SettingsCardFromParams params={normalParams} />);
+    expect(screen.queryByText("Review labor, tax, and shop settings")).not.toBeInTheDocument();
+
+    rerender(<SettingsCardFromParams params={onboardingParams} />);
+    expect(screen.getByText("Review labor, tax, and shop settings")).toBeInTheDocument();
+  });
+
+  it("explains the settings surface and focuses the operations defaults area", async () => {
+    const onFocusSettingsArea = vi.fn();
+    render(<SettingsOnboardingSetupCard guidedQuery={guidedQuery} onFocusSettingsArea={onFocusSettingsArea} />);
+
+    expect(
+      screen.getByText("This is where labor, tax, supplies, diagnostic fees, authorization defaults, and shop operations settings live."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Review these settings now so quotes, totals, invoices, and work orders calculate correctly."),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /review operations defaults/i }));
+    expect(onFocusSettingsArea).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the settings guided step reviewed and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SettingsOnboardingSetupCard guidedQuery={guidedQuery} onFocusSettingsArea={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark settings reviewed/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/labor_tax_shop_settings/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Labor, tax, and shop settings reviewed.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the settings guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SettingsOnboardingSetupCard guidedQuery={guidedQuery} onFocusSettingsArea={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip settings for now/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/labor_tax_shop_settings/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "Labor, tax, and shop settings skipped during onboarding." }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Continue wiring Guided Onboarding V2 by routing the "Labor, tax, and shop settings" step into the real owner settings page so owners/admins can review operational defaults in-context.
- Preserve security and semantics: only surface onboarding UI when safe guided query params are present, keep owner/admin guard and do not trust or pass `shop_id` via URL.

### Description
- Updated the guided registry: changed the step question text and changed `highlightKey` to `shop-settings` in `features/onboarding-v2/guided/steps.ts` and ensured the destination is `/dashboard/owner/settings`.
- Added `SettingsOnboardingSetupCard` at `features/dashboard/components/owner-settings/SettingsOnboardingSetupCard.tsx` which parses guided query params, renders the explanatory card, posts to the guided `complete`/`skip` endpoints for `labor_tax_shop_settings`, and exposes a CTA to focus the operations/pricing area.
- Wired the owner settings feature page (`features/dashboard/app/dashboard/owner/settings/page.tsx`) to parse guided params, render the new settings onboarding card only in onboarding mode, and wrap the existing `OwnerSettingsOperationsSection` in `OnboardingHighlightFrame` while keeping form behavior unchanged.
- Tests added/adjusted: registry/query assertions and a new `settings-onboarding-card` test that verifies render gating, focus CTA, and complete/skip POSTs and return routing.

### Testing
- Ran targeted unit tests: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/customer-onboarding-card.test.tsx tests/onboarding-v2/vehicle-onboarding-card.test.tsx tests/onboarding-v2/staff-onboarding-card.test.tsx tests/onboarding-v2/settings-onboarding-card.test.tsx` and all tests passed.
- Typecheck: `npx tsc --noEmit` completed successfully.
- Lint: `npx eslint` on touched files completed without reported errors.
- Repo hygiene: `git diff --check` returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f21f25e483288718866e3b0073fe)