### PR TITLE
Fix work order detail route context typing

### DIFF
--- a/app/api/work-orders/[id]/detail/route.ts
+++ b/app/api/work-orders/[id]/detail/route.ts
@@ -55,7 +55,7 @@ async function loadWorkOrder(admin: ReturnType<typeof createAdminSupabase>, rout
   return { data: match ?? null, error: null } as const;
 }
 
-export async function GET(_req: Request, context: { params: Promise<{ id: string }> | { id: string } }) {
+export async function GET(_req: Request, context: { params: Promise<{ id: string }> }) {
   const access = await requireShopScopedApiAccess();
   const params = await context.params;
   const routeId = params.id;

--- a/tests/work-order-assignment-regression.test.ts
+++ b/tests/work-order-assignment-regression.test.ts
@@ -168,7 +168,7 @@ describe("assignables and detail API", () => {
     store.work_order_line_technicians.push({ work_order_line_id: "line-uuid", technician_id: "tech-a" });
     setup(store);
     const { GET } = await import("../app/api/work-orders/[id]/detail/route");
-    const res = await GET(get("/api/work-orders/00000000-0000-0000-0000-000000000001/detail"), { params: { id: "00000000-0000-0000-0000-000000000001" } });
+    const res = await GET(get("/api/work-orders/00000000-0000-0000-0000-000000000001/detail"), { params: Promise.resolve({ id: "00000000-0000-0000-0000-000000000001" }) });
     const payload = await res.json();
     expect(res.status).toBe(200);
     expect(payload.data.work_order.id).toBe("00000000-0000-0000-0000-000000000001");
@@ -183,7 +183,7 @@ describe("assignables and detail API", () => {
     store.vehicles = [];
     setup(store);
     const { GET } = await import("../app/api/work-orders/[id]/detail/route");
-    const res = await GET(get("/api/work-orders/00000000-0000-0000-0000-000000000001/detail"), { params: { id: "00000000-0000-0000-0000-000000000001" } });
+    const res = await GET(get("/api/work-orders/00000000-0000-0000-0000-000000000001/detail"), { params: Promise.resolve({ id: "00000000-0000-0000-0000-000000000001" }) });
     const payload = await res.json();
     expect(res.status).toBe(200);
     expect(payload.data.customer).toBeNull();


### PR DESCRIPTION
### Motivation
- Next.js route export validation rejected the `GET` handler in `app/api/work-orders/[id]/detail/route.ts` because its second-argument context used a union type for `params` (`Promise<{ id: string }> | { id: string }`), which is not allowed by the App Router typing in this repo's Next.js version. 
- The change is strictly to resolve the TypeScript/Next export typing error so the deployment/build can proceed; no business, assignment, auth, or response behavior is altered.

### Description
- Updated the `GET` route signature in `app/api/work-orders/[id]/detail/route.ts` to use `context: { params: Promise<{ id: string }> }` (removed the invalid union). 
- Kept the handler body unchanged; it still `await`s `context.params` and preserves the same lookup, auth, shop-access, and JSON response shape. 
- Updated test call sites in `tests/work-order-assignment-regression.test.ts` to pass `params` as a promise (`Promise.resolve({ id: ... })`) so they match the corrected route signature.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `pnpm vitest run tests/work-order-assignment-regression.test.ts` and the targeted test file passed. 
- Attempted `pnpm build` but the local Next.js build was blocked by external Google Fonts fetch failures for `Inter` and `Black Ops One` (font fetch errors prevented completion before any route typing errors could reappear).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2357cd9b188328b014e00c9d6c5d6c)