### PR TITLE
Customer import: use cookie-backed Supabase route client (fix 401)

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type DB = Database;
 type CustomerInsert = DB["public"]["Tables"]["customers"]["Insert"];
@@ -101,7 +101,7 @@ function normalizeRow(row: ImportRow, userId: string, shopId: string): CustomerI
 }
 
 async function findExistingCustomer(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   shopId: string,
   customer: CustomerInsert,
 ): Promise<CustomerMatch | null> {
@@ -139,6 +139,38 @@ async function findExistingCustomer(
   return null;
 }
 
+function getCustomerImportCookieDiagnostics() {
+  try {
+    const cookieStore = cookies() as unknown as {
+      getAll?: () => { name: string; value?: string }[];
+    };
+    const cookieNames = cookieStore.getAll?.().map((cookie) => cookie.name) ?? [];
+    const supabaseAuthCookieCount = cookieNames.filter((name) => name.startsWith("sb-")).length;
+
+    return {
+      hasSupabaseAuthCookies: supabaseAuthCookieCount > 0,
+      supabaseAuthCookieCount,
+    };
+  } catch {
+    return {
+      hasSupabaseAuthCookies: false,
+      supabaseAuthCookieCount: 0,
+    };
+  }
+}
+
+function logCustomerImportAuthDiagnostic(
+  stage: "auth" | "profile",
+  details: {
+    hasSupabaseAuthCookies: boolean;
+    supabaseAuthCookieCount: number;
+    hasUserId?: boolean;
+    hasProfileShopId?: boolean;
+  },
+) {
+  console.info("[customers-import] auth diagnostic", { stage, ...details });
+}
+
 function updatePayload(customer: CustomerInsert): CustomerUpdate {
   const update: CustomerUpdate = { updated_at: new Date().toISOString() };
   for (const key of [
@@ -164,11 +196,17 @@ function updatePayload(customer: CustomerInsert): CustomerUpdate {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
+  const cookieDiagnostics = getCustomerImportCookieDiagnostics();
   const {
     data: { user },
     error: userError,
   } = await supabase.auth.getUser();
+
+  logCustomerImportAuthDiagnostic("auth", {
+    ...cookieDiagnostics,
+    hasUserId: Boolean(user?.id),
+  });
 
   if (userError || !user?.id) {
     return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
@@ -180,7 +218,17 @@ export async function POST(req: Request) {
     .eq("id", user.id)
     .maybeSingle<{ shop_id: string | null }>();
 
-  if (profileError || !profile?.shop_id) {
+  logCustomerImportAuthDiagnostic("profile", {
+    ...cookieDiagnostics,
+    hasUserId: true,
+    hasProfileShopId: Boolean(profile?.shop_id),
+  });
+
+  if (profileError || !profile) {
+    return NextResponse.json({ ok: false, error: "Profile for current user not found" }, { status: 403 });
+  }
+
+  if (!profile.shop_id) {
     return NextResponse.json({ ok: false, error: "Missing shop" }, { status: 403 });
   }
 

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import { POST as importCustomers } from "../../app/api/customers/import/route";
 
@@ -10,7 +11,7 @@ const { router, mockSupabaseState } = vi.hoisted(() => ({
   router: { push: vi.fn(), back: vi.fn() },
   mockSupabaseState: {
     user: { id: "user-1" } as { id: string } | null,
-    profileShopId: "shop-real" as string | null,
+    profile: { shop_id: "shop-real" } as { shop_id: string | null } | null,
     customers: [] as Array<Record<string, unknown>>,
     inserts: [] as Array<Record<string, unknown>>,
     updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
@@ -44,7 +45,7 @@ function makeQuery(table: string): MockQuery {
       return query;
     }),
     maybeSingle: vi.fn(async () => {
-      if (table === "profiles") return { data: { shop_id: mockSupabaseState.profileShopId }, error: null };
+      if (table === "profiles") return { data: mockSupabaseState.profile, error: null };
       const match: Record<string, unknown> | undefined = mockSupabaseState.customers.find((customer) => {
         if (query.filters.email) return customer.email === query.filters.email && customer.shop_id === query.filters.shop_id;
         if (query.filters.name) return customer.name === query.filters.name && customer.shop_id === query.filters.shop_id;
@@ -71,8 +72,8 @@ function makeQuery(table: string): MockQuery {
   return query;
 }
 
-vi.mock("@supabase/auth-helpers-nextjs", () => ({
-  createRouteHandlerClient: vi.fn(() => ({
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRoute: vi.fn(() => ({
     auth: {
       getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })),
     },
@@ -80,7 +81,11 @@ vi.mock("@supabase/auth-helpers-nextjs", () => ({
   })),
 }));
 
-vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => ({
+    getAll: () => [{ name: "sb-test-auth-token", value: "redacted" }],
+  })),
+}));
 
 const guidedQuery: GuidedOnboardingQuery = {
   onboardingSession: "session-123",
@@ -104,7 +109,7 @@ describe("CustomerCsvImportCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSupabaseState.user = { id: "user-1" };
-    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.profile = { shop_id: "shop-real" };
     mockSupabaseState.customers = [];
     mockSupabaseState.inserts = [];
     mockSupabaseState.updates = [];
@@ -184,10 +189,21 @@ describe("CustomerCsvImportCard", () => {
 describe("POST /api/customers/import", () => {
   beforeEach(() => {
     mockSupabaseState.user = { id: "user-1" };
-    mockSupabaseState.profileShopId = "shop-real";
+    mockSupabaseState.profile = { shop_id: "shop-real" };
     mockSupabaseState.customers = [];
     mockSupabaseState.inserts = [];
     mockSupabaseState.updates = [];
+  });
+
+  it("uses the shared cookie-backed Supabase route client for authenticated imports", async () => {
+    const response = await importCustomers(new Request("http://localhost/api/customers/import", {
+      method: "POST",
+      body: JSON.stringify({ rows: [{ name: "Ada Lovelace", email: "ada@example.com" }] }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(createServerSupabaseRoute)).toHaveBeenCalled();
+    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1" });
   });
 
   it("rejects unauthenticated imports", async () => {
@@ -197,8 +213,17 @@ describe("POST /api/customers/import", () => {
     expect(response.status).toBe(401);
   });
 
+  it("rejects imports when the authenticated user profile is missing", async () => {
+    mockSupabaseState.profile = null;
+    const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.error).toBe("Profile for current user not found");
+  });
+
   it("rejects imports when the user has no shop", async () => {
-    mockSupabaseState.profileShopId = null;
+    mockSupabaseState.profile = { shop_id: null };
     const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
 
     expect(response.status).toBe(403);


### PR DESCRIPTION
### Motivation
- The customer CSV import route was still using `@supabase/auth-helpers-nextjs`'s `createRouteHandlerClient`, which caused Supabase to see an anon/bad JWT and return `403 bad_jwt` in production.
- The fix should be minimal and scoped to the customer import path without touching global auth, middleware, or RLS.

### Description
- Replaced the old auth-helper client in the customer import route with the repo's shared cookie-backed route client by importing and using `createServerSupabaseRoute()` from `features/shared/lib/supabase/server` in `app/api/customers/import/route.ts`.
- Added safe, scoped diagnostics in `app/api/customers/import/route.ts` that log only whether `sb-*` auth cookies exist and counts, whether a user id was found, and whether the profile contains a `shop_id` (no tokens or raw cookie values are logged).
- Tightened auth/profile checks so the route returns `401` only when there is no authenticated user, `403` for missing profile or missing `shop_id`, and `400` for an invalid payload while keeping import upsert behavior unchanged.
- Updated and extended tests in `tests/onboarding-v2/customer-onboarding-card.test.tsx` to assert the route uses the shared server client, rejects unauthenticated requests, ignores client-supplied `shop_id`, and handles missing profile/shop correctly.

### Testing
- Ran `grep` for legacy auth-helper usage in the inspected scope and confirmed the import route was the culprit and is now using the shared helper (remaining unrelated import in a client page outside the patch scope). — OK
- Ran `npx tsc --noEmit` to validate types; it completed successfully. — OK
- Ran `npx eslint` for the relevant files; lint completed with a repo ignore warning about `features/shared/lib/supabase/server.ts` being ignored by config but no new errors introduced. — OK (warning)
- Ran the targeted tests with `npx vitest run tests/onboarding-v2/customer-onboarding-card.test.tsx`; all tests passed (12 tests). — OK
- Verified `git diff --check` produced no whitespace/errors related to the change. — OK

Files changed:
- app/api/customers/import/route.ts
- tests/onboarding-v2/customer-onboarding-card.test.tsx

Notes / next steps:
- This change is intentionally limited to the customer import API route and its tests to avoid broad auth-helper rewrites.
- After deploying, verify in production Vercel logs for `POST /api/customers/import` that the `[customers-import] auth diagnostic` entries show `hasSupabaseAuthCookies: true`, `hasUserId: true`, and `hasProfileShopId: true`, and confirm Supabase logs no longer show `x_client_info: @supabase/auth-helpers-nextjs@0.10.0` for this route.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21c3fac4f08328ac55751c40ec2c90)