### PR TITLE
Fix vehicle directory customer resolution

### DIFF
--- a/features/vehicles/lib/list.ts
+++ b/features/vehicles/lib/list.ts
@@ -26,8 +26,8 @@ type VehicleDirectoryVehicleRow = Pick<
   | "created_at"
 >;
 
-type VehicleDirectoryCustomerRow = Pick<Customer, "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone"> & {
-  phone_number?: string | null;
+type VehicleDirectoryCustomerRow = Pick<Customer, "id" | "external_id" | "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> & {
+  display_name?: string | null;
 };
 
 export type VehicleListRow = VehicleDirectoryVehicleRow & {
@@ -43,11 +43,12 @@ export function vehicleCustomerName(customer: VehicleListRow["customers"]): stri
   return (
     customer.business_name?.trim() ||
     customer.name?.trim() ||
-    [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ").trim() ||
+    customer.display_name?.trim() ||
+    [customer.first_name ?? "", customer.last_name ?? ""].map((name) => name.trim()).filter(Boolean).join(" ").trim() ||
     customer.email?.trim() ||
     customer.phone?.trim() ||
     customer.phone_number?.trim() ||
-    null
+    "Customer"
   );
 }
 
@@ -91,7 +92,7 @@ export function filterSortAndCapVehicles(rows: VehicleListRow[], query: string, 
 
 const VEHICLE_DIRECTORY_PAGE_SIZE = 1000;
 const VEHICLE_DIRECTORY_SELECT = "id, shop_id, customer_id, external_id, unit_number, vin, license_plate, year, make, model, submodel, mileage, engine_hours, engine, fuel_type, source_row_id, import_notes, created_at";
-const VEHICLE_DIRECTORY_CUSTOMER_SELECT = "id, external_id, name, first_name, last_name, business_name, email, phone";
+const VEHICLE_DIRECTORY_CUSTOMER_SELECT = "id, external_id, name, first_name, last_name, business_name, email, phone, phone_number";
 
 type VehicleDirectoryClient = {
   from: (table: string) => any;
@@ -113,6 +114,87 @@ function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value))));
 }
 
