### PR TITLE
Fix vehicle CSV import batching and diagnostics

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -9,15 +9,51 @@ type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
 type VehicleRow = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "customer_id" | "vin" | "unit_number" | "license_plate" | "external_id" | "year" | "make" | "model" | "submodel" | "color" | "engine" | "engine_type" | "engine_family" | "transmission" | "fuel_type" | "drivetrain" | "engine_hours" | "mileage" | "import_notes" | "source_row_id">;
 type CustomerRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number">;
-type CustomerLookupCache = { allRows?: CustomerRow[] };
-
-const CUSTOMER_LOOKUP_PAGE_SIZE = 1000;
 
 type ImportBody = { rows?: unknown; shop_id?: unknown };
 
 type NormalizedVehicleImportRow = VehicleImportRow & {
   sourceRowNumber: number;
 };
+
+type ImportWarning = { row: number; message: string };
+type ImportError = { row: number; message: string };
+type VehicleWriteItem = { row: NormalizedVehicleImportRow; payload: VehicleInsert };
+type VehicleMatchKind = "vin" | "external_id" | "unit_number" | "license_plate";
+type VehicleDiagnostic = {
+  row: number;
+  external_id: string | null;
+  vin: string | null;
+  unit_number: string | null;
+  plate: string | null;
+  customer_external_id: string | null;
+  code: string | null;
+  status: number | null;
+  message: string;
+  details: string | null;
+  hint: string | null;
+  payloadKeys: string[];
+  containsUserId: boolean;
+};
+
+type VehicleIndexes = {
+  byVin: Map<string, VehicleRow>;
+  byExternalId: Map<string, VehicleRow>;
+  byUnitNumber: Map<string, VehicleRow>;
+  byLicensePlate: Map<string, VehicleRow>;
+};
+
+type CustomerIndexes = {
+  byId: Map<string, CustomerRow>;
+  byExternalId: Map<string, CustomerRow[]>;
+};
+
+const PAGE_SIZE = 1000;
+const VEHICLE_INSERT_BATCH_SIZE = 100;
+const SAMPLE_LIMIT = 25;
+
+const VEHICLE_SELECT = "id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id";
+const CUSTOMER_SELECT = "id,external_id,business_name,name,first_name,last_name,email,phone,phone_number";
 
 function numberValue(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -117,7 +153,7 @@ function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: st
     mileage: row.odometer ?? null,
     import_notes: notes,
     source_row_id: String(row.sourceRowNumber),
-  };
+  } satisfies VehicleInsert;
 }
 
 function setMeaningfulString(patch: VehicleUpdate, key: keyof VehicleUpdate, value: string | undefined) {
@@ -162,80 +198,234 @@ function customerMatches(row: NormalizedVehicleImportRow, customer: CustomerRow)
   return Boolean(wantedName && names.some((value) => value === wantedName));
 }
 
