### PR TITLE
Fix vehicle CSV import mapping, dedupe, list/search, and imported field display

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -7,8 +7,8 @@ import { cleanVehicleImportText, normalizeImportPlate, normalizeImportVin, type 
 type DB = Database;
 type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
-type VehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "customer_id" | "vin" | "unit_number" | "license_plate">;
-type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
+type VehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "customer_id" | "vin" | "unit_number" | "license_plate" | "external_id" | "year" | "make" | "model" | "submodel" | "color" | "engine" | "engine_type" | "engine_family" | "transmission" | "fuel_type" | "drivetrain" | "engine_hours" | "mileage" | "import_notes" | "source_row_id">;
+type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
 
 type ImportBody = { rows?: unknown; shop_id?: unknown };
 
@@ -31,13 +31,14 @@ function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
     return {
       sourceRowNumber: numberValue(row.sourceRowNumber) ?? index + 1,
       sourceFilename: cleanVehicleImportText(row.sourceFilename),
-      unit_number: cleanVehicleImportText(row.unit_number),
+      external_id: cleanVehicleImportText(row.external_id) ?? cleanVehicleImportText(row.vehicle_id) ?? cleanVehicleImportText(row.vehicleid),
+      unit_number: cleanVehicleImportText(row.unit_number) ?? cleanVehicleImportText(row.unit) ?? cleanVehicleImportText(row.fleet_number),
       vin: normalizeImportVin(row.vin),
-      license_plate: normalizeImportPlate(row.license_plate),
+      license_plate: normalizeImportPlate(row.license_plate) ?? normalizeImportPlate(row.plate),
       year: numberValue(row.year),
       make: cleanVehicleImportText(row.make),
       model: cleanVehicleImportText(row.model),
-      submodel: cleanVehicleImportText(row.submodel),
+      submodel: cleanVehicleImportText(row.submodel) ?? cleanVehicleImportText(row.trim),
       color: cleanVehicleImportText(row.color),
       engine: cleanVehicleImportText(row.engine),
       engine_type: cleanVehicleImportText(row.engine_type),
@@ -46,8 +47,11 @@ function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
       fuel_type: cleanVehicleImportText(row.fuel_type),
       drivetrain: cleanVehicleImportText(row.drivetrain),
       engine_hours: numberValue(row.engine_hours),
-      odometer: cleanVehicleImportText(row.odometer),
+      odometer: cleanVehicleImportText(row.odometer) ?? cleanVehicleImportText(row.mileage),
+      notes: cleanVehicleImportText(row.notes),
+      status: cleanVehicleImportText(row.status),
       customer_id: cleanVehicleImportText(row.customer_id),
+      customer_external_id: cleanVehicleImportText(row.customer_external_id),
       customer_name: cleanVehicleImportText(row.customer_name),
       customer_email: cleanVehicleImportText(row.customer_email)?.toLowerCase(),
       customer_phone: cleanVehicleImportText(row.customer_phone),
@@ -56,15 +60,24 @@ function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
 }
 
 function hasIdentity(row: NormalizedVehicleImportRow): boolean {
-  return Boolean(row.vin || row.unit_number || row.license_plate || (row.year && row.make && row.model));
+  return Boolean(row.vin || row.external_id || row.unit_number || row.license_plate || (row.year && row.make && row.model));
 }
 
-function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: string; userId: string; customerId: string | null }): VehicleInsert {
-  const notes = [`Vehicle CSV import row ${row.sourceRowNumber}`, row.sourceFilename ? `source file: ${row.sourceFilename}` : null].filter(Boolean).join("; ");
+function buildImportNotes(row: NormalizedVehicleImportRow): string | null {
+  const notes = [
+    row.notes ?? null,
+    `Vehicle CSV import row ${row.sourceRowNumber}`,
+    row.sourceFilename ? `source file: ${row.sourceFilename}` : null,
+  ].filter(Boolean).join("; ");
+  return notes || null;
+}
+
+function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: string; customerId: string | null }): VehicleInsert {
+  const notes = buildImportNotes(row);
   return {
     shop_id: args.shopId,
-    user_id: args.userId,
     customer_id: args.customerId,
+    external_id: row.external_id ?? null,
     unit_number: row.unit_number ?? null,
     vin: row.vin ?? null,
     license_plate: row.license_plate ?? null,
@@ -81,32 +94,42 @@ function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: st
     drivetrain: row.drivetrain ?? null,
     engine_hours: row.engine_hours ?? null,
     mileage: row.odometer ?? null,
-    import_notes: notes || null,
+    import_notes: notes,
     source_row_id: String(row.sourceRowNumber),
   };
 }
 
