### PR TITLE
Fix customer CSV import conflict handling

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -6,7 +6,31 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 type DB = Database;
 type CustomerInsert = DB["public"]["Tables"]["customers"]["Insert"];
 type CustomerUpdate = DB["public"]["Tables"]["customers"]["Update"];
-type CustomerMatch = Pick<DB["public"]["Tables"]["customers"]["Row"], "id">;
+type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
+type CustomerMatch = Pick<
+  CustomerRow,
+  | "id"
+  | "shop_id"
+  | "business_name"
+  | "name"
+  | "first_name"
+  | "last_name"
+  | "email"
+  | "phone"
+  | "phone_number"
+  | "address"
+  | "street"
+  | "city"
+  | "province"
+  | "postal_code"
+  | "notes"
+  | "import_notes"
+>;
+type SupabaseRouteClient = ReturnType<typeof createServerSupabaseRoute>;
+type SupabaseQuery = {
+  eq: (column: string, value: unknown) => SupabaseQuery;
+  or: (filters: string) => SupabaseQuery;
+};
 
 type ImportRow = {
   first_name?: unknown;
@@ -34,6 +58,34 @@ type Counts = {
   failed: number;
 };
 
+type ImportDiagnostic = {
+  row: number;
+  identity: SafeRowIdentity;
+  reason: string;
+  code?: string;
+  constraint?: string;
+};
+
+type SafeRowIdentity = {
+  email?: string | null;
+  phone?: string | null;
+  name?: string | null;
+};
+
+type SupabaseErrorLike = {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
+  status?: number;
+  name?: string;
+};
+
+const CUSTOMER_SELECT =
+  "id,shop_id,business_name,name,first_name,last_name,email,phone,phone_number,address,street,city,province,postal_code,notes,import_notes";
+const MAX_IMPORT_ROWS = 5000;
+const MAX_DIAGNOSTICS = 25;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -54,20 +106,44 @@ function cleanPhone(value: unknown): string | null {
   return digits || raw;
 }
 
-function splitName(name: string | null): { firstName: string | null; lastName: string | null } {
+function normalizeComparable(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitName(name: string | null): {
+  firstName: string | null;
+  lastName: string | null;
+} {
   if (!name) return { firstName: null, lastName: null };
   const parts = name.split(/\s+/).filter(Boolean);
   if (parts.length === 0) return { firstName: null, lastName: null };
   if (parts.length === 1) return { firstName: parts[0], lastName: null };
-  return { firstName: parts.slice(0, -1).join(" "), lastName: parts.at(-1) ?? null };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts.at(-1) ?? null,
+  };
 }
 
 function escapeOrValue(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll(",", "\\,").replaceAll("%", "\\%").replaceAll("_", "\\_");
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll(",", "\\,")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
 }
 
-function normalizeRow(row: ImportRow, userId: string, shopId: string): CustomerInsert | null {
-  const businessName = cleanString(row.business_name) ?? cleanString(row.company_name);
+function normalizeRow(
+  row: ImportRow,
+  userId: string,
+  shopId: string,
+): CustomerInsert | null {
+  const businessName =
+    cleanString(row.business_name) ?? cleanString(row.company_name);
   const explicitName = cleanString(row.name);
   const split = splitName(explicitName);
   const firstName = cleanString(row.first_name) ?? split.firstName;
@@ -100,43 +176,105 @@ function normalizeRow(row: ImportRow, userId: string, shopId: string): CustomerI
   };
 }
 
+async function findSingleCustomer(
+  supabase: SupabaseRouteClient,
+  buildQuery: (query: SupabaseQuery) => unknown,
+): Promise<CustomerMatch | null> {
+  const query = buildQuery(
+    supabase.from("customers").select(CUSTOMER_SELECT).limit(1),
+  );
+  const { data, error } = (await query) as {
+    data: CustomerMatch[] | null;
+    error: SupabaseErrorLike | null;
+  };
+  if (error) return null;
+  return data?.[0] ?? null;
+}
+
+function locationKey(customer: CustomerInsert | CustomerMatch): string {
+  return [
+    customer.street ?? customer.address,
+    customer.city,
+    customer.province,
+    customer.postal_code,
+  ]
+    .map(normalizeComparable)
+    .filter(Boolean)
+    .join("|");
+}
+
+function nameKey(customer: CustomerInsert | CustomerMatch): string {
+  const displayName =
+    customer.business_name ||
+    customer.name ||
+    [customer.first_name, customer.last_name].filter(Boolean).join(" ");
+  return normalizeComparable(displayName);
+}
+
+async function findByNameAndLocationFallback(
+  supabase: SupabaseRouteClient,
+  shopId: string,
+  customer: CustomerInsert,
+): Promise<CustomerMatch | null> {
+  const targetName = nameKey(customer);
+  if (!targetName) return null;
+
+  const targetLocation = locationKey(customer);
+  if (!targetLocation && !customer.city && !customer.postal_code) return null;
+
+  const { data, error } = (await supabase
+    .from("customers")
+    .select(CUSTOMER_SELECT)
+    .eq("shop_id", shopId)
+    .limit(5000)) as {
+    data: CustomerMatch[] | null;
+    error: SupabaseErrorLike | null;
+  };
+
+  if (error || !data?.length) return null;
+
+  return (
+    data.find((candidate) => {
+      if (candidate.shop_id !== shopId) return false;
+      if (nameKey(candidate) !== targetName) return false;
+      const candidateLocation = locationKey(candidate);
+      if (targetLocation && candidateLocation)
+        return candidateLocation === targetLocation;
+      return (
+        normalizeComparable(candidate.city) ===
+          normalizeComparable(customer.city) &&
+        normalizeComparable(candidate.postal_code) ===
+          normalizeComparable(customer.postal_code)
+      );
+    }) ?? null
+  );
+}
+
 async function findExistingCustomer(
-  supabase: ReturnType<typeof createServerSupabaseRoute>,
+  supabase: SupabaseRouteClient,
   shopId: string,
   customer: CustomerInsert,
 ): Promise<CustomerMatch | null> {
   if (customer.email) {
-    const { data } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("email", customer.email)
-      .maybeSingle<CustomerMatch>();
-    if (data?.id) return data;
+    const match = await findSingleCustomer(supabase, (query) =>
+      query.eq("shop_id", shopId).eq("email", customer.email),
+    );
+    if (match?.id) return match;
   }
 
   const phone = customer.phone ?? customer.phone_number;
   if (phone) {
-    const { data } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .or(`phone.eq.${escapeOrValue(phone)},phone_number.eq.${escapeOrValue(phone)}`)
-      .maybeSingle<CustomerMatch>();
-    if (data?.id) return data;
+    const match = await findSingleCustomer(supabase, (query) =>
+      query
+        .eq("shop_id", shopId)
+        .or(
+          `phone.eq.${escapeOrValue(phone)},phone_number.eq.${escapeOrValue(phone)}`,
+        ),
+    );
+    if (match?.id) return match;
   }
 
-  if (customer.name) {
-    const { data } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("name", customer.name)
-      .maybeSingle<CustomerMatch>();
-    if (data?.id) return data;
-  }
-
-  return null;
+  return findByNameAndLocationFallback(supabase, shopId, customer);
 }
 
 function getCustomerImportCookieDiagnostics() {
@@ -144,8 +282,11 @@ function getCustomerImportCookieDiagnostics() {
     const cookieStore = cookies() as unknown as {
       getAll?: () => { name: string; value?: string }[];
     };
-    const cookieNames = cookieStore.getAll?.().map((cookie) => cookie.name) ?? [];
-    const supabaseAuthCookieCount = cookieNames.filter((name) => name.startsWith("sb-")).length;
+    const cookieNames =
+      cookieStore.getAll?.().map((cookie) => cookie.name) ?? [];
+    const supabaseAuthCookieCount = cookieNames.filter((name) =>
+      name.startsWith("sb-"),
+    ).length;
 
     return {
       hasSupabaseAuthCookies: supabaseAuthCookieCount > 0,
@@ -195,6 +336,108 @@ function updatePayload(customer: CustomerInsert): CustomerUpdate {
   return update;
 }
 
+function hasMeaningfulChanges(
+  existing: CustomerMatch,
+  update: CustomerUpdate,
+): boolean {
+  return (Object.keys(update) as Array<keyof CustomerUpdate>).some((key) => {
+    if (key === "updated_at") return false;
+    return (
+      update[key] != null &&
+      update[key] !== existing[key as keyof CustomerMatch]
+    );
+  });
+}
+
+function getSafeIdentity(customer: CustomerInsert): SafeRowIdentity {
+  return {
+    email: customer.email ?? null,
+    phone: customer.phone ?? customer.phone_number ?? null,
+    name:
+      (customer.name ??
+        customer.business_name ??
+        [customer.first_name, customer.last_name].filter(Boolean).join(" ")) ||
+      null,
+  };
+}
+
+function getConstraint(
+  error: SupabaseErrorLike | null | undefined,
+): string | undefined {
+  const text = [error?.message, error?.details].filter(Boolean).join(" ");
+  return (
+    text.match(/constraint\s+"([^"]+)"/)?.[1] ??
+    text.match(/unique\s+constraint\s+"([^"]+)"/)?.[1]
+  );
+}
+
+function isDuplicateError(
+  error: SupabaseErrorLike | null | undefined,
+): boolean {
+  return (
+    error?.code === "23505" ||
+    error?.status === 409 ||
+    /duplicate key|unique constraint/i.test(error?.message ?? "")
+  );
+}
+
+function addDiagnostic(
+  collection: ImportDiagnostic[],
+  diagnostic: ImportDiagnostic,
+) {
+  if (collection.length < MAX_DIAGNOSTICS) collection.push(diagnostic);
+}
+
+function logRowImportIssue(
+  row: number,
+  customer: CustomerInsert,
+  error: SupabaseErrorLike,
+  context: string,
+) {
+  console.warn("[customers-import] row import issue", {
+    row,
+    context,
+    identity: getSafeIdentity(customer),
+    code: error.code,
+    status: error.status,
+    constraint: getConstraint(error),
+    message: error.message,
+  });
+}
+
+async function updateExistingCustomer(
+  supabase: SupabaseRouteClient,
+  shopId: string,
+  existing: CustomerMatch,
+  customer: CustomerInsert,
+): Promise<{
+  status: "updated" | "skipped" | "failed";
+  error?: SupabaseErrorLike;
+  reason?: string;
+}> {
+  if (existing.shop_id && existing.shop_id !== shopId) {
+    return {
+      status: "failed",
+      reason: "Matched customer is outside the authenticated shop scope.",
+    };
+  }
+
+  const update = updatePayload(customer);
+  if (!hasMeaningfulChanges(existing, update))
+    return {
+      status: "skipped",
+      reason: "Existing customer already has the same import values.",
+    };
+
+  const { error } = (await supabase
+    .from("customers")
+    .update(update)
+    .eq("shop_id", shopId)
+    .eq("id", existing.id)) as { error: SupabaseErrorLike | null };
+  if (error) return { status: "failed", error };
+  return { status: "updated" };
+}
+
 export async function POST(req: Request) {
   const supabase = createServerSupabaseRoute();
   const cookieDiagnostics = getCustomerImportCookieDiagnostics();
@@ -209,7 +452,10 @@ export async function POST(req: Request) {
   });
 
   if (userError || !user?.id) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { ok: false, error: "Unauthorized" },
+      { status: 401 },
+    );
   }
 
   const { data: profile, error: profileError } = await supabase
@@ -225,54 +471,192 @@ export async function POST(req: Request) {
   });
 
   if (profileError || !profile) {
-    return NextResponse.json({ ok: false, error: "Profile for current user not found" }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: "Profile for current user not found" },
+      { status: 403 },
+    );
   }
 
   if (!profile.shop_id) {
-    return NextResponse.json({ ok: false, error: "Missing shop" }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: "Missing shop" },
+      { status: 403 },
+    );
   }
 
   const body = (await req.json().catch(() => null)) as unknown;
   if (!isRecord(body) || !Array.isArray(body.rows)) {
-    return NextResponse.json({ ok: false, error: "Invalid customer import payload" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "Invalid customer import payload" },
+      { status: 400 },
+    );
   }
 
   const counts: Counts = { created: 0, updated: 0, skipped: 0, failed: 0 };
