### PR TITLE
Add dedicated vehicles page foundation

### DIFF
--- a/app/vehicles/page.tsx
+++ b/app/vehicles/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/features/vehicles/app/vehicles/page";

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -55,9 +55,9 @@ export const GUIDED_ONBOARDING_STEPS = [
     stepKey: "vehicles",
     label: "Vehicles",
     question: "Do you want to bring in your vehicle list now?",
-    destinationPath: "/customers",
+    destinationPath: "/vehicles",
     highlightKey: "vehicle-import",
-    description: "Use Customers for now because vehicles are managed from customer files today.",
+    description: "Route to the dedicated Vehicles directory for unit, VIN, plate, and asset setup.",
     implementationStatus: "placeholder",
   },
   {

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -127,6 +127,14 @@ export const TILES: Tile[] = [
   section: "Operations",
   },
   {
+    href: "/vehicles",
+    title: "Vehicles",
+    subtitle: "Units, VINs & plates",
+    roles: ["advisor", "manager", "owner", "admin"],
+    scopes: ["work_orders", "all"],
+    section: "Operations",
+  },
+  {
     href: "/billing",
     title: "Billing",
     subtitle: "Ready to invoice",

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -23,6 +23,7 @@ const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
   "/work-orders/view": "Operations",
   "/work-orders/quote-review": "Operations",
   "/customers/search": "Operations",
+  "/vehicles": "Operations",
   "/billing": "Operations",
   "/work-orders/history": "Operations",
   "/parts": "Parts",

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -84,6 +84,12 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     roles: ["owner", "admin", "manager", "advisor"],
   },
 
+  "/vehicles": {
+    title: () => "Vehicles",
+    icon: "🚗",
+    roles: ["owner", "admin", "manager", "advisor"],
+  },
+
   "/work-orders/[id]": {
     title: (href) => `WO #${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
     icon: "🔧",

--- a/features/vehicles/app/vehicles/actions.ts
+++ b/features/vehicles/app/vehicles/actions.ts
@@ -1,0 +1,112 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+import type { Database } from "@shared/types/types/supabase";
+
+type VehicleInsert = Database["public"]["Tables"]["vehicles"]["Insert"];
+
+export type CreateVehicleState = {
+  ok: boolean;
+  message: string | null;
+};
+
+const EMPTY_STATE: CreateVehicleState = { ok: false, message: null };
+
+function cleanText(value: FormDataEntryValue | string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  return text.length ? text : null;
+}
+
+function cleanYear(value: FormDataEntryValue | null): number | null {
+  const text = cleanText(value);
+  if (!text) return null;
+  const year = Number.parseInt(text, 10);
+  if (!Number.isInteger(year) || year < 1900 || year > 2100) return null;
+  return year;
+}
+
+function normalizeVinForStorage(value: string | null): string | null {
+  if (!value) return null;
+  const normalized = normalizeVinInput(value);
+  return normalized.vin || value.toUpperCase();
+}
+
+export async function createVehicleAction(
+  _prevState: CreateVehicleState = EMPTY_STATE,
+  formData: FormData,
+): Promise<CreateVehicleState> {
+  const supabase = createServerSupabaseRSC();
+  const actor = await resolveCurrentActor(supabase);
+
+  if (!actor.user?.id) return { ok: false, message: "You must be signed in to add a vehicle." };
+  if (!actor.shopId) return { ok: false, message: "Your profile is not linked to a shop yet." };
+
+  const customerId = cleanText(formData.get("customer_id"));
+  const unitNumber = cleanText(formData.get("unit_number"));
+  const vin = normalizeVinForStorage(cleanText(formData.get("vin")));
+  const licensePlate = cleanText(formData.get("license_plate"))?.toUpperCase() ?? null;
+  const year = cleanYear(formData.get("year"));
+  const make = cleanText(formData.get("make"));
+  const model = cleanText(formData.get("model"));
+
+  if (!unitNumber && !vin && !licensePlate && !year && !make && !model) {
+    return { ok: false, message: "Add at least one vehicle identifier or year/make/model value." };
+  }
+
+  if (customerId) {
+    const { data: customer, error: customerError } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("id", customerId)
+      .eq("shop_id", actor.shopId)
+      .maybeSingle();
+    if (customerError) return { ok: false, message: "Unable to validate the selected customer." };
+    if (!customer?.id) return { ok: false, message: "Selected customer does not belong to this shop." };
+  }
+
+  if (vin) {
+    const { data: existingVin, error: vinError } = await supabase
+      .from("vehicles")
+      .select("id")
+      .eq("shop_id", actor.shopId)
+      .eq("vin", vin)
+      .limit(1)
+      .maybeSingle();
+    if (vinError) return { ok: false, message: "Unable to check for duplicate VINs." };
+    if (existingVin?.id) return { ok: false, message: "A vehicle with this VIN already exists in this shop." };
+  }
+
+  if (unitNumber) {
+    const { data: existingUnit, error: unitError } = await supabase
+      .from("vehicles")
+      .select("id")
+      .eq("shop_id", actor.shopId)
+      .ilike("unit_number", unitNumber)
+      .limit(1)
+      .maybeSingle();
+    if (unitError) return { ok: false, message: "Unable to check for duplicate unit numbers." };
+    if (existingUnit?.id) return { ok: false, message: "A vehicle with this unit number already exists in this shop." };
+  }
+
+  const payload: VehicleInsert = {
+    shop_id: actor.shopId,
+    user_id: actor.user.id,
+    customer_id: customerId,
+    unit_number: unitNumber,
+    vin,
+    license_plate: licensePlate,
+    year,
+    make,
+    model,
+  };
+
+  const { error } = await supabase.from("vehicles").insert(payload);
+  if (error) return { ok: false, message: "Unable to add this vehicle right now." };
+
+  revalidatePath("/vehicles");
+  return { ok: true, message: "Vehicle added." };
+}

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -1,0 +1,157 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { VehicleOnboardingSetupCard } from "@/features/vehicles/components/VehicleOnboardingSetupCard";
+import { VehicleCreateForm } from "@/features/vehicles/components/VehicleCreateForm";
+import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
+import { formatVehicleDisplayLabel, formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
+
+type DB = Database;
+type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
+type Customer = DB["public"]["Tables"]["customers"]["Row"];
+
+type VehicleRow = Pick<Vehicle, "id" | "unit_number" | "year" | "make" | "model" | "vin" | "license_plate" | "customer_id"> & {
+  customers?: Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null;
+};
+
+type CustomerOption = Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function paramToString(value: string | string[] | undefined): string | null {
+  if (!value) return null;
+  return Array.isArray(value) ? value[0] ?? null : value;
+}
+
+function customerName(customer: VehicleRow["customers"]): string | null {
+  if (!customer) return null;
+  return (
+    customer.business_name?.trim() ||
+    customer.name?.trim() ||
+    [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim() ||
+    customer.email ||
+    customer.phone ||
+    customer.phone_number ||
+    null
+  );
+}
+
+function vehicleMatchesSearch(row: VehicleRow, query: string): boolean {
+  if (!query) return true;
+  const haystack = [
+    row.unit_number,
+    row.vin,
+    row.license_plate,
+    row.year != null ? String(row.year) : null,
+    row.make,
+    row.model,
+    customerName(row.customers),
+    formatVehicleDisplayLabel(row),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query.toLowerCase());
+}
+
+export default async function VehiclesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
+  const params = (await searchParams) ?? {};
+  const query = paramToString(params.q)?.trim() ?? "";
+  const guidedQuery = parseGuidedOnboardingQuery(new URLSearchParams(Object.entries(params).flatMap(([key, value]) => {
+    if (Array.isArray(value)) return value.map((item) => [key, item] as [string, string]);
+    return value == null ? [] : [[key, value] as [string, string]];
+  })));
+  const vehiclesHighlightActive = shouldShowVehicleOnboardingCard(guidedQuery);
+
+  const supabase = createServerSupabaseRSC();
+  const actor = await resolveCurrentActor(supabase);
+
+  if (!actor.user?.id) redirect(`/sign-in?redirect=${encodeURIComponent("/vehicles")}`);
+  if (!actor.shopId) redirect("/account/shop-assignment-required");
+
+  const [{ data: vehicleRows, error: vehicleError }, { data: customerRows }] = await Promise.all([
+    supabase
+      .from("vehicles")
+      .select("id, unit_number, year, make, model, vin, license_plate, customer_id, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)")
+      .eq("shop_id", actor.shopId)
+      .order("created_at", { ascending: false })
+      .limit(200),
+    supabase
+      .from("customers")
+      .select("id, business_name, name, first_name, last_name, email, phone, phone_number")
+      .eq("shop_id", actor.shopId)
+      .order("updated_at", { ascending: false })
+      .limit(200),
+  ]);
+
+  const vehicles = ((vehicleRows ?? []) as unknown as VehicleRow[]).map((row) => ({ ...row, customers: Array.isArray(row.customers) ? row.customers[0] ?? null : row.customers })).filter((row) => vehicleMatchesSearch(row, query));
+  const customers = (customerRows ?? []) as CustomerOption[];
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-6 lg:p-8">
+      <header className="rounded-[28px] border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.18),rgba(15,23,42,0.90)_36%,rgba(2,6,23,0.96))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">Operations directory</p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight text-white">Vehicles</h1>
+            <p className="mt-2 max-w-2xl text-sm text-neutral-300">Units, VINs, plates, and customer-linked assets.</p>
+          </div>
+          <a href="#add-vehicle" className="inline-flex items-center justify-center rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)]">Add vehicle</a>
+        </div>
+      </header>
+
+      {vehiclesHighlightActive && guidedQuery ? <VehicleOnboardingSetupCard guidedQuery={guidedQuery} /> : null}
+
+      <VehicleCreateForm customers={customers} />
+
+      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[0_18px_45px_rgba(0,0,0,0.45)]">
+        <form className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Vehicle directory</h2>
+            <p className="mt-1 text-sm text-neutral-400">Showing current-shop vehicles only.</p>
+          </div>
+          <input name="q" defaultValue={query} placeholder="Search VIN, plate, unit, YMM, customer…" className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)] sm:max-w-md" />
+        </form>
+
+        {vehicleError ? <div className="mt-4 rounded-xl border border-red-500/30 bg-red-950/25 p-3 text-sm text-red-100">Unable to load vehicles right now.</div> : null}
+
+        {!vehicleError && vehicles.length === 0 ? (
+          <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-black/20 p-8 text-center">
+            <h3 className="text-xl font-semibold text-white">No vehicles yet</h3>
+            <p className="mx-auto mt-2 max-w-xl text-sm text-neutral-400">Add your first vehicle/unit here, or keep managing vehicles from customer files while this dedicated directory grows.</p>
+            <a href="#add-vehicle" className="mt-5 inline-flex rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50">Add a vehicle/unit</a>
+          </div>
+        ) : null}
+
+        {vehicles.length > 0 ? (
+          <div className="mt-4 grid gap-3">
+            {vehicles.map((vehicle) => {
+              const name = customerName(vehicle.customers);
+              return (
+                <article key={vehicle.id} className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                    <div className="min-w-0">
+                      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-orange-200/80">{formatVehicleIdentifier(vehicle)}</div>
+                      <h3 className="mt-1 truncate text-lg font-semibold text-white">{formatVehicleYearMakeModel(vehicle)}</h3>
+                      <p className="mt-1 text-sm text-neutral-400">{name ? `Linked to ${name}` : "No customer linked"}</p>
+                    </div>
+                    {vehicle.customer_id && name ? <Link href={`/customers/${encodeURIComponent(vehicle.customer_id)}`} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-3 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Open customer file</Link> : null}
+                  </div>
+                  <dl className="mt-4 grid gap-2 md:grid-cols-4">
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Unit</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.unit_number) ?? "—"}</dd></div>
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">VIN</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.vin) ?? "—"}</dd></div>
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Plate</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.license_plate) ?? "—"}</dd></div>
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer</dt><dd className="mt-1 truncate text-sm font-medium text-white">{name ?? "No customer linked"}</dd></div>
+                  </dl>
+                </article>
+              );
+            })}
+          </div>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/features/vehicles/components/VehicleCreateForm.tsx
+++ b/features/vehicles/components/VehicleCreateForm.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import type { Database } from "@shared/types/types/supabase";
+import { createVehicleAction, type CreateVehicleState } from "@/features/vehicles/app/vehicles/actions";
+
+type CustomerOption = Pick<Database["public"]["Tables"]["customers"]["Row"], "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
+
+const INITIAL_STATE: CreateVehicleState = { ok: false, message: null };
+
+function customerLabel(customer: CustomerOption): string {
+  return (
+    customer.business_name?.trim() ||
+    customer.name?.trim() ||
+    [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim() ||
+    customer.email ||
+    customer.phone ||
+    customer.phone_number ||
+    "Customer"
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending} className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] disabled:opacity-55">
+      {pending ? "Adding…" : "Add vehicle"}
+    </button>
+  );
+}
+
+export function VehicleCreateForm({ customers }: { customers: CustomerOption[] }) {
+  const [state, formAction] = useFormState(createVehicleAction, INITIAL_STATE);
+
+  return (
+    <form id="add-vehicle" action={formAction} className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[0_18px_45px_rgba(0,0,0,0.45)]">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Add vehicle</h2>
+          <p className="mt-1 text-sm text-neutral-400">Create an unlinked unit or connect it to an existing same-shop customer.</p>
+        </div>
+        <SubmitButton />
+      </div>
+
+      {state.message ? <div className={`mt-4 rounded-xl border p-3 text-sm ${state.ok ? "border-emerald-500/30 bg-emerald-950/25 text-emerald-100" : "border-red-500/30 bg-red-950/25 text-red-100"}`}>{state.message}</div> : null}
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Unit number<input name="unit_number" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]" /></label>
+        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">VIN<input name="vin" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]" /></label>
+        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">License plate<input name="license_plate" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]" /></label>
+        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Year<input name="year" inputMode="numeric" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]" /></label>
+        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Make<input name="make" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]" /></label>
+        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Model<input name="model" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]" /></label>
+        <label className="md:col-span-3 text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Customer link<select name="customer_id" className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm normal-case tracking-normal text-white outline-none focus:border-[var(--accent-copper-soft)]"><option value="">No customer linked</option>{customers.map((customer) => <option key={customer.id} value={customer.id}>{customerLabel(customer)}</option>)}</select></label>
+      </div>
+    </form>
+  );
+}

--- a/features/vehicles/components/VehicleOnboardingSetupCard.tsx
+++ b/features/vehicles/components/VehicleOnboardingSetupCard.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+type Props = {
+  guidedQuery: GuidedOnboardingQuery;
+  addVehicleTargetId?: string;
+};
+
+const COMPLETE_SUMMARY = {
+  manualSetup: true,
+  importedCount: 0,
+  note: "Vehicle setup step completed manually from the Vehicles directory.",
+};
+
+export function VehicleOnboardingSetupCard({ guidedQuery, addVehicleTargetId = "add-vehicle" }: Props) {
+  const router = useRouter();
+  const [busyAction, setBusyAction] = useState<"complete" | "skip" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function postStepAction(action: "complete" | "skip") {
+    setBusyAction(action);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(action === "complete" ? { summary: COMPLETE_SUMMARY } : { skippedReason: "Vehicle import is not available yet." }),
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!response.ok || payload.ok === false) throw new Error(payload.error ?? "Unable to update the vehicles onboarding step.");
+      router.push(guidedQuery.returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the vehicles onboarding step.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const disabled = busyAction !== null;
+
+  return (
+    <OnboardingHighlightFrame
+      active
+      highlightKey={guidedQuery.highlight}
+      title="Vehicle import/setup"
+      description="Guided onboarding brought you here because Vehicles owns unit, VIN, plate, and asset setup."
+    >
+      <section data-testid="vehicles-onboarding-card" className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.16),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Vehicles</div>
+            <h2 className="mt-2 text-xl font-semibold text-white">Vehicle import/setup</h2>
+            <div className="mt-3 space-y-2 text-sm text-neutral-300">
+              <p>Guided onboarding brought you here because Vehicles owns unit, VIN, plate, and asset setup.</p>
+              <p>CSV import will be added here next. For now, add vehicles manually or mark this step complete.</p>
+            </div>
+            {error ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{error}</div> : null}
+          </div>
+
+          <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
+            <a href={`#${addVehicleTargetId}`} className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.26),rgba(197,122,74,0.14))] px-4 py-2 text-center text-sm font-semibold text-orange-50 hover:border-[var(--accent-copper)] hover:bg-orange-400/15">
+              Add vehicle
+            </a>
+            <button type="button" onClick={() => void postStepAction("complete")} disabled={disabled} className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30 disabled:opacity-55">
+              {busyAction === "complete" ? "Marking complete…" : "Mark vehicles step complete"}
+            </button>
+            <button type="button" onClick={() => void postStepAction("skip")} disabled={disabled} className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55">
+              {busyAction === "skip" ? "Skipping…" : "Skip vehicles"}
+            </button>
+            <Link href={guidedQuery.returnTo} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">
+              Back to Data Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/vehicles/lib/display.ts
+++ b/features/vehicles/lib/display.ts
@@ -1,0 +1,39 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type VehicleLike = Pick<
+  Database["public"]["Tables"]["vehicles"]["Row"],
+  "year" | "make" | "model" | "vin" | "license_plate" | "unit_number"
+>;
+
+export function normalizeVehicleText(value: string | number | null | undefined): string | null {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+}
+
+export function normalizeVehicleIdentifier(value: string | null | undefined): string | null {
+  return normalizeVehicleText(value)?.toUpperCase() ?? null;
+}
+
+export function formatVehicleYearMakeModel(vehicle: Pick<VehicleLike, "year" | "make" | "model">): string {
+  return [vehicle.year != null ? String(vehicle.year) : null, vehicle.make, vehicle.model]
+    .map((part) => normalizeVehicleText(part))
+    .filter(Boolean)
+    .join(" ") || "Vehicle";
+}
+
+export function formatVehicleIdentifier(vehicle: Pick<VehicleLike, "unit_number" | "vin" | "license_plate">): string {
+  const unit = normalizeVehicleText(vehicle.unit_number);
+  if (unit) return `Unit ${unit}`;
+  const plate = normalizeVehicleIdentifier(vehicle.license_plate);
+  if (plate) return `Plate ${plate}`;
+  const vin = normalizeVehicleIdentifier(vehicle.vin);
+  if (vin) return `VIN ${vin}`;
+  return "No identifier";
+}
+
+export function formatVehicleDisplayLabel(vehicle: VehicleLike): string {
+  const title = formatVehicleYearMakeModel(vehicle);
+  const identifier = formatVehicleIdentifier(vehicle);
+  return identifier === "No identifier" ? title : `${title} · ${identifier}`;
+}

--- a/features/vehicles/lib/guided.ts
+++ b/features/vehicles/lib/guided.ts
@@ -1,0 +1,5 @@
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+export function shouldShowVehicleOnboardingCard(guidedQuery: GuidedOnboardingQuery | null): boolean {
+  return guidedQuery?.onboardingStep === "vehicles" && guidedQuery.highlight === "vehicle-import";
+}

--- a/tests/onboarding-v2/guided-registry-and-query.test.ts
+++ b/tests/onboarding-v2/guided-registry-and-query.test.ts
@@ -17,7 +17,7 @@ describe("guided onboarding step registry", () => {
     ]);
 
     expect(getGuidedOnboardingStep("customers")).toMatchObject({ destinationPath: "/customers", highlightKey: "customer-import" });
-    expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/customers", highlightKey: "vehicle-import" });
+    expect(getGuidedOnboardingStep("vehicles")).toMatchObject({ destinationPath: "/vehicles", highlightKey: "vehicle-import" });
     expect(getGuidedOnboardingStep("staff")).toMatchObject({ destinationPath: "/dashboard/owner/create-user", highlightKey: "staff-import" });
     expect(getGuidedOnboardingStep("labor_tax_shop_settings")).toMatchObject({ destinationPath: "/dashboard/owner/settings", highlightKey: "shop-settings" });
     expect(getGuidedOnboardingStep("inspection_templates")).toMatchObject({
@@ -63,7 +63,7 @@ describe("guided onboarding query helpers", () => {
     const url = buildGuidedOnboardingDestinationUrl({ sessionId: "session-123", stepKey: "vehicles" });
     const parsedUrl = new URL(url, "https://app.profixiq.test");
 
-    expect(parsedUrl.pathname).toBe("/customers");
+    expect(parsedUrl.pathname).toBe("/vehicles");
     expect(parsedUrl.searchParams.get("onboardingSession")).toBe("session-123");
     expect(parsedUrl.searchParams.get("onboardingStep")).toBe("vehicles");
     expect(parsedUrl.searchParams.get("highlight")).toBe("vehicle-import");

--- a/tests/onboarding-v2/vehicles-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/vehicles-onboarding-card.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VehicleOnboardingSetupCard } from "@/features/vehicles/components/VehicleOnboardingSetupCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const router = { push: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "vehicles",
+  highlight: "vehicle-import",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function okJson() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+describe("Vehicles page onboarding setup card", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the Vehicles-owned guided import/setup copy", () => {
+    render(<VehicleOnboardingSetupCard guidedQuery={guidedQuery} />);
+
+    expect(screen.getByTestId("vehicles-onboarding-card")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Vehicle import/setup" })).toBeInTheDocument();
+    expect(screen.getAllByText("Guided onboarding brought you here because Vehicles owns unit, VIN, plate, and asset setup.").length).toBeGreaterThan(0);
+    expect(screen.getByText("CSV import will be added here next. For now, add vehicles manually or mark this step complete.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /add vehicle/i })).toHaveAttribute("href", "#add-vehicle");
+  });
+
+  it("marks the vehicles guided step complete and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VehicleOnboardingSetupCard guidedQuery={guidedQuery} />);
+    await userEvent.click(screen.getByRole("button", { name: /mark vehicles step complete/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/vehicles/complete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          summary: {
+            manualSetup: true,
+            importedCount: 0,
+            note: "Vehicle setup step completed manually from the Vehicles directory.",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("skips the vehicles guided step and returns to onboarding", async () => {
+    const fetchMock = vi.fn(async () => okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<VehicleOnboardingSetupCard guidedQuery={guidedQuery} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip vehicles/i }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding-v2/guided/sessions/session-123/steps/vehicles/skip",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ skippedReason: "Vehicle import is not available yet." }),
+      }),
+    );
+  });
+});

--- a/tests/vehicles/create-vehicle-action.test.ts
+++ b/tests/vehicles/create-vehicle-action.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVehicleAction } from "@/features/vehicles/app/vehicles/actions";
+
+const { mockSupabaseState } = vi.hoisted(() => ({
+  mockSupabaseState: {
+    user: { id: "user-1" } as { id: string } | null,
+    profileShopId: "shop-real" as string | null,
+    customers: [] as Array<Record<string, unknown>>,
+    vehicles: [] as Array<Record<string, unknown>>,
+    inserts: [] as Array<Record<string, unknown>>,
+  },
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+function makeQuery(table: string) {
+  const filters: Record<string, unknown> = {};
+  const query: Record<string, ReturnType<typeof vi.fn>> = {
+    select: vi.fn(() => query),
+    or: vi.fn(() => query),
+    eq: vi.fn((column: string, value: unknown) => {
+      filters[column] = value;
+      return query;
+    }),
+    ilike: vi.fn((column: string, value: unknown) => {
+      filters[column] = value;
+      return query;
+    }),
+    limit: vi.fn(() => query),
+    maybeSingle: vi.fn(async () => {
+      if (table === "profiles") return { data: mockSupabaseState.profileShopId ? { shop_id: mockSupabaseState.profileShopId, role: "advisor" } : { shop_id: null, role: "advisor" }, error: null };
+      if (table === "customers") {
+        const found = mockSupabaseState.customers.find((row) => row.id === filters.id && row.shop_id === filters.shop_id);
+        return { data: found ? { id: found.id } : null, error: null };
+      }
+      if (table === "vehicles") {
+        const found = mockSupabaseState.vehicles.find((row) => {
+          if (row.shop_id !== filters.shop_id) return false;
+          if (filters.vin) return row.vin === filters.vin;
+          if (filters.unit_number) return String(row.unit_number).toLowerCase() === String(filters.unit_number).toLowerCase();
+          return false;
+        });
+        return { data: found ? { id: found.id } : null, error: null };
+      }
+      return { data: null, error: null };
+    }),
+    insert: vi.fn(async (payload: Record<string, unknown>) => {
+      mockSupabaseState.inserts.push(payload);
+      return { error: null };
+    }),
+  };
+  return query;
+}
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRSC: vi.fn(() => ({
+    auth: { getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })) },
+    from: vi.fn((table: string) => makeQuery(table)),
+  })),
+}));
+
+function form(values: Record<string, string>) {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(values)) data.set(key, value);
+  return data;
+}
+
+describe("createVehicleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabaseState.user = { id: "user-1" };
+    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.customers = [];
+    mockSupabaseState.vehicles = [];
+    mockSupabaseState.inserts = [];
+  });
+
+  it("rejects unauthenticated users", async () => {
+    mockSupabaseState.user = null;
+    const result = await createVehicleAction(undefined, form({ unit_number: "A1" }));
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/signed in/i);
+  });
+
+  it("rejects users without a shop", async () => {
+    mockSupabaseState.profileShopId = null;
+    const result = await createVehicleAction(undefined, form({ unit_number: "A1" }));
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not linked to a shop/i);
+  });
+
+  it("ignores client shop_id and inserts into the authenticated profile shop", async () => {
+    const result = await createVehicleAction(undefined, form({ unit_number: "A1", vin: "1HGCM82633A004352", shop_id: "evil-shop" }));
+    expect(result.ok).toBe(true);
+    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1", unit_number: "A1", vin: "1HGCM82633A004352" });
+    expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
+  });
+
+  it("rejects cross-shop customer_id", async () => {
+    mockSupabaseState.customers = [{ id: "customer-1", shop_id: "other-shop" }];
+    const result = await createVehicleAction(undefined, form({ unit_number: "A1", customer_id: "customer-1" }));
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/does not belong/i);
+  });
+
+  it("blocks duplicate VIN in the same shop", async () => {
+    mockSupabaseState.vehicles = [{ id: "vehicle-1", shop_id: "shop-real", vin: "1HGCM82633A004352" }];
+    const result = await createVehicleAction(undefined, form({ vin: "1HGCM82633A004352" }));
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/VIN already exists/i);
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+  });
+});

