### PR TITLE
Add customer CSV import to guided onboarding customers page

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -1,0 +1,230 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type CustomerInsert = DB["public"]["Tables"]["customers"]["Insert"];
+type CustomerUpdate = DB["public"]["Tables"]["customers"]["Update"];
+type CustomerMatch = Pick<DB["public"]["Tables"]["customers"]["Row"], "id">;
+
+type ImportRow = {
+  first_name?: unknown;
+  last_name?: unknown;
+  name?: unknown;
+  company_name?: unknown;
+  business_name?: unknown;
+  email?: unknown;
+  phone?: unknown;
+  phone_number?: unknown;
+  address?: unknown;
+  street?: unknown;
+  city?: unknown;
+  province?: unknown;
+  state?: unknown;
+  postal_code?: unknown;
+  zip?: unknown;
+  notes?: unknown;
+};
+
+type Counts = {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function cleanString(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+
+function cleanEmail(value: unknown): string | null {
+  return cleanString(value)?.toLowerCase() ?? null;
+}
+
+function cleanPhone(value: unknown): string | null {
+  const raw = cleanString(value);
+  if (!raw) return null;
+  const digits = raw.replace(/\D/g, "");
+  return digits || raw;
+}
+
+function splitName(name: string | null): { firstName: string | null; lastName: string | null } {
+  if (!name) return { firstName: null, lastName: null };
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: null, lastName: null };
+  if (parts.length === 1) return { firstName: parts[0], lastName: null };
+  return { firstName: parts.slice(0, -1).join(" "), lastName: parts.at(-1) ?? null };
+}
+
+function escapeOrValue(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll(",", "\\,").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+function normalizeRow(row: ImportRow, userId: string, shopId: string): CustomerInsert | null {
+  const businessName = cleanString(row.business_name) ?? cleanString(row.company_name);
+  const explicitName = cleanString(row.name);
+  const split = splitName(explicitName);
+  const firstName = cleanString(row.first_name) ?? split.firstName;
+  const lastName = cleanString(row.last_name) ?? split.lastName;
+  const email = cleanEmail(row.email);
+  const phone = cleanPhone(row.phone) ?? cleanPhone(row.phone_number);
+  const personName = [firstName, lastName].filter(Boolean).join(" ").trim();
+  const displayName = businessName ?? explicitName ?? (personName || null);
+
+  if (!displayName && !email && !phone) return null;
+
+  return {
+    shop_id: shopId,
+    user_id: userId,
+    is_fleet: Boolean(businessName),
+    business_name: businessName,
+    name: displayName,
+    first_name: firstName,
+    last_name: lastName,
+    email,
+    phone,
+    phone_number: phone,
+    address: cleanString(row.address) ?? cleanString(row.street),
+    street: cleanString(row.street) ?? cleanString(row.address),
+    city: cleanString(row.city),
+    province: cleanString(row.province) ?? cleanString(row.state),
+    postal_code: cleanString(row.postal_code) ?? cleanString(row.zip),
+    notes: cleanString(row.notes),
+    import_notes: "Imported from Customers CSV import.",
+  };
+}
+
+async function findExistingCustomer(
+  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  shopId: string,
+  customer: CustomerInsert,
+): Promise<CustomerMatch | null> {
+  if (customer.email) {
+    const { data } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("shop_id", shopId)
+      .eq("email", customer.email)
+      .maybeSingle<CustomerMatch>();
+    if (data?.id) return data;
+  }
+
+  const phone = customer.phone ?? customer.phone_number;
+  if (phone) {
+    const { data } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("shop_id", shopId)
+      .or(`phone.eq.${escapeOrValue(phone)},phone_number.eq.${escapeOrValue(phone)}`)
+      .maybeSingle<CustomerMatch>();
+    if (data?.id) return data;
+  }
+
+  if (customer.name) {
+    const { data } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("shop_id", shopId)
+      .eq("name", customer.name)
+      .maybeSingle<CustomerMatch>();
+    if (data?.id) return data;
+  }
+
+  return null;
+}
+
+function updatePayload(customer: CustomerInsert): CustomerUpdate {
+  const update: CustomerUpdate = { updated_at: new Date().toISOString() };
+  for (const key of [
+    "business_name",
+    "name",
+    "first_name",
+    "last_name",
+    "email",
+    "phone",
+    "phone_number",
+    "address",
+    "street",
+    "city",
+    "province",
+    "postal_code",
+    "notes",
+    "import_notes",
+  ] as const) {
+    const value = customer[key];
+    if (value != null && value !== "") update[key] = value;
+  }
+  return update;
+}
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user?.id) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null }>();
+
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ ok: false, error: "Missing shop" }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => null)) as unknown;
+  if (!isRecord(body) || !Array.isArray(body.rows)) {
+    return NextResponse.json({ ok: false, error: "Invalid customer import payload" }, { status: 400 });
+  }
+
+  const counts: Counts = { created: 0, updated: 0, skipped: 0, failed: 0 };
+  const shopId = profile.shop_id;
+  const inputRows = body.rows.slice(0, 1000);
+
+  for (const rawRow of inputRows) {
+    if (!isRecord(rawRow)) {
+      counts.skipped += 1;
+      continue;
+    }
+
+    const customer = normalizeRow(rawRow as ImportRow, user.id, shopId);
+    if (!customer) {
+      counts.skipped += 1;
+      continue;
+    }
+
+    try {
+      const existing = await findExistingCustomer(supabase, shopId, customer);
+      if (existing?.id) {
+        const { error } = await supabase
+          .from("customers")
+          .update(updatePayload(customer))
+          .eq("shop_id", shopId)
+          .eq("id", existing.id);
+        if (error) counts.failed += 1;
+        else counts.updated += 1;
+        continue;
+      }
+
+      const { error } = await supabase.from("customers").insert(customer);
+      if (error) counts.failed += 1;
+      else counts.created += 1;
+    } catch {
+      counts.failed += 1;
+    }
+  }
+
+  return NextResponse.json({ ok: true, counts });
+}

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
-import { CustomerOnboardingSetupCard } from "@/features/customers/components/CustomerOnboardingSetupCard";
+import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
 import { VehicleOnboardingSetupCard } from "@/features/customers/components/VehicleOnboardingSetupCard";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
