### PR TITLE
Fix vehicle CSV source_row_id handling

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -89,6 +89,7 @@ function normalizeRows(input: unknown): NormalizedVehicleImportRow[] {
     return {
       sourceRowNumber: numberValue(row.sourceRowNumber) ?? index + 1,
       sourceFilename: cleanVehicleImportText(row.sourceFilename),
+      source_row_id: cleanVehicleImportText(row.source_row_id) ?? cleanVehicleImportText(row.sourceRowId),
       external_id: cleanVehicleImportText(row.external_id) ?? cleanVehicleImportText(row.vehicle_id) ?? cleanVehicleImportText(row.vehicleid),
       unit_number: cleanVehicleImportText(row.unit_number) ?? cleanVehicleImportText(row.unit) ?? cleanVehicleImportText(row.fleet_number),
       vin: normalizeImportVin(row.vin),
@@ -129,9 +130,19 @@ function buildImportNotes(row: NormalizedVehicleImportRow): string | null {
   return notes || null;
 }
 
+function normalizedSourceRowId(row: NormalizedVehicleImportRow): string | undefined {
+  const sourceRowId = row.source_row_id?.trim();
+  return sourceRowId && isUuid(sourceRowId) ? sourceRowId : undefined;
+}
+
+function sourceRowIdWarning(row: NormalizedVehicleImportRow): ImportWarning | null {
+  if (!row.source_row_id || isUuid(row.source_row_id)) return null;
+  return { row: row.sourceRowNumber, message: "Invalid source_row_id was omitted because vehicles.source_row_id only accepts UUID source row references." };
+}
+
 function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: string; customerId: string | null }): VehicleInsert {
   const notes = buildImportNotes(row);
-  return {
+  const payload: VehicleInsert = {
     shop_id: args.shopId,
     customer_id: args.customerId,
     external_id: row.external_id ?? null,
@@ -152,8 +163,10 @@ function buildVehiclePayload(row: NormalizedVehicleImportRow, args: { shopId: st
     engine_hours: row.engine_hours ?? null,
     mileage: row.odometer ?? null,
     import_notes: notes,
-    source_row_id: String(row.sourceRowNumber),
-  } satisfies VehicleInsert;
+  };
+  const sourceRowId = normalizedSourceRowId(row);
+  if (sourceRowId) payload.source_row_id = sourceRowId;
+  return payload;
 }
 
 function setMeaningfulString(patch: VehicleUpdate, key: keyof VehicleUpdate, value: string | undefined) {
@@ -185,7 +198,7 @@ function buildVehiclePatch(row: NormalizedVehicleImportRow, existing: VehicleRow
   setMeaningfulNumber(patch, "engine_hours", row.engine_hours);
   setMeaningfulString(patch, "mileage", row.odometer);
   setMeaningfulString(patch, "import_notes", buildImportNotes(row) ?? undefined);
-  patch.source_row_id = String(row.sourceRowNumber);
+  setMeaningfulString(patch, "source_row_id", normalizedSourceRowId(row));
   return patch;
 }
 
@@ -468,6 +481,9 @@ export async function POST(req: Request) {
     const inserts: VehicleWriteItem[] = [];
 
     for (const row of rows) {
+      const sourceWarning = sourceRowIdWarning(row);
+      if (sourceWarning) samplePush(warnings, sourceWarning);
+
       const vinKey = normalizeImportLookupValue(row.vin);
       const externalIdKey = normalizeImportLookupValue(row.external_id);
       const unitKey = normalizeImportLookupValue(row.unit_number);

--- a/features/vehicles/lib/importCsv.ts
+++ b/features/vehicles/lib/importCsv.ts
@@ -15,6 +15,7 @@ export type VehicleImportCustomerOption = {
 export type VehicleImportRow = {
   sourceRowNumber: number;
   sourceFilename?: string;
+  source_row_id?: string;
   external_id?: string;
   unit_number?: string;
   vin?: string;
@@ -63,6 +64,8 @@ const HEADER_ALIASES: Record<string, keyof VehicleImportRow> = {
   vehicle_id: "external_id",
   externalid: "external_id",
   external_id: "external_id",
+  sourcerowid: "source_row_id",
+  source_row_id: "source_row_id",
   unitnumber: "unit_number",
   unit: "unit_number",
   unitno: "unit_number",

--- a/tests/vehicles/vehicle-import-route.test.ts
+++ b/tests/vehicles/vehicle-import-route.test.ts
@@ -180,6 +180,58 @@ describe("POST /api/vehicles/import", () => {
     expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
   });
 
+  it("omits CSV row numbers from source_row_id and keeps the row number in import notes", async () => {
+    const response = await POST(request([{ sourceRowNumber: 2, external_id: "VEH-200000", unit: "TRK-957", plate: "C-240-T", customer_id: "CUST-100425" }]));
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("source_row_id");
+    expect(String(mockSupabaseState.inserts[0].import_notes)).toContain("Vehicle CSV import row 2");
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("user_id");
+  });
+
+  it("omits and warns for invalid source_row_id CSV values instead of posting them", async () => {
+    const response = await POST(request([{ sourceRowNumber: 2, unit_number: "A-1", source_row_id: "2" }]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0]).not.toHaveProperty("source_row_id");
+    expect(String(mockSupabaseState.inserts[0].import_notes)).toContain("Vehicle CSV import row 2");
+    expect(payload.warnings).toContainEqual(expect.objectContaining({ row: 2, message: expect.stringMatching(/Invalid source_row_id was omitted/i) }));
+  });
+
+  it("includes valid UUID source_row_id CSV values as source row references", async () => {
+    const sourceRowId = "11111111-1111-4111-8111-111111111111";
+    const response = await POST(request([{ unit_number: "A-1", source_row_id: sourceRowId }]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockSupabaseState.inserts[0].source_row_id).toBe(sourceRowId);
+    expect(payload.warnings).toEqual([]);
+  });
+
+  it("400 schema diagnostics keep payload keys and report containsUserId false without source_row_id for normal CSV rows", async () => {
+    mockSupabaseState.insertErrors = [{ code: "22P02", status: 400, message: 'invalid input syntax for type uuid: "2"' }];
+
+    const response = await POST(request([{ sourceRowNumber: 2, external_id: "VEH-200000", unit: "TRK-957", plate: "C-240-T", customer_id: "CUST-100425", user_id: "csv-user" }]));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toMatch(/Vehicle insert payload rejected by database schema/i);
+    expect(payload.diagnostics[0]).toMatchObject({
+      row: 2,
+      external_id: "VEH-200000",
+      unit_number: "TRK-957",
+      plate: "C-240-T",
+      customer_external_id: "CUST-100425",
+      status: 400,
+      containsUserId: false,
+    });
+    expect(payload.diagnostics[0].payloadKeys).toContain("shop_id");
+    expect(payload.diagnostics[0].payloadKeys).not.toContain("source_row_id");
+    expect(payload.diagnostics[0].payloadKeys).not.toContain("user_id");
+    expect(JSON.stringify(payload.diagnostics[0])).not.toContain("csv-user");
+  });
+
   it("resolves customer_external_id in the authenticated shop before customer fallback", async () => {
     mockSupabaseState.customers = [
       { id: "other-customer", shop_id: "other-shop", external_id: "cust-legacy", email: "fleet@example.com", name: "Fleet Co" },


### PR DESCRIPTION
### Motivation
- Production imports failed because CSV row numbers (e.g. "2") were being written into `vehicles.source_row_id` which is a UUID column, causing Postgres to reject inserts with `invalid input syntax for type uuid`.
- The import flow should preserve CSV row numbers for diagnostics and `import_notes` but must not write them into the DB `source_row_id` unless a true UUID is provided.
- Keep existing customer linking by same-shop `customers.external_id`, omit `user_id`, and continue using the authenticated `profile.shop_id` as before.

### Description
- Read an explicit CSV/body `source_row_id` into the normalized row but stop mapping the CSV row number into `source_row_id`; CSV row numbers remain in `sourceRowNumber` and are retained in `import_notes` only (`app/api/vehicles/import/route.ts`).
- Add `normalizedSourceRowId` which returns a value only when `isUuid(value) === true`, and only set `payload.source_row_id` when this validation passes; otherwise omit it and emit a warning (`app/api/vehicles/import/route.ts`).
- Stop setting `source_row_id = String(row.sourceRowNumber)` for inserts and updates, and instead use `setMeaningfulString(patch, "source_row_id", normalizedSourceRowId(row))` for updates so invalid values are not written (`app/api/vehicles/import/route.ts`).
- Introduce a small warning when the CSV contains a `source_row_id` column with a non-UUID value to avoid failing the whole import (`app/api/vehicles/import/route.ts`).
- Accept an explicit `source_row_id` CSV header (and alias `sourcerowid`) in the CSV parser but treat it as a potential UUID reference rather than the CSV-generated row number (`features/vehicles/lib/importCsv.ts`).
- Add/expand tests covering: omission of CSV row numbers from `source_row_id`, retention of CSV row number in `import_notes`, warnings for invalid `source_row_id`, acceptance of valid UUID `source_row_id`, diagnostic payload keys (no `source_row_id` present for normal CSV rows), continued omission of `user_id`, and preserved customer external-ID linking (`tests/vehicles/vehicle-import-route.test.ts`).

### Testing
- Ran the vehicle import route unit tests and UIs with `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` and all tests passed. 
- Verified TypeScript correctness with `npx tsc --noEmit`, which completed successfully. 
- Confirmed no diff-check issues with `git diff --check`, which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f6262d308328b13b483b2f1980d7)