### PR TITLE
Customer CSV import: batching, in-memory match index, and supabase client consolidation

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -27,11 +27,6 @@ type CustomerMatch = Pick<
   | "import_notes"
 >;
 type SupabaseRouteClient = ReturnType<typeof createServerSupabaseRoute>;
-type SupabaseQuery = {
-  eq: (column: string, value: unknown) => SupabaseQuery;
-  or: (filters: string) => SupabaseQuery;
-};
-
 type ImportRow = {
   first_name?: unknown;
   last_name?: unknown;
@@ -85,6 +80,7 @@ const CUSTOMER_SELECT =
   "id,shop_id,business_name,name,first_name,last_name,email,phone,phone_number,address,street,city,province,postal_code,notes,import_notes";
 const MAX_IMPORT_ROWS = 5000;
 const MAX_DIAGNOSTICS = 25;
+const INSERT_BATCH_SIZE = 250;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -138,19 +134,7 @@ function splitName(name: string | null): {
   };
 }
 
-function escapeOrValue(value: string): string {
-  return value
-    .replaceAll("\\", "\\\\")
-    .replaceAll(",", "\\,")
-    .replaceAll("%", "\\%")
-    .replaceAll("_", "\\_");
-}
-
-function normalizeRow(
-  row: ImportRow,
-  userId: string,
-  shopId: string,
-): CustomerInsert | null {
+function normalizeRow(row: ImportRow, shopId: string): CustomerInsert | null {
   const businessName =
     cleanString(row.business_name) ?? cleanString(row.company_name);
   const explicitName = cleanString(row.name);
@@ -166,7 +150,6 @@ function normalizeRow(
 
   return {
     shop_id: shopId,
-    user_id: userId,
     is_fleet: Boolean(businessName),
     business_name: businessName,
     name: displayName,
@@ -185,20 +168,11 @@ function normalizeRow(
   };
 }
 
-async function findSingleCustomer(
-  supabase: SupabaseRouteClient,
-  buildQuery: (query: SupabaseQuery) => unknown,
-): Promise<CustomerMatch | null> {
-  const query = buildQuery(
-    supabase.from("customers").select(CUSTOMER_SELECT).limit(1),
-  );
-  const { data, error } = (await query) as {
-    data: CustomerMatch[] | null;
-    error: SupabaseErrorLike | null;
-  };
-  if (error) return null;
-  return data?.[0] ?? null;
-}
+type CustomerMatchIndex = {
+  byEmail: Map<string, CustomerMatch>;
+  byPhone: Map<string, CustomerMatch>;
+  byNameLocation: Map<string, CustomerMatch>;
+};
 
 function locationKey(customer: CustomerInsert | CustomerMatch): string {
   return [
@@ -220,6 +194,83 @@ function nameKey(customer: CustomerInsert | CustomerMatch): string {
   return normalizeComparable(displayName);
 }
 
+function nameLocationKey(customer: CustomerInsert | CustomerMatch): string {
+  const targetName = nameKey(customer);
+  if (!targetName) return "";
+
+  const targetLocation = locationKey(customer);
+  if (targetLocation) return `${targetName}|${targetLocation}`;
+
+  const city = normalizeComparable(customer.city);
+  const postalCode = normalizeComparable(customer.postal_code);
+  if (!city && !postalCode) return "";
+  return `${targetName}|${city}|${postalCode}`;
+}
+
+function createCustomerMatchIndex(customers: CustomerMatch[]): CustomerMatchIndex {
+  const index: CustomerMatchIndex = {
+    byEmail: new Map(),
+    byPhone: new Map(),
+    byNameLocation: new Map(),
+  };
+
+  for (const customer of customers) {
+    const email = normalizeEmailComparable(customer.email);
+    if (email && !index.byEmail.has(email)) index.byEmail.set(email, customer);
+
+    for (const phoneValue of [customer.phone, customer.phone_number]) {
+      const phone = normalizePhoneComparable(phoneValue);
+      if (phone && !index.byPhone.has(phone)) index.byPhone.set(phone, customer);
+    }
+
+    const combinedNameLocation = nameLocationKey(customer);
+    if (combinedNameLocation && !index.byNameLocation.has(combinedNameLocation))
+      index.byNameLocation.set(combinedNameLocation, customer);
+  }
+
+  return index;
+}
+
+function addCustomerToMatchIndex(
+  index: CustomerMatchIndex,
+  customer: CustomerMatch,
+) {
+  const scopedIndex = createCustomerMatchIndex([customer]);
+  for (const [key, value] of scopedIndex.byEmail) {
+    if (!index.byEmail.has(key)) index.byEmail.set(key, value);
+  }
+  for (const [key, value] of scopedIndex.byPhone) {
+    if (!index.byPhone.has(key)) index.byPhone.set(key, value);
+  }
+  for (const [key, value] of scopedIndex.byNameLocation) {
+    if (!index.byNameLocation.has(key)) index.byNameLocation.set(key, value);
+  }
+}
+
+function customerInsertToMatch(
+  customer: CustomerInsert,
+  id = customer.id ?? `pending-${Math.random().toString(36).slice(2)}`,
+): CustomerMatch {
+  return {
+    id,
+    shop_id: customer.shop_id ?? null,
+    business_name: customer.business_name ?? null,
+    name: customer.name ?? null,
+    first_name: customer.first_name ?? null,
+    last_name: customer.last_name ?? null,
+    email: customer.email ?? null,
+    phone: customer.phone ?? null,
+    phone_number: customer.phone_number ?? null,
+    address: customer.address ?? null,
+    street: customer.street ?? null,
+    city: customer.city ?? null,
+    province: customer.province ?? null,
+    postal_code: customer.postal_code ?? null,
+    notes: customer.notes ?? null,
+    import_notes: customer.import_notes ?? null,
+  };
+}
+
 async function getShopCustomerCandidates(
   supabase: SupabaseRouteClient,
   shopId: string,
@@ -228,7 +279,7 @@ async function getShopCustomerCandidates(
     .from("customers")
     .select(CUSTOMER_SELECT)
     .eq("shop_id", shopId)
-    .limit(5000)) as {
+    .limit(10000)) as {
     data: CustomerMatch[] | null;
     error: SupabaseErrorLike | null;
   };
@@ -237,108 +288,26 @@ async function getShopCustomerCandidates(
   return data.filter((candidate) => candidate.shop_id === shopId);
 }
 
-async function findByNormalizedEmailFallback(
-  supabase: SupabaseRouteClient,
-  shopId: string,
-  email: string | null | undefined,
-): Promise<CustomerMatch | null> {
-  const targetEmail = normalizeEmailComparable(email);
-  if (!targetEmail) return null;
-  const candidates = await getShopCustomerCandidates(supabase, shopId);
-  return (
-    candidates.find(
-      (candidate) => normalizeEmailComparable(candidate.email) === targetEmail,
-    ) ?? null
-  );
-}
-
-async function findByNormalizedPhoneFallback(
-  supabase: SupabaseRouteClient,
-  shopId: string,
-  phone: string | null | undefined,
-): Promise<CustomerMatch | null> {
-  const targetPhone = normalizePhoneComparable(phone);
-  if (!targetPhone) return null;
-  const candidates = await getShopCustomerCandidates(supabase, shopId);
-  return (
-    candidates.find(
-      (candidate) =>
-        normalizePhoneComparable(candidate.phone) === targetPhone ||
-        normalizePhoneComparable(candidate.phone_number) === targetPhone,
-    ) ?? null
-  );
-}
-
-async function findByNameAndLocationFallback(
-  supabase: SupabaseRouteClient,
+function findExistingCustomer(
+  index: CustomerMatchIndex,
   shopId: string,
   customer: CustomerInsert,
-): Promise<CustomerMatch | null> {
-  const targetName = nameKey(customer);
-  if (!targetName) return null;
+): CustomerMatch | null {
+  const email = normalizeEmailComparable(customer.email);
+  const emailMatch = email ? index.byEmail.get(email) : null;
+  if (emailMatch?.shop_id === shopId) return emailMatch;
 
-  const targetLocation = locationKey(customer);
-  if (!targetLocation && !customer.city && !customer.postal_code) return null;
+  const phone = normalizePhoneComparable(customer.phone ?? customer.phone_number);
+  const phoneMatch = phone ? index.byPhone.get(phone) : null;
+  if (phoneMatch?.shop_id === shopId) return phoneMatch;
 
-  const candidates = await getShopCustomerCandidates(supabase, shopId);
-  if (!candidates.length) return null;
+  const namedLocation = nameLocationKey(customer);
+  const namedLocationMatch = namedLocation
+    ? index.byNameLocation.get(namedLocation)
+    : null;
+  if (namedLocationMatch?.shop_id === shopId) return namedLocationMatch;
 
-  return (
-    candidates.find((candidate) => {
-      if (candidate.shop_id !== shopId) return false;
-      if (nameKey(candidate) !== targetName) return false;
-      const candidateLocation = locationKey(candidate);
-      if (targetLocation && candidateLocation)
-        return candidateLocation === targetLocation;
-      return (
-        normalizeComparable(candidate.city) ===
-          normalizeComparable(customer.city) &&
-        normalizeComparable(candidate.postal_code) ===
-          normalizeComparable(customer.postal_code)
-      );
-    }) ?? null
-  );
-}
-
-async function findExistingCustomer(
-  supabase: SupabaseRouteClient,
-  shopId: string,
-  customer: CustomerInsert,
-): Promise<CustomerMatch | null> {
-  if (customer.email) {
-    const match = await findSingleCustomer(supabase, (query) =>
-      query.eq("shop_id", shopId).eq("email", customer.email),
-    );
-    if (match?.id) return match;
-
-    const normalizedMatch = await findByNormalizedEmailFallback(
-      supabase,
-      shopId,
-      customer.email,
-    );
-    if (normalizedMatch?.id) return normalizedMatch;
-  }
-
-  const phone = customer.phone ?? customer.phone_number;
-  if (phone) {
-    const match = await findSingleCustomer(supabase, (query) =>
-      query
-        .eq("shop_id", shopId)
-        .or(
-          `phone.eq.${escapeOrValue(phone)},phone_number.eq.${escapeOrValue(phone)}`,
-        ),
-    );
-    if (match?.id) return match;
-
-    const normalizedMatch = await findByNormalizedPhoneFallback(
-      supabase,
-      shopId,
-      phone,
-    );
-    if (normalizedMatch?.id) return normalizedMatch;
-  }
-
-  return findByNameAndLocationFallback(supabase, shopId, customer);
+  return null;
 }
 
 function getCustomerImportCookieDiagnostics() {
@@ -469,6 +438,144 @@ function logRowImportIssue(
   });
 }
 
+
+function isPendingImportMatch(customer: CustomerMatch): boolean {
+  return customer.id.startsWith("pending-");
+}
+
+type PendingCustomerInsert = {
+  rowNumber: number;
+  customer: CustomerInsert;
+};
+
+function duplicateUserIdConstraintReason(constraint?: string): string {
+  if (constraint === "customers_user_id_uq")
+    return "CSV import unexpectedly hit customers_user_id_uq even though customer user_id is not set; row skipped for safe recovery.";
+  return "Duplicate customer constraint hit, but no safe same-shop match was found to update.";
+}
+
+async function insertCustomerBatch(
+  supabase: SupabaseRouteClient,
+  shopId: string,
+  rows: PendingCustomerInsert[],
+  matchIndex: CustomerMatchIndex,
+  counts: Counts,
+  warnings: ImportDiagnostic[],
+  errors: ImportDiagnostic[],
+) {
+  if (!rows.length) return;
+
+  const payload = rows.map(({ customer }) => customer);
+  const { error } = (await supabase.from("customers").insert(payload)) as {
+    error: SupabaseErrorLike | null;
+  };
+
+  if (!error) {
+    counts.created += rows.length;
+    for (const { customer } of rows) {
+      addCustomerToMatchIndex(matchIndex, customerInsertToMatch(customer));
+    }
+    return;
+  }
+
+  if (!isDuplicateError(error)) {
+    for (const { rowNumber, customer } of rows) {
+      logRowImportIssue(rowNumber, customer, error, "batch-insert");
+      counts.failed += 1;
+      addDiagnostic(errors, {
+        row: rowNumber,
+        identity: getSafeIdentity(customer),
+        reason: error.message ?? "Unable to import customer.",
+        code: error.code,
+        constraint: getConstraint(error),
+      });
+    }
+    return;
+  }
+
+  for (const { rowNumber, customer } of rows) {
+    const { error: rowError } = (await supabase
+      .from("customers")
+      .insert(customer)) as { error: SupabaseErrorLike | null };
+
+    if (!rowError) {
+      counts.created += 1;
+      addCustomerToMatchIndex(matchIndex, customerInsertToMatch(customer));
+      continue;
+    }
+
+    logRowImportIssue(rowNumber, customer, rowError, "insert");
+
+    if (!isDuplicateError(rowError)) {
+      counts.failed += 1;
+      addDiagnostic(errors, {
+        row: rowNumber,
+        identity: getSafeIdentity(customer),
+        reason: rowError.message ?? "Unable to import customer.",
+        code: rowError.code,
+        constraint: getConstraint(rowError),
+      });
+      continue;
+    }
+
+    const refreshedCustomers = await getShopCustomerCandidates(supabase, shopId);
+    const refreshedIndex = createCustomerMatchIndex(refreshedCustomers);
+    const duplicateMatch = findExistingCustomer(refreshedIndex, shopId, customer);
+
+    if (duplicateMatch?.id) {
+      const result = await updateExistingCustomer(
+        supabase,
+        shopId,
+        duplicateMatch,
+        customer,
+      );
+      if (result.status === "updated") {
+        counts.updated += 1;
+        addCustomerToMatchIndex(
+          matchIndex,
+          customerInsertToMatch(customer, duplicateMatch.id),
+        );
+      } else if (result.status === "skipped") {
+        counts.skipped += 1;
+        addDiagnostic(warnings, {
+          row: rowNumber,
+          identity: getSafeIdentity(customer),
+          reason: result.reason ?? "Duplicate customer already exists.",
+        });
+      } else {
+        counts.failed += 1;
+        if (result.error)
+          logRowImportIssue(
+            rowNumber,
+            customer,
+            result.error,
+            "duplicate-update",
+          );
+        addDiagnostic(errors, {
+          row: rowNumber,
+          identity: getSafeIdentity(customer),
+          reason:
+            result.error?.message ??
+            result.reason ??
+            "Duplicate customer could not be updated.",
+          code: result.error?.code,
+          constraint: getConstraint(result.error),
+        });
+      }
+      continue;
+    }
+
+    counts.skipped += 1;
+    addDiagnostic(warnings, {
+      row: rowNumber,
+      identity: getSafeIdentity(customer),
+      reason: duplicateUserIdConstraintReason(getConstraint(rowError)),
+      code: rowError.code,
+      constraint: getConstraint(rowError),
+    });
+  }
+}
+
 async function updateExistingCustomer(
   supabase: SupabaseRouteClient,
   shopId: string,
@@ -582,6 +689,10 @@ export async function POST(req: Request) {
     });
   }
 
+  const existingCustomers = await getShopCustomerCandidates(supabase, shopId);
+  const matchIndex = createCustomerMatchIndex(existingCustomers);
+  const pendingInserts: PendingCustomerInsert[] = [];
+
   for (const [index, rawRow] of inputRows.entries()) {
     const rowNumber = index + 1;
     if (!isRecord(rawRow)) {
@@ -594,7 +705,7 @@ export async function POST(req: Request) {
       continue;
     }
 
-    const customer = normalizeRow(rawRow as ImportRow, user.id, shopId);
+    const customer = normalizeRow(rawRow as ImportRow, shopId);
     if (!customer) {
       counts.skipped += 1;
       addDiagnostic(warnings, {
@@ -606,16 +717,32 @@ export async function POST(req: Request) {
     }
 
     try {
-      const existing = await findExistingCustomer(supabase, shopId, customer);
+      const existing = findExistingCustomer(matchIndex, shopId, customer);
       if (existing?.id) {
+        if (isPendingImportMatch(existing)) {
+          counts.skipped += 1;
+          addDiagnostic(warnings, {
+            row: rowNumber,
+            identity: getSafeIdentity(customer),
+            reason:
+              "Duplicate customer already exists earlier in this import batch.",
+          });
+          continue;
+        }
+
         const result = await updateExistingCustomer(
           supabase,
           shopId,
           existing,
           customer,
         );
-        if (result.status === "updated") counts.updated += 1;
-        else if (result.status === "skipped") {
+        if (result.status === "updated") {
+          counts.updated += 1;
+          addCustomerToMatchIndex(
+            matchIndex,
+            customerInsertToMatch(customer, existing.id),
+          );
+        } else if (result.status === "skipped") {
           counts.skipped += 1;
           addDiagnostic(warnings, {
             row: rowNumber,
@@ -640,80 +767,11 @@ export async function POST(req: Request) {
         continue;
       }
 
-      const { error } = (await supabase.from("customers").insert(customer)) as {
-        error: SupabaseErrorLike | null;
-      };
-      if (!error) {
-        counts.created += 1;
-        continue;
-      }
-
-      logRowImportIssue(rowNumber, customer, error, "insert");
-
-      if (isDuplicateError(error)) {
-        const duplicateMatch = await findExistingCustomer(
-          supabase,
-          shopId,
-          customer,
-        );
-        if (duplicateMatch?.id) {
-          const result = await updateExistingCustomer(
-            supabase,
-            shopId,
-            duplicateMatch,
-            customer,
-          );
-          if (result.status === "updated") counts.updated += 1;
-          else if (result.status === "skipped") {
-            counts.skipped += 1;
-            addDiagnostic(warnings, {
-              row: rowNumber,
-              identity: getSafeIdentity(customer),
-              reason: result.reason ?? "Duplicate customer already exists.",
-            });
-          } else {
-            counts.failed += 1;
-            if (result.error)
-              logRowImportIssue(
-                rowNumber,
-                customer,
-                result.error,
-                "duplicate-update",
-              );
-            addDiagnostic(errors, {
-              row: rowNumber,
-              identity: getSafeIdentity(customer),
-              reason:
-                result.error?.message ??
-                result.reason ??
-                "Duplicate customer could not be updated.",
-              code: result.error?.code,
-              constraint: getConstraint(result.error),
-            });
-          }
-          continue;
-        }
-
-        counts.skipped += 1;
-        addDiagnostic(warnings, {
-          row: rowNumber,
-          identity: getSafeIdentity(customer),
-          reason:
-            "Duplicate customer constraint hit, but no safe same-shop match was found to update.",
-          code: error.code,
-          constraint: getConstraint(error),
-        });
-        continue;
-      }
-
-      counts.failed += 1;
-      addDiagnostic(errors, {
-        row: rowNumber,
-        identity: getSafeIdentity(customer),
-        reason: error.message ?? "Unable to import customer.",
-        code: error.code,
-        constraint: getConstraint(error),
-      });
+      pendingInserts.push({ rowNumber, customer });
+      addCustomerToMatchIndex(
+        matchIndex,
+        customerInsertToMatch(customer, `pending-${rowNumber}`),
+      );
     } catch (error) {
       counts.failed += 1;
       const message =
@@ -730,6 +788,18 @@ export async function POST(req: Request) {
         reason: message,
       });
     }
+  }
+
+  for (let index = 0; index < pendingInserts.length; index += INSERT_BATCH_SIZE) {
+    await insertCustomerBatch(
+      supabase,
+      shopId,
+      pendingInserts.slice(index, index + INSERT_BATCH_SIZE),
+      matchIndex,
+      counts,
+      warnings,
+      errors,
+    );
   }
 
   return NextResponse.json({ ok: true, counts, warnings, errors });

--- a/features/auth/components/ForcePasswordChangeModal.tsx
+++ b/features/auth/components/ForcePasswordChangeModal.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 type Props = {
   open: boolean;
   onDone: () => void;
@@ -23,7 +19,7 @@ export default function ForcePasswordChangeModal({
   title = "Set your new password",
   subtitle = "This account was created by an owner/manager. You must choose a new password before continuing.",
 }: Props): JSX.Element | null {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");

--- a/features/branding/server/brand.ts
+++ b/features/branding/server/brand.ts
@@ -1,14 +1,10 @@
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-import { getRouteHandlerCookies } from "@/features/shared/lib/server/owner-pin";
-
-type DB = Database;
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 const WRITE_ROLES = new Set(["owner", "admin", "manager"]);
 
 export type BrandReadAuth =
   | {
       ok: true;
-      supabase: ReturnType<typeof createRouteHandlerClient<DB>>;
+      supabase: ReturnType<typeof createServerSupabaseRoute>;
       userId: string;
       shopId: string;
       role: string;
@@ -24,7 +20,7 @@ export type BrandWriteAuth = BrandReadAuth;
 export async function requireBrandShopReadAccess(
   requestedShopId?: string | null
 ): Promise<BrandReadAuth> {
-  const supabase = createRouteHandlerClient<DB>({ cookies: getRouteHandlerCookies() });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import UserAvatar from "@/features/chat/components/UserAvatar";
 import ModalShell from "@/features/shared/components/ModalShell";
@@ -121,7 +121,7 @@ export default function InboxModal({
   seedConversationId = null,
 }: Props): JSX.Element | null {
   const pathname = usePathname() ?? "/dashboard";
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [me, setMe] = useState<string | null>(null);
   const [rows, setRows] = useState<ConversationPayload[]>([]);

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -3,7 +3,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
@@ -351,7 +351,7 @@ export default function CustomerProfilePage(): JSX.Element {
   const router = useRouter();
   const sp = useSearchParams();
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const rawId = useMemo(() => {
     const raw = (params as ParamsShape)?.id;

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { Toaster } from "sonner";
 
@@ -80,7 +80,7 @@ function daysUntil(iso: string | null): number | null {
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const { data: activeBrand } = useActiveBrand();
 
   const [userId, setUserId] = useState<string | null>(null);

--- a/features/shared/components/ShiftTracker.tsx
+++ b/features/shared/components/ShiftTracker.tsx
@@ -1,12 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { formatDistanceToNow } from "date-fns";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-
 type ShiftType = "shift" | "break" | "lunch";
 type Mode = "none" | "shift" | "break" | "lunch" | "ended";
 
@@ -45,7 +41,7 @@ export default function ShiftTracker({
   userId: string;
   defaultShiftType?: ShiftType;
 }): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shiftId, setShiftId] = useState<string | null>(null);
   const [startTime, setStartTime] = useState<string | null>(null);

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -18,8 +18,10 @@ const { router, mockSupabaseState } = vi.hoisted(() => ({
       payload: Record<string, unknown>;
       filters: Record<string, unknown>;
     }>,
+    customerSelects: 0,
+    profileSelects: 0,
     insertError: null as
-      | ((payload: Record<string, unknown>) => Record<string, unknown> | null)
+      | ((payload: Record<string, unknown> | Record<string, unknown>[]) => Record<string, unknown> | null)
       | null,
     updateError: null as
       | ((payload: Record<string, unknown>) => Record<string, unknown> | null)
@@ -70,21 +72,26 @@ function makeQuery(table: string): MockQuery {
     }),
     limit: vi.fn(() => query),
     maybeSingle: vi.fn(async () => {
-      if (table === "profiles")
+      if (table === "profiles") {
+        mockSupabaseState.profileSelects += 1;
         return { data: mockSupabaseState.profile, error: null };
+      }
       const match: Record<string, unknown> | undefined = selectCustomers(
         query.filters,
       )[0];
       return { data: match ? { ...match } : null, error: null };
     }),
-    insert: vi.fn(async (payload: Record<string, unknown>) => {
+    insert: vi.fn(async (payload: Record<string, unknown> | Record<string, unknown>[]) => {
       const error = mockSupabaseState.insertError?.(payload) ?? null;
       if (error) return { data: null, error };
-      mockSupabaseState.inserts.push(payload);
-      mockSupabaseState.customers.push({
-        id: `inserted-${mockSupabaseState.inserts.length}`,
-        ...payload,
-      });
+      const rows = Array.isArray(payload) ? payload : [payload];
+      for (const row of rows) {
+        mockSupabaseState.inserts.push(row);
+        mockSupabaseState.customers.push({
+          id: `inserted-${mockSupabaseState.inserts.length}`,
+          ...row,
+        });
+      }
       return { data: null, error: null };
     }),
     update: vi.fn((payload: Record<string, unknown>) => {
@@ -109,10 +116,12 @@ function makeQuery(table: string): MockQuery {
       return updateQuery;
     }),
     then: vi.fn((resolve: (value: unknown) => unknown) => {
-      if (table === "customers")
+      if (table === "customers") {
+        mockSupabaseState.customerSelects += 1;
         return Promise.resolve(
           resolve({ data: selectCustomers(query.filters), error: null }),
         );
+      }
       return Promise.resolve(resolve({ data: null, error: null }));
     }),
   };
@@ -167,6 +176,8 @@ describe("CustomerCsvImportCard", () => {
     mockSupabaseState.updates = [];
     mockSupabaseState.insertError = null;
     mockSupabaseState.updateError = null;
+    mockSupabaseState.customerSelects = 0;
+    mockSupabaseState.profileSelects = 0;
   });
 
   it("renders the Customers-owned import card in normal mode", () => {
@@ -331,6 +342,8 @@ describe("POST /api/customers/import", () => {
     mockSupabaseState.updates = [];
     mockSupabaseState.insertError = null;
     mockSupabaseState.updateError = null;
+    mockSupabaseState.customerSelects = 0;
+    mockSupabaseState.profileSelects = 0;
   });
 
   it("uses the shared cookie-backed Supabase route client for authenticated imports", async () => {
@@ -347,8 +360,8 @@ describe("POST /api/customers/import", () => {
     expect(vi.mocked(createServerSupabaseRoute)).toHaveBeenCalled();
     expect(mockSupabaseState.inserts[0]).toMatchObject({
       shop_id: "shop-real",
-      user_id: "user-1",
     });
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
   });
 
   it("rejects unauthenticated imports", async () => {
@@ -415,9 +428,9 @@ describe("POST /api/customers/import", () => {
     });
     expect(mockSupabaseState.inserts[0]).toMatchObject({
       shop_id: "shop-real",
-      user_id: "user-1",
       email: "ada@example.com",
     });
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
     expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
   });
 
@@ -550,6 +563,106 @@ describe("POST /api/customers/import", () => {
       code: "23505",
       constraint: "customers_shop_email_uq",
     });
+  });
+
+  it("does not trigger customers_user_id_uq during normal imports because user_id is omitted", async () => {
+    mockSupabaseState.insertError = (payload) => {
+      const rows = Array.isArray(payload) ? payload : [payload];
+      if (rows.some((row) => Object.hasOwn(row, "user_id"))) {
+        return {
+          code: "23505",
+          status: 409,
+          message:
+            'duplicate key value violates unique constraint "customers_user_id_uq"',
+        };
+      }
+      return null;
+    };
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            { name: "Ada Lovelace", email: "ada@example.com" },
+            { name: "Grace Hopper", email: "grace@example.com" },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 2,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts).toHaveLength(2);
+    expect(mockSupabaseState.inserts.every((row) => !("user_id" in row))).toBe(
+      true,
+    );
+  });
+
+  it("recovers safely if customers_user_id_uq is unexpectedly returned", async () => {
+    mockSupabaseState.insertError = () => ({
+      code: "23505",
+      status: 409,
+      message:
+        'duplicate key value violates unique constraint "customers_user_id_uq"',
+    });
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [{ name: "Ada Lovelace", email: "ada@example.com" }],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    expect(payload.warnings[0]).toMatchObject({
+      row: 1,
+      code: "23505",
+      constraint: "customers_user_id_uq",
+      reason:
+        "CSV import unexpectedly hit customers_user_id_uq even though customer user_id is not set; row skipped for safe recovery.",
+    });
+  });
+
+  it("prefetches same-shop customers once for a large import instead of per row", async () => {
+    const rows = Array.from({ length: 600 }, (_, index) => ({
+      name: `Customer ${index}`,
+      email: `customer-${index}@example.com`,
+    }));
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({ rows }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 600,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.profileSelects).toBe(1);
+    expect(mockSupabaseState.customerSelects).toBe(1);
+    expect(mockSupabaseState.inserts).toHaveLength(600);
+    expect(mockSupabaseState.inserts.every((row) => !("user_id" in row))).toBe(
+      true,
+    );
   });
 
   it("skips an unsafe duplicate constraint during update instead of failing the batch", async () => {


### PR DESCRIPTION
### Motivation

- Reduce per-row database queries and improve import throughput for large CSV imports by batching inserts and prefetched matching.  
- Make imports more robust against unexpected unique-constraint failures (notably `customers_user_id_uq`) and avoid attaching `user_id` on imported customers.  
- Standardize Supabase client usage across client and server code to use the shared `createBrowserSupabase` / `createServerSupabaseRoute` helpers.

### Description

- Reworked the customers import flow in `app/api/customers/import/route.ts` to prefetch same-shop customers once and build an in-memory `CustomerMatchIndex` for email/phone/name+location lookups instead of querying per-row.  
- Added batched insert logic (`INSERT_BATCH_SIZE = 250`) and a resilient `insertCustomerBatch` that falls back to per-row insert/update and refreshes the server-side index when duplicate errors occur.  
- Removed `user_id` from normalized insert payloads and added helpers `createCustomerMatchIndex`, `addCustomerToMatchIndex`, `customerInsertToMatch`, `nameLocationKey`, and `isPendingImportMatch` to manage matching across the import batch.  
- Improved duplicate handling: `findExistingCustomer` now consults the in-memory index, import skips duplicates already queued in the current batch, and recovers safely when encountering `customers_user_id_uq`.  
- Replaced usages of `createClientComponentClient` with `createBrowserSupabase` in several client components (`ForcePasswordChangeModal`, `InboxModal`, `CustomerProfilePage`, `AppShell`, `ShiftTracker`) and replaced server-side Supabase client usage with `createServerSupabaseRoute` in branding code.  
- Updated test mocks and `tests/onboarding-v2/customer-onboarding-card.test.tsx` to support array inserts, track prefetch counts, and add tests that assert omission of `user_id`, recovery from `customers_user_id_uq`, and single prefetch behavior for large imports.

### Testing

- Ran the unit tests for the import-related spec `tests/onboarding-v2/customer-onboarding-card.test.tsx` under `vitest`, which include cases for authenticated/unauthenticated behavior, duplicate handling, batch inserts, and recovery from `customers_user_id_uq`, and they passed.  
- Executed the updated test suite that covers client component usages of the new `createBrowserSupabase` helper, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e039db208328801897d3a58822a8)