@@ -1192,17 +1192,15 @@ export default function CustomerProfilePage(): JSX.Element {
       <PageShell>
         <TopBar rightLabel="Customers" onBack={() => router.back()} />
 
-        {guidedCustomerOnboarding ? (
-          <div className="mb-4">
-            <CustomerOnboardingSetupCard
-              guidedQuery={guidedCustomerOnboarding}
-              onCreateCustomer={() => {
-                setCreateCustomerError(null);
-                setCreateCustomerOpen(true);
-              }}
-            />
-          </div>
-        ) : null}
+        <div className="mb-4">
+          <CustomerCsvImportCard
+            guidedQuery={guidedCustomerOnboarding}
+            onCreateCustomer={() => {
+              setCreateCustomerError(null);
+              setCreateCustomerOpen(true);
+            }}
+          />
+        </div>
 
         {guidedVehicleOnboarding ? (
           <div className="mb-4">

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import React, { useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Papa from "papaparse";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+type CustomerImportRow = {
+  first_name?: string | null;
+  last_name?: string | null;
+  name?: string | null;
+  company_name?: string | null;
+  business_name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  phone_number?: string | null;
+  address?: string | null;
+  street?: string | null;
+  city?: string | null;
+  province?: string | null;
+  state?: string | null;
+  postal_code?: string | null;
+  zip?: string | null;
+  notes?: string | null;
+};
+
+type ImportCounts = {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+};
+
+type ImportResponse = {
+  ok?: boolean;
+  error?: string;
+  counts?: ImportCounts;
+};
+
+type Props = {
+  guidedQuery?: GuidedOnboardingQuery | null;
+  onCreateCustomer?: () => void;
+};
+
+const SUPPORTED_COLUMNS = [
+  "first_name",
+  "last_name",
+  "name",
+  "company_name",
+  "business_name",
+  "email",
+  "phone",
+  "phone_number",
+  "address",
+  "street",
+  "city",
+  "province",
+  "state",
+  "postal_code",
+  "zip",
+  "notes",
+] as const;
+
+const RECOMMENDED_COLUMNS = "first_name, last_name, email, phone, address, city, province/state, postal_code/zip";
+
+function cleanHeader(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, "");
+}
+
+function cleanCell(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+
+function normalizeParsedRow(row: Record<string, unknown>): CustomerImportRow {
+  const normalized: CustomerImportRow = {};
+  for (const [header, value] of Object.entries(row)) {
+    const key = cleanHeader(header) as keyof CustomerImportRow;
+    if ((SUPPORTED_COLUMNS as readonly string[]).includes(key)) {
+      normalized[key] = cleanCell(value);
+    }
+  }
+  return normalized;
+}
+
+function hasImportableIdentity(row: CustomerImportRow): boolean {
+  return Boolean(
+    row.email ||
+      row.phone ||
+      row.phone_number ||
+      row.name ||
+      row.company_name ||
+      row.business_name ||
+      row.first_name ||
+      row.last_name,
+  );
+}
+
+function displayName(row: CustomerImportRow): string {
+  return (
+    row.company_name ||
+    row.business_name ||
+    row.name ||
+    [row.first_name, row.last_name].filter(Boolean).join(" ").trim() ||
+    row.email ||
+    row.phone ||
+    row.phone_number ||
+    "—"
+  );
+}
+
+export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<CustomerImportRow[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [counts, setCounts] = useState<ImportCounts | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [completingOnboarding, setCompletingOnboarding] = useState(false);
+  const [busyAction, setBusyAction] = useState<"skip" | "manual-complete" | null>(null);
+
+  const isOnboarding = Boolean(guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "customers");
+  const importableRows = useMemo(() => rows.filter(hasImportableIdentity), [rows]);
+  const skippedPreviewCount = rows.length - importableRows.length;
+  const previewRows = importableRows.slice(0, 5);
+  const importSucceeded = Boolean(counts && counts.created + counts.updated > 0 && counts.failed === 0);
+
+  function resetImportState() {
+    setRows([]);
+    setHeaders([]);
+    setCounts(null);
+    setParseError(null);
+    setImportError(null);
+  }
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    resetImportState();
+    if (!file) {
+      setFileName(null);
+      return;
+    }
+    setFileName(file.name);
+    if (!file.name.toLowerCase().endsWith(".csv")) {
+      setParseError("Please choose a .csv file.");
+      return;
+    }
+
+    Papa.parse<Record<string, unknown>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (results) => {
+        const parsedRows = (results.data ?? []).map(normalizeParsedRow).filter((row) => Object.keys(row).length > 0);
+        setHeaders((results.meta.fields ?? []).map(cleanHeader).filter(Boolean));
+        setRows(parsedRows);
+        if (!parsedRows.length) {
+          setParseError("No customer rows were found in that CSV.");
+        }
+      },
+      error: (error) => {
+        setParseError(error.message || "Unable to parse that CSV file.");
+      },
+    });
+  }
+
+  async function completeOnboardingAfterImport(nextCounts: ImportCounts) {
+    if (!guidedQuery) return;
+    setCompletingOnboarding(true);
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/customers/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ summary: { importType: "customer_csv", ...nextCounts } }),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Customer import succeeded, but onboarding completion failed.");
+      }
+    } finally {
+      setCompletingOnboarding(false);
+    }
+  }
+
+  async function confirmImport() {
+    if (!importableRows.length) {
+      setImportError("Upload a CSV with at least one customer name, company, email, or phone before importing.");
+      return;
+    }
+    setImporting(true);
+    setImportError(null);
+    setCounts(null);
+    try {
+      const response = await fetch("/api/customers/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows: importableRows }),
+      });
+      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      if (!response.ok || payload.ok === false || !payload.counts) {
+        throw new Error(payload.error ?? "Unable to import customers.");
+      }
+      setCounts(payload.counts);
+      if (isOnboarding && payload.counts.created + payload.counts.updated > 0 && payload.counts.failed === 0) {
+        await completeOnboardingAfterImport(payload.counts);
+      }
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : "Unable to import customers.");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  async function postSecondaryOnboardingAction(action: "skip" | "manual-complete") {
+    if (!guidedQuery) return;
+    const endpointAction = action === "skip" ? "skip" : "complete";
+    setBusyAction(action);
+    setImportError(null);
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/customers/${endpointAction}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            action === "skip"
+              ? { skippedReason: "Customer import skipped during onboarding." }
+              : { summary: { manualSetup: true, importedCount: 0, note: "Customer setup step completed manually after reviewing import option." } },
+          ),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.error ?? "Unable to update the customers onboarding step.");
+      }
+      router.push(guidedQuery!.returnTo);
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : "Unable to update the customers onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const content = (
+    <section
+      data-testid="customer-csv-import-card"
+      className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.13),rgba(15,23,42,0.92)_36%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">
+            {isOnboarding ? "Guided onboarding · Customers" : "Customer files"}
+          </div>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            {isOnboarding ? "Upload your customer CSV here" : "Import customers"}
+          </h2>
+          <div className="mt-3 space-y-2 text-sm text-neutral-300">
+            {isOnboarding ? <p>This import lives on the Customers page so you can find it later.</p> : null}
+            <p>Upload a CSV, review the parsed customer preview, then explicitly confirm the import.</p>
+            <p>
+              Supported columns include <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>. Optional fields can be omitted.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+          <input ref={fileInputRef} data-testid="customer-csv-file-input" type="file" accept=".csv,text/csv" onChange={handleFileChange} className="sr-only" />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15"
+          >
+            Choose CSV file
+          </button>
+          {onCreateCustomer ? (
+            <button
+              type="button"
+              onClick={onCreateCustomer}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08]"
+            >
+              + Create customer
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <span className="font-semibold text-neutral-100">Selected file:</span> {fileName ?? "No CSV selected"}
+          </div>
+          {headers.length ? <div className="text-xs text-neutral-400">Detected {headers.length} columns</div> : null}
+        </div>
+        {parseError ? <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">{parseError}</div> : null}
+        {rows.length ? (
+          <div className="mt-3 grid gap-2 sm:grid-cols-3">
+            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2"><div className="text-lg font-semibold text-white">{rows.length}</div><div className="text-xs text-neutral-400">Rows parsed</div></div>
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2"><div className="text-lg font-semibold text-emerald-100">{importableRows.length}</div><div className="text-xs text-neutral-400">Ready to import</div></div>
+            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2"><div className="text-lg font-semibold text-amber-100">{skippedPreviewCount}</div><div className="text-xs text-neutral-400">Missing identity</div></div>
+          </div>
+        ) : null}
+      </div>
+
+      {previewRows.length ? (
+        <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
+          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Preview</div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[720px] text-left text-sm">
+              <thead className="text-xs uppercase tracking-[0.12em] text-neutral-500">
+                <tr>
+                  <th className="px-3 py-2">Customer</th><th className="px-3 py-2">Email</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">Location</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-neutral-200">
+                {previewRows.map((row, index) => (
+                  <tr key={`${displayName(row)}-${index}`}>
+                    <td className="px-3 py-2 font-medium text-white">{displayName(row)}</td>
+                    <td className="px-3 py-2">{row.email ?? "—"}</td>
+                    <td className="px-3 py-2">{row.phone ?? row.phone_number ?? "—"}</td>
+                    <td className="px-3 py-2">{[row.city, row.province ?? row.state].filter(Boolean).join(", ") || "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+
+      {counts ? (
+        <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
+          Import results: created {counts.created}, updated {counts.updated}, skipped {counts.skipped}, failed {counts.failed}.
+        </div>
+      ) : null}
+      {importError ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{importError}</div> : null}
+
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <button
+          type="button"
+          onClick={() => void confirmImport()}
+          disabled={importing || completingOnboarding || !importableRows.length}
+          className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
+        >
+          {importing ? "Importing…" : completingOnboarding ? "Completing onboarding…" : "Confirm import"}
+        </button>
+        {isOnboarding && counts ? (
+          <button
+            type="button"
+            onClick={() => router.push(guidedQuery!.returnTo)}
+            className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
+          >
+            {importSucceeded ? "Continue onboarding" : "Back to Data Onboarding"}
+          </button>
+        ) : null}
+        {isOnboarding ? (
+          <>
+            <button
+              type="button"
+              onClick={() => void postSecondaryOnboardingAction("skip")}
+              disabled={busyAction !== null || importing || completingOnboarding}
+              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+            >
+              {busyAction === "skip" ? "Skipping…" : "Skip customers"}
+            </button>
+            <Link href={guidedQuery!.returnTo} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">
+              Back to Data Onboarding
+            </Link>
+            <button
+              type="button"
+              onClick={() => void postSecondaryOnboardingAction("manual-complete")}
+              disabled={busyAction !== null || importing || completingOnboarding}
+              className="rounded-xl border border-white/10 bg-transparent px-4 py-2 text-sm font-semibold text-neutral-300 hover:bg-white/[0.04] disabled:opacity-55"
+            >
+              {busyAction === "manual-complete" ? "Marking complete…" : "Mark complete manually"}
+            </button>
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+
+  if (!isOnboarding || !guidedQuery) return content;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Customer setup/import"
+      description="Upload your customer CSV on the real Customers page."
+    >
+      {content}
+    </OnboardingHighlightFrame>
+  );
+}

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -1,15 +1,86 @@
 import React from "react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { CustomerOnboardingSetupCard } from "@/features/customers/components/CustomerOnboardingSetupCard";
+import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { POST as importCustomers } from "../../app/api/customers/import/route";
 
-const router = { push: vi.fn() };
+const { router, mockSupabaseState } = vi.hoisted(() => ({
+  router: { push: vi.fn(), back: vi.fn() },
+  mockSupabaseState: {
+    user: { id: "user-1" } as { id: string } | null,
+    profileShopId: "shop-real" as string | null,
+    customers: [] as Array<Record<string, unknown>>,
+    inserts: [] as Array<Record<string, unknown>>,
+    updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
+  },
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => router,
 }));
+
+type MockQuery = {
+  filters: Record<string, unknown>;
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+function makeQuery(table: string): MockQuery {
+  const query: MockQuery = {
+    filters: {} as Record<string, unknown>,
+    select: vi.fn(() => query),
+    eq: vi.fn((column: string, value: unknown) => {
+      query.filters[column] = value;
+      return query;
+    }),
+    or: vi.fn((value: string) => {
+      query.filters.or = value;
+      return query;
+    }),
+    maybeSingle: vi.fn(async () => {
+      if (table === "profiles") return { data: { shop_id: mockSupabaseState.profileShopId }, error: null };
+      const match: Record<string, unknown> | undefined = mockSupabaseState.customers.find((customer) => {
+        if (query.filters.email) return customer.email === query.filters.email && customer.shop_id === query.filters.shop_id;
+        if (query.filters.name) return customer.name === query.filters.name && customer.shop_id === query.filters.shop_id;
+        if (query.filters.or) return (customer.phone === "5551112222" || customer.phone_number === "5551112222") && customer.shop_id === query.filters.shop_id;
+        return false;
+      });
+      return { data: match ? { id: match.id } : null, error: null };
+    }),
+    insert: vi.fn(async (payload: Record<string, unknown>) => {
+      mockSupabaseState.inserts.push(payload);
+      return { data: null, error: null };
+    }),
+    update: vi.fn((payload: Record<string, unknown>) => {
+      const updateQuery: { eq: ReturnType<typeof vi.fn> } = {
+        eq: vi.fn((column: string, value: unknown) => {
+          query.filters[column] = value;
+          if (column === "id") mockSupabaseState.updates.push({ payload, filters: { ...query.filters } });
+          return updateQuery;
+        }),
+      };
+      return updateQuery;
+    }),
+  };
+  return query;
+}
+
+vi.mock("@supabase/auth-helpers-nextjs", () => ({
+  createRouteHandlerClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })),
+    },
+    from: vi.fn((table: string) => makeQuery(table)),
+  })),
+}));
+
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
 
 const guidedQuery: GuidedOnboardingQuery = {
   onboardingSession: "session-123",
@@ -23,60 +94,143 @@ function okJson() {
   return { ok: true, json: async () => ({ ok: true }) };
 }
 
-describe("CustomerOnboardingSetupCard", () => {
+async function uploadCsv(csv: string) {
+  const input = screen.getByTestId("customer-csv-file-input") as HTMLInputElement;
+  const file = new File([csv], "customers.csv", { type: "text/csv" });
+  await userEvent.upload(input, file);
+}
+
+describe("CustomerCsvImportCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSupabaseState.user = { id: "user-1" };
+    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.customers = [];
+    mockSupabaseState.inserts = [];
+    mockSupabaseState.updates = [];
   });
 
-  it("explains the placeholder customer import ownership and opens manual creation", async () => {
-    const onCreateCustomer = vi.fn();
-    render(<CustomerOnboardingSetupCard guidedQuery={guidedQuery} onCreateCustomer={onCreateCustomer} />);
+  it("renders the Customers-owned import card in normal mode", () => {
+    render(<CustomerCsvImportCard onCreateCustomer={vi.fn()} />);
 
-    expect(screen.getByText("This is where customer setup/import will live.")).toBeInTheDocument();
-    expect(screen.getByText("For now, you can create customers manually or mark this onboarding step complete.")).toBeInTheDocument();
-    expect(screen.getByText("CSV import will be added here next.")).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole("button", { name: /create customer/i }));
-    expect(onCreateCustomer).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("customer-csv-import-card")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Import customers" })).toBeInTheDocument();
+    expect(screen.queryByText("Back to Data Onboarding")).not.toBeInTheDocument();
   });
 
-  it("marks the customers guided step complete and returns to onboarding", async () => {
-    const fetchMock = vi.fn(async () => okJson());
+  it("highlights the Customers-owned import card in onboarding mode", () => {
+    render(<CustomerCsvImportCard guidedQuery={guidedQuery} onCreateCustomer={vi.fn()} />);
+
+    expect(screen.getByText("Customer setup/import")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Upload your customer CSV here" })).toBeInTheDocument();
+    expect(screen.getByText("This import lives on the Customers page so you can find it later.")).toBeInTheDocument();
+    expect(screen.getByText("Back to Data Onboarding")).toBeInTheDocument();
+  });
+
+  it("shows a CSV preview after selecting a valid CSV", async () => {
+    render(<CustomerCsvImportCard />);
+
+    await uploadCsv("first_name,last_name,email,phone\nAda,Lovelace,ada@example.com,(555) 111-2222\n");
+
+    expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Rows parsed")).toBeInTheDocument();
+  });
+
+  it("calls onboarding completion only after a successful onboarding import", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/customers/import") return { ok: true, json: async () => ({ ok: true, counts: { created: 1, updated: 0, skipped: 0, failed: 0 } }) };
+      return okJson();
+    });
     vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard guidedQuery={guidedQuery} />);
 
-    render(<CustomerOnboardingSetupCard guidedQuery={guidedQuery} onCreateCustomer={vi.fn()} />);
-    await userEvent.click(screen.getByRole("button", { name: /mark customers step complete/i }));
+    await uploadCsv("first_name,last_name,email\nAda,Lovelace,ada@example.com\n");
+    await userEvent.click(await screen.findByRole("button", { name: /confirm import/i }));
 
-    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
-    expect(fetchMock).toHaveBeenCalledWith(
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
       "/api/onboarding-v2/guided/sessions/session-123/steps/customers/complete",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          summary: {
-            manualSetup: true,
-            importedCount: 0,
-            note: "Customer setup step completed manually.",
-          },
-        }),
-      }),
-    );
+      expect.objectContaining({ method: "POST" }),
+    ));
   });
 
