### PR TITLE
Fix vehicle directory customer links

### DIFF
--- a/features/vehicles/components/VehicleDirectory.tsx
+++ b/features/vehicles/components/VehicleDirectory.tsx
@@ -1,15 +1,21 @@
 "use client";
 
+import React from "react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { formatVehicleIdentifier, formatVehicleYearMakeModel, normalizeVehicleIdentifier, normalizeVehicleText } from "@/features/vehicles/lib/display";
-import { filterSortAndCapVehicles, vehicleCustomerName, type VehicleListRow } from "@/features/vehicles/lib/list";
+import { filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
 
 type Props = {
   vehicles: VehicleListRow[];
   vehicleError?: string | null;
   initialQuery?: string;
 };
+
+function vehicleCustomerDisplay(vehicle: VehicleListRow): string {
+  if (vehicle.customerName) return vehicle.customerName;
+  return vehicle.customer_id ? "Customer link missing" : "No customer linked";
+}
 
 export function VehicleDirectory({ vehicles: sourceVehicles, vehicleError = null, initialQuery = "" }: Props) {
   const [query, setQuery] = useState(initialQuery);
@@ -44,24 +50,25 @@ export function VehicleDirectory({ vehicles: sourceVehicles, vehicleError = null
       {vehicles.length > 0 ? (
         <div className="mt-4 grid gap-3">
           {vehicles.map((vehicle) => {
-            const name = vehicleCustomerName(vehicle.customers);
-            const customerExternalId = normalizeVehicleText(vehicle.customers?.external_id);
+            const name = vehicleCustomerDisplay(vehicle);
+            const hasResolvedCustomer = Boolean(vehicle.customerName);
+            const customerExternalId = normalizeVehicleText(vehicle.customerExternalId ?? vehicle.customers?.external_id);
             return (
               <article key={vehicle.id} className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
                 <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                   <div className="min-w-0">
                     <div className="text-xs font-semibold uppercase tracking-[0.16em] text-orange-200/80">{formatVehicleIdentifier(vehicle)}</div>
                     <h3 className="mt-1 truncate text-lg font-semibold text-white">{formatVehicleYearMakeModel(vehicle)}</h3>
-                    <p className="mt-1 text-sm text-neutral-400">{name ? `Linked to ${name}${customerExternalId ? ` (${customerExternalId})` : ""}` : "No customer linked"}</p>
+                    <p className="mt-1 text-sm text-neutral-400">{hasResolvedCustomer ? `Linked to ${name}${customerExternalId ? ` (${customerExternalId})` : ""}` : name}</p>
                   </div>
-                  {vehicle.customer_id && name ? <Link href={`/customers/${encodeURIComponent(vehicle.customer_id)}`} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-3 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Open customer file</Link> : null}
+                  {vehicle.customer_id && hasResolvedCustomer ? <Link href={`/customers/${encodeURIComponent(vehicle.customer_id)}`} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-3 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">Open customer file</Link> : null}
                 </div>
                 <dl className="mt-4 grid gap-2 md:grid-cols-4">
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">External ID</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.external_id) ?? "—"}</dd></div>
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Unit</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.unit_number) ?? "—"}</dd></div>
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">VIN</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.vin) ?? "—"}</dd></div>
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Plate</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleIdentifier(vehicle.license_plate) ?? "—"}</dd></div>
-                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer</dt><dd className="mt-1 truncate text-sm font-medium text-white">{name ?? "No customer linked"}</dd></div>
+                  <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer</dt><dd className="mt-1 truncate text-sm font-medium text-white">{name}</dd></div>
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Customer external ID</dt><dd className="mt-1 truncate text-sm font-medium text-white">{customerExternalId ?? "—"}</dd></div>
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Mileage</dt><dd className="mt-1 truncate text-sm font-medium text-white">{normalizeVehicleText(vehicle.mileage) ?? "—"}</dd></div>
                   <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3"><dt className="text-[11px] uppercase tracking-[0.14em] text-neutral-500">Engine hours</dt><dd className="mt-1 truncate text-sm font-medium text-white">{vehicle.engine_hours ?? "—"}</dd></div>

--- a/features/vehicles/lib/list.ts
+++ b/features/vehicles/lib/list.ts
@@ -4,8 +4,38 @@ import type { Database } from "@shared/types/types/supabase";
 type Vehicle = Database["public"]["Tables"]["vehicles"]["Row"];
 type Customer = Database["public"]["Tables"]["customers"]["Row"];
 
-export type VehicleListRow = Pick<Vehicle, "id" | "external_id" | "unit_number" | "year" | "make" | "model" | "submodel" | "vin" | "license_plate" | "customer_id" | "mileage" | "engine_hours" | "engine" | "fuel_type" | "import_notes" | "source_row_id"> & {
-  customers?: Pick<Customer, "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null;
+type VehicleDirectoryVehicleRow = Pick<
+  Vehicle,
+  | "id"
+  | "shop_id"
+  | "customer_id"
+  | "external_id"
+  | "unit_number"
+  | "vin"
+  | "license_plate"
+  | "year"
+  | "make"
+  | "model"
+  | "submodel"
+  | "mileage"
+  | "engine_hours"
+  | "engine"
+  | "fuel_type"
+  | "source_row_id"
+  | "import_notes"
+  | "created_at"
+>;
+
+type VehicleDirectoryCustomerRow = Pick<Customer, "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone"> & {
+  phone_number?: string | null;
+};
+
+export type VehicleListRow = VehicleDirectoryVehicleRow & {
+  customers?: VehicleDirectoryCustomerRow | null;
+  customerName?: string | null;
+  customerExternalId?: string | null;
+  customerEmail?: string | null;
+  customerPhone?: string | null;
 };
 
 export function vehicleCustomerName(customer: VehicleListRow["customers"]): string | null {
@@ -14,9 +44,9 @@ export function vehicleCustomerName(customer: VehicleListRow["customers"]): stri
     customer.business_name?.trim() ||
     customer.name?.trim() ||
     [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim() ||
-    customer.email ||
-    customer.phone ||
-    customer.phone_number ||
+    customer.email?.trim() ||
+    customer.phone?.trim() ||
+    customer.phone_number?.trim() ||
     null
   );
 }
@@ -29,6 +59,8 @@ function searchText(row: VehicleListRow): string {
     row.year != null ? String(row.year) : null,
     row.make,
     row.model,
+    row.customerName,
+    row.customerExternalId,
     vehicleCustomerName(row.customers),
     row.customers?.external_id,
     row.external_id,
@@ -58,8 +90,8 @@ export function filterSortAndCapVehicles(rows: VehicleListRow[], query: string, 
 }
 
 const VEHICLE_DIRECTORY_PAGE_SIZE = 1000;
-const VEHICLE_DIRECTORY_SELECT = "id, external_id, unit_number, year, make, model, submodel, vin, license_plate, customer_id, mileage, engine_hours, engine, fuel_type, import_notes, source_row_id";
-const VEHICLE_DIRECTORY_CUSTOMER_SELECT = "id, external_id, business_name, name, first_name, last_name, email, phone, phone_number";
+const VEHICLE_DIRECTORY_SELECT = "id, shop_id, customer_id, external_id, unit_number, vin, license_plate, year, make, model, submodel, mileage, engine_hours, engine, fuel_type, source_row_id, import_notes, created_at";
+const VEHICLE_DIRECTORY_CUSTOMER_SELECT = "id, external_id, name, first_name, last_name, business_name, email, phone";
 
 type VehicleDirectoryClient = {
   from: (table: string) => any;
@@ -82,7 +114,7 @@ function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
 }
 
 export async function fetchVehicleDirectoryRows(supabase: VehicleDirectoryClient, shopId: string): Promise<{ rows: VehicleListRow[]; error: unknown | null }> {
-  const vehiclesResult = await fetchPagedRows<Omit<VehicleListRow, "customers">>(
+  const vehiclesResult = await fetchPagedRows<VehicleDirectoryVehicleRow>(
     supabase
       .from("vehicles")
       .select(VEHICLE_DIRECTORY_SELECT)
@@ -95,7 +127,7 @@ export async function fetchVehicleDirectoryRows(supabase: VehicleDirectoryClient
 
   const vehicles = vehiclesResult.rows;
   const customerIds = uniqueNonEmpty(vehicles.map((row) => row.customer_id));
-  const customersById = new Map<string, VehicleListRow["customers"]>();
+  const customersById = new Map<string, VehicleDirectoryCustomerRow>();
 
   for (let index = 0; index < customerIds.length; index += VEHICLE_DIRECTORY_PAGE_SIZE) {
     const ids = customerIds.slice(index, index + VEHICLE_DIRECTORY_PAGE_SIZE);
@@ -106,13 +138,31 @@ export async function fetchVehicleDirectoryRows(supabase: VehicleDirectoryClient
       .in("id", ids);
 
     if (error) continue;
-    for (const customer of (data ?? []) as NonNullable<VehicleListRow["customers"]>[]) {
+    for (const customer of (data ?? []) as VehicleDirectoryCustomerRow[]) {
       customersById.set(customer.id, customer);
     }
   }
 
+  if (customerIds.length > 0) {
+    console.info("Vehicle directory customer resolution", {
+      shopId,
+      vehicleCustomerIdCount: customerIds.length,
+      matchedCustomerRowCount: customersById.size,
+    });
+  }
+
   return {
-    rows: vehicles.map((row) => ({ ...row, customers: row.customer_id ? customersById.get(row.customer_id) ?? null : null })),
+    rows: vehicles.map((row) => {
+      const customer = row.customer_id ? customersById.get(row.customer_id) ?? null : null;
+      return {
+        ...row,
+        customers: customer,
+        customerName: vehicleCustomerName(customer),
+        customerExternalId: customer?.external_id?.trim() || null,
+        customerEmail: customer?.email?.trim() || null,
+        customerPhone: customer?.phone?.trim() || customer?.phone_number?.trim() || null,
+      };
+    }),
     error: vehiclesResult.error,
   };
 }

--- a/tests/vehicles/vehicles-page-guided-card.test.ts
+++ b/tests/vehicles/vehicles-page-guided-card.test.ts
@@ -1,6 +1,12 @@
+import React from "react";
 import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
+import { VehicleDirectory } from "@/features/vehicles/components/VehicleDirectory";
+import { fetchVehicleImportCustomers } from "@/features/vehicles/lib/importCustomers";
+import { fetchVehicleDirectoryRows, filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
 
 describe("Vehicles page guided onboarding card visibility", () => {
   it("does not show the onboarding card during a normal Vehicles visit", () => {
@@ -20,10 +26,11 @@ describe("Vehicles page guided onboarding card visibility", () => {
   });
 });
 
-import { fetchVehicleDirectoryRows, filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
 
 const baseVehicle = (overrides: Partial<VehicleListRow>): VehicleListRow => ({
   id: String(overrides.id ?? "vehicle"),
+  shop_id: "shop-real",
+  created_at: null,
   external_id: null,
   unit_number: null,
   year: null,
@@ -88,7 +95,52 @@ describe("Vehicles page list filtering", () => {
   });
 });
 
-import { fetchVehicleImportCustomers } from "@/features/vehicles/lib/importCustomers";
+describe("VehicleDirectory", () => {
+  it("displays linked customer names and customer external IDs", () => {
+    render(React.createElement(VehicleDirectory, {
+      vehicles: [baseVehicle({ id: "vehicle-1", unit_number: "TRK-110", customer_id: "customer-1", customerName: "Edward Nguyen", customerExternalId: "CUST-101788" })],
+    }));
+
+    expect(screen.getByText("Linked to Edward Nguyen (CUST-101788)")).toBeInTheDocument();
+    expect(screen.getByText("Edward Nguyen")).toBeInTheDocument();
+    expect(screen.getByText("CUST-101788")).toBeInTheDocument();
+  });
+
+  it("shows unlinked and missing customer-link states without hiding vehicles", () => {
+    render(React.createElement(VehicleDirectory, {
+      vehicles: [
+        baseVehicle({ id: "unlinked", unit_number: "A-1", customer_id: null }),
+        baseVehicle({ id: "missing", unit_number: "B-1", customer_id: "missing-customer", customerName: null, customerExternalId: null }),
+      ],
+    }));
+
+    expect(screen.getAllByText("No customer linked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Customer link missing").length).toBeGreaterThan(0);
+    expect(screen.getByText("A-1")).toBeInTheDocument();
+    expect(screen.getByText("B-1")).toBeInTheDocument();
+  });
+
+  it("searches by customer name and customer external ID", async () => {
+    const user = userEvent.setup();
+    render(React.createElement(VehicleDirectory, {
+      vehicles: [
+        baseVehicle({ id: "match", unit_number: "TRK-110", external_id: "VEH-201126", customer_id: "customer-1", customerName: "Edward Nguyen", customerExternalId: "CUST-101788" }),
+        baseVehicle({ id: "miss", unit_number: "VAN-220", customer_id: null }),
+      ],
+    }));
+
+    const search = screen.getByPlaceholderText(/search vin/i);
+    await user.type(search, "Edward Nguyen");
+    expect(screen.getByText("TRK-110")).toBeInTheDocument();
+    expect(screen.queryByText("VAN-220")).not.toBeInTheDocument();
+
+    await user.clear(search);
+    await user.type(search, "CUST-101788");
+    expect(screen.getByText("TRK-110")).toBeInTheDocument();
+    expect(screen.queryByText("VAN-220")).not.toBeInTheDocument();
+  });
+});
+
 
 describe("Vehicles import customer lookup", () => {
   it("paginates same-shop customers beyond the first 1000 rows for CSV preview linking", async () => {
@@ -167,6 +219,8 @@ describe("Vehicles page directory data loading", () => {
     expect(result.error).toBeNull();
     expect(result.rows.map((row) => row.id)).toEqual(["vehicle-unlinked", "vehicle-linked", "vehicle-missing-customer"]);
     expect(result.rows.find((row) => row.id === "vehicle-linked")?.customers?.external_id).toBe("CUST-1");
+    expect(result.rows.find((row) => row.id === "vehicle-linked")?.customerName).toBe("Linked Fleet");
+    expect(result.rows.find((row) => row.id === "vehicle-linked")?.customerExternalId).toBe("CUST-1");
     expect(result.rows.find((row) => row.id === "vehicle-unlinked")?.customers).toBeNull();
     expect(result.rows.find((row) => row.id === "vehicle-missing-customer")?.customers).toBeNull();
     expect(calls).toContainEqual(expect.objectContaining({ table: "vehicles", column: "shop_id", value: "shop-real" }));


### PR DESCRIPTION
### Motivation
- Linked vehicles imported correctly, but the Vehicle Directory was showing “No customer linked” because customer rows were not being resolved/mapped into the vehicle rows used by the UI and search. 
- The intent is to resolve same-shop customers by `customers.id`, attach normalized display fields, and make search and UI reflect resolved vs missing links without hiding vehicles.

### Description
- Updated `fetchVehicleDirectoryRows` to select the required vehicle fields (including `shop_id`, `customer_id`, `created_at`, etc.), collect non-null `customer_id` values, and page both vehicles and customers safely. (`features/vehicles/lib/list.ts`)
- Customer resolution now queries `public.customers` scoped to the same `shop_id` with `in('id', ...)`, builds `customersById`, and attaches `customerName`, `customerExternalId`, `customerEmail`, and `customerPhone` to each `VehicleListRow`; a safe `console.info` diagnostic records counts. (`features/vehicles/lib/list.ts`)
- Search was extended to include `customerName` and `customerExternalId` before the 20-result cap so searches for customer names or external IDs match imported vehicles. (`features/vehicles/lib/list.ts`)
- UI changes in `VehicleDirectory` show resolved customer names and external IDs, display `Customer link missing` when `customer_id` exists but the customer row could not be resolved, and keep `No customer linked` for truly unlinked vehicles; the customer link/button only appears when a resolved customer is present. (`features/vehicles/components/VehicleDirectory.tsx`)
- Added/updated focused tests to assert customer resolution, same-shop scoping, missing-link behavior, search by customer name and external ID, and default capping. (`tests/vehicles/vehicles-page-guided-card.test.ts`) 

### Testing
- Ran targeted test suite: `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts`, and all specified tests passed. 
- Ran typecheck: `npx tsc --noEmit` with no errors. 
- Ran `git diff --check` to ensure no whitespace/patch issues; no problems found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2308f7c0c48328a26dda4846ac4607)