+  const warnings: ImportDiagnostic[] = [];
+  const errors: ImportDiagnostic[] = [];
   const shopId = profile.shop_id;
-  const inputRows = body.rows.slice(0, 1000);
+  const inputRows = body.rows.slice(0, MAX_IMPORT_ROWS);
 
-  for (const rawRow of inputRows) {
+  if (body.rows.length > MAX_IMPORT_ROWS) {
+    const skipped = body.rows.length - MAX_IMPORT_ROWS;
+    counts.skipped += skipped;
+    addDiagnostic(warnings, {
+      row: MAX_IMPORT_ROWS + 1,
+      identity: {},
+      reason: `Import is limited to ${MAX_IMPORT_ROWS} rows per request; ${skipped} extra rows were skipped.`,
+    });
+  }
+
+  for (const [index, rawRow] of inputRows.entries()) {
+    const rowNumber = index + 1;
     if (!isRecord(rawRow)) {
       counts.skipped += 1;
+      addDiagnostic(warnings, {
+        row: rowNumber,
+        identity: {},
+        reason: "Row is not an object.",
+      });
       continue;
     }
 
     const customer = normalizeRow(rawRow as ImportRow, user.id, shopId);
     if (!customer) {
       counts.skipped += 1;
+      addDiagnostic(warnings, {
+        row: rowNumber,
+        identity: {},
+        reason: "Missing customer identity fields.",
+      });
       continue;
     }
 
     try {
       const existing = await findExistingCustomer(supabase, shopId, customer);
       if (existing?.id) {
-        const { error } = await supabase
-          .from("customers")
-          .update(updatePayload(customer))
-          .eq("shop_id", shopId)
-          .eq("id", existing.id);
-        if (error) counts.failed += 1;
-        else counts.updated += 1;
+        const result = await updateExistingCustomer(
+          supabase,
+          shopId,
+          existing,
+          customer,
+        );
+        if (result.status === "updated") counts.updated += 1;
+        else if (result.status === "skipped") {
+          counts.skipped += 1;
+          addDiagnostic(warnings, {
+            row: rowNumber,
+            identity: getSafeIdentity(customer),
+            reason: result.reason ?? "Existing customer skipped.",
+          });
+        } else {
+          counts.failed += 1;
+          if (result.error)
+            logRowImportIssue(rowNumber, customer, result.error, "update");
+          addDiagnostic(errors, {
+            row: rowNumber,
+            identity: getSafeIdentity(customer),
+            reason:
+              result.error?.message ??
+              result.reason ??
+              "Unable to update existing customer.",
+            code: result.error?.code,
+            constraint: getConstraint(result.error),
+          });
+        }
         continue;
       }
 
-      const { error } = await supabase.from("customers").insert(customer);
-      if (error) counts.failed += 1;
-      else counts.created += 1;
-    } catch {
+      const { error } = (await supabase.from("customers").insert(customer)) as {
+        error: SupabaseErrorLike | null;
+      };
+      if (!error) {
+        counts.created += 1;
+        continue;
+      }
+
+      logRowImportIssue(rowNumber, customer, error, "insert");
+
+      if (isDuplicateError(error)) {
+        const duplicateMatch = await findExistingCustomer(
+          supabase,
+          shopId,
+          customer,
+        );
+        if (duplicateMatch?.id) {
+          const result = await updateExistingCustomer(
+            supabase,
+            shopId,
+            duplicateMatch,
+            customer,
+          );
+          if (result.status === "updated") counts.updated += 1;
+          else if (result.status === "skipped") {
+            counts.skipped += 1;
+            addDiagnostic(warnings, {
+              row: rowNumber,
+              identity: getSafeIdentity(customer),
+              reason: result.reason ?? "Duplicate customer already exists.",
+            });
+          } else {
+            counts.failed += 1;
+            if (result.error)
+              logRowImportIssue(
+                rowNumber,
+                customer,
+                result.error,
+                "duplicate-update",
+              );
+            addDiagnostic(errors, {
+              row: rowNumber,
+              identity: getSafeIdentity(customer),
+              reason:
+                result.error?.message ??
+                result.reason ??
+                "Duplicate customer could not be updated.",
+              code: result.error?.code,
+              constraint: getConstraint(result.error),
+            });
+          }
+          continue;
+        }
+
+        counts.skipped += 1;
+        addDiagnostic(warnings, {
+          row: rowNumber,
+          identity: getSafeIdentity(customer),
+          reason:
+            "Duplicate customer constraint hit, but no safe same-shop match was found to update.",
+          code: error.code,
+          constraint: getConstraint(error),
+        });
+        continue;
+      }
+
       counts.failed += 1;
+      addDiagnostic(errors, {
+        row: rowNumber,
+        identity: getSafeIdentity(customer),
+        reason: error.message ?? "Unable to import customer.",
+        code: error.code,
+        constraint: getConstraint(error),
+      });
+    } catch (error) {
+      counts.failed += 1;
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unexpected customer import error.";
+      console.warn("[customers-import] row import exception", {
+        row: rowNumber,
+        message,
+      });
+      addDiagnostic(errors, {
+        row: rowNumber,
+        identity: getSafeIdentity(customer),
+        reason: message,
+      });
     }
   }
 
-  return NextResponse.json({ ok: true, counts });
+  return NextResponse.json({ ok: true, counts, warnings, errors });
 }

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -33,10 +33,24 @@ type ImportCounts = {
   failed: number;
 };
 