-function buildVehiclePatch(row: NormalizedVehicleImportRow, customerId: string | null): VehicleUpdate {
-  return {
-    customer_id: customerId,
-    unit_number: row.unit_number ?? null,
-    vin: row.vin ?? null,
-    license_plate: row.license_plate ?? null,
-    year: row.year ?? null,
-    make: row.make ?? null,
-    model: row.model ?? null,
-    submodel: row.submodel ?? null,
-    color: row.color ?? null,
-    engine: row.engine ?? null,
-    engine_type: row.engine_type ?? null,
-    engine_family: row.engine_family ?? null,
-    transmission: row.transmission ?? null,
-    fuel_type: row.fuel_type ?? null,
-    drivetrain: row.drivetrain ?? null,
-    engine_hours: row.engine_hours ?? null,
-    mileage: row.odometer ?? null,
-    source_row_id: String(row.sourceRowNumber),
-  };
+function setMeaningfulString(patch: VehicleUpdate, key: keyof VehicleUpdate, value: string | undefined) {
+  if (value && value.trim()) (patch as Record<string, unknown>)[key] = value;
+}
+
+function setMeaningfulNumber(patch: VehicleUpdate, key: keyof VehicleUpdate, value: number | undefined) {
+  if (typeof value === "number" && Number.isFinite(value)) (patch as Record<string, unknown>)[key] = value;
+}
+
+function buildVehiclePatch(row: NormalizedVehicleImportRow, existing: VehicleRow, customerId: string | null): VehicleUpdate {
+  const patch: VehicleUpdate = {};
+  if (!existing.customer_id && customerId) patch.customer_id = customerId;
+  setMeaningfulString(patch, "external_id", row.external_id);
+  setMeaningfulString(patch, "unit_number", row.unit_number);
+  setMeaningfulString(patch, "vin", row.vin);
+  setMeaningfulString(patch, "license_plate", row.license_plate);
+  setMeaningfulNumber(patch, "year", row.year);
+  setMeaningfulString(patch, "make", row.make);
+  setMeaningfulString(patch, "model", row.model);
+  setMeaningfulString(patch, "submodel", row.submodel);
+  setMeaningfulString(patch, "color", row.color);
+  setMeaningfulString(patch, "engine", row.engine);
+  setMeaningfulString(patch, "engine_type", row.engine_type);
+  setMeaningfulString(patch, "engine_family", row.engine_family);
+  setMeaningfulString(patch, "transmission", row.transmission);
+  setMeaningfulString(patch, "fuel_type", row.fuel_type);
+  setMeaningfulString(patch, "drivetrain", row.drivetrain);
+  setMeaningfulNumber(patch, "engine_hours", row.engine_hours);
+  setMeaningfulString(patch, "mileage", row.odometer);
+  setMeaningfulString(patch, "import_notes", buildImportNotes(row) ?? undefined);
+  patch.source_row_id = String(row.sourceRowNumber);
+  return patch;
 }
 
 function customerMatches(row: NormalizedVehicleImportRow, customer: CustomerRow): boolean {
@@ -126,9 +149,17 @@ async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerC
     return { customerId: String(customer.id) };
   }
 
-  if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null };
+  if (row.customer_external_id) {
+    const { data: customers, error } = await supabase.from("customers").select("id,external_id").eq("shop_id", shopId).limit(500);
+    if (error) return { customerId: null, error: error.message };
+    const matches = ((customers ?? []) as CustomerRow[]).filter((customer) => customer.external_id?.trim().toLowerCase() === row.customer_external_id?.trim().toLowerCase());
+    if (matches.length === 1) return { customerId: matches[0].id };
+    if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer external ID match; vehicle imported without a customer link." };
+  }
 
-  const { data: customers, error } = await supabase.from("customers").select("id,business_name,name,first_name,last_name,email,phone,phone_number").eq("shop_id", shopId).limit(200);
+  if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null, warning: row.customer_external_id ? "No matching customer found; this vehicle will import without a customer link." : undefined };
+
+  const { data: customers, error } = await supabase.from("customers").select("id,external_id,business_name,name,first_name,last_name,email,phone,phone_number").eq("shop_id", shopId).limit(200);
   if (error) return { customerId: null, error: error.message };
   const matches = ((customers ?? []) as CustomerRow[]).filter((customer) => customerMatches(row, customer));
   if (matches.length === 1) return { customerId: matches[0].id };
@@ -136,21 +167,26 @@ async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerC
   return { customerId: null, warning: "No matching customer found; this vehicle will import without a customer link." };
 }
 
-async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ vehicle: VehicleRow | null; warning?: string; error?: string }> {
+async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ vehicle: VehicleRow | null; matchKind?: "vin" | "external_id" | "unit_number" | "license_plate"; warning?: string; error?: string }> {
   if (row.vin) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate").eq("shop_id", shopId).eq("vin", row.vin).limit(1).maybeSingle();
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("vin", row.vin).limit(1).maybeSingle();
     if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow };
+    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "vin" };
+  }
+  if (row.external_id) {
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("external_id", row.external_id).limit(1).maybeSingle();
+    if (error) return { vehicle: null, error: error.message };
+    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "external_id" };
   }
   if (row.unit_number) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate").eq("shop_id", shopId).ilike("unit_number", row.unit_number).limit(1).maybeSingle();
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).ilike("unit_number", row.unit_number).limit(1).maybeSingle();
     if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow };
+    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "unit_number" };
   }
   if (row.license_plate) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate").eq("shop_id", shopId).eq("license_plate", row.license_plate).limit(1).maybeSingle();
+    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("license_plate", row.license_plate).limit(1).maybeSingle();
     if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow, warning: "Duplicate plate matched an existing vehicle; existing vehicle selected." };
+    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "license_plate", warning: "Duplicate plate matched an existing vehicle; existing vehicle selected." };
   }
   return { vehicle: null };
 }