-async function fetchSameShopCustomers(supabase: SupabaseClient<DB>, shopId: string, cache: CustomerLookupCache): Promise<{ customers: CustomerRow[]; error?: string }> {
-  if (cache.allRows) return { customers: cache.allRows };
+function addUniqueIndexValue(index: Map<string, VehicleRow>, key: string | null | undefined, row: VehicleRow) {
+  const normalized = normalizeImportLookupValue(key);
+  if (normalized && !index.has(normalized)) index.set(normalized, row);
+}
 
+function indexVehicles(vehicles: VehicleRow[]): VehicleIndexes {
+  const indexes: VehicleIndexes = { byVin: new Map(), byExternalId: new Map(), byUnitNumber: new Map(), byLicensePlate: new Map() };
+  for (const vehicle of vehicles) {
+    addUniqueIndexValue(indexes.byVin, vehicle.vin, vehicle);
+    addUniqueIndexValue(indexes.byExternalId, vehicle.external_id, vehicle);
+    addUniqueIndexValue(indexes.byUnitNumber, vehicle.unit_number, vehicle);
+    addUniqueIndexValue(indexes.byLicensePlate, vehicle.license_plate, vehicle);
+  }
+  return indexes;
+}
+
+function indexCustomers(customers: CustomerRow[]): CustomerIndexes {
+  const indexes: CustomerIndexes = { byId: new Map(), byExternalId: new Map() };
+  for (const customer of customers) {
+    indexes.byId.set(customer.id, customer);
+    const externalId = normalizeImportLookupValue(customer.external_id);
+    if (externalId) indexes.byExternalId.set(externalId, [...(indexes.byExternalId.get(externalId) ?? []), customer]);
+  }
+  return indexes;
+}
+
+function findExistingVehicleFromIndexes(row: NormalizedVehicleImportRow, indexes: VehicleIndexes, options: { skipUnitNumberMatch?: boolean } = {}): { vehicle: VehicleRow | null; matchKind?: VehicleMatchKind; warning?: string } {
+  const vin = normalizeImportLookupValue(row.vin);
+  if (vin && indexes.byVin.has(vin)) return { vehicle: indexes.byVin.get(vin) ?? null, matchKind: "vin" };
+  const externalId = normalizeImportLookupValue(row.external_id);
+  if (externalId && indexes.byExternalId.has(externalId)) return { vehicle: indexes.byExternalId.get(externalId) ?? null, matchKind: "external_id" };
+  const unitNumber = normalizeImportLookupValue(row.unit_number);
+  if (unitNumber && !options.skipUnitNumberMatch && indexes.byUnitNumber.has(unitNumber)) return { vehicle: indexes.byUnitNumber.get(unitNumber) ?? null, matchKind: "unit_number" };
+  const plate = normalizeImportLookupValue(row.license_plate);
+  if (plate && indexes.byLicensePlate.has(plate)) return { vehicle: indexes.byLicensePlate.get(plate) ?? null, matchKind: "license_plate", warning: "Duplicate plate matched an existing vehicle; existing vehicle selected." };
+  return { vehicle: null };
+}
+
+async function fetchSameShopCustomers(supabase: SupabaseClient<DB>, shopId: string): Promise<{ customers: CustomerRow[]; error?: string }> {
   const customers: CustomerRow[] = [];
-  for (let from = 0; ; from += CUSTOMER_LOOKUP_PAGE_SIZE) {
-    const to = from + CUSTOMER_LOOKUP_PAGE_SIZE - 1;
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id,external_id,business_name,name,first_name,last_name,email,phone,phone_number")
-      .eq("shop_id", shopId)
-      .range(from, to);
-
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const to = from + PAGE_SIZE - 1;
+    const { data, error } = await supabase.from("customers").select(CUSTOMER_SELECT).eq("shop_id", shopId).range(from, to);
     if (error) return { customers: [], error: error.message };
-
     const page = (data ?? []) as CustomerRow[];
     customers.push(...page);
-    if (page.length < CUSTOMER_LOOKUP_PAGE_SIZE) break;
+    if (page.length < PAGE_SIZE) break;
   }
-
-  cache.allRows = customers;
   return { customers };
 }
 
-async function resolveCustomerId(supabase: SupabaseClient<DB>, shopId: string, row: NormalizedVehicleImportRow, cache: CustomerLookupCache): Promise<{ customerId: string | null; warning?: string; error?: string }> {
-  const customerExternalId = normalizeImportLookupValue(row.customer_external_id);
+async function fetchSameShopVehicles(supabase: SupabaseClient<DB>, shopId: string): Promise<{ vehicles: VehicleRow[]; error?: string }> {
+  const vehicles: VehicleRow[] = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const to = from + PAGE_SIZE - 1;
+    const { data, error } = await supabase.from("vehicles").select(VEHICLE_SELECT).eq("shop_id", shopId).range(from, to);
+    if (error) return { vehicles: [], error: error.message };
+    const page = (data ?? []) as VehicleRow[];
+    vehicles.push(...page);
+    if (page.length < PAGE_SIZE) break;
+  }
+  return { vehicles };
+}
 
+function resolveCustomerId(row: NormalizedVehicleImportRow, customers: CustomerIndexes): { customerId: string | null; warning?: string } {
+  const customerExternalId = normalizeImportLookupValue(row.customer_external_id);
   if (customerExternalId) {
-    const { customers, error } = await fetchSameShopCustomers(supabase, shopId, cache);
-    if (error) return { customerId: null, error };
-    const matches = customers.filter((customer) => normalizeImportLookupValue(customer.external_id) === customerExternalId);
+    const matches = customers.byExternalId.get(customerExternalId) ?? [];
     if (matches.length === 1) return { customerId: matches[0].id };
     if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer external ID match; vehicle imported without a customer link." };
     return { customerId: null, warning: "No matching customer found by external ID; this vehicle will import without a customer link." };
   }
 
   if (row.customer_id && isUuid(row.customer_id)) {
-    const { data: customer, error } = await supabase.from("customers").select("id").eq("shop_id", shopId).eq("id", row.customer_id.trim()).maybeSingle();
-    if (error) return { customerId: null, error: error.message };
-    if (!customer?.id) return { customerId: null, warning: "No matching customer found by ID; this vehicle will import without a customer link." };
-    return { customerId: String(customer.id) };
+    if (customers.byId.has(row.customer_id.trim())) return { customerId: row.customer_id.trim() };
+    return { customerId: null, warning: "No matching customer found by ID; this vehicle will import without a customer link." };
   }
 
   if (!row.customer_name && !row.customer_email && !row.customer_phone) return { customerId: null };
 
-  const { customers, error } = await fetchSameShopCustomers(supabase, shopId, cache);
-  if (error) return { customerId: null, error };
-  const matches = customers.filter((customer) => customerMatches(row, customer));
+  const matches = Array.from(customers.byId.values()).filter((customer) => customerMatches(row, customer));
   if (matches.length === 1) return { customerId: matches[0].id };
   if (matches.length > 1) return { customerId: null, warning: "Ambiguous customer match; vehicle imported without a customer link." };
   return { customerId: null, warning: "No matching customer found; this vehicle will import without a customer link." };
 }
 
-async function findExistingVehicle(supabase: SupabaseClient<DB>, shopId: string, row: NormalizedVehicleImportRow, options: { skipUnitNumberMatch?: boolean } = {}): Promise<{ vehicle: VehicleRow | null; matchKind?: "vin" | "external_id" | "unit_number" | "license_plate"; warning?: string; error?: string }> {
-  if (row.vin) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("vin", row.vin).limit(1).maybeSingle();
-    if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "vin" };
+function samplePush<T>(items: T[], item: T) {
+  if (items.length < SAMPLE_LIMIT) items.push(item);
+}
+
+function buildImportResponseBody(args: {
+  ok?: boolean;
+  error?: string;
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  warnings: ImportWarning[];
+  errors: ImportError[];
+  diagnostics: VehicleDiagnostic[];
+}) {
+  return {
+    ...(typeof args.ok === "boolean" ? { ok: args.ok } : {}),
+    ...(args.error ? { error: args.error } : {}),
+    created: args.created,
+    updated: args.updated,
+    skipped: args.skipped,
+    failed: args.failed,
+    counts: { created: args.created, updated: args.updated, skipped: args.skipped, failed: args.failed, warnings: args.warnings.length },
+    warnings: args.warnings,
+    errors: args.errors,
+    diagnostics: args.diagnostics,
+  };
+}
+
+function errorField(error: unknown, field: "code" | "message" | "details" | "hint"): string | null {
+  if (!error || typeof error !== "object") return null;
+  const value = (error as Record<string, unknown>)[field];
+  return typeof value === "string" && value ? value : null;
+}
+
+function errorStatus(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+  const value = (error as Record<string, unknown>).status;
+  return typeof value === "number" ? value : null;
+}
+
+function isDuplicateConflict(error: unknown): boolean {
+  return errorField(error, "code") === "23505" || /duplicate key/i.test(errorField(error, "message") ?? "");
+}
+
+function isBadPayloadError(error: unknown): boolean {
+  const status = errorStatus(error);
+  const code = errorField(error, "code") ?? "";
+  const message = errorField(error, "message") ?? "";
+  return status === 400 || code.startsWith("PGRST") || /column .* does not exist|schema cache|invalid input syntax|violates check constraint/i.test(message);
+}
+
+function buildDiagnostic(row: NormalizedVehicleImportRow, payload: VehicleInsert | VehicleUpdate, error: unknown): VehicleDiagnostic {
+  const payloadKeys = Object.keys(payload).sort();
+  return {
+    row: row.sourceRowNumber,
+    external_id: row.external_id ?? null,
+    vin: row.vin ?? null,
+    unit_number: row.unit_number ?? null,
+    plate: row.license_plate ?? null,
+    customer_external_id: row.customer_external_id ?? null,
+    code: errorField(error, "code"),
+    status: errorStatus(error),
+    message: errorField(error, "message") ?? (error instanceof Error ? error.message : "Vehicle write failed"),
+    details: errorField(error, "details"),
+    hint: errorField(error, "hint"),
+    payloadKeys,
+    containsUserId: payloadKeys.includes("user_id"),
+  };
+}
+
+async function updateExistingVehicle(supabase: SupabaseClient<DB>, shopId: string, row: NormalizedVehicleImportRow, existing: VehicleRow, customerId: string | null): Promise<{ ok: true } | { ok: false; error: unknown; diagnostic: VehicleDiagnostic }> {
+  const patch = buildVehiclePatch(row, existing, existing.customer_id ?? customerId);
+  const { error } = await supabase.from("vehicles").update(patch).eq("shop_id", shopId).eq("id", existing.id);
+  if (error) return { ok: false, error, diagnostic: buildDiagnostic(row, patch, error) };
+  return { ok: true };
+}
+
+async function findExistingVehicleOnce(supabase: SupabaseClient<DB>, shopId: string, row: NormalizedVehicleImportRow): Promise<{ vehicle: VehicleRow | null; error?: unknown }> {
+  const identities: Array<{ column: "vin" | "external_id" | "unit_number" | "license_plate"; value: string | undefined }> = [
+    { column: "vin", value: row.vin },
+    { column: "external_id", value: row.external_id },
+    { column: "unit_number", value: row.unit_number },
+    { column: "license_plate", value: row.license_plate },
+  ];
+
+  for (const identity of identities) {
+    if (!identity.value) continue;
+    const query = supabase.from("vehicles").select(VEHICLE_SELECT).eq("shop_id", shopId).limit(1);
+    const { data, error } = identity.column === "unit_number"
+      ? await query.ilike("unit_number", identity.value).maybeSingle()
+      : await query.eq(identity.column, identity.value).maybeSingle();
+    if (error) return { vehicle: null, error };
+    if (data?.id) return { vehicle: data as VehicleRow };
   }
-  if (row.external_id) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("external_id", row.external_id).limit(1).maybeSingle();
-    if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "external_id" };
-  }
-  if (row.unit_number && !options.skipUnitNumberMatch) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).ilike("unit_number", row.unit_number).limit(1).maybeSingle();
-    if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "unit_number" };
-  }
-  if (row.license_plate) {
-    const { data, error } = await supabase.from("vehicles").select("id,customer_id,vin,unit_number,license_plate,external_id,year,make,model,submodel,color,engine,engine_type,engine_family,transmission,fuel_type,drivetrain,engine_hours,mileage,import_notes,source_row_id").eq("shop_id", shopId).eq("license_plate", row.license_plate).limit(1).maybeSingle();
-    if (error) return { vehicle: null, error: error.message };
-    if (data?.id) return { vehicle: data as VehicleRow, matchKind: "license_plate", warning: "Duplicate plate matched an existing vehicle; existing vehicle selected." };
-  }
+
   return { vehicle: null };
