### PR TITLE
Fix vehicle import customer external ID linking

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -9,6 +9,7 @@ type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
 type VehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "customer_id" | "vin" | "unit_number" | "license_plate" | "external_id" | "year" | "make" | "model" | "submodel" | "color" | "engine" | "engine_type" | "engine_family" | "transmission" | "fuel_type" | "drivetrain" | "engine_hours" | "mileage" | "import_notes" | "source_row_id">;
 type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
+type CustomerLookupCache = { externalRows?: CustomerRow[] };
 
 type ImportBody = { rows?: unknown; shop_id?: unknown };
 
@@ -51,7 +52,7 @@ function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
       notes: cleanVehicleImportText(row.notes),
       status: cleanVehicleImportText(row.status),
       customer_id: cleanVehicleImportText(row.customer_id),
-      customer_external_id: cleanVehicleImportText(row.customer_external_id),
+      customer_external_id: cleanVehicleImportText(row.customer_external_id) ?? cleanVehicleImportText(row.customer_id),
       customer_name: cleanVehicleImportText(row.customer_name),
       customer_email: cleanVehicleImportText(row.customer_email)?.toLowerCase(),
       customer_phone: cleanVehicleImportText(row.customer_phone),
@@ -141,20 +142,25 @@ function customerMatches(row: NormalizedVehicleImportRow, customer: CustomerRow)
   return Boolean(wantedName && names.some((value) => value === wantedName));
 }
 
-async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ customerId: string | null; warning?: string; error?: string }> {
-  if (row.customer_id) {
+async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow, cache: CustomerLookupCache): Promise<{ customerId: string | null; warning?: string; error?: string }> {
+  const customerExternalId = row.customer_external_id?.trim();
+
+  if (customerExternalId) {
+    if (!cache.externalRows) {
+      const { data: customers, error } = await supabase.from("customers").select("id,external_id").eq("shop_id", shopId).limit(5000);
+      if (error) return { customerId: null, error: error.message };
+      cache.externalRows = (customers ?? []) as CustomerRow[];
+    }
+    const matches = cache.externalRows.filter((customer) => customer.external_id?.trim().toLowerCase() === customerExternalId.toLowerCase());
+    if (matches.length === 1) return { customerId: matches[0].id };
+    if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer external ID match; vehicle imported without a customer link." };
+  }
+
+  if (row.customer_id && row.customer_id !== customerExternalId) {
     const { data: customer, error } = await supabase.from("customers").select("id").eq("shop_id", shopId).eq("id", row.customer_id).maybeSingle();
     if (error) return { customerId: null, error: error.message };
     if (!customer?.id) return { customerId: null, error: "Customer ID does not belong to this shop." };
     return { customerId: String(customer.id) };
-  }
-
-  if (row.customer_external_id) {
-    const { data: customers, error } = await supabase.from("customers").select("id,external_id").eq("shop_id", shopId).limit(500);
-    if (error) return { customerId: null, error: error.message };
-    const matches = ((customers ?? []) as CustomerRow[]).filter((customer) => customer.external_id?.trim().toLowerCase() === row.customer_external_id?.trim().toLowerCase());
-    if (matches.length === 1) return { customerId: matches[0].id };
-    if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer external ID match; vehicle imported without a customer link." };
   }
 
   if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null, warning: row.customer_external_id ? "No matching customer found; this vehicle will import without a customer link." : undefined };
@@ -167,7 +173,7 @@ async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerC
   return { customerId: null, warning: "No matching customer found; this vehicle will import without a customer link." };
 }
 
-async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ vehicle: VehicleRow | null; matchKind?: "vin" | "external_id" | "unit_number" | "license_plate"; warning?: string; error?: string }> {
+async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow, options: { skipUnitNumberMatch?: boolean } = {}): Promise<{ vehicle: VehicleRow | null; matchKind?: "vin" | "external_id" | "unit_number" | "license_plate"; warning?: string; error?: string }> {
   if (row.vin) {
     const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("vin", row.vin).limit(1).maybeSingle();
     if (error) return { vehicle: null, error: error.message };
@@ -178,7 +184,7 @@ async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandle
     if (error) return { vehicle: null, error: error.message };
     if (data?.id) return { vehicle: data as VehicleRow, matchKind: "external_id" };
   }
-  if (row.unit_number) {
+  if (row.unit_number && !options.skipUnitNumberMatch) {
     const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).ilike("unit_number", row.unit_number).limit(1).maybeSingle();
     if (error) return { vehicle: null, error: error.message };
     if (data?.id) return { vehicle: data as VehicleRow, matchKind: "unit_number" };
@@ -216,6 +222,7 @@ export async function POST(req: Request) {
     let created = 0;
     let updated = 0;
     let skipped = 0;
+    const customerLookupCache: CustomerLookupCache = {};
 
     for (const row of rows) {
       try {
@@ -229,10 +236,14 @@ export async function POST(req: Request) {
           warnings.push({ row: row.sourceRowNumber, message: "Duplicate external vehicle ID in submitted import; skipped duplicate row." });
           continue;
         }
-        if (row.unit_number && seenUnits.has(row.unit_number.trim().toLowerCase())) {
+        const duplicateUnitNumberInImport = Boolean(row.unit_number && seenUnits.has(row.unit_number.trim().toLowerCase()));
+        if (duplicateUnitNumberInImport && !row.vin && !row.external_id) {
           skipped += 1;
-          warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import; skipped duplicate row." });
+          warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import and no unique VIN or external vehicle ID was provided; skipped duplicate row." });
           continue;
+        }
+        if (duplicateUnitNumberInImport) {
+          warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import; continuing because VIN or external vehicle ID can identify this vehicle." });
         }
         if (row.license_plate && seenPlates.has(row.license_plate.trim().toLowerCase())) {
           skipped += 1;
@@ -244,14 +255,14 @@ export async function POST(req: Request) {
         if (row.unit_number) seenUnits.add(row.unit_number.trim().toLowerCase());
         if (row.license_plate) seenPlates.add(row.license_plate.trim().toLowerCase());
 
-        const customer = await resolveCustomerId(supabase, shopId, row);
+        const customer = await resolveCustomerId(supabase, shopId, row, customerLookupCache);
         if (customer.error) {
           errors.push({ row: row.sourceRowNumber, message: customer.error });
           continue;
         }
         if (customer.warning) warnings.push({ row: row.sourceRowNumber, message: customer.warning });
 
-        const existing = await findExistingVehicle(supabase, shopId, row);
+        const existing = await findExistingVehicle(supabase, shopId, row, { skipUnitNumberMatch: duplicateUnitNumberInImport && Boolean(row.vin || row.external_id) });
         if (existing.error) throw new Error(existing.error);
         if (existing.warning) warnings.push({ row: row.sourceRowNumber, message: existing.warning });
 

--- a/features/vehicles/lib/importCsv.ts
+++ b/features/vehicles/lib/importCsv.ts
@@ -153,17 +153,15 @@ function customerLabel(customer: VehicleImportCustomerOption): string {
 }
 
 function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomerOption[]): { id?: string; warning?: string } {
-  const customerExternalId = row.customer_external_id?.trim();
+  const customerExternalId = (row.customer_external_id ?? row.customer_id)?.trim();
   if (customerExternalId) {
-    const match = customers.find((customer) => customer.external_id?.trim().toLowerCase() === customerExternalId.toLowerCase());
-    if (match) return { id: match.id };
-  }
+    const externalMatch = customers.find((customer) => customer.external_id?.trim().toLowerCase() === customerExternalId.toLowerCase());
+    if (externalMatch) return { id: externalMatch.id };
 
-  const customerId = row.customer_id?.trim();
-  if (customerId) {
-    const match = customers.find((customer) => customer.id === customerId);
-    if (match) return { id: match.id };
-    return { warning: "No matching customer found; this vehicle will import without a customer link." };
+    const directIdMatch = customers.find((customer) => customer.id === customerExternalId);
+    if (directIdMatch) return { id: directIdMatch.id };
+
+    return { warning: "No matching customer found by external ID; this vehicle will import without a customer link." };
   }
 
   const candidates = customers.filter((customer) => {
@@ -224,7 +222,7 @@ export function previewVehicleCsv(csvText: string, customers: VehicleImportCusto
     if (!hasAnyValue) errors.push("Row is empty.");
     if (hasAnyValue && !hasIdentity(row)) errors.push("Add VIN, unit number, license plate, or year + make + model.");
     if (row.vin && (vinCounts.get(row.vin) ?? 0) > 1) warnings.push("Duplicate VIN inside this CSV; the server will import only one unambiguous vehicle.");
-    if (row.unit_number && (unitCounts.get(row.unit_number.trim().toLowerCase()) ?? 0) > 1) warnings.push("Duplicate unit number inside this CSV; the server will import only one unambiguous vehicle.");
+    if (row.unit_number && (unitCounts.get(row.unit_number.trim().toLowerCase()) ?? 0) > 1) warnings.push("Duplicate unit number inside this CSV; expected for some fleets and will not block rows with a unique VIN or external vehicle ID.");
 
     const customer = resolveCustomer(row, customers);
     if (customer.warning) warnings.push(customer.warning);

--- a/tests/vehicles/vehicle-csv-import-card.test.tsx
+++ b/tests/vehicles/vehicle-csv-import-card.test.tsx
@@ -66,6 +66,17 @@ describe("VehicleCsvImportCard", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/vehicles/import", expect.objectContaining({ method: "POST" })));
   });
 
+  it("previews vehicle customer_id as a linked customer external_id", async () => {
+    render(<VehicleCsvImportCard customers={[{ id: "customer-uuid", external_id: "CUST-100425", name: "Fleet Customer" }]} />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "vehicle_id,unit_number,customer_id\nVEH-1,A-1,CUST-100425");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+
+    expect(screen.getByText("customer-uuid")).toBeInTheDocument();
+    expect(screen.queryByText("Unlinked")).not.toBeInTheDocument();
+    expect(screen.queryByText(/No matching customer found/i)).not.toBeInTheDocument();
+  });
+
 
   it("clears selected CSV and disables confirm after a successful import", async () => {
     const fetchMock = vi.fn(async () => importOk());

--- a/tests/vehicles/vehicle-import-route.test.ts
+++ b/tests/vehicles/vehicle-import-route.test.ts
@@ -167,13 +167,32 @@ describe("POST /api/vehicles/import", () => {
     expect(mockSupabaseState.inserts[0].customer_id).toBe("real-customer");
   });
 
-  it("rejects cross-shop customer_id", async () => {
-    mockSupabaseState.customers = [{ id: "customer-1", shop_id: "other-shop" }];
-    const response = await POST(request([{ unit_number: "A-1", customer_id: "customer-1" }]));
+  it("treats vehicle CSV customer_id as a same-shop customer external_id", async () => {
+    mockSupabaseState.customers = [
+      { id: "other-customer", shop_id: "other-shop", external_id: "CUST-100425" },
+      { id: "real-customer-uuid", shop_id: "shop-real", external_id: " CUST-100425 " },
+    ];
+
+    const response = await POST(request([{ vehicle_id: "VEH-1", unit_number: "A-1", customer_id: "CUST-100425", shop_id: "csv-evil-shop", user_id: "csv-user" }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0]).toMatchObject({
+      shop_id: "shop-real",
+      customer_id: "real-customer-uuid",
+      external_id: "VEH-1",
+    });
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+  });
+
+  it("does not link a missing same-shop customer external_id to another shop", async () => {
+    mockSupabaseState.customers = [{ id: "other-customer", shop_id: "other-shop", external_id: "CUST-100425" }];
+
+    const response = await POST(request([{ unit_number: "A-1", customer_id: "CUST-100425" }]));
     const payload = await response.json();
-    expect(response.status).toBe(400);
-    expect(payload.errors[0].message).toMatch(/does not belong/i);
-    expect(mockSupabaseState.inserts).toHaveLength(0);
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0].customer_id).toBeNull();
+    expect(payload.warnings[0].message).toMatch(/without a customer link/i);
   });
 
   it("customer email/name lookup is shop scoped", async () => {
@@ -267,11 +286,25 @@ describe("POST /api/vehicles/import", () => {
     expect(mockSupabaseState.inserts).toHaveLength(1);
   });
 
-  it("duplicate unit number is handled/skipped", async () => {
+  it("duplicate unit number without a stronger identity is handled/skipped", async () => {
     const response = await POST(request([{ unit_number: "A-1" }, { unit_number: "a-1" }]));
     const payload = await response.json();
     expect(response.status).toBe(200);
     expect(payload.counts).toMatchObject({ created: 1, skipped: 1 });
     expect(mockSupabaseState.inserts).toHaveLength(1);
+    expect(payload.warnings[0].message).toMatch(/no unique VIN or external vehicle ID/i);
+  });
+
+  it("duplicate unit number does not block unique VIN or external vehicle ID imports", async () => {
+    const response = await POST(request([
+      { vehicle_id: "VEH-1", unit_number: "A-1", vin: "1HGCM82633A004352" },
+      { vehicle_id: "VEH-2", unit_number: "a-1", vin: "2HGCM82633A004352" },
+    ]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 2, skipped: 0 });
+    expect(mockSupabaseState.inserts).toHaveLength(2);
+    expect(payload.warnings[0].message).toMatch(/continuing because VIN or external vehicle ID/i);
   });
 });


### PR DESCRIPTION
### Motivation
- The vehicle import preview and server route were failing to link vehicles to customers when the CSV used a customer external ID in the `customer_id` column, causing many rows to show as “Unlinked”.
- The import must match vehicle CSV `customer_id` values like `CUST-100425` to the same-shop `customers.external_id` while preserving shop scoping and not trusting CSV `shop_id` or importing `user_id`.

### Description
- Treat the vehicle CSV `customer_id` as an external customer identifier during parsing and preview, and resolve it against same-shop `customers.external_id` (trim/normalize) before falling back to other matching strategies; added request-level caching for external-id lookups to limit queries. (files changed: `app/api/vehicles/import/route.ts`, `features/vehicles/lib/importCsv.ts`)
- Update server import resolution to prefer same-shop `customers.external_id` matches and to ignore CSV/body `shop_id` and `user_id` when inserting vehicles, inserting into the authenticated user’s `shop_id` only. (file changed: `app/api/vehicles/import/route.ts`)
- Adjust preview logic to align with the server so previewed rows with a CSV `customer_id` that matches a customer external ID show the linked customer UUID instead of “Unlinked”. (file changed: `features/vehicles/lib/importCsv.ts`)
- Improve duplicate-unit handling and messaging so duplicate unit numbers warn but do not block rows that include a stronger identity (`vin` or `external_id`), while still skipping rows that only have ambiguous unit identity. (file changed: `app/api/vehicles/import/route.ts`)
- Added tests and a preview test case covering same-shop external ID linking, cross-shop non-linking, CSV shop/user field ignoring, resolved preview display, and duplicate unit-number behavior. (files changed: `tests/vehicles/vehicle-import-route.test.ts`, `tests/vehicles/vehicle-csv-import-card.test.tsx`)

### Testing
- Ran the vehicle tests with `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` and all tests passed (45/45). 
- Ran TypeScript validation with `npx tsc --noEmit` which completed successfully with no errors. 
- Ran `git diff --check` to ensure no whitespace/git-diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d613b4b08328ac1912fc6f0de62a)