--- a/tests/vehicles/vehicles-page-guided-card.test.ts
+++ b/tests/vehicles/vehicles-page-guided-card.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
+
+describe("Vehicles page guided onboarding card visibility", () => {
+  it("does not show the onboarding card during a normal Vehicles visit", () => {
+    expect(shouldShowVehicleOnboardingCard(parseGuidedOnboardingQuery(new URLSearchParams()))).toBe(false);
+  });
+
+  it("shows the onboarding card for the vehicles import highlight query", () => {
+    const guidedQuery = parseGuidedOnboardingQuery(new URLSearchParams({
+      onboardingSession: "session-123",
+      onboardingStep: "vehicles",
+      highlight: "vehicle-import",
+      returnTo: "/dashboard/onboarding-v2/session-123",
+      source: "guided-onboarding",
+    }));
+
+    expect(shouldShowVehicleOnboardingCard(guidedQuery)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a dedicated internal `/vehicles` directory as the canonical home for vehicle/unit management so Guided Onboarding V2 can route the Vehicles step to `/vehicles` without disrupting existing customer-file workflows.
- Keep scope small and safe: do not change auth, middleware, schema, or remove existing customer vehicle flows while enabling manual vehicle creation and onboarding wiring.

### Description
- Add a new `/vehicles` route that delegates into `features/vehicles` and requires the authenticated shop context, deriving `shop_id` from the server-resolved profile and only querying current-shop vehicles/customers. 
- Implement a minimal Vehicle directory UI and a small create-flow: `features/vehicles/app/vehicles/page.tsx`, `features/vehicles/components/VehicleCreateForm.tsx`, and server action `features/vehicles/app/vehicles/actions.ts` that validate actor/shop, reject client `shop_id`, validate optional `customer_id` belongs to the same shop, block duplicate VINs and duplicate unit numbers, and revalidate the `/vehicles` path after create.
- Add small display helpers in `features/vehicles/lib/display.ts` and an onboarding visibility helper in `features/vehicles/lib/guided.ts` and onboard-card component `features/vehicles/components/VehicleOnboardingSetupCard.tsx` which posts complete/skip to the existing guided endpoints.
- Update Guided Onboarding V2 registry to route the `vehicles` step to `/vehicles` and add Vehicles to Operations navigation metadata without changing Fleet entries (`features/onboarding-v2/guided/steps.ts`, `features/shared/config/tiles.ts`, `features/shared/lib/ownerSidebarNav.ts`, `features/shared/lib/routeMeta.ts`).
- Add focused tests for guided registry/query, onboarding-card behavior, create action guardrails and duplicate checks (`tests/onboarding-v2/*`, `tests/vehicles/*`).

### Testing
- Ran typecheck: `npx tsc --noEmit` — succeeded.
- Linted changed files: `npx eslint ...` (targeted files) — succeeded with no errors on changed files.
- Ran unit tests: `npx vitest run` for the new/modified test suites (`tests/onboarding-v2/guided-registry-and-query.test.ts`, `tests/onboarding-v2/vehicles-onboarding-card.test.tsx`, `tests/vehicles/create-vehicle-action.test.ts`, `tests/vehicles/vehicles-page-guided-card.test.ts`) — all tests passed.
- Ran `git diff --check` for whitespace/merge issues — no problems detected.

Risks / Follow-ups
- Vehicle CSV import remains pending and is explicitly marked on the onboarding card as “will be added here next.”
- No DB migrations or constraints were added; duplicate VIN/unit enforcement is implemented at the server-action level for this foundation PR.
- The existing customer-file vehicle workflow remains intact and unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218f5b3c848328a3bfc0298e7b9b7f)