### PR TITLE
Fix owner/admin work order technician assignment scoping

### DIFF
--- a/app/api/assignables/route.ts
+++ b/app/api/assignables/route.ts
@@ -1,31 +1,154 @@
 // app/api/assignables/route.ts
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  ASSIGNABLE_TECHNICIAN_ROLES,
+  canActorAssignInShop,
+  canRoleAssignWorkOrders,
+  logAssignmentDiagnostic,
+} from "@/features/work-orders/lib/server/assignment-access";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY! // server-side ONLY
-);
+type WorkOrderScope = { id: string; shop_id: string | null };
+type WorkOrderLineScope = { id: string; work_order_id: string; shop_id: string | null };
 
-export async function GET() {
+function jsonError(error: string, status: number, message?: string) {
+  return NextResponse.json({ error, message: message ?? error }, { status });
+}
+
+export async function GET(req: Request) {
   const access = await requireShopScopedApiAccess();
-  if (!access.ok) return access.response;
-  const shopId = access.profile.shop_id;
-
-  let query = supabase
-    .from("profiles")
-    .select("id, full_name, role, shop_id")
-    .in("role", ["mechanic", "tech", "foreman", "lead_hand"])
-    .order("full_name", { ascending: true });
-
-  query = query.eq("shop_id", shopId);
-
-  const { data, error } = await query;
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+  if (!access.ok) {
+    logAssignmentDiagnostic({ actorPresent: false, reason: "not_authenticated" });
+    return jsonError("not_authenticated", 401, "Not authenticated");
   }
 
-  return NextResponse.json({ data });
+  const admin = createAdminSupabase();
+  const url = new URL(req.url);
+  const workOrderId = url.searchParams.get("work_order_id")?.trim() || null;
+  const workOrderLineId = url.searchParams.get("work_order_line_id")?.trim() || null;
+
+  let targetShopId = access.profile.shop_id;
+  let resolvedWorkOrderId: string | null = workOrderId;
+
+  if (!canRoleAssignWorkOrders(access.profile.role)) {
+    logAssignmentDiagnostic({
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      workOrderId,
+      lineId: workOrderLineId,
+      reason: "forbidden_assignment_role",
+    });
+    return jsonError("forbidden_assignment_role", 403, "Current role cannot assign technicians");
+  }
+
+  if (workOrderLineId) {
+    const { data: line, error: lineErr } = await admin
+      .from("work_order_lines")
+      .select("id, work_order_id, shop_id")
+      .eq("id", workOrderLineId)
+      .maybeSingle<WorkOrderLineScope>();
+
+    if (lineErr) return jsonError("assignment_failed", 400, lineErr.message);
+    if (!line) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        lineId: workOrderLineId,
+        reason: "line_not_found",
+      });
+      return jsonError("line_not_found", 404, "Work order line not found");
+    }
+
+    resolvedWorkOrderId = line.work_order_id;
+    const { data: wo, error: woErr } = await admin
+      .from("work_orders")
+      .select("id, shop_id")
+      .eq("id", line.work_order_id)
+      .maybeSingle<WorkOrderScope>();
+
+    if (woErr) return jsonError("assignment_failed", 400, woErr.message);
+    if (!wo?.shop_id) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId: line.work_order_id,
+        lineId: workOrderLineId,
+        reason: "work_order_not_found",
+      });
+      return jsonError("work_order_not_found", 404, "Work order not found");
+    }
+    targetShopId = wo.shop_id;
+  } else if (workOrderId) {
+    const { data: wo, error: woErr } = await admin
+      .from("work_orders")
+      .select("id, shop_id")
+      .eq("id", workOrderId)
+      .maybeSingle<WorkOrderScope>();
+
+    if (woErr) return jsonError("assignment_failed", 400, woErr.message);
+    if (!wo?.shop_id) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        reason: "work_order_not_found",
+      });
+      return jsonError("work_order_not_found", 404, "Work order not found");
+    }
+    targetShopId = wo.shop_id;
+  } else {
+    console.warn("[assignables] target work order was not provided; using actor active shop", {
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      targetShopId,
+      reason: "target_not_provided",
+    });
+  }
+
+  const canAssignInTargetShop = await canActorAssignInShop({
+    admin,
+    profile: access.profile,
+    targetShopId,
+  });
+
+  if (!canAssignInTargetShop) {
+    logAssignmentDiagnostic({
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      targetShopId,
+      workOrderId: resolvedWorkOrderId,
+      lineId: workOrderLineId,
+      reason: "forbidden_shop",
+    });
+    return jsonError("forbidden_shop", 403, "Current user cannot assign in this shop");
+  }
+
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id, full_name, role, shop_id")
+    .eq("shop_id", targetShopId)
+    .in("role", [...ASSIGNABLE_TECHNICIAN_ROLES])
+    .order("full_name", { ascending: true });
+
+  if (error) {
+    return jsonError("assignment_failed", 400, error.message);
+  }
+
+  return NextResponse.json({ data: data ?? [], target_shop_id: targetShopId });
 }

