### PR TITLE
Fix customer CSV import UI reset

### DIFF
--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -188,6 +188,7 @@ export function CustomerCsvImportCard({
   const importSucceeded = Boolean(
     counts && counts.created + counts.updated > 0 && counts.failed === 0,
   );
+  const canConfirmImport = Boolean(fileName && importableRows.length);
 
   function resetImportState() {
     setRows([]);
@@ -196,6 +197,14 @@ export function CustomerCsvImportCard({
     setDiagnostics({});
     setParseError(null);
     setImportError(null);
+  }
+
+  function clearSelectedCsv() {
+    setFileName(null);
+    setRows([]);
+    setHeaders([]);
+    setParseError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -262,10 +271,7 @@ export function CustomerCsvImportCard({
   }
 
   async function confirmImport() {
-    if (!importableRows.length) {
-      setImportError(
-        "Upload a CSV with at least one customer name, company, email, or phone before importing.",
-      );
+    if (!canConfirmImport) {
       return;
     }
     setImporting(true);
@@ -290,10 +296,7 @@ export function CustomerCsvImportCard({
         errors: payload.errors ?? [],
       });
       if (payload.counts.failed === 0) {
-        setRows([]);
-        setHeaders([]);
-        setFileName(null);
-        if (fileInputRef.current) fileInputRef.current.value = "";
+        clearSelectedCsv();
       }
       if (
         isOnboarding &&
@@ -545,7 +548,7 @@ export function CustomerCsvImportCard({
         <button
           type="button"
           onClick={() => void confirmImport()}
-          disabled={importing || completingOnboarding || !importableRows.length}
+          disabled={importing || completingOnboarding || !canConfirmImport}
           className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
         >
           {importing

--- a/tests/onboarding-v2/customer-onboarding-card.test.tsx
+++ b/tests/onboarding-v2/customer-onboarding-card.test.tsx
@@ -300,7 +300,7 @@ describe("CustomerCsvImportCard", () => {
     );
   });
 
-  it("clears the selected CSV and disables confirm after a successful import", async () => {
+  it("clears the selected CSV state and keeps the success summary after a successful import", async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       json: async () => ({
@@ -325,6 +325,70 @@ describe("CustomerCsvImportCard", () => {
     await waitFor(() => expect(confirmButton).toBeDisabled());
     expect(screen.getByText("No CSV selected")).toBeInTheDocument();
     expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rows parsed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Preview")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Detected \d+ columns/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Import results: created 1, updated 0, skipped 0, failed 0.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      (screen.getByTestId("customer-csv-file-input") as HTMLInputElement)
+        .value,
+    ).toBe("");
+  });
+
+  it("does not send another import request when confirm is clicked after a successful import", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        counts: { created: 1, updated: 0, skipped: 0, failed: 0 },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard />);
+
+    await uploadCsv("first_name,last_name,email\nAda,Lovelace,ada@example.com\n");
+    const confirmButton = await screen.findByRole("button", {
+      name: /confirm import/i,
+    });
+
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+
+    await userEvent.click(confirmButton);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-enables confirm after selecting and parsing a new valid CSV", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        counts: { created: 1, updated: 0, skipped: 0, failed: 0 },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<CustomerCsvImportCard />);
+
+    await uploadCsv("first_name,last_name,email\nAda,Lovelace,ada@example.com\n");
+    const confirmButton = await screen.findByRole("button", {
+      name: /confirm import/i,
+    });
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+    expect(screen.getByText("No CSV selected")).toBeInTheDocument();
+
+    await uploadCsv("first_name,last_name,email\nGrace,Hopper,grace@example.com\n");
+
+    expect(await screen.findByText("Grace Hopper")).toBeInTheDocument();
+    expect(confirmButton).toBeEnabled();
   });
 
   it("does not call onboarding completion when the import has hard failures", async () => {


### PR DESCRIPTION
### Motivation
- After a successful customer CSV import the UI continued to show the previous parsed file and allowed the user to click `Confirm import` again even though the file input had been cleared, creating a confusing and unsafe UX.

### Description
- Compute a `canConfirmImport` guard from `fileName` and `importableRows.length` and use it to enable/disable and gate the `confirmImport` action.
- Add `clearSelectedCsv()` which clears `fileName`, parsed `rows`, `headers`, `parseError` and resets the native file input value so the selected CSV and preview are fully cleared on successful import.
- Update `confirmImport()` to early-return when `!canConfirmImport` and to call `clearSelectedCsv()` when the import succeeds with no failures while preserving the import `counts` summary.
- Update tests in `tests/onboarding-v2/customer-onboarding-card.test.tsx` to assert the post-success UI state (shows “No CSV selected”, preview/headers cleared, native input reset), that `Confirm import` is disabled and does not POST again after success, and that selecting a new CSV re-enables `Confirm import`.
- Files changed: `features/customers/components/CustomerCsvImportCard.tsx`, `tests/onboarding-v2/customer-onboarding-card.test.tsx`.

### Testing
- Ran `npx vitest run tests/onboarding-v2/customer-onboarding-card.test.tsx` and all tests passed.
- Ran `npx tsc --noEmit` and the TypeScript check passed.
- Ran `git diff --check` and there were no diff/whitespace issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22434436a48328b3ad0074743839ff)