### PR TITLE
Wire inspection templates step into guided onboarding

### DIFF
--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import FleetFormImportCard from "@/features/inspections/components/FleetFormImportCard";
+import {
+  InspectionTemplatesOnboardingSetupCard,
+  getInspectionTemplatesGuidedOnboardingQuery,
+} from "@/features/inspections/components/InspectionTemplatesOnboardingSetupCard";
 
 type DB = Database;
 type Template = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -13,6 +18,14 @@ type Scope = "mine" | "shared" | "all";
 
 export default function InspectionTemplatesPage() {
   const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const searchParams = useSearchParams();
+  const guidedQuery = useMemo(
+    () =>
+      getInspectionTemplatesGuidedOnboardingQuery(
+        new URLSearchParams(searchParams.toString()),
+      ),
+    [searchParams],
+  );
   const [scope, setScope] = useState<Scope>("mine");
   const [search, setSearch] = useState("");
   const [mine, setMine] = useState<Template[]>([]);
@@ -132,6 +145,15 @@ export default function InspectionTemplatesPage() {
   }, [scope, mine, shared, search]);
 
   const canEditOrDelete = (t: Template) => !!userId && t.user_id === userId;
+
+  const focusTemplateImportArea = useCallback(() => {
+    const importArea = document.getElementById("inspection-template-import-area");
+    if (!importArea) return;
+    importArea.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (typeof importArea.focus === "function") {
+      importArea.focus({ preventScroll: true });
+    }
+  }, []);
 
   async function handleDelete(id: string) {
     if (!userId) return;
@@ -286,8 +308,25 @@ export default function InspectionTemplatesPage() {
           </div>
         </div>
 
+        {guidedQuery ? (
+          <InspectionTemplatesOnboardingSetupCard
+            guidedQuery={guidedQuery}
+            onFocusTemplateArea={focusTemplateImportArea}
+          />
+        ) : null}
+
         {/* Fleet import card */}
-        <FleetFormImportCard />
+        <div
+          id="inspection-template-import-area"
+          tabIndex={-1}
+          className={
+            guidedQuery
+              ? "scroll-mt-24 rounded-2xl outline-none ring-1 ring-[rgba(197,122,74,0.38)] ring-offset-2 ring-offset-black"
+              : "scroll-mt-24 outline-none"
+          }
+        >
+          <FleetFormImportCard />
+        </div>
 
         {/* Templates list */}
         <div className={listCard + " px-4 py-4 md:px-6 md:py-5"}>

--- a/features/inspections/components/InspectionTemplatesOnboardingSetupCard.tsx
+++ b/features/inspections/components/InspectionTemplatesOnboardingSetupCard.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import { GUIDED_ONBOARDING_SOURCE } from "@/features/onboarding-v2/guided/steps";
+import {
+  isSafeGuidedReturnTo,
+  parseGuidedOnboardingQuery,
+  type GuidedOnboardingQuery,
+} from "@/features/onboarding-v2/guided/query";
+
+const STEP_KEY = "inspection_templates" as const;
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Inspection templates reviewed.",
+};
+
+const SKIP_REASON = "Inspection templates skipped during onboarding.";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery;
+  onFocusTemplateArea?: () => void;
+};
+
+export function getInspectionTemplatesGuidedOnboardingQuery(params: URLSearchParams): GuidedOnboardingQuery | null {
+  const parsed = parseGuidedOnboardingQuery(params);
+  if (parsed?.onboardingStep === STEP_KEY) return parsed;
+
+  const onboardingSession = params.get("onboardingSession") ?? "";
+  const onboardingStep = params.get("onboardingStep") ?? "";
+  const highlight = params.get("highlight") ?? "";
+  const returnTo = params.get("returnTo") ?? "";
+
+  if (!onboardingSession) return null;
+  if (onboardingStep !== STEP_KEY) return null;
+  if (!highlight) return null;
+  if (!isSafeGuidedReturnTo(returnTo)) return null;
+
+  return {
+    onboardingSession,
+    onboardingStep: STEP_KEY,
+    highlight,
+    returnTo,
+    source: GUIDED_ONBOARDING_SOURCE,
+  };
+}
+
+export function InspectionTemplatesOnboardingSetupCard({ guidedQuery, onFocusTemplateArea }: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/${STEP_KEY}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "complete"
+              ? { summary: COMPLETE_SUMMARY }
+              : { skippedReason: SKIP_REASON },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the inspection templates onboarding step.");
+      }
+      router.push(guidedQuery.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the inspection templates onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Inspection templates setup/import"
+      description="Guided onboarding brought you here because reusable inspection templates are created and imported on this templates page."
+    >
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Inspection templates</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Set up or import inspection templates</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>Inspection templates are reusable checklists for PMs, CVIP-style inspections, customer inspections, and shop-specific forms.</p>
+              <p>You can create templates manually or import an existing form and review it before using it.</p>
+            </div>
+            {error ? (
+              <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div>
+            ) : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <button
+              type="button"
+              onClick={onFocusTemplateArea}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+            >
+              Review template creation/import
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("complete")}
+              disabled={disabled}
+              className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55"
+            >
+              {busyAction === "complete" ? "Marking reviewed…" : "Mark templates reviewed"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("skip")}
+              disabled={disabled}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip inspection templates for now"}
+            </button>
+            <Link
+              href={guidedQuery.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -81,9 +81,9 @@ export const GUIDED_ONBOARDING_STEPS = [
   {
     stepKey: "inspection_templates",
     label: "Inspection templates",
-    question: "Do you want to configure inspection templates now?",
+    question: "Do you want to set up or import inspection templates now?",
     destinationPath: "/inspections/templates",
-    highlightKey: "inspection-templates-setup",
+    highlightKey: "inspection-template-import",
     description: "Use the real inspection template management page.",
     implementationStatus: "placeholder",
   },

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -20,7 +20,11 @@ describe("guided onboarding step registry", () => {
     expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicle-import" });
     expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-import" });
     expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings" });
-    expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({ destinationPath: "/inspections/templates", highlightKey: "inspection-templates-setup" });
+    expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({
+      destinationPath: "/inspections/templates",
+      highlightKey: "inspection-template-import",
+      question: "Do you want to set up or import inspection templates now?",
+    });
     expect(getGuidedOnboardingStep("service_menu")).toMatchObject({ destinationPath: "/menu", highlightKey: "service-menu-setup" });
     expect(getGuidedOnboardingStep("inventory_parts")).toMatchObject({ destinationPath: "/parts/inventory", highlightKey: "parts-csv-import", implementationStatus: "available" });
     expect(getGuidedOnboardingStep("invoices")).toMatchObject({ implementationStatus: "future" });
@@ -97,6 +101,26 @@ describe("guided onboarding query helpers", () => {
       onboardingSession: "session-123",
       onboardingStep: "labor_tax_shop_settings",
       highlight: "shop-settings",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+  });
+
+  it("builds the exact Inspection templates destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "inspection_templates" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/inspections/templates");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("inspection_templates");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("inspection-template-import");
+    expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+
+    expect(parseGuidedOnboardingQuery(parsedUrl.searchParams)).toMatchObject({
+      onboardingSession: "session-123",
+      onboardingStep: "inspection_templates",
+      highlight: "inspection-template-import",
       returnTo: "/dashboard/onboarding-v2/session-123",
       source: "guided-onboarding",
     });

--- a/tests/onboarding-v2/inspection-templates-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/inspection-templates-onboarding-card.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  InspectionTemplatesOnboardingSetupCard,
+  getInspectionTemplatesGuidedOnboardingQuery,
+} from "@/features/inspections/components/InspectionTemplatesOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "inspection_templates",
+  highlight: "inspection-template-import",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+function InspectionTemplatesCardFromParams({ params }: { params: URLSearchParams }) {
+  const query = getInspectionTemplatesGuidedOnboardingQuery(params);
+  return query ? <InspectionTemplatesOnboardingSetupCard guidedQuery={query} onFocusTemplateArea={vi.fn()} /> : null;
+}
+
+describe("InspectionTemplatesOnboardingSetupCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders only in inspection templates onboarding mode", () => {
+    const onboardingParams = new URLSearchParams({
+      onboardingSession: "session-123",
+      onboardingStep: "inspection_templates",
+      highlight: "inspection-template-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+    const normalParams = new URLSearchParams();
+
+    const { rerender } = render(<InspectionTemplatesCardFromParams params={normalParams} />);
+    expect(screen.queryByText("Set up or import inspection templates")).not.toBeInTheDocument();
+
+    rerender(<InspectionTemplatesCardFromParams params={onboardingParams} />);
+    expect(screen.getByText("Set up or import inspection templates")).toBeInTheDocument();
+  });
+
+  it("explains template setup/import and focuses the existing template area", async () => {
+    const onFocusTemplateArea = vi.fn();
+    render(<InspectionTemplatesOnboardingSetupCard guidedQuery={guidedQuery} onFocusTemplateArea={onFocusTemplateArea} />);
+
+    expect(
+      screen.getByText(
+        "Inspection templates are reusable checklists for PMs, CVIP-style inspections, customer inspections, and shop-specific forms.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You can create templates manually or import an existing form and review it before using it."),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /review template creation\/import/i }));
+    expect(onFocusTemplateArea).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the inspection templates guided step reviewed and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<InspectionTemplatesOnboardingSetupCard guidedQuery={guidedQuery} onFocusTemplateArea={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark templates reviewed/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/inspection_templates/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Inspection templates reviewed.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the inspection templates guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<InspectionTemplatesOnboardingSetupCard guidedQuery={guidedQuery} onFocusTemplateArea={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip inspection templates for now/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/inspection_templates/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "Inspection templates skipped during onboarding." }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Continue Guided Onboarding V2 by routing the `inspection_templates` step to the real templates management page and surfacing onboarding guidance there without changing existing import/save semantics.
- Keep tenant/auth rules intact, require owner/admin guarded endpoints for complete/skip, and avoid rebuilding `FleetFormImportCard` or changing upload behavior.

### Description
- Updated the guided step registry in `features/onboarding-v2/guided/steps.ts` to use the question `Do you want to set up or import inspection templates now?` and the highlight key `inspection-template-import` for the `inspection_templates` step.
- Added `InspectionTemplatesOnboardingSetupCard` in `features/inspections/components/InspectionTemplatesOnboardingSetupCard.tsx` with query parsing, explanation copy, CTA to focus the existing import/creation area, `Mark templates reviewed`, `Skip inspection templates for now`, and `Back to Data Onboarding`; complete/skip actions post to the owner/admin protected endpoints for `inspection_templates`.
- Wired the real templates page `features/inspections/app/inspection/templates/page.tsx` to parse guided query params via `getInspectionTemplatesGuidedOnboardingQuery`, render the onboarding card only when in onboarding mode, and add a low-risk wrapper (id `inspection-template-import-area`, focus/scroll, highlight ring) around the existing `FleetFormImportCard` without altering its behavior.
- Added/updated tests: expanded `tests/onboarding-v2/guided-registry-and-query.test.ts` and added `tests/onboarding-v2/inspection-templates-onboarding-card.test.tsx` to assert destination URL/query params, onboarding-only rendering, focus CTA, and correct calls to the guided complete/skip endpoints.

### Testing
- Ran unit tests: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/customer-onboarding-card.test.tsx tests/onboarding-v2/vehicle-onboarding-card.test.tsx tests/onboarding-v2/staff-onboarding-card.test.tsx tests/onboarding-v2/settings-onboarding-card.test.tsx tests/onboarding-v2/inspection-templates-onboarding-card.test.tsx` and all specified tests passed (6 files, 27 tests).
- Typecheck: `npx tsc --noEmit` completed without errors.
- Lint: `npx eslint` on touched files completed without errors and `git diff --check` returned no issues.
- Tests specifically verified that the built destination URL contains `onboardingSession`, `onboardingStep=inspection_templates`, `highlight=inspection-template-import`, `returnTo`, and `source=guided-onboarding`, and that complete/skip POSTs hit `/api/onboarding-v2/guided/sessions/:sessionId/steps/inspection_templates/{complete|skip}` and then route back to `returnTo`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f52295288328a8f9f488277f2aad)