### PR TITLE
Fix vehicle directory listing and search

### DIFF
--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { Database } from "@shared/types/types/supabase";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
@@ -7,9 +6,12 @@ import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/quer
 import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
 import { VehicleCreateForm } from "@/features/vehicles/components/VehicleCreateForm";
 import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
-import { formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
-import { filterSortAndCapVehicles, vehicleCustomerName, type VehicleListRow } from "@/features/vehicles/lib/list";
+import { fetchVehicleDirectoryRows } from "@/features/vehicles/lib/list";
 import { fetchVehicleImportCustomers } from "@/features/vehicles/lib/importCustomers";
+import { VehicleDirectory } from "@/features/vehicles/components/VehicleDirectory";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 type DB = Database;
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
@@ -38,15 +40,11 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
   if (!actor.user?.id) redirect(`/sign-in?redirect=${encodeURIComponent("/vehicles")}`);
   if (!actor.shopId) redirect("/account/shop-assignment-required");
 
-  const [{ data: vehicleRows, error: vehicleError }, importCustomers] = await Promise.all([
-    supabase
-      .from("vehicles")
-      .select("id, external_id, unit_number, year, make, model, submodel, vin, license_plate, customer_id, mileage, engine_hours, engine, fuel_type, import_notes, source_row_id, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)")
-      .eq("shop_id", actor.shopId),
+  const [{ rows: vehicles, error: vehicleError }, importCustomers] = await Promise.all([
+    fetchVehicleDirectoryRows(supabase, actor.shopId),
     fetchVehicleImportCustomers(supabase, actor.shopId),
   ]);
 
-  const vehicles = filterSortAndCapVehicles(((vehicleRows ?? []) as unknown as VehicleListRow[]).map((row) => ({ ...row, customers: Array.isArray(row.customers) ? row.customers[0] ?? null : row.customers })), query);
   const customers = importCustomers as CustomerOption[];
 
   return (
@@ -66,62 +64,7 @@ export default async function VehiclesPage({ searchParams }: { searchParams?: Pr
 
       <VehicleCreateForm customers={customers} />
 
-      <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[0_18px_45px_rgba(0,0,0,0.45)]">
-        <form className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-white">Vehicle directory</h2>
-            <p className="mt-1 text-sm text-neutral-400">Showing current-shop vehicles only.</p>
-          </div>
-          <input name="q" defaultValue={query} placeholder="Search VIN, plate, unit, YMM, customer, external ID…" className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)] sm:max-w-md" />
-        </form>
-
-        {vehicleError ? <div className="mt-4 rounded-xl border border-red-500/30 bg-red-950/25 p-3 text-sm text-red-100">Unable to load vehicles right now.</div> : null}
-
-        {!vehicleError && vehicles.length === 0 ? (
-          <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-black/20 p-8 text-center">
-            <h3 className="text-xl font-semibold text-white">No vehicles yet</h3>
-            <p className="mx-auto mt-2 max-w-xl text-sm text-neutral-400">Add your first vehicle/unit here, or keep managing vehicles from customer files while this dedicated directory grows.</p>
-            <a href="#add-vehicle" className="mt-5 inline-flex rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50">Add a vehicle/unit</a>
-          </div>
-        ) : null}
-
-        {vehicles.length > 0 ? (
-          <div className="mt-4 grid gap-3">
-            {vehicles.map((vehicle) => {
-              const name = vehicleCustomerName(vehicle.customers);
-              return (
-                <article key={vehicle.id} className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
-                  <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="min-w-0">
-                      <div className="text-xs font-semibold uppercase tracking-[0.16em] text-orange-200/80">{formatVehicleIdentifier(vehicle)}</div>
-                      <h3 className="mt-1 truncate text-lg font-semibold text-white">{formatVehicleYearMakeModel(vehicle)}</h3>
-                      <p className="mt-1 text-sm text-neutral-400">{name ? `Linked to ${name}` : "No customer linked"}</p>
-                    </div>
-                    {vehicle.customer_id && name ? <Link href={`/customers/${encodeURIComponent(vehicle.customer_id)}`} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-3 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Open customer file</Link> : null}
-                  </div>
-                  <dl className="mt-4 grid gap-2 md:grid-cols-4">
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">External ID</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.external_id) ?? "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Unit</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.unit_number) ?? "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">VIN</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.vin) ?? "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Plate</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.license_plate) ?? "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Mileage</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.mileage) ?? "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine hours</dt><dd className="mt-1 truncate text-sm font-medium text-white">{vehicle.engine_hours ?? "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine / fuel</dt><dd className="mt-1 truncate text-sm font-medium text-white">{[vehicle.engine, vehicle.fuel_type].map(normalizeVehicleText).filter(Boolean).join(" · ") || "—"}</dd></div>
-                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer</dt><dd className="mt-1 truncate text-sm font-medium text-white">{name ?? "No customer linked"}</dd></div>
-                  </dl>
-                  {(vehicle.import_notes || vehicle.source_row_id || vehicle.submodel) ? (
-                    <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-neutral-400">
-                      {vehicle.submodel ? <span className="rounded-full border border-white/10 bg-black/20 px-2 py-1">Trim: {vehicle.submodel}</span> : null}
-                      {vehicle.source_row_id ? <span className="rounded-full border border-white/10 bg-black/20 px-2 py-1">Source row: {vehicle.source_row_id}</span> : null}
-                      {vehicle.import_notes ? <span className="max-w-full truncate rounded-full border border-white/10 bg-black/20 px-2 py-1">Import notes: {vehicle.import_notes}</span> : null}
-                    </div>
-                  ) : null}
-                </article>
-              );
-            })}
-          </div>
-        ) : null}
-      </section>
+      <VehicleDirectory vehicles={vehicles} vehicleError={vehicleError ? "Unable to load vehicles right now." : null} initialQuery={query} />
     </main>
   );
 }

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import { previewVehicleCsv, type VehicleImportCustomerOption, type VehicleImportPreview } from "@/features/vehicles/lib/importCsv";
@@ -77,6 +78,7 @@ function formatImportFailure(payload: ImportResponse): string {
 }
 
 export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighted = false }: Props) {
+  const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [csvText, setCsvText] = useState("");
   const [fileName, setFileName] = useState<string | undefined>();
@@ -148,6 +150,7 @@ export function VehicleCsvImportCard({ customers, guidedQuery = null, highlighte
       if (!response.ok || payload.ok === false) throw new Error(formatImportFailure(payload));
       setSuccess(payload);
       clearSelectedCsvAfterSuccess();
+      router.refresh();
 
       if (guidedQuery) {
         const completeResponse = await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/complete`, {

--- a/features/vehicles/components/VehicleDirectory.tsx
+++ b/features/vehicles/components/VehicleDirectory.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
+import { filterSortAndCapVehicles, vehicleCustomerName, type VehicleListRow } from "@/features/vehicles/lib/list";
+
+type Props = {
+  vehicles: VehicleListRow[];
+  vehicleError?: string | null;
+  initialQuery?: string;
+};
+
+export function VehicleDirectory({ vehicles: sourceVehicles, vehicleError = null, initialQuery = "" }: Props) {
+  const [query, setQuery] = useState(initialQuery);
+  const vehicles = useMemo(() => filterSortAndCapVehicles(sourceVehicles, query), [sourceVehicles, query]);
+
+  return (
+    <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[0_18px_45px_rgba(0,0,0,0.45)]">
+      <form className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between" onSubmit={(event) => event.preventDefault()}>
+        <div>
+          <h2 className="text-lg font-semibold text-white">Vehicle directory</h2>
+          <p className="mt-1 text-sm text-neutral-400">Showing current-shop vehicles only.</p>
+        </div>
+        <input
+          name="q"
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Search VIN, plate, unit, YMM, customer, external ID…"
+          className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-black/25 px-3 py-2 text-sm text-white outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)] sm:max-w-md"
+        />
+      </form>
+
+      {vehicleError ? <div className="mt-4 rounded-xl border border-red-500/30 bg-red-950/25 p-3 text-sm text-red-100">Unable to load vehicles right now.</div> : null}
+
+      {!vehicleError && vehicles.length === 0 ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--desktop-border)] bg-black/20 p-8 text-center">
+          <h3 className="text-xl font-semibold text-white">No vehicles yet</h3>
+          <p className="mx-auto mt-2 max-w-xl text-sm text-neutral-400">Add your first vehicle/unit here, or keep managing vehicles from customer files while this dedicated directory grows.</p>
+          <a href="#add-vehicle" className="mt-5 inline-flex rounded-xl border border-[var(--accent-copper-soft)]/60 bg-[linear-gradient(135deg,rgba(197,122,74,0.28),rgba(197,122,74,0.16))] px-4 py-2 text-sm font-semibold text-orange-50">Add a vehicle/unit</a>
+        </div>
+      ) : null}
+
+      {vehicles.length > 0 ? (
+        <div className="mt-4 grid gap-3">
+          {vehicles.map((vehicle) => {
+            const name = vehicleCustomerName(vehicle.customers);
+            const customerExternalId = normalizeVehicleText(vehicle.customers?.external_id);
+            return (
+              <article key={vehicle.id} className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="text-xs font-semibold uppercase tracking-[0.16em] text-orange-200/80">{formatVehicleIdentifier(vehicle)}</div>
+                    <h3 className="mt-1 truncate text-lg font-semibold text-white">{formatVehicleYearMakeModel(vehicle)}</h3>
+                    <p className="mt-1 text-sm text-neutral-400">{name ? `Linked to ${name}${customerExternalId ? ` (${customerExternalId})` : ""}` : "No customer linked"}</p>
+                  </div>
+                  {vehicle.customer_id && name ? <Link href={`/customers/${encodeURIComponent(vehicle.customer_id)}`} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-3 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Open customer file</Link> : null}
+                </div>
+                <dl className="mt-4 grid gap-2 md:grid-cols-4">
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">External ID</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.external_id) ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Unit</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.unit_number) ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">VIN</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.vin) ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Plate</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.license_plate) ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer</dt><dd className="mt-1 truncate text-sm font-medium text-white">{name ?? "No customer linked"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer external ID</dt><dd className="mt-1 truncate text-sm font-medium text-white">{customerExternalId ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Mileage</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.mileage) ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine hours</dt><dd className="mt-1 truncate text-sm font-medium text-white">{vehicle.engine_hours ?? "—"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3 md:col-span-2"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Year / make / model / submodel</dt><dd className="mt-1 truncate text-sm font-medium text-white">{formatVehicleYearMakeModel(vehicle)}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3 md:col-span-2"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine / fuel</dt><dd className="mt-1 truncate text-sm font-medium text-white">{[vehicle.engine, vehicle.fuel_type].map(normalizeVehicleText).filter(Boolean).join(" · ") || "—"}</dd></div>
+                </dl>
+                {(vehicle.import_notes || vehicle.source_row_id) ? (
+                  <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-neutral-400">
+                    {vehicle.source_row_id ? <span className="rounded-full border border-white/10 bg-black/20 px-2 py-1">Source row: {vehicle.source_row_id}</span> : null}
+                    {vehicle.import_notes ? <span className="max-w-full truncate rounded-full border border-white/10 bg-black/20 px-2 py-1">Import notes: {vehicle.import_notes}</span> : null}
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/vehicles/lib/display.ts
+++ b/features/vehicles/lib/display.ts
@@ -2,7 +2,7 @@ import type { Database } from "@shared/types/types/supabase";
 
 type VehicleLike = Pick<
   Database["public"]["Tables"]["vehicles"]["Row"],
-  "year" | "make" | "model" | "vin" | "license_plate" | "unit_number"
+  "year" | "make" | "model" | "submodel" | "vin" | "license_plate" | "unit_number"
 >;
 
 export function normalizeVehicleText(value: string | number | null | undefined): string | null {
@@ -15,8 +15,8 @@ export function normalizeVehicleIdentifier(value: string | null | undefined): st
   return normalizeVehicleText(value)?.toUpperCase() ?? null;
 }
 
-export function formatVehicleYearMakeModel(vehicle: Pick<VehicleLike, "year" | "make" | "model">): string {
-  return [vehicle.year != null ? String(vehicle.year) : null, vehicle.make, vehicle.model]
+export function formatVehicleYearMakeModel(vehicle: Pick<VehicleLike, "year" | "make" | "model"> & Partial<Pick<VehicleLike, "submodel">>): string {
+  return [vehicle.year != null ? String(vehicle.year) : null, vehicle.make, vehicle.model, vehicle.submodel]
     .map((part) => normalizeVehicleText(part))
     .filter(Boolean)
     .join(" ") || "Vehicle";

--- a/features/vehicles/lib/list.ts
+++ b/features/vehicles/lib/list.ts
@@ -5,7 +5,7 @@ type Vehicle = Database["public"]["Tables"]["vehicles"]["Row"];
 type Customer = Database["public"]["Tables"]["customers"]["Row"];
 
 export type VehicleListRow = Pick<Vehicle, "id" | "external_id" | "unit_number" | "year" | "make" | "model" | "submodel" | "vin" | "license_plate" | "customer_id" | "mileage" | "engine_hours" | "engine" | "fuel_type" | "import_notes" | "source_row_id"> & {
-  customers?: Pick<Customer, "id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null;
+  customers?: Pick<Customer, "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null;
 };
 
 export function vehicleCustomerName(customer: VehicleListRow["customers"]): string | null {
@@ -30,6 +30,7 @@ function searchText(row: VehicleListRow): string {
     row.make,
     row.model,
     vehicleCustomerName(row.customers),
+    row.customers?.external_id,
     row.external_id,
     formatVehicleDisplayLabel(row),
   ]
@@ -54,4 +55,64 @@ export function filterSortAndCapVehicles(rows: VehicleListRow[], query: string, 
       return a.id.localeCompare(b.id);
     })
     .slice(0, limit);
+}
+
+const VEHICLE_DIRECTORY_PAGE_SIZE = 1000;
+const VEHICLE_DIRECTORY_SELECT = "id, external_id, unit_number, year, make, model, submodel, vin, license_plate, customer_id, mileage, engine_hours, engine, fuel_type, import_notes, source_row_id";
+const VEHICLE_DIRECTORY_CUSTOMER_SELECT = "id, external_id, business_name, name, first_name, last_name, email, phone, phone_number";
+
+type VehicleDirectoryClient = {
+  from: (table: string) => any;
+};
+
+async function fetchPagedRows<T>(baseQuery: any): Promise<{ rows: T[]; error: unknown | null }> {
+  const rows: T[] = [];
+  for (let from = 0; ; from += VEHICLE_DIRECTORY_PAGE_SIZE) {
+    const to = from + VEHICLE_DIRECTORY_PAGE_SIZE - 1;
+    const { data, error } = await baseQuery.range(from, to);
+    if (error) return { rows, error };
+    const page = (data ?? []) as T[];
+    rows.push(...page);
+    if (page.length < VEHICLE_DIRECTORY_PAGE_SIZE) return { rows, error: null };
+  }
+}
+
+function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value))));
+}
+
+export async function fetchVehicleDirectoryRows(supabase: VehicleDirectoryClient, shopId: string): Promise<{ rows: VehicleListRow[]; error: unknown | null }> {
+  const vehiclesResult = await fetchPagedRows<Omit<VehicleListRow, "customers">>(
+    supabase
+      .from("vehicles")
+      .select(VEHICLE_DIRECTORY_SELECT)
+      .eq("shop_id", shopId)
+      .order("unit_number", { ascending: true, nullsFirst: false })
+      .order("make", { ascending: true, nullsFirst: false })
+      .order("model", { ascending: true, nullsFirst: false })
+      .order("external_id", { ascending: true, nullsFirst: false }),
+  );
+
+  const vehicles = vehiclesResult.rows;
+  const customerIds = uniqueNonEmpty(vehicles.map((row) => row.customer_id));
+  const customersById = new Map<string, VehicleListRow["customers"]>();
+
+  for (let index = 0; index < customerIds.length; index += VEHICLE_DIRECTORY_PAGE_SIZE) {
+    const ids = customerIds.slice(index, index + VEHICLE_DIRECTORY_PAGE_SIZE);
+    const { data, error } = await supabase
+      .from("customers")
+      .select(VEHICLE_DIRECTORY_CUSTOMER_SELECT)
+      .eq("shop_id", shopId)
+      .in("id", ids);
+
+    if (error) continue;
+    for (const customer of (data ?? []) as NonNullable<VehicleListRow["customers"]>[]) {
+      customersById.set(customer.id, customer);
+    }
+  }
+
+  return {
+    rows: vehicles.map((row) => ({ ...row, customers: row.customer_id ? customersById.get(row.customer_id) ?? null : null })),
+    error: vehiclesResult.error,
+  };
 }

--- a/tests/vehicles/vehicle-csv-import-card.test.tsx
+++ b/tests/vehicles/vehicle-csv-import-card.test.tsx
@@ -6,6 +6,12 @@ import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvI
 import { parseVehicleCsv } from "@/features/vehicles/lib/importCsv";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
+const router = { refresh: vi.fn() };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
 const guidedQuery: GuidedOnboardingQuery = {
   onboardingSession: "session-123",
   onboardingStep: "vehicles",
@@ -25,6 +31,7 @@ function onboardingOk() {
 describe("VehicleCsvImportCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    router.refresh.mockClear();
     vi.unstubAllGlobals();
   });
 
@@ -118,6 +125,7 @@ describe("VehicleCsvImportCard", () => {
     expect(screen.getByLabelText(/paste csv text/i)).toHaveValue("");
     expect(screen.queryByText("A-1")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /confirm import/i })).toBeDisabled();
+    expect(router.refresh).toHaveBeenCalledTimes(1);
   });
 
   it("does not POST again when confirm is clicked after a successful import", async () => {

--- a/tests/vehicles/vehicles-page-guided-card.test.ts
+++ b/tests/vehicles/vehicles-page-guided-card.test.ts
@@ -20,7 +20,7 @@ describe("Vehicles page guided onboarding card visibility", () => {
   });
 });
 
-import { filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
+import { fetchVehicleDirectoryRows, filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
 
 const baseVehicle = (overrides: Partial<VehicleListRow>): VehicleListRow => ({
   id: String(overrides.id ?? "vehicle"),
@@ -61,8 +61,10 @@ describe("Vehicles page list filtering", () => {
     ["year", "2021", { year: 2021 }],
     ["make", "hino", { make: "Hino" }],
     ["model", "268", { model: "268" }],
-    ["customer name", "acme", { customers: { id: "customer-1", business_name: "Acme Fleet", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null } }],
+    ["year/make/model", "2019 ford super", { year: 2019, make: "Ford", model: "Super Duty F-350" }],
+    ["customer name", "acme", { customers: { id: "customer-1", business_name: "Acme Fleet", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null, external_id: null } }],
     ["external_id", "legacy-99", { external_id: "legacy-99" }],
+    ["customer external_id", "cust-42", { customers: { id: "customer-1", external_id: "CUST-42", business_name: "Acme Fleet", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null } }],
   ])("matches %s without pre-capping the source list", (_label, query, match) => {
     const rows = Array.from({ length: 220 }, (_, index) => baseVehicle({ id: `vehicle-${index}`, unit_number: `Unit-${index}` }));
     rows.push(baseVehicle({ id: "older-match", unit_number: "Unit-999", ...match }));
@@ -70,6 +72,19 @@ describe("Vehicles page list filtering", () => {
     const result = filterSortAndCapVehicles(rows, query);
 
     expect(result.map((row) => row.id)).toContain("older-match");
+  });
+
+
+  it("keeps duplicate units, null customer_id vehicles, and linked customer vehicles visible", () => {
+    const rows = [
+      baseVehicle({ id: "duplicate-1", unit_number: "DUP-1", customer_id: null }),
+      baseVehicle({ id: "duplicate-2", unit_number: "DUP-1", customer_id: null }),
+      baseVehicle({ id: "unlinked", unit_number: "UNLINKED", customer_id: null }),
+      baseVehicle({ id: "linked", unit_number: "LINKED", customer_id: "customer-1", customers: { id: "customer-1", external_id: "CUST-1", business_name: "Linked Fleet", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null } }),
+    ];
+
+    expect(filterSortAndCapVehicles(rows, "").map((row) => row.id)).toEqual(["duplicate-1", "duplicate-2", "linked", "unlinked"]);
+    expect(filterSortAndCapVehicles(rows, "Linked Fleet").map((row) => row.id)).toEqual(["linked"]);
   });
 });
 
@@ -113,5 +128,68 @@ describe("Vehicles import customer lookup", () => {
     ]);
     expect(customers).toContainEqual(expect.objectContaining({ id: "customer-1001", external_id: "CUST-100247" }));
     expect(customers).not.toContainEqual(expect.objectContaining({ id: "customer-1000" }));
+  });
+});
+
+describe("Vehicles page directory data loading", () => {
+  it("loads current-shop public.vehicles without user_id filtering and keeps unlinked/customer-join-missing rows", async () => {
+    const calls: Array<{ table: string; column?: string; value?: unknown; values?: unknown[]; from?: number; to?: number }> = [];
+    const vehicleRows = [
+      baseVehicle({ id: "vehicle-unlinked", unit_number: "A-1", customer_id: null }),
+      baseVehicle({ id: "vehicle-linked", unit_number: "B-1", customer_id: "customer-1" }),
+      baseVehicle({ id: "vehicle-missing-customer", unit_number: "C-1", customer_id: "missing-customer" }),
+    ];
+    const customerRows = [{ id: "customer-1", external_id: "CUST-1", business_name: "Linked Fleet", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null }];
+
+    function makeQuery(table: string) {
+      const query = {
+        select: () => query,
+        eq: (column: string, value: unknown) => {
+          calls.push({ table, column, value });
+          return query;
+        },
+        order: () => query,
+        in: (column: string, values: unknown[]) => {
+          calls.push({ table, column, values });
+          return query;
+        },
+        range: async (from: number, to: number) => {
+          calls.push({ table, from, to });
+          return { data: table === "vehicles" ? vehicleRows : [], error: null };
+        },
+        then: (resolve: (value: { data: unknown[]; error: null }) => void) => resolve({ data: table === "customers" ? customerRows : [], error: null }),
+      };
+      return query;
+    }
+
+    const result = await fetchVehicleDirectoryRows({ from: (table: string) => makeQuery(table) }, "shop-real");
+
+    expect(result.error).toBeNull();
+    expect(result.rows.map((row) => row.id)).toEqual(["vehicle-unlinked", "vehicle-linked", "vehicle-missing-customer"]);
+    expect(result.rows.find((row) => row.id === "vehicle-linked")?.customers?.external_id).toBe("CUST-1");
+    expect(result.rows.find((row) => row.id === "vehicle-unlinked")?.customers).toBeNull();
+    expect(result.rows.find((row) => row.id === "vehicle-missing-customer")?.customers).toBeNull();
+    expect(calls).toContainEqual(expect.objectContaining({ table: "vehicles", column: "shop_id", value: "shop-real" }));
+    expect(calls).toContainEqual(expect.objectContaining({ table: "customers", column: "shop_id", value: "shop-real" }));
+    expect(calls).not.toContainEqual(expect.objectContaining({ column: "user_id" }));
+  });
+
+  it("still returns vehicles when the customer lookup fails", async () => {
+    function makeQuery(table: string) {
+      const query = {
+        select: () => query,
+        eq: () => query,
+        order: () => query,
+        in: () => query,
+        range: async () => ({ data: [baseVehicle({ id: "vehicle-1", unit_number: "A-1", customer_id: "customer-1" })], error: null }),
+        then: (resolve: (value: { data: unknown[]; error: unknown | null }) => void) => resolve({ data: [], error: table === "customers" ? new Error("customer lookup failed") : null }),
+      };
+      return query;
+    }
+
+    const result = await fetchVehicleDirectoryRows({ from: (table: string) => makeQuery(table) }, "shop-real");
+
+    expect(result.error).toBeNull();
+    expect(result.rows).toEqual([expect.objectContaining({ id: "vehicle-1", customers: null })]);
   });
 });


### PR DESCRIPTION
### Motivation
- The Vehicles directory showed “No vehicles yet” despite production `public.vehicles` rows; the server page was not loading the same current-shop rows and could hide vehicles when customer links are absent or when server caching prevented fresh results. 
- Search needed parity with Customers (match unit/external_id/vin/plate/year/make/model/customer name/customer external_id) and results should be capped/sorted consistently.

### Description
- Load directory rows from `public.vehicles` scoped only by `shop_id` with paginated fetch and no `user_id` filtering via `fetchVehicleDirectoryRows` in `features/vehicles/lib/list.ts` and return vehicles even when customer lookup fails. (added pagination, customer batch lookup and safe merge). 
- Replace inline server-side join/render with a server call to `fetchVehicleDirectoryRows` and render the UI via a new client component `VehicleDirectory` so search updates immediately; set page to dynamic with `export const dynamic = "force-dynamic";` and `revalidate = 0`. (`features/vehicles/app/vehicles/page.tsx`, `features/vehicles/components/VehicleDirectory.tsx`).
- Expand searchable fields and sorting behavior to include linked customer `external_id`, keep duplicate `unit_number` rows visible, and cap visible results to 20 using `filterSortAndCapVehicles` (`features/vehicles/lib/list.ts`).
- Show requested vehicle metadata in cards (unit/external_id, year/make/model/submodel, VIN, plate, customer name & customer external_id, mileage, engine_hours, engine, fuel_type, import_notes/source_row_id) (`features/vehicles/components/VehicleDirectory.tsx`, `features/vehicles/lib/display.ts`).
- After a successful CSV import the import card now clears state and calls `router.refresh()` so the server-rendered directory reloads once import completes while still preventing repeated POSTs (`features/vehicles/components/VehicleCsvImportCard.tsx`).
- Tests updated/added to assert directory loading, search matching, visibility of unlinked/missing-customer rows, cap/sort behavior, and `router.refresh()` call after import (`tests/vehicles/vehicle-csv-import-card.test.tsx`, `tests/vehicles/vehicles-page-guided-card.test.ts`).

### Testing
- Ran the vehicle-related tests: `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` and all test files passed (69 tests total passed). 
- Type-check: `npx tsc --noEmit` completed successfully. 
- Checked diffs: `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22feb80a4c8328897227b4b591598e)