### PR TITLE
Add owner shop switcher

### DIFF
--- a/app/api/shops/available/route.ts
+++ b/app/api/shops/available/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getAvailableShopContext } from "@/features/shops/server/shop-switcher";
+
+type ProfileRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "role" | "shop_id" | "business_name" | "shop_name"
+>;
+
+export async function GET() {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const admin = createAdminSupabase();
+  const { data: profile, error: profileError } = await admin
+    .from("profiles")
+    .select("id, role, shop_id, business_name, shop_name")
+    .eq("id", user.id)
+    .maybeSingle<ProfileRow>();
+
+  if (profileError || !profile) {
+    return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
+  }
+
+  const context = await getAvailableShopContext({ admin, profile });
+
+  return NextResponse.json({
+    currentShop: context.currentShop,
+    shops: context.shops,
+    canSwitch: context.canSwitch,
+  });
+}

--- a/app/api/shops/switch/route.ts
+++ b/app/api/shops/switch/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { switchActiveShop } from "@/features/shops/server/shop-switcher";
+
+type ProfileRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "role" | "shop_id" | "business_name" | "shop_name"
+>;
+
+export async function POST(request: Request) {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { shop_id?: unknown } | null;
+  const requestedShopId = typeof body?.shop_id === "string" ? body.shop_id : "";
+
+  if (!requestedShopId.trim()) {
+    return NextResponse.json({ error: "shop_id is required" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase();
+  const { data: profile, error: profileError } = await admin
+    .from("profiles")
+    .select("id, role, shop_id, business_name, shop_name")
+    .eq("id", user.id)
+    .maybeSingle<ProfileRow>();
+
+  if (profileError || !profile) {
+    return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
+  }
+
+  const result = await switchActiveShop({
+    admin,
+    actorProfile: profile,
+    requestedShopId,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({
+    currentShop: result.currentShop,
+    shops: result.shops,
+  });
+}

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/features/shared/utils/cn";
 import TabsBridge from "@/features/shared/components/tabs/TabsBridge";
 import ForcePasswordChangeModal from "@/features/auth/components/ForcePasswordChangeModal";
 import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
+import ShopSwitcher from "@/features/shops/components/ShopSwitcher";
 import { useActiveBrand } from "@/features/branding/hooks/useActiveBrand";
 import { isBillingAttentionStatus } from "@/features/stripe/lib/stripe/subscriptionStatus";
 
@@ -391,6 +392,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             </div>
 
             <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 lg:gap-2">
+              <div className="hidden max-w-[280px] md:block">
+                <ShopSwitcher compact />
+              </div>
+
               <BillingBadge />
 
               <ActionButton
@@ -450,6 +455,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           ) : null}
 
           <main className="flex w-full min-w-0 flex-1 flex-col overflow-x-hidden px-3 pb-14 pt-16 md:px-4 md:pb-6 md:pt-16 lg:px-6 lg:pt-[4.25rem] xl:px-8 2xl:px-10">
+            <div className="mb-3 md:hidden">
+              <ShopSwitcher compact />
+            </div>
+
             <TabsBridge tabsSubdued={chatOpen}>
               <div className="relative z-0 min-w-0">{children}</div>
             </TabsBridge>

--- a/features/shops/components/ShopSwitcher.tsx
+++ b/features/shops/components/ShopSwitcher.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { cn } from "@/features/shared/utils/cn";
+
+type AvailableShop = {
+  id: string;
+  name: string;
+  current: boolean;
+  membershipRole: string | null;
+};
+
+type AvailableShopsResponse = {
+  currentShop: AvailableShop | null;
+  shops: AvailableShop[];
+  canSwitch: boolean;
+  error?: string;
+};
+
+export default function ShopSwitcher({ compact = false }: { compact?: boolean }) {
+  const router = useRouter();
+  const [currentShop, setCurrentShop] = useState<AvailableShop | null>(null);
+  const [shops, setShops] = useState<AvailableShop[]>([]);
+  const [canSwitch, setCanSwitch] = useState(false);
+  const [selectedShopId, setSelectedShopId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [switching, setSwitching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadAvailableShops() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch("/api/shops/available", { cache: "no-store" });
+        const payload = (await response.json()) as AvailableShopsResponse;
+
+        if (!active) return;
+
+        if (!response.ok) {
+          setError(payload.error ?? "Unable to load shop context");
+          return;
+        }
+
+        setCurrentShop(payload.currentShop ?? null);
+        setShops(payload.shops ?? []);
+        setCanSwitch(Boolean(payload.canSwitch));
+        setSelectedShopId(payload.currentShop?.id ?? "");
+      } catch (err) {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : "Unable to load shop context");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void loadAvailableShops();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const sortedShops = useMemo(() => {
+    return [...shops].sort((a, b) => {
+      if (a.current) return -1;
+      if (b.current) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [shops]);
+
+  async function handleSwitch() {
+    if (!selectedShopId || selectedShopId === currentShop?.id) return;
+
+    setSwitching(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/shops/switch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shop_id: selectedShopId }),
+      });
+      const payload = (await response.json()) as AvailableShopsResponse;
+
+      if (!response.ok) {
+        const message = payload.error ?? "Unable to switch shops";
+        setError(message);
+        toast.error(message);
+        return;
+      }
+
+      setCurrentShop(payload.currentShop ?? null);
+      setShops(payload.shops ?? []);
+      setCanSwitch((payload.shops ?? []).length > 1);
+      setSelectedShopId(payload.currentShop?.id ?? selectedShopId);
+      toast.success(`Switched to ${payload.currentShop?.name ?? "selected shop"}`);
+      router.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to switch shops";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setSwitching(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-xs text-neutral-400">
+        Loading shop…
+      </div>
+    );
+  }
+
+  if (error && !currentShop) {
+    return (
+      <div className="rounded-lg border border-red-500/20 bg-red-950/20 px-3 py-2 text-xs text-red-100">
+        Shop context unavailable
+      </div>
+    );
+  }
+
+  if (!currentShop) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border backdrop-blur-md",
+        compact ? "px-2.5 py-1.5" : "px-3 py-2",
+      )}
+      style={{
+        borderColor: "color-mix(in srgb, var(--brand-primary,#C1663B) 28%, rgba(148,163,184,0.22))",
+        background:
+          "linear-gradient(135deg, rgba(0,0,0,0.58), color-mix(in srgb, var(--brand-secondary,#0F172A) 64%, black))",
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+            Current shop
+          </div>
+          <div className="truncate text-xs font-semibold text-neutral-100" title={currentShop.name}>
+            {currentShop.name}
+          </div>
+        </div>
+        {!canSwitch ? (
+          <span className="rounded-full border border-white/10 px-2 py-0.5 text-[0.58rem] font-semibold uppercase tracking-[0.16em] text-neutral-400">
+            Active
+          </span>
+        ) : null}
+      </div>
+
+      {canSwitch ? (
+        <div className="mt-2 flex gap-1.5">
+          <select
+            aria-label="Switch active shop"
+            value={selectedShopId}
+            disabled={switching}
+            onChange={(event) => setSelectedShopId(event.target.value)}
+            className="min-w-0 flex-1 rounded-md border border-white/10 bg-black/70 px-2 py-1 text-xs text-neutral-100 outline-none transition focus:border-[var(--brand-primary,#C1663B)]"
+          >
+            {sortedShops.map((shop) => (
+              <option key={shop.id} value={shop.id}>
+                {shop.name}{shop.current ? " (current)" : ""}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            disabled={switching || selectedShopId === currentShop.id}
+            onClick={handleSwitch}
+            className="rounded-md border border-white/10 px-2 py-1 text-xs font-semibold text-neutral-100 transition hover:border-[var(--brand-primary,#C1663B)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {switching ? "Switching…" : "Switch"}
+          </button>
+        </div>
+      ) : null}
+
+      {error ? <div className="mt-1 text-[0.68rem] text-red-200">{error}</div> : null}
+    </div>
+  );
+}

--- a/features/shops/server/shop-switcher.ts
+++ b/features/shops/server/shop-switcher.ts
@@ -1,0 +1,217 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type DB = Database;
+
+type ProfileRow = Pick<
+  DB["public"]["Tables"]["profiles"]["Row"],
+  "id" | "role" | "shop_id" | "business_name" | "shop_name"
+>;
+
+type ShopRow = Pick<
+  DB["public"]["Tables"]["shops"]["Row"],
+  "id" | "business_name" | "email" | "city"
+>;
+
+type ShopMemberRow = Pick<
+  DB["public"]["Tables"]["shop_members"]["Row"],
+  "shop_id" | "role"
+>;
+
+type AuditLogInsert = DB["public"]["Tables"]["audit_logs"]["Insert"];
+
+export type AvailableShop = {
+  id: string;
+  name: string;
+  current: boolean;
+  membershipRole: string | null;
+};
+
+export type ShopSwitchContext = {
+  profile: ProfileRow;
+  currentShop: AvailableShop | null;
+  shops: AvailableShop[];
+  canSwitch: boolean;
+};
+
+const ACTOR_SWITCH_ROLES = new Set(["owner", "admin"]);
+const MANAGEABLE_MEMBERSHIP_ROLES = new Set(["owner", "admin"]);
+
+function shopDisplayName(shop: ShopRow | null | undefined, profile?: ProfileRow | null): string {
+  const name =
+    shop?.business_name?.trim() ||
+    profile?.shop_name?.trim() ||
+    profile?.business_name?.trim() ||
+    shop?.email?.trim() ||
+    shop?.city?.trim();
+
+  return name || "Current shop";
+}
+
+function uniqueShopIds(ids: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(ids.filter((id): id is string => Boolean(id))));
+}
+
+async function loadCurrentShop(admin: SupabaseClient<DB>, profile: ProfileRow) {
+  if (!profile.shop_id) return null;
+
+  const { data } = await admin
+    .from("shops")
+    .select("id, business_name, email, city")
+    .eq("id", profile.shop_id)
+    .maybeSingle<ShopRow>();
+
+  return data ?? null;
+}
+
+async function loadShopsById(admin: SupabaseClient<DB>, shopIds: string[]) {
+  if (shopIds.length === 0) return new Map<string, ShopRow>();
+
+  const { data } = await admin
+    .from("shops")
+    .select("id, business_name, email, city")
+    .in("id", shopIds);
+
+  return new Map((data ?? []).map((shop) => [shop.id, shop as ShopRow]));
+}
+
+async function loadManageableMemberships(admin: SupabaseClient<DB>, actorProfileId: string) {
+  const { data, error } = await admin
+    .from("shop_members")
+    .select("shop_id, role")
+    .eq("user_id", actorProfileId)
+    .in("role", Array.from(MANAGEABLE_MEMBERSHIP_ROLES));
+
+  if (error) {
+    console.warn("[shop-switcher] shop_members lookup failed; falling back to current shop only", {
+      code: error.code,
+      message: error.message,
+    });
+    return [] as ShopMemberRow[];
+  }
+
+  return (data ?? []) as ShopMemberRow[];
+}
+
+export function canActorSwitchShops(role: string | null | undefined): boolean {
+  return ACTOR_SWITCH_ROLES.has(canonicalizeRole(role));
+}
+
+export async function getAvailableShopContext(params: {
+  admin?: SupabaseClient<DB>;
+  profile: ProfileRow;
+}): Promise<ShopSwitchContext> {
+  const admin = params.admin ?? createAdminSupabase();
+  const profile = params.profile;
+  const actorCanSwitch = canActorSwitchShops(profile.role);
+
+  const [currentShop, memberships] = await Promise.all([
+    loadCurrentShop(admin, profile),
+    actorCanSwitch ? loadManageableMemberships(admin, profile.id) : Promise.resolve([] as ShopMemberRow[]),
+  ]);
+
+  const manageableShopIds = actorCanSwitch
+    ? uniqueShopIds(memberships.map((membership) => membership.shop_id))
+    : [];
+  const shopIds = uniqueShopIds([profile.shop_id, ...manageableShopIds]);
+  const shopsById = await loadShopsById(admin, shopIds);
+
+  if (currentShop && !shopsById.has(currentShop.id)) {
+    shopsById.set(currentShop.id, currentShop);
+  }
+
+  const roleByShopId = new Map(
+    memberships.map((membership) => [membership.shop_id, membership.role]),
+  );
+
+  const shops = shopIds.map((shopId) => {
+    const shop = shopsById.get(shopId) ?? null;
+    return {
+      id: shopId,
+      name: shopDisplayName(shop, shopId === profile.shop_id ? profile : null),
+      current: shopId === profile.shop_id,
+      membershipRole: roleByShopId.get(shopId) ?? null,
+    };
+  });
+
+  const currentShopOption = profile.shop_id
+    ? shops.find((shop) => shop.id === profile.shop_id) ?? {
+        id: profile.shop_id,
+        name: shopDisplayName(currentShop, profile),
+        current: true,
+        membershipRole: roleByShopId.get(profile.shop_id) ?? null,
+      }
+    : null;
+
+  return {
+    profile,
+    currentShop: currentShopOption,
+    shops,
+    canSwitch: actorCanSwitch && shops.length > 1,
+  };
+}
+
+export async function switchActiveShop(params: {
+  admin?: SupabaseClient<DB>;
+  actorProfile: ProfileRow;
+  requestedShopId: string;
+}): Promise<
+  | { ok: true; currentShop: AvailableShop; shops: AvailableShop[] }
+  | { ok: false; status: 400 | 403 | 404 | 500; error: string }
+> {
+  const requestedShopId = params.requestedShopId.trim();
+  if (!requestedShopId) {
+    return { ok: false, status: 400, error: "shop_id is required" };
+  }
+
+  if (!canActorSwitchShops(params.actorProfile.role)) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  const admin = params.admin ?? createAdminSupabase();
+  const beforeContext = await getAvailableShopContext({ admin, profile: params.actorProfile });
+  const authorizedShop = beforeContext.shops.find((shop) => shop.id === requestedShopId);
+
+  if (!authorizedShop || !authorizedShop.membershipRole) {
+    return { ok: false, status: 403, error: "Requested shop is not authorized for this user" };
+  }
+
+  const { data: updatedProfile, error: updateError } = await admin
+    .from("profiles")
+    .update({ shop_id: requestedShopId, updated_at: new Date().toISOString() })
+    .eq("id", params.actorProfile.id)
+    .select("id, role, shop_id, business_name, shop_name")
+    .maybeSingle<ProfileRow>();
+
+  if (updateError) {
+    return { ok: false, status: 500, error: updateError.message };
+  }
+
+  if (!updatedProfile?.shop_id) {
+    return { ok: false, status: 404, error: "Updated profile not found" };
+  }
+
+  await admin.from("audit_logs").insert({
+    actor_id: params.actorProfile.id,
+    action: "shop_context_switched",
+    target: "profiles.shop_id",
+    metadata: {
+      profile_id: params.actorProfile.id,
+      from_shop_id: params.actorProfile.shop_id,
+      to_shop_id: requestedShopId,
+    },
+  } satisfies AuditLogInsert);
+
+  const afterContext = await getAvailableShopContext({ admin, profile: updatedProfile });
+  const currentShop = afterContext.currentShop;
+
+  if (!currentShop) {
+    return { ok: false, status: 404, error: "Current shop not found" };
+  }
+
+  return { ok: true, currentShop, shops: afterContext.shops };
+}

--- a/tests/shop-switcher-server.test.ts
+++ b/tests/shop-switcher-server.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentUser: { id: "actor-1" },
+  createServerSupabaseRoute: vi.fn(),
+  createAdminSupabase: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRoute: mocks.createServerSupabaseRoute,
+  createAdminSupabase: mocks.createAdminSupabase,
+}));
+
+type ProfileRow = {
+  id: string;
+  role: string | null;
+  shop_id: string | null;
+  business_name: string | null;
+  shop_name: string | null;
+};
+
+type ShopRow = {
+  id: string;
+  business_name: string | null;
+  email: string | null;
+  city: string | null;
+};
+
+type MemberRow = { shop_id: string; role: string };
+
+function jsonRequest(path: string, body?: unknown) {
+  return new Request(`http://localhost${path}`, {
+    method: body ? "POST" : "GET",
+    body: body ? JSON.stringify(body) : undefined,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+  });
+}
+
+function buildAdminClient(options: {
+  profile: ProfileRow;
+  shops: ShopRow[];
+  memberships: MemberRow[];
+  membershipError?: { code: string; message: string } | null;
+}) {
+  const updates: Array<{ table: string; patch: Record<string, unknown>; eq?: [string, string] }> = [];
+  const inserts: Array<{ table: string; row: unknown }> = [];
+
+  const shopsById = new Map(options.shops.map((shop) => [shop.id, shop]));
+  let profile = { ...options.profile };
+
+  function profileReadQuery() {
+    return {
+      eq: vi.fn(() => ({
+        maybeSingle: vi.fn(async () => ({ data: profile, error: null })),
+      })),
+    };
+  }
+
+  function profileUpdateQuery(patch: Record<string, unknown>) {
+    const updateCall = { table: "profiles", patch, eq: undefined as [string, string] | undefined };
+    updates.push(updateCall);
+    return {
+      eq: vi.fn((column: string, value: string) => {
+        updateCall.eq = [column, value];
+        if (column === "id" && value === profile.id) {
+          profile = { ...profile, ...patch } as ProfileRow;
+        }
+        return {
+          select: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: profile, error: null })),
+          })),
+        };
+      }),
+    };
+  }
+
+  const admin = {
+    from: vi.fn((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: vi.fn(() => profileReadQuery()),
+          update: vi.fn((patch: Record<string, unknown>) => profileUpdateQuery(patch)),
+        };
+      }
+
+      if (table === "shops") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn((_column: string, id: string) => ({
+              maybeSingle: vi.fn(async () => ({ data: shopsById.get(id) ?? null, error: null })),
+            })),
+            in: vi.fn(async (_column: string, ids: string[]) => ({
+              data: ids.map((id) => shopsById.get(id)).filter(Boolean),
+              error: null,
+            })),
+          })),
+        };
+      }
+
+      if (table === "shop_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn(async () => ({ data: options.memberships, error: options.membershipError ?? null })),
+            })),
+          })),
+        };
+      }
+
+      if (table === "audit_logs") {
+        return {
+          insert: vi.fn(async (row: unknown) => {
+            inserts.push({ table, row });
+            return { data: null, error: null };
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+
+  return { admin, updates, inserts, getProfile: () => profile };
+}
+
+function setupAuth() {
+  mocks.createServerSupabaseRoute.mockReturnValue({
+    auth: { getUser: vi.fn(async () => ({ data: { user: mocks.currentUser }, error: null })) },
+  });
+}
+
+describe("shop switcher server authorization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupAuth();
+  });
+
+  it("returns only the current shop for regular staff", async () => {
+    const { admin } = buildAdminClient({
+      profile: { id: "actor-1", role: "advisor", shop_id: "shop-demo", business_name: null, shop_name: null },
+      shops: [{ id: "shop-demo", business_name: "Prairie Fleet & Diesel Demo", email: null, city: null }],
+      memberships: [{ shop_id: "shop-pro", role: "owner" }],
+    });
+    mocks.createAdminSupabase.mockReturnValue(admin);
+
+    const { GET } = await import("../app/api/shops/available/route");
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.currentShop.name).toBe("Prairie Fleet & Diesel Demo");
+    expect(payload.canSwitch).toBe(false);
+    expect(payload.shops).toEqual([
+      expect.objectContaining({ id: "shop-demo", current: true }),
+    ]);
+  });
+
+  it("allows owner/admin actors to switch only among explicit shop memberships", async () => {
+    const { admin, updates, inserts, getProfile } = buildAdminClient({
+      profile: { id: "actor-1", role: "owner", shop_id: "shop-demo", business_name: null, shop_name: null },
+      shops: [
+        { id: "shop-demo", business_name: "Prairie Fleet & Diesel Demo", email: null, city: null },
+        { id: "shop-pro", business_name: "PRO FIX", email: null, city: null },
+      ],
+      memberships: [
+        { shop_id: "shop-demo", role: "owner" },
+        { shop_id: "shop-pro", role: "admin" },
+      ],
+    });
+    mocks.createAdminSupabase.mockReturnValue(admin);
+
+    const { POST } = await import("../app/api/shops/switch/route");
+    const response = await POST(jsonRequest("/api/shops/switch", { shop_id: "shop-pro" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.currentShop).toEqual(expect.objectContaining({ id: "shop-pro", name: "PRO FIX" }));
+    expect(updates).toHaveLength(1);
+    expect(updates[0].eq).toEqual(["id", "actor-1"]);
+    expect(updates[0].patch.shop_id).toBe("shop-pro");
+    expect(getProfile().shop_id).toBe("shop-pro");
+    expect(inserts).toHaveLength(1);
+  });
+
+  it("rejects unauthorized client-provided shop_id and does not update profiles", async () => {
+    const { admin, updates } = buildAdminClient({
+      profile: { id: "actor-1", role: "admin", shop_id: "shop-demo", business_name: null, shop_name: null },
+      shops: [{ id: "shop-demo", business_name: "Prairie Fleet & Diesel Demo", email: null, city: null }],
+      memberships: [{ shop_id: "shop-demo", role: "admin" }],
+    });
+    mocks.createAdminSupabase.mockReturnValue(admin);
+
+    const { POST } = await import("../app/api/shops/switch/route");
+    const response = await POST(jsonRequest("/api/shops/switch", { shop_id: "shop-other" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.error).toMatch(/not authorized/i);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("rejects regular staff switch attempts even if the client posts a shop_id", async () => {
+    const { admin, updates } = buildAdminClient({
+      profile: { id: "actor-1", role: "advisor", shop_id: "shop-demo", business_name: null, shop_name: null },
+      shops: [{ id: "shop-demo", business_name: "Prairie Fleet & Diesel Demo", email: null, city: null }],
+      memberships: [{ shop_id: "shop-pro", role: "owner" }],
+    });
+    mocks.createAdminSupabase.mockReturnValue(admin);
+
+    const { POST } = await import("../app/api/shops/switch/route");
+    const response = await POST(jsonRequest("/api/shops/switch", { shop_id: "shop-pro" }));
+
+    expect(response.status).toBe(403);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("falls back to current shop only when shop_members is unavailable", async () => {
+    const { admin } = buildAdminClient({
+      profile: { id: "actor-1", role: "owner", shop_id: "shop-demo", business_name: null, shop_name: null },
+      shops: [{ id: "shop-demo", business_name: "Prairie Fleet & Diesel Demo", email: null, city: null }],
+      memberships: [{ shop_id: "shop-pro", role: "owner" }],
+      membershipError: { code: "42P01", message: "relation does not exist" },
+    });
+    mocks.createAdminSupabase.mockReturnValue(admin);
+
+    const { GET } = await import("../app/api/shops/available/route");
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.canSwitch).toBe(false);
+    expect(payload.shops).toHaveLength(1);
+    expect(payload.shops[0]).toEqual(expect.objectContaining({ id: "shop-demo" }));
+  });
+});

--- a/tests/shop-switcher-ui.test.tsx
+++ b/tests/shop-switcher-ui.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ShopSwitcher from "@/features/shops/components/ShopSwitcher";
+
+const routerMocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMocks,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ShopSwitcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the current shop name without switch controls for non-switchable users", async () => {
+    global.fetch = vi.fn(async () =>
+      jsonResponse({
+        currentShop: { id: "shop-demo", name: "Prairie Fleet & Diesel Demo", current: true, membershipRole: null },
+        shops: [{ id: "shop-demo", name: "Prairie Fleet & Diesel Demo", current: true, membershipRole: null }],
+        canSwitch: false,
+      }),
+    ) as typeof fetch;
+
+    render(<ShopSwitcher />);
+
+    expect(await screen.findByText("Prairie Fleet & Diesel Demo")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: /switch active shop/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("switches authorized shops and refreshes app context", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/shops/available")) {
+        return jsonResponse({
+          currentShop: { id: "shop-demo", name: "Prairie Fleet & Diesel Demo", current: true, membershipRole: "owner" },
+          shops: [
+            { id: "shop-demo", name: "Prairie Fleet & Diesel Demo", current: true, membershipRole: "owner" },
+            { id: "shop-pro", name: "PRO FIX", current: false, membershipRole: "admin" },
+          ],
+          canSwitch: true,
+        });
+      }
+
+      return jsonResponse({
+        currentShop: { id: "shop-pro", name: "PRO FIX", current: true, membershipRole: "admin" },
+        shops: [
+          { id: "shop-demo", name: "Prairie Fleet & Diesel Demo", current: false, membershipRole: "owner" },
+          { id: "shop-pro", name: "PRO FIX", current: true, membershipRole: "admin" },
+        ],
+        canSwitch: true,
+      });
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<ShopSwitcher />);
+
+    const select = await screen.findByRole("combobox", { name: /switch active shop/i });
+    await userEvent.selectOptions(select, "shop-pro");
+    await userEvent.click(screen.getByRole("button", { name: "Switch" }));
+
+    await waitFor(() => expect(routerMocks.refresh).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/shops/switch",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ shop_id: "shop-pro" }),
+      }),
+    );
+    expect(await screen.findByText("PRO FIX")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- Owners/admins needed a clear, safe way to change the active shop context because `profiles.shop_id` is the pointer most loaders use and accounts can become scoped to the demo shop unintentionally. 
- The change must be surgical, preserve tenant isolation, and only permit authorized actors to change their own active shop.

### Description
- Add server helpers `features/shops/server/shop-switcher.ts` with `getAvailableShopContext` and `switchActiveShop` that compute manageable shops from `shop_members` (owner/admin only), fall back to current-shop-only when membership lookup fails, and update only the authenticated actor's `profiles.shop_id` with an `audit_logs` insert. 
- Add API routes `GET /api/shops/available` and `POST /api/shops/switch` that authenticate, load the actor profile server-side, validate authorization, and call the server helpers. 
- Add a client `ShopSwitcher` component that displays current shop, shows a select for manageable shops to owner/admins, posts to `/api/shops/switch`, shows success/error toasts, and calls `router.refresh()` on success. 
- Wire a compact `ShopSwitcher` into the AppShell header and mobile area so the active shop is visible in sidebar/header without major layout changes. 

### Testing
- Ran unit/integration tests: `npx vitest run tests/shop-switcher-server.test.ts tests/shop-switcher-ui.test.tsx` — all tests passed (7/7). 
- Typecheck: `npx tsc --noEmit` — succeeded. 
- Lint: relevant files passed `eslint` checks in the working set — no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2325dde76883288bfcf643ec0e2f90)