+type ImportDiagnostic = {
+  row: number;
+  reason: string;
+  code?: string;
+  constraint?: string;
+  identity?: {
+    email?: string | null;
+    phone?: string | null;
+    name?: string | null;
+  };
+};
+
 type ImportResponse = {
   ok?: boolean;
   error?: string;
   counts?: ImportCounts;
+  warnings?: ImportDiagnostic[];
+  errors?: ImportDiagnostic[];
 };
 
 type Props = {
@@ -63,10 +77,15 @@ const SUPPORTED_COLUMNS = [
   "notes",
 ] as const;
 
-const RECOMMENDED_COLUMNS = "first_name, last_name, email, phone, address, city, province/state, postal_code/zip";
+const RECOMMENDED_COLUMNS =
+  "first_name, last_name, email, phone, address, city, province/state, postal_code/zip";
 
 function cleanHeader(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, "");
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
 }
 
 function cleanCell(value: unknown): string | null {
@@ -88,13 +107,13 @@ function normalizeParsedRow(row: Record<string, unknown>): CustomerImportRow {
 function hasImportableIdentity(row: CustomerImportRow): boolean {
   return Boolean(
     row.email ||
-      row.phone ||
-      row.phone_number ||
-      row.name ||
-      row.company_name ||
-      row.business_name ||
-      row.first_name ||
-      row.last_name,
+    row.phone ||
+    row.phone_number ||
+    row.name ||
+    row.company_name ||
+    row.business_name ||
+    row.first_name ||
+    row.last_name,
   );
 }
 
@@ -111,7 +130,10 @@ function displayName(row: CustomerImportRow): string {
   );
 }
 
-export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) {
+export function CustomerCsvImportCard({
+  guidedQuery,
+  onCreateCustomer,
+}: Props) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
@@ -120,20 +142,32 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
   const [parseError, setParseError] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [counts, setCounts] = useState<ImportCounts | null>(null);
+  const [diagnostics, setDiagnostics] = useState<
+    Pick<ImportResponse, "warnings" | "errors">
+  >({});
   const [importing, setImporting] = useState(false);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [busyAction, setBusyAction] = useState<"skip" | null>(null);
 
-  const isOnboarding = Boolean(guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "customers");
-  const importableRows = useMemo(() => rows.filter(hasImportableIdentity), [rows]);
+  const isOnboarding = Boolean(
+    guidedQuery?.onboardingSession &&
+    guidedQuery.onboardingStep === "customers",
+  );
+  const importableRows = useMemo(
+    () => rows.filter(hasImportableIdentity),
+    [rows],
+  );
   const skippedPreviewCount = rows.length - importableRows.length;
   const previewRows = importableRows.slice(0, 5);
-  const importSucceeded = Boolean(counts && counts.created + counts.updated > 0 && counts.failed === 0);
+  const importSucceeded = Boolean(
+    counts && counts.created + counts.updated > 0 && counts.failed === 0,
+  );
 
   function resetImportState() {
     setRows([]);
     setHeaders([]);
     setCounts(null);
+    setDiagnostics({});
     setParseError(null);
     setImportError(null);
   }
@@ -155,8 +189,12 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
       header: true,
       skipEmptyLines: true,
       complete: (results) => {
-        const parsedRows = (results.data ?? []).map(normalizeParsedRow).filter((row) => Object.keys(row).length > 0);
-        setHeaders((results.meta.fields ?? []).map(cleanHeader).filter(Boolean));
+        const parsedRows = (results.data ?? [])
+          .map(normalizeParsedRow)
+          .filter((row) => Object.keys(row).length > 0);
+        setHeaders(
+          (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
+        );
         setRows(parsedRows);
         if (!parsedRows.length) {
           setParseError("No customer rows were found in that CSV.");
@@ -177,12 +215,20 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ summary: { importType: "customer_csv", ...nextCounts } }),
+          body: JSON.stringify({
+            summary: { importType: "customer_csv", ...nextCounts },
+          }),
         },
       );