+}
+
+function addVehicleToIndexes(indexes: VehicleIndexes, vehicle: VehicleRow) {
+  addUniqueIndexValue(indexes.byVin, vehicle.vin, vehicle);
+  addUniqueIndexValue(indexes.byExternalId, vehicle.external_id, vehicle);
+  addUniqueIndexValue(indexes.byUnitNumber, vehicle.unit_number, vehicle);
+  addUniqueIndexValue(indexes.byLicensePlate, vehicle.license_plate, vehicle);
+}
+
+async function handleDuplicateConflict(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  item: VehicleWriteItem;
+  vehicleIndexes: VehicleIndexes;
+  warnings: ImportWarning[];
+  errors: ImportError[];
+  diagnostics: VehicleDiagnostic[];
+}): Promise<"updated" | "skipped" | "failed"> {
+  const { supabase, shopId, item, vehicleIndexes, warnings, errors, diagnostics } = args;
+  const lookup = await findExistingVehicleOnce(supabase, shopId, item.row);
+  if (lookup.error) {
+    samplePush(errors, { row: item.row.sourceRowNumber, message: errorField(lookup.error, "message") ?? "Duplicate recovery lookup failed." });
+    return "failed";
+  }
+  if (!lookup.vehicle?.id) {
+    samplePush(warnings, { row: item.row.sourceRowNumber, message: "Duplicate conflict detected, but no deterministic same-shop vehicle match was found; row skipped." });
+    return "skipped";
+  }
+  if (lookup.vehicle.customer_id && item.payload.customer_id && lookup.vehicle.customer_id !== item.payload.customer_id) {
+    samplePush(warnings, { row: item.row.sourceRowNumber, message: "Duplicate conflict matched a vehicle linked to another customer; skipped to avoid silent reassignment." });
+    return "skipped";
+  }
+  if (item.row.vin && lookup.vehicle.vin && lookup.vehicle.vin !== item.row.vin) {
+    samplePush(warnings, { row: item.row.sourceRowNumber, message: "Duplicate conflict matched a vehicle with a conflicting VIN; skipped." });
+    return "skipped";
+  }
+  const result = await updateExistingVehicle(supabase, shopId, item.row, lookup.vehicle, item.payload.customer_id ?? null);
+  if (!result.ok) {
+    samplePush(errors, { row: item.row.sourceRowNumber, message: result.diagnostic.message });
+    samplePush(diagnostics, result.diagnostic);
+    return "failed";
+  }
+  addVehicleToIndexes(vehicleIndexes, lookup.vehicle);
+  samplePush(warnings, { row: item.row.sourceRowNumber, message: "Duplicate conflict recovered by updating a deterministic same-shop vehicle match." });
+  return "updated";
 }
 
 export async function POST(req: Request) {
@@ -254,89 +444,132 @@ export async function POST(req: Request) {
     const rows = normalizeRows(body?.rows).filter(hasIdentity);
     if (rows.length === 0) return NextResponse.json({ error: "No valid vehicle rows to import" }, { status: 400 });
 
+    const warnings: ImportWarning[] = [];
+    const errors: ImportError[] = [];
+    const diagnostics: VehicleDiagnostic[] = [];
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    const [{ customers, error: customersError }, { vehicles, error: vehiclesError }] = await Promise.all([
+      fetchSameShopCustomers(supabase, shopId),
+      fetchSameShopVehicles(supabase, shopId),
+    ]);
+    if (customersError) return NextResponse.json({ error: customersError }, { status: 500 });
+    if (vehiclesError) return NextResponse.json({ error: vehiclesError }, { status: 500 });
+
+    const customerIndexes = indexCustomers(customers);
+    const vehicleIndexes = indexVehicles(vehicles);
     const seenVins = new Set<string>();
     const seenExternalIds = new Set<string>();
     const seenUnits = new Set<string>();
     const seenPlates = new Set<string>();
-    const warnings: Array<{ row: number; message: string }> = [];
-    const errors: Array<{ row: number; message: string }> = [];
-    let created = 0;
-    let updated = 0;
-    let skipped = 0;
-    const customerLookupCache: CustomerLookupCache = {};
+    const inserts: VehicleWriteItem[] = [];
 
     for (const row of rows) {
-      try {
-        if (row.vin && seenVins.has(row.vin)) {
-          skipped += 1;
-          warnings.push({ row: row.sourceRowNumber, message: "Duplicate VIN in submitted import; skipped duplicate row." });
-          continue;
-        }
-        if (row.external_id && seenExternalIds.has(row.external_id.trim().toLowerCase())) {
-          skipped += 1;
-          warnings.push({ row: row.sourceRowNumber, message: "Duplicate external vehicle ID in submitted import; skipped duplicate row." });
-          continue;
-        }
-        const duplicateUnitNumberInImport = Boolean(row.unit_number && seenUnits.has(row.unit_number.trim().toLowerCase()));
-        if (duplicateUnitNumberInImport && !row.vin && !row.external_id) {
-          skipped += 1;
-          warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import and no unique VIN or external vehicle ID was provided; skipped duplicate row." });
-          continue;
-        }
-        if (duplicateUnitNumberInImport) {
-          warnings.push({ row: row.sourceRowNumber, message: "Duplicate unit number in submitted import; continuing because VIN or external vehicle ID can identify this vehicle." });
-        }
-        if (row.license_plate && seenPlates.has(row.license_plate.trim().toLowerCase())) {
-          skipped += 1;
-          warnings.push({ row: row.sourceRowNumber, message: "Duplicate license plate in submitted import; skipped duplicate row." });
-          continue;
-        }
-        if (row.vin) seenVins.add(row.vin);
-        if (row.external_id) seenExternalIds.add(row.external_id.trim().toLowerCase());
-        if (row.unit_number) seenUnits.add(row.unit_number.trim().toLowerCase());
-        if (row.license_plate) seenPlates.add(row.license_plate.trim().toLowerCase());
+      const vinKey = normalizeImportLookupValue(row.vin);
+      const externalIdKey = normalizeImportLookupValue(row.external_id);
+      const unitKey = normalizeImportLookupValue(row.unit_number);
+      const plateKey = normalizeImportLookupValue(row.license_plate);
 
-        const customer = await resolveCustomerId(supabase, shopId, row, customerLookupCache);
-        if (customer.error) {
-          errors.push({ row: row.sourceRowNumber, message: customer.error });
+      if (vinKey && seenVins.has(vinKey)) {
+        skipped += 1;
+        samplePush(warnings, { row: row.sourceRowNumber, message: "Duplicate VIN in submitted import; skipped duplicate row." });
+        continue;
+      }
+      if (externalIdKey && seenExternalIds.has(externalIdKey)) {
+        skipped += 1;
+        samplePush(warnings, { row: row.sourceRowNumber, message: "Duplicate external vehicle ID in submitted import; skipped duplicate row." });
+        continue;
+      }
+      const duplicateUnitNumberInImport = Boolean(unitKey && seenUnits.has(unitKey));
+      if (duplicateUnitNumberInImport && !vinKey && !externalIdKey) {
+        skipped += 1;
+        samplePush(warnings, { row: row.sourceRowNumber, message: "Duplicate unit number in submitted import and no unique VIN or external vehicle ID was provided; skipped duplicate row." });
+        continue;
+      }
+      if (duplicateUnitNumberInImport) samplePush(warnings, { row: row.sourceRowNumber, message: "Duplicate unit number in submitted import; continuing because VIN or external vehicle ID can identify this vehicle." });
+      if (plateKey && seenPlates.has(plateKey)) {
+        skipped += 1;
+        samplePush(warnings, { row: row.sourceRowNumber, message: "Duplicate license plate in submitted import; skipped duplicate row." });
+        continue;
+      }
+
+      if (vinKey) seenVins.add(vinKey);
+      if (externalIdKey) seenExternalIds.add(externalIdKey);
+      if (unitKey) seenUnits.add(unitKey);
+      if (plateKey) seenPlates.add(plateKey);
+
+      const customer = resolveCustomerId(row, customerIndexes);
+      if (customer.warning) samplePush(warnings, { row: row.sourceRowNumber, message: customer.warning });
+
+      const existing = findExistingVehicleFromIndexes(row, vehicleIndexes, { skipUnitNumberMatch: duplicateUnitNumberInImport && Boolean(vinKey || externalIdKey) });
+      if (existing.warning) samplePush(warnings, { row: row.sourceRowNumber, message: existing.warning });
+
+      if (existing.vehicle?.id) {
+        if (existing.vehicle.customer_id && customer.customerId && existing.vehicle.customer_id !== customer.customerId) {
+          skipped += 1;
+          samplePush(warnings, { row: row.sourceRowNumber, message: "Existing vehicle is linked to another customer; skipped to avoid silent reassignment." });
           continue;
         }
-        if (customer.warning) warnings.push({ row: row.sourceRowNumber, message: customer.warning });
-
-        const existing = await findExistingVehicle(supabase, shopId, row, { skipUnitNumberMatch: duplicateUnitNumberInImport && Boolean(row.vin || row.external_id) });
-        if (existing.error) throw new Error(existing.error);
-        if (existing.warning) warnings.push({ row: row.sourceRowNumber, message: existing.warning });
-
-        if (existing.vehicle?.id) {
-          if (existing.vehicle.customer_id && customer.customerId && existing.vehicle.customer_id !== customer.customerId) {
-            skipped += 1;
-            warnings.push({ row: row.sourceRowNumber, message: "Existing vehicle is linked to another customer; skipped to avoid silent reassignment." });
-            continue;
+        if (row.vin && existing.vehicle.vin && existing.vehicle.vin !== row.vin) {
+          skipped += 1;
+          samplePush(warnings, { row: row.sourceRowNumber, message: "Matched an existing vehicle by a weaker identity, but the imported VIN conflicts; skipped to avoid overwriting vehicle identity." });
+          continue;
+        }
+        const result = await updateExistingVehicle(supabase, shopId, row, existing.vehicle, customer.customerId);
+        if (!result.ok) {
+          failed += 1;
+          samplePush(errors, { row: row.sourceRowNumber, message: result.diagnostic.message });
+          samplePush(diagnostics, result.diagnostic);
+          if (isBadPayloadError(result.error)) {
+            return NextResponse.json(buildImportResponseBody({ error: "Vehicle update payload rejected by database schema.", created, updated, skipped, failed, warnings, errors, diagnostics }), { status: 400 });
           }
-          if (row.vin && existing.vehicle.vin && existing.vehicle.vin !== row.vin) {
-            skipped += 1;
-            warnings.push({ row: row.sourceRowNumber, message: "Matched an existing vehicle by a weaker identity, but the imported VIN conflicts; skipped to avoid overwriting vehicle identity." });
-            continue;
-          }
-          const patch = buildVehiclePatch(row, existing.vehicle, existing.vehicle.customer_id ?? customer.customerId);
-          const { error } = await supabase.from("vehicles").update(patch).eq("shop_id", shopId).eq("id", existing.vehicle.id);
-          if (error) throw new Error(error.message);
-          updated += 1;
-        } else {
-          const insert = buildVehiclePayload(row, { shopId, customerId: customer.customerId });
-          const { error } = await supabase.from("vehicles").insert(insert);
-          if (error) throw new Error(error.message);
-          created += 1;
+          continue;
         }
-      } catch (err) {
-        errors.push({ row: row.sourceRowNumber, message: err instanceof Error ? err.message : "Import failed for this row" });
+        updated += 1;
+      } else {
+        inserts.push({ row, payload: buildVehiclePayload(row, { shopId, customerId: customer.customerId }) });
       }
     }
 
-    const failed = errors.length;
-    if (created + updated === 0) return NextResponse.json({ error: "No rows were imported", counts: { created, updated, skipped, failed, warnings: warnings.length }, warnings, errors }, { status: 400 });
+    for (let index = 0; index < inserts.length; index += VEHICLE_INSERT_BATCH_SIZE) {
+      const chunk = inserts.slice(index, index + VEHICLE_INSERT_BATCH_SIZE);
+      const payloads = chunk.map((item) => item.payload);
+      const { error } = await supabase.from("vehicles").insert(payloads);
+      if (!error) {
+        created += chunk.length;
+        for (const item of chunk) {
+          addVehicleToIndexes(vehicleIndexes, { id: `imported:${item.row.sourceRowNumber}`, ...item.payload } as VehicleRow);
+        }
+        continue;
+      }
 
-    return NextResponse.json({ ok: true, counts: { created, updated, skipped, failed, warnings: warnings.length }, warnings, errors });
+      if (isDuplicateConflict(error)) {
+        for (const item of chunk) {
+          const result = await handleDuplicateConflict({ supabase, shopId, item, vehicleIndexes, warnings, errors, diagnostics });
+          if (result === "updated") updated += 1;
+          else if (result === "skipped") skipped += 1;
+          else failed += 1;
+        }
+        continue;
+      }
+
+      const diagnostic = buildDiagnostic(chunk[0].row, chunk[0].payload, error);
+      samplePush(diagnostics, diagnostic);
+      failed += 1;
+      samplePush(errors, { row: chunk[0].row.sourceRowNumber, message: diagnostic.message });
+      if (isBadPayloadError(error)) {
+        return NextResponse.json(buildImportResponseBody({ error: "Vehicle insert payload rejected by database schema.", created, updated, skipped, failed, warnings, errors, diagnostics }), { status: 400 });
+      }
+      skipped += chunk.length;
+      samplePush(warnings, { row: chunk[0].row.sourceRowNumber, message: "Vehicle insert batch failed and was skipped to prevent repeated retries." });
+    }
+
+    if (created + updated === 0) return NextResponse.json(buildImportResponseBody({ error: "No rows were imported", created, updated, skipped, failed, warnings, errors, diagnostics }), { status: 400 });
+
+    return NextResponse.json(buildImportResponseBody({ ok: true, created, updated, skipped, failed, warnings, errors, diagnostics }));
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
   }

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -20,15 +20,61 @@ type ImportCounts = {
   warnings: number;
 };
 
+type ImportDiagnostic = {
+  row?: number;
+  external_id?: string | null;
+  vin?: string | null;
+  unit_number?: string | null;
+  plate?: string | null;
+  customer_external_id?: string | null;
+  code?: string | null;
+  status?: number | null;
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+  payloadKeys?: string[];
+  containsUserId?: boolean;
+};
+
 type ImportResponse = {
   ok?: boolean;
   counts?: ImportCounts;
   warnings?: Array<{ row: number; message: string }>;
   errors?: Array<{ row: number; message: string }>;
+  diagnostics?: ImportDiagnostic[];
   error?: string;
 };
 
 const EMPTY_COUNTS: ImportCounts = { created: 0, updated: 0, skipped: 0, failed: 0, warnings: 0 };
+
+function formatImportFailure(payload: ImportResponse): string {
+  const parts = [payload.error?.trim() || "Vehicle import failed."];
+  const firstError = payload.errors?.find((item) => item.message);
+  if (firstError) parts.push(`Row ${firstError.row}: ${firstError.message}`);
+
+  const diagnostic = payload.diagnostics?.[0];
+  if (diagnostic) {
+    const identity = [
+      diagnostic.external_id ? `external_id ${diagnostic.external_id}` : null,
+      diagnostic.vin ? `VIN ${diagnostic.vin}` : null,
+      diagnostic.unit_number ? `unit ${diagnostic.unit_number}` : null,
+      diagnostic.plate ? `plate ${diagnostic.plate}` : null,
+      diagnostic.customer_external_id ? `customer ${diagnostic.customer_external_id}` : null,
+    ].filter(Boolean).join(", ");
+    const status = [diagnostic.code, diagnostic.status ? `HTTP ${diagnostic.status}` : null].filter(Boolean).join(" / ");
+    const payloadKeys = diagnostic.payloadKeys?.length ? `Payload keys: ${diagnostic.payloadKeys.join(", ")}.` : null;
+    parts.push([
+      `Diagnostic row ${diagnostic.row ?? "unknown"}${identity ? ` (${identity})` : ""}: ${diagnostic.message ?? "database rejected the vehicle payload"}`,
+      status ? `(${status})` : null,
+      diagnostic.details ? `Details: ${diagnostic.details}.` : null,
+      diagnostic.hint ? `Hint: ${diagnostic.hint}.` : null,
+      payloadKeys,
+      typeof diagnostic.containsUserId === "boolean" ? `Contains user_id: ${diagnostic.containsUserId ? "yes" : "no"}.` : null,
+    ].filter(Boolean).join(" "));
+  }
+
+  return parts.join(" ");
+}
 
 export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighted = false }: Props) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -99,7 +145,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
         body: JSON.stringify({ rows: validRows }),
       });
       const payload = (await response.json().catch(() => ({}))) as ImportResponse;
-      if (!response.ok || payload.ok === false) throw new Error(payload.error ?? "Vehicle import failed.");
+      if (!response.ok || payload.ok === false) throw new Error(formatImportFailure(payload));
       setSuccess(payload);
       clearSelectedCsvAfterSuccess();
 

--- a/tests/vehicles/vehicle-csv-import-card.test.tsx
+++ b/tests/vehicles/vehicle-csv-import-card.test.tsx
@@ -147,6 +147,42 @@ describe("VehicleCsvImportCard", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/onboarding-v2/guided/sessions/session-123/steps/vehicles/complete", expect.objectContaining({ method: "POST" })));
   });
 