+function customerLookupErrorSummary(error: unknown): { code: string | null; message: string } | null {
+  if (!error) return null;
+  if (typeof error === "object") {
+    const record = error as { code?: unknown; message?: unknown };
+    return {
+      code: typeof record.code === "string" ? record.code : null,
+      message: typeof record.message === "string" ? record.message : String(error),
+    };
+  }
+  return { code: null, message: String(error) };
+}
+
+function vehicleDirectoryCustomerDiagnostics(
+  shopId: string,
+  vehicles: VehicleDirectoryVehicleRow[],
+  customersById: Map<string, VehicleDirectoryCustomerRow>,
+  customerLookupError: unknown | null,
+) {
+  console.info("Vehicle directory customer resolution", {
+    shopId,
+    vehicleCountLoaded: vehicles.length,
+    nonNullCustomerIdCount: vehicles.filter((row) => Boolean(row.customer_id?.trim())).length,
+    firstVehicleCustomerIds: vehicles.map((row) => row.customer_id?.trim()).filter(Boolean).slice(0, 3),
+    customerLookupCount: customersById.size,
+    firstLoadedCustomers: Array.from(customersById.values()).slice(0, 3).map((customer) => ({
+      id: customer.id,
+      external_id: customer.external_id ?? null,
+      display_name: customer.display_name ?? null,
+      name: customer.name ?? null,
+      business_name: customer.business_name ?? null,
+    })),
+    customerLookupError: customerLookupErrorSummary(customerLookupError),
+  });
+}
+
+async function fetchCustomersByDirectIds(
+  supabase: VehicleDirectoryClient,
+  shopId: string,
+  customerIds: string[],
+): Promise<{ customersById: Map<string, VehicleDirectoryCustomerRow>; error: unknown | null }> {
+  const customersById = new Map<string, VehicleDirectoryCustomerRow>();
+
+  for (let index = 0; index < customerIds.length; index += VEHICLE_DIRECTORY_PAGE_SIZE) {
+    const ids = customerIds.slice(index, index + VEHICLE_DIRECTORY_PAGE_SIZE);
+    const { data, error } = await supabase
+      .from("customers")
+      .select(VEHICLE_DIRECTORY_CUSTOMER_SELECT)
+      .eq("shop_id", shopId)
+      .in("id", ids);
+
+    if (error) return { customersById, error };
+    for (const customer of (data ?? []) as VehicleDirectoryCustomerRow[]) {
+      customersById.set(customer.id, customer);
+    }
+  }
+
+  return { customersById, error: null };
+}
+
+async function fetchCustomersBySameShopFallback(
+  supabase: VehicleDirectoryClient,
+  shopId: string,
+  customerIds: string[],
+): Promise<{ customersById: Map<string, VehicleDirectoryCustomerRow>; error: unknown | null }> {
+  const wantedIds = new Set(customerIds);
+  const customersById = new Map<string, VehicleDirectoryCustomerRow>();
+  const customersResult = await fetchPagedRows<VehicleDirectoryCustomerRow>(
+    supabase
+      .from("customers")
+      .select(VEHICLE_DIRECTORY_CUSTOMER_SELECT)
+      .eq("shop_id", shopId)
+      .order("id", { ascending: true }),
+  );
+
+  for (const customer of customersResult.rows) {
+    if (wantedIds.has(customer.id)) customersById.set(customer.id, customer);
+  }
+
+  return { customersById, error: customersResult.error };
+}
+
 export async function fetchVehicleDirectoryRows(supabase: VehicleDirectoryClient, shopId: string): Promise<{ rows: VehicleListRow[]; error: unknown | null }> {
   const vehiclesResult = await fetchPagedRows<VehicleDirectoryVehicleRow>(
     supabase
@@ -127,29 +209,28 @@ export async function fetchVehicleDirectoryRows(supabase: VehicleDirectoryClient
 
   const vehicles = vehiclesResult.rows;
   const customerIds = uniqueNonEmpty(vehicles.map((row) => row.customer_id));
-  const customersById = new Map<string, VehicleDirectoryCustomerRow>();
+  let customersById = new Map<string, VehicleDirectoryCustomerRow>();
+  let customerLookupError: unknown | null = null;
 
-  for (let index = 0; index < customerIds.length; index += VEHICLE_DIRECTORY_PAGE_SIZE) {
-    const ids = customerIds.slice(index, index + VEHICLE_DIRECTORY_PAGE_SIZE);
-    const { data, error } = await supabase
-      .from("customers")
-      .select(VEHICLE_DIRECTORY_CUSTOMER_SELECT)
-      .eq("shop_id", shopId)
-      .in("id", ids);
+  if (customerIds.length > 0) {
+    const directResult = await fetchCustomersByDirectIds(supabase, shopId, customerIds);
+    customersById = directResult.customersById;
+    customerLookupError = directResult.error;
 
-    if (error) continue;
-    for (const customer of (data ?? []) as VehicleDirectoryCustomerRow[]) {
-      customersById.set(customer.id, customer);
+    if (directResult.error || directResult.customersById.size === 0) {
+      console.warn("Vehicle directory direct customer lookup failed or returned no matches; falling back to same-shop customer scan", {
+        shopId,
+        customerIdCount: customerIds.length,
+        directCustomerLookupCount: directResult.customersById.size,
+        customerLookupError: customerLookupErrorSummary(directResult.error),
+      });
+      const fallbackResult = await fetchCustomersBySameShopFallback(supabase, shopId, customerIds);
+      customersById = fallbackResult.customersById;
+      customerLookupError = fallbackResult.error ?? directResult.error;
     }
   }
 
-  if (customerIds.length > 0) {
-    console.info("Vehicle directory customer resolution", {
-      shopId,
-      vehicleCustomerIdCount: customerIds.length,
-      matchedCustomerRowCount: customersById.size,
-    });
-  }
+  vehicleDirectoryCustomerDiagnostics(shopId, vehicles, customersById, customerLookupError);
 
   return {
     rows: vehicles.map((row) => {

--- a/tests/vehicles/vehicles-page-guided-card.test.ts
+++ b/tests/vehicles/vehicles-page-guided-card.test.ts
@@ -6,7 +6,7 @@ import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/quer
 import { shouldShowVehicleOnboardingCard } from "@/features/vehicles/lib/guided";
 import { VehicleDirectory } from "@/features/vehicles/components/VehicleDirectory";
 import { fetchVehicleImportCustomers } from "@/features/vehicles/lib/importCustomers";
-import { fetchVehicleDirectoryRows, filterSortAndCapVehicles, type VehicleListRow } from "@/features/vehicles/lib/list";
+import { fetchVehicleDirectoryRows, filterSortAndCapVehicles, vehicleCustomerName, type VehicleListRow } from "@/features/vehicles/lib/list";
 
 describe("Vehicles page guided onboarding card visibility", () => {
   it("does not show the onboarding card during a normal Vehicles visit", () => {
@@ -226,6 +226,69 @@ describe("Vehicles page directory data loading", () => {
     expect(calls).toContainEqual(expect.objectContaining({ table: "vehicles", column: "shop_id", value: "shop-real" }));
     expect(calls).toContainEqual(expect.objectContaining({ table: "customers", column: "shop_id", value: "shop-real" }));
     expect(calls).not.toContainEqual(expect.objectContaining({ column: "user_id" }));
+    expect(calls).not.toContainEqual(expect.objectContaining({ column: "email" }));
+    expect(calls).not.toContainEqual(expect.objectContaining({ column: "external_id" }));
+  });
+
+
+  it("uses the supported customer display-name fallback order", () => {
+    expect(vehicleCustomerName({ id: "business", external_id: null, business_name: "Business Fleet", name: "Named Customer", display_name: "Display Customer", first_name: "First", last_name: "Last", email: "email@example.com", phone: "555-1111", phone_number: "555-2222" })).toBe("Business Fleet");
+    expect(vehicleCustomerName({ id: "name", external_id: null, business_name: null, name: "Named Customer", display_name: "Display Customer", first_name: "First", last_name: "Last", email: "email@example.com", phone: "555-1111", phone_number: "555-2222" })).toBe("Named Customer");
+    expect(vehicleCustomerName({ id: "display", external_id: null, business_name: null, name: null, display_name: "Display Customer", first_name: "First", last_name: "Last", email: "email@example.com", phone: "555-1111", phone_number: "555-2222" })).toBe("Display Customer");
+    expect(vehicleCustomerName({ id: "person", external_id: null, business_name: null, name: null, display_name: null, first_name: "Edward", last_name: "Nguyen", email: "email@example.com", phone: "555-1111", phone_number: "555-2222" })).toBe("Edward Nguyen");
+    expect(vehicleCustomerName({ id: "email", external_id: null, business_name: null, name: null, display_name: null, first_name: null, last_name: null, email: "email@example.com", phone: "555-1111", phone_number: "555-2222" })).toBe("email@example.com");
+    expect(vehicleCustomerName({ id: "phone", external_id: null, business_name: null, name: null, display_name: null, first_name: null, last_name: null, email: null, phone: "555-1111", phone_number: "555-2222" })).toBe("555-1111");
+    expect(vehicleCustomerName({ id: "fallback", external_id: null, business_name: null, name: null, display_name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null })).toBe("Customer");
+  });
+
+  it("falls back to a paginated same-shop customer scan when the direct id lookup fails", async () => {
+    const calls: Array<{ table: string; column?: string; value?: unknown; values?: unknown[]; from?: number; to?: number }> = [];
+    const vehicleRows = [baseVehicle({ id: "vehicle-linked", unit_number: "TRK-110", customer_id: "customer-1" })];
+    const customerRows = [
+      { id: "other-shop-customer", shop_id: "other-shop", external_id: "CUST-OTHER", business_name: "Wrong Shop", name: null, first_name: null, last_name: null, email: null, phone: null, phone_number: null },
+      { id: "customer-1", shop_id: "shop-real", external_id: "CUST-101788", business_name: null, name: "Edward Nguyen", first_name: null, last_name: null, email: null, phone: null, phone_number: null },
+    ];
+
+    function makeQuery(table: string) {
+      const query = {
+        shopId: "",
+        directLookup: false,
+        select: () => query,
+        eq: (column: string, value: unknown) => {
+          calls.push({ table, column, value });
+          if (column === "shop_id") query.shopId = String(value);
+          return query;
+        },
+        order: () => query,
+        in: (column: string, values: unknown[]) => {
+          calls.push({ table, column, values });
+          query.directLookup = true;
+          return query;
+        },
+        range: async (from: number, to: number) => {
+          calls.push({ table, from, to });
+          const data = table === "vehicles"
+            ? vehicleRows
+            : customerRows.filter((row) => row.shop_id === query.shopId).slice(from, to + 1);
+          return { data, error: null };
+        },
+        then: (resolve: (value: { data: unknown[]; error: unknown | null }) => void) => {
+          resolve({ data: [], error: query.directLookup ? { code: "414", message: "URI too long" } : null });
+        },
+      };
+      return query;
+    }
+
+    const result = await fetchVehicleDirectoryRows({ from: (table: string) => makeQuery(table) }, "shop-real");
+
+    expect(result.error).toBeNull();
+    expect(result.rows).toEqual([expect.objectContaining({
+      id: "vehicle-linked",
+      customerName: "Edward Nguyen",
+      customerExternalId: "CUST-101788",
+    })]);
+    expect(calls).toContainEqual(expect.objectContaining({ table: "customers", column: "id", values: ["customer-1"] }));
+    expect(calls).toContainEqual(expect.objectContaining({ table: "customers", from: 0, to: 999 }));
   });
 
   it("still returns vehicles when the customer lookup fails", async () => {


### PR DESCRIPTION
### Motivation
- Vehicle directory showed "Customer link missing" despite vehicles being linked in the DB because the customer lookup could return no matches or be filtered incorrectly, hiding resolved customer rows. 
- The lookup needed to be robust to IN/URL-size/RLS failures and must not filter customers by `user_id`, `email`, or `external_id` when matching by `customer_id`.

### Description
- Reworked `fetchVehicleDirectoryRows` to collect distinct non-null `customer_id` values and resolve same-shop customers with `customers WHERE id IN (...) AND shop_id = <shopId>` and to fall back to a paginated same-shop scan when the direct IN lookup fails or returns no matches. (`features/vehicles/lib/list.ts`)
- Added safe diagnostic logging with `shopId`, `vehicleCountLoaded`, `nonNullCustomerIdCount`, `firstVehicleCustomerIds`, `customerLookupCount`, `firstLoadedCustomers` (id/external_id/display_name/name/business_name) and a safe `customerLookupError` summary function to record error `code`/`message` without leaking tokens/cookies. (`features/vehicles/lib/list.ts`)
- Updated the customer select and display logic to include `phone_number` and optional `display_name`, and implemented the requested name fallback order: `business_name`, `name`, `display_name`, `first_name + last_name`, `email`, `phone`, `phone_number`, then the literal `"Customer"`. (`features/vehicles/lib/list.ts`)
- Kept the directory search and UI behavior intact (search includes resolved `customerName` and `customerExternalId`, results capped to 20), and left import/batching untouched; added tests exercising resolution, fallback, and display logic. (`tests/vehicles/vehicles-page-guided-card.test.ts`)

### Testing
- Ran unit tests: `npx vitest run tests/vehicles/vehicle-import-route.test.ts tests/vehicles/vehicle-csv-import-card.test.tsx tests/vehicles/vehicles-page-guided-card.test.ts` and all targeted tests passed (3 test files, 74 tests total passed). 
- Ran type check: `npx tsc --noEmit` and it completed successfully. 
- Checked diffs: `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230c2d6dfc8328854b3697e7a9c1ca)