### PR TITLE
Harden staff onboarding user setup

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -6,14 +6,36 @@ import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { assertShopHasAvailableSeat } from "@/features/shared/lib/server/shop-seat-limit";
+import { getShopSeatLimitSnapshot } from "@/features/shared/lib/server/shop-seat-limit";
 import {
   buildShopUserAuthEmail,
   buildShopUsernameNamespace,
   normalizeProvisioningUsername,
   withShopUsernameSuffix,
 } from "@/features/users/lib/username";
-import { canonicalizeRole } from "@/features/shared/lib/rbac";
+import { canonicalizeRole, type CanonicalRole } from "@/features/shared/lib/rbac";
+
+
+const OWNER_CREATABLE_ROLES: ReadonlySet<CanonicalRole> = new Set([
+  "admin",
+  "manager",
+  "advisor",
+  "mechanic",
+  "parts",
+]);
+
+const ADMIN_CREATABLE_ROLES: ReadonlySet<CanonicalRole> = new Set([
+  "manager",
+  "advisor",
+  "mechanic",
+  "parts",
+]);
+
+function canCreateRole(actorRole: CanonicalRole, requestedRole: CanonicalRole): boolean {
+  if (actorRole === "owner") return OWNER_CREATABLE_ROLES.has(requestedRole);
+  if (actorRole === "admin") return ADMIN_CREATABLE_ROLES.has(requestedRole);
+  return false;
+}
 
 type Body = {
   username: string;
@@ -34,9 +56,12 @@ function logCreateUserStep(
     role?: string | null;
     authUserId?: string | null;
     profileId?: string | null;
-    normalizedUsername?: string | null;
-    syntheticAuthEmail?: string | null;
-    contactEmail?: string | null;
+    hasActorId?: boolean;
+    requestedRole?: string | null;
+    plan?: string | null;
+    cap?: number | null;
+    activeUsers?: number | null;
+    reason?: string | null;
     hasContactEmail?: boolean;
     emailConfirmed?: boolean | null;
   } = {},
@@ -52,9 +77,12 @@ function logCreateUserError(
     role?: string | null;
     authUserId?: string | null;
     profileId?: string | null;
-    normalizedUsername?: string | null;
-    syntheticAuthEmail?: string | null;
-    contactEmail?: string | null;
+    hasActorId?: boolean;
+    requestedRole?: string | null;
+    plan?: string | null;
+    cap?: number | null;
+    activeUsers?: number | null;
+    reason?: string | null;
     hasContactEmail?: boolean;
     emailConfirmed?: boolean | null;
     error?: string | null;
@@ -78,7 +106,7 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           error:
-            "Invalid role. Allowed roles: owner, admin, manager, foreman, lead_hand, advisor, service, dispatcher, parts, mechanic, fleet_manager, driver, customer.",
+            "Invalid role. Allowed roles for staff creation: admin, manager, advisor, mechanic/tech, parts.",
         },
         { status: 400 }
       );
@@ -101,10 +129,27 @@ export async function POST(req: Request) {
     }
 
     logCreateUserStep("access_authorized", {
+      hasActorId: Boolean(access.profile.id),
       adminId: access.profile.id,
       targetShopId: effectiveShopId,
-      role: canonicalRole,
+      requestedRole: canonicalRole,
     });
+
+    if (!canCreateRole(access.canonicalRole, canonicalRole)) {
+      logCreateUserError("role_not_allowed", {
+        hasActorId: Boolean(access.profile.id),
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        requestedRole: canonicalRole,
+        reason: `actor_${access.canonicalRole}_cannot_create_requested_role`,
+      });
+      return NextResponse.json(
+        { error: "You are not allowed to create users with that role." },
+        { status: 403 },
+      );
+    }
+
+    // Future multi-location staff creation should use a verified manageable-shop resolver.
 
     // Service-role client is created server-side only and is never exposed to the browser.
     const serviceSupabase = createAdminSupabase();