+  it("shows API diagnostic samples when vehicle import fails", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({
+        error: "Vehicle insert payload rejected by database schema.",
+        errors: [{ row: 1, message: "Could not find the 'import_notes' column" }],
+        diagnostics: [{
+          row: 1,
+          external_id: "VEH-1",
+          vin: "1HGCM82633A004352",
+          unit_number: "A-1",
+          plate: "ABC123",
+          customer_external_id: "CUST-100425",
+          code: "PGRST204",
+          status: 400,
+          message: "Could not find the 'import_notes' column",
+          details: "schema cache",
+          hint: "reload schema",
+          payloadKeys: ["customer_id", "external_id", "shop_id", "unit_number", "vin"],
+          containsUserId: false,
+        }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<VehicleCsvImportCard customers={[]} />);
+
+    await userEvent.type(screen.getByLabelText(/paste csv text/i), "vehicle_id,unit,vin,plate,customer_id\nVEH-1,A-1,1HGCM82633A004352,ABC123,CUST-100425");
+    await userEvent.click(screen.getByRole("button", { name: /preview csv/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm import/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/payload rejected by database schema/i));
+    expect(screen.getByRole("alert")).toHaveTextContent(/PGRST204/);
+    expect(screen.getByRole("alert")).toHaveTextContent(/Payload keys: customer_id, external_id, shop_id, unit_number, vin/);
+    expect(screen.getByRole("alert")).toHaveTextContent(/Contains user_id: no/);
+  });
+
   it("does not call guided completion on failed import or cancel", async () => {
     const fetchMock = vi.fn(async () => ({ ok: false, json: async () => ({ error: "failed" }) }));
     vi.stubGlobal("fetch", fetchMock);

--- a/tests/vehicles/vehicle-import-route.test.ts
+++ b/tests/vehicles/vehicle-import-route.test.ts
@@ -10,6 +10,11 @@ const { mockSupabaseState } = vi.hoisted(() => ({
     inserts: [] as Array<Record<string, unknown>>,
     updates: [] as Array<{ payload: Record<string, unknown>; filters: Record<string, unknown> }>,
     customerRanges: [] as Array<{ from: number; to: number; shopId: unknown }>,
+    vehicleRanges: [] as Array<{ from: number; to: number; shopId: unknown }>,
+    insertErrors: [] as Array<Record<string, unknown>>,
+    insertCallCount: 0,
+    duplicateLookupCount: 0,
+    duplicateRecoveryVehicles: [] as Array<Record<string, unknown>>,
   },
 }));
 
@@ -42,6 +47,10 @@ function makeQuery(table: string): MockQuery {
         mockSupabaseState.customerRanges.push({ from, to, shopId: query.filters.shop_id });
         return Promise.resolve({ data: mockSupabaseState.customers.filter((row) => row.shop_id === query.filters.shop_id).slice(from, to + 1), error: null });
       }
+      if (table === "vehicles" && query.filters.shop_id) {
+        mockSupabaseState.vehicleRanges.push({ from, to, shopId: query.filters.shop_id });
+        return Promise.resolve({ data: mockSupabaseState.vehicles.filter((row) => row.shop_id === query.filters.shop_id).slice(from, to + 1), error: null });
+      }
       return query;
     }),
     maybeSingle: vi.fn(async () => {
@@ -51,7 +60,9 @@ function makeQuery(table: string): MockQuery {
         return { data: found ?? null, error: null };
       }
       if (table === "vehicles") {
-        const found = mockSupabaseState.vehicles.find((row) => {
+        mockSupabaseState.duplicateLookupCount += 1;
+        const lookupRows = [...mockSupabaseState.vehicles, ...mockSupabaseState.duplicateRecoveryVehicles];
+        const found = lookupRows.find((row) => {
           if (row.shop_id !== query.filters.shop_id) return false;
           if (query.filters.vin) return row.vin === query.filters.vin;
           if (query.filters.external_id) return row.external_id === query.filters.external_id;
@@ -63,9 +74,12 @@ function makeQuery(table: string): MockQuery {
       }
       return { data: null, error: null };
     }),
-    insert: vi.fn(async (payload: Record<string, unknown>) => {
-      mockSupabaseState.inserts.push(payload);
-      mockSupabaseState.vehicles.push({ id: `vehicle-${mockSupabaseState.vehicles.length + 1}`, ...payload });
+    insert: vi.fn(async (payload: Record<string, unknown> | Array<Record<string, unknown>>) => {
+      mockSupabaseState.insertCallCount += 1;
+      if (mockSupabaseState.insertErrors.length > 0) return { error: mockSupabaseState.insertErrors.shift() ?? null };
+      const rows = Array.isArray(payload) ? payload : [payload];
+      mockSupabaseState.inserts.push(...rows);
+      mockSupabaseState.vehicles.push(...rows.map((row) => ({ id: `vehicle-${mockSupabaseState.vehicles.length + 1}`, ...row })));
       return { error: null };
     }),
     update: vi.fn((payload: Record<string, unknown>) => {
@@ -105,6 +119,11 @@ describe("POST /api/vehicles/import", () => {
     mockSupabaseState.inserts = [];
     mockSupabaseState.updates = [];
     mockSupabaseState.customerRanges = [];
+    mockSupabaseState.vehicleRanges = [];
+    mockSupabaseState.insertErrors = [];
+    mockSupabaseState.insertCallCount = 0;
+    mockSupabaseState.duplicateLookupCount = 0;
+    mockSupabaseState.duplicateRecoveryVehicles = [];
   });
 
   it("rejects unauthenticated import", async () => {
@@ -338,4 +357,83 @@ describe("POST /api/vehicles/import", () => {
     expect(mockSupabaseState.inserts).toHaveLength(2);
     expect(payload.warnings[0].message).toMatch(/continuing because VIN or external vehicle ID/i);
   });
+  it("large import prefetches customers and vehicles instead of per-row lookups", async () => {
+    mockSupabaseState.customers = Array.from({ length: 1001 }, (_, index) => ({
+      id: `customer-${index}`,
+      shop_id: "shop-real",
+      external_id: `CUST-${index}`,
+    }));
+    mockSupabaseState.vehicles = Array.from({ length: 1001 }, (_, index) => ({
+      id: `existing-${index}`,
+      shop_id: "shop-real",
+      vin: `EXISTINGVIN${index}`,
+    }));
+    const rows = Array.from({ length: 2600 }, (_, index) => ({ unit_number: `UNIT-${index}`, customer_id: `CUST-${index % 1001}` }));
+
+    const response = await POST(request(rows));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts.created).toBe(2600);
+    expect(mockSupabaseState.customerRanges).toEqual([
+      { from: 0, to: 999, shopId: "shop-real" },
+      { from: 1000, to: 1999, shopId: "shop-real" },
+    ]);
+    expect(mockSupabaseState.vehicleRanges).toEqual([
+      { from: 0, to: 999, shopId: "shop-real" },
+      { from: 1000, to: 1999, shopId: "shop-real" },
+    ]);
+    expect(mockSupabaseState.duplicateLookupCount).toBe(0);
+    expect(mockSupabaseState.insertCallCount).toBe(26);
+  });
+
+  it("PostgREST 400 insert error is not retried and returns a safe diagnostic", async () => {
+    mockSupabaseState.insertErrors = [{ code: "PGRST204", status: 400, message: "Could not find the 'import_notes' column", details: "schema cache", hint: "reload schema" }];
+
+    const response = await POST(request([{ unit_number: "A-1", vin: "1HGCM82633A004352", user_id: "csv-user" }]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(mockSupabaseState.insertCallCount).toBe(1);
+    expect(payload.error).toMatch(/payload rejected/i);
+    expect(payload.diagnostics[0]).toMatchObject({
+      row: 1,
+      vin: "1HGCM82633A004352",
+      unit_number: "A-1",
+      code: "PGRST204",
+      status: 400,
+      containsUserId: false,
+    });
+    expect(payload.diagnostics[0].payloadKeys).toContain("shop_id");
+    expect(payload.diagnostics[0].payloadKeys).not.toContain("user_id");
+    expect(JSON.stringify(payload.diagnostics[0])).not.toContain("csv-user");
+  });
+
+  it("duplicate conflict recovery re-queries a deterministic same-shop vehicle once", async () => {
+    mockSupabaseState.insertErrors = [{ code: "23505", status: 409, message: "duplicate key value violates unique constraint" }];
+    mockSupabaseState.duplicateRecoveryVehicles = [{ id: "vehicle-existing", shop_id: "shop-real", vin: "1HGCM82633A004352" }];
+
+    const response = await POST(request([{ vin: "1HGCM82633A004352", make: "Honda" }]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.counts).toMatchObject({ created: 0, updated: 1 });
+    expect(mockSupabaseState.insertCallCount).toBe(1);
+    expect(mockSupabaseState.duplicateLookupCount).toBe(1);
+    expect(mockSupabaseState.updates[0].filters).toMatchObject({ shop_id: "shop-real", id: "vehicle-existing" });
+  });
+
+  it("returns promptly on schema rejection instead of attempting later batches", async () => {
+    mockSupabaseState.insertErrors = [{ code: "PGRST204", status: 400, message: "unknown vehicle column" }];
+    const rows = Array.from({ length: 250 }, (_, index) => ({ unit_number: `UNIT-${index}` }));
+
+    const response = await POST(request(rows));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(mockSupabaseState.insertCallCount).toBe(1);
+    expect(payload.counts.created).toBe(0);
+    expect(payload.diagnostics[0].payloadKeys).toContain("unit_number");
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Large vehicle CSV imports were timing out and repeatedly hitting PostgREST 400 errors due to per-row writes and blind retries, causing 504s on Vercel.  
- We need fail-fast diagnostics for schema/payload issues, ensure payloads are shop-scoped and omit `user_id`, and make large imports efficient and non-retrying on non-recoverable errors.  

### Description
- Implemented paginated prefetch of same-shop customers and vehicles and built in-memory indexes to match by `vin`, `external_id`, `unit_number`, then `license_plate`, deduping the CSV up-front to avoid per-row lookups and excessive queries.  
- Batched vehicle writes with a bounded `VEHICLE_INSERT_BATCH_SIZE`, added deterministic duplicate-conflict recovery that re-queries the same-shop vehicle only once, and skipped non-deterministic conflicts to avoid repeated retries.  
- Added safe PostgREST diagnostics for insert/update failures that include `code`, `status`, `message`, `details`, `hint`, `payloadKeys` (no payload values), row identity (`row`, `external_id`, `vin`, `unit_number`, `plate`, `customer_external_id`) and `containsUserId` flag; 400/schema errors now fail fast and return a diagnostic sample.  
- Ensured every write payload uses the authenticated profile `shop_id` and explicitly omits `user_id`; CSV `shop_id`/`user_id` are ignored and CSV `customer_id` values are treated as same-shop `customer.external_id` when appropriate.  
- Surface diagnostics in the UI: `VehicleCsvImportCard` now formats API diagnostics into a clear failure message instead of a generic "Vehicle import failed."  
- Key files changed: `app/api/vehicles/import/route.ts`, `features/vehicles/components/VehicleCsvImportCard.tsx`, and tests under `tests/vehicles/*` to cover batching, diagnostics, and UI display.  

### Testing
- Ran targeted unit tests with `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` and all tests passed (`60 passed`).  
- Type-checking completed with `npx tsc --noEmit` with no errors.  
- Ran `git diff --check` and ensured staged changes are clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ee405c0483288d313b2aa8f530ad)