@@ -172,7 +208,9 @@ export async function POST(req: Request) {
     if (rows.length === 0) return NextResponse.json({ error: "No valid vehicle rows to import" }, { status: 400 });
 
     const seenVins = new Set<string>();
+    const seenExternalIds = new Set<string>();
     const seenUnits = new Set<string>();
+    const seenPlates = new Set<string>();
     const warnings: Array<{ row: number; message: string }> = [];
     const errors: Array<{ row: number; message: string }> = [];
     let created = 0;
@@ -186,13 +224,25 @@ export async function POST(req: Request) {
           warnings.push({ row: row.sourceRowNumber, message: "Duplicate VIN in submitted import; skipped duplicate row." });
           continue;
         }
+        if (row.external_id && seenExternalIds.has(row.external_id.trim().toLowerCase())) {
+          skipped += 1;
+          warnings.push({ row: row.sourceRowNumber, message: "Duplicate external vehicle ID in submitted import; skipped duplicate row." });
+          continue;
+        }
         if (row.unit_number && seenUnits.has(row.unit_number.trim().toLowerCase())) {
           skipped += 1;
           warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import; skipped duplicate row." });
           continue;
         }
+        if (row.license_plate && seenPlates.has(row.license_plate.trim().toLowerCase())) {
+          skipped += 1;
+          warnings.push({ row: row.sourceRowNumber, message: "Duplicate license plate in submitted import; skipped duplicate row." });
+          continue;
+        }
         if (row.vin) seenVins.add(row.vin);
+        if (row.external_id) seenExternalIds.add(row.external_id.trim().toLowerCase());
         if (row.unit_number) seenUnits.add(row.unit_number.trim().toLowerCase());
+        if (row.license_plate) seenPlates.add(row.license_plate.trim().toLowerCase());
 
         const customer = await resolveCustomerId(supabase, shopId, row);
         if (customer.error) {
@@ -211,12 +261,17 @@ export async function POST(req: Request) {
             warnings.push({ row: row.sourceRowNumber, message: "Existing vehicle is linked to another customer; skipped to avoid silent reassignment." });
             continue;
           }
-          const patch = buildVehiclePatch(row, existing.vehicle.customer_id ?? customer.customerId);
+          if (row.vin && existing.vehicle.vin && existing.vehicle.vin !== row.vin) {
+            skipped += 1;
+            warnings.push({ row: row.sourceRowNumber, message: "Matched an existing vehicle by a weaker identity, but the imported VIN conflicts; skipped to avoid overwriting vehicle identity." });
+            continue;
+          }
+          const patch = buildVehiclePatch(row, existing.vehicle, existing.vehicle.customer_id ?? customer.customerId);
           const { error } = await supabase.from("vehicles").update(patch).eq("shop_id", shopId).eq("id", existing.vehicle.id);
           if (error) throw new Error(error.message);
           updated += 1;
         } else {
-          const insert = buildVehiclePayload(row, { shopId, userId: user.id, customerId: customer.customerId });
+          const insert = buildVehiclePayload(row, { shopId, customerId: customer.customerId });
           const { error } = await supabase.from("vehicles").insert(insert);
           if (error) throw new Error(error.message);
           created += 1;

--- a/app/work-orders/components/WorkOrderPreview.tsx
+++ b/app/work-orders/components/WorkOrderPreview.tsx
@@ -15,7 +15,7 @@ type WO = Pick<
 >;
 
 type Customer = Pick<Tables<"customers">, "name" | "email" | "phone" | "first_name" | "last_name">;
-type Vehicle  = Pick<Tables<"vehicles">, "year" | "make" | "model" | "license_plate" | "vin" | "color" | "mileage" | "unit_number">;
+type Vehicle  = Pick<Tables<"vehicles">, "external_id" | "year" | "make" | "model" | "submodel" | "license_plate" | "vin" | "color" | "mileage" | "unit_number" | "engine_hours" | "engine" | "fuel_type">;
 
 type WOLine = Pick<
   Tables<"work_order_lines">,
@@ -71,7 +71,7 @@ export function WorkOrderPreview({ woId }: Props) {
         if (woData.vehicle_id) {
           const { data: v } = await supabase
             .from("vehicles")
-            .select("year,make,model,license_plate,vin,color,mileage,unit_number")
+            .select("external_id,year,make,model,submodel,license_plate,vin,color,mileage,unit_number,engine_hours,engine,fuel_type")
             .eq("id", woData.vehicle_id)
             .single<Vehicle>();
           if (!active) return;
@@ -130,7 +130,7 @@ export function WorkOrderPreview({ woId }: Props) {
     customer?.name ??
     ([customer?.first_name, customer?.last_name].filter(Boolean).join(" ") || "—");
 
-  const vehicleLabel = [vehicle?.year, vehicle?.make, vehicle?.model].filter(Boolean).join(" ");
+  const vehicleLabel = [vehicle?.year, vehicle?.make, vehicle?.model, vehicle?.submodel].filter(Boolean).join(" ");
   const plateOrVin = vehicle?.license_plate ?? vehicle?.vin ?? "—";
 
   return (
@@ -166,7 +166,13 @@ export function WorkOrderPreview({ woId }: Props) {
           <div className="text-neutral-100">{vehicleLabel || "—"}</div>
           <div className="text-neutral-300">Plate/VIN: {plateOrVin}</div>
           <div className="text-neutral-300">
-            Color: {vehicle?.color || "—"} · Mileage: {vehicle?.mileage ?? "—"} · Unit: {vehicle?.unit_number || "—"}
+            External ID: {vehicle?.external_id || "—"} · Unit: {vehicle?.unit_number || "—"}
+          </div>
+          <div className="text-neutral-300">
+            Color: {vehicle?.color || "—"} · Mileage: {vehicle?.mileage ?? "—"} · Hours: {vehicle?.engine_hours ?? "—"}
+          </div>
+          <div className="text-neutral-300">
+            Engine: {vehicle?.engine || "—"} · Fuel: {vehicle?.fuel_type || "—"}
           </div>
         </section>
       </div>

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -370,6 +370,8 @@ function computeVehicleExtraDetails(
 
     { label: "Fuel Type", key: "fuel_type", kind: "string" },
     { label: "Drivetrain", key: "drivetrain", kind: "string" },
+    { label: "Import Notes", key: "import_notes", kind: "string" },
+    { label: "Source Row", key: "source_row_id", kind: "string" },
   ];
 
   const out: Array<{ label: string; value: string | number }> = [];
@@ -1696,6 +1698,7 @@ export default function CustomerProfilePage(): JSX.Element {
                     <div className="text-sm font-semibold text-white">{fmtVehicleLabel(selectedVehicle)}</div>
 
                     <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <DetailRow label="External ID" value={selectedVehicle.external_id} />
                       <DetailRow label="VIN" value={selectedVehicle.vin} />
                       <DetailRow
                         label="License Plate"

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -7,15 +7,11 @@ import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/quer
 import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
 import { VehicleCreateForm } from "@/features/vehicles/components/VehicleCreateForm";
 import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
-import { formatVehicleDisplayLabel, formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
+import { formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
+import { filterSortAndCapVehicles, vehicleCustomerName, type VehicleListRow } from "@/features/vehicles/lib/list";
 
 type DB = Database;
-type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
-
-type VehicleRow = Pick<Vehicle, "id" | "unit_number" | "year" | "make" | "model" | "vin" | "license_plate" | "customer_id"> & {
-  customers?: Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null;
-};
 
 type CustomerOption = Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
 
@@ -24,37 +20,6 @@ type SearchParams = Record<string, string | string[] | undefined>;
 function paramToString(value: string | string[] | undefined): string | null {
   if (!value) return null;
   return Array.isArray(value) ? value[0] ?? null : value;
-}
-
-function customerName(customer: VehicleRow["customers"]): string | null {
-  if (!customer) return null;
-  return (
-    customer.business_name?.trim() ||
-    customer.name?.trim() ||
-    [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim() ||
-    customer.email ||
-    customer.phone ||
-    customer.phone_number ||
-    null
-  );
-}
-
-function vehicleMatchesSearch(row: VehicleRow, query: string): boolean {
-  if (!query) return true;
-  const haystack = [
-    row.unit_number,
-    row.vin,
-    row.license_plate,
-    row.year != null ? String(row.year) : null,
-    row.make,
-    row.model,
-    customerName(row.customers),
-    formatVehicleDisplayLabel(row),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  return haystack.includes(query.toLowerCase());
 }
 
 export default async function VehiclesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
@@ -75,10 +40,8 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
   const [{ data: vehicleRows, error: vehicleError }, { data: customerRows }] = await Promise.all([
     supabase
       .from("vehicles")
-      .select("id, unit_number, year, make, model, vin, license_plate, customer_id, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)")
-      .eq("shop_id", actor.shopId)
-      .order("created_at", { ascending: false })
-      .limit(200),
+      .select("id, external_id, unit_number, year, make, model, submodel, vin, license_plate, customer_id, mileage, engine_hours, engine, fuel_type, import_notes, source_row_id, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)")
+      .eq("shop_id", actor.shopId),
     supabase
       .from("customers")
       .select("id, business_name, name, first_name, last_name, email, phone, phone_number")
@@ -87,7 +50,7 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
       .limit(200),
   ]);
 
-  const vehicles = ((vehicleRows ?? []) as unknown as VehicleRow[]).map((row) => ({ ...row, customers: Array.isArray(row.customers) ? row.customers[0] ?? null : row.customers })).filter((row) => vehicleMatchesSearch(row, query));
+  const vehicles = filterSortAndCapVehicles(((vehicleRows ?? []) as unknown as VehicleListRow[]).map((row) => ({ ...row, customers: Array.isArray(row.customers) ? row.customers[0] ?? null : row.customers })), query);
   const customers = (customerRows ?? []) as CustomerOption[];
 
   return (
@@ -113,7 +76,7 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
             <h2 className="text-lg font-semibold text-white">Vehicle directory</h2>
             <p className="mt-1 text-sm text-neutral-400">Showing current-shop vehicles only.</p>
           </div>
-          <input name="q" defaultValue={query} placeholder="Search VIN, plate, unit, YMM, customer…" className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)] sm:max-w-md" />
+          <input name="q" defaultValue={query} placeholder="Search VIN, plate, unit, YMM, customer, external ID…" className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)] sm:max-w-md" />
         </form>
 
         {vehicleError ? <div className="mt-4 rounded-xl border border-red-500/30 bg-red-950/25 p-3 text-sm text-red-100">Unable to load vehicles right now.</div> : null}
@@ -129,7 +92,7 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
         {vehicles.length > 0 ? (
           <div className="mt-4 grid gap-3">
             {vehicles.map((vehicle) => {
-              const name = customerName(vehicle.customers);
+              const name = vehicleCustomerName(vehicle.customers);
               return (
                 <article key={vehicle.id} className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
                   <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -141,11 +104,22 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
                     {vehicle.customer_id && name ? <Link href={`/customers/${encodeURIComponent(vehicle.customer_id)}`} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-3 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Open customer file</Link> : null}
                   </div>
                   <dl className="mt-4 grid gap-2 md:grid-cols-4">
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">External ID</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.external_id) ?? "—"}</dd></div>
                     <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Unit</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.unit_number) ?? "—"}</dd></div>
                     <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">VIN</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.vin) ?? "—"}</dd></div>
                     <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Plate</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.license_plate) ?? "—"}</dd></div>
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Mileage</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.mileage) ?? "—"}</dd></div>
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine hours</dt><dd className="mt-1 truncate text-sm font-medium text-white">{vehicle.engine_hours ?? "—"}</dd></div>
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine / fuel</dt><dd className="mt-1 truncate text-sm font-medium text-white">{[vehicle.engine, vehicle.fuel_type].map(normalizeVehicleText).filter(Boolean).join(" · ") || "—"}</dd></div>
                     <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer</dt><dd className="mt-1 truncate text-sm font-medium text-white">{name ?? "No customer linked"}</dd></div>
                   </dl>
+                  {(vehicle.import_notes || vehicle.source_row_id || vehicle.submodel) ? (
+                    <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-neutral-400">
+                      {vehicle.submodel ? <span className="rounded-full border border-white/10 bg-black/20 px-2 py-1">Trim: {vehicle.submodel}</span> : null}
+                      {vehicle.source_row_id ? <span className="rounded-full border border-white/10 bg-black/20 px-2 py-1">Source row: {vehicle.source_row_id}</span> : null}
+                      {vehicle.import_notes ? <span className="max-w-full truncate rounded-full border border-white/10 bg-black/20 px-2 py-1">Import notes: {vehicle.import_notes}</span> : null}
+                    </div>
+                  ) : null}
                 </article>
               );
             })}

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
@@ -31,6 +31,7 @@ type ImportResponse = {
 const EMPTY_COUNTS: ImportCounts = { created: 0, updated: 0, skipped: 0, failed: 0, warnings: 0 };
 
 export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighted = false }: Props) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [csvText, setCsvText] = useState("");
   const [fileName, setFileName] = useState<string | undefined>();
   const [preview, setPreview] = useState<VehicleImportPreview | null>(null);
@@ -41,6 +42,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
 
   const guidedMode = Boolean(guidedQuery && highlighted);
   const validRows = useMemo(() => preview?.rows.filter((row) => row.status === "valid") ?? [], [preview]);
+  const canConfirmImport = Boolean(preview && validRows.length > 0 && !success);
 
   function reset() {
     setCsvText("");
@@ -49,6 +51,14 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
     setSuccess(null);
     setError(null);
     setOnboardingCompleted(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function clearSelectedCsvAfterSuccess() {
+    setCsvText("");
+    setFileName(undefined);
+    setPreview(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
   async function readFile(file: File | null) {
@@ -56,7 +66,15 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
     setError(null);
     if (!file) return;
     setFileName(file.name);
-    setCsvText(await file.text());
+    const text = typeof file.text === "function"
+      ? await file.text()
+      : await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result ?? ""));
+        reader.onerror = () => reject(reader.error ?? new Error("Unable to read CSV file."));
+        reader.readAsText(file);
+      });
+    setCsvText(text);
     setPreview(null);
   }
 
@@ -69,7 +87,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
   }
 
   async function confirmImport() {
-    if (!preview || validRows.length === 0) return;
+    if (!canConfirmImport) return;
     setBusy(true);
     setError(null);
     setSuccess(null);
@@ -83,6 +101,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
       const payload = (await response.json().catch(() => ({}))) as ImportResponse;
       if (!response.ok || payload.ok === false) throw new Error(payload.error ?? "Vehicle import failed.");
       setSuccess(payload);
+      clearSelectedCsvAfterSuccess();
 
       if (guidedQuery) {
         const completeResponse = await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/complete`, {
@@ -120,7 +139,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
         <div className="space-y-3">
           <label className="block rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-black/20 p-4 text-sm text-neutral-300">
             <span className="block font-semibold text-white">Upload .csv file</span>
-            <input data-testid="vehicle-csv-file" className="mt-3 block w-full text-sm text-neutral-300 file:mr-4 file:rounded-xl file:border-0 file:bg-orange-400/15 file:px-4 file:py-2 file:font-semibold file:text-orange-50" type="file" accept=".csv,text/csv" onChange={(event) => void readFile(event.currentTarget.files?.[0] ?? null)} />
+            <input ref={fileInputRef} data-testid="vehicle-csv-file" className="mt-3 block w-full text-sm text-neutral-300 file:mr-4 file:rounded-xl file:border-0 file:bg-orange-400/15 file:px-4 file:py-2 file:font-semibold file:text-orange-50" type="file" accept=".csv,text/csv" onChange={(event) => void readFile(event.currentTarget.files?.[0] ?? null)} />
           </label>
           <label className="block text-sm font-medium text-neutral-200">
             Paste CSV text
@@ -138,7 +157,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
           </dl>
           <div className="mt-4 flex flex-col gap-2">
             <button type="button" onClick={buildPreview} disabled={!csvText.trim() || busy} className="rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50 disabled:opacity-55">Preview CSV</button>
-            <button type="button" onClick={() => void confirmImport()} disabled={!preview || validRows.length === 0 || busy} className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-55">{busy ? "Importing…" : "Confirm import"}</button>
+            <button type="button" onClick={() => void confirmImport()} disabled={!canConfirmImport || busy} className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-55">{busy ? "Importing…" : "Confirm import"}</button>
             <button type="button" onClick={reset} disabled={busy} className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 disabled:opacity-55">Cancel/reset</button>
           </div>
         </aside>

--- a/features/vehicles/lib/importCsv.ts
+++ b/features/vehicles/lib/importCsv.ts
@@ -9,11 +9,13 @@ export type VehicleImportCustomerOption = {
   email?: string | null;
   phone?: string | null;
   phone_number?: string | null;
+  external_id?: string | null;
 };
 
 export type VehicleImportRow = {
   sourceRowNumber: number;
   sourceFilename?: string;
+  external_id?: string;
   unit_number?: string;
   vin?: string;
   license_plate?: string;
@@ -30,7 +32,10 @@ export type VehicleImportRow = {
   drivetrain?: string;
   engine_hours?: number;
   odometer?: string;
+  notes?: string;
+  status?: string;
   customer_id?: string;
+  customer_external_id?: string;
   customer_name?: string;
   customer_email?: string;
   customer_phone?: string;
@@ -53,6 +58,10 @@ export type VehicleImportPreview = {
 };
 
 const HEADER_ALIASES: Record<string, keyof VehicleImportRow> = {
+  vehicleid: "external_id",
+  vehicle_id: "external_id",
+  externalid: "external_id",
+  external_id: "external_id",
   unitnumber: "unit_number",
   unit: "unit_number",
   unitno: "unit_number",
@@ -60,8 +69,8 @@ const HEADER_ALIASES: Record<string, keyof VehicleImportRow> = {
   unitid: "unit_number",
   unitfleetnumber: "unit_number",
   fleetnumber: "unit_number",
+  fleet_number: "unit_number",
   vehiclenumber: "unit_number",
-  vehicleid: "unit_number",
   vin: "vin",
   serial: "vin",
   serialnumber: "vin",
@@ -87,7 +96,11 @@ const HEADER_ALIASES: Record<string, keyof VehicleImportRow> = {
   hours: "engine_hours",
   odometer: "odometer",
   mileage: "odometer",
+  notes: "notes",
+  status: "status",
   customerid: "customer_id",
+  customerexternalid: "customer_external_id",
+  customer_external_id: "customer_external_id",
   customername: "customer_name",
   customer: "customer_name",
   customeremail: "customer_email",
@@ -140,6 +153,12 @@ function customerLabel(customer: VehicleImportCustomerOption): string {
 }
 
 function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomerOption[]): { id?: string; warning?: string } {
+  const customerExternalId = row.customer_external_id?.trim();
+  if (customerExternalId) {
+    const match = customers.find((customer) => customer.external_id?.trim().toLowerCase() === customerExternalId.toLowerCase());
+    if (match) return { id: match.id };
+  }
+
   const customerId = row.customer_id?.trim();
   if (customerId) {
     const match = customers.find((customer) => customer.id === customerId);
@@ -160,7 +179,7 @@ function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomer
 
   if (candidates.length === 1) return { id: candidates[0].id };
   if (candidates.length > 1) return { warning: `Ambiguous customer match (${candidates.map(customerLabel).join(", ")}); this vehicle will import without a customer link.` };
-  if (row.customer_name || row.customer_email || row.customer_phone) return { warning: "No matching customer found; this vehicle will import without a customer link." };
+  if (row.customer_external_id || row.customer_name || row.customer_email || row.customer_phone) return { warning: "No matching customer found; this vehicle will import without a customer link." };
   return {};
 }
 

--- a/features/vehicles/lib/list.ts
+++ b/features/vehicles/lib/list.ts
@@ -1,0 +1,57 @@
+import { formatVehicleDisplayLabel, normalizeVehicleText } from "@/features/vehicles/lib/display";
+import type { Database } from "@shared/types/types/supabase";
+
+type Vehicle = Database["public"]["Tables"]["vehicles"]["Row"];
+type Customer = Database["public"]["Tables"]["customers"]["Row"];
+
+export type VehicleListRow = Pick<Vehicle, "id" | "external_id" | "unit_number" | "year" | "make" | "model" | "submodel" | "vin" | "license_plate" | "customer_id" | "mileage" | "engine_hours" | "engine" | "fuel_type" | "import_notes" | "source_row_id"> & {
+  customers?: Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null;
+};
+
+export function vehicleCustomerName(customer: VehicleListRow["customers"]): string | null {
+  if (!customer) return null;
+  return (
+    customer.business_name?.trim() ||
+    customer.name?.trim() ||
+    [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim() ||
+    customer.email ||
+    customer.phone ||
+    customer.phone_number ||
+    null
+  );
+}
+
+function searchText(row: VehicleListRow): string {
+  return [
+    row.vin,
+    row.unit_number,
+    row.license_plate,
+    row.year != null ? String(row.year) : null,
+    row.make,
+    row.model,
+    vehicleCustomerName(row.customers),
+    row.external_id,
+    formatVehicleDisplayLabel(row),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function sortKey(row: VehicleListRow): string {
+  return (normalizeVehicleText(row.unit_number) || formatVehicleDisplayLabel(row) || row.external_id || row.id).toLowerCase();
+}
+
+export function filterSortAndCapVehicles(rows: VehicleListRow[], query: string, limit = 20): VehicleListRow[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  return rows
+    .filter((row) => !normalizedQuery || searchText(row).includes(normalizedQuery))
+    .sort((a, b) => {
+      const byPrimary = sortKey(a).localeCompare(sortKey(b), undefined, { numeric: true, sensitivity: "base" });
+      if (byPrimary !== 0) return byPrimary;
+      const byLabel = formatVehicleDisplayLabel(a).localeCompare(formatVehicleDisplayLabel(b), undefined, { numeric: true, sensitivity: "base" });
+      if (byLabel !== 0) return byLabel;
+      return a.id.localeCompare(b.id);
+    })
+    .slice(0, limit);
+}

--- a/tests/vehicles/vehicle-csv-import-card.test.tsx
+++ b/tests/vehicles/vehicle-csv-import-card.test.tsx
@@ -66,6 +66,41 @@ describe("VehicleCsvImportCard", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/vehicles/import", expect.objectContaining({ method: "POST" })));
   });
 
+
+  it("clears selected CSV and disables confirm after a successful import", async () => {
+    const fetchMock = vi.fn(async () => importOk());
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} />);
+
+    const fileInput = screen.getByTestId("vehicle-csv-file") as HTMLInputElement;
+    await userEvent.upload(fileInput, new File(["unit,vin\nA-1,1HGCM82633A004352"], "vehicles.csv", { type: "text/csv" }));
+    expect(fileInput.files?.[0]?.name).toBe("vehicles.csv");
+
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    const confirmButton = screen.getByRole("button", { name: /confirm import/i });
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => expect(screen.getByText(/import complete: 1 created/i)).toBeInTheDocument());
+    expect(fileInput.value).toBe("");
+    expect(screen.getByLabelText(/paste csv text/i)).toHaveValue("");
+    expect(screen.queryByText("A-1")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm import/i })).toBeDisabled();
+  });
+
+  it("does not POST again when confirm is clicked after a successful import", async () => {
+    const fetchMock = vi.fn(async () => importOk());
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "unit\nA-1");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm import/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(screen.getByRole("button", { name: /confirm import/i }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("calls guided completion only after successful import", async () => {
     const fetchMock = vi.fn(async (url: string) => (url.includes("/api/vehicles/import") ? importOk() : onboardingOk()));
     vi.stubGlobal("fetch", fetchMock);

--- a/tests/vehicles/vehicle-import-route.test.ts
+++ b/tests/vehicles/vehicle-import-route.test.ts
@@ -48,6 +48,7 @@ function makeQuery(table: string): MockQuery {
         const found = mockSupabaseState.vehicles.find((row) => {
           if (row.shop_id !== query.filters.shop_id) return false;
           if (query.filters.vin) return row.vin === query.filters.vin;
+          if (query.filters.external_id) return row.external_id === query.filters.external_id;
           if (query.filters.unit_number) return String(row.unit_number).toLowerCase() === String(query.filters.unit_number).toLowerCase();
           if (query.filters.license_plate) return row.license_plate === query.filters.license_plate;
           return false;
@@ -116,8 +117,54 @@ describe("POST /api/vehicles/import", () => {
     const payload = await response.json();
     expect(response.status).toBe(200);
     expect(payload.counts.created).toBe(1);
-    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", user_id: "user-1", unit_number: "A-1", vin: "1HGCM82633A004352" });
+    expect(mockSupabaseState.inserts[0]).toMatchObject({ shop_id: "shop-real", unit_number: "A-1", vin: "1HGCM82633A004352" });
     expect(mockSupabaseState.inserts[0].shop_id).not.toBe("evil-shop");
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+  });
+
+
+  it("maps supported CSV fields into the vehicle insert payload", async () => {
+    const response = await POST(request([{
+      vehicle_id: "veh-legacy-1",
+      unit: "Unit-7",
+      plate: "abc123",
+      odometer: "123456",
+      trim: "XL",
+      notes: "Imported note",
+      engine: "6.7L",
+      fuel_type: "Diesel",
+      engine_hours: "4567",
+      shop_id: "csv-evil-shop",
+    }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      external_id: "veh-legacy-1",
+      unit_number: "Unit-7",
+      license_plate: "ABC123",
+      mileage: "123456",
+      submodel: "XL",
+      engine: "6.7L",
+      fuel_type: "Diesel",
+      engine_hours: 4567,
+    });
+    expect(String(mockSupabaseState.inserts[0].import_notes)).toContain("Imported note");
+    expect(mockSupabaseState.inserts[0].shop_id).not.toBe("csv-evil-shop");
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+  });
+
+  it("resolves customer_external_id in the authenticated shop before customer fallback", async () => {
+    mockSupabaseState.customers = [
+      { id: "other-customer", shop_id: "other-shop", external_id: "cust-legacy", email: "fleet@example.com", name: "Fleet Co" },
+      { id: "real-customer", shop_id: "shop-real", external_id: "cust-legacy", email: "other@example.com", name: "Other Name" },
+      { id: "fallback-customer", shop_id: "shop-real", external_id: "fallback", email: "fleet@example.com", name: "Fleet Co" },
+    ];
+
+    const response = await POST(request([{ unit_number: "A-1", customer_external_id: "cust-legacy", customer_email: "fleet@example.com", customer_name: "Fleet Co" }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0].customer_id).toBe("real-customer");
   });
 
   it("rejects cross-shop customer_id", async () => {
@@ -137,6 +184,79 @@ describe("POST /api/vehicles/import", () => {
     const response = await POST(request([{ unit_number: "A-1", customer_email: "jane@example.com", customer_name: "Jane" }]));
     expect(response.status).toBe(200);
     expect(mockSupabaseState.inserts[0].customer_id).toBe("real-customer");
+  });
+
+
+  it.each([
+    ["VIN", { vin: "1HGCM82633A004352", make: "Honda" }, { vin: "1HGCM82633A004352" }],
+    ["external_id", { external_id: "veh-1", model: "Transit" }, { external_id: "veh-1" }],
+    ["unit_number", { unit_number: "A-1", year: 2020 }, { unit_number: "a-1" }],
+    ["license_plate", { license_plate: "ABC123", make: "Ford" }, { license_plate: "ABC123" }],
+  ])("existing same-shop %s updates instead of inserting", async (_label, importRow, existingVehicle) => {
+    mockSupabaseState.vehicles = [{ id: "vehicle-existing", shop_id: "shop-real", ...existingVehicle }];
+
+    const response = await POST(request([importRow]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 0, updated: 1 });
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({ shop_id: "shop-real", id: "vehicle-existing" });
+  });
+
+  it.each([
+    ["VIN", [{ vin: "1HGCM82633A004352" }, { vin: "1HGCM82633A004352", make: "Honda" }]],
+    ["external_id", [{ external_id: "veh-1" }, { external_id: "veh-1", make: "Honda" }]],
+    ["unit_number", [{ unit_number: "A-1" }, { unit_number: "a-1", make: "Honda" }]],
+    ["license_plate", [{ license_plate: "ABC123" }, { license_plate: "abc123", make: "Honda" }]],
+  ])("same-file duplicate %s is skipped", async (_label, rows) => {
+    const response = await POST(request(rows));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 1, skipped: 1 });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+  });
+
+  it.each([
+    ["VIN", { vin: "1HGCM82633A004352" }],
+    ["external_id", { external_id: "veh-1" }],
+    ["unit_number", { unit_number: "A-1" }],
+    ["license_plate", { license_plate: "ABC123" }],
+  ])("cross-shop duplicate %s does not block current shop import", async (_label, identity) => {
+    mockSupabaseState.vehicles = [{ id: "other-vehicle", shop_id: "other-shop", ...identity }];
+
+    const response = await POST(request([identity]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 1, updated: 0 });
+    expect(mockSupabaseState.inserts).toHaveLength(1);
+  });
+
+  it("sparse duplicate import does not erase existing non-empty fields", async () => {
+    mockSupabaseState.vehicles = [{ id: "vehicle-existing", shop_id: "shop-real", vin: "1HGCM82633A004352", make: "Ford", model: "F-150", mileage: "1000" }];
+
+    const response = await POST(request([{ vin: "1HGCM82633A004352", unit_number: "A-1" }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.updates[0].payload).toMatchObject({ vin: "1HGCM82633A004352", unit_number: "A-1" });
+    expect(mockSupabaseState.updates[0].payload).not.toHaveProperty("make");
+    expect(mockSupabaseState.updates[0].payload).not.toHaveProperty("model");
+    expect(mockSupabaseState.updates[0].payload).not.toHaveProperty("mileage");
+  });
+
+  it("conflicting weak match does not overwrite VIN", async () => {
+    mockSupabaseState.vehicles = [{ id: "vehicle-existing", shop_id: "shop-real", unit_number: "A-1", vin: "1HGCM82633A004352" }];
+
+    const response = await POST(request([{ unit_number: "A-1", vin: "2HGCM82633A004352" }]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.counts).toMatchObject({ created: 0, updated: 0, skipped: 1 });
+    expect(mockSupabaseState.updates).toHaveLength(0);
+    expect(mockSupabaseState.inserts).toHaveLength(0);
+    expect(payload.warnings[0].message).toMatch(/conflicts/i);
   });
 
   it("duplicate VIN is not inserted twice", async () => {

--- a/tests/vehicles/vehicles-page-guided-card.test.ts
+++ b/tests/vehicles/vehicles-page-guided-card.test.ts
@@ -19,3 +19,56 @@ describe("Vehicles page guided onboarding card visibility", () => {
     expect(shouldShowVehicleOnboardingCard(guidedQuery)).toBe(true);
   });
 });
+
+import { filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
+
+const baseVehicle = (overrides: Partial<VehicleListRow>): VehicleListRow => ({
+  id: String(overrides.id ?? "vehicle"),
+  external_id: null,
+  unit_number: null,
+  year: null,
+  make: null,
+  model: null,
+  submodel: null,
+  vin: null,
+  license_plate: null,
+  customer_id: null,
+  mileage: null,
+  engine_hours: null,
+  engine: null,
+  fuel_type: null,
+  import_notes: null,
+  source_row_id: null,
+  customers: null,
+  ...overrides,
+});
+
+describe("Vehicles page list filtering", () => {
+  it("sorts the default list alphabetically by unit/display label and caps to 20", () => {
+    const rows = Array.from({ length: 25 }, (_, index) => baseVehicle({ id: `vehicle-${index}`, unit_number: `Unit-${String(25 - index).padStart(2, "0")}` }));
+
+    const result = filterSortAndCapVehicles(rows, "");
+
+    expect(result).toHaveLength(20);
+    expect(result[0].unit_number).toBe("Unit-01");
+    expect(result[19].unit_number).toBe("Unit-20");
+  });
+
+  it.each([
+    ["VIN", "older-vin", { vin: "OLDER-VIN" }],
+    ["unit_number", "unit 42", { unit_number: "Unit 42" }],
+    ["license_plate", "abc123", { license_plate: "ABC123" }],
+    ["year", "2021", { year: 2021 }],
+    ["make", "hino", { make: "Hino" }],
+    ["model", "268", { model: "268" }],
+    ["customer name", "acme", { customers: { id: "customer-1", business_name: "Acme Fleet", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null } }],
+    ["external_id", "legacy-99", { external_id: "legacy-99" }],
+  ])("matches %s without pre-capping the source list", (_label, query, match) => {
+    const rows = Array.from({ length: 220 }, (_, index) => baseVehicle({ id: `vehicle-${index}`, unit_number: `Unit-${index}` }));
+    rows.push(baseVehicle({ id: "older-match", unit_number: "Unit-999", ...match }));
+
+    const result = filterSortAndCapVehicles(rows, query);
+
+    expect(result.map((row) => row.id)).toContain("older-match");
+  });
+});


### PR DESCRIPTION
### Motivation
- Vehicle CSV import needed to be shop-scoped, deterministic, deduped, safely retryable, correctly mapped from common CSV aliases, and to mirror customer import UX (clear file and disable Confirm after success). 
- Vehicles list/search needed stable ordering, broad search matching (not just newest rows), and inclusion of imported fields for visibility. 

### Description
- Update import parsing and route so CSV aliases map to canonical vehicle fields (`vehicle_id`/`vehicleid`/`external_id` → `external_id`, `unit`/`unit_number`/`fleet_number` → `unit_number`, `odometer`/`mileage` → `mileage`, `trim` → `submodel`, `notes` → `import_notes`, support `customer_external_id`, etc.) and always derive `shop_id` from the authenticated profile while dropping `user_id` from import payloads. 
- Implement deterministic dedupe and matching priority (VIN → external_id → unit_number → license_plate), same-file duplicate skipping with warnings, same-shop updates (non-destructive: only overwrite meaningful values), and skip-on-conflict for weaker matches that conflict with existing VIN identity. 
- Improve import UX in the Vehicle CSV card to clear selected file/input/preview on successful import, keep a visible success summary, and prevent repeat POSTs after success. 
- Replace Vehicles list filtering with a pure helper that searches VIN, unit_number, license_plate, year, make, model, customer name and `external_id`, sorts alphabetically by unit/display label, caps results to 20, and surface imported metadata (external_id, mileage, engine_hours, engine/fuel, submodel, import_notes, source_row_id) in Vehicles, customer vehicle panel, and work order preview. 
- Add and extend unit tests covering mapping, ownership scoping, dedupe/update behavior, customer external ID resolution, import reset UX, prevention of duplicate POSTs, and list/search behavior. 

### Testing
- Ran unit tests with `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` and all tests passed. 
- Ran TypeScript validation with `npx tsc --noEmit` which completed successfully. 
- Ran quick checks (`git diff --check`) during development; no check failures remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d0549c248328bf5fb5ab89c33c42)