### PR TITLE
Fix customer import external_id dedupe

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -92,6 +92,7 @@ const CUSTOMER_SELECT =
 const MAX_IMPORT_ROWS = 5000;
 const MAX_DIAGNOSTICS = 25;
 const INSERT_BATCH_SIZE = 250;
+const CUSTOMER_PREFETCH_PAGE_SIZE = 1000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -129,6 +130,12 @@ function normalizeComparable(value: unknown): string {
     .replace(/[^a-z0-9]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function normalizeExternalIdComparable(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
 }
 
 function splitName(name: string | null): {
@@ -248,7 +255,7 @@ function createCustomerMatchIndex(
   };
 
   for (const customer of customers) {
-    const externalId = normalizeComparable(customer.external_id);
+    const externalId = normalizeExternalIdComparable(customer.external_id);
     if (externalId && !index.byExternalId.has(externalId))
       index.byExternalId.set(externalId, customer);
 
@@ -318,19 +325,42 @@ async function getShopCustomerCandidates(
   supabase: SupabaseRouteClient,
   shopId: string,
 ): Promise<CustomerMatch[]> {
-  const { data, error } = (await supabase
-    .from("customers")
-    .select(CUSTOMER_SELECT)
-    .eq("shop_id", shopId)
-    .order("created_at", { ascending: true })
-    .order("id", { ascending: true })
-    .limit(10000)) as {
-    data: CustomerMatch[] | null;
-    error: SupabaseErrorLike | null;
-  };
+  const customers: CustomerMatch[] = [];
 
-  if (error || !data?.length) return [];
-  return data.filter((candidate) => candidate.shop_id === shopId);
+  for (let from = 0; ; from += CUSTOMER_PREFETCH_PAGE_SIZE) {
+    const to = from + CUSTOMER_PREFETCH_PAGE_SIZE - 1;
+    const { data, error } = (await supabase
+      .from("customers")
+      .select(CUSTOMER_SELECT)
+      .eq("shop_id", shopId)
+      .order("created_at", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, to)) as {
+      data: CustomerMatch[] | null;
+      error: SupabaseErrorLike | null;
+    };
+
+    if (error) {
+      console.warn("[customers-import] customer prefetch failed", {
+        shopId,
+        from,
+        to,
+        code: error.code,
+        status: error.status,
+        message: error.message,
+      });
+      break;
+    }
+
+    const page = (data ?? []).filter(
+      (candidate) => candidate.shop_id === shopId,
+    );
+    customers.push(...page);
+
+    if (!data || data.length < CUSTOMER_PREFETCH_PAGE_SIZE) break;
+  }
+
+  return customers;
 }
 
 function findExistingCustomer(
@@ -338,7 +368,7 @@ function findExistingCustomer(
   shopId: string,
   customer: CustomerInsert,
 ): CustomerMatch | null {
-  const externalId = normalizeComparable(customer.external_id);
+  const externalId = normalizeExternalIdComparable(customer.external_id);
   const externalMatch = externalId ? index.byExternalId.get(externalId) : null;
   if (externalMatch?.shop_id === shopId) return externalMatch;
 
@@ -809,6 +839,7 @@ export async function POST(req: Request) {
   const existingCustomers = await getShopCustomerCandidates(supabase, shopId);
   const matchIndex = createCustomerMatchIndex(existingCustomers);
   const pendingInserts: PendingCustomerInsert[] = [];
+  const importedExternalIds = new Set<string>();
 
   for (const [index, rawRow] of inputRows.entries()) {
     const rowNumber = index + 1;
@@ -831,6 +862,21 @@ export async function POST(req: Request) {
         reason: "Missing customer identity fields.",
       });
       continue;
+    }
+
+    const externalId = normalizeExternalIdComparable(customer.external_id);
+    if (externalId) {
+      if (importedExternalIds.has(externalId)) {
+        counts.skipped += 1;
+        addDiagnostic(warnings, {
+          row: rowNumber,
+          identity: getSafeIdentity(customer),
+          reason:
+            "Duplicate external_id already exists earlier in this import batch.",
+        });
+        continue;
+      }
+      importedExternalIds.add(externalId);
     }
 
     try {

--- a/db/sql/2026-06-05_customer_external_id_dedupe_guard.sql
+++ b/db/sql/2026-06-05_customer_external_id_dedupe_guard.sql
@@ -1,0 +1,92 @@
+-- Customer import dedupe guard
+--
+-- Production currently contains duplicate customer external_id values per shop, so a
+-- plain unique index would fail during deployment. This migration safely:
+-- 1. normalizes blank/whitespace-only external_id values to NULL;
+-- 2. trims leading/trailing whitespace from populated external_id values;
+-- 3. installs a trigger that rejects any new normalized same-shop duplicate;
+-- 4. creates the normalized partial unique index only when existing data is clean.
+--
+-- Duplicate audit query to run before/after cleanup:
+-- select shop_id,
+--        lower(btrim(external_id)) as normalized_external_id,
+--        count(*) as duplicate_count,
+--        array_agg(id order by created_at nulls last, id) as customer_ids
+-- from public.customers
+-- where external_id is not null and btrim(external_id) <> ''
+-- group by shop_id, lower(btrim(external_id))
+-- having count(*) > 1
+-- order by duplicate_count desc, normalized_external_id;
+
+update public.customers
+set external_id = null
+where external_id is not null
+  and btrim(external_id) = '';
+
+update public.customers
+set external_id = btrim(external_id)
+where external_id is not null
+  and external_id <> btrim(external_id);
+
+create or replace function public.prevent_duplicate_customer_external_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.shop_id is null or new.external_id is null or btrim(new.external_id) = '' then
+    return new;
+  end if;
+
+  new.external_id := btrim(new.external_id);
+
+  -- Serialize competing writes for the same shop/external_id pair so the guard
+  -- remains effective even before the unique index can be created on dirty data.
+  perform pg_advisory_xact_lock(
+    hashtextextended(new.shop_id::text || ':' || lower(new.external_id), 0)
+  );
+
+  if exists (
+    select 1
+    from public.customers c
+    where c.shop_id = new.shop_id
+      and c.id <> new.id
+      and c.external_id is not null
+      and lower(btrim(c.external_id)) = lower(new.external_id)
+  ) then
+    raise exception 'duplicate customer external_id % for shop %', new.external_id, new.shop_id
+      using errcode = '23505', constraint = 'customers_shop_external_id_normalized_uq';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists customers_prevent_duplicate_external_id on public.customers;
+
+create trigger customers_prevent_duplicate_external_id
+before insert or update of shop_id, external_id on public.customers
+for each row
+execute function public.prevent_duplicate_customer_external_id();
+
+do $$
+begin
+  if not exists (
+    select 1
+    from (
+      select shop_id, lower(btrim(external_id)) as normalized_external_id
+      from public.customers
+      where external_id is not null and btrim(external_id) <> ''
+      group by shop_id, lower(btrim(external_id))
+      having count(*) > 1
+    ) duplicates
+  ) then
+    create unique index if not exists customers_shop_external_id_normalized_uq
+      on public.customers (shop_id, lower(btrim(external_id)))
+      where external_id is not null and btrim(external_id) <> '';
+  else
+    raise warning 'Skipped customers_shop_external_id_normalized_uq because duplicate customer external_id rows still exist. Run the duplicate audit query in this migration, merge duplicate customers, then create the index.';
+  end if;
+end;
+$$;

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -37,12 +37,15 @@ vi.mock("next/navigation", () => ({
 
 type MockQuery = {
   filters: Record<string, unknown>;
+  rangeFrom: number | null;
+  rangeTo: number | null;
   select: ReturnType<typeof vi.fn>;
   eq: ReturnType<typeof vi.fn>;
   or: ReturnType<typeof vi.fn>;
   order: ReturnType<typeof vi.fn>;
   maybeSingle: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
+  range: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   then: ReturnType<typeof vi.fn>;
@@ -51,6 +54,8 @@ type MockQuery = {
 function selectCustomers(filters: Record<string, unknown>) {
   return mockSupabaseState.customers.filter((customer) => {
     if (filters.shop_id && customer.shop_id !== filters.shop_id) return false;
+    if (filters.external_id && customer.external_id !== filters.external_id)
+      return false;
     if (filters.email && customer.email !== filters.email) return false;
     if (filters.name && customer.name !== filters.name) return false;
     if (filters.or) {
@@ -64,6 +69,8 @@ function selectCustomers(filters: Record<string, unknown>) {
 function makeQuery(table: string): MockQuery {
   const query: MockQuery = {
     filters: {} as Record<string, unknown>,
+    rangeFrom: null,
+    rangeTo: null,
     select: vi.fn(() => query),
     eq: vi.fn((column: string, value: unknown) => {
       query.filters[column] = value;
@@ -74,6 +81,11 @@ function makeQuery(table: string): MockQuery {
       return query;
     }),
     limit: vi.fn(() => query),
+    range: vi.fn((from: number, to: number) => {
+      query.rangeFrom = from;
+      query.rangeTo = to;
+      return query;
+    }),
     order: vi.fn(() => query),
     maybeSingle: vi.fn(async () => {
       if (table === "profiles") {
@@ -124,9 +136,12 @@ function makeQuery(table: string): MockQuery {
     then: vi.fn((resolve: (value: unknown) => unknown) => {
       if (table === "customers") {
         mockSupabaseState.customerSelects += 1;
-        return Promise.resolve(
-          resolve({ data: selectCustomers(query.filters), error: null }),
-        );
+        const rows = selectCustomers(query.filters);
+        const pagedRows =
+          query.rangeFrom == null || query.rangeTo == null
+            ? rows
+            : rows.slice(query.rangeFrom, query.rangeTo + 1);
+        return Promise.resolve(resolve({ data: pagedRows, error: null }));
       }
       return Promise.resolve(resolve({ data: null, error: null }));
     }),
@@ -551,6 +566,130 @@ describe("POST /api/customers/import", () => {
           String(customer.email).toLowerCase() === "ada@example.com",
       ),
     ).toHaveLength(1);
+  });
+
+  it("updates an older same-shop customer matched by normalized external_id before email, phone, or name", async () => {
+    mockSupabaseState.customers = [
+      {
+        id: "older-external-customer",
+        shop_id: "shop-real",
+        external_id: " cust-100011 ",
+        business_name: null,
+        email: null,
+        name: null,
+      },
+      {
+        id: "email-collision",
+        shop_id: "shop-real",
+        external_id: "CUST-OTHER",
+        business_name: "Email Collision",
+        email: "ada@example.com",
+        name: "Email Collision",
+      },
+    ];
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            {
+              external_id: "CUST-100011",
+              business_name: "Ada Logistics",
+              email: "ada@example.com",
+            },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+    expect(mockSupabaseState.updates[0]).toMatchObject({
+      filters: { shop_id: "shop-real", id: "older-external-customer" },
+      payload: expect.objectContaining({
+        external_id: "CUST-100011",
+        business_name: "Ada Logistics",
+        email: "ada@example.com",
+      }),
+    });
+  });
+
+  it("prefetches beyond the first 1000 same-shop customers before matching external_id", async () => {
+    mockSupabaseState.customers = Array.from({ length: 1205 }, (_, index) => ({
+      id: `customer-${index}`,
+      shop_id: "shop-real",
+      external_id: `CUST-${String(index).padStart(6, "0")}`,
+      created_at: `2026-04-${String((index % 28) + 1).padStart(2, "0")}`,
+    }));
+
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            {
+              external_id: "CUST-001200",
+              business_name: "Customer 1200 Updated",
+            },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockSupabaseState.customerSelects).toBe(2);
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({
+      shop_id: "shop-real",
+      id: "customer-1200",
+    });
+  });
+
+  it("dedupes repeated external_id values inside one CSV before insert", async () => {
+    const response = await importCustomers(
+      new Request("http://localhost/api/customers/import", {
+        method: "POST",
+        body: JSON.stringify({
+          rows: [
+            { external_id: "CUST-100011", business_name: "Ada One" },
+            { external_id: " cust-100011 ", business_name: "Ada Two" },
+          ],
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(payload.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      external_id: "CUST-100011",
+      business_name: "Ada One",
+    });
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+    expect(payload.warnings[0]).toMatchObject({
+      row: 2,
+      reason:
+        "Duplicate external_id already exists earlier in this import batch.",
+    });
   });
 
   it("updates or skips a duplicate email in the same shop instead of failing", async () => {


### PR DESCRIPTION
### Motivation
- Production imports created duplicate `customers` rows sharing the same `external_id` because existing prefetch and matching missed same-shop rows and external_id comparison was not normalized.
- The import flow must prioritize normalized `external_id` matching, dedupe repeated IDs within a single CSV, and avoid inserting `user_id` into imported payloads.
- A database-side guard and eventual unique index are required to prevent future normalized same-shop duplicates while preserving safe rollout on dirty production data.

### Description
- Page same-shop customer prefetching in `app/api/customers/import/route.ts` using `CUSTOMER_PREFETCH_PAGE_SIZE` and `.range()` so imports load all candidates instead of relying on a single limited select.
- Add `normalizeExternalIdComparable` and use it in `createCustomerMatchIndex` and `findExistingCustomer` so `external_id` is trimmed/lowercased and matched before email/phone/name.
- Deduplicate repeated `external_id` values inside a single import payload via an `importedExternalIds` Set to skip duplicate rows before queueing inserts, and keep `user_id` omitted from inserted payloads.
- Add a safe DB migration `db/sql/2026-06-05_customer_external_id_dedupe_guard.sql` that trims/normalizes existing `external_id` values, installs a trigger to reject new normalized duplicates, and conditionally creates a partial normalized unique index only when existing duplicates are cleaned; update tests in `tests/onboarding-v2/customer-onboarding-card.test.tsx` to cover the new behaviors.

### Testing
- Ran `npx vitest run tests/onboarding-v2/customer-onboarding-card.test.tsx` and all tests passed.
- Ran `npx tsc --noEmit` and the typecheck succeeded.
- Ran `git diff --check` with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223d3c6e388328b1deee77d1dc831e)