-      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      const payload = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
       if (!response.ok || payload.ok === false) {
-        throw new Error(payload.error ?? "Customer import succeeded, but onboarding completion failed.");
+        throw new Error(
+          payload.error ??
+            "Customer import succeeded, but onboarding completion failed.",
+        );
       }
     } finally {
       setCompletingOnboarding(false);
@@ -191,28 +237,43 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
 
   async function confirmImport() {
     if (!importableRows.length) {
-      setImportError("Upload a CSV with at least one customer name, company, email, or phone before importing.");
+      setImportError(
+        "Upload a CSV with at least one customer name, company, email, or phone before importing.",
+      );
       return;
     }
     setImporting(true);
     setImportError(null);
     setCounts(null);
+    setDiagnostics({});
     try {
       const response = await fetch("/api/customers/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ rows: importableRows }),
       });
-      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as ImportResponse;
       if (!response.ok || payload.ok === false || !payload.counts) {
         throw new Error(payload.error ?? "Unable to import customers.");
       }
       setCounts(payload.counts);
-      if (isOnboarding && payload.counts.created + payload.counts.updated > 0 && payload.counts.failed === 0) {
+      setDiagnostics({
+        warnings: payload.warnings ?? [],
+        errors: payload.errors ?? [],
+      });
+      if (
+        isOnboarding &&
+        payload.counts.created + payload.counts.updated > 0 &&
+        payload.counts.failed === 0
+      ) {
         await completeOnboardingAfterImport(payload.counts);
       }
     } catch (error) {
-      setImportError(error instanceof Error ? error.message : "Unable to import customers.");
+      setImportError(
+        error instanceof Error ? error.message : "Unable to import customers.",
+      );
     } finally {
       setImporting(false);
     }
@@ -228,16 +289,27 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ skippedReason: "Customer import skipped during onboarding." }),
+          body: JSON.stringify({
+            skippedReason: "Customer import skipped during onboarding.",
+          }),
         },
       );
-      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      const payload = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
       if (!response.ok || payload.ok === false) {
-        throw new Error(payload.error ?? "Unable to skip customer onboarding step.");
+        throw new Error(
+          payload.error ?? "Unable to skip customer onboarding step.",
+        );
       }
       router.push(guidedQuery.returnTo);
     } catch (error) {
-      setImportError(error instanceof Error ? error.message : "Unable to skip customer onboarding step.");
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "Unable to skip customer onboarding step.",
+      );
     } finally {
       setBusyAction(null);
     }
@@ -254,19 +326,38 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
             {isOnboarding ? "Guided onboarding · Customers" : "Customer files"}
           </div>
           <h2 className="mt-2 text-xl font-semibold text-white">
-            {isOnboarding ? "Upload your customer CSV here" : "Import customers"}
+            {isOnboarding
+              ? "Upload your customer CSV here"
+              : "Import customers"}
           </h2>
           <div className="mt-3 space-y-2 text-sm text-neutral-300">
-            {isOnboarding ? <p>This import lives on the Customers page so you can find it later.</p> : null}
-            <p>Upload a CSV, review the parsed customer preview, then explicitly confirm the import.</p>
+            {isOnboarding ? (
+              <p>
+                This import lives on the Customers page so you can find it
+                later.
+              </p>
+            ) : null}
             <p>
-              Supported columns include <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>. Optional fields can be omitted.
+              Upload a CSV, review the parsed customer preview, then explicitly
+              confirm the import.
+            </p>
+            <p>
+              Supported columns include{" "}
+              <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>.
+              Optional fields can be omitted.
             </p>
           </div>
         </div>
 
         <div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-72">