--- a/app/api/work-orders/[id]/detail/route.ts
+++ b/app/api/work-orders/[id]/detail/route.ts
@@ -1,0 +1,167 @@
+// app/api/work-orders/[id]/detail/route.ts
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  canActorAccessWorkOrderShop,
+  logAssignmentDiagnostic,
+} from "@/features/work-orders/lib/server/assignment-access";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type Customer = DB["public"]["Tables"]["customers"]["Row"];
+type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
+type LineTech = DB["public"]["Tables"]["work_order_line_technicians"]["Row"];
+
+const looksLikeUuid = (s: string) => s.includes("-") && s.length >= 36;
+
+function splitCustomId(raw: string): { prefix: string; n: number | null } {
+  const m = raw.toUpperCase().match(/^([A-Z]+)\s*0*?(\d+)?$/);
+  if (!m) return { prefix: raw.toUpperCase(), n: null };
+  const n = m[2] ? parseInt(m[2], 10) : null;
+  return { prefix: m[1], n: Number.isFinite(n) ? n : null };
+}
+
+function jsonError(error: string, status: number, message?: string) {
+  return NextResponse.json({ error, message: message ?? error }, { status });
+}
+
+async function loadWorkOrder(admin: ReturnType<typeof createAdminSupabase>, routeId: string) {
+  if (looksLikeUuid(routeId)) {
+    const byId = await admin.from("work_orders").select("*").eq("id", routeId).maybeSingle<WorkOrder>();
+    if (byId.error || byId.data) return byId;
+  }
+
+  const byCustomId = await admin.from("work_orders").select("*").eq("custom_id", routeId).maybeSingle<WorkOrder>();
+  if (byCustomId.error || byCustomId.data) return byCustomId;
+
+  const byCustomIdIlike = await admin.from("work_orders").select("*").ilike("custom_id", routeId.toUpperCase()).maybeSingle<WorkOrder>();
+  if (byCustomIdIlike.error || byCustomIdIlike.data) return byCustomIdIlike;
+
+  const { prefix, n } = splitCustomId(routeId);
+  if (n === null) return { data: null, error: null } as const;
+
+  const cands = await admin.from("work_orders").select("*").ilike("custom_id", `${prefix}%`).limit(50);
+  if (cands.error) return { data: null, error: cands.error };
+  const wanted = `${prefix}${n}`;
+  const match = ((cands.data ?? []) as WorkOrder[]).find(
+    (row) => (row.custom_id ?? "").toUpperCase().replace(/^([A-Z]+)0+/, "$1") === wanted,
+  );
+  return { data: match ?? null, error: null } as const;
+}
+
+export async function GET(_req: Request, context: { params: Promise<{ id: string }> | { id: string } }) {
+  const access = await requireShopScopedApiAccess();
+  const params = await context.params;
+  const routeId = params.id;
+
+  if (!access.ok) {
+    logAssignmentDiagnostic({ actorPresent: false, workOrderId: routeId, reason: "not_authenticated" });
+    return jsonError("not_authenticated", 401, "Not authenticated");
+  }
+
+  const admin = createAdminSupabase();
+  const { data: workOrder, error: workOrderError } = await loadWorkOrder(admin, routeId);
+
+  if (workOrderError) return jsonError("assignment_failed", 400, workOrderError.message);
+  if (!workOrder?.shop_id) {
+    logAssignmentDiagnostic({
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      workOrderId: routeId,
+      reason: "work_order_not_found",
+    });
+    return jsonError("work_order_not_found", 404, "Work order not found");
+  }
+
+  const targetShopId = workOrder.shop_id;
+  const canAccess = await canActorAccessWorkOrderShop({ admin, profile: access.profile, targetShopId });
+  if (!canAccess) {
+    logAssignmentDiagnostic({
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      targetShopId,
+      workOrderId: workOrder.id,
+      reason: "forbidden_shop",
+    });
+    return jsonError("forbidden_shop", 403, "Current user cannot access this work order shop");
+  }
+
+  const { data: lines, error: linesError } = await admin
+    .from("work_order_lines")
+    .select("*")
+    .eq("work_order_id", workOrder.id)
+    .eq("shop_id", targetShopId)
+    .order("created_at", { ascending: true });
+
+  if (linesError) return jsonError("assignment_failed", 400, linesError.message);
+  const lineRows = (lines ?? []) as WorkOrderLine[];
+  const lineIds = lineRows.map((line) => line.id);
+
+  const [vehicleRes, customerRes, lineTechsRes] = await Promise.all([
+    workOrder.vehicle_id
+      ? admin.from("vehicles").select("*").eq("id", workOrder.vehicle_id).eq("shop_id", targetShopId).maybeSingle<Vehicle>()
+      : Promise.resolve({ data: null, error: null } as const),
+    workOrder.customer_id
+      ? admin.from("customers").select("*").eq("id", workOrder.customer_id).eq("shop_id", targetShopId).maybeSingle<Customer>()
+      : Promise.resolve({ data: null, error: null } as const),
+    lineIds.length
+      ? admin.from("work_order_line_technicians").select("*").in("work_order_line_id", lineIds)
+      : Promise.resolve({ data: [], error: null } as const),
+  ]);
+
+  if (vehicleRes.error) {
+    console.warn("[work-order-detail] vehicle lookup failed", {
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      targetShopId,
+      workOrderId: workOrder.id,
+      reason: "vehicle_lookup_failed",
+      code: vehicleRes.error.code,
+      message: vehicleRes.error.message,
+    });
+  }
+
+  if (customerRes.error) {
+    console.warn("[work-order-detail] customer lookup failed", {
+      actorPresent: true,
+      actorProfileId: access.profile.id,
+      actorRole: access.profile.role,
+      activeShopId: access.profile.shop_id,
+      targetShopId,
+      workOrderId: workOrder.id,
+      reason: "customer_lookup_failed",
+      code: customerRes.error.code,
+      message: customerRes.error.message,
+    });
+  }
+
+  if (lineTechsRes.error) return jsonError("assignment_failed", 400, lineTechsRes.error.message);
+
+  return NextResponse.json({
+    data: {
+      work_order: workOrder,
+      lines: lineRows,
+      customer: customerRes.error ? null : ((customerRes.data as Customer | null) ?? null),
+      vehicle: vehicleRes.error ? null : ((vehicleRes.data as Vehicle | null) ?? null),
+      line_technicians: (lineTechsRes.data ?? []) as LineTech[],
+      actor: {
+        profile_id: access.profile.id,
+        role: access.profile.role,
+        active_shop_id: access.profile.shop_id,
+      },
+      target_shop_id: targetShopId,
+    },
+  });
+}

--- a/app/api/work-orders/assign-all/route.ts
+++ b/app/api/work-orders/assign-all/route.ts
@@ -5,6 +5,12 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  canActorAssignInShop,
+  canRoleAssignWorkOrders,
+  isAssignableTechnicianRole,
+  logAssignmentDiagnostic,
+} from "@/features/work-orders/lib/server/assignment-access";
 
 type Body = {
   work_order_id: string;
@@ -18,143 +24,189 @@ type LineTechInsert = {
   assigned_by?: string | null;
 };
 
-const ASSIGNABLE_ROLES = new Set([
-  "mechanic",
-  "tech",
-  "foreman",
-  "lead_hand",
-]);
+type WorkOrderScope = { id: string; shop_id: string | null };
+type TechnicianScope = { id: string; role: string | null; full_name: string | null; shop_id: string | null };
 
-function isAssignableRole(role: unknown): boolean {
-  return ASSIGNABLE_ROLES.has(String(role ?? "").toLowerCase());
+function jsonError(error: string, status: number, message?: string) {
+  return NextResponse.json({ error, message: message ?? error }, { status });
 }
 
 export async function POST(req: Request) {
+  let access: Awaited<ReturnType<typeof requireShopScopedApiAccess>> | null = null;
+  let workOrderId: string | null = null;
+  let targetShopId: string | null = null;
+
   try {
     const body = (await req.json()) as Partial<Body>;
     const { work_order_id, tech_id, only_unassigned = true } = body;
+    workOrderId = work_order_id ?? null;
 
-    if (!work_order_id) {
-      return NextResponse.json(
-        { error: "work_order_id is required" },
-        { status: 400 },
-      );
+    access = await requireShopScopedApiAccess();
+    if (!access.ok) {
+      logAssignmentDiagnostic({ actorPresent: false, workOrderId, reason: "not_authenticated" });
+      return jsonError("not_authenticated", 401, "Not authenticated");
     }
 
-    if (!tech_id) {
-      return NextResponse.json(
-        { error: "tech_id is required" },
-        { status: 400 },
-      );
+    if (!work_order_id || !tech_id) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        reason: "missing_assignment_fields",
+      });
+      return jsonError("assignment_failed", 400, "work_order_id and tech_id are required");
     }
 
-    const access = await requireShopScopedApiAccess({
-      requiredCapability: "canManageWorkOrders",
-    });
-    if (!access.ok) return access.response;
+    const actorProfile = access.profile;
+    const admin = createAdminSupabase();
 
-    const admin = await createAdminSupabase();
-    const assigned_by = access.profile.id;
-    const shopId = access.profile.shop_id;
+    if (!canRoleAssignWorkOrders(access.profile.role)) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        reason: "forbidden_assignment_role",
+      });
+      return jsonError("forbidden_assignment_role", 403, "Current role cannot assign technicians");
+    }
 
-    // Work order: use admin client
     const { data: wo, error: woErr } = await admin
       .from("work_orders")
       .select("id, shop_id")
       .eq("id", work_order_id)
-      .maybeSingle();
+      .maybeSingle<WorkOrderScope>();
 
     if (woErr) {
-      return NextResponse.json({ error: woErr.message }, { status: 400 });
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        reason: "work_order_lookup_failed",
+      });
+      return jsonError("assignment_failed", 400, woErr.message);
     }
 
