### PR TITLE
Fix parts CSV import guided onboarding flow

### DIFF
--- a/app/api/parts/import/route.ts
+++ b/app/api/parts/import/route.ts
@@ -1,0 +1,211 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type PartInsert = DB["public"]["Tables"]["parts"]["Insert"];
+type PartUpdate = DB["public"]["Tables"]["parts"]["Update"];
+
+type PartsImportRow = {
+  name?: unknown;
+  sku?: unknown;
+  partNumber?: unknown;
+  part_number?: unknown;
+  category?: unknown;
+  price?: unknown;
+  qty?: unknown;
+};
+
+type PartsImportBody = {
+  rows?: unknown;
+  defaultLocationId?: unknown;
+};
+
+function textValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === "") return undefined;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeRows(input: unknown): Array<{
+  name: string;
+  sku?: string;
+  partNumber?: string;
+  category?: string;
+  price?: number;
+  qty?: number;
+}> {
+  if (!Array.isArray(input)) return [];
+
+  return input
+    .map((raw): {
+      name: string;
+      sku?: string;
+      partNumber?: string;
+      category?: string;
+      price?: number;
+      qty?: number;
+    } | null => {
+      const row = raw as PartsImportRow;
+      const name = textValue(row.name);
+      if (!name) return null;
+
+      const price = numberValue(row.price);
+      const qty = numberValue(row.qty);
+
+      return {
+        name,
+        sku: textValue(row.sku),
+        partNumber: textValue(row.partNumber) ?? textValue(row.part_number),
+        category: textValue(row.category),
+        price: price !== undefined && price >= 0 ? price : undefined,
+        qty: qty !== undefined && qty > 0 ? qty : undefined,
+      };
+    })
+    .filter((row): row is NonNullable<typeof row> => Boolean(row));
+}
+
+async function applyCsvReceive(
+  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  args: { partId: string; locationId: string; qty: number },
+): Promise<void> {
+  const { error } = await supabase.rpc("apply_stock_move", {
+    p_part: args.partId,
+    p_loc: args.locationId,
+    p_qty: args.qty,
+    p_reason: "receive",
+    p_ref_kind: "csv_import",
+    p_ref_id: null,
+  } as unknown as DB["public"]["Functions"]["apply_stock_move"]["Args"]);
+
+  if (error) throw new Error(error.message);
+}
+
+export async function POST(req: Request) {
+  try {
+    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError) return NextResponse.json({ error: userError.message }, { status: 401 });
+    if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (profileError) return NextResponse.json({ error: profileError.message }, { status: 500 });
+
+    const shopId = typeof profile?.shop_id === "string" ? profile.shop_id : "";
+    if (!shopId) return NextResponse.json({ error: "No shop is associated with this user" }, { status: 403 });
+
+    const body = (await req.json().catch(() => null)) as PartsImportBody | null;
+    const rows = normalizeRows(body?.rows);
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "No valid part rows to import" }, { status: 400 });
+    }
+
+    const requestedLocationId = textValue(body?.defaultLocationId) ?? "";
+    let defaultLocationId = "";
+    if (requestedLocationId) {
+      const { data: location, error: locationError } = await supabase
+        .from("stock_locations")
+        .select("id")
+        .eq("shop_id", shopId)
+        .eq("id", requestedLocationId)
+        .maybeSingle();
+
+      if (locationError) return NextResponse.json({ error: locationError.message }, { status: 500 });
+      if (!location?.id) return NextResponse.json({ error: "Default receive location is not available for this shop" }, { status: 400 });
+      defaultLocationId = String(location.id);
+    }
+
+    const errors: Array<{ row: number; message: string }> = [];
+    let importedCount = 0;
+    let createdCount = 0;
+    let updatedCount = 0;
+    let stockReceiveCount = 0;
+
+    for (const [index, row] of rows.entries()) {
+      try {
+        let partId: string | null = null;
+
+        if (row.sku) {
+          const { data: found, error: findError } = await supabase
+            .from("parts")
+            .select("id")
+            .eq("shop_id", shopId)
+            .eq("sku", row.sku)
+            .maybeSingle();
+
+          if (findError) throw new Error(findError.message);
+          if (found?.id) partId = String(found.id);
+        }
+
+        if (!partId) {
+          const insert: PartInsert = {
+            shop_id: shopId,
+            name: row.name,
+            sku: row.sku ?? null,
+            part_number: row.partNumber ?? null,
+            category: row.category ?? null,
+            price: row.price ?? null,
+          };
+          const { data: created, error: insertError } = await supabase.from("parts").insert(insert).select("id").single();
+          if (insertError) throw new Error(insertError.message);
+          partId = String(created?.id ?? "");
+          createdCount += 1;
+        } else {
+          const patch: PartUpdate = {
+            name: row.name,
+            sku: row.sku ?? null,
+            part_number: row.partNumber ?? null,
+            category: row.category ?? null,
+            price: row.price ?? null,
+          };
+          const { error: updateError } = await supabase.from("parts").update(patch).eq("shop_id", shopId).eq("id", partId);
+          if (updateError) throw new Error(updateError.message);
+          updatedCount += 1;
+        }
+
+        importedCount += 1;
+
+        if (partId && defaultLocationId && row.qty) {
+          await applyCsvReceive(supabase, { partId, locationId: defaultLocationId, qty: row.qty });
+          stockReceiveCount += 1;
+        }
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Import failed for this row";
+        errors.push({ row: index + 1, message });
+      }
+    }
+
+    if (importedCount === 0) {
+      return NextResponse.json({ error: "No rows were imported", errors }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      counts: {
+        importedCount,
+        createdCount,
+        updatedCount,
+        stockReceiveCount,
+        failedCount: errors.length,
+      },
+      errors,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -1,7 +1,7 @@
 // app/parts/inventory/page.tsx
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
@@ -71,6 +71,7 @@ function Modal(props: {
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        aria-label={title}
       >
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-lg font-semibold">{title}</h2>
@@ -330,10 +331,13 @@ export default function InventoryPage(): JSX.Element {
   const [csvOpen, setCsvOpen] = useState<boolean>(false);
   const [csvText, setCsvText] = useState<string>("");
   const [csvRows, setCsvRows] = useState<
-    { name: string; sku?: string; category?: string; price?: number; qty?: number }[]
+    { name: string; sku?: string; partNumber?: string; category?: string; price?: number; qty?: number }[]
   >([]);
   const [csvPreview, setCsvPreview] = useState<boolean>(false);
   const [csvDefaultLoc, setCsvDefaultLoc] = useState<string>("");
+  const [csvError, setCsvError] = useState<string>("");
+  const [csvImporting, setCsvImporting] = useState<boolean>(false);
+  const [csvImportResult, setCsvImportResult] = useState<{ importedCount: number; stockReceiveCount: number } | null>(null);
 
   // ---- Theme (glass + neutral accent styling) ----
   const ACCENT_TEXT = "text-[var(--theme-text-primary,#E2E8F0)]";
@@ -679,11 +683,12 @@ export default function InventoryPage(): JSX.Element {
       name: header.indexOf("name"),
       sku: header.indexOf("sku"),
       category: header.indexOf("category"),
+      partNumber: header.indexOf("part_number") >= 0 ? header.indexOf("part_number") : header.indexOf("part number"),
       price: header.indexOf("price"),
       qty: header.indexOf("qty"),
     };
 
-    const out: { name: string; sku?: string; category?: string; price?: number; qty?: number }[] = [];
+    const out: { name: string; sku?: string; partNumber?: string; category?: string; price?: number; qty?: number }[] = [];
 
     for (let r = 1; r < rows.length; r++) {
       const row = rows[r];
@@ -693,6 +698,7 @@ export default function InventoryPage(): JSX.Element {
 
       const sku = idx.sku >= 0 ? (row[idx.sku] ?? "").trim() : "";
       const category = idx.category >= 0 ? (row[idx.category] ?? "").trim() : "";
+      const partNumber = idx.partNumber >= 0 ? (row[idx.partNumber] ?? "").trim() : "";
       const priceStr = idx.price >= 0 ? (row[idx.price] ?? "").trim() : "";
       const qtyStr = idx.qty >= 0 ? (row[idx.qty] ?? "").trim() : "";
 
@@ -702,6 +708,7 @@ export default function InventoryPage(): JSX.Element {
       out.push({
         name,
         sku: sku || undefined,
+        partNumber: partNumber || undefined,
         category: category || undefined,
         price: Number.isFinite(priceNum) ? priceNum : undefined,
         qty: Number.isFinite(qtyNum) ? qtyNum : undefined,
@@ -710,100 +717,76 @@ export default function InventoryPage(): JSX.Element {
 
     setCsvRows(out);
     setCsvPreview(true);
+    setCsvImportResult(null);
+    setCsvError(out.length ? "" : "No importable rows found. Include a name column with at least one value.");
   };
 
   const handleCsvFile = async (file: File) => {
+    setCsvError("");
+    setCsvImportResult(null);
     const text = await file.text();
     setCsvText(text);
     parseAndPreviewCSV(text);
   };
 
-  const runCsvImport = async () => {
-    if (!shopId || !csvRows.length) return;
-
-    let importedCount = 0;
-    let stockReceiveCount = 0;
-
-    // NOTE: intentionally sequential to keep it safe and predictable for now.
-    for (const row of csvRows) {
-      let partId: string | null = null;
-
-      if (row.sku) {
-        const { data: found } = await supabase
-          .from("parts")
-          .select("id")
-          .eq("shop_id", shopId)
-          .eq("sku", row.sku)
-          .maybeSingle();
-
-        if (found?.id) partId = String(found.id);
-      }
-
-      if (!partId) {
-        const id = uuidv4();
-        const insert: PartInsert = {
-          id,
-          shop_id: shopId,
-          name: row.name,
-          sku: row.sku || undefined,
-          category: row.category || undefined,
-          price: typeof row.price === "number" ? row.price : undefined,
-        };
-        const { error } = await supabase.from("parts").insert(insert);
-        if (error) {
-          // eslint-disable-next-line no-console
-          console.warn("Insert failed:", row, error.message);
-          continue;
-        }
-        importedCount += 1;
-        partId = id;
-      } else {
-        const patch: PartUpdate = {
-          name: row.name || undefined,
-          sku: row.sku || undefined,
-          category: row.category || undefined,
-          price: typeof row.price === "number" ? row.price : undefined,
-        };
-        await supabase.from("parts").update(patch).eq("id", partId);
-        importedCount += 1;
-      }
-
-      if (partId && csvDefaultLoc && typeof row.qty === "number" && row.qty > 0) {
-        try {
-          await applyStockMoveRPC(supabase, {
-            p_part: partId,
-            p_loc: csvDefaultLoc,
-            p_qty: row.qty,
-            p_reason: "receive",
-            p_ref_kind: "csv_import",
-            p_ref_id: null,
-          });
-          stockReceiveCount += 1;
-        } catch (err: unknown) {
-          // eslint-disable-next-line no-console
-          console.warn("Stock receive failed for row:", row, errMsg(err));
-        }
-      }
-    }
-
-    setCsvOpen(false);
+  const resetCsvImportState = () => {
     setCsvPreview(false);
     setCsvText("");
     setCsvRows([]);
-    await load(shopId);
+    setCsvError("");
+    setCsvImportResult(null);
+  };
 
-    if (guidedOnboarding?.onboardingStep === "inventory_parts") {
-      await fetch(
-        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedOnboarding.onboardingSession)}/steps/inventory_parts/complete`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ summary: { importedCount, stockReceiveCount, source: "parts-csv-import" } }),
-        },
-      ).catch((err: unknown) => {
-        // eslint-disable-next-line no-console
-        console.warn("Guided onboarding completion callback failed:", errMsg(err));
+  const runCsvImport = async () => {
+    if (!csvRows.length || csvImporting) return;
+
+    setCsvError("");
+    setCsvImportResult(null);
+    setCsvImporting(true);
+
+    try {
+      const response = await fetch("/api/parts/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows: csvRows, defaultLocationId: csvDefaultLoc || undefined }),
       });
+      const payload = (await response.json().catch(() => null)) as {
+        counts?: { importedCount?: number; stockReceiveCount?: number };
+        error?: string;
+      } | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "CSV import failed");
+      }
+
+      const importedCount = Number(payload?.counts?.importedCount ?? 0);
+      const stockReceiveCount = Number(payload?.counts?.stockReceiveCount ?? 0);
+
+      setCsvImportResult({ importedCount, stockReceiveCount });
+      setCsvPreview(false);
+      setCsvText("");
+      setCsvRows([]);
+
+      if (shopId) await load(shopId);
+
+      if (guidedOnboarding?.onboardingStep === "inventory_parts") {
+        const completeResponse = await fetch(
+          `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedOnboarding.onboardingSession)}/steps/inventory_parts/complete`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ summary: { importedCount, stockReceiveCount, source: "parts-csv-import" } }),
+          },
+        );
+
+        if (!completeResponse.ok) {
+          setCsvError("Import succeeded, but guided onboarding was not marked complete. Use Return to Data Onboarding to continue.");
+        }
+      }
+    } catch (err: unknown) {
+      setCsvError(errMsg(err));
+    } finally {
+      setCsvImporting(false);
     }
   };
 
@@ -867,7 +850,15 @@ export default function InventoryPage(): JSX.Element {
                 title="Import inventory parts"
                 description="Open CSV Import, review the preview, then import. ProFixIQ will mark this guided step complete only after you explicitly import."
               >
-                <button className={btnBlue} onClick={() => setCsvOpen(true)} disabled={!shopId}>
+                <button
+                  className={btnBlue}
+                  onClick={() => {
+                    setCsvError("");
+                    setCsvImportResult(null);
+                    setCsvOpen(true);
+                  }}
+                  disabled={!shopId}
+                >
                   CSV Import
                 </button>
               </OnboardingHighlightFrame>
@@ -1131,7 +1122,7 @@ export default function InventoryPage(): JSX.Element {
       {/* CSV Import */}
       <Modal
         open={csvOpen}
-        title="CSV Import"
+        title="Import inventory parts from CSV"
         onClose={() => setCsvOpen(false)}
         widthClass="max-w-3xl"
         footer={
@@ -1155,20 +1146,18 @@ export default function InventoryPage(): JSX.Element {
               <button
                 className={btnGhost}
                 onClick={() => {
-                  setCsvPreview(false);
-                  setCsvText("");
-                  setCsvRows([]);
+                  resetCsvImportState();
                   setCsvOpen(false);
                 }}
               >
-                Close
+                Cancel
               </button>
               <button
                 className={btnBlue}
                 onClick={runCsvImport}
-                disabled={!csvPreview || csvRows.length === 0}
+                disabled={!csvPreview || csvRows.length === 0 || csvImporting}
               >
-                Import
+                {csvImporting ? "Importing…" : "Confirm import"}
               </button>
             </div>
           </div>
@@ -1176,27 +1165,33 @@ export default function InventoryPage(): JSX.Element {
       >
         <div className="grid gap-3">
           <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-sm text-neutral-300">
-            Expected headers (case-insensitive): <code className={ACCENT_TEXT}>name, sku, category, price, qty</code>.
-            Extra columns are ignored.
+            Expected headers (case-insensitive): <code className={ACCENT_TEXT}>name, sku, part_number, category, price, qty</code>.
+            Choose a CSV file or paste CSV text, preview rows, then explicitly confirm import. Extra columns are ignored.
           </div>
 
-          <div className="flex flex-wrap items-center gap-2">
-            <input
-              type="file"
-              accept=".csv,text/csv"
-              onChange={(e) => {
-                const f = e.target.files?.[0];
-                if (f) void handleCsvFile(f);
-              }}
-              className="text-sm text-neutral-200"
-            />
+          <div className="flex flex-wrap items-end gap-3">
+            <label className="grid gap-1 text-xs font-semibold text-neutral-300">
+              Upload CSV file
+              <input
+                data-testid="parts-csv-file-input"
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) void handleCsvFile(f);
+                }}
+                className="text-sm text-neutral-200 file:mr-3 file:rounded-lg file:border file:border-[color:var(--desktop-border)] file:bg-[color:var(--desktop-item-bg)] file:px-3 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-white/5"
+              />
+            </label>
             <button
               className={btnGhost}
               onClick={() => {
+                setCsvError("");
                 if (csvText.trim().length) parseAndPreviewCSV(csvText);
+                else setCsvError("Paste CSV text or choose a CSV file before previewing.");
               }}
             >
-              Parse text
+              Preview CSV
             </button>
           </div>
 
@@ -1204,21 +1199,42 @@ export default function InventoryPage(): JSX.Element {
             rows={8}
             className={`${inputBase} font-mono text-xs`}
             placeholder={`Paste CSV here… e.g.:
-name,sku,category,price,qty
-Oil Filter – Ford,OF-FORD-01,Filters,9.95,10
-Spark Plug – Iridium,SP-IR-01,Ignition,9.95,24
+name,sku,part_number,category,price,qty
+Oil Filter – Ford,OF-FORD-01,FL-400S,Filters,9.95,10
+Spark Plug – Iridium,SP-IR-01,SP-IR,Ignition,9.95,24
 `}
             value={csvText}
             onChange={(e) => setCsvText(e.target.value)}
           />
 
+          {csvError ? (
+            <div role="alert" className="rounded-xl border border-red-500/30 bg-red-950/30 p-3 text-sm text-red-100">
+              {csvError}
+            </div>
+          ) : null}
+
+          {csvImportResult ? (
+            <div className="rounded-xl border border-emerald-500/30 bg-emerald-950/25 p-3 text-sm text-emerald-100">
+              Imported {csvImportResult.importedCount} part row(s) successfully
+              {csvImportResult.stockReceiveCount ? ` and received stock for ${csvImportResult.stockReceiveCount} row(s)` : ""}.
+              {guidedOnboarding?.onboardingStep === "inventory_parts" ? (
+                <div className="mt-3">
+                  <Link className={btnCopper} href={guidedOnboarding.returnTo}>
+                    Return to Data Onboarding
+                  </Link>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
           {csvPreview && (
-            <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
+            <div aria-label="CSV import preview" className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
               <table className="w-full text-sm">
                 <thead className="bg-white/5 text-left text-neutral-400">
                   <tr>
                     <th className="p-3">Name</th>
                     <th className="p-3">SKU</th>
+                    <th className="p-3">Part #</th>
                     <th className="p-3">Category</th>
                     <th className="p-3">Price</th>
                     <th className="p-3">Qty</th>
@@ -1229,6 +1245,7 @@ Spark Plug – Iridium,SP-IR-01,Ignition,9.95,24
                     <tr key={i} className="border-t border-[color:var(--desktop-border)]">
                       <td className="p-3">{r.name}</td>
                       <td className="p-3">{r.sku ?? "—"}</td>
+                      <td className="p-3">{r.partNumber ?? "—"}</td>
                       <td className="p-3">{r.category ?? "—"}</td>
                       <td className="p-3 tabular-nums">
                         {typeof r.price === "number" ? r.price.toFixed(2) : "—"}

--- a/tests/onboarding-v2/parts-inventory-import-page.test.tsx
+++ b/tests/onboarding-v2/parts-inventory-import-page.test.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InventoryPage from "../../app/parts/inventory/page";
+
+const { searchParamsState, mockSupabaseState } = vi.hoisted(() => ({
+  searchParamsState: { params: new URLSearchParams() },
+  mockSupabaseState: {
+    user: { id: "user-1" } as { id: string } | null,
+    profileShopId: "shop-1" as string | null,
+    locations: [{ id: "loc-1", shop_id: "shop-1", code: "MAIN", name: "Main" }] as Array<Record<string, unknown>>,
+    parts: [] as Array<Record<string, unknown>>,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsState.params,
+}));
+
+vi.mock("uuid", () => ({ v4: () => "part-generated" }));
+
+type MockQuery = {
+  filters: Record<string, unknown>;
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  then: (resolve: (value: { data: unknown; error: null }) => unknown) => Promise<unknown>;
+};
+
+function rowsFor(table: string): unknown[] {
+  if (table === "parts") return mockSupabaseState.parts;
+  if (table === "stock_locations") return mockSupabaseState.locations;
+  if (table === "stock_moves") return [];
+  if (table === "shop_parts_source_aliases") return [];
+  if (table === "shop_parts_import_staging") return [];
+  return [];
+}
+
+function makeQuery(table: string): MockQuery {
+  const query: MockQuery = {
+    filters: {},
+    select: vi.fn(() => query),
+    eq: vi.fn((column: string, value: unknown) => {
+      query.filters[column] = value;
+      return query;
+    }),
+    in: vi.fn((column: string, value: unknown) => {
+      query.filters[column] = value;
+      return query;
+    }),
+    order: vi.fn(() => query),
+    or: vi.fn(() => query),
+    maybeSingle: vi.fn(async () => {
+      if (table === "profiles") return { data: { shop_id: mockSupabaseState.profileShopId }, error: null };
+      return { data: null, error: null };
+    }),
+    insert: vi.fn(() => query),
+    update: vi.fn(() => query),
+    then: (resolve) => Promise.resolve(resolve({ data: rowsFor(table), error: null })),
+  };
+  return query;
+}
+
+vi.mock("@supabase/auth-helpers-nextjs", () => ({
+  createClientComponentClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })),
+    },
+    from: vi.fn((table: string) => makeQuery(table)),
+    rpc: vi.fn(async () => ({ data: null, error: null })),
+  })),
+}));
+
+function setGuidedParams() {
+  searchParamsState.params = new URLSearchParams({
+    onboardingSession: "session-123",
+    onboardingStep: "inventory_parts",
+    highlight: "parts-csv-import",
+    returnTo: "/dashboard/onboarding-v2/session-123",
+    source: "guided-onboarding",
+  });
+}
+
+async function openAndPreviewCsv(csv = "name,sku,part_number,category,price,qty\nOil Filter,OF-1,FL-1,Filters,9.95,10\n") {
+  await userEvent.click(await screen.findByRole("button", { name: "CSV Import" }));
+  expect(screen.getByRole("dialog", { name: "Import inventory parts from CSV" })).toBeInTheDocument();
+  await userEvent.type(screen.getByPlaceholderText(/Paste CSV here/i), csv);
+  await userEvent.click(screen.getByRole("button", { name: "Preview CSV" }));
+  expect(await screen.findByLabelText("CSV import preview")).toBeInTheDocument();
+}
+
+describe("Parts inventory CSV import page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    searchParamsState.params = new URLSearchParams();
+    mockSupabaseState.user = { id: "user-1" };
+    mockSupabaseState.profileShopId = "shop-1";
+    mockSupabaseState.locations = [{ id: "loc-1", shop_id: "shop-1", code: "MAIN", name: "Main" }];
+    mockSupabaseState.parts = [];
+  });
+
+  it("renders the CSV Import button in normal mode", async () => {
+    render(<InventoryPage />);
+
+    expect(await screen.findByRole("button", { name: "CSV Import" })).toBeInTheDocument();
+    expect(screen.queryByText("Upload/setup here")).not.toBeInTheDocument();
+  });
+
+  it("opens clear upload and preview UI when CSV Import is clicked", async () => {
+    render(<InventoryPage />);
+
+    await openAndPreviewCsv();
+
+    expect(screen.getByTestId("parts-csv-file-input")).toBeInTheDocument();
+    expect(screen.getByText("Oil Filter")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm import" })).toBeEnabled();
+  });
+
+  it("renders the highlighted import area in guided onboarding mode", async () => {
+    setGuidedParams();
+    render(<InventoryPage />);
+
+    expect(await screen.findByText("Import inventory parts")).toBeInTheDocument();
+    expect(screen.getByText(/mark this guided step complete only after you explicitly import/i)).toBeInTheDocument();
+    expect(screen.getByText("Return to guided onboarding")).toBeInTheDocument();
+  });
+
+  it("calls guided completion only after a successful explicit import", async () => {
+    setGuidedParams();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/parts/import") {
+        return { ok: true, json: async () => ({ ok: true, counts: { importedCount: 1, stockReceiveCount: 1 } }) };
+      }
+      return { ok: true, json: async () => ({ ok: true }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<InventoryPage />);
+
+    await openAndPreviewCsv();
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/api/onboarding-v2/"), expect.anything());
+    await userEvent.click(screen.getByRole("button", { name: "Confirm import" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/inventory_parts/complete",
+      expect.objectContaining({ method: "POST" }),
+    ));
+    expect(screen.getByText("Return to Data Onboarding")).toBeInTheDocument();
+  });
+
+  it("does not call guided completion when import fails", async () => {
+    setGuidedParams();
+    const fetchMock = vi.fn(async () => ({ ok: false, json: async () => ({ error: "Bad CSV" }) }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<InventoryPage />);
+
+    await openAndPreviewCsv();
+    await userEvent.click(screen.getByRole("button", { name: "Confirm import" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Bad CSV"));
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/api/onboarding-v2/"), expect.anything());
+  });
+
+  it("does not call guided completion when the modal is cancelled", async () => {
+    setGuidedParams();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    render(<InventoryPage />);
+
+    await openAndPreviewCsv();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call guided completion without onboarding params", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true, counts: { importedCount: 1, stockReceiveCount: 0 } }) }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<InventoryPage />);
+
+    await openAndPreviewCsv();
+    await userEvent.click(screen.getByRole("button", { name: "Confirm import" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/parts/import", expect.objectContaining({ method: "POST" })));
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/api/onboarding-v2/"), expect.anything());
+  });
+});

--- a/tests/parts-import-route.test.ts
+++ b/tests/parts-import-route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../app/api/parts/import/route";
+
+const { mockSupabaseState } = vi.hoisted(() => ({
+  mockSupabaseState: {
+    user: { id: "user-1" } as { id: string } | null,
+    profileShopId: "shop-real" as string | null,
+    locations: [{ id: "loc-real", shop_id: "shop-real" }] as Array<Record<string, unknown>>,
+    parts: [] as Array<Record<string, unknown>>,
+    inserts: [] as Array<Record<string, unknown>>,
+    updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
+    rpcCalls: [] as Array<Record<string, unknown>>,
+  },
+}));
+
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+
+type MockQuery = {
+  filters: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+};
+
+function makeQuery(table: string): MockQuery {
+  const query: MockQuery = {
+    filters: {},
+    select: vi.fn(() => query),
+    eq: vi.fn((column: string, value: unknown) => {
+      query.filters[column] = value;
+      return query;
+    }),
+    maybeSingle: vi.fn(async () => {
+      if (table === "profiles") return { data: { shop_id: mockSupabaseState.profileShopId }, error: null };
+      if (table === "stock_locations") {
+        const location = mockSupabaseState.locations.find(
+          (row) => row.id === query.filters.id && row.shop_id === query.filters.shop_id,
+        );
+        return { data: location ?? null, error: null };
+      }
+      if (table === "parts") {
+        const part = mockSupabaseState.parts.find(
+          (row) => row.sku === query.filters.sku && row.shop_id === query.filters.shop_id,
+        );
+        return { data: part ? { id: part.id } : null, error: null };
+      }
+      return { data: null, error: null };
+    }),
+    insert: vi.fn((payload: Record<string, unknown>) => {
+      query.payload = payload;
+      mockSupabaseState.inserts.push(payload);
+      return query;
+    }),
+    update: vi.fn((payload: Record<string, unknown>) => {
+      query.payload = payload;
+      return query;
+    }),
+    single: vi.fn(async () => ({ data: { id: "created-part" }, error: null })),
+  };
+
+  query.eq = vi.fn((column: string, value: unknown) => {
+    query.filters[column] = value;
+    if (table === "parts" && query.payload && column === "id") {
+      mockSupabaseState.updates.push({ payload: query.payload, filters: { ...query.filters } });
+    }
+    return query;
+  });
+
+  return query;
+}
+
+vi.mock("@supabase/auth-helpers-nextjs", () => ({
+  createRouteHandlerClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })),
+    },
+    from: vi.fn((table: string) => makeQuery(table)),
+    rpc: vi.fn(async (_name: string, args: Record<string, unknown>) => {
+      mockSupabaseState.rpcCalls.push(args);
+      return { data: null, error: null };
+    }),
+  })),
+}));
+
+describe("POST /api/parts/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabaseState.user = { id: "user-1" };
+    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.locations = [{ id: "loc-real", shop_id: "shop-real" }];
+    mockSupabaseState.parts = [];
+    mockSupabaseState.inserts = [];
+    mockSupabaseState.updates = [];
+    mockSupabaseState.rpcCalls = [];
+  });
+
+  it("rejects unauthenticated imports", async () => {
+    mockSupabaseState.user = null;
+
+    const response = await POST(new Request("http://localhost/api/parts/import", {
+      method: "POST",
+      body: JSON.stringify({ rows: [{ name: "Oil Filter" }] }),
+    }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("derives shop_id from the authenticated profile and ignores client shop_id", async () => {
+    const response = await POST(new Request("http://localhost/api/parts/import", {
+      method: "POST",
+      body: JSON.stringify({
+        defaultLocationId: "loc-real",
+        rows: [{ name: "Oil Filter", sku: "OF-1", category: "Filters", price: 9.95, qty: 4, shop_id: "evil-shop" }],
+      }),
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ importedCount: 1, createdCount: 1, stockReceiveCount: 1 });
+    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", name: "Oil Filter", sku: "OF-1" });
+    expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
+    expect(mockSupabaseState.rpcCalls[0]).toMatchObject({ p_part: "created-part", p_loc: "loc-real", p_qty: 4, p_ref_kind: "csv_import" });
+  });
+
+  it("rejects default receive locations outside the authenticated shop", async () => {
+    const response = await POST(new Request("http://localhost/api/parts/import", {
+      method: "POST",
+      body: JSON.stringify({ defaultLocationId: "other-loc", rows: [{ name: "Oil Filter" }] }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Motivation

- Guided Onboarding V2 routes users to the real `/parts/inventory` page with a highlighted CSV import action, but the upload/confirm flow was not exposing a clear upload/preview/confirm UI and did not reliably mark the guided step complete only after an explicit successful import. 
- The import previously relied on client-side sequencing and local-only logic which made guided completion coupling and tenant safety brittle.

### Description

- Add a server-backed import API at `POST /api/parts/import` that derives `shop_id` from the authenticated profile, validates the chosen default receive location belongs to that shop, inserts/updates `parts` scoped to the authenticated shop, and applies receive stock moves using `apply_stock_move` (file: `app/api/parts/import/route.ts`).
- Replace the modal/UX wiring on the real inventory page to expose a clear upload/paste/preview/confirm flow, show parse/errors and an import result panel, and require an explicit `Confirm import` before calling the server (file: `app/parts/inventory/page.tsx`).
- Wire guided onboarding completion so the `/api/onboarding-v2/guided/sessions/[sessionId]/steps/inventory_parts/complete` callback is invoked only after the server import returns success, and show a `Return to Data Onboarding` affordance after success (changes in `app/parts/inventory/page.tsx`).
- Keep the existing client-side parsing/preview logic but delegate actual persistence and stock receives to the new server route to avoid trusting client-supplied `shop_id` and to centralize error handling (see `parseAndPreviewCSV` usage and `runCsvImport` changes).
- Add focused tests that cover normal and guided onboarding behavior and server-side tenant derivation: `tests/onboarding-v2/parts-inventory-import-page.test.tsx` and `tests/parts-import-route.test.ts`.

### Testing

- Ran the targeted UI + route tests with Vitest: `npx vitest run tests/onboarding-v2/guided-registry-and-query.test.ts tests/onboarding-v2/parts-inventory-import-page.test.tsx tests/parts-import-route.test.ts` and all tests passed.
- Type-check: `npx tsc --noEmit` completed successfully with no new type errors.
- Lint: `npx eslint app/parts/inventory/page.tsx features/parts app/api` ran (existing unrelated warnings remained but no new blocking errors from this change).
- Verified `git diff --check` reported no whitespace/merge issues.

Files changed/added (key):
- Added: `app/api/parts/import/route.ts` (server import endpoint)
- Modified: `app/parts/inventory/page.tsx` (CSV import modal/flow, guided completion wiring)
- Added tests: `tests/onboarding-v2/parts-inventory-import-page.test.tsx`, `tests/parts-import-route.test.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218871ddf483288ad0a194a28e9d27)