-          <input ref={fileInputRef} data-testid="customer-csv-file-input" type="file" accept=".csv,text/csv" onChange={handleFileChange} className="sr-only" />
+          <input
+            ref={fileInputRef}
+            data-testid="customer-csv-file-input"
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="sr-only"
+          />
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
@@ -289,37 +380,76 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
       <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <span className="font-semibold text-neutral-100">Selected file:</span> {fileName ?? "No CSV selected"}
+            <span className="font-semibold text-neutral-100">
+              Selected file:
+            </span>{" "}
+            {fileName ?? "No CSV selected"}
           </div>
-          {headers.length ? <div className="text-xs text-neutral-400">Detected {headers.length} columns</div> : null}
+          {headers.length ? (
+            <div className="text-xs text-neutral-400">
+              Detected {headers.length} columns
+            </div>
+          ) : null}
         </div>
-        {parseError ? <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">{parseError}</div> : null}
+        {parseError ? (
+          <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">
+            {parseError}
+          </div>
+        ) : null}
         {rows.length ? (
           <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2"><div className="text-lg font-semibold text-white">{rows.length}</div><div className="text-xs text-neutral-400">Rows parsed</div></div>
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2"><div className="text-lg font-semibold text-emerald-100">{importableRows.length}</div><div className="text-xs text-neutral-400">Ready to import</div></div>
-            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2"><div className="text-lg font-semibold text-amber-100">{skippedPreviewCount}</div><div className="text-xs text-neutral-400">Missing identity</div></div>
+            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+              <div className="text-lg font-semibold text-white">
+                {rows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Rows parsed</div>
+            </div>
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2">
+              <div className="text-lg font-semibold text-emerald-100">
+                {importableRows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Ready to import</div>
+            </div>
+            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2">
+              <div className="text-lg font-semibold text-amber-100">
+                {skippedPreviewCount}
+              </div>
+              <div className="text-xs text-neutral-400">Missing identity</div>
+            </div>
           </div>
         ) : null}
       </div>
 
       {previewRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
-          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Preview</div>
+          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
+            Preview
+          </div>
           <div className="overflow-x-auto">
             <table className="w-full min-w-[720px] text-left text-sm">
               <thead className="text-xs uppercase tracking-[0.12em] text-neutral-500">
                 <tr>
-                  <th className="px-3 py-2">Customer</th><th className="px-3 py-2">Email</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">Location</th>
+                  <th className="px-3 py-2">Customer</th>
+                  <th className="px-3 py-2">Email</th>
+                  <th className="px-3 py-2">Phone</th>
+                  <th className="px-3 py-2">Location</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10 text-neutral-200">
                 {previewRows.map((row, index) => (
                   <tr key={`${displayName(row)}-${index}`}>
-                    <td className="px-3 py-2 font-medium text-white">{displayName(row)}</td>
+                    <td className="px-3 py-2 font-medium text-white">
+                      {displayName(row)}
+                    </td>
                     <td className="px-3 py-2">{row.email ?? "—"}</td>
-                    <td className="px-3 py-2">{row.phone ?? row.phone_number ?? "—"}</td>
-                    <td className="px-3 py-2">{[row.city, row.province ?? row.state].filter(Boolean).join(", ") || "—"}</td>
+                    <td className="px-3 py-2">
+                      {row.phone ?? row.phone_number ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {[row.city, row.province ?? row.state]
+                        .filter(Boolean)
+                        .join(", ") || "—"}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -330,10 +460,50 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
 
       {counts ? (
         <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
-          Import results: created {counts.created}, updated {counts.updated}, skipped {counts.skipped}, failed {counts.failed}.
+          Import results: created {counts.created}, updated {counts.updated},
+          skipped {counts.skipped}, failed {counts.failed}.
         </div>
       ) : null}
-      {importError ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{importError}</div> : null}
+
+      {diagnostics.errors?.length || diagnostics.warnings?.length ? (
+        <div className="mt-3 space-y-2 rounded-xl border border-amber-500/20 bg-amber-950/20 p-3 text-xs text-amber-50">
+          {diagnostics.errors?.length ? (
+            <div>
+              <div className="font-semibold text-red-100">
+                Import errors sample
+              </div>
+              <ul className="mt-1 list-disc space-y-1 pl-4">
+                {diagnostics.errors.slice(0, 3).map((item) => (
+                  <li key={`error-${item.row}-${item.reason}`}>
+                    Row {item.row}: {item.reason}
+                    {item.code ? ` (${item.code})` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {diagnostics.warnings?.length ? (
+            <div>
+              <div className="font-semibold text-amber-100">
+                Import warnings sample
+              </div>
+              <ul className="mt-1 list-disc space-y-1 pl-4">
+                {diagnostics.warnings.slice(0, 3).map((item) => (
+                  <li key={`warning-${item.row}-${item.reason}`}>
+                    Row {item.row}: {item.reason}
+                    {item.code ? ` (${item.code})` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      {importError ? (
+        <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">
+          {importError}
+        </div>
+      ) : null}
 
       <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
         <button
@@ -342,7 +512,11 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
           disabled={importing || completingOnboarding || !importableRows.length}
           className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
         >
-          {importing ? "Importing…" : completingOnboarding ? "Completing onboarding…" : "Confirm import"}
+          {importing
+            ? "Importing…"
+            : completingOnboarding
+              ? "Completing onboarding…"
+              : "Confirm import"}
         </button>
         {isOnboarding && counts ? (
           <button
@@ -350,7 +524,9 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
             onClick={() => router.push(guidedQuery!.returnTo)}
             className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
           >
-            {importSucceeded ? "Continue onboarding" : "Return to Data Onboarding"}
+            {importSucceeded
+              ? "Continue onboarding"
+              : "Return to Data Onboarding"}
           </button>
         ) : null}
         {isOnboarding ? (
@@ -358,12 +534,17 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
             <button
               type="button"
               onClick={() => void skipOnboardingStep()}
-              disabled={busyAction !== null || importing || completingOnboarding}
+              disabled={
+                busyAction !== null || importing || completingOnboarding
+              }
               className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
             >
               {busyAction === "skip" ? "Skipping…" : "Skip for now"}
             </button>
-            <Link href={guidedQuery!.returnTo} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">
+            <Link
+              href={guidedQuery!.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
               Return to Data Onboarding
             </Link>
           </>

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -14,7 +14,13 @@ const { router, mockSupabaseState } = vi.hoisted(() => ({
     profile: { shop_id: "shop-real" } as { shop_id: string | null } | null,
     customers: [] as Array<Record<string, unknown>>,
     inserts: [] as Array<Record<string, unknown>>,
-    updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
+    updates: [] as Array<{
+      payload: Record<string, unknown>;
+      filters: Record<string, unknown>;
+    }>,
+    insertError: null as
+      | ((payload: Record<string, unknown>) => Record<string, unknown> | null)
+      | null,
   },
 }));
 
@@ -28,9 +34,24 @@ type MockQuery = {
   eq: ReturnType<typeof vi.fn>;
   or: ReturnType<typeof vi.fn>;
   maybeSingle: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
+  then: ReturnType<typeof vi.fn>;
 };
+
+function selectCustomers(filters: Record<string, unknown>) {
+  return mockSupabaseState.customers.filter((customer) => {
+    if (filters.shop_id && customer.shop_id !== filters.shop_id) return false;
+    if (filters.email && customer.email !== filters.email) return false;
+    if (filters.name && customer.name !== filters.name) return false;
+    if (filters.or) {
+      const phone = String(filters.or).match(/phone\.eq\.([^,]+)/)?.[1];
+      return customer.phone === phone || customer.phone_number === phone;
+    }
+    return true;
+  });
+}
 
 function makeQuery(table: string): MockQuery {
   const query: MockQuery = {
@@ -44,29 +65,45 @@ function makeQuery(table: string): MockQuery {
       query.filters.or = value;
       return query;
     }),
+    limit: vi.fn(() => query),
     maybeSingle: vi.fn(async () => {
-      if (table === "profiles") return { data: mockSupabaseState.profile, error: null };
-      const match: Record<string, unknown> | undefined = mockSupabaseState.customers.find((customer) => {
-        if (query.filters.email) return customer.email === query.filters.email && customer.shop_id === query.filters.shop_id;
-        if (query.filters.name) return customer.name === query.filters.name && customer.shop_id === query.filters.shop_id;
-        if (query.filters.or) return (customer.phone === "5551112222" || customer.phone_number === "5551112222") && customer.shop_id === query.filters.shop_id;
-        return false;
-      });
-      return { data: match ? { id: match.id } : null, error: null };
+      if (table === "profiles")
+        return { data: mockSupabaseState.profile, error: null };
+      const match: Record<string, unknown> | undefined = selectCustomers(
+        query.filters,
+      )[0];
+      return { data: match ? { ...match } : null, error: null };
     }),
     insert: vi.fn(async (payload: Record<string, unknown>) => {
+      const error = mockSupabaseState.insertError?.(payload) ?? null;
+      if (error) return { data: null, error };
       mockSupabaseState.inserts.push(payload);
+      mockSupabaseState.customers.push({
+        id: `inserted-${mockSupabaseState.inserts.length}`,
+        ...payload,
+      });
       return { data: null, error: null };
     }),
     update: vi.fn((payload: Record<string, unknown>) => {
       const updateQuery: { eq: ReturnType<typeof vi.fn> } = {
         eq: vi.fn((column: string, value: unknown) => {
           query.filters[column] = value;
-          if (column === "id") mockSupabaseState.updates.push({ payload, filters: { ...query.filters } });
+          if (column === "id")
+            mockSupabaseState.updates.push({
+              payload,
+              filters: { ...query.filters },
+            });
           return updateQuery;
         }),
       };
       return updateQuery;
+    }),
+    then: vi.fn((resolve: (value: unknown) => unknown) => {
+      if (table === "customers")
+        return Promise.resolve(
+          resolve({ data: selectCustomers(query.filters), error: null }),
+        );
+      return Promise.resolve(resolve({ data: null, error: null }));
     }),
   };
   return query;
@@ -75,7 +112,10 @@ function makeQuery(table: string): MockQuery {
 vi.mock("@/features/shared/lib/supabase/server", () => ({
   createServerSupabaseRoute: vi.fn(() => ({
     auth: {
-      getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })),
+      getUser: vi.fn(async () => ({
+        data: { user: mockSupabaseState.user },
+        error: null,
+      })),
     },
     from: vi.fn((table: string) => makeQuery(table)),
   })),
@@ -100,7 +140,9 @@ function okJson() {
 }
 
 async function uploadCsv(csv: string) {
-  const input = screen.getByTestId("customer-csv-file-input") as HTMLInputElement;
+  const input = screen.getByTestId(
+    "customer-csv-file-input",
+  ) as HTMLInputElement;
   const file = new File([csv], "customers.csv", { type: "text/csv" });
   await userEvent.upload(input, file);
 }
@@ -113,29 +155,47 @@ describe("CustomerCsvImportCard", () => {
     mockSupabaseState.customers = [];
     mockSupabaseState.inserts = [];
     mockSupabaseState.updates = [];
+    mockSupabaseState.insertError = null;
   });
 
   it("renders the Customers-owned import card in normal mode", () => {
     render(<CustomerCsvImportCard onCreateCustomer={vi.fn()} />);
 
     expect(screen.getByTestId("customer-csv-import-card")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Import customers" })).toBeInTheDocument();
-    expect(screen.queryByText("Return to Data Onboarding")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Import customers" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Return to Data Onboarding"),
+    ).not.toBeInTheDocument();
   });
 
   it("highlights the Customers-owned import card in onboarding mode", () => {
-    render(<CustomerCsvImportCard guidedQuery={guidedQuery} onCreateCustomer={vi.fn()} />);
+    render(
+      <CustomerCsvImportCard
+        guidedQuery={guidedQuery}
+        onCreateCustomer={vi.fn()}
+      />,
+    );
 
     expect(screen.getByText("Customer setup/import")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Upload your customer CSV here" })).toBeInTheDocument();
-    expect(screen.getByText("This import lives on the Customers page so you can find it later.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Upload your customer CSV here" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This import lives on the Customers page so you can find it later.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("Return to Data Onboarding")).toBeInTheDocument();
   });
 
   it("shows a CSV preview after selecting a valid CSV", async () => {
     render(<CustomerCsvImportCard />);
 
-    await uploadCsv("first_name,last_name,email,phone\nAda,Lovelace,ada@example.com,(555) 111-2222\n");
+    await uploadCsv(
+      "first_name,last_name,email,phone\nAda,Lovelace,ada@example.com,(555) 111-2222\n",
+    );
 
     expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByText("ada@example.com")).toBeInTheDocument();
@@ -144,31 +204,90 @@ describe("CustomerCsvImportCard", () => {
 
   it("calls onboarding completion only after a successful onboarding import", async () => {
     const fetchMock = vi.fn(async (url: string) => {
-      if (url === "/api/customers/import") return { ok: true, json: async () => ({ ok: true, counts: { created: 1, updated: 0, skipped: 0, failed: 0 } }) };
+      if (url === "/api/customers/import")
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            counts: { created: 1, updated: 0, skipped: 0, failed: 0 },
+          }),
+        };
       return okJson();
     });
     vi.stubGlobal("fetch", fetchMock);
     render(<CustomerCsvImportCard guidedQuery={guidedQuery} />);
 
-    await uploadCsv("first_name,last_name,email\nAda,Lovelace,ada@example.com\n");
-    await userEvent.click(await screen.findByRole("button", { name: /confirm import/i }));
+    await uploadCsv(
+      "first_name,last_name,email\nAda,Lovelace,ada@example.com\n",
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: /confirm import/i }),
+    );
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      "/api/onboarding-v2/guided/sessions/session-123/steps/customers/complete",
-      expect.objectContaining({ method: "POST" }),
-    ));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/onboarding-v2/guided/sessions/session-123/steps/customers/complete",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
   });
 
   it("does not call onboarding completion in normal mode", async () => {
-    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true, counts: { created: 1, updated: 0, skipped: 0, failed: 0 } }) }));
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        counts: { created: 1, updated: 0, skipped: 0, failed: 0 },
+      }),
+    }));
     vi.stubGlobal("fetch", fetchMock);
     render(<CustomerCsvImportCard />);
 
-    await uploadCsv("first_name,last_name,email\nAda,Lovelace,ada@example.com\n");
-    await userEvent.click(await screen.findByRole("button", { name: /confirm import/i }));
+    await uploadCsv(
+      "first_name,last_name,email\nAda,Lovelace,ada@example.com\n",
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: /confirm import/i }),
+    );
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining("/api/onboarding-v2/"), expect.anything());
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/onboarding-v2/"),
+      expect.anything(),
+    );
+  });
+
+  it("does not call onboarding completion when the import has hard failures", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/customers/import")
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            counts: { created: 1, updated: 0, skipped: 0, failed: 1 },
+            errors: [{ row: 2, reason: "Constraint violation", code: "23514" }],
+          }),
+        };
+      return okJson();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard guidedQuery={guidedQuery} />);
+
+    await uploadCsv(
+      "first_name,last_name,email\nAda,Lovelace,ada@example.com\nGrace,Hopper,grace@example.com\n",
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: /confirm import/i }),
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/steps/customers/complete"),
+      expect.anything(),
+    );
+    expect(
+      await screen.findByText(/Import errors sample/i),
+    ).toBeInTheDocument();
   });
 
   it("keeps skip customers available during onboarding", async () => {
@@ -176,9 +295,15 @@ describe("CustomerCsvImportCard", () => {
     vi.stubGlobal("fetch", fetchMock);
     render(<CustomerCsvImportCard guidedQuery={guidedQuery} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /skip for now/i }),
+    );
 
-    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123"));
+    await waitFor(() =>
+      expect(router.push).toHaveBeenCalledWith(
+        "/dashboard/onboarding-v2/session-123",
+      ),
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/onboarding-v2/guided/sessions/session-123/steps/customers/skip",
       expect.objectContaining({ method: "POST" }),
@@ -193,29 +318,47 @@ describe("POST /api/customers/import", () => {
     mockSupabaseState.customers = [];
     mockSupabaseState.inserts = [];
     mockSupabaseState.updates = [];
+    mockSupabaseState.insertError = null;
   });
 
   it("uses the shared cookie-backed Supabase route client for authenticated imports", async () => {
-    const response = await importCustomers(new Request("http://localhost/api/customers/import", {
-      method: "POST",
-      body: JSON.stringify({ rows: [{ name: "Ada Lovelace", email: "ada@example.com" }] }),
-    }));
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Ada Lovelace", email: "ada@example.com" }],
+        }),
+      }),
+    );
 
     expect(response.status).toBe(200);
     expect(vi.mocked(createServerSupabaseRoute)).toHaveBeenCalled();
-    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1" });
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      user_id: "user-1",
+    });
   });
 
   it("rejects unauthenticated imports", async () => {
     mockSupabaseState.user = null;
-    const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({ rows: [] }),
+      }),
+    );
 
     expect(response.status).toBe(401);
   });
 
   it("rejects imports when the authenticated user profile is missing", async () => {
     mockSupabaseState.profile = null;
-    const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({ rows: [] }),
+      }),
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(403);
@@ -224,38 +367,295 @@ describe("POST /api/customers/import", () => {
 
   it("rejects imports when the user has no shop", async () => {
     mockSupabaseState.profile = { shop_id: null };
-    const response = await importCustomers(new Request("http://localhost/api/customers/import", { method: "POST", body: JSON.stringify({ rows: [] }) }));
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({ rows: [] }),
+      }),
+    );
 
     expect(response.status).toBe(403);
   });
 
   it("does not accept client shop_id and imports into the authenticated profile shop", async () => {
-    const response = await importCustomers(new Request("http://localhost/api/customers/import", {
-      method: "POST",
-      body: JSON.stringify({ rows: [{ first_name: "Ada", last_name: "Lovelace", email: "Ada@Example.com", shop_id: "evil-shop" }] }),
-    }));
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            {
+              first_name: "Ada",
+              last_name: "Lovelace",
+              email: "Ada@Example.com",
+              shop_id: "evil-shop",
+            },
+          ],
+        }),
+      }),
+    );
     const payload = await response.json();
 