-    if (!wo) {
-      return NextResponse.json(
-        { error: "Work order not found" },
-        { status: 404 },
-      );
+    if (!wo?.shop_id) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        reason: "work_order_not_found",
+      });
+      return jsonError("work_order_not_found", 404, "Work order not found");
     }
 
-    if (wo.shop_id !== shopId) {
-      return NextResponse.json(
-        { error: "Forbidden: cross-shop assignment" },
-        { status: 403 },
-      );
+    targetShopId = wo.shop_id;
+
+    const canAssignInTargetShop = await canActorAssignInShop({
+      admin,
+      profile: access.profile,
+      targetShopId,
+    });
+
+    if (!canAssignInTargetShop) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        reason: "forbidden_shop",
+      });
+      return jsonError("forbidden_shop", 403, "Current user cannot assign in this shop");
     }
 
-    // Tech profile: use admin client
     const { data: techProfile, error: techErr } = await admin
       .from("profiles")
       .select("id, role, full_name, shop_id")
       .eq("id", tech_id)
-      .maybeSingle();
+      .eq("shop_id", targetShopId)
+      .maybeSingle<TechnicianScope>();
 
     if (techErr) {
-      return NextResponse.json(
-        { error: `Failed to load tech profile: ${techErr.message}` },
-        { status: 400 },
-      );
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        reason: "technician_lookup_failed",
+      });
+      return jsonError("assignment_failed", 400, techErr.message);
     }
 
-    if (!techProfile) {
-      return NextResponse.json(
-        { error: "Tech profile not found for that id." },
-        { status: 404 },
-      );
-    }
-
-    if (techProfile.shop_id !== shopId) {
-      return NextResponse.json(
-        { error: "Tech is not in the same shop." },
-        { status: 403 },
-      );
-    }
-
-    if (!isAssignableRole(techProfile.role)) {
-      return NextResponse.json(
-        { error: "Selected profile is not assignable." },
-        { status: 400 },
-      );
+    if (!techProfile || !isAssignableTechnicianRole(techProfile.role)) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        reason: "technician_not_found",
+      });
+      return jsonError("technician_not_found", 404, "Assignable technician not found in target shop");
     }
 
     let updateQuery = admin
       .from("work_order_lines")
       .update({ assigned_tech_id: tech_id })
       .eq("work_order_id", work_order_id)
+      .eq("shop_id", targetShopId)
       .eq("line_type", "job");
 
     if (only_unassigned) {
       updateQuery = updateQuery.is("assigned_tech_id", null);
     }
 
-    const { data: updatedRows, error: updErr } = await updateQuery
-      .select("id");
+    const { data: updatedRows, error: updErr } = await updateQuery.select("id");
 
     if (updErr) {
-      return NextResponse.json(
-        { error: `Update failed: ${updErr.message}` },
-        { status: 400 },
-      );
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        reason: "assignment_failed",
+      });
+      return jsonError("assignment_failed", 400, updErr.message);
     }
 
     if (updatedRows && updatedRows.length > 0) {
       const linkRows: LineTechInsert[] = updatedRows.map((row) => ({
         work_order_line_id: row.id,
         technician_id: tech_id,
-        assigned_by,
+        assigned_by: actorProfile.id,
       }));
 
       const { error: linkErr } = await admin
         .from("work_order_line_technicians")
-        .upsert(linkRows, {
-          onConflict: "work_order_line_id,technician_id",
-        });
+        .upsert(linkRows, { onConflict: "work_order_line_id,technician_id" });
 
       if (linkErr) {
-        console.warn(
-          "assign-all: failed to upsert work_order_line_technicians:",
-          linkErr.message,
-        );
+        console.warn("[work-order-assignment] bridge upsert failed", {
+          actorPresent: true,
+          actorProfileId: access.profile.id,
+          actorRole: access.profile.role,
+          activeShopId: access.profile.shop_id,
+          targetShopId,
+          workOrderId,
+          reason: "bridge_upsert_failed",
+          code: linkErr.code,
+          message: linkErr.message,
+        });
       }
     }
 
@@ -169,6 +221,16 @@ export async function POST(req: Request) {
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected error.";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const profile = access?.ok ? access.profile : null;
+    logAssignmentDiagnostic({
+      actorPresent: Boolean(profile),
+      actorProfileId: profile?.id,
+      actorRole: profile?.role,
+      activeShopId: profile?.shop_id,
+      targetShopId,
+      workOrderId,
+      reason: "assignment_failed",
+    });
+    return jsonError("assignment_failed", 500, msg);
   }
 }

--- a/app/api/work-orders/assign-line/route.ts
+++ b/app/api/work-orders/assign-line/route.ts
@@ -1,111 +1,285 @@
 // app/api/work-orders/assign-line/route.ts
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  canActorAssignInShop,
+  canRoleAssignWorkOrders,
+  isAssignableTechnicianRole,
+  logAssignmentDiagnostic,
+} from "@/features/work-orders/lib/server/assignment-access";
 
-type DB = Database;
+type Body = {
+  work_order_line_id?: string;
+  tech_id?: string;
+};
 
-const ASSIGNABLE_TECH_ROLES = ["mechanic", "tech", "foreman", "lead_hand"] as const;
+type WorkOrderLineScope = {
+  id: string;
+  line_type: string | null;
+  work_order_id: string;
+  shop_id: string | null;
+};
 
-function must(name: string): string {
-  const v = process.env[name];
-  if (!v) throw new Error(`Missing env ${name}`);
-  return v;
+type WorkOrderScope = {
+  id: string;
+  shop_id: string | null;
+};
+
+type TechnicianScope = {
+  id: string;
+  role: string | null;
+  full_name: string | null;
+  shop_id: string | null;
+};
+
+function jsonError(error: string, status: number, message?: string) {
+  return NextResponse.json({ error, message: message ?? error }, { status });
 }
 
 export async function POST(req: Request) {
-  try {
-    const body = (await req.json()) as {
-      work_order_line_id?: string;
-      tech_id?: string;
-    };
+  let access: Awaited<ReturnType<typeof requireShopScopedApiAccess>> | null = null;
+  let lineId: string | null = null;
+  let workOrderId: string | null = null;
+  let targetShopId: string | null = null;
 
-    const lineId = body.work_order_line_id;
-    const techId = body.tech_id;
-    const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
-    if (!access.ok) return access.response;
-    const assignedBy = access.profile.id;
-    const shopId = access.profile.shop_id;
+  try {
+    const body = (await req.json()) as Body;
+    lineId = body.work_order_line_id ?? null;
+    const techId = body.tech_id ?? null;
+
+    access = await requireShopScopedApiAccess();
+    if (!access.ok) {
+      logAssignmentDiagnostic({ actorPresent: false, lineId, reason: "not_authenticated" });
+      return jsonError("not_authenticated", 401, "Not authenticated");
+    }
 
     if (!lineId || !techId) {
-      return NextResponse.json(
-        { error: "work_order_line_id and tech_id are required" },
-        { status: 400 }
-      );
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        lineId,
+        reason: "missing_assignment_fields",
+      });
+      return jsonError("assignment_failed", 400, "work_order_line_id and tech_id are required");
     }
 
-    const url = must("NEXT_PUBLIC_SUPABASE_URL");
-    const service = must("SUPABASE_SERVICE_ROLE_KEY");
-    const supabase = createClient<DB>(url, service);
+    const admin = createAdminSupabase();
 
-    const { data: line, error: lineReadErr } = await supabase
+    if (!canRoleAssignWorkOrders(access.profile.role)) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        lineId,
+        reason: "forbidden_assignment_role",
+      });
+      return jsonError("forbidden_assignment_role", 403, "Current role cannot assign technicians");
+    }
+
+    const { data: line, error: lineReadErr } = await admin
       .from("work_order_lines")