-  it("skips the customers guided step and returns to onboarding", async () => {
+  it("does not call onboarding completion in normal mode", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true, counts: { created: 1, updated: 0, skipped: 0, failed: 0 } }) }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard />);
+
+    await uploadCsv("first_name,last_name,email\nAda,Lovelace,ada@example.com\n");
+    await userEvent.click(await screen.findByRole("button", { name: /confirm import/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/api/onboarding-v2/"), expect.anything());
+  });
+
+  it("keeps skip customers available during onboarding", async () => {
     const fetchMock = vi.fn(async () => okJson());
     vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard guidedQuery={guidedQuery} />);
 
-    render(<CustomerOnboardingSetupCard guidedQuery={guidedQuery} onCreateCustomer={vi.fn()} />);
     await userEvent.click(screen.getByRole("button", { name: /skip customers/i }));
 
     await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/onboarding-v2/guided/sessions/session-123/steps/customers/skip",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ skippedReason: "No customer import during onboarding." }),
-      }),
+      expect.objectContaining({ method: "POST" }),
     );
+  });
+});
+
+describe("POST /api/customers/import", () => {
+  beforeEach(() => {
+    mockSupabaseState.user = { id: "user-1" };
+    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.customers = [];
+    mockSupabaseState.inserts = [];
+    mockSupabaseState.updates = [];
+  });
+
+  it("rejects unauthenticated imports", async () => {
+    mockSupabaseState.user = null;
+    const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects imports when the user has no shop", async () => {
+    mockSupabaseState.profileShopId = null;
+    const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("does not accept client shop_id and imports into the authenticated profile shop", async () => {
+    const response = await importCustomers(new Request("http://localhost/api/customers/import", {
+      method: "POST",
+      body: JSON.stringify({ rows: [{ first_name: "Ada", last_name: "Lovelace", email: "Ada@Example.com", shop_id: "evil-shop" }] }),
+    }));
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({ created: 1, updated: 0, skipped: 0, failed: 0 });
+    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1", email: "ada@example.com" });
+    expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
+  });
+
+  it("returns successful created and updated counts", async () => {
+    mockSupabaseState.customers = [{ id: "customer-1", shop_id: "shop-real", email: "existing@example.com" }];
+    const response = await importCustomers(new Request("http://localhost/api/customers/import", {
+      method: "POST",
+      body: JSON.stringify({ rows: [
+        { first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" },
+        { name: "Existing Customer", email: "existing@example.com", phone: "555-111-2222" },
+        { notes: "blank row" },
+      ] }),
+    }));
+    const payload = await response.json();
+
+    expect(payload).toMatchObject({ ok: true, counts: { created: 1, updated: 1, skipped: 1, failed: 0 } });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+    expect(mockSupabaseState.updates).toHaveLength(1);
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({ shop_id: "shop-real", id: "customer-1" });
   });
 });


### PR DESCRIPTION
### Motivation
- Replace the placeholder onboarding-only card with a real Customers-owned CSV import so imports live on the Customers page and work in both normal and guided onboarding flows.
- Ensure imports run with proper tenant scoping and explicit user confirmation rather than trusting client-provided `shop_id`.
- Keep onboarding flow controls (highlight, skip, manual-complete, return) while preferring actual import first.

### Description
- Added a reusable import UI `CustomerCsvImportCard` in `features/customers/components/CustomerCsvImportCard.tsx` that accepts `.csv`, parses with `papaparse`, shows parsed preview and counts, requires explicit `Confirm import`, and surfaces created/updated/skipped/failed results.
- Mounted the import card on the real Customers directory page at `features/customers/app/customers/[id]/page.tsx` so it appears in normal mode and receives guided onboarding query params (e.g. `onboardingSession`, `onboardingStep=customers`, `highlight=customer-import`).
- Implemented a safe server import endpoint `POST /api/customers/import` at `app/api/customers/import/route.ts` that requires authentication, derives `shop_id` from the authenticated profile, rejects missing shop, ignores any client `shop_id`, matches existing customers in-shop by `email` / `phone` / `name`, and returns import counts; inserts/updates are performed under the resolved shop scope.
- Wire up onboarding completion: in onboarding mode the card posts to `/api/onboarding-v2/guided/sessions/[sessionId]/steps/customers/complete` only after a successful explicit import; also retains secondary `Skip customers`, `Back to Data Onboarding`, and manual `Mark complete` actions.
- Tests: added/updated tests in `tests/onboarding-v2/customer-onboarding-card.test.tsx` to validate normal vs onboarding rendering, CSV preview, import API behavior (auth/shop enforcement), and onboarding completion only after import; kept `guided-registry` tests intact.

### Testing
- Ran targeted unit tests: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/customer-onboarding-card.test.tsx`, and all tests passed.
- Typecheck: `npx tsc --noEmit` completed successfully.
- Lint: `npx eslint features/customers/components features/customers/app/customers/[id]/page.tsx app/api/customers/import/route.ts` completed without reported errors.
- Basic repository checks: `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217d1f2f508328978ae159004c6939)