-    expect(payload.counts).toMatchObject({ created: 1, updated: 0, skipped: 0, failed: 0 });
-    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1", email: "ada@example.com" });
+    expect(payload.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      user_id: "user-1",
+      email: "ada@example.com",
+    });
     expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
   });
 
-  it("returns successful created and updated counts", async () => {
-    mockSupabaseState.customers = [{ id: "customer-1", shop_id: "shop-real", email: "existing@example.com" }];
-    const response = await importCustomers(new Request("http://localhost/api/customers/import", {
-      method: "POST",
-      body: JSON.stringify({ rows: [
-        { first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" },
-        { name: "Existing Customer", email: "existing@example.com", phone: "555-111-2222" },
-        { notes: "blank row" },
-      ] }),
-    }));
+  it("updates or skips a duplicate email in the same shop instead of failing", async () => {
+    mockSupabaseState.customers = [
+      {
+        id: "customer-email",
+        shop_id: "shop-real",
+        email: "ada@example.com",
+        name: "Ada Old",
+      },
+    ];
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Ada Lovelace", email: "ada@example.com" }],
+        }),
+      }),
+    );
     const payload = await response.json();
 
-    expect(payload).toMatchObject({ ok: true, counts: { created: 1, updated: 1, skipped: 1, failed: 0 } });
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({
+      shop_id: "shop-real",
+      id: "customer-email",
+    });
+  });
+
+  it("updates or skips a duplicate phone in the same shop instead of failing", async () => {
+    mockSupabaseState.customers = [
+      {
+        id: "customer-phone",
+        shop_id: "shop-real",
+        phone: "5551112222",
+        phone_number: "5551112222",
+        name: "Phone Existing",
+      },
+    ];
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Phone Updated", phone: "(555) 111-2222" }],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({
+      shop_id: "shop-real",
+      id: "customer-phone",
+    });
+  });
+
+  it("does not update a duplicate customer from another shop", async () => {
+    mockSupabaseState.customers = [
+      {
+        id: "other-shop-customer",
+        shop_id: "shop-other",
+        email: "ada@example.com",
+        name: "Other Shop Ada",
+      },
+    ];
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Ada Lovelace", email: "ada@example.com" }],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.updates).toHaveLength(0);
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      email: "ada@example.com",
+    });
+  });
+
+  it("handles a duplicate constraint 409 gracefully without failing the batch", async () => {
+    mockSupabaseState.insertError = () => ({
+      code: "23505",
+      status: 409,
+      message:
+        'duplicate key value violates unique constraint "customers_shop_email_uq"',
+    });
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Ada Lovelace", email: "ada@example.com" }],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    expect(payload.warnings[0]).toMatchObject({
+      row: 1,
+      code: "23505",
+      constraint: "customers_shop_email_uq",
+    });
+  });
+
+  it("returns useful counts for a mixed file with created rows and duplicates", async () => {
+    mockSupabaseState.customers = [
+      {
+        id: "existing-email",
+        shop_id: "shop-real",
+        email: "existing@example.com",
+        name: "Existing",
+      },
+      {
+        id: "existing-phone",
+        shop_id: "shop-real",
+        phone: "5551112222",
+        phone_number: "5551112222",
+        name: "Phone",
+      },
+    ];
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            { name: "New Customer", email: "new@example.com" },
+            { name: "Existing Updated", email: "existing@example.com" },
+            { name: "Phone Updated", phone: "555-111-2222" },
+            { notes: "missing identity" },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 1,
+      updated: 2,
+      skipped: 1,
+      failed: 0,
+    });
+    expect(payload.warnings[0]).toMatchObject({
+      row: 4,
+      reason: "Missing customer identity fields.",
+    });
+  });
+
+  it("recovers from a race-condition duplicate insert by re-querying and updating the same-shop match", async () => {
+    mockSupabaseState.insertError = (payload) => {
+      mockSupabaseState.customers.push({
+        id: "raced-customer",
+        ...payload,
+        name: "Race Existing",
+      });
+      return {
+        code: "23505",
+        status: 409,
+        message:
+          'duplicate key value violates unique constraint "customers_shop_email_uq"',
+      };
+    };
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Race Updated", email: "race@example.com" }],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({
+      shop_id: "shop-real",
+      id: "raced-customer",
+    });
+  });
+
+  it("returns successful created and updated counts", async () => {
+    mockSupabaseState.customers = [
+      { id: "customer-1", shop_id: "shop-real", email: "existing@example.com" },
+    ];
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            {
+              first_name: "Ada",
+              last_name: "Lovelace",
+              email: "ada@example.com",
+            },
+            {
+              name: "Existing Customer",
+              email: "existing@example.com",
+              phone: "555-111-2222",
+            },
+            { notes: "blank row" },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload).toMatchObject({
+      ok: true,
+      counts: { created: 1, updated: 1, skipped: 1, failed: 0 },
+    });
     expect(mockSupabaseState.inserts).toHaveLength(1);
     expect(mockSupabaseState.updates).toHaveLength(1);
-    expect(mockSupabaseState.updates[0].filters).toMatchObject({ shop_id: "shop-real", id: "customer-1" });
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({
+      shop_id: "shop-real",
+      id: "customer-1",
+    });
   });
 });