-      .select("id, line_type, work_order_id, work_orders!inner(id, shop_id)")
+      .select("id, line_type, work_order_id, shop_id")
       .eq("id", lineId)
-      .eq("work_orders.shop_id", shopId)
-      .maybeSingle();
+      .maybeSingle<WorkOrderLineScope>();
 
     if (lineReadErr) {
-      return NextResponse.json({ error: lineReadErr.message }, { status: 400 });
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        lineId,
+        reason: "line_lookup_failed",
+      });
+      return jsonError("assignment_failed", 400, lineReadErr.message);
     }
+
     if (!line) {
-      return NextResponse.json({ error: "Line not found" }, { status: 404 });
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        lineId,
+        reason: "line_not_found",
+      });
+      return jsonError("line_not_found", 404, "Work order line not found");
     }
+
+    workOrderId = line.work_order_id;
+
+    const { data: workOrder, error: workOrderErr } = await admin
+      .from("work_orders")
+      .select("id, shop_id")
+      .eq("id", line.work_order_id)
+      .maybeSingle<WorkOrderScope>();
+
+    if (workOrderErr) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        lineId,
+        reason: "work_order_lookup_failed",
+      });
+      return jsonError("assignment_failed", 400, workOrderErr.message);
+    }
+
+    if (!workOrder?.shop_id) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        workOrderId,
+        lineId,
+        reason: "work_order_not_found",
+      });
+      return jsonError("work_order_not_found", 404, "Work order not found");
+    }
+
+    targetShopId = workOrder.shop_id;
+
     if ((line.line_type ?? "job") === "info") {
-      return NextResponse.json({ error: "Info lines cannot be technician-assigned." }, { status: 409 });
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        lineId,
+        reason: "info_line_not_assignable",
+      });
+      return jsonError("assignment_failed", 409, "Info lines cannot be technician-assigned");
     }
 
-    const { data: technician, error: technicianErr } = await supabase
+    const canAssignInTargetShop = await canActorAssignInShop({
+      admin,
+      profile: access.profile,
+      targetShopId,
+    });
+
+    if (!canAssignInTargetShop) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        lineId,
+        reason: "forbidden_shop",
+      });
+      return jsonError("forbidden_shop", 403, "Current user cannot assign in this shop");
+    }
+
+    const { data: technician, error: technicianErr } = await admin
       .from("profiles")
-      .select("id, role")
+      .select("id, role, full_name, shop_id")
       .eq("id", techId)
-      .eq("shop_id", shopId)
-      .maybeSingle();
+      .eq("shop_id", targetShopId)
+      .maybeSingle<TechnicianScope>();
+
     if (technicianErr) {
-      return NextResponse.json({ error: technicianErr.message }, { status: 400 });
-    }
-    if (!technician) {
-      return NextResponse.json({ error: "Technician not found" }, { status: 404 });
-    }
-    if (!technician.role || !ASSIGNABLE_TECH_ROLES.includes(technician.role as (typeof ASSIGNABLE_TECH_ROLES)[number])) {
-      return NextResponse.json({ error: "Technician not found" }, { status: 404 });
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        lineId,
+        reason: "technician_lookup_failed",
+      });
+      return jsonError("assignment_failed", 400, technicianErr.message);
     }
 
-    // 1) keep the simple column up to date
-    const { error: lineErr } = await supabase
+    if (!technician || !isAssignableTechnicianRole(technician.role)) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        lineId,
+        reason: "technician_not_found",
+      });
+      return jsonError("technician_not_found", 404, "Assignable technician not found in target shop");
+    }
+
+    const { data: updatedLine, error: lineErr } = await admin
       .from("work_order_lines")
       .update({ assigned_tech_id: techId })
       .eq("id", lineId)
-      .eq("work_order_id", line.work_order_id);
+      .eq("shop_id", targetShopId)
+      .select("id")
+      .maybeSingle<{ id: string }>();
 
-    if (lineErr) {
-      return NextResponse.json({ error: lineErr.message }, { status: 400 });
+    if (lineErr || !updatedLine) {
+      logAssignmentDiagnostic({
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        lineId,
+        reason: "assignment_failed",
+      });
+      return jsonError("assignment_failed", 400, lineErr?.message ?? "Assignment update failed");
     }
 
-    // 2) also record in the 1..n table (ignore duplicates)
-    const { error: relErr } = await supabase
+    const { error: relErr } = await admin
       .from("work_order_line_technicians")
       .upsert(
         {
           work_order_line_id: lineId,
           technician_id: techId,
-          assigned_by: assignedBy,
+          assigned_by: access.profile.id,
         },
-        {
-          // because you declared unique (work_order_line_id, technician_id)
-          onConflict: "work_order_line_id,technician_id",
-        }
+        { onConflict: "work_order_line_id,technician_id" },
       );
 
     if (relErr) {
-      // not fatal for UI
-      console.warn("assign-line: technician link failed:", relErr.message);
+      console.warn("[work-order-assignment] bridge upsert failed", {
+        actorPresent: true,
+        actorProfileId: access.profile.id,
+        actorRole: access.profile.role,
+        activeShopId: access.profile.shop_id,
+        targetShopId,
+        workOrderId,
+        lineId,
+        reason: "bridge_upsert_failed",
+        code: relErr.code,
+        message: relErr.message,
+      });
     }
 
     return NextResponse.json({ ok: true });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const profile = access?.ok ? access.profile : null;
+    logAssignmentDiagnostic({
+      actorPresent: Boolean(profile),
+      actorProfileId: profile?.id,
+      actorRole: profile?.role,
+      activeShopId: profile?.shop_id,
+      targetShopId,
+      workOrderId,
+      lineId,
+      reason: "assignment_failed",
+    });
+    return jsonError("assignment_failed", 500, msg);
   }
 }

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -61,6 +61,15 @@ type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"] & {
   parts?: { name: string | null; sku?: string | null } | null;
 };
 type LineTechRow = DB["public"]["Tables"]["work_order_line_technicians"]["Row"];