@@ -137,7 +182,7 @@ export async function POST(req: Request) {
       logCreateUserError("username_lookup_failed", {
         adminId: access.profile.id,
         targetShopId: effectiveShopId,
-        role: canonicalRole,
+        requestedRole: canonicalRole,
         error: existingErr.message,
       });
       return NextResponse.json(
@@ -153,11 +198,31 @@ export async function POST(req: Request) {
       );
     }
 
-    try {
-      await assertShopHasAvailableSeat(serviceSupabase, effectiveShopId);
-    } catch (seatErr) {
-      const msg = seatErr instanceof Error ? seatErr.message : "Shop user limit reached for your current plan.";
-      return NextResponse.json({ error: msg }, { status: 400 });
+    const seatSnapshot = await getShopSeatLimitSnapshot(serviceSupabase, effectiveShopId);
+    logCreateUserStep("seat_limit_checked", {
+      hasActorId: Boolean(access.profile.id),
+      adminId: access.profile.id,
+      targetShopId: effectiveShopId,
+      requestedRole: canonicalRole,
+      plan: seatSnapshot.plan,
+      cap: seatSnapshot.cap,
+      activeUsers: seatSnapshot.activeUsers,
+    });
+    if (seatSnapshot.activeUsers >= seatSnapshot.cap) {
+      logCreateUserError("seat_limit_reached", {
+        hasActorId: Boolean(access.profile.id),
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        requestedRole: canonicalRole,
+        plan: seatSnapshot.plan,
+        cap: seatSnapshot.cap,
+        activeUsers: seatSnapshot.activeUsers,
+        reason: "current_plan_cap_reached",
+      });
+      return NextResponse.json(
+        { error: "Shop user limit reached for your current plan." },
+        { status: 400 },
+      );
     }
 
     // Staff username auth is primary: Supabase Auth uses the same synthetic email
@@ -167,12 +232,13 @@ export async function POST(req: Request) {
     const contactEmail = inputEmail || null;
 
     logCreateUserStep("creating_auth_user", {
+      hasActorId: Boolean(access.profile.id),
       adminId: access.profile.id,
       targetShopId: effectiveShopId,
-      role: canonicalRole,
-      normalizedUsername: username,
-      syntheticAuthEmail: syntheticEmail,
-      contactEmail,
+      requestedRole: canonicalRole,
+      plan: seatSnapshot.plan,
+      cap: seatSnapshot.cap,
+      activeUsers: seatSnapshot.activeUsers,
       hasContactEmail: Boolean(contactEmail),
     });
 
@@ -195,7 +261,8 @@ export async function POST(req: Request) {
       logCreateUserError("auth_user_create_failed", {
         adminId: access.profile.id,
         targetShopId: effectiveShopId,
-        role: canonicalRole,
+        requestedRole: canonicalRole,
+        reason: "auth_create_failed",
         error: createErr?.message ?? "No auth user returned",
       });
       const safeMessage = createErr?.message?.toLowerCase().includes("already been registered")
@@ -206,14 +273,37 @@ export async function POST(req: Request) {
     }
 
     const newUserId = created.user.id;
+    const cleanupCreatedAuthUser = async (reason: string): Promise<void> => {
+      const { error: cleanupErr } = await serviceSupabase.auth.admin.deleteUser(newUserId);
+      if (cleanupErr) {
+        logCreateUserError("auth_user_cleanup_failed", {
+          hasActorId: Boolean(access.profile.id),
+          adminId: access.profile.id,
+          targetShopId: effectiveShopId,
+          requestedRole: canonicalRole,
+          authUserId: newUserId,
+          reason,
+          error: cleanupErr.message,
+        });
+        return;
+      }
+
+      logCreateUserStep("auth_user_cleanup_completed", {
+        hasActorId: Boolean(access.profile.id),
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        requestedRole: canonicalRole,
+        authUserId: newUserId,
+        reason,
+      });
+    };
+
     logCreateUserStep("auth_user_created", {
+      hasActorId: Boolean(access.profile.id),
       adminId: access.profile.id,
       targetShopId: effectiveShopId,
-      role: canonicalRole,
+      requestedRole: canonicalRole,
       authUserId: newUserId,
-      normalizedUsername: username,
-      syntheticAuthEmail: syntheticEmail,
-      contactEmail,
       hasContactEmail: Boolean(contactEmail),
       emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
     });
@@ -241,6 +331,7 @@ export async function POST(req: Request) {
 
     if (profileErr) {
       if (String(profileErr.message ?? "").toLowerCase().includes("shop user limit reached")) {
+        await cleanupCreatedAuthUser("profile_seat_limit_failure");
         return NextResponse.json(
           { error: "Shop user limit reached for your current plan." },
           { status: 400 }
@@ -249,10 +340,12 @@ export async function POST(req: Request) {
       logCreateUserError("profile_upsert_failed", {
         adminId: access.profile.id,
         targetShopId: effectiveShopId,
-        role: canonicalRole,
+        requestedRole: canonicalRole,
         authUserId: newUserId,
+        reason: "profile_upsert_failed",
         error: profileErr.message,
       });
+      await cleanupCreatedAuthUser("profile_upsert_failed");
       return NextResponse.json(
         { error: "Profile upsert failed.", code: "profile_upsert_failed" },
         { status: 400 }
@@ -277,10 +370,12 @@ export async function POST(req: Request) {
       logCreateUserError("workforce_profile_seed_failed", {
         adminId: access.profile.id,
         targetShopId: effectiveShopId,
-        role: canonicalRole,
+        requestedRole: canonicalRole,
         authUserId: newUserId,
+        reason: "workforce_profile_seed_failed",
         error: workforceErr.message,
       });
+      await cleanupCreatedAuthUser("workforce_profile_seed_failed");
       return NextResponse.json(
         { error: "Workforce profile seed failed.", code: "workforce_profile_seed_failed" },
         { status: 400 }
@@ -288,14 +383,12 @@ export async function POST(req: Request) {
     }
 
     logCreateUserStep("completed", {
+      hasActorId: Boolean(access.profile.id),
       adminId: access.profile.id,
       targetShopId: effectiveShopId,
-      role: canonicalRole,
+      requestedRole: canonicalRole,
       authUserId: newUserId,
       profileId: newUserId,
-      normalizedUsername: username,
-      syntheticAuthEmail: syntheticEmail,
-      contactEmail,
       hasContactEmail: Boolean(contactEmail),
       emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
     });

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -3,7 +3,11 @@ import { NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-const MAX_ROWS = 500;
+const MAX_ROWS = 20;
+
+function escapePostgrestSearchValue(value: string): string {
+  return value.replace(/[\\%_,]/g, (char) => `\\${char}`);
+}
 
 export async function GET(req: Request) {
   const access = await requireShopScopedApiAccess({
@@ -19,13 +23,21 @@ export async function GET(req: Request) {
 
   let query = admin
     .from("profiles")
-    .select("id, full_name, email, phone, role, created_at, shop_id")
+    .select("id, full_name, email, phone, role, username, created_at, shop_id")
     .eq("shop_id", access.profile.shop_id)
-    .order("created_at", { ascending: false })
+    .order("full_name", { ascending: true, nullsFirst: false })
+    .order("username", { ascending: true, nullsFirst: false })
     .limit(MAX_ROWS);
 
   if (q) {
-    query = query.or(`full_name.ilike.%${q}%,email.ilike.%${q}%,phone.ilike.%${q}%`);
+    const like = `%${escapePostgrestSearchValue(q)}%`;
+    query = query.or([
+      `full_name.ilike.${like}`,
+      `email.ilike.${like}`,
+      `username.ilike.${like}`,
+      `phone.ilike.${like}`,
+      `role.ilike.${like}`,
+    ].join(","));
   }
 
   const { data: users, error: usersErr } = await query;

--- a/features/admin/components/UsersList.tsx
+++ b/features/admin/components/UsersList.tsx
@@ -24,6 +24,7 @@ type UserRow = {
   email: string | null;
   phone: string | null;
   role: UserRole | null;
+  username: string | null;
   created_at: string | null;
   shop_id: string | null;
 };
@@ -33,7 +34,8 @@ const ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = [
   { value: "admin", label: "Admin" },
   { value: "manager", label: "Manager" },
   { value: "advisor", label: "Advisor" },
-  { value: "mechanic", label: "Mechanic" },
+  { value: "mechanic", label: "Mechanic / Tech" },
+  { value: "parts", label: "Parts" },
 ];
 
 function safeMsg(e: unknown, fallback: string): string {
@@ -158,7 +160,7 @@ export default function UsersList(): JSX.Element {
       <AdminPanel>
         <AdminPanelTitle
           title="Filter & Locate"
-          description="Search by name, email, or phone, then narrow by role for targeted governance actions."
+          description="Search by name, email, username, phone, or role, then narrow by role for targeted governance actions."
           action={
             <Button type="button" variant="default" className="font-semibold" onClick={() => void load()} disabled={loading}>
               {loading ? "Loading…" : "Refresh"}
@@ -170,7 +172,7 @@ export default function UsersList(): JSX.Element {
           <AdminField label="Search" className="flex-1">
             <input
               className="w-full rounded-lg border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/70 px-3 py-2 text-sm text-neutral-100 outline-none placeholder:text-neutral-500 focus:border-[var(--accent-copper-soft)]"
-              placeholder="Search name, email, or phone…"
+              placeholder="Search name, email, username, phone, or role…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
             />
@@ -225,8 +227,10 @@ export default function UsersList(): JSX.Element {
               {filteredRows.map((u) => (
                 <tr key={u.id} className="text-neutral-200">
                   <td className="px-4 py-2.5">
-                    <div className="font-medium text-neutral-100">{u.full_name ?? "—"}</div>
-                    <div className="text-xs text-neutral-500">{u.id.slice(0, 8)}</div>
+                    <div className="font-medium text-neutral-100">{u.full_name ?? u.username ?? "—"}</div>
+                    <div className="text-xs text-neutral-500">
+                      {u.username ? `@${u.username}` : u.id.slice(0, 8)}
+                    </div>
                   </td>
                   <td className="px-4 py-2.5">{u.email ?? "—"}</td>
                   <td className="px-4 py-2.5">{u.phone ?? "—"}</td>
@@ -270,8 +274,10 @@ export default function UsersList(): JSX.Element {
 
           {!loading && filteredRows.length === 0 ? (
             <AdminEmptyState
-              title="No users found"
-              body="Try adjusting search and role filters, or confirm users exist in the current shop scope."
+              title={rows.length === 0 && !search.trim() && roleFilter === "all" ? "No staff yet" : "No matching staff"}
+              body={rows.length === 0 && !search.trim() && roleFilter === "all"
+                ? "Create your first staff user above. Results are scoped to your current shop."
+                : "Try adjusting search and role filters. Results are capped to the first 20 matching staff in your current shop."}
             />
           ) : null}
 

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -33,6 +33,18 @@ const PANEL_CLASS =
 const INPUT_CLASS =
   "w-full rounded-lg border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)] focus:border-[var(--metal-border-strong,#64748b)]";
 
+const OWNER_ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = [
+  { value: "admin", label: "Admin" },
+  { value: "manager", label: "Manager" },
+  { value: "advisor", label: "Advisor" },
+  { value: "mechanic", label: "Mechanic / Tech" },
+  { value: "parts", label: "Parts" },
+];
+
+const ADMIN_ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = OWNER_ROLE_OPTIONS.filter(
+  (role) => role.value !== "admin",
+);
+
 export default function CreateUserPage(): JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -68,9 +80,11 @@ export default function CreateUserPage(): JSX.Element {
   const [resetBusy, setResetBusy] = useState(false);
   const [resetMsg, setResetMsg] = useState<string | null>(null);
 
-  // creator’s shop id (for auto-fill)
+  // creator’s shop context (server still enforces/overrides shop_id)
   const [creatorShopId, setCreatorShopId] = useState<string | null>(null);
   const [creatorShopName, setCreatorShopName] = useState<string | null>(null);
+  const [actorRole, setActorRole] = useState<UserRole | null>(null);
+  const roleOptions = actorRole === "admin" ? ADMIN_ROLE_OPTIONS : OWNER_ROLE_OPTIONS;
   const [usernameTouched, setUsernameTouched] = useState(false);
 
   // load current user's shop_id once
@@ -83,12 +97,17 @@ export default function CreateUserPage(): JSX.Element {
 
       const { data: profile } = await supabase
         .from("profiles")
-        .select("shop_id")
+        .select("shop_id, role")
         .eq("id", user.id)
         .maybeSingle();
 
       const shopId = profile?.shop_id ?? null;
       setCreatorShopId(shopId);
+      const role = (profile?.role ?? null) as UserRole | null;
+      setActorRole(role);
+      if (role === "admin") {
+        setForm((prev) => (prev.role === "owner" || prev.role === "admin" ? { ...prev, role: "manager" } : prev));
+      }
 
       if (shopId) {
         const { data: shop } = await supabase
@@ -142,7 +161,8 @@ export default function CreateUserPage(): JSX.Element {
         email: (form.email ?? "").trim().toLowerCase() || null,
         full_name: (form.full_name ?? "").trim() || null,
         role: form.role ?? null,
-        shop_id: (form.shop_id ?? "")?.trim() || creatorShopId || null,
+        // Server intentionally ignores/overrides any client shop_id.
+        // Future multi-location staff creation should use a verified manageable-shop resolver.
         phone: (form.phone ?? "")?.trim() || null,
       };
 
@@ -195,7 +215,7 @@ export default function CreateUserPage(): JSX.Element {
         email: "",
         full_name: "",
         phone: "",
-        shop_id: body.shop_id ?? creatorShopId ?? null,
+        shop_id: creatorShopId ?? null,
       }));
       setUsernameTouched(false);
 
@@ -394,44 +414,25 @@ export default function CreateUserPage(): JSX.Element {
                   setForm({ ...form, role: e.target.value as UserRole })
                 }
               >
-                <option value="owner">Owner</option>
-                <option value="admin">Admin</option>
-                <option value="manager">Manager</option>
-                <option value="foreman">Foreman</option>
-                <option value="lead_hand">Lead Hand</option>
-                <option value="advisor">Advisor</option>
-                <option value="mechanic">Mechanic / Technician</option>
-                <option value="parts">Parts</option>
-                <option value="driver">Driver</option>
-                <option value="dispatcher">Dispatcher</option>
-                <option value="fleet_manager">Fleet manager</option>
+                {roleOptions.map((role) => (
+                  <option key={role.value} value={role.value}>
+                    {role.label}
+                  </option>
+                ))}
               </select>
               <p className="text-[11px] text-neutral-500">
                 App role controls access and permissions. Workforce title/category is managed
-                separately in the People profile. Use{" "}
-                <span style={{ color: COPPER }}>driver / dispatcher / fleet manager</span> for
-                Fleet Portal accounts.
+                separately in the People profile.
               </p>
             </div>
 
-            <div className="space-y-1">
-              <label className="text-xs font-medium uppercase tracking-[0.14em] text-neutral-300">
-                Shop ID{" "}
-                <span className="text-neutral-500">
-                  {creatorShopId ? "(auto from your profile)" : "(optional)"}
-                </span>
-              </label>
-              <input
-                className={INPUT_CLASS}
-                placeholder="Shop ID"
-                value={form.shop_id ?? ""}
-                onChange={(e) =>
-                  setForm({
-                    ...form,
-                    shop_id: e.target.value || null,
-                  })
-                }
-              />
+            <div className="space-y-1 rounded-xl border border-[color:var(--metal-border-soft,#334155)] bg-slate-950/60 px-3 py-2">
+              <div className="text-xs font-medium uppercase tracking-[0.14em] text-neutral-300">
+                Current shop
+              </div>
+              <p className="text-sm text-neutral-200">
+                New staff will be added to your current shop{creatorShopName ? `: ${creatorShopName}` : "."}
+              </p>
             </div>
           </div>
 

--- a/tests/admin-users-route.test.ts
+++ b/tests/admin-users-route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+  createAdminSupabase: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdminSupabase,
+}));
+
+type ProfileRow = {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  username: string | null;
+  phone: string | null;
+  role: string | null;
+  created_at: string | null;
+  shop_id: string;
+};
+
+function buildUsers(count: number, shopId = "shop-1"): ProfileRow[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `user-${String(index + 1).padStart(2, "0")}`,
+    full_name: `Staff ${String(index + 1).padStart(2, "0")}`,
+    email: `staff${index + 1}@example.com`,
+    username: `staff${index + 1}`,
+    phone: `555-010${index % 10}`,
+    role: index % 2 === 0 ? "mechanic" : "advisor",
+    created_at: null,
+    shop_id: shopId,
+  }));
+}
+
+function jsonRequest(path: string): Request {
+  return new Request(`http://localhost${path}`);
+}
+
+function setupUsersRoute(rows: ProfileRow[]) {
+  const calls: { table?: string; select?: string; eq?: [string, string | null]; order: unknown[]; limit?: number; or?: string } = {
+    order: [],
+  };
+
+  const query: {
+    select: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    order: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+    or: ReturnType<typeof vi.fn>;
+    then: (resolve: (value: { data: ProfileRow[]; error: null }) => void) => void;
+  } = {
+    select: vi.fn((columns: string) => {
+      calls.select = columns;
+      return query;
+    }),
+    eq: vi.fn((column: string, value: string | null) => {
+      calls.eq = [column, value];
+      return query;
+    }),
+    order: vi.fn((column: string, options: unknown) => {
+      calls.order.push([column, options]);
+      return query;
+    }),
+    limit: vi.fn((limit: number) => {
+      calls.limit = limit;
+      return query;
+    }),
+    or: vi.fn((filter: string) => {
+      calls.or = filter;
+      return query;
+    }),
+    then: (resolve: (value: { data: ProfileRow[]; error: null }) => void) => resolve({ data: rows.slice(0, calls.limit ?? rows.length), error: null }),
+  };
+
+  const adminClient = {
+    from: vi.fn((table: string) => {
+      calls.table = table;
+      return query;
+    }),
+  };
+
+  mocks.requireShopScopedApiAccess.mockResolvedValue({
+    ok: true,
+    profile: { id: "actor-1", shop_id: "shop-1", role: "owner" },
+    canonicalRole: "owner",
+  });
+  mocks.createAdminSupabase.mockReturnValue(adminClient);
+
+  return { calls, query, adminClient };
+}
+
+describe("GET /api/admin/users", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the first 20 shop-scoped staff alphabetically by default", async () => {
+    const { GET } = await import("../app/api/admin/users/route");
+    const { calls } = setupUsersRoute(buildUsers(25));
+
+    const response = await GET(jsonRequest("/api/admin/users"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.users).toHaveLength(20);
+    expect(calls.select).toContain("username");
+    expect(calls.eq).toEqual(["shop_id", "shop-1"]);
+    expect(calls.order).toEqual([
+      ["full_name", { ascending: true, nullsFirst: false }],
+      ["username", { ascending: true, nullsFirst: false }],
+    ]);
+    expect(calls.limit).toBe(20);
+    expect(calls.or).toBeUndefined();
+  });
+
+  it.each([
+    ["name", "Sam Tech", "full_name.ilike.%Sam Tech%"],
+    ["email", "sam@example.com", "email.ilike.%sam@example.com%"],
+    ["username", "samtech", "username.ilike.%samtech%"],
+    ["phone", "555-1212", "phone.ilike.%555-1212%"],
+    ["role", "mechanic", "role.ilike.%mechanic%"],
+  ])("searches by %s and caps results to 20", async (_label, term, expectedFilter) => {
+    const { GET } = await import("../app/api/admin/users/route");
+    const { calls } = setupUsersRoute(buildUsers(30));
+
+    const response = await GET(jsonRequest(`/api/admin/users?q=${encodeURIComponent(term)}`));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.users).toHaveLength(20);
+    expect(calls.or).toContain(expectedFilter);
+    expect(calls.limit).toBe(20);
+    expect(calls.eq).toEqual(["shop_id", "shop-1"]);
+  });
+});

--- a/tests/user-auth-normalization.test.ts
+++ b/tests/user-auth-normalization.test.ts
@@ -11,7 +11,7 @@ import {
 const mocks = vi.hoisted(() => ({
   requireShopScopedApiAccess: vi.fn(),
   createAdminSupabase: vi.fn(),
-  assertShopHasAvailableSeat: vi.fn(),
+  getShopSeatLimitSnapshot: vi.fn(),
 }));
 
 vi.mock("@/features/shared/lib/server/admin-access", () => ({
@@ -23,7 +23,7 @@ vi.mock("@/features/shared/lib/supabase/server", () => ({
 }));
 
 vi.mock("@/features/shared/lib/server/shop-seat-limit", () => ({
-  assertShopHasAvailableSeat: mocks.assertShopHasAvailableSeat,
+  getShopSeatLimitSnapshot: mocks.getShopSeatLimitSnapshot,
 }));
 
 type CreateUserPayload = {
@@ -46,6 +46,10 @@ type MockAdminOptions = {
   shopName?: string;
   sameShopProfiles?: { id: string; username: string | null }[];
   createdUserId?: string;
+  actorRole?: "owner" | "admin";
+  profileError?: { message: string } | null;
+  workforceError?: { message: string } | null;
+  seatSnapshot?: { plan: "starter" | "pro" | "unlimited"; cap: number; activeUsers: number; source: string };
 };
 
 function jsonRequest(body: Record<string, unknown>): Request {
@@ -64,11 +68,12 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
     data: { user: { id: createdUserId } },
     error: null,
   }));
-  const profileUpsert = vi.fn(async (_payload: ProfileUpsertPayload) => ({ error: null }));
-  const workforceUpsert = vi.fn(async (_payload: Record<string, unknown>) => ({ error: null }));
+  const deleteUser = vi.fn(async (_id: string) => ({ error: null }));
+  const profileUpsert = vi.fn(async (_payload: ProfileUpsertPayload) => ({ error: options.profileError ?? null }));
+  const workforceUpsert = vi.fn(async (_payload: Record<string, unknown>) => ({ error: options.workforceError ?? null }));
 
   const adminClient = {
-    auth: { admin: { createUser } },
+    auth: { admin: { createUser, deleteUser } },
     from: vi.fn((table: string) => {
       if (table === "shops") {
         return {
@@ -106,12 +111,18 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
 
   mocks.requireShopScopedApiAccess.mockResolvedValue({
     ok: true,
-    profile: { id: adminId, shop_id: shopId },
+    profile: { id: adminId, shop_id: shopId, role: options.actorRole ?? "owner" },
+    canonicalRole: options.actorRole ?? "owner",
   });
   mocks.createAdminSupabase.mockReturnValue(adminClient);
-  mocks.assertShopHasAvailableSeat.mockResolvedValue(undefined);
+  mocks.getShopSeatLimitSnapshot.mockResolvedValue(options.seatSnapshot ?? {
+    plan: "starter",
+    cap: 10,
+    activeUsers: 0,
+    source: "shop.plan",
+  });
 
-  return { createUser, profileUpsert, workforceUpsert, shopId, adminId, createdUserId };
+  return { createUser, deleteUser, profileUpsert, workforceUpsert, shopId, adminId, createdUserId };
 }
 
 describe("shop user auth normalization", () => {
@@ -242,6 +253,92 @@ describe("shop user auth normalization", () => {
     expect(response.status).toBe(400);
     expect(payload.error).toBe("A user with this username already exists in this shop.");
     expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects admin users creating owner or admin roles before auth user creation", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser } = buildCreateUserRouteMocks({ actorRole: "admin" });
+
+    const ownerResponse = await POST(jsonRequest({
+      username: "Privileged Owner",
+      password: "temporary-password",
+      role: "owner",
+    }));
+    const adminResponse = await POST(jsonRequest({
+      username: "Privileged Admin",
+      password: "temporary-password",
+      role: "admin",
+    }));
+
+    expect(ownerResponse.status).toBe(403);
+    expect(adminResponse.status).toBe(403);
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it.each(["manager", "advisor", "mechanic", "tech", "parts"])(
+    "allows admin users to create %s staff roles",
+    async (role) => {
+      const { POST } = await import("../app/api/admin/create-user/route");
+      const { createUser } = buildCreateUserRouteMocks({ actorRole: "admin" });
+
+      const response = await POST(jsonRequest({
+        username: `Allowed ${role}`,
+        password: "temporary-password",
+        role,
+      }));
+
+      expect(response.status).toBe(200);
+      expect(createUser).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("allows owner users to create admin users", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser } = buildCreateUserRouteMocks({ actorRole: "owner" });
+
+    const response = await POST(jsonRequest({
+      username: "Shop Admin",
+      password: "temporary-password",
+      role: "admin",
+    }));
+
+    expect(response.status).toBe(200);
+    expect(createUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects over-seat-limit staff creation before auth user creation with a clear error", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser } = buildCreateUserRouteMocks({
+      seatSnapshot: { plan: "starter", cap: 10, activeUsers: 10, source: "shop.plan" },
+    });
+
+    const response = await POST(jsonRequest({
+      username: "Seat Limited",
+      password: "temporary-password",
+      role: "mechanic",
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Shop user limit reached for your current plan.");
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("cleans up the created auth user when profile creation fails", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser, deleteUser, createdUserId } = buildCreateUserRouteMocks({
+      profileError: { message: "profile insert failed" },
+    });
+
+    const response = await POST(jsonRequest({
+      username: "Cleanup User",
+      password: "temporary-password",
+      role: "mechanic",
+    }));
+
+    expect(response.status).toBe(400);
+    expect(createUser).toHaveBeenCalledTimes(1);
+    expect(deleteUser).toHaveBeenCalledWith(createdUserId);
   });
 
   it("uses the server-side shop namespace, so different shop namespaces produce different usernames and auth emails", () => {


### PR DESCRIPTION
### Motivation
- Make manual staff creation safe and shop-scoped by ensuring server-side enforcement of the actor's current shop and removing a free-text Shop ID client surface. 
- Prevent privilege escalation by restricting which roles an actor may create and by rejecting admin -> owner/admin creations. 
- Enforce per-shop seat limits early with clear errors and avoid orphaned auth users when downstream profile/workforce writes fail. 
- Make the staff directory behave like other directories (Customers/Vehicles): shop-scoped, alphabetized, searchable, and capped.

### Description
- Server: hardened `POST /api/admin/create-user` to always use `access.profile.shop_id`, ignore client `shop_id`, normalize the requested role with `canonicalizeRole`, enforce role-creation guards (`owner` vs `admin` allowed targets), and add a TODO: "Future multi-location staff creation should use a verified manageable-shop resolver." (`app/api/admin/create-user/route.ts`).
- Server: check seat limits with `getShopSeatLimitSnapshot` before creating auth users, return a clear message `"Shop user limit reached for your current plan."`, and log only safe diagnostics (actor present, profile id, target shop id, requested role, plan/cap/active count, failure reason) while avoiding sensitive fields (`app/api/admin/create-user/route.ts`).
- Server: attempt compensating cleanup by deleting the newly-created auth user when profile/workforce upserts fail, and log cleanup outcome without exposing secrets (`app/api/admin/create-user/route.ts`).
- API: replaced the users endpoint to be shop-scoped, return `username`, default to first 20 alphabetically, support immediate search across `full_name`, `email`, `username`, `phone`, and `role`, and cap results to 20 (`app/api/admin/users/route.ts`).
- UI: removed the editable Shop ID input and replaced it with a read-only "New staff will be added to your current shop" block, expose current shop name when cheaply available, and filter role options so `admin` actors do not see owner/admin choices (page still uses actor’s shop; server enforces shop) (`features/dashboard/app/dashboard/owner/create-user/page.tsx`).
- UI: Users list updated to include `username` display, reflect the new search placeholder, and present distinct empty states for no staff vs no matching staff (`features/admin/components/UsersList.tsx`).
- Tests: added/expanded unit tests covering acceptance criteria (role guards, server-side shop scoping, seat-limit pre-checks, auth cleanup on downstream failure, staff directory search/scope/cap, and onboarding staff step behavior) (`tests/user-auth-normalization.test.ts`, `tests/admin-users-route.test.ts`, onboarding tests already present updated/covered).

### Testing
- Ran targeted unit tests with Vitest: `npx vitest run tests/user-auth-normalization.test.ts tests/admin-users-route.test.ts tests/onboarding-v2/staff-onboarding-card.test.tsx tests/onboarding-v2/guided-registry-and-query.test.ts` and all tests passed. 
- Typecheck: `npx tsc --noEmit` completed successfully after fixes. 
- Additional validation: `git diff --check` produced no new whitespace/conflict issues. 
- Notes: Playwright screenshot was attempted in the environment but the `playwright` package was not installed (non-blocking; visual smoke checks not required for this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23171888cc83289330d1f7ab9658c0)