### PR TITLE
Wire service menu step into guided onboarding

### DIFF
--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -7,8 +7,8 @@
 
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { useUser } from "@auth/hooks/useUser";
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 
 import { PartPicker, type PickedPart } from "@parts/components/PartPicker";
 import { masterServicesList } from "@inspections/lib/inspection/masterServicesList";
+import { ServiceMenuOnboardingSetupCard, getServiceMenuGuidedOnboardingQuery } from "@/features/menu/components/ServiceMenuOnboardingSetupCard";
 
 type DB = Database;
 
@@ -93,6 +94,8 @@ type PartsRequestBody = {
 export default function MenuItemsPage() {
   const supabase = createClientComponentClient<DB>();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const createSectionRef = useRef<HTMLElement | null>(null);
   const { user, isLoading } = useUser();
 
   const [menuItems, setMenuItems] = useState<MenuItemRow[]>([]);
@@ -126,6 +129,16 @@ export default function MenuItemsPage() {
     useState<boolean>(true);
 
   const shopId = useMemo(() => getShopIdFromUser(user), [user]);
+
+  const guidedServiceMenuOnboarding = useMemo(
+    () => getServiceMenuGuidedOnboardingQuery(new URLSearchParams(searchParams.toString())),
+    [searchParams],
+  );
+
+  const focusCreateMenuItemArea = useCallback(() => {
+    createSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    createSectionRef.current?.focus({ preventScroll: true });
+  }, []);
 
   const currency: "CAD" | "USD" = useMemo(
     () => (shopDefaults?.country === "CA" ? "CAD" : "USD"),
@@ -621,8 +634,18 @@ export default function MenuItemsPage() {
         </div>
       </section>
 
+      <ServiceMenuOnboardingSetupCard
+        guidedQuery={guidedServiceMenuOnboarding}
+        onFocusCreateArea={focusCreateMenuItemArea}
+      />
+
       {/* Create */}
-      <section className="metal-card rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/65 p-4 shadow-[0_22px_45px_rgba(0,0,0,0.9)] backdrop-blur-xl md:p-6">
+      <section
+        ref={createSectionRef}
+        id="service-menu-create-item"
+        tabIndex={-1}
+        className="metal-card rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-black/65 p-4 shadow-[0_22px_45px_rgba(0,0,0,0.9)] backdrop-blur-xl outline-none md:p-6"
+      >
         <div className="mb-4 flex items-center justify-between gap-3">
           <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-neutral-400">
             Create menu item

--- a/features/menu/components/ServiceMenuOnboardingSetupCard.tsx
+++ b/features/menu/components/ServiceMenuOnboardingSetupCard.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import { GUIDED_ONBOARDING_SOURCE } from "@/features/onboarding-v2/guided/steps";
+import {
+  isSafeGuidedReturnTo,
+  parseGuidedOnboardingQuery,
+  type GuidedOnboardingQuery,
+} from "@/features/onboarding-v2/guided/query";
+
+const STEP_KEY = "service_menu" as const;
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Service menu reviewed.",
+};
+
+const SKIP_REASON = "Service menu skipped during onboarding.";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery | null;
+  onFocusCreateArea?: () => void;
+};
+
+export function getServiceMenuGuidedOnboardingQuery(params: URLSearchParams): GuidedOnboardingQuery | null {
+  const parsed = parseGuidedOnboardingQuery(params);
+  if (parsed?.onboardingStep === STEP_KEY) return parsed;
+
+  const onboardingSession = params.get("onboardingSession") ?? "";
+  const onboardingStep = params.get("onboardingStep") ?? "";
+  const highlight = params.get("highlight") ?? "";
+  const returnTo = params.get("returnTo") ?? "";
+
+  if (!onboardingSession) return null;
+  if (onboardingStep !== STEP_KEY) return null;
+  if (!highlight) return null;
+  if (!isSafeGuidedReturnTo(returnTo)) return null;
+
+  return {
+    onboardingSession,
+    onboardingStep: STEP_KEY,
+    highlight,
+    returnTo,
+    source: GUIDED_ONBOARDING_SOURCE,
+  };
+}
+
+export function ServiceMenuOnboardingSetupCard({ guidedQuery, onFocusCreateArea }: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!guidedQuery) return null;
+
+  const query = guidedQuery;
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(query.onboardingSession)}/steps/${STEP_KEY}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "complete"
+              ? { summary: COMPLETE_SUMMARY }
+              : { skippedReason: SKIP_REASON },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the service menu onboarding step.");
+      }
+      router.push(query.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the service menu onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={query.highlight}
+      title="Service menu setup"
+      description="Guided onboarding brought you here because reusable service menu items and canned jobs are managed on this service menu page."
+    >
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Service menu</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Review or create your service menu</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>Service menu items are reusable jobs, canned repairs, inspection recommendations, and common services your team can add quickly to work orders.</p>
+              <p>For now, review or create your most common services manually. CSV import/staging can be added here later.</p>
+            </div>
+            {error ? (
+              <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div>
+            ) : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <button
+              type="button"
+              onClick={onFocusCreateArea}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+            >
+              Review menu item creation
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("complete")}
+              disabled={disabled}
+              className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55"
+            >
+              {busyAction === "complete" ? "Marking reviewed…" : "Mark service menu reviewed"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void postStepAction("skip")}
+              disabled={disabled}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip service menu for now"}
+            </button>
+            <Link
+              href={query.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -90,7 +90,7 @@ export const GUIDED_ONBOARDING_STEPS = [
   {
     stepKey: "service_menu",
     label: "Service menu",
-    question: "Do you want to set up your canned services or menu now?",
+    question: "Do you want to set up service menu items, canned jobs, or common repairs now?",
     destinationPath: "/menu",
     highlightKey: "service-menu-setup",
     description: "Route to the service menu page where menu items are owned.",

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -25,7 +25,11 @@ describe("guided onboarding step registry", () => {
       highlightKey: "inspection-template-import",
       question: "Do you want to set up or import inspection templates now?",
     });
-    expect(getGuidedOnboardingStep("service_menu")).toMatchObject({ destinationPath: "/menu", highlightKey: "service-menu-setup" });
+    expect(getGuidedOnboardingStep("service_menu")).toMatchObject({
+      destinationPath: "/menu",
+      highlightKey: "service-menu-setup",
+      question: "Do you want to set up service menu items, canned jobs, or common repairs now?",
+    });
     expect(getGuidedOnboardingStep("inventory_parts")).toMatchObject({ destinationPath: "/parts/inventory", highlightKey: "parts-csv-import", implementationStatus: "available" });
     expect(getGuidedOnboardingStep("invoices")).toMatchObject({ implementationStatus: "future" });
     expect(getGuidedOnboardingStep("service_history")).toMatchObject({ destinationPath: "/work-orders/history", highlightKey: "service-history-setup" });
@@ -121,6 +125,26 @@ describe("guided onboarding query helpers", () => {
       onboardingSession: "session-123",
       onboardingStep: "inspection_templates",
       highlight: "inspection-template-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+  });
+
+  it("builds the exact Service menu destination query params", () => {
+    const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "service_menu" });
+    const parsedUrl = new URL(url, "https://app.profixiq.test");
+
+    expect(parsedUrl.pathname).toBe("/menu");
+    expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
+    expect(parsedUrl.searchParams.get("onboardingStep")).toBe("service_menu");
+    expect(parsedUrl.searchParams.get("highlight")).toBe("service-menu-setup");
+    expect(parsedUrl.searchParams.get("returnTo")).toBe("/dashboard/onboarding-v2/session-123");
+    expect(parsedUrl.searchParams.get("source")).toBe("guided-onboarding");
+
+    expect(parseGuidedOnboardingQuery(parsedUrl.searchParams)).toMatchObject({
+      onboardingSession: "session-123",
+      onboardingStep: "service_menu",
+      highlight: "service-menu-setup",
       returnTo: "/dashboard/onboarding-v2/session-123",
       source: "guided-onboarding",
     });

--- a/tests/onboarding-v2/service-menu-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/service-menu-onboarding-card.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  ServiceMenuOnboardingSetupCard,
+  getServiceMenuGuidedOnboardingQuery,
+} from "@/features/menu/components/ServiceMenuOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "service_menu",
+  highlight: "service-menu-setup",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+function ServiceMenuCardFromParams({ params }: { params: URLSearchParams }) {
+  return (
+    <ServiceMenuOnboardingSetupCard
+      guidedQuery={getServiceMenuGuidedOnboardingQuery(params)}
+      onFocusCreateArea={vi.fn()}
+    />
+  );
+}
+
+describe("ServiceMenuOnboardingSetupCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders only in service menu onboarding mode", () => {
+    const onboardingParams = new URLSearchParams({
+      onboardingSession: "session-123",
+      onboardingStep: "service_menu",
+      highlight: "service-menu-setup",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    });
+    const normalParams = new URLSearchParams();
+
+    const { rerender } = render(<ServiceMenuCardFromParams params={normalParams} />);
+    expect(screen.queryByText("Review or create your service menu")).not.toBeInTheDocument();
+
+    rerender(<ServiceMenuCardFromParams params={onboardingParams} />);
+    expect(screen.getByText("Review or create your service menu")).toBeInTheDocument();
+  });
+
+  it("explains manual service menu setup and focuses the creation area", async () => {
+    const onFocusCreateArea = vi.fn();
+    render(<ServiceMenuOnboardingSetupCard guidedQuery={guidedQuery} onFocusCreateArea={onFocusCreateArea} />);
+
+    expect(
+      screen.getByText(
+        "Service menu items are reusable jobs, canned repairs, inspection recommendations, and common services your team can add quickly to work orders.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "For now, review or create your most common services manually. CSV import/staging can be added here later.",
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /review menu item creation/i }));
+    expect(onFocusCreateArea).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the service menu guided step reviewed and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ServiceMenuOnboardingSetupCard guidedQuery={guidedQuery} onFocusCreateArea={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark service menu reviewed/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/service_menu/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Service menu reviewed.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the service menu guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ServiceMenuOnboardingSetupCard guidedQuery={guidedQuery} onFocusCreateArea={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip service menu for now/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/service_menu/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "Service menu skipped during onboarding." }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Continue Guided Onboarding V2 by routing users from the control room into the real Service Menu management surface so owners/admins can review or create menu items in the canonical place.
- Keep onboarding as a routing/highlight/recording layer only and avoid auto-creating or importing service/menu items in this PR.
- Ensure the real `/menu` page shows onboarding UI only when the guided onboarding query indicates `service_menu` mode and preserves safe `shop_id` and RLS patterns.

### Description
- Update the guided step copy for `service_menu` to ask: “Do you want to set up service menu items, canned jobs, or common repairs now?”.
- Add `ServiceMenuOnboardingSetupCard` (query helper + component) that renders only when the guided query resolves for `service_menu`, explains manual setup, provides CTA to focus the existing create area, and posts complete/skip to the guided endpoints.
- Wire the real `/menu` page to parse guided onboarding params, mount the new onboarding card only in onboarding mode, and add a focusable anchor for the existing “Create menu item” area so the card can scroll/focus it.
- Add tests that assert the destination URL/query params, onboarding-only rendering, focus CTA behavior, complete and skip POST payloads and return routing, and update the registry/query tests accordingly.

### Testing
- Ran unit tests: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/customer-onboarding-card.test.tsx tests/onboarding-v2/vehicle-onboarding-card.test.tsx tests/onboarding-v2/staff-onboarding-card.test.tsx tests/onboarding-v2/settings-onboarding-card.test.tsx tests/onboarding-v2/inspection-templates-onboarding-card.test.tsx tests/onboarding-v2/service-menu-onboarding-card.test.tsx` and all tests passed (7 files, 32 tests).
- Type check: `npx tsc --noEmit` completed without errors.
- Lint and git checks: `npx eslint` on touched files and `git diff --check` ran and reported no issues.
- Changed files: `app/menu/page.tsx`, `features/onboarding-v2/guided/steps.ts`, new `features/menu/components/ServiceMenuOnboardingSetupCard.tsx`, updated `tests/onboarding-v2/guided-registry-and-query.test.ts`, and new `tests/onboarding-v2/service-menu-onboarding-card.test.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f85277288328a408db9282cb8b55)