### PR TITLE
Fix customer CSV import mapping and dedupe

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -11,6 +11,7 @@ type CustomerMatch = Pick<
   CustomerRow,
   | "id"
   | "shop_id"
+  | "external_id"
   | "business_name"
   | "name"
   | "first_name"
@@ -25,18 +26,25 @@ type CustomerMatch = Pick<
   | "postal_code"
   | "notes"
   | "import_notes"
+  | "created_at"
 >;
 type SupabaseRouteClient = ReturnType<typeof createServerSupabaseRoute>;
 type ImportRow = {
+  customer_id?: unknown;
+  external_id?: unknown;
   first_name?: unknown;
   last_name?: unknown;
   name?: unknown;
+  display_name?: unknown;
   company_name?: unknown;
   business_name?: unknown;
   email?: unknown;
   phone?: unknown;
   phone_number?: unknown;
+  phone_primary?: unknown;
+  phone_secondary?: unknown;
   address?: unknown;
+  address1?: unknown;
   street?: unknown;
   city?: unknown;
   province?: unknown;
@@ -44,6 +52,8 @@ type ImportRow = {
   postal_code?: unknown;
   zip?: unknown;
   notes?: unknown;
+  tags?: unknown;
+  customer_type?: unknown;
 };
 
 type Counts = {
@@ -78,7 +88,7 @@ type SupabaseErrorLike = {
 };
 
 const CUSTOMER_SELECT =
-  "id,shop_id,business_name,name,first_name,last_name,email,phone,phone_number,address,street,city,province,postal_code,notes,import_notes";
+  "id,shop_id,external_id,business_name,name,first_name,last_name,email,phone,phone_number,address,street,city,province,postal_code,notes,import_notes,created_at";
 const MAX_IMPORT_ROWS = 5000;
 const MAX_DIAGNOSTICS = 25;
 const INSERT_BATCH_SIZE = 250;
@@ -136,31 +146,49 @@ function splitName(name: string | null): {
 }
 
 function normalizeRow(row: ImportRow, shopId: string): CustomerInsert | null {
+  const externalId =
+    cleanString(row.external_id) ?? cleanString(row.customer_id);
   const businessName =
     cleanString(row.business_name) ?? cleanString(row.company_name);
-  const explicitName = cleanString(row.name);
+  const explicitName = cleanString(row.display_name) ?? cleanString(row.name);
   const split = splitName(explicitName);
   const firstName = cleanString(row.first_name) ?? split.firstName;
   const lastName = cleanString(row.last_name) ?? split.lastName;
   const email = cleanEmail(row.email);
-  const phone = cleanPhone(row.phone) ?? cleanPhone(row.phone_number);
+  const primaryPhone = cleanPhone(row.phone_primary) ?? cleanPhone(row.phone);
+  const secondaryPhone =
+    cleanPhone(row.phone_secondary) ?? cleanPhone(row.phone_number);
+  const phone = primaryPhone ?? secondaryPhone;
   const personName = [firstName, lastName].filter(Boolean).join(" ").trim();
-  const displayName = businessName ?? explicitName ?? (personName || null);
+  const displayName = explicitName ?? businessName ?? (personName || null);
+  const customerType = normalizeComparable(row.customer_type);
+  const isFleet =
+    Boolean(businessName) ||
+    customerType === "fleet" ||
+    customerType === "business" ||
+    customerType === "company";
 
-  if (!displayName && !email && !phone) return null;
+  if (!externalId && !displayName && !email && !phone) return null;
 
   return {
     shop_id: shopId,
-    is_fleet: Boolean(businessName),
+    external_id: externalId,
+    is_fleet: isFleet,
     business_name: businessName,
     name: displayName,
     first_name: firstName,
     last_name: lastName,
     email,
     phone,
-    phone_number: phone,
-    address: cleanString(row.address) ?? cleanString(row.street),
-    street: cleanString(row.street) ?? cleanString(row.address),
+    phone_number: secondaryPhone ?? phone,
+    address:
+      cleanString(row.address1) ??
+      cleanString(row.address) ??
+      cleanString(row.street),
+    street:
+      cleanString(row.street) ??
+      cleanString(row.address1) ??
+      cleanString(row.address),
     city: cleanString(row.city),
     province: cleanString(row.province) ?? cleanString(row.state),
     postal_code: cleanString(row.postal_code) ?? cleanString(row.zip),
@@ -170,6 +198,7 @@ function normalizeRow(row: ImportRow, shopId: string): CustomerInsert | null {
 }
 
 type CustomerMatchIndex = {
+  byExternalId: Map<string, CustomerMatch>;
   byEmail: Map<string, CustomerMatch>;
   byPhone: Map<string, CustomerMatch>;
   byNameLocation: Map<string, CustomerMatch>;
@@ -212,12 +241,17 @@ function createCustomerMatchIndex(
   customers: CustomerMatch[],
 ): CustomerMatchIndex {
   const index: CustomerMatchIndex = {
+    byExternalId: new Map(),
     byEmail: new Map(),
     byPhone: new Map(),
     byNameLocation: new Map(),
   };
 
   for (const customer of customers) {
+    const externalId = normalizeComparable(customer.external_id);
+    if (externalId && !index.byExternalId.has(externalId))
+      index.byExternalId.set(externalId, customer);
+
     const email = normalizeEmailComparable(customer.email);
     if (email && !index.byEmail.has(email)) index.byEmail.set(email, customer);
 
@@ -240,6 +274,9 @@ function addCustomerToMatchIndex(
   customer: CustomerMatch,
 ) {
   const scopedIndex = createCustomerMatchIndex([customer]);
+  for (const [key, value] of scopedIndex.byExternalId) {
+    if (!index.byExternalId.has(key)) index.byExternalId.set(key, value);
+  }
   for (const [key, value] of scopedIndex.byEmail) {
     if (!index.byEmail.has(key)) index.byEmail.set(key, value);
   }
@@ -258,6 +295,7 @@ function customerInsertToMatch(
   return {
     id,
     shop_id: customer.shop_id ?? null,
+    external_id: customer.external_id ?? null,
     business_name: customer.business_name ?? null,
     name: customer.name ?? null,
     first_name: customer.first_name ?? null,
@@ -272,6 +310,7 @@ function customerInsertToMatch(
     postal_code: customer.postal_code ?? null,
     notes: customer.notes ?? null,
     import_notes: customer.import_notes ?? null,
+    created_at: customer.created_at ?? null,
   };
 }
 
@@ -283,6 +322,8 @@ async function getShopCustomerCandidates(
     .from("customers")
     .select(CUSTOMER_SELECT)
     .eq("shop_id", shopId)
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true })
     .limit(10000)) as {
     data: CustomerMatch[] | null;
     error: SupabaseErrorLike | null;
@@ -297,6 +338,10 @@ function findExistingCustomer(
   shopId: string,
   customer: CustomerInsert,
 ): CustomerMatch | null {
+  const externalId = normalizeComparable(customer.external_id);
+  const externalMatch = externalId ? index.byExternalId.get(externalId) : null;
+  if (externalMatch?.shop_id === shopId) return externalMatch;
+
   const email = normalizeEmailComparable(customer.email);
   const emailMatch = email ? index.byEmail.get(email) : null;
   if (emailMatch?.shop_id === shopId) return emailMatch;
@@ -354,6 +399,7 @@ function logCustomerImportAuthDiagnostic(
 function updatePayload(customer: CustomerInsert): CustomerUpdate {
   const update: CustomerUpdate = { updated_at: new Date().toISOString() };
   for (const key of [
+    "external_id",
     "business_name",
     "name",
     "first_name",

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -28,6 +28,11 @@ type CustomerSearchRow = Pick<
   | "email"
   | "phone"
   | "phone_number"
+  | "address"
+  | "street"
+  | "city"
+  | "province"
+  | "postal_code"
   | "created_at"
 >;
 
@@ -176,10 +181,11 @@ function compactSecondaryDetails(input: {
   phoneNumber?: string | null;
   city?: string | null;
   province?: string | null;
+  postalCode?: string | null;
 }): string | null {
   const contactName = [input.firstName ?? "", input.lastName ?? ""].filter(Boolean).join(" ").trim();
   const phone = input.phone ?? input.phoneNumber ?? null;
-  const location = [input.city ?? "", input.province ?? ""].filter(Boolean).join(", ").trim();
+  const location = [input.city ?? "", input.province ?? "", input.postalCode ?? ""].filter(Boolean).join(", ").trim();
   const parts = [contactName, phone ?? "", input.email ?? "", location].filter((part) => part && part !== input.businessName);
   return parts.length ? parts.join(" • ") : null;
 }
@@ -444,7 +450,7 @@ export default function CustomerProfilePage(): JSX.Element {
         const { data: cust, error: custErr } = await supabase
           .from("customers")
           .select(
-            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, address, city, province, postal_code",
+            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, address, street, city, province, postal_code, created_at",
           )
           .eq("id", customerId)
           .maybeSingle();
@@ -798,7 +804,7 @@ export default function CustomerProfilePage(): JSX.Element {
       const { data, error } = await supabase
         .from("customers")
         .select(
-          "id, first_name, last_name, name, business_name, email, phone, phone_number, created_at",
+          "id, first_name, last_name, name, business_name, email, phone, phone_number, address, street, city, province, postal_code, created_at",
         )
         .or(
           [
@@ -809,6 +815,11 @@ export default function CustomerProfilePage(): JSX.Element {
             `email.ilike.${like}`,
             `phone.ilike.${like}`,
             `phone_number.ilike.${like}`,
+            `address.ilike.${like}`,
+            `street.ilike.${like}`,
+            `city.ilike.${like}`,
+            `province.ilike.${like}`,
+            `postal_code.ilike.${like}`,
           ].join(","),
         )
         .order("created_at", { ascending: false })
@@ -1295,7 +1306,7 @@ export default function CustomerProfilePage(): JSX.Element {
                                   : "—"}
                           </div>
                           <div className="mt-0.5 text-[11px] text-neutral-400">
-                            {compactSecondaryDetails({ firstName: r.first_name, lastName: r.last_name, businessName: r.business_name, email: r.email, phone: r.phone, phoneNumber: r.phone_number }) ?? "No contact details imported"}
+                            {compactSecondaryDetails({ firstName: r.first_name, lastName: r.last_name, businessName: r.business_name, email: r.email, phone: r.phone, phoneNumber: r.phone_number, city: r.city, province: r.province, postalCode: r.postal_code }) ?? "No contact details imported"}
                           </div>
                         </div>
                         <div className="text-[10px] text-neutral-500">{safeDate(r.created_at)}</div>
@@ -1551,6 +1562,7 @@ export default function CustomerProfilePage(): JSX.Element {
                             phoneNumber: customer.phone_number,
                             city: typeof customerRecord["city"] === "string" ? customerRecord["city"] : null,
                             province: typeof customerRecord["province"] === "string" ? customerRecord["province"] : null,
+                            postalCode: typeof customerRecord["postal_code"] === "string" ? customerRecord["postal_code"] : null,
                           }) ?? "No contact details imported"}
                         </div>
                       </>
@@ -1558,7 +1570,7 @@ export default function CustomerProfilePage(): JSX.Element {
                   })()}
 
                   <div className="mt-2 text-sm leading-6 text-neutral-400">
-                    <div>{asText((customer as unknown as Record<string, unknown>)["address"])}</div>
+                    <div>{asText((customer as unknown as Record<string, unknown>)["address"] ?? (customer as unknown as Record<string, unknown>)["street"])}</div>
                     <div>
                       {[
                         (customer as unknown as Record<string, unknown>)["city"],

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -8,15 +8,21 @@ import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/On
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type CustomerImportRow = {
+  customer_id?: string | null;
+  external_id?: string | null;
   first_name?: string | null;
   last_name?: string | null;
   name?: string | null;
+  display_name?: string | null;
   company_name?: string | null;
   business_name?: string | null;
   email?: string | null;
   phone?: string | null;
   phone_number?: string | null;
+  phone_primary?: string | null;
+  phone_secondary?: string | null;
   address?: string | null;
+  address1?: string | null;
   street?: string | null;
   city?: string | null;
   province?: string | null;
@@ -24,6 +30,8 @@ type CustomerImportRow = {
   postal_code?: string | null;
   zip?: string | null;
   notes?: string | null;
+  tags?: string | null;
+  customer_type?: string | null;
 };
 
 type ImportCounts = {
@@ -59,15 +67,21 @@ type Props = {
 };
 
 const SUPPORTED_COLUMNS = [
+  "customer_id",
+  "external_id",
   "first_name",
   "last_name",
   "name",
+  "display_name",
   "company_name",
   "business_name",
   "email",
   "phone",
   "phone_number",
+  "phone_primary",
+  "phone_secondary",
   "address",
+  "address1",
   "street",
   "city",
   "province",
@@ -75,10 +89,12 @@ const SUPPORTED_COLUMNS = [
   "postal_code",
   "zip",
   "notes",
+  "tags",
+  "customer_type",
 ] as const;
 
 const RECOMMENDED_COLUMNS =
-  "first_name, last_name, email, phone, address, city, province/state, postal_code/zip";
+  "customer_id, company_name/display_name, first_name, last_name, email, phone_primary/phone, address1/address, city, province/state, postal_code/zip";
 
 function cleanHeader(value: string): string {
   return value
@@ -106,10 +122,15 @@ function normalizeParsedRow(row: Record<string, unknown>): CustomerImportRow {
 
 function hasImportableIdentity(row: CustomerImportRow): boolean {
   return Boolean(
+    row.customer_id ||
+    row.external_id ||
     row.email ||
+    row.phone_primary ||
     row.phone ||
+    row.phone_secondary ||
     row.phone_number ||
     row.name ||
+    row.display_name ||
     row.company_name ||
     row.business_name ||
     row.first_name ||
@@ -121,10 +142,15 @@ function displayName(row: CustomerImportRow): string {
   return (
     row.company_name ||
     row.business_name ||
+    row.display_name ||
     row.name ||
     [row.first_name, row.last_name].filter(Boolean).join(" ").trim() ||
+    row.customer_id ||
+    row.external_id ||
     row.email ||
+    row.phone_primary ||
     row.phone ||
+    row.phone_secondary ||
     row.phone_number ||
     "—"
   );
@@ -263,6 +289,12 @@ export function CustomerCsvImportCard({
         warnings: payload.warnings ?? [],
         errors: payload.errors ?? [],
       });
+      if (payload.counts.failed === 0) {
+        setRows([]);
+        setHeaders([]);
+        setFileName(null);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
       if (
         isOnboarding &&
         payload.counts.created + payload.counts.updated > 0 &&
@@ -443,7 +475,11 @@ export function CustomerCsvImportCard({
                     </td>
                     <td className="px-3 py-2">{row.email ?? "—"}</td>
                     <td className="px-3 py-2">
-                      {row.phone ?? row.phone_number ?? "—"}
+                      {row.phone_primary ??
+                        row.phone ??
+                        row.phone_secondary ??
+                        row.phone_number ??
+                        "—"}
                     </td>
                     <td className="px-3 py-2">
                       {[row.city, row.province ?? row.state]

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -40,6 +40,7 @@ type MockQuery = {
   select: ReturnType<typeof vi.fn>;
   eq: ReturnType<typeof vi.fn>;
   or: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
   maybeSingle: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
@@ -73,6 +74,7 @@ function makeQuery(table: string): MockQuery {
       return query;
     }),
     limit: vi.fn(() => query),
+    order: vi.fn(() => query),
     maybeSingle: vi.fn(async () => {
       if (table === "profiles") {
         mockSupabaseState.profileSelects += 1;
@@ -283,6 +285,33 @@ describe("CustomerCsvImportCard", () => {
     );
   });
 
+  it("clears the selected CSV and disables confirm after a successful import", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        counts: { created: 1, updated: 0, skipped: 0, failed: 0 },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard />);
+
+    await uploadCsv(
+      "display_name,email,phone_primary,address1,city,province,postal_code\nAda Lovelace,ada@example.com,(555) 111-2222,123 Engine Way,Toronto,ON,M5V 2T6\n",
+    );
+    const confirmButton = await screen.findByRole("button", {
+      name: /confirm import/i,
+    });
+    expect(confirmButton).toBeEnabled();
+
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+    expect(screen.getByText("No CSV selected")).toBeInTheDocument();
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+  });
+
   it("does not call onboarding completion when the import has hard failures", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url === "/api/customers/import")
@@ -436,6 +465,92 @@ describe("POST /api/customers/import", () => {
     });
     expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
     expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
+  });
+
+  it("maps uploaded CSV-style customer fields into the customer insert payload without user_id", async () => {
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            {
+              customer_id: "CUST-100",
+              customer_type: "fleet",
+              company_name: "Ada Logistics",
+              display_name: "Ada Logistics Display",
+              first_name: "Ada",
+              last_name: "Lovelace",
+              email: "ADA@EXAMPLE.COM",
+              phone_primary: "(555) 111-2222",
+              phone_secondary: "(555) 333-4444",
+              address1: "123 Engine Way",
+              city: "Toronto",
+              province: "ON",
+              postal_code: "M5V 2T6",
+              notes: "VIP fleet",
+            },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      external_id: "CUST-100",
+      is_fleet: true,
+      business_name: "Ada Logistics",
+      name: "Ada Logistics Display",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      email: "ada@example.com",
+      phone: "5551112222",
+      phone_number: "5553334444",
+      address: "123 Engine Way",
+      street: "123 Engine Way",
+      city: "Toronto",
+      province: "ON",
+      postal_code: "M5V 2T6",
+      notes: "VIP fleet",
+    });
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+  });
+
+  it("does not create duplicate customer records for duplicate emails in the same shop import", async () => {
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            { name: "Ada One", email: "ada@example.com" },
+            { name: "Ada Two", email: "ADA@example.com" },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+    expect(
+      mockSupabaseState.customers.filter(
+        (customer) =>
+          customer.shop_id === "shop-real" &&
+          String(customer.email).toLowerCase() === "ada@example.com",
+      ),
+    ).toHaveLength(1);
   });
 
   it("updates or skips a duplicate email in the same shop instead of failing", async () => {


### PR DESCRIPTION
### Motivation
- Normalize and reliably map incoming CSV columns (customer id, display/company name, phones, address fields, etc.) into the canonical `customers` payload so imported data appears in customer detail/search views.
- Make imports idempotent and shop-scoped so duplicate CSV imports don't create new rows and same-shop duplicate emails update the existing customer instead of failing or inserting duplicates.

### Description
- Extended CSV parsing and supported columns in the UI `CustomerCsvImportCard` to accept `customer_id`, `external_id`, `display_name`, `phone_primary`/`phone_secondary`, `address1`, `tags`, and `customer_type`, and updated identity detection and preview to prefer those fields. (`features/customers/components/CustomerCsvImportCard.tsx`).
- Expanded `normalizeRow` to map CSV fields into `customers` insert payload including `external_id`, `is_fleet` inference from `customer_type`/company, primary/secondary phone handling, `address`/`street`/`address1` fallbacks, and preserved `shop_id` from the authenticated profile (no `user_id` in payload). (`app/api/customers/import/route.ts`).
- Made matching deterministic and shop-scoped by prefetching same-shop candidates in a stable order and matching by: `external_id` first, normalized `email` second, normalized `phone` third, and name+location last; updated indexing to include `external_id`. (`app/api/customers/import/route.ts`).
- On successful import (no failures) clear parsed rows, headers, file input and selected file label so `Confirm import` is disabled until a new file is chosen. (`features/customers/components/CustomerCsvImportCard.tsx`).
- Surface imported address/location fields in the customer detail and directory/search queries and display (use `street` fallback when `address` is missing). (`features/customers/app/customers/[id]/page.tsx`).
- Added tests that assert: CSV-style fields map into the insert payload without `user_id`, duplicate emails in same-shop imports do not create duplicate rows, and the UI clears/disables after a successful import. (`tests/onboarding-v2/customer-onboarding-card.test.tsx`).

### Testing
- Ran the onboarding customer import unit tests with `npx vitest run tests/onboarding-v2/customer-onboarding-card.test.tsx` and all tests passed (27/27).
- Ran TypeScript validation with `npx tsc --noEmit` and it succeeded with no errors.
- Ran `git diff --check` to ensure no whitespace/errors and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22385005248328b7069e9f567ac3e4)