### PR TITLE
Add vehicle CSV import flow

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -1,0 +1,236 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@shared/types/types/supabase";
+import { cleanVehicleImportText, normalizeImportPlate, normalizeImportVin, type VehicleImportRow } from "@/features/vehicles/lib/importCsv";
+
+type DB = Database;
+type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
+type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
+type VehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "customer_id" | "vin" | "unit_number" | "license_plate">;
+type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
+
+type ImportBody = { rows?: unknown; shop_id?: unknown };
+
+type NormalizedVehicleImportRow = VehicleImportRow & {
+  sourceRowNumber: number;
+};
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const text = cleanVehicleImportText(value);
+  if (!text) return undefined;
+  const parsed = Number(text.replace(/,/g, ""));
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
+  if (!Array.isArray(input)) return [];
+  return input.map((raw, index) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      sourceRowNumber: numberValue(row.sourceRowNumber) ?? index + 1,
+      sourceFilename: cleanVehicleImportText(row.sourceFilename),
+      unit_number: cleanVehicleImportText(row.unit_number),
+      vin: normalizeImportVin(row.vin),
+      license_plate: normalizeImportPlate(row.license_plate),
+      year: numberValue(row.year),
+      make: cleanVehicleImportText(row.make),
+      model: cleanVehicleImportText(row.model),
+      submodel: cleanVehicleImportText(row.submodel),
+      color: cleanVehicleImportText(row.color),
+      engine: cleanVehicleImportText(row.engine),
+      engine_type: cleanVehicleImportText(row.engine_type),
+      engine_family: cleanVehicleImportText(row.engine_family),
+      transmission: cleanVehicleImportText(row.transmission),
+      fuel_type: cleanVehicleImportText(row.fuel_type),
+      drivetrain: cleanVehicleImportText(row.drivetrain),
+      engine_hours: numberValue(row.engine_hours),
+      odometer: cleanVehicleImportText(row.odometer),
+      customer_id: cleanVehicleImportText(row.customer_id),
+      customer_name: cleanVehicleImportText(row.customer_name),
+      customer_email: cleanVehicleImportText(row.customer_email)?.toLowerCase(),
+      customer_phone: cleanVehicleImportText(row.customer_phone),
+    };
+  });
+}
+
+function hasIdentity(row: NormalizedVehicleImportRow): boolean {
+  return Boolean(row.vin || row.unit_number || row.license_plate || (row.year && row.make && row.model));
+}
+
+function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: string; userId: string; customerId: string | null }): VehicleInsert {
+  const notes = [`Vehicle CSV import row ${row.sourceRowNumber}`, row.sourceFilename ? `source file: ${row.sourceFilename}` : null].filter(Boolean).join("; ");
+  return {
+    shop_id: args.shopId,
+    user_id: args.userId,
+    customer_id: args.customerId,
+    unit_number: row.unit_number ?? null,
+    vin: row.vin ?? null,
+    license_plate: row.license_plate ?? null,
+    year: row.year ?? null,
+    make: row.make ?? null,
+    model: row.model ?? null,
+    submodel: row.submodel ?? null,
+    color: row.color ?? null,
+    engine: row.engine ?? null,
+    engine_type: row.engine_type ?? null,
+    engine_family: row.engine_family ?? null,
+    transmission: row.transmission ?? null,
+    fuel_type: row.fuel_type ?? null,
+    drivetrain: row.drivetrain ?? null,
+    engine_hours: row.engine_hours ?? null,
+    mileage: row.odometer ?? null,
+    import_notes: notes || null,
+    source_row_id: String(row.sourceRowNumber),
+  };
+}
+
+function buildVehiclePatch(row: NormalizedVehicleImportRow, customerId: string | null): VehicleUpdate {
+  return {
+    customer_id: customerId,
+    unit_number: row.unit_number ?? null,
+    vin: row.vin ?? null,
+    license_plate: row.license_plate ?? null,
+    year: row.year ?? null,
+    make: row.make ?? null,
+    model: row.model ?? null,
+    submodel: row.submodel ?? null,
+    color: row.color ?? null,
+    engine: row.engine ?? null,
+    engine_type: row.engine_type ?? null,
+    engine_family: row.engine_family ?? null,
+    transmission: row.transmission ?? null,
+    fuel_type: row.fuel_type ?? null,
+    drivetrain: row.drivetrain ?? null,
+    engine_hours: row.engine_hours ?? null,
+    mileage: row.odometer ?? null,
+    source_row_id: String(row.sourceRowNumber),
+  };
+}
+
+function customerMatches(row: NormalizedVehicleImportRow, customer: CustomerRow): boolean {
+  if (row.customer_email && customer.email?.trim().toLowerCase() === row.customer_email) return true;
+  const phone = row.customer_phone?.replace(/\D/g, "");
+  if (phone && [customer.phone, customer.phone_number].some((value) => value?.replace(/\D/g, "") === phone)) return true;
+  const wantedName = row.customer_name?.trim().toLowerCase();
+  const names = [customer.business_name, customer.name, [customer.first_name, customer.last_name].filter(Boolean).join(" ")].map((value) => value?.trim().toLowerCase());
+  return Boolean(wantedName && names.some((value) => value === wantedName));
+}
+
+async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ customerId: string | null; warning?: string; error?: string }> {
+  if (row.customer_id) {
+    const { data: customer, error } = await supabase.from("customers").select("id").eq("shop_id", shopId).eq("id", row.customer_id).maybeSingle();
+    if (error) return { customerId: null, error: error.message };
+    if (!customer?.id) return { customerId: null, error: "Customer ID does not belong to this shop." };
+    return { customerId: String(customer.id) };
+  }
+
+  if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null };
+
+  const { data: customers, error } = await supabase.from("customers").select("id,business_name,name,first_name,last_name,email,phone,phone_number").eq("shop_id", shopId).limit(200);
+  if (error) return { customerId: null, error: error.message };
+  const matches = ((customers ?? []) as CustomerRow[]).filter((customer) => customerMatches(row, customer));
+  if (matches.length === 1) return { customerId: matches[0].id };
+  if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer match; vehicle imported without a customer link." };
+  return { customerId: null, warning: "No matching customer found; this vehicle will import without a customer link." };
+}
+
+async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ vehicle: VehicleRow | null; warning?: string; error?: string }> {
+  if (row.vin) {
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate").eq("shop_id", shopId).eq("vin", row.vin).limit(1).maybeSingle();
+    if (error) return { vehicle: null, error: error.message };
+    if (data?.id) return { vehicle: data as VehicleRow };
+  }
+  if (row.unit_number) {
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate").eq("shop_id", shopId).ilike("unit_number", row.unit_number).limit(1).maybeSingle();
+    if (error) return { vehicle: null, error: error.message };
+    if (data?.id) return { vehicle: data as VehicleRow };
+  }
+  if (row.license_plate) {
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate").eq("shop_id", shopId).eq("license_plate", row.license_plate).limit(1).maybeSingle();
+    if (error) return { vehicle: null, error: error.message };
+    if (data?.id) return { vehicle: data as VehicleRow, warning: "Duplicate plate matched an existing vehicle; existing vehicle selected." };
+  }
+  return { vehicle: null };
+}
+
+export async function POST(req: Request) {
+  try {
+    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError) return NextResponse.json({ error: userError.message }, { status: 401 });
+    if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    const { data: profile, error: profileError } = await supabase.from("profiles").select("shop_id").eq("user_id", user.id).maybeSingle();
+    if (profileError) return NextResponse.json({ error: profileError.message }, { status: 500 });
+    const shopId = typeof profile?.shop_id === "string" ? profile.shop_id : "";
+    if (!shopId) return NextResponse.json({ error: "No shop is associated with this user" }, { status: 403 });
+
+    const body = (await req.json().catch(() => null)) as ImportBody | null;
+    const rows = normalizeRows(body?.rows).filter(hasIdentity);
+    if (rows.length === 0) return NextResponse.json({ error: "No valid vehicle rows to import" }, { status: 400 });
+
+    const seenVins = new Set<string>();
+    const seenUnits = new Set<string>();
+    const warnings: Array<{ row: number; message: string }> = [];
+    const errors: Array<{ row: number; message: string }> = [];
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const row of rows) {
+      try {
+        if (row.vin && seenVins.has(row.vin)) {
+          skipped += 1;
+          warnings.push({ row: row.sourceRowNumber, message: "Duplicate VIN in submitted import; skipped duplicate row." });
+          continue;
+        }
+        if (row.unit_number && seenUnits.has(row.unit_number.trim().toLowerCase())) {
+          skipped += 1;
+          warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import; skipped duplicate row." });
+          continue;
+        }
+        if (row.vin) seenVins.add(row.vin);
+        if (row.unit_number) seenUnits.add(row.unit_number.trim().toLowerCase());
+
+        const customer = await resolveCustomerId(supabase, shopId, row);
+        if (customer.error) {
+          errors.push({ row: row.sourceRowNumber, message: customer.error });
+          continue;
+        }
+        if (customer.warning) warnings.push({ row: row.sourceRowNumber, message: customer.warning });
+
+        const existing = await findExistingVehicle(supabase, shopId, row);
+        if (existing.error) throw new Error(existing.error);
+        if (existing.warning) warnings.push({ row: row.sourceRowNumber, message: existing.warning });
+
+        if (existing.vehicle?.id) {
+          if (existing.vehicle.customer_id && customer.customerId && existing.vehicle.customer_id !== customer.customerId) {
+            skipped += 1;
+            warnings.push({ row: row.sourceRowNumber, message: "Existing vehicle is linked to another customer; skipped to avoid silent reassignment." });
+            continue;
+          }
+          const patch = buildVehiclePatch(row, existing.vehicle.customer_id ?? customer.customerId);
+          const { error } = await supabase.from("vehicles").update(patch).eq("shop_id", shopId).eq("id", existing.vehicle.id);
+          if (error) throw new Error(error.message);
+          updated += 1;
+        } else {
+          const insert = buildVehiclePayload(row, { shopId, userId: user.id, customerId: customer.customerId });
+          const { error } = await supabase.from("vehicles").insert(insert);
+          if (error) throw new Error(error.message);
+          created += 1;
+        }
+      } catch (err) {
+        errors.push({ row: row.sourceRowNumber, message: err instanceof Error ? err.message : "Import failed for this row" });
+      }
+    }
+
+    const failed = errors.length;
+    if (created + updated === 0) return NextResponse.json({ error: "No rows were imported", counts: { created, updated, skipped, failed, warnings: warnings.length }, warnings, errors }, { status: 400 });
+
+    return NextResponse.json({ ok: true, counts: { created, updated, skipped, failed, warnings: warnings.length }, warnings, errors });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
+  }
+}

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -4,7 +4,7 @@ import type { Database } from "@shared/types/types/supabase";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
-import { VehicleOnboardingSetupCard } from "@/features/vehicles/components/VehicleOnboardingSetupCard";
+import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
 import { VehicleCreateForm } from "@/features/vehicles/components/VehicleCreateForm";
 import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
 import { formatVehicleDisplayLabel, formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
@@ -103,7 +103,7 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
         </div>
       </header>
 
-      {vehiclesHighlightActive && guidedQuery ? <VehicleOnboardingSetupCard guidedQuery={guidedQuery} /> : null}
+      <VehicleCsvImportCard customers={customers} guidedQuery={guidedQuery} highlighted={vehiclesHighlightActive} />
 
       <VehicleCreateForm customers={customers} />
 

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import Link from "next/link";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { previewVehicleCsv, type VehicleImportCustomerOption, type VehicleImportPreview } from "@/features/vehicles/lib/importCsv";
+
+type Props = {
+  customers: VehicleImportCustomerOption[];
+  guidedQuery?: GuidedOnboardingQuery | null;
+  highlighted?: boolean;
+};
+
+type ImportCounts = {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  warnings: number;
+};
+
+type ImportResponse = {
+  ok?: boolean;
+  counts?: ImportCounts;
+  warnings?: Array<{ row: number; message: string }>;
+  errors?: Array<{ row: number; message: string }>;
+  error?: string;
+};
+
+const EMPTY_COUNTS: ImportCounts = { created: 0, updated: 0, skipped: 0, failed: 0, warnings: 0 };
+
+export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighted = false }: Props) {
+  const [csvText, setCsvText] = useState("");
+  const [fileName, setFileName] = useState<string | undefined>();
+  const [preview, setPreview] = useState<VehicleImportPreview | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [success, setSuccess] = useState<ImportResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [onboardingCompleted, setOnboardingCompleted] = useState(false);
+
+  const guidedMode = Boolean(guidedQuery && highlighted);
+  const validRows = useMemo(() => preview?.rows.filter((row) => row.status === "valid") ?? [], [preview]);
+
+  function reset() {
+    setCsvText("");
+    setFileName(undefined);
+    setPreview(null);
+    setSuccess(null);
+    setError(null);
+    setOnboardingCompleted(false);
+  }
+
+  async function readFile(file: File | null) {
+    setSuccess(null);
+    setError(null);
+    if (!file) return;
+    setFileName(file.name);
+    setCsvText(await file.text());
+    setPreview(null);
+  }
+
+  function buildPreview() {
+    setSuccess(null);
+    setError(null);
+    const nextPreview = previewVehicleCsv(csvText, customers, fileName);
+    setPreview(nextPreview);
+    if (nextPreview.validCount === 0) setError("No valid vehicle rows are ready to import.");
+  }
+
+  async function confirmImport() {
+    if (!preview || validRows.length === 0) return;
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch("/api/vehicles/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows: validRows }),
+      });
+      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      if (!response.ok || payload.ok === false) throw new Error(payload.error ?? "Vehicle import failed.");
+      setSuccess(payload);
+
+      if (guidedQuery) {
+        const completeResponse = await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/complete`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ summary: { vehicleImport: payload.counts ?? EMPTY_COUNTS, sourceFilename: fileName ?? null } }),
+        });
+        const completePayload = (await completeResponse.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+        if (!completeResponse.ok || completePayload.ok === false) throw new Error(completePayload.error ?? "Vehicle import succeeded, but guided onboarding was not updated.");
+        setOnboardingCompleted(true);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Vehicle import failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const card = (
+    <section data-testid="vehicle-csv-import-card" id="vehicle-import" className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.14),rgba(15,23,42,0.92)_35%,rgba(2,6,23,0.96))] p-4 shadow-[0_18px_55px_rgba(0,0,0,0.48)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-200/85">{guidedMode ? "Guided onboarding · Upload/setup here" : "Daily import"}</div>
+          <h2 className="mt-2 text-xl font-semibold text-white">Vehicle CSV import</h2>
+          <p className="mt-2 text-sm text-neutral-300">
+            {guidedMode
+              ? "Guided onboarding routed you to the real Vehicles page. Upload a CSV, preview validation, then confirm import to complete the Vehicles step."
+              : "Upload units, VINs, plates, and customer links without leaving the Vehicles directory."}
+          </p>
+        </div>
+        {guidedQuery ? <Link href={guidedQuery.returnTo} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Return to Data Onboarding</Link> : null}
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+        <div className="space-y-3">
+          <label className="block rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-black/20 p-4 text-sm text-neutral-300">
+            <span className="block font-semibold text-white">Upload .csv file</span>
+            <input data-testid="vehicle-csv-file" className="mt-3 block w-full text-sm text-neutral-300 file:mr-4 file:rounded-xl file:border-0 file:bg-orange-400/15 file:px-4 file:py-2 file:font-semibold file:text-orange-50" type="file" accept=".csv,text/csv" onChange={(event) => void readFile(event.currentTarget.files?.[0] ?? null)} />
+          </label>
+          <label className="block text-sm font-medium text-neutral-200">
+            Paste CSV text
+            <textarea value={csvText} onChange={(event) => { setCsvText(event.target.value); setPreview(null); setSuccess(null); setError(null); }} rows={6} placeholder="unit #,vin,plate number,year,make,model,customer email" className="mt-2 w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)]" />
+          </label>
+        </div>
+
+        <aside className="rounded-2xl border border-[color:var(--desktop-border)] bg-black/25 p-4">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.14em] text-neutral-300">Preview totals</h3>
+          <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
+            <div className="rounded-xl bg-white/[0.04] p-3"><dt className="text-neutral-500">Rows</dt><dd className="text-lg font-semibold text-white">{preview?.rowCount ?? 0}</dd></div>
+            <div className="rounded-xl bg-white/[0.04] p-3"><dt className="text-neutral-500">Valid</dt><dd className="text-lg font-semibold text-emerald-200">{preview?.validCount ?? 0}</dd></div>
+            <div className="rounded-xl bg-white/[0.04] p-3"><dt className="text-neutral-500">Invalid</dt><dd className="text-lg font-semibold text-red-200">{preview?.invalidCount ?? 0}</dd></div>
+            <div className="rounded-xl bg-white/[0.04] p-3"><dt className="text-neutral-500">Warnings</dt><dd className="text-lg font-semibold text-amber-200">{(preview?.duplicateWarnings ?? 0) + (preview?.unlinkedCustomerWarnings ?? 0)}</dd></div>
+          </dl>
+          <div className="mt-4 flex flex-col gap-2">
+            <button type="button" onClick={buildPreview} disabled={!csvText.trim() || busy} className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 disabled:opacity-55">Preview CSV</button>
+            <button type="button" onClick={() => void confirmImport()} disabled={!preview || validRows.length === 0 || busy} className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-55">{busy ? "Importing…" : "Confirm import"}</button>
+            <button type="button" onClick={reset} disabled={busy} className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 disabled:opacity-55">Cancel/reset</button>
+          </div>
+        </aside>
+      </div>
+
+      {error ? <div role="alert" className="mt-4 rounded-xl border border-red-500/30 bg-red-950/25 p-3 text-sm text-red-100">{error}</div> : null}
+      {success ? <div className="mt-4 rounded-xl border border-emerald-500/30 bg-emerald-950/25 p-3 text-sm text-emerald-100">Import complete: {success.counts?.created ?? 0} created, {success.counts?.updated ?? 0} updated, {success.counts?.skipped ?? 0} skipped, {success.counts?.failed ?? 0} failed. {onboardingCompleted ? "Vehicles onboarding step completed." : null}</div> : null}
+
+      {preview ? (
+        <div className="mt-4 overflow-x-auto rounded-2xl border border-[color:var(--desktop-border)] bg-black/20">
+          <table className="min-w-full divide-y divide-white/10 text-sm">
+            <thead className="bg-white/[0.03] text-left text-xs uppercase tracking-[0.14em] text-neutral-400"><tr><th className="p-3">Row</th><th className="p-3">Vehicle</th><th className="p-3">Customer</th><th className="p-3">Status</th><th className="p-3">Warnings / errors</th></tr></thead>
+            <tbody className="divide-y divide-white/10">
+              {preview.rows.slice(0, 25).map((row) => (
+                <tr key={row.sourceRowNumber} className="text-neutral-200">
+                  <td className="p-3">{row.sourceRowNumber}</td>
+                  <td className="p-3">{row.unit_number || row.vin || row.license_plate || [row.year, row.make, row.model].filter(Boolean).join(" ") || "—"}</td>
+                  <td className="p-3">{row.resolvedCustomerId ?? row.customer_name ?? row.customer_email ?? row.customer_phone ?? "Unlinked"}</td>
+                  <td className="p-3"><span className={row.status === "valid" ? "text-emerald-200" : "text-red-200"}>{row.status}</span></td>
+                  <td className="p-3 text-amber-100">{[...row.errors, ...row.warnings].join(" ") || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+
+  if (!guidedMode) return card;
+  return (
+    <OnboardingHighlightFrame active highlightKey={guidedQuery?.highlight ?? "vehicle-import"} title="Vehicle CSV import" description="Upload/setup here on the real Vehicles page.">
+      {card}
+    </OnboardingHighlightFrame>
+  );
+}

--- a/features/vehicles/lib/importCsv.ts
+++ b/features/vehicles/lib/importCsv.ts
@@ -1,0 +1,224 @@
+import Papa from "papaparse";
+
+export type VehicleImportCustomerOption = {
+  id: string;
+  business_name?: string | null;
+  name?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  phone_number?: string | null;
+};
+
+export type VehicleImportRow = {
+  sourceRowNumber: number;
+  sourceFilename?: string;
+  unit_number?: string;
+  vin?: string;
+  license_plate?: string;
+  year?: number;
+  make?: string;
+  model?: string;
+  submodel?: string;
+  color?: string;
+  engine?: string;
+  engine_type?: string;
+  engine_family?: string;
+  transmission?: string;
+  fuel_type?: string;
+  drivetrain?: string;
+  engine_hours?: number;
+  odometer?: string;
+  customer_id?: string;
+  customer_name?: string;
+  customer_email?: string;
+  customer_phone?: string;
+};
+
+export type VehicleImportPreviewRow = VehicleImportRow & {
+  status: "valid" | "invalid";
+  warnings: string[];
+  errors: string[];
+  resolvedCustomerId?: string;
+};
+
+export type VehicleImportPreview = {
+  rows: VehicleImportPreviewRow[];
+  rowCount: number;
+  validCount: number;
+  invalidCount: number;
+  duplicateWarnings: number;
+  unlinkedCustomerWarnings: number;
+};
+
+const HEADER_ALIASES: Record<string, keyof VehicleImportRow> = {
+  unitnumber: "unit_number",
+  unit: "unit_number",
+  unitno: "unit_number",
+  unitnum: "unit_number",
+  unitid: "unit_number",
+  unitfleetnumber: "unit_number",
+  fleetnumber: "unit_number",
+  vehiclenumber: "unit_number",
+  vehicleid: "unit_number",
+  vin: "vin",
+  serial: "vin",
+  serialnumber: "vin",
+  licenseplate: "license_plate",
+  plate: "license_plate",
+  platenumber: "license_plate",
+  licplate: "license_plate",
+  year: "year",
+  make: "make",
+  model: "model",
+  submodel: "submodel",
+  trim: "submodel",
+  color: "color",
+  engine: "engine",
+  enginetype: "engine_type",
+  enginefamily: "engine_family",
+  transmission: "transmission",
+  transmissiontype: "transmission",
+  fueltype: "fuel_type",
+  fuel: "fuel_type",
+  drivetrain: "drivetrain",
+  enginehours: "engine_hours",
+  hours: "engine_hours",
+  odometer: "odometer",
+  mileage: "odometer",
+  customerid: "customer_id",
+  customername: "customer_name",
+  customer: "customer_name",
+  customeremail: "customer_email",
+  email: "customer_email",
+  customerphone: "customer_phone",
+  phone: "customer_phone",
+};
+
+function normalizeHeader(value: string): string {
+  return value.toLowerCase().replace(/[#_\-./()]/g, " ").replace(/\s+/g, "").trim();
+}
+
+export function cleanVehicleImportText(value: unknown): string | undefined {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const text = String(value).trim();
+  return text.length ? text : undefined;
+}
+
+export function normalizeImportVin(value: unknown): string | undefined {
+  const text = cleanVehicleImportText(value)?.replace(/\s+/g, "").toUpperCase();
+  return text || undefined;
+}
+
+export function normalizeImportPlate(value: unknown): string | undefined {
+  const text = cleanVehicleImportText(value)?.toUpperCase();
+  return text || undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  const text = cleanVehicleImportText(value);
+  if (!text) return undefined;
+  const parsed = Number(text.replace(/,/g, ""));
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseYear(value: unknown): number | undefined {
+  const year = numberValue(value);
+  if (!year || !Number.isInteger(year) || year < 1900 || year > 2100) return undefined;
+  return year;
+}
+
+function hasIdentity(row: VehicleImportRow): boolean {
+  return Boolean(row.vin || row.unit_number || row.license_plate || (row.year && row.make && row.model));
+}
+
+function customerLabel(customer: VehicleImportCustomerOption): string {
+  return [customer.business_name, customer.name, [customer.first_name, customer.last_name].filter(Boolean).join(" "), customer.email, customer.phone, customer.phone_number]
+    .map((value) => value?.trim())
+    .find(Boolean) ?? customer.id;
+}
+
+function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomerOption[]): { id?: string; warning?: string } {
+  const customerId = row.customer_id?.trim();
+  if (customerId) {
+    const match = customers.find((customer) => customer.id === customerId);
+    if (match) return { id: match.id };
+    return { warning: "No matching customer found; this vehicle will import without a customer link." };
+  }
+
+  const candidates = customers.filter((customer) => {
+    const emailMatch = row.customer_email && customer.email?.trim().toLowerCase() === row.customer_email.trim().toLowerCase();
+    const phoneValue = row.customer_phone?.replace(/\D/g, "");
+    const customerPhones = [customer.phone, customer.phone_number].map((value) => value?.replace(/\D/g, ""));
+    const phoneMatch = phoneValue && customerPhones.some((value) => value === phoneValue);
+    const wantedName = row.customer_name?.trim().toLowerCase();
+    const names = [customer.business_name, customer.name, [customer.first_name, customer.last_name].filter(Boolean).join(" ")].map((value) => value?.trim().toLowerCase());
+    const nameMatch = wantedName && names.some((value) => value === wantedName);
+    return Boolean(emailMatch || phoneMatch || nameMatch);
+  });
+
+  if (candidates.length === 1) return { id: candidates[0].id };
+  if (candidates.length > 1) return { warning: `Ambiguous customer match (${candidates.map(customerLabel).join(", ")}); this vehicle will import without a customer link.` };
+  if (row.customer_name || row.customer_email || row.customer_phone) return { warning: "No matching customer found; this vehicle will import without a customer link." };
+  return {};
+}
+
+export function parseVehicleCsv(csvText: string, sourceFilename?: string): VehicleImportRow[] {
+  const parsed = Papa.parse<Record<string, unknown>>(csvText, { header: true, skipEmptyLines: false, transformHeader: (header) => header.trim() });
+  return parsed.data.map((raw, index) => {
+    const row: VehicleImportRow = { sourceRowNumber: index + 2, sourceFilename };
+    for (const [header, value] of Object.entries(raw)) {
+      const key = HEADER_ALIASES[normalizeHeader(header)];
+      if (!key) continue;
+      if (key === "year") {
+        row.year = parseYear(value);
+      } else if (key === "engine_hours") {
+        row.engine_hours = numberValue(value);
+      } else if (key === "vin") {
+        row.vin = normalizeImportVin(value);
+      } else if (key === "license_plate") {
+        row.license_plate = normalizeImportPlate(value);
+      } else {
+        const text = cleanVehicleImportText(value);
+        if (text) (row as Record<string, unknown>)[key] = text;
+      }
+    }
+    return row;
+  });
+}
+
+export function previewVehicleCsv(csvText: string, customers: VehicleImportCustomerOption[] = [], sourceFilename?: string): VehicleImportPreview {
+  const rows = parseVehicleCsv(csvText, sourceFilename);
+  const vinCounts = new Map<string, number>();
+  const unitCounts = new Map<string, number>();
+  for (const row of rows) {
+    if (row.vin) vinCounts.set(row.vin, (vinCounts.get(row.vin) ?? 0) + 1);
+    if (row.unit_number) unitCounts.set(row.unit_number.trim().toLowerCase(), (unitCounts.get(row.unit_number.trim().toLowerCase()) ?? 0) + 1);
+  }
+
+  const previewRows = rows.map((row): VehicleImportPreviewRow => {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const hasAnyValue = Object.entries(row).some(([key, value]) => key !== "sourceRowNumber" && key !== "sourceFilename" && value !== undefined && value !== null && String(value).trim().length > 0);
+
+    if (!hasAnyValue) errors.push("Row is empty.");
+    if (hasAnyValue && !hasIdentity(row)) errors.push("Add VIN, unit number, license plate, or year + make + model.");
+    if (row.vin && (vinCounts.get(row.vin) ?? 0) > 1) warnings.push("Duplicate VIN inside this CSV; the server will import only one unambiguous vehicle.");
+    if (row.unit_number && (unitCounts.get(row.unit_number.trim().toLowerCase()) ?? 0) > 1) warnings.push("Duplicate unit number inside this CSV; the server will import only one unambiguous vehicle.");
+
+    const customer = resolveCustomer(row, customers);
+    if (customer.warning) warnings.push(customer.warning);
+
+    return { ...row, resolvedCustomerId: customer.id, status: errors.length ? "invalid" : "valid", errors, warnings };
+  });
+
+  return {
+    rows: previewRows,
+    rowCount: previewRows.length,
+    validCount: previewRows.filter((row) => row.status === "valid").length,
+    invalidCount: previewRows.filter((row) => row.status === "invalid").length,
+    duplicateWarnings: previewRows.filter((row) => row.warnings.some((warning) => warning.toLowerCase().includes("duplicate"))).length,
+    unlinkedCustomerWarnings: previewRows.filter((row) => row.warnings.some((warning) => warning.toLowerCase().includes("without a customer link"))).length,
+  };
+}

--- a/tests/vehicles/vehicle-csv-import-card.test.tsx
+++ b/tests/vehicles/vehicle-csv-import-card.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+
+const guidedQuery: GuidedOnboardingQuery = {
+  onboardingSession: "session-123",
+  onboardingStep: "vehicles",
+  highlight: "vehicle-import",
+  returnTo: "/dashboard/onboarding-v2/session-123",
+  source: "guided-onboarding",
+};
+
+function importOk() {
+  return { ok: true, json: async () => ({ ok: true, counts: { created: 1, updated: 0, skipped: 0, failed: 0, warnings: 0 } }) };
+}
+
+function onboardingOk() {
+  return { ok: true, json: async () => ({ ok: true }) };
+}
+
+describe("VehicleCsvImportCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows import entry in normal mode without onboarding highlight", () => {
+    render(<VehicleCsvImportCard customers={[]} />);
+
+    expect(screen.getByTestId("vehicle-csv-import-card")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /vehicle csv import/i })).toBeInTheDocument();
+    expect(screen.queryByText(/guided onboarding routed/i)).not.toBeInTheDocument();
+  });
+
+  it("shows guided copy and return link for guided URL state", () => {
+    render(<VehicleCsvImportCard customers={[]} guidedQuery={guidedQuery} highlighted />);
+
+    expect(screen.getByText(/Guided onboarding routed you to the real Vehicles page/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /return to data onboarding/i })).toHaveAttribute("href", "/dashboard/onboarding-v2/session-123");
+  });
+
+  it("previews invalid rows and does not import on preview", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "unit,vin\n,\n");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+
+    expect(screen.getAllByText("invalid").length).toBeGreaterThan(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls vehicle import on confirm", async () => {
+    const fetchMock = vi.fn(async () => importOk());
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "unit,make,model\nA-1,Ford,F-150");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm import/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/vehicles/import", expect.objectContaining({ method: "POST" })));
+  });
+
+  it("calls guided completion only after successful import", async () => {
+    const fetchMock = vi.fn(async (url: string) => (url.includes("/api/vehicles/import") ? importOk() : onboardingOk()));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} guidedQuery={guidedQuery} highlighted />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "unit\nA-1");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    expect(fetchMock).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: /confirm import/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/onboarding-v2/guided/sessions/session-123/steps/vehicles/complete", expect.objectContaining({ method: "POST" })));
+  });
+
+  it("does not call guided completion on failed import or cancel", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, json: async () => ({ error: "failed" }) }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} guidedQuery={guidedQuery} highlighted />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "unit\nA-1");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel\/reset/i }));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "unit\nA-1");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm import/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("failed"));
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/steps/vehicles/complete"), expect.anything());
+  });
+});

--- a/tests/vehicles/vehicle-import-csv.test.ts
+++ b/tests/vehicles/vehicle-import-csv.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { previewVehicleCsv } from "@/features/vehicles/lib/importCsv";
+
+describe("vehicle CSV preview", () => {
+  it("parses common aliases and counts valid rows", () => {
+    const preview = previewVehicleCsv("unit #,serial,plate number,year,make,model,customer email\nA-1,1hgcm82633a004352,abc123,2021,Ford,F-150,jane@example.com", [
+      { id: "customer-1", email: "jane@example.com" },
+    ]);
+
+    expect(preview.rowCount).toBe(1);
+    expect(preview.validCount).toBe(1);
+    expect(preview.rows[0]).toMatchObject({ unit_number: "A-1", vin: "1HGCM82633A004352", license_plate: "ABC123", resolvedCustomerId: "customer-1" });
+  });
+
+  it("shows invalid rows and unlinked customer warnings before import", () => {
+    const preview = previewVehicleCsv("unit,vin,customer name\n,,Missing Customer\nA-1,1HGCM82633A004352,\nA-1,1HGCM82633A004352,", []);
+
+    expect(preview.invalidCount).toBe(1);
+    expect(preview.rows[0].errors.join(" ")).toMatch(/VIN, unit number, license plate/i);
+    expect(preview.rows[0].warnings.join(" ")).toMatch(/without a customer link/i);
+    expect(preview.duplicateWarnings).toBe(2);
+  });
+});

--- a/tests/vehicles/vehicle-import-route.test.ts
+++ b/tests/vehicles/vehicle-import-route.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../../app/api/vehicles/import/route";
+
+const { mockSupabaseState } = vi.hoisted(() => ({
+  mockSupabaseState: {
+    user: { id: "user-1" } as { id: string } | null,
+    profileShopId: "shop-real" as string | null,
+    customers: [] as Array<Record<string, unknown>>,
+    vehicles: [] as Array<Record<string, unknown>>,
+    inserts: [] as Array<Record<string, unknown>>,
+    updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
+  },
+}));
+
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+
+type MockQuery = {
+  filters: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  ilike: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+
+function makeQuery(table: string): MockQuery {
+  const query: MockQuery = {
+    filters: {},
+    select: vi.fn(() => query),
+    eq: vi.fn((column: string, value: unknown) => { query.filters[column] = value; return query; }),
+    ilike: vi.fn((column: string, value: unknown) => { query.filters[column] = value; return query; }),
+    limit: vi.fn(() => {
+      if (table === "customers" && query.filters.shop_id && !query.filters.id) {
+        return Promise.resolve({ data: mockSupabaseState.customers.filter((row) => row.shop_id === query.filters.shop_id), error: null });
+      }
+      return query;
+    }),
+    maybeSingle: vi.fn(async () => {
+      if (table === "profiles") return { data: { shop_id: mockSupabaseState.profileShopId }, error: null };
+      if (table === "customers") {
+        const found = mockSupabaseState.customers.find((row) => row.id === query.filters.id && row.shop_id === query.filters.shop_id);
+        return { data: found ?? null, error: null };
+      }
+      if (table === "vehicles") {
+        const found = mockSupabaseState.vehicles.find((row) => {
+          if (row.shop_id !== query.filters.shop_id) return false;
+          if (query.filters.vin) return row.vin === query.filters.vin;
+          if (query.filters.unit_number) return String(row.unit_number).toLowerCase() === String(query.filters.unit_number).toLowerCase();
+          if (query.filters.license_plate) return row.license_plate === query.filters.license_plate;
+          return false;
+        });
+        return { data: found ?? null, error: null };
+      }
+      return { data: null, error: null };
+    }),
+    insert: vi.fn(async (payload: Record<string, unknown>) => {
+      mockSupabaseState.inserts.push(payload);
+      mockSupabaseState.vehicles.push({ id: `vehicle-${mockSupabaseState.vehicles.length + 1}`, ...payload });
+      return { error: null };
+    }),
+    update: vi.fn((payload: Record<string, unknown>) => {
+      query.payload = payload;
+      return query;
+    }),
+  };
+  query.eq = vi.fn((column: string, value: unknown) => {
+    query.filters[column] = value;
+    if (table === "vehicles" && query.payload && column === "id") {
+      mockSupabaseState.updates.push({ payload: query.payload, filters: { ...query.filters } });
+    }
+    return query;
+  });
+  query.select = vi.fn(() => query);
+  return query;
+}
+
+vi.mock("@supabase/auth-helpers-nextjs", () => ({
+  createRouteHandlerClient: vi.fn(() => ({
+    auth: { getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })) },
+    from: vi.fn((table: string) => makeQuery(table)),
+  })),
+}));
+
+function request(rows: unknown[]) {
+  return new Request("http://localhost/api/vehicles/import", { method: "POST", body: JSON.stringify({ rows, shop_id: "evil-shop" }) });
+}
+
+describe("POST /api/vehicles/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabaseState.user = { id: "user-1" };
+    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.customers = [];
+    mockSupabaseState.vehicles = [];
+    mockSupabaseState.inserts = [];
+    mockSupabaseState.updates = [];
+  });
+
+  it("rejects unauthenticated import", async () => {
+    mockSupabaseState.user = null;
+    const response = await POST(request([{ unit_number: "A-1" }]));
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects no-shop profiles", async () => {
+    mockSupabaseState.profileShopId = null;
+    const response = await POST(request([{ unit_number: "A-1" }]));
+    expect(response.status).toBe(403);
+  });
+
+  it("ignores client shop_id and inserts into authenticated shop", async () => {
+    const response = await POST(request([{ unit_number: "A-1", vin: "1hgcm82633a004352" }]));
+    const payload = await response.json();
+    expect(response.status).toBe(200);
+    expect(payload.counts.created).toBe(1);
+    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1", unit_number: "A-1", vin: "1HGCM82633A004352" });
+    expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
+  });
+
+  it("rejects cross-shop customer_id", async () => {
+    mockSupabaseState.customers = [{ id: "customer-1", shop_id: "other-shop" }];
+    const response = await POST(request([{ unit_number: "A-1", customer_id: "customer-1" }]));
+    const payload = await response.json();
+    expect(response.status).toBe(400);
+    expect(payload.errors[0].message).toMatch(/does not belong/i);
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+  });
+
+  it("customer email/name lookup is shop scoped", async () => {
+    mockSupabaseState.customers = [
+      { id: "other-customer", shop_id: "other-shop", email: "jane@example.com", name: "Jane" },
+      { id: "real-customer", shop_id: "shop-real", email: "jane@example.com", name: "Jane" },
+    ];
+    const response = await POST(request([{ unit_number: "A-1", customer_email: "jane@example.com", customer_name: "Jane" }]));
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0].customer_id).toBe("real-customer");
+  });
+
+  it("duplicate VIN is not inserted twice", async () => {
+    const response = await POST(request([{ vin: "1HGCM82633A004352" }, { vin: "1HGCM82633A004352" }]));
+    const payload = await response.json();
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 1, skipped: 1 });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+  });
+
+  it("duplicate unit number is handled/skipped", async () => {
+    const response = await POST(request([{ unit_number: "A-1" }, { unit_number: "a-1" }]));
+    const payload = await response.json();
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 1, skipped: 1 });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a real daily-use Vehicle CSV import experience on the dedicated `/vehicles` page that works in both normal and guided onboarding modes while preserving existing customer→vehicle workflows and tenancy boundaries. 
- Offer CSV preview/validation so users can see row counts, warnings, and invalid rows before any server-side changes occur, and prevent silent customer creation or cross-shop writes. 

### Description
- Added a client-side CSV parser and previewer in `features/vehicles/lib/importCsv.ts` that supports flexible header aliases, identity rules (VIN | unit | plate | year+make+model), duplicate VIN/unit detection, and shop-scoped customer resolution warnings without auto-creating customers. 
- Implemented `VehicleCsvImportCard` UI at `features/vehicles/components/VehicleCsvImportCard.tsx` with file upload, paste input, preview totals, row table, explicit `Confirm import` / `Cancel/reset` controls, and guided onboarding copy/return behavior. 
- Added server import endpoint `POST /api/vehicles/import` at `app/api/vehicles/import/route.ts` that authenticates the user, derives `shop_id` from the authenticated profile (ignoring any client-supplied `shop_id`), enforces shop-scoped customer validation, and applies conservative upsert/skip logic for duplicate VINs/unit numbers while returning counts and warnings. 
- Integrated the import card onto the Vehicles page (`features/vehicles/app/vehicles/page.tsx`) so the card appears above the manual create form and added focused tests in `tests/vehicles/*` covering preview parsing, UI flows, guided completion, and route-level auth/shop/customer/duplicate handling. 

### Testing
- Ran typecheck with `npx tsc --noEmit` which completed successfully. 
- Ran lint checks with `npx eslint` against changed files which passed without errors. 
- Executed targeted unit and integration tests with `npx vitest` for the new vehicle import coverage and related vehicle tests, and all tests passed (`22` tests across the added vehicle tests). 
- Ran `git diff --check` (whitespace/cleanliness) which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2195208b7c83288dff27ba6ce1f8d5)