### PR DESCRIPTION
### Motivation

- Customer CSV imports were failing entire batches when some rows hit unique-constraint conflicts (409), producing large numbers of `failed` rows instead of updating or skipping duplicates.  
- The import must be shop-scoped, deterministic, and resilient to race conditions so a few constrained rows do not block the whole file.  
- Guided onboarding completion must only be marked when the import produced at least one create/update and zero hard failures, and `shop_id` must always come from the authenticated profile.

### Description

- Enhanced the server import route `POST /api/customers/import` to perform deterministic, shop-scoped matching (email → phone → normalized name+location fallback) before inserts and to always derive `shop_id` and `user_id` from the authenticated profile; implemented `findExistingCustomer` and `updateExistingCustomer` helpers for safe updates.  
- Implemented per-row duplicate/error recovery so insert `23505/409` conflicts are handled gracefully by re-querying same-shop matches and updating/skipping instead of failing the batch, and added diagnostic capture (`warnings` / `errors`) with safe identity fields and constraint/code info.  
- Updated the customer CSV import UI (`CustomerCsvImportCard`) to accept and display imported diagnostics samples, to keep onboarding completion gated (requires created/updated > 0 and failed === 0), and to avoid exposing sensitive cookies/tokens in logs.  
- Added and updated tests in `tests/onboarding-v2/customer-onboarding-card.test.tsx` to cover duplicate email, duplicate phone, cross-shop isolation, 409 constraint handling, mixed create/update/skipped counts, race-condition duplicate insertion recovery, and onboarding completion suppression when there are hard failures.

### Testing

- Ran TypeScript check with `npx tsc --noEmit` and it completed without type errors.  
- Ran the targeted test file with `npx vitest run tests/onboarding-v2/customer-onboarding-card.test.tsx` and all tests passed (`19 tests` passed).  
- Ran `git diff --check` and no whitespace/errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21c76bf64c8328ab3bcdbb7c5a7b9d)