+type WorkOrderDetailPayload = {
+  work_order: WorkOrder;
+  lines: WorkOrderLine[];
+  customer: Customer | null;
+  vehicle: Vehicle | null;
+  line_technicians: LineTechRow[];
+  actor?: { profile_id: string; role: string | null; active_shop_id: string | null };
+  target_shop_id?: string | null;
+};
 
 type WorkOrderLineWithInspectionMeta = WorkOrderLine & {
   // real DB column
@@ -96,15 +105,6 @@ type PropertyContext = {
   assetType: string | null;
   latestVendorAssignment: string | null;
 };
-
-const looksLikeUuid = (s: string) => s.includes("-") && s.length >= 36;
-
-function splitCustomId(raw: string): { prefix: string; n: number | null } {
-  const m = raw.toUpperCase().match(/^([A-Z]+)\s*0*?(\d+)?$/);
-  if (!m) return { prefix: raw.toUpperCase(), n: null };
-  const n = m[2] ? parseInt(m[2], 10) : null;
-  return { prefix: m[1], n: Number.isFinite(n!) ? n : null };
-}
 
 function isCompletedLineStatus(status: string | null | undefined): boolean {
   const normalized = String(status ?? "").trim().toLowerCase();
@@ -380,27 +380,6 @@ export default function WorkOrderIdClient(): JSX.Element {
       setUserId(uid);
       setAuthChecked(true);
 
-      if (uid) {
-        const { data: prof } = await supabase
-          .from("profiles")
-          .select("role")
-          .eq("id", uid)
-          .maybeSingle();
-        setCurrentUserRole(prof?.role ?? null);
-      }
-
-      try {
-        const res = await fetch("/api/assignables");
-        const json = (await res.json().catch(() => null)) as
-          | { data?: Array<Pick<Profile, "id" | "full_name" | "role">> }
-          | null;
-        if (res.ok && Array.isArray(json?.data)) {
-          setAssignables(json.data);
-        }
-      } catch {
-        // ignore
-      }
-
       if (!uid) setLoading(false);
     };
 
@@ -430,62 +409,22 @@ export default function WorkOrderIdClient(): JSX.Element {
       setViewError(null);
 
       try {
-        let woRow: WorkOrder | null = null;
-
-        // by UUID
-        if (looksLikeUuid(routeId)) {
-          const { data, error } = await supabase
-            .from("work_orders")
-            .select("*")
-            .eq("id", routeId)
-            .maybeSingle();
-          if (!error) woRow = (data as WorkOrder | null) ?? null;
-        }
-
-        // by custom_id
-        if (!woRow) {
-          const eqRes = await supabase
-            .from("work_orders")
-            .select("*")
-            .eq("custom_id", routeId)
-            .maybeSingle();
-          woRow = (eqRes.data as WorkOrder | null) ?? null;
-
-          if (!woRow) {
-            const ilikeRes = await supabase
-              .from("work_orders")
-              .select("*")
-              .ilike("custom_id", routeId.toUpperCase())
-              .maybeSingle();
-            woRow = (ilikeRes.data as WorkOrder | null) ?? null;
-          }
-
-          if (!woRow) {
-            const { prefix, n } = splitCustomId(routeId);
-            if (n !== null) {
-              const { data: cands } = await supabase
-                .from("work_orders")
-                .select("*")
-                .ilike("custom_id", `${prefix}%`)
-                .limit(50);
-              const wanted = `${prefix}${n}`;
-              const match = (cands ?? []).find(
-                (r) =>
-                  (r.custom_id ?? "")
-                    .toUpperCase()
-                    .replace(/^([A-Z]+)0+/, "$1") === wanted,
-              );
-              if (match) woRow = match as WorkOrder;
-            }
-          }
-        }
+        const detailRes = await fetch(`/api/work-orders/${encodeURIComponent(routeId)}/detail`, {
+          cache: "no-store",
+        });
+        const detailJson = (await detailRes.json().catch(() => null)) as
+          | { data?: WorkOrderDetailPayload; error?: string; message?: string }
+          | null;
+        const detail = detailJson?.data ?? null;
+        const woRow: WorkOrder | null = detail?.work_order ?? null;
+        const detailErrorMessage = detailJson?.message || detailJson?.error || "Work order not visible / not found.";
 
         if (!woRow) {
           if (retry < 2) {
             await new Promise((r) => setTimeout(r, 200 * Math.pow(2, retry)));
             return fetchAll(retry + 1);
           }
-          setViewError("Work order not visible / not found.");
+          setViewError(detailRes.ok ? "Work order not visible / not found." : detailErrorMessage);
           if (!loadedOnce) {
             setWo(null);
             setLines([]);
@@ -508,6 +447,25 @@ export default function WorkOrderIdClient(): JSX.Element {
         }
 
         setWo(woRow);
+        if (detail?.actor) setCurrentUserRole(detail.actor.role ?? null);
+
+        try {
+          const params = new URLSearchParams({ work_order_id: woRow.id });
+          const res = await fetch(`/api/assignables?${params.toString()}`);
+          const json = (await res.json().catch(() => null)) as
+            | { data?: Array<Pick<Profile, "id" | "full_name" | "role">>; error?: string; message?: string }
+            | null;
+          if (!res.ok || !Array.isArray(json?.data)) {
+            throw new Error(json?.message || json?.error || "Unable to load assignable technicians.");
+          }
+          setAssignables(json.data);
+        } catch (assignablesError) {
+          setAssignables([]);
+          console.warn("[WO id page] assignables load failed", {
+            workOrderId: woRow.id,
+            reason: assignablesError instanceof Error ? assignablesError.message : "unknown",
+          });
+        }
 
         // ✅ reset review state until loaded for this WO
         setReviewChecked(false);
@@ -521,31 +479,17 @@ export default function WorkOrderIdClient(): JSX.Element {
           setWarnedMissing(true);
         }
 
-        const [linesRes, quoteRes, vehRes, custRes, shopRes, propertyReqRes] = await Promise.all([
-          supabase
-            .from("work_order_lines")
-            .select("*")
-            .eq("work_order_id", woRow.id)
-            .order("created_at", { ascending: true }),
+        const lineRows = detail?.lines ?? [];
+        setLines(lineRows);
+        setVehicle(detail?.vehicle ?? null);
+        setCustomer(detail?.customer ?? null);
+
+        const [quoteRes, shopRes, propertyReqRes] = await Promise.all([
           supabase
             .from("work_order_quote_lines")
             .select("*")
             .eq("work_order_id", woRow.id)
             .order("created_at", { ascending: true }),
-          woRow.vehicle_id
-            ? supabase
-                .from("vehicles")
-                .select("*")
-                .eq("id", woRow.vehicle_id)
-                .maybeSingle()
-            : Promise.resolve({ data: null, error: null } as const),
-          woRow.customer_id
-            ? supabase
-                .from("customers")
-                .select("*")
-                .eq("id", woRow.customer_id)
-                .maybeSingle()
-            : Promise.resolve({ data: null, error: null } as const),
           woRow.shop_id
             ? supabase
                 .from("shops")
@@ -560,19 +504,9 @@ export default function WorkOrderIdClient(): JSX.Element {
             .maybeSingle(),
         ]);
 
-        if (linesRes.error) throw linesRes.error;
-        const lineRows = (linesRes.data ?? []) as WorkOrderLine[];
-        setLines(lineRows);
-
         if (quoteRes.error) throw quoteRes.error;
         const quoteRows = (quoteRes.data ?? []) as WorkOrderQuoteLine[];
         setQuoteLines(quoteRows);
-
-        if (vehRes?.error) throw vehRes.error;
-        setVehicle((vehRes?.data as Vehicle | null) ?? null);
-
-        if (custRes?.error) throw custRes.error;
-        setCustomer((custRes?.data as Customer | null) ?? null);
 
         if (shopRes?.error) throw shopRes.error;
         setShopLaborRate(
@@ -641,7 +575,7 @@ export default function WorkOrderIdClient(): JSX.Element {
 
         // allocations + line techs
         if (lineRows.length) {
-          const [allocsQuery, stagedQuery, lineTechsQuery] = await Promise.all([
+          const [allocsQuery, stagedQuery] = await Promise.all([
             supabase
               .from("work_order_part_allocations")
               .select("*, parts(name)")
@@ -654,14 +588,6 @@ export default function WorkOrderIdClient(): JSX.Element {
             supabase
               .from("work_order_parts")
               .select("*, parts(name, sku)")
-              .in(
-                "work_order_line_id",
-                lineRows.map((l) => l.id),
-              ),
-
-            supabase
-              .from("work_order_line_technicians")
-              .select("work_order_line_id, technician_id")
               .in(
                 "work_order_line_id",
                 lineRows.map((l) => l.id),
@@ -688,7 +614,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           setStagedPartsByLine(stagedByLine);
 
           const techMap: Record<string, string[]> = {};
-          (lineTechsQuery.data as LineTechRow[] | null)?.forEach((lt) => {
+          (detail?.line_technicians ?? []).forEach((lt) => {
             const lnId = lt.work_order_line_id;
             const techId = lt.technician_id;
             if (!techMap[lnId]) techMap[lnId] = [];

--- a/features/work-orders/components/workorders/extras/AssignTechModal.tsx
+++ b/features/work-orders/components/workorders/extras/AssignTechModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { useEffect, useState } from "react";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { toast } from "sonner";
 
@@ -28,10 +27,10 @@ export default function AssignTechModal({
   mechanics,
   onAssigned,
 }: Props) {
-  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [users, setUsers] = useState<Assignable[]>(() => mechanics ?? initialMechanics ?? []);
   const [techId, setTechId] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -39,32 +38,27 @@ export default function AssignTechModal({
     const pref = mechanics ?? initialMechanics;
     if (pref && pref.length) {
       setUsers(pref);
+      setLoadError(null);
       return;
     }
 
     (async () => {
-      // try API first
+      setLoadError(null);
       try {
-        const res = await fetch("/api/assignables");
-        const json = (await res.json().catch(() => null)) as { data?: Assignable[] } | null;
-        if (res.ok && Array.isArray(json?.data)) {
-          setUsers(json.data);
-          return;
+        const params = new URLSearchParams({ work_order_line_id: workOrderLineId });
+        const res = await fetch(`/api/assignables?${params.toString()}`);
+        const json = (await res.json().catch(() => null)) as { data?: Assignable[]; error?: string; message?: string } | null;
+        if (!res.ok || !Array.isArray(json?.data)) {
+          throw new Error(json?.message || json?.error || "Unable to load assignable technicians.");
         }
-      } catch {
-        // fall through
+        setUsers(json.data);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Unable to load assignable technicians.";
+        setUsers([]);
+        setLoadError(msg);
       }
-
-      // fallback to profiles query
-      const { data } = await supabase
-        .from("profiles")
-        .select("id, full_name, role")
-        .in("role", ["mechanic", "tech", "foreman", "lead_hand"])
-        .order("full_name", { ascending: true });
-
-      setUsers((data as Assignable[]) ?? []);
     })();
-  }, [isOpen, mechanics, initialMechanics, supabase]);
+  }, [isOpen, mechanics, initialMechanics, workOrderLineId]);
 
   const submit = async () => {
     if (submitting) return;
@@ -113,6 +107,11 @@ export default function AssignTechModal({
       <p className="mb-2 text-xs text-muted-foreground">
         Primary tech is the operational owner. Additional techs are supporting collaborators.
       </p>
+      {loadError && (
+        <div className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          {loadError}
+        </div>
+      )}
       <label className="block text-sm">
         <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Choose primary tech
@@ -121,6 +120,7 @@ export default function AssignTechModal({
           className="w-full rounded border border-border/60 bg-background px-3 py-2 text-sm text-foreground dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
           value={techId}
           onChange={(e) => setTechId(e.target.value)}
+          disabled={Boolean(loadError) || users.length === 0}
         >
           <option value="">Select…</option>
           {users.map((u) => (

--- a/features/work-orders/lib/server/assignment-access.ts
+++ b/features/work-orders/lib/server/assignment-access.ts
@@ -1,0 +1,150 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
+
+export type DB = Database;
+
+export type AssignmentActorProfile = Pick<
+  DB["public"]["Tables"]["profiles"]["Row"],
+  "id" | "role" | "shop_id"
+>;
+
+type ShopMemberScope = Pick<
+  DB["public"]["Tables"]["shop_members"]["Row"],
+  "shop_id" | "role" | "user_id"
+>;
+
+const ASSIGNMENT_ACTOR_ROLES = new Set([
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "lead_hand",
+  "foreman",
+]);
+
+const CROSS_SHOP_ACTOR_ROLES = new Set(["owner", "admin"]);
+const CROSS_SHOP_MEMBER_ROLES = new Set(["owner", "admin", "manager"]);
+
+export const ASSIGNABLE_TECHNICIAN_ROLES = [
+  "mechanic",
+  "tech",
+  "technician",
+  "lead_hand",
+  "foreman",
+] as const;
+
+const ASSIGNABLE_TECHNICIAN_ROLE_SET = new Set<string>(ASSIGNABLE_TECHNICIAN_ROLES);
+
+function normalizeRole(role: string | null | undefined): string {
+  return String(role ?? "").trim().toLowerCase();
+}
+
+export function canRoleAssignWorkOrders(role: string | null | undefined): boolean {
+  return ASSIGNMENT_ACTOR_ROLES.has(canonicalizeRole(role));
+}
+
+export function isAssignableTechnicianRole(role: string | null | undefined): boolean {
+  return ASSIGNABLE_TECHNICIAN_ROLE_SET.has(normalizeRole(role));
+}
+
+export async function canActorAssignInShop(params: {
+  admin: SupabaseClient<DB>;
+  profile: AssignmentActorProfile;
+  targetShopId: string | null | undefined;
+}): Promise<boolean> {
+  const targetShopId = params.targetShopId;
+  if (!targetShopId) return false;
+
+  const actorRole = canonicalizeRole(params.profile.role);
+  if (!ASSIGNMENT_ACTOR_ROLES.has(actorRole)) return false;
+
+  if (params.profile.shop_id === targetShopId) return true;
+
+  if (!CROSS_SHOP_ACTOR_ROLES.has(actorRole)) return false;
+
+  const { data, error } = await params.admin
+    .from("shop_members")
+    .select("user_id, shop_id, role")
+    .eq("user_id", params.profile.id)
+    .eq("shop_id", targetShopId)
+    .in("role", Array.from(CROSS_SHOP_MEMBER_ROLES))
+    .maybeSingle<ShopMemberScope>();
+
+  if (error) {
+    console.warn("[work-order-assignment] shop_members authorization lookup failed", {
+      actorPresent: true,
+      actorProfileId: params.profile.id,
+      actorRole,
+      activeShopId: params.profile.shop_id,
+      targetShopId,
+      reason: "shop_members_lookup_failed",
+      code: error.code,
+      message: error.message,
+    });
+    return false;
+  }
+
+  return Boolean(data);
+}
+
+export async function canActorAccessWorkOrderShop(params: {
+  admin: SupabaseClient<DB>;
+  profile: AssignmentActorProfile;
+  targetShopId: string | null | undefined;
+}): Promise<boolean> {
+  const targetShopId = params.targetShopId;
+  if (!targetShopId) return false;
+  if (params.profile.shop_id === targetShopId) return true;
+
+  const actorRole = canonicalizeRole(params.profile.role);
+  if (!CROSS_SHOP_ACTOR_ROLES.has(actorRole)) return false;
+
+  const { data, error } = await params.admin
+    .from("shop_members")
+    .select("user_id, shop_id, role")
+    .eq("user_id", params.profile.id)
+    .eq("shop_id", targetShopId)
+    .in("role", Array.from(CROSS_SHOP_MEMBER_ROLES))
+    .maybeSingle<ShopMemberScope>();
+
+  if (error) {
+    console.warn("[work-order-access] shop_members authorization lookup failed", {
+      actorPresent: true,
+      actorProfileId: params.profile.id,
+      actorRole,
+      activeShopId: params.profile.shop_id,
+      targetShopId,
+      reason: "shop_members_lookup_failed",
+      code: error.code,
+      message: error.message,
+    });
+    return false;
+  }
+
+  return Boolean(data);
+}
+
+export function logAssignmentDiagnostic(context: {
+  actorPresent: boolean;
+  actorProfileId?: string | null;
+  actorRole?: string | null;
+  activeShopId?: string | null;
+  targetShopId?: string | null;
+  workOrderId?: string | null;
+  lineId?: string | null;
+  reason: string;
+}) {
+  console.warn("[work-order-assignment] validation", {
+    actorPresent: context.actorPresent,
+    actorProfileId: context.actorProfileId ?? null,
+    actorRole: context.actorRole ?? null,
+    activeShopId: context.activeShopId ?? null,
+    targetShopId: context.targetShopId ?? null,
+    workOrderId: context.workOrderId ?? null,
+    lineId: context.lineId ?? null,
+    reason: context.reason,
+  });
+}

--- a/tests/work-order-assignment-regression.test.ts
+++ b/tests/work-order-assignment-regression.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+  createAdminSupabase: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdminSupabase,
+}));
+
+type Row = Record<string, any>;
+type Store = Record<string, Row[]>;
+type Operation = { table: string; op: string; filters: Record<string, any>; inFilters: Record<string, any[]>; payload?: any };
+
+class Query {
+  filters: Record<string, any> = {};
+  inFilters: Record<string, any[]> = {};
+  selectValue = "*";
+  constructor(private table: string, private store: Store, private operations: Operation[], private op = "select", private payload?: any) {}
+  select(value = "*") { this.selectValue = value; return this; }
+  eq(k: string, v: any) { this.filters[k] = v; return this; }
+  in(k: string, v: any[]) { this.inFilters[k] = v; return this; }
+  is(k: string, v: any) { this.filters[k] = v; return this; }
+  ilike(k: string, v: string) { this.filters[k] = v.replaceAll("%", "").toLowerCase(); return this; }
+  order() { return this; }
+  limit() { return this; }
+  update(payload: any) { const q = new Query(this.table, this.store, this.operations, "update", payload); q.filters = { ...this.filters }; q.inFilters = { ...this.inFilters }; return q; }
+  upsert(payload: any) { const q = new Query(this.table, this.store, this.operations, "upsert", payload); q.filters = { ...this.filters }; q.inFilters = { ...this.inFilters }; return q; }
+  async maybeSingle() { const v = await this; return { data: Array.isArray(v.data) ? v.data[0] ?? null : v.data, error: v.error }; }
+  then(resolve: (value: { data: any; error: any }) => void, _reject?: (reason?: any) => void) {
+    this.operations.push({ table: this.table, op: this.op, filters: { ...this.filters }, inFilters: { ...this.inFilters }, payload: this.payload });
+    let rows = [...(this.store[this.table] ?? [])];
+    for (const [key, value] of Object.entries(this.filters)) {
+      rows = rows.filter((row) => String(row[key] ?? "").toLowerCase() === String(value ?? "").toLowerCase());
+    }
+    for (const [key, values] of Object.entries(this.inFilters)) rows = rows.filter((row) => values.includes(row[key]));
+    if (this.op === "update") {
+      rows.forEach((row) => Object.assign(row, this.payload));
+      resolve({ data: rows, error: null });
+      return;
+    }
+    if (this.op === "upsert") {
+      const payloads = Array.isArray(this.payload) ? this.payload : [this.payload];
+      this.store[this.table] = [...(this.store[this.table] ?? []), ...payloads];
+      resolve({ data: payloads, error: null });
+      return;
+    }
+    resolve({ data: rows, error: null });
+  }
+}
+
+function setup(store: Store, actor = { id: "owner-1", role: "owner", shop_id: "shop-a" }) {
+  const operations: Operation[] = [];
+  const admin = { from: vi.fn((table: string) => new Query(table, store, operations)) };
+  mocks.createAdminSupabase.mockReturnValue(admin);
+  mocks.requireShopScopedApiAccess.mockResolvedValue({ ok: true, profile: actor, canonicalRole: actor.role, supabase: {} });
+  return { operations, admin };
+}
+
+function post(body: any) {
+  return new Request("http://localhost/api/work-orders/assign-line", { method: "POST", body: JSON.stringify(body) });
+}
+
+function get(path: string) {
+  return new Request(`http://localhost${path}`);
+}
+
+const baseStore = (): Store => ({
+  work_orders: [{ id: "wo-a", custom_id: "RO100", shop_id: "shop-a", customer_id: "cust-a", vehicle_id: "veh-a" }, { id: "00000000-0000-0000-0000-000000000001", custom_id: "RO101", shop_id: "shop-a", customer_id: "cust-a", vehicle_id: "veh-a" }],
+  work_order_lines: [{ id: "line-a", work_order_id: "wo-a", shop_id: "shop-a", line_type: "job", assigned_tech_id: null }, { id: "line-uuid", work_order_id: "00000000-0000-0000-0000-000000000001", shop_id: "shop-a", line_type: "job", assigned_tech_id: null }],
+  profiles: [
+    { id: "tech-a", full_name: "Tech A", role: "mechanic", shop_id: "shop-a" },
+    { id: "tech-alias", full_name: "Alias Tech", role: "technician", shop_id: "shop-a" },
+    { id: "tech-b", full_name: "Tech B", role: "mechanic", shop_id: "shop-b" },
+  ],
+  shop_members: [{ user_id: "owner-1", shop_id: "shop-a", role: "owner" }],
+  work_order_line_technicians: [],
+  customers: [{ id: "cust-a", shop_id: "shop-a", name: "Customer A" }],
+  vehicles: [{ id: "veh-a", shop_id: "shop-a", make: "Ford" }],
+});
+
+describe("work order assignment regression", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("owner can assign mechanic and writes primary plus bridge row while ignoring client shop_id", async () => {
+    const store = baseStore();
+    const { operations } = setup(store);
+    const { POST } = await import("../app/api/work-orders/assign-line/route");
+
+    const res = await POST(post({ work_order_line_id: "line-a", tech_id: "tech-a", shop_id: "shop-b" }));
+
+    expect(res.status).toBe(200);
+    expect(store.work_order_lines[0].assigned_tech_id).toBe("tech-a");
+    expect(store.work_order_line_technicians).toContainEqual(expect.objectContaining({ work_order_line_id: "line-a", technician_id: "tech-a" }));
+    expect(operations.find((op) => op.table === "work_order_lines" && op.op === "update")?.filters).toMatchObject({ id: "line-a", shop_id: "shop-a" });
+  });
+
+  it("mechanic cannot assign through API", async () => {
+    setup(baseStore(), { id: "mech-1", role: "mechanic", shop_id: "shop-a" });
+    const { POST } = await import("../app/api/work-orders/assign-line/route");
+    const res = await POST(post({ work_order_line_id: "line-a", tech_id: "tech-a" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "forbidden_assignment_role" });
+  });
+
+  it("cross-shop assignment is rejected unless owner/admin has authorized membership", async () => {
+    const store = baseStore();
+    store.work_orders[0].shop_id = "shop-b";
+    store.work_order_lines[0].shop_id = "shop-b";
+    setup(store);
+    const { POST } = await import("../app/api/work-orders/assign-line/route");
+    const res = await POST(post({ work_order_line_id: "line-a", tech_id: "tech-b" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "forbidden_shop" });
+  });
+
+  it("owner with shop_members access can assign into target shop when active shop differs and technician alias is accepted", async () => {
+    const store = baseStore();
+    store.work_orders[0].shop_id = "shop-b";
+    store.work_order_lines[0].shop_id = "shop-b";
+    store.profiles.push({ id: "tech-c", full_name: "Tech C", role: "technician", shop_id: "shop-b" });
+    store.shop_members.push({ user_id: "owner-1", shop_id: "shop-b", role: "manager" });
+    setup(store);
+    const { POST } = await import("../app/api/work-orders/assign-line/route");
+    const res = await POST(post({ work_order_line_id: "line-a", tech_id: "tech-c" }));
+    expect(res.status).toBe(200);
+    expect(store.work_order_lines[0].assigned_tech_id).toBe("tech-c");
+  });
+});
+
+describe("assignables and detail API", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("assignables returns staff for target work order shop, not actor active shop", async () => {
+    const store = baseStore();
+    store.work_orders[0].shop_id = "shop-b";
+    store.shop_members.push({ user_id: "owner-1", shop_id: "shop-b", role: "admin" });
+    setup(store);
+    const { GET } = await import("../app/api/assignables/route");
+    const res = await GET(get("/api/assignables?work_order_id=wo-a"));
+    const payload = await res.json();
+    expect(res.status).toBe(200);
+    expect(payload.data.map((row: Row) => row.id)).toEqual(["tech-b"]);
+  });
+
+  it("assignables rejects unauthorized target shop", async () => {
+    const store = baseStore();
+    store.work_orders[0].shop_id = "shop-b";
+    setup(store);
+    const { GET } = await import("../app/api/assignables/route");
+    const res = await GET(get("/api/assignables?work_order_id=wo-a"));
+    expect(res.status).toBe(403);
+  });
+
+  it("detail API loads work order, lines, customer, vehicle, and line techs separately by shop", async () => {
+    const store = baseStore();
+    store.work_order_line_technicians.push({ work_order_line_id: "line-uuid", technician_id: "tech-a" });
+    setup(store);
+    const { GET } = await import("../app/api/work-orders/[id]/detail/route");
+    const res = await GET(get("/api/work-orders/00000000-0000-0000-0000-000000000001/detail"), { params: { id: "00000000-0000-0000-0000-000000000001" } });
+    const payload = await res.json();
+    expect(res.status).toBe(200);
+    expect(payload.data.work_order.id).toBe("00000000-0000-0000-0000-000000000001");
+    expect(payload.data.customer.id).toBe("cust-a");
+    expect(payload.data.vehicle.id).toBe("veh-a");
+    expect(payload.data.line_technicians).toHaveLength(1);
+  });
+
+  it("detail API does not crash when customer/vehicle are missing", async () => {
+    const store = baseStore();
+    store.customers = [];
+    store.vehicles = [];
+    setup(store);
+    const { GET } = await import("../app/api/work-orders/[id]/detail/route");
+    const res = await GET(get("/api/work-orders/00000000-0000-0000-0000-000000000001/detail"), { params: { id: "00000000-0000-0000-0000-000000000001" } });
+    const payload = await res.json();
+    expect(res.status).toBe(200);
+    expect(payload.data.customer).toBeNull();
+    expect(payload.data.vehicle).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix a regression where owner/admin shop switching could mutate `profiles.shop_id` and cause assignment routes and browser-side queries to trust the wrong shop, breaking owner/admin assignment flows. 
- Remove RLS-sensitive browser-side queries that could fail (customers/vehicles) and prevent assignment controls from appearing. 
- Restore a safe, server-scoped assignment flow that derives the target shop from the work order/line and enforces explicit role/shop checks.

### Description
- Add a focused server helper `features/work-orders/lib/server/assignment-access.ts` that encodes assigner roles, technician role aliases (`mechanic`, `tech`, `technician`, `lead_hand`, `foreman`), cross-shop membership checks, and safe diagnostic logging via `logAssignmentDiagnostic`.
- Replace client-trusted scoping in assignment endpoints with server-side auth/validation: `app/api/work-orders/assign-line/route.ts` now authenticates server-side, resolves the actor profile server-side, derives `targetShopId` from the work order, verifies actor role (owner/admin/manager/advisor/lead_hand/foreman), verifies actor membership for cross-shop access, verifies technician belongs to `targetShopId` and accepts role aliases, updates `work_order_lines` using explicit `id` + `shop_id` filters, and upserts `work_order_line_technicians` while keeping bridge failures non-fatal.
- Update bulk assign endpoint `app/api/work-orders/assign-all/route.ts` to use the same target-shop authorization model, validate technician shop/role, and scope updates by `work_order_id` + `shop_id`.
- Scope assignables via `app/api/assignables/route.ts` to accept optional `work_order_id` or `work_order_line_id`, derive `targetShopId` from the referenced work order/line, verify actor assignment rights with the same helper, and return only same-shop assignable staff including the `technician` alias; keep a safe diagnostic log if no target is provided and preserve backward compatibility to fall back to actor active shop only when target is omitted.
- Remove browser-side profile fallback queries for assignables: `features/work-orders/components/workorders/extras/AssignTechModal.tsx` now fetches `/api/assignables?work_order_line_id=...` and shows a clear non-crashing error UI when the API fails, rather than querying `profiles` directly from the browser.
- Add a server-scoped work-order detail API at `app/api/work-orders/[id]/detail/route.ts` which authenticates server-side, resolves/authorizes by target work-order shop, loads lines, customers, vehicles, and line technicians scoped to the work-order shop, and returns a normalized payload so browser RLS errors on customers/vehicles cannot block core detail/assignment controls.
- Update `app/work-orders/[id]/Client.tsx` to use the server detail API for the initial work-order/detail load and to request assignables by target work-order; preserve UI behavior and realtime subscriptions.
- Add regression tests `tests/work-order-assignment-regression.test.ts` covering: owner/admin assignment success, mechanic assignment rejection, cross-shop rejection without membership, owner/admin cross-shop assignment via `shop_members`, ignored client-provided `shop_id`, assignables scoping, and detail API behavior when customers/vehicles are missing.

### Testing
- Ran targeted unit/integration test suite: `npx vitest run tests/work-orders-list-shop-scoping.test.ts tests/user-auth-normalization.test.ts tests/admin-users-route.test.ts tests/onboarding-v2/staff-onboarding-card.test.tsx tests/onboarding-v2/guided-registry-and-query.test.ts tests/work-order-assignment-regression.test.ts` and the full set above passed (including the new regression tests).
- Type check: `npx tsc --noEmit` completed successfully with no type errors.
- Sanity checks: `git diff --check` (whitespace/patch checks) completed clean.

All automated tests listed above passed and the TypeScript build is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2352b43a148328b285108683204cba)