### PR TITLE
Link vehicles to customers by external_id in preview & import; replace legacy Supabase auth helper in targeted paths

### DIFF
--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
 import {
   getLatestRunAttemptSummary,
@@ -79,7 +77,7 @@ async function renderPdf(report: Record<string, unknown>): Promise<Buffer> {
 
 export async function GET(req: Request, context: RouteContext) {
   const { id } = await context.params;
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -1,8 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { toIntakeProgress } from "@/features/integrations/shopBoost/status";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
 import {
@@ -13,13 +10,12 @@ import {
   summarizeRunJobsDetailed,
 } from "@/features/integrations/shopBoost/orchestrator";
 
-type DB = Database;
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
 export async function GET() {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/shop-boost/intakes/process/route.ts
+++ b/app/api/shop-boost/intakes/process/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
 import {
   ensureRun,
@@ -21,7 +19,7 @@ function asRecord(value: unknown): Record<string, unknown> {
 export async function POST(req: NextRequest) {
   // Public control-plane route: enqueue/trigger only.
   // Execution happens in /api/internal/shop-boost/run.
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/shop-boost/refresh/route.ts
+++ b/app/api/shop-boost/refresh/route.ts
@@ -1,15 +1,10 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-
-import type { Database } from "@shared/types/types/supabase";
-import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 
-type DB = Database;
 
 export async function POST() {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/shop-boost/review-items/[id]/route.ts
+++ b/app/api/shop-boost/review-items/[id]/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { resolveAndMaterializeReviewItem } from "@/features/integrations/shopBoost/reviewMaterialization";
 
-type DB = Database;
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function PATCH(req: Request, context: RouteContext) {
   const { id } = await context.params;
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/review-items/reprocess/route.ts
+++ b/app/api/shop-boost/review-items/reprocess/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { reprocessReviewItems } from "@/features/integrations/shopBoost/reviewMaterialization";
 
-type DB = Database;
 
 export async function POST(req: Request) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/review-items/resolve-bulk/route.ts
+++ b/app/api/shop-boost/review-items/resolve-bulk/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { applyHighConfidenceRecommendations, bulkResolveReviewItems } from "@/features/integrations/shopBoost/reviewMaterialization";
 
-type DB = Database;
 
 export async function POST(req: Request) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
-import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
 import { confidenceLabelFromScore, deriveReviewRecommendation, type RecommendedAction, type ReviewRecommendation } from "@/features/integrations/shopBoost/reviewGuidance";
 
@@ -101,7 +99,7 @@ function deriveRecommendationExplanation(recommendation: RecommendationDto): str
 }
 
 export async function GET(req: Request) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -1,15 +1,17 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { cleanVehicleImportText, normalizeImportPlate, normalizeImportVin, type VehicleImportRow } from "@/features/vehicles/lib/importCsv";
+import { cleanVehicleImportText, isUuid, normalizeImportLookupValue, normalizeImportPlate, normalizeImportVin, type VehicleImportRow } from "@/features/vehicles/lib/importCsv";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type DB = Database;
 type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
 type VehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "customer_id" | "vin" | "unit_number" | "license_plate" | "external_id" | "year" | "make" | "model" | "submodel" | "color" | "engine" | "engine_type" | "engine_family" | "transmission" | "fuel_type" | "drivetrain" | "engine_hours" | "mileage" | "import_notes" | "source_row_id">;
 type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
-type CustomerLookupCache = { externalRows?: CustomerRow[] };
+type CustomerLookupCache = { allRows?: CustomerRow[] };
+
+const CUSTOMER_LOOKUP_PAGE_SIZE = 1000;
 
 type ImportBody = { rows?: unknown; shop_id?: unknown };
 
@@ -23,6 +25,25 @@ function numberValue(value: unknown): number | undefined {
   if (!text) return undefined;
   const parsed = Number(text.replace(/,/g, ""));
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeCustomerReference(row: Record<string, unknown>): Pick<NormalizedVehicleImportRow, "customer_id" | "customer_external_id"> {
+  const explicitExternalId = cleanVehicleImportText(row.customer_external_id)
+    ?? cleanVehicleImportText(row.customerExternalId)
+    ?? cleanVehicleImportText(row.external_customer_id)
+    ?? cleanVehicleImportText(row.externalCustomerId);
+  const customerId = cleanVehicleImportText(row.customer_id) ?? cleanVehicleImportText(row.customerid) ?? cleanVehicleImportText(row.customerId);
+
+  if (explicitExternalId) {
+    return {
+      customer_external_id: explicitExternalId,
+      customer_id: customerId && isUuid(customerId) ? customerId.trim() : undefined,
+    };
+  }
+
+  if (!customerId) return {};
+  if (isUuid(customerId)) return { customer_id: customerId.trim() };
+  return { customer_external_id: customerId.trim() };
 }
 
 function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
@@ -51,8 +72,7 @@ function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
       odometer: cleanVehicleImportText(row.odometer) ?? cleanVehicleImportText(row.mileage),
       notes: cleanVehicleImportText(row.notes),
       status: cleanVehicleImportText(row.status),
-      customer_id: cleanVehicleImportText(row.customer_id),
-      customer_external_id: cleanVehicleImportText(row.customer_external_id) ?? cleanVehicleImportText(row.customer_id),
+      ...normalizeCustomerReference(row),
       customer_name: cleanVehicleImportText(row.customer_name),
       customer_email: cleanVehicleImportText(row.customer_email)?.toLowerCase(),
       customer_phone: cleanVehicleImportText(row.customer_phone),
@@ -142,38 +162,59 @@ function customerMatches(row: NormalizedVehicleImportRow, customer: CustomerRow)
   return Boolean(wantedName && names.some((value) => value === wantedName));
 }
 
-async function resolveCustomerId(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow, cache: CustomerLookupCache): Promise<{ customerId: string | null; warning?: string; error?: string }> {
-  const customerExternalId = row.customer_external_id?.trim();
+async function fetchSameShopCustomers(supabase: SupabaseClient<DB>, shopId: string, cache: CustomerLookupCache): Promise<{ customers: CustomerRow[]; error?: string }> {
+  if (cache.allRows) return { customers: cache.allRows };
 
-  if (customerExternalId) {
-    if (!cache.externalRows) {
-      const { data: customers, error } = await supabase.from("customers").select("id,external_id").eq("shop_id", shopId).limit(5000);
-      if (error) return { customerId: null, error: error.message };
-      cache.externalRows = (customers ?? []) as CustomerRow[];
-    }
-    const matches = cache.externalRows.filter((customer) => customer.external_id?.trim().toLowerCase() === customerExternalId.toLowerCase());
-    if (matches.length === 1) return { customerId: matches[0].id };
-    if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer external ID match; vehicle imported without a customer link." };
+  const customers: CustomerRow[] = [];
+  for (let from = 0; ; from += CUSTOMER_LOOKUP_PAGE_SIZE) {
+    const to = from + CUSTOMER_LOOKUP_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from("customers")
+      .select("id,external_id,business_name,name,first_name,last_name,email,phone,phone_number")
+      .eq("shop_id", shopId)
+      .range(from, to);
+
+    if (error) return { customers: [], error: error.message };
+
+    const page = (data ?? []) as CustomerRow[];
+    customers.push(...page);
+    if (page.length < CUSTOMER_LOOKUP_PAGE_SIZE) break;
   }
 
-  if (row.customer_id && row.customer_id !== customerExternalId) {
-    const { data: customer, error } = await supabase.from("customers").select("id").eq("shop_id", shopId).eq("id", row.customer_id).maybeSingle();
+  cache.allRows = customers;
+  return { customers };
+}
+
+async function resolveCustomerId(supabase: SupabaseClient<DB>, shopId: string, row: NormalizedVehicleImportRow, cache: CustomerLookupCache): Promise<{ customerId: string | null; warning?: string; error?: string }> {
+  const customerExternalId = normalizeImportLookupValue(row.customer_external_id);
+
+  if (customerExternalId) {
+    const { customers, error } = await fetchSameShopCustomers(supabase, shopId, cache);
+    if (error) return { customerId: null, error };
+    const matches = customers.filter((customer) => normalizeImportLookupValue(customer.external_id) === customerExternalId);
+    if (matches.length === 1) return { customerId: matches[0].id };
+    if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer external ID match; vehicle imported without a customer link." };
+    return { customerId: null, warning: "No matching customer found by external ID; this vehicle will import without a customer link." };
+  }
+
+  if (row.customer_id && isUuid(row.customer_id)) {
+    const { data: customer, error } = await supabase.from("customers").select("id").eq("shop_id", shopId).eq("id", row.customer_id.trim()).maybeSingle();
     if (error) return { customerId: null, error: error.message };
-    if (!customer?.id) return { customerId: null, error: "Customer ID does not belong to this shop." };
+    if (!customer?.id) return { customerId: null, warning: "No matching customer found by ID; this vehicle will import without a customer link." };
     return { customerId: String(customer.id) };
   }
 
-  if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null, warning: row.customer_external_id ? "No matching customer found; this vehicle will import without a customer link." : undefined };
+  if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null };
 
-  const { data: customers, error } = await supabase.from("customers").select("id,external_id,business_name,name,first_name,last_name,email,phone,phone_number").eq("shop_id", shopId).limit(200);
-  if (error) return { customerId: null, error: error.message };
-  const matches = ((customers ?? []) as CustomerRow[]).filter((customer) => customerMatches(row, customer));
+  const { customers, error } = await fetchSameShopCustomers(supabase, shopId, cache);
+  if (error) return { customerId: null, error };
+  const matches = customers.filter((customer) => customerMatches(row, customer));
   if (matches.length === 1) return { customerId: matches[0].id };
   if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer match; vehicle imported without a customer link." };
   return { customerId: null, warning: "No matching customer found; this vehicle will import without a customer link." };
 }
 
-async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string, row: NormalizedVehicleImportRow, options: { skipUnitNumberMatch?: boolean } = {}): Promise<{ vehicle: VehicleRow | null; matchKind?: "vin" | "external_id" | "unit_number" | "license_plate"; warning?: string; error?: string }> {
+async function findExistingVehicle(supabase: SupabaseClient<DB>, shopId: string, row: NormalizedVehicleImportRow, options: { skipUnitNumberMatch?: boolean } = {}): Promise<{ vehicle: VehicleRow | null; matchKind?: "vin" | "external_id" | "unit_number" | "license_plate"; warning?: string; error?: string }> {
   if (row.vin) {
     const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("vin", row.vin).limit(1).maybeSingle();
     if (error) return { vehicle: null, error: error.message };
@@ -199,7 +240,7 @@ async function findExistingVehicle(supabase: ReturnType<typeof createRouteHandle
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const { data: { user }, error: userError } = await supabase.auth.getUser();
     if (userError) return NextResponse.json({ error: userError.message }, { status: 401 });
     if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });

--- a/features/auth/components/SignOutButton.tsx
+++ b/features/auth/components/SignOutButton.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function SignOutButton() {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();

--- a/features/chat/components/ChatDock.tsx
+++ b/features/chat/components/ChatDock.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import RecipientPickerModal from "@/features/shared/chat/components/RecipientPickerModalWrapper";
 
@@ -16,7 +16,7 @@ type Conversation = {
 };
 
 export default function ChatDock(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   // dock open/close
   const [open, setOpen] = useState<boolean>(false);

--- a/features/shared/components/ProFixIQLanding.tsx
+++ b/features/shared/components/ProFixIQLanding.tsx
@@ -4,8 +4,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Toaster } from "sonner";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import LandingHero from "@shared/components/ui/LandingHero";
 import LandingShopBoost from "@shared/components/ui/LandingShopBoost";
@@ -21,7 +20,7 @@ import LandingReviews from "@shared/components/ui/LandingReviews";
 type Interval = "monthly" | "yearly";
 
 export default function ProFixIQLanding() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [sessionExists, setSessionExists] = useState(false);
 
   useEffect(() => {

--- a/features/shared/components/RoleNavAdmin.tsx
+++ b/features/shared/components/RoleNavAdmin.tsx
@@ -3,12 +3,11 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 
 export default function RoleNavAdmin() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isAdmin, setIsAdmin] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavAdvisor.tsx
+++ b/features/shared/components/RoleNavAdvisor.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavManager.tsx
+++ b/features/shared/components/RoleNavManager.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavOwner.tsx
+++ b/features/shared/components/RoleNavOwner.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavOwner() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [userId, setUserId] = useState<string | null>(null);
   const [isOwner, setIsOwner] = useState(false);
 

--- a/features/shared/components/RoleNavParts.tsx
+++ b/features/shared/components/RoleNavParts.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavTech.tsx
+++ b/features/shared/components/RoleNavTech.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/nav/NavFromTiles.tsx
+++ b/features/shared/components/nav/NavFromTiles.tsx
@@ -2,8 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import RoleHubTiles from "@/features/shared/components/RoleHubTiles/RoleHubTiles";
 import type { Role, Scope } from "@/features/shared/components/RoleHubTiles/tiles";
@@ -19,7 +18,7 @@ export default function NavFromTiles({
   description?: string;
   rolesOverride?: Role[];
 }) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [roles, setRoles] = useState<Role[]>([]);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);

--- a/features/shared/components/reviews/ReviewForm.tsx
+++ b/features/shared/components/reviews/ReviewForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER_LIGHT = "var(--accent-copper-light)";
@@ -31,7 +31,7 @@ function Star({ filled }: { filled: boolean }) {
 }
 
 export default function ReviewForm({ shopId, onCreated }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [rating, setRating] = useState<number>(5);
   const [comment, setComment] = useState<string>("");
   const [submitting, setSubmitting] = useState<boolean>(false);

--- a/features/shared/components/reviews/ReviewsList.tsx
+++ b/features/shared/components/reviews/ReviewsList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER = "var(--pfq-copper)";
@@ -42,7 +42,7 @@ function StarsRow({ rating }: { rating: number }) {
 }
 
 export default function ReviewsList({ shopId }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [reviews, setReviews] = useState<ReviewRow[]>([]);
   const [me, setMe] = useState<Profile | null>(null);
   const [loading, setLoading] = useState<boolean>(true);

--- a/features/shared/components/summary.tsx
+++ b/features/shared/components/summary.tsx
@@ -3,14 +3,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { extractSummaryFromSession } from "@inspections/lib/inspection/summary";
 import type { InspectionSession } from "@inspections/lib/inspection/types";
 
 export default function InspectionSummaryPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [summary, setSummary] = useState("");
   const [loading, setLoading] = useState(false);

--- a/features/shared/components/ui/LandingReviews.tsx
+++ b/features/shared/components/ui/LandingReviews.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER_LIGHT = "var(--accent-copper-light)";
@@ -101,7 +101,7 @@ function StatPill({ label, value }: { label: string; value: string }) {
 }
 
 export default function LandingReviews() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [reviews, setReviews] = useState<PublicReview[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/features/shared/components/ui/PunchController.tsx
+++ b/features/shared/components/ui/PunchController.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import PunchInOutButton from "@shared/components/PunchInOutButton";
@@ -28,7 +28,7 @@ function safeMsg(e: unknown, fallback: string): string {
 }
 
 export default function PunchController(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
   const [shopId, setShopId] = useState<string | null>(null);

--- a/features/shared/components/ui/ShopBoostWidget.tsx
+++ b/features/shared/components/ui/ShopBoostWidget.tsx
@@ -4,8 +4,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 type VHealthLatestRow = {
   snapshot_id: string;
@@ -66,7 +65,7 @@ const TONE_STYLES: Record<
 };
 
 export default function ShopBoostWidget({ shopId, canViewShopHealth }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -9,11 +9,12 @@ import { VehicleCreateForm } from "@/features/vehicles/components/VehicleCreateF
 import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
 import { formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
 import { filterSortAndCapVehicles, vehicleCustomerName, type VehicleListRow } from "@/features/vehicles/lib/list";
+import { fetchVehicleImportCustomers } from "@/features/vehicles/lib/importCustomers";
 
 type DB = Database;
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
 
-type CustomerOption = Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
+type CustomerOption = Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number" | "external_id">;
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -37,21 +38,16 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
   if (!actor.user?.id) redirect(`/sign-in?redirect=${encodeURIComponent("/vehicles")}`);
   if (!actor.shopId) redirect("/account/shop-assignment-required");
 
-  const [{ data: vehicleRows, error: vehicleError }, { data: customerRows }] = await Promise.all([
+  const [{ data: vehicleRows, error: vehicleError }, importCustomers] = await Promise.all([
     supabase
       .from("vehicles")
       .select("id, external_id, unit_number, year, make, model, submodel, vin, license_plate, customer_id, mileage, engine_hours, engine, fuel_type, import_notes, source_row_id, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)")
       .eq("shop_id", actor.shopId),
-    supabase
-      .from("customers")
-      .select("id, business_name, name, first_name, last_name, email, phone, phone_number")
-      .eq("shop_id", actor.shopId)
-      .order("updated_at", { ascending: false })
-      .limit(200),
+    fetchVehicleImportCustomers(supabase, actor.shopId),
   ]);
 
   const vehicles = filterSortAndCapVehicles(((vehicleRows ?? []) as unknown as VehicleListRow[]).map((row) => ({ ...row, customers: Array.isArray(row.customers) ? row.customers[0] ?? null : row.customers })), query);
-  const customers = (customerRows ?? []) as CustomerOption[];
+  const customers = importCustomers as CustomerOption[];
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-6 lg:p-8">

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -175,7 +175,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
                 <tr key={row.sourceRowNumber} className="text-neutral-200">
                   <td className="p-3">{row.sourceRowNumber}</td>
                   <td className="p-3">{row.unit_number || row.vin || row.license_plate || [row.year, row.make, row.model].filter(Boolean).join(" ") || "—"}</td>
-                  <td className="p-3">{row.resolvedCustomerId ?? row.customer_name ?? row.customer_email ?? row.customer_phone ?? "Unlinked"}</td>
+                  <td className="p-3">{row.resolvedCustomerLabel ?? row.resolvedCustomerId ?? row.customer_name ?? row.customer_email ?? row.customer_phone ?? "Unlinked"}</td>
                   <td className="p-3"><span className={row.status === "valid" ? "text-emerald-200" : "text-red-200"}>{row.status}</span></td>
                   <td className="p-3 text-amber-100">{[...row.errors, ...row.warnings].join(" ") || "—"}</td>
                 </tr>

--- a/features/vehicles/lib/importCsv.ts
+++ b/features/vehicles/lib/importCsv.ts
@@ -46,6 +46,7 @@ export type VehicleImportPreviewRow = VehicleImportRow & {
   warnings: string[];
   errors: string[];
   resolvedCustomerId?: string;
+  resolvedCustomerLabel?: string;
 };
 
 export type VehicleImportPreview = {
@@ -101,6 +102,8 @@ const HEADER_ALIASES: Record<string, keyof VehicleImportRow> = {
   customerid: "customer_id",
   customerexternalid: "customer_external_id",
   customer_external_id: "customer_external_id",
+  externalcustomerid: "customer_external_id",
+  external_customer_id: "customer_external_id",
   customername: "customer_name",
   customer: "customer_name",
   customeremail: "customer_email",
@@ -146,22 +149,46 @@ function hasIdentity(row: VehicleImportRow): boolean {
   return Boolean(row.vin || row.unit_number || row.license_plate || (row.year && row.make && row.model));
 }
 
+export function isUuid(value: unknown): boolean {
+  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+export function normalizeImportLookupValue(value: unknown): string | undefined {
+  const text = cleanVehicleImportText(value);
+  return text ? text.toLowerCase() : undefined;
+}
+
+function normalizeCustomerReference(row: VehicleImportRow): VehicleImportRow {
+  const customerId = cleanVehicleImportText(row.customer_id);
+  const customerExternalId = cleanVehicleImportText(row.customer_external_id);
+  if (!customerId && !customerExternalId) return row;
+  if (customerExternalId) return { ...row, customer_id: customerId && isUuid(customerId) ? customerId.trim() : undefined, customer_external_id: customerExternalId.trim() };
+  if (!customerId) return row;
+  if (isUuid(customerId)) return { ...row, customer_id: customerId.trim() };
+  return { ...row, customer_id: undefined, customer_external_id: customerId.trim() };
+}
+
 function customerLabel(customer: VehicleImportCustomerOption): string {
   return [customer.business_name, customer.name, [customer.first_name, customer.last_name].filter(Boolean).join(" "), customer.email, customer.phone, customer.phone_number]
     .map((value) => value?.trim())
     .find(Boolean) ?? customer.id;
 }
 
-function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomerOption[]): { id?: string; warning?: string } {
-  const customerExternalId = (row.customer_external_id ?? row.customer_id)?.trim();
+function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomerOption[]): { id?: string; label?: string; warning?: string } {
+  const customerExternalId = normalizeImportLookupValue(row.customer_external_id);
   if (customerExternalId) {
-    const externalMatch = customers.find((customer) => customer.external_id?.trim().toLowerCase() === customerExternalId.toLowerCase());
-    if (externalMatch) return { id: externalMatch.id };
-
-    const directIdMatch = customers.find((customer) => customer.id === customerExternalId);
-    if (directIdMatch) return { id: directIdMatch.id };
+    const externalMatches = customers.filter((customer) => normalizeImportLookupValue(customer.external_id) === customerExternalId);
+    if (externalMatches.length === 1) return { id: externalMatches[0].id, label: customerLabel(externalMatches[0]) };
+    if (externalMatches.length > 1) return { warning: `Ambiguous customer external ID match (${externalMatches.map(customerLabel).join(", ")}); this vehicle will import without a customer link.` };
 
     return { warning: "No matching customer found by external ID; this vehicle will import without a customer link." };
+  }
+
+  const customerUuid = row.customer_id?.trim();
+  if (customerUuid && isUuid(customerUuid)) {
+    const directIdMatch = customers.find((customer) => customer.id === customerUuid);
+    if (directIdMatch) return { id: directIdMatch.id, label: customerLabel(directIdMatch) };
+    return { warning: "No matching customer found by ID; this vehicle will import without a customer link." };
   }
 
   const candidates = customers.filter((customer) => {
@@ -175,7 +202,7 @@ function resolveCustomer(row: VehicleImportRow, customers: VehicleImportCustomer
     return Boolean(emailMatch || phoneMatch || nameMatch);
   });
 
-  if (candidates.length === 1) return { id: candidates[0].id };
+  if (candidates.length === 1) return { id: candidates[0].id, label: customerLabel(candidates[0]) };
   if (candidates.length > 1) return { warning: `Ambiguous customer match (${candidates.map(customerLabel).join(", ")}); this vehicle will import without a customer link.` };
   if (row.customer_external_id || row.customer_name || row.customer_email || row.customer_phone) return { warning: "No matching customer found; this vehicle will import without a customer link." };
   return {};
@@ -201,7 +228,7 @@ export function parseVehicleCsv(csvText: string, sourceFilename?: string): Vehic
         if (text) (row as Record<string, unknown>)[key] = text;
       }
     }
-    return row;
+    return normalizeCustomerReference(row);
   });
 }
 
@@ -227,7 +254,7 @@ export function previewVehicleCsv(csvText: string, customers: VehicleImportCusto
     const customer = resolveCustomer(row, customers);
     if (customer.warning) warnings.push(customer.warning);
 
-    return { ...row, resolvedCustomerId: customer.id, status: errors.length ? "invalid" : "valid", errors, warnings };
+    return { ...row, resolvedCustomerId: customer.id, resolvedCustomerLabel: customer.label, status: errors.length ? "invalid" : "valid", errors, warnings };
   });
 
   return {

--- a/features/vehicles/lib/importCustomers.ts
+++ b/features/vehicles/lib/importCustomers.ts
@@ -1,0 +1,31 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import type { VehicleImportCustomerOption } from "@/features/vehicles/lib/importCsv";
+
+type DB = Database;
+
+type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number" | "external_id">;
+
+const CUSTOMER_PAGE_SIZE = 1000;
+
+export async function fetchVehicleImportCustomers(supabase: SupabaseClient<DB>, shopId: string): Promise<VehicleImportCustomerOption[]> {
+  const customers: CustomerRow[] = [];
+
+  for (let from = 0; ; from += CUSTOMER_PAGE_SIZE) {
+    const to = from + CUSTOMER_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from("customers")
+      .select("id, business_name, name, first_name, last_name, email, phone, phone_number, external_id")
+      .eq("shop_id", shopId)
+      .order("updated_at", { ascending: false })
+      .range(from, to);
+
+    if (error) throw new Error(error.message);
+
+    const page = (data ?? []) as CustomerRow[];
+    customers.push(...page);
+    if (page.length < CUSTOMER_PAGE_SIZE) break;
+  }
+
+  return customers;
+}

--- a/tests/vehicles/vehicle-csv-import-card.test.tsx
+++ b/tests/vehicles/vehicle-csv-import-card.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
+import { parseVehicleCsv } from "@/features/vehicles/lib/importCsv";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 const guidedQuery: GuidedOnboardingQuery = {
@@ -66,13 +67,34 @@ describe("VehicleCsvImportCard", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/vehicles/import", expect.objectContaining({ method: "POST" })));
   });
 
-  it("previews vehicle customer_id as a linked customer external_id", async () => {
-    render(<VehicleCsvImportCard customers={[{ id: "customer-uuid", external_id: "CUST-100425", name: "Fleet Customer" }]} />);
+  it("maps vehicle CSV customer_id to customer_external_id instead of a database customer UUID", () => {
+    expect(parseVehicleCsv("vehicle_id,unit_number,customer_id\nVEH-1,A-1,CUST-100247")[0]).toMatchObject({
+      external_id: "VEH-1",
+      unit_number: "A-1",
+      customer_external_id: "CUST-100247",
+    });
+    expect(parseVehicleCsv("vehicle_id,unit_number,customer_id\nVEH-1,A-1,CUST-100247")[0].customer_id).toBeUndefined();
+  });
 
-    await userEvent.type(screen.getByLabelText(/paste csv text/i), "vehicle_id,unit_number,customer_id\nVEH-1,A-1,CUST-100425");
+  it.each([
+    "customer_id",
+    "customerid",
+    "customer_external_id",
+    "customerExternalId",
+    "external_customer_id",
+    "externalCustomerId",
+  ])("supports %s as a customer external ID CSV header alias", (header) => {
+    const row = parseVehicleCsv(`unit_number,${header}\nA-1,CUST-100247`)[0];
+    expect(row.customer_external_id).toBe("CUST-100247");
+  });
+
+  it("previews vehicle customer_id as a linked customer external_id", async () => {
+    render(<VehicleCsvImportCard customers={[{ id: "customer-uuid", external_id: "CUST-100247", name: "Fleet Customer" }]} />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "vehicle_id,unit_number,customer_id\nVEH-1,A-1,CUST-100247");
     await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
 
-    expect(screen.getByText("customer-uuid")).toBeInTheDocument();
+    expect(screen.getByText("Fleet Customer")).toBeInTheDocument();
     expect(screen.queryByText("Unlinked")).not.toBeInTheDocument();
     expect(screen.queryByText(/No matching customer found/i)).not.toBeInTheDocument();
   });

--- a/tests/vehicles/vehicle-import-route.test.ts
+++ b/tests/vehicles/vehicle-import-route.test.ts
@@ -9,6 +9,7 @@ const { mockSupabaseState } = vi.hoisted(() => ({
     vehicles: [] as Array<Record<string, unknown>>,
     inserts: [] as Array<Record<string, unknown>>,
     updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
+    customerRanges: [] as Array<{ from: number; to: number; shopId: unknown }>,
   },
 }));
 
@@ -21,6 +22,8 @@ type MockQuery = {
   eq: ReturnType<typeof vi.fn>;
   ilike: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
+  range: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
   maybeSingle: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
@@ -32,9 +35,12 @@ function makeQuery(table: string): MockQuery {
     select: vi.fn(() => query),
     eq: vi.fn((column: string, value: unknown) => { query.filters[column] = value; return query; }),
     ilike: vi.fn((column: string, value: unknown) => { query.filters[column] = value; return query; }),
-    limit: vi.fn(() => {
+    limit: vi.fn(() => query),
+    order: vi.fn(() => query),
+    range: vi.fn((from: number, to: number) => {
       if (table === "customers" && query.filters.shop_id && !query.filters.id) {
-        return Promise.resolve({ data: mockSupabaseState.customers.filter((row) => row.shop_id === query.filters.shop_id), error: null });
+        mockSupabaseState.customerRanges.push({ from, to, shopId: query.filters.shop_id });
+        return Promise.resolve({ data: mockSupabaseState.customers.filter((row) => row.shop_id === query.filters.shop_id).slice(from, to + 1), error: null });
       }
       return query;
     }),
@@ -78,8 +84,8 @@ function makeQuery(table: string): MockQuery {
   return query;
 }
 
-vi.mock("@supabase/auth-helpers-nextjs", () => ({
-  createRouteHandlerClient: vi.fn(() => ({
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRoute: vi.fn(() => ({
     auth: { getUser: vi.fn(async () => ({ data: { user: mockSupabaseState.user }, error: null })) },
     from: vi.fn((table: string) => makeQuery(table)),
   })),
@@ -98,6 +104,7 @@ describe("POST /api/vehicles/import", () => {
     mockSupabaseState.vehicles = [];
     mockSupabaseState.inserts = [];
     mockSupabaseState.updates = [];
+    mockSupabaseState.customerRanges = [];
   });
 
   it("rejects unauthenticated import", async () => {
@@ -182,6 +189,30 @@ describe("POST /api/vehicles/import", () => {
       external_id: "VEH-1",
     });
     expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+  });
+
+  it("paginates same-shop customer external_id lookup beyond 1000 rows", async () => {
+    mockSupabaseState.customers = Array.from({ length: 1002 }, (_, index) => ({
+      id: `customer-${index}`,
+      shop_id: "shop-real",
+      external_id: index === 1001 ? "CUST-100247" : `CUST-${index}`,
+    }));
+
+    const response = await POST(request([{ unit_number: "A-1", customer_id: "CUST-100247" }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.customerRanges).toEqual([
+      { from: 0, to: 999, shopId: "shop-real" },
+      { from: 1000, to: 1999, shopId: "shop-real" },
+    ]);
+    expect(mockSupabaseState.inserts[0].customer_id).toBe("customer-1001");
+  });
+
+  it("does not use a non-UUID vehicle CSV customer_id as vehicles.customer_id directly", async () => {
+    const response = await POST(request([{ unit_number: "A-1", customer_id: "CUST-404" }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0].customer_id).toBeNull();
   });
 
   it("does not link a missing same-shop customer external_id to another shop", async () => {

--- a/tests/vehicles/vehicles-page-guided-card.test.ts
+++ b/tests/vehicles/vehicles-page-guided-card.test.ts
@@ -72,3 +72,46 @@ describe("Vehicles page list filtering", () => {
     expect(result.map((row) => row.id)).toContain("older-match");
   });
 });
+
+import { fetchVehicleImportCustomers } from "@/features/vehicles/lib/importCustomers";
+
+describe("Vehicles import customer lookup", () => {
+  it("paginates same-shop customers beyond the first 1000 rows for CSV preview linking", async () => {
+    const rows = Array.from({ length: 1002 }, (_, index) => ({
+      id: `customer-${index}`,
+      shop_id: index === 1000 ? "other-shop" : "shop-real",
+      external_id: index === 1001 ? "CUST-100247" : `CUST-${index}`,
+      business_name: index === 1001 ? "Fleet Customer" : null,
+      name: null,
+      first_name: null,
+      last_name: null,
+      email: null,
+      phone: null,
+      phone_number: null,
+    }));
+    const ranges: Array<{ from: number; to: number; shopId: string }> = [];
+    const query = {
+      select: () => query,
+      eq: (_column: string, shopId: string) => {
+        query.shopId = shopId;
+        return query;
+      },
+      order: () => query,
+      range: async (from: number, to: number) => {
+        ranges.push({ from, to, shopId: query.shopId });
+        return { data: rows.filter((row) => row.shop_id === query.shopId).slice(from, to + 1), error: null };
+      },
+      shopId: "",
+    };
+    const supabase = { from: () => query } as any;
+
+    const customers = await fetchVehicleImportCustomers(supabase, "shop-real");
+
+    expect(ranges).toEqual([
+      { from: 0, to: 999, shopId: "shop-real" },
+      { from: 1000, to: 1999, shopId: "shop-real" },
+    ]);
+    expect(customers).toContainEqual(expect.objectContaining({ id: "customer-1001", external_id: "CUST-100247" }));
+    expect(customers).not.toContainEqual(expect.objectContaining({ id: "customer-1000" }));
+  });
+});


### PR DESCRIPTION
### Motivation
- Vehicle CSV preview showed every row as “Unlinked” even when customers were already imported with their CSV `external_id`, so preview and server import must match by `customers.external_id` instead of assuming `customer_id` is a DB UUID.
- CSVs commonly use IDs like `CUST-100247` which must be treated as external IDs, not UUIDs, to avoid incorrect linking or warnings.
- Preview/customer lookup must be shop-scoped and paginate beyond the Supabase page size to find customers when a shop has >1000 customers.
- `/vehicles` runtime and a small set of shop-boost routes were still using `@supabase/auth-helpers-nextjs`, producing cookie parsing/auth noise; replace usage only in the runtime paths exercised by the Vehicles page and the shop-boost runtime surface. 

### Description
- CSV parsing: expanded header aliases and introduced `normalizeCustomerReference` so non-UUID `customer_id` becomes `customer_external_id`, and `customer_id` is used only when it's a valid UUID; added `normalizeImportLookupValue` and `isUuid` helpers. (`features/vehicles/lib/importCsv.ts`).
- Preview customer resolution: preview now matches normalized `customer_external_id` → `customers.external_id` and returns a human label for display; preview shows customer name (not the raw UUID) when matched. (`features/vehicles/lib/importCsv.ts`, `features/vehicles/components/VehicleCsvImportCard.tsx`).
- Server import route: replaced legacy auth-helper client with the shared SSR helper (`createServerSupabaseRoute`), ignore incoming CSV/body `shop_id`, prefetch same-shop customers with paginated ranges (pages of 1000) and match by normalized `external_id` first, only attempt direct customer.id lookup when `customer_id` is a valid UUID, and ensure `vehicles.user_id` is not inserted. (`app/api/vehicles/import/route.ts`, `features/vehicles/lib/importCustomers.ts`).
- Vehicles page preview: added `fetchVehicleImportCustomers` to load same-shop customers paginated (includes `external_id`) and pass them into the client preview so preview can resolve links even when >1000 customers exist. (`features/vehicles/app/vehicles/page.tsx`, `features/vehicles/lib/importCustomers.ts`).
- Targeted auth-helper cleanup: replaced `@supabase/auth-helpers-nextjs` usages in the runtime path(s) invoked by the Vehicles page and shop-boost route handlers with the shared `@supabase/ssr` helpers and replaced client helper calls in specific browser components with the `createBrowserSupabase` wrapper; changes were limited to the routes/components exercised by the Vehicles surface. (examples: `app/api/shop-boost/*`, `features/shared/components/*`).
- Tests: added and updated focused tests covering CSV header aliases, parser normalization (non-UUID `customer_id` → `customer_external_id`), preview customer linking and label display, pagination beyond 1000 customers, server import external-ID linking and cross-shop isolation, non-UUID safety, ignoring CSV/body `shop_id` and `user_id`, and import reset behavior. (`tests/vehicles/*`).

### Testing
- Ran a targeted search to confirm old helpers were removed in the affected runtime paths: `rg --no-ignore -n "createClientComponentClient|createRouteHandlerClient|createServerComponentClient|@supabase/auth-helpers-nextjs" app/api/shop-boost features/shop-boost features/vehicles features/shared/components features/auth/components features/chat/components app/providers.tsx app/api/vehicles/import/route.ts`, and found no remaining matches in the requested scope.
- Unit/behavior tests: `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` — all test files passed (55 tests passed total).
- Typecheck: `npx tsc --noEmit` completed successfully with no errors.
- Quick repo hygiene: `git diff --check` reported no whitespace/check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e3544b0883288776a2e59d0b1380)