### PR TITLE
Stabilize scoped history, dispatch and parts pages (server shop context fixes)

### DIFF
--- a/app/api/parts/dashboard/route.ts
+++ b/app/api/parts/dashboard/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+
+import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+function summarizeError(error: { message?: string; code?: string | null } | null | undefined) {
+  if (!error) return null;
+  return { message: error.message ?? "Unknown error", code: error.code ?? null };
+}
+
+export async function GET() {
+  const supabase = createServerSupabaseRoute();
+  const actor = await resolveCurrentActor(supabase);
+
+  if (!actor.user || !actor.shopId) {
+    console.info("[PartsDashboard] server auth unavailable", {
+      actorPresent: Boolean(actor.user),
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/parts/dashboard",
+    });
+    return NextResponse.json({ error: "Unable to resolve shop context." }, { status: 401 });
+  }
+
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: actor.shopId,
+  });
+
+  if (contextError) {
+    console.info("[PartsDashboard] set_current_shop_id failed", {
+      actorPresent: true,
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/parts/dashboard",
+      code: contextError.code,
+      message: contextError.message,
+    });
+    return NextResponse.json({ error: contextError.message }, { status: 500 });
+  }
+
+  const now = new Date();
+  const d30Ago = new Date(now.getTime() - 30 * 24 * 3600 * 1000);
+
+  const [partsRes, movesRes, openReqRes, openPoRes, receiveQueueRes] = await Promise.all([
+    supabase
+      .from("parts")
+      .select("id, created_at, sku, name, part_number, normalized_part_key, import_confidence, source_intake_id")
+      .eq("shop_id", actor.shopId),
+    supabase
+      .from("stock_moves")
+      .select("id, part_id, qty_change, reason, created_at, reference_kind, reference_id")
+      .eq("shop_id", actor.shopId)
+      .gte("created_at", d30Ago.toISOString())
+      .order("created_at", { ascending: true }),
+    supabase
+      .from("part_requests")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .in("status", ["requested", "quoted", "approved"]),
+    supabase
+      .from("purchase_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .in("status", ["draft", "sent", "partially_received"]),
+    supabase
+      .from("part_request_items")
+      .select("qty_approved, qty_received")
+      .eq("shop_id", actor.shopId)
+      .gt("qty_approved", 0),
+  ]);
+
+  const coreError = partsRes.error ?? movesRes.error ?? openReqRes.error ?? openPoRes.error ?? receiveQueueRes.error;
+  if (coreError) {
+    console.info("[PartsDashboard] load query failed", {
+      actorPresent: true,
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/parts/dashboard",
+      error: summarizeError(coreError),
+    });
+    return NextResponse.json({ error: coreError.message }, { status: 500 });
+  }
+
+  const stagingRes = await (supabase as any)
+    .from("shop_parts_import_staging")
+    .select("status")
+    .eq("shop_id", actor.shopId);
+  const candidateRes = await (supabase as any)
+    .from("shop_parts_import_match_candidates")
+    .select("staging_id, candidate_part_id");
+
+  if (stagingRes.error || candidateRes.error) {
+    console.info("[PartsDashboard] optional import trust query failed", {
+      actorPresent: true,
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/parts/dashboard",
+      stagingError: summarizeError(stagingRes.error),
+      candidateError: summarizeError(candidateRes.error),
+    });
+  }
+
+  return NextResponse.json({
+    shopId: actor.shopId,
+    parts: partsRes.data ?? [],
+    moves: movesRes.data ?? [],
+    openRequestsCount: openReqRes.count ?? 0,
+    openPoCount: openPoRes.count ?? 0,
+    receiveQueueItems: receiveQueueRes.data ?? [],
+    staging: stagingRes.error ? [] : (stagingRes.data ?? []),
+    candidates: candidateRes.error ? [] : (candidateRes.data ?? []),
+  });
+}

--- a/app/api/parts/requests/active/route.ts
+++ b/app/api/parts/requests/active/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+
+import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+const VISIBLE_STATUSES = ["requested", "quoted", "approved", "fulfilled"];
+
+export async function GET() {
+  const supabase = createServerSupabaseRoute();
+  const actor = await resolveCurrentActor(supabase);
+
+  if (!actor.user || !actor.shopId) {
+    console.info("[PartsRequests] server auth unavailable", {
+      actorPresent: Boolean(actor.user),
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/parts/requests/active",
+      table: "part_requests",
+    });
+    return NextResponse.json({ error: "Unable to resolve shop context." }, { status: 401 });
+  }
+
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: actor.shopId,
+  });
+
+  if (contextError) {
+    console.info("[PartsRequests] set_current_shop_id failed", {
+      actorPresent: true,
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/parts/requests/active",
+      table: "part_requests",
+      code: contextError.code,
+      message: contextError.message,
+    });
+    return NextResponse.json({ error: contextError.message }, { status: 500 });
+  }
+
+  const { data: requests, error: requestsError } = await supabase
+    .from("part_requests")
+    .select("*")
+    .eq("shop_id", actor.shopId)
+    .in("status", VISIBLE_STATUSES)
+    .order("created_at", { ascending: false });
+
+  if (requestsError) return NextResponse.json({ error: requestsError.message }, { status: 500 });
+
+  const requestIds = (requests ?? []).map((request) => request.id);
+  const workOrderIds = Array.from(
+    new Set(
+      (requests ?? [])
+        .map((request) => request.work_order_id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  );
+
+  const [itemsRes, workOrdersRes] = await Promise.all([
+    requestIds.length
+      ? supabase
+          .from("part_request_items")
+          .select("request_id, description, part_id, qty, quoted_price, status, qty_approved, qty_received, qty_consumed")
+          .eq("shop_id", actor.shopId)
+          .in("request_id", requestIds)
+      : Promise.resolve({ data: [], error: null }),
+    workOrderIds.length
+      ? supabase
+          .from("work_orders")
+          .select(`
+            id,
+            custom_id,
+            customer_id,
+            vehicle_id,
+            customers (
+              first_name,
+              last_name
+            ),
+            vehicles (
+              year,
+              make,
+              model
+            )
+          `)
+          .eq("shop_id", actor.shopId)
+          .in("id", workOrderIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  const error = itemsRes.error ?? workOrdersRes.error;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    shopId: actor.shopId,
+    requests: requests ?? [],
+    items: itemsRes.data ?? [],
+    workOrders: workOrdersRes.data ?? [],
+  });
+}

--- a/app/api/parts/requests/delete-bucket/route.ts
+++ b/app/api/parts/requests/delete-bucket/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+export async function DELETE(request: Request) {
+  const supabase = createServerSupabaseRoute();
+  const actor = await resolveCurrentActor(supabase);
+
+  if (!actor.user || !actor.shopId) {
+    return NextResponse.json({ error: "Unable to resolve shop context." }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { requestIds?: string[] } | null;
+  const requestIds = Array.isArray(body?.requestIds)
+    ? body.requestIds.filter((id): id is string => typeof id === "string" && id.length > 0)
+    : [];
+
+  if (!requestIds.length) return NextResponse.json({ error: "No request ids provided." }, { status: 400 });
+
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: actor.shopId,
+  });
+  if (contextError) return NextResponse.json({ error: contextError.message }, { status: 500 });
+
+  const { data: scopedRequests, error: scopeError } = await supabase
+    .from("part_requests")
+    .select("id")
+    .eq("shop_id", actor.shopId)
+    .in("id", requestIds);
+
+  if (scopeError) return NextResponse.json({ error: scopeError.message }, { status: 500 });
+
+  const scopedIds = (scopedRequests ?? []).map((row) => row.id);
+  if (!scopedIds.length) return NextResponse.json({ ok: true, deleted: 0 });
+
+  const { error: itemsError } = await supabase
+    .from("part_request_items")
+    .delete()
+    .eq("shop_id", actor.shopId)
+    .in("request_id", scopedIds);
+  if (itemsError) return NextResponse.json({ error: itemsError.message }, { status: 500 });
+
+  const { error: requestsError } = await supabase
+    .from("part_requests")
+    .delete()
+    .eq("shop_id", actor.shopId)
+    .in("id", scopedIds);
+  if (requestsError) return NextResponse.json({ error: requestsError.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true, deleted: scopedIds.length });
+}

--- a/app/api/work-orders/history/route.ts
+++ b/app/api/work-orders/history/route.ts
@@ -19,6 +19,24 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "You must be signed in to view service history." }, { status: 401 });
   }
 
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: actor.shopId,
+  });
+
+  if (contextError) {
+    console.info("[ServiceHistory] set_current_shop_id failed", {
+      actorPresent: true,
+      profileId: actor.profile?.id ?? null,
+      profileRole: actor.role ?? null,
+      activeShopId: actor.shopId,
+      route: "/api/work-orders/history",
+      table: "history",
+      code: contextError.code,
+      message: contextError.message,
+    });
+    return NextResponse.json({ error: contextError.message }, { status: 500 });
+  }
+
   const params = new URL(request.url).searchParams;
   const from = params.get("from") ?? "";
   const to = params.get("to") ?? "";
@@ -26,7 +44,6 @@ export async function GET(request: Request) {
   let query = supabase
     .from("history")
     .select("id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_sale, parts_sale, tax, total, symptom, cause, correction, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)")
-    .eq("shop_id", actor.shopId)
     .order("service_date", { ascending: false })
     .limit(300);
 

--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -40,7 +40,7 @@ export default async function OperationsDashboardView() {
         }
         actions={[
           { label: "Create work order", href: "/work-orders/create", tone: "primary" },
-          { label: "Dispatch", href: "/dashboard/manager/dispatch", tone: "secondary" },
+          { label: "Dispatch", href: "/fleet/dispatch", tone: "secondary" },
         ]}
       />
 
@@ -231,7 +231,7 @@ export default async function OperationsDashboardView() {
                 {payload.technicianActivity.map((tech) => (
                   <Link
                     key={tech.id}
-                    href="/dashboard/manager/dispatch"
+                    href="/fleet/dispatch"
                     className="group grid grid-cols-[minmax(0,1fr)_76px_auto] items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-2.5 py-2 transition hover:border-white/20 hover:bg-black/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
                   >
                     <div className="min-w-0">

--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -2,9 +2,8 @@
 
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
@@ -12,7 +11,7 @@ import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktop
 type DB = Database;
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type StockMoveRow = DB["public"]["Tables"]["stock_moves"]["Row"];
-type RequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
+type PartRequestItem = DB["public"]["Tables"]["part_request_items"]["Row"];
 type TrustExtendedPart = {
   part_number?: string | null;
   normalized_part_key?: string | null;
@@ -74,7 +73,6 @@ function sourceLabel(kind: string | null, reason: string | null): string {
 }
 
 export default function PartsDashboardPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
   const [loading, setLoading] = useState(true);
   const [skuTotal, setSkuTotal] = useState(0);
   const [skuNewThis7d, setSkuNewThis7d] = useState(0);
@@ -94,29 +92,33 @@ export default function PartsDashboardPage(): JSX.Element {
       const d7Ago = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
       const d30Ago = new Date(now.getTime() - 30 * 24 * 3600 * 1000);
 
-      const [partsRes, movesRes, openReqRes, openPoRes, receiveQueueRes, stagingRes, candidateRes] = await Promise.all([
-        supabase.from("parts").select("id, created_at, sku, part_number, normalized_part_key, import_confidence, source_intake_id"),
-        supabase
-          .from("stock_moves")
-          .select("id, part_id, qty_change, reason, created_at, reference_kind, reference_id")
-          .gte("created_at", d30Ago.toISOString())
-          .order("created_at", { ascending: true }),
-        supabase.from("part_requests").select("id", { count: "exact", head: true }).in("status", ["requested", "quoted", "approved"] as RequestRow["status"][]),
-        supabase.from("purchase_orders").select("id", { count: "exact", head: true }).in("status", ["draft", "sent", "partially_received"]),
-        supabase.from("part_request_items").select("qty_approved, qty_received").gt("qty_approved", 0),
-        supabase.from("shop_parts_import_staging").select("status"),
-        supabase.from("shop_parts_import_match_candidates").select("staging_id, candidate_part_id"),
-      ]);
+      const res = await fetch("/api/parts/dashboard", { credentials: "same-origin" });
+      const payload = (await res.json().catch(() => null)) as {
+        parts?: Array<Pick<PartRow, "id" | "created_at" | "sku"> & TrustExtendedPart>;
+        moves?: RecentMove[];
+        openRequestsCount?: number;
+        openPoCount?: number;
+        receiveQueueItems?: Array<Pick<PartRequestItem, "qty_approved" | "qty_received">>;
+        staging?: Array<{ status: string | null }>;
+        candidates?: Array<{ staging_id: string | null; candidate_part_id: string | null }>;
+        error?: string;
+      } | null;
 
-      const partsRows = (partsRes.data ?? []) as Array<Pick<PartRow, "id" | "created_at" | "sku"> & TrustExtendedPart>;
+      if (!res.ok) {
+        console.error("[parts] dashboard load failed:", payload?.error ?? res.statusText);
+        setLoading(false);
+        return;
+      }
+
+      const partsRows = payload?.parts ?? [];
 
       setSkuTotal(partsRows.length);
       setSkuNewThis7d(partsRows.filter((p) => !!p.created_at && new Date(p.created_at) >= d7Ago && new Date(p.created_at) < now).length);
 
       const lowTrust = partsRows.filter((p) => !p.sku?.trim() || !p.part_number?.trim() || !p.normalized_part_key?.trim() || (typeof p.import_confidence === "number" && p.import_confidence < 0.75)).length;
-      const reviewStaging = (stagingRes.data ?? []).filter((s) => ["pending", "review", "ambiguous"].includes(String(s.status ?? "").toLowerCase())).length;
+      const reviewStaging = (payload?.staging ?? []).filter((s) => ["pending", "review", "ambiguous"].includes(String(s.status ?? "").toLowerCase())).length;
       const candidateCounts: Record<string, number> = {};
-      for (const row of candidateRes.data ?? []) {
+      for (const row of payload?.candidates ?? []) {
         const key = String(row.staging_id ?? row.candidate_part_id ?? "");
         if (!key) continue;
         candidateCounts[key] = (candidateCounts[key] ?? 0) + 1;
@@ -124,7 +126,7 @@ export default function PartsDashboardPage(): JSX.Element {
       const ambiguousCandidates = Object.values(candidateCounts).filter((count) => count > 1).length;
       setTrustSummary({ lowTrust, reviewStaging, ambiguousCandidates });
 
-      const mv = (movesRes.data ?? []) as RecentMove[];
+      const mv = payload?.moves ?? [];
       setMoves7dCount(mv.filter((m) => new Date(String(m.created_at)) >= d7Ago).length);
       const buckets = Array<number>(30).fill(0);
       for (const m of mv) {
@@ -138,21 +140,22 @@ export default function PartsDashboardPage(): JSX.Element {
 
       const partIds = [...new Set(recent.map((x) => String(x.part_id ?? "")).filter(Boolean))];
       if (partIds.length) {
-        const partInfo = await supabase.from("parts").select("id, name, sku").in("id", partIds);
         const map: Record<string, { name: string | null; sku: string | null }> = {};
-        for (const p of partInfo.data ?? []) map[String(p.id)] = { name: p.name ?? null, sku: p.sku ?? null };
+        for (const p of partsRows) {
+          if (partIds.includes(String(p.id))) map[String(p.id)] = { name: (p as { name?: string | null }).name ?? null, sku: p.sku ?? null };
+        }
         setPartNameById(map);
       } else {
         setPartNameById({});
       }
 
-      setOpenRequestsCount(openReqRes.count ?? 0);
-      setOpenPoCount(openPoRes.count ?? 0);
-      const receiveQueue = (receiveQueueRes.data ?? []).filter((r) => Number(r.qty_received ?? 0) < Number(r.qty_approved ?? 0)).length;
+      setOpenRequestsCount(payload?.openRequestsCount ?? 0);
+      setOpenPoCount(payload?.openPoCount ?? 0);
+      const receiveQueue = (payload?.receiveQueueItems ?? []).filter((r) => Number(r.qty_received ?? 0) < Number(r.qty_approved ?? 0)).length;
       setReceiveQueueCount(receiveQueue);
       setLoading(false);
     })();
-  }, [supabase]);
+  }, []);
 
   const openReqDisplay = openRequestsCount == null || loading ? "…" : openRequestsCount.toLocaleString();
   const hasOpenRequests = (openRequestsCount ?? 0) > 0;

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import { requestFlowLabel, toItemFlowDisplay, toRequestFlowDisplay } from "@/features/parts/lib/status-display";
@@ -43,13 +42,6 @@ type WorkOrderListRow = {
     | { year: string | number | null; make: string | null; model: string | null }[]
     | null;
 };
-
-const VISIBLE_STATUSES: PartRequest["status"][] = [
-  "requested",
-  "quoted",
-  "approved",
-  "fulfilled",
-];
 
 function looksLikeUuid(s: string): boolean {
   return s.includes("-") && s.length >= 36;
@@ -97,8 +89,6 @@ function buildVehicleLabel(input: {
 }
 
 export default function PartsRequestsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
-
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<
@@ -147,20 +137,22 @@ export default function PartsRequestsPage(): JSX.Element {
   const reload = async (): Promise<void> => {
     setLoading(true);
 
-    const { data: reqs, error } = await supabase
-      .from("part_requests")
-      .select("*")
-      .in("status", VISIBLE_STATUSES)
-      .order("created_at", { ascending: false });
+    const res = await fetch("/api/parts/requests/active", { credentials: "same-origin" });
+    const payload = (await res.json().catch(() => null)) as {
+      requests?: PartRequest[];
+      items?: Array<Pick<PartRequestItem, "request_id" | "description" | "part_id" | "qty" | "quoted_price"> & { status?: string | null; qty_approved?: unknown; qty_received?: unknown; qty_consumed?: unknown }>;
+      workOrders?: WorkOrderListRow[];
+      error?: string;
+    } | null;
 
-    if (error) {
-      console.error("[parts/requests] load part_requests failed:", error);
+    if (!res.ok) {
+      console.error("[parts/requests] load active requests failed:", payload?.error ?? res.statusText);
       toast.error("Failed to load parts requests");
       setLoading(false);
       return;
     }
 
-    const requestList = (reqs ?? []) as PartRequest[];
+    const requestList = payload?.requests ?? [];
 
     const requestIds = requestList.map((r) => r.id);
     const itemsCountByRequest: Record<string, number> = {};
@@ -169,18 +161,7 @@ export default function PartsRequestsPage(): JSX.Element {
     const itemStatesByRequest: Record<string, ReturnType<typeof toItemFlowDisplay>[]> = {};
 
     if (requestIds.length) {
-      const { data: items, error: itemsErr } = await supabase
-        .from("part_request_items")
-        .select("request_id, description, part_id, qty, quoted_price, status, qty_approved, qty_received, qty_consumed")
-        .in("request_id", requestIds);
-
-      if (itemsErr) {
-        console.error(
-          "[parts/requests] load part_request_items failed:",
-          itemsErr,
-        );
-      } else {
-        (items ?? []).forEach((it) => {
+      (payload?.items ?? []).forEach((it) => {
           const row = it as Pick<
             PartRequestItem,
             "request_id" | "description" | "part_id" | "qty" | "quoted_price"
@@ -207,7 +188,6 @@ export default function PartsRequestsPage(): JSX.Element {
             }),
           );
         });
-      }
     }
 
     const woIds = Array.from(
@@ -221,33 +201,10 @@ export default function PartsRequestsPage(): JSX.Element {
     const woById: Record<string, WorkOrderListRow> = {};
 
     if (woIds.length) {
-      const { data: wos, error: woErr } = await supabase
-        .from("work_orders")
-        .select(`
-          id,
-          custom_id,
-          customer_id,
-          vehicle_id,
-          customers (
-            first_name,
-            last_name
-          ),
-          vehicles (
-            year,
-            make,
-            model
-          )
-        `)
-        .in("id", woIds);
-
-      if (woErr) {
-        console.error("[parts/requests] load work_orders failed:", woErr);
-      } else {
-        (wos ?? []).forEach((w) => {
-          const row = w as WorkOrderListRow;
-          woById[row.id] = row;
-        });
-      }
+      (payload?.workOrders ?? []).forEach((w) => {
+        const row = w as WorkOrderListRow;
+        woById[row.id] = row;
+      });
     }
 
     const byWo: Record<string, WoBucket> = {};
@@ -371,24 +328,16 @@ export default function PartsRequestsPage(): JSX.Element {
     const t = toast.loading("Deleting requests…");
 
     try {
-      const { error: itemsErr } = await supabase
-        .from("part_request_items")
-        .delete()
-        .in("request_id", requestIds);
+      const deleteRes = await fetch("/api/parts/requests/delete-bucket", {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ requestIds }),
+      });
+      const deletePayload = (await deleteRes.json().catch(() => null)) as { error?: string } | null;
 
-      if (itemsErr) {
-        console.error("[parts/requests] delete items failed:", itemsErr);
-        toast.error("Failed to delete request items", { id: t });
-        return;
-      }
-
-      const { error: reqErr } = await supabase
-        .from("part_requests")
-        .delete()
-        .in("id", requestIds);
-
-      if (reqErr) {
-        console.error("[parts/requests] delete requests failed:", reqErr);
+      if (!deleteRes.ok) {
+        console.error("[parts/requests] delete bucket failed:", deletePayload?.error ?? deleteRes.statusText);
         toast.error("Failed to delete requests", { id: t });
         return;
       }

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -602,7 +602,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
             },
         {
           label: "Check dispatch notes",
-          href: "/dashboard/manager/dispatch",
+          href: "/fleet/dispatch",
           tone: "neutral",
           detail: "Confirm assignment updates and immediate next actions.",
         },
@@ -636,7 +636,7 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
             },
         {
           label: "Open dispatch view",
-          href: "/dashboard/manager/dispatch",
+          href: "/fleet/dispatch",
           tone: "neutral",
           detail: "Review technician assignment and bay balancing.",
         },

--- a/features/shared/components/DashboardQuickActions.tsx
+++ b/features/shared/components/DashboardQuickActions.tsx
@@ -23,7 +23,7 @@ const ACTIONS: Record<Role, Action[]> = {
     { label: "📝 Create Work Order", href: "/dashboard/advisor/work-orders/create" },
   ],
   manager: [
-    { label: "📊 Dispatch Board", href: "/dashboard/manager/dispatch" },
+    { label: "📊 Dispatch Board", href: "/fleet/dispatch" },
     { label: "🧾 All Work Orders", href: "/dashboard/manager/work-orders" },
   ],
 };

--- a/tests/auth-regression-pages.test.ts
+++ b/tests/auth-regression-pages.test.ts
@@ -53,7 +53,49 @@ describe("post-deploy auth regression coverage", () => {
     expect(page).toContain("/api/work-orders/history");
     for (const pattern of browserAuthPatterns) expect(page).not.toContain(pattern);
     expect(route).toContain("resolveCurrentActor");
+    expect(route).toContain('rpc("set_current_shop_id"');
+    expect(route).not.toContain('.eq("shop_id", actor.shopId)');
+  });
+
+  it("loads parts dashboard through server-scoped shop context", () => {
+    const page = read("app/parts/page.tsx");
+    const route = read("app/api/parts/dashboard/route.ts");
+
+    expect(page).toContain("/api/parts/dashboard");
+    for (const pattern of browserAuthPatterns) expect(page).not.toContain(pattern);
+    expect(route).toContain("resolveCurrentActor");
+    expect(route).toContain('rpc("set_current_shop_id"');
     expect(route).toContain('.eq("shop_id", actor.shopId)');
+  });
+
+  it("loads active parts requests through server-scoped shop context", () => {
+    const page = read("app/parts/requests/page.tsx");
+    const route = read("app/api/parts/requests/active/route.ts");
+
+    expect(page).toContain("/api/parts/requests/active");
+    for (const pattern of browserAuthPatterns) expect(page).not.toContain(pattern);
+    expect(route).toContain("resolveCurrentActor");
+    expect(route).toContain('rpc("set_current_shop_id"');
+    expect(route).toContain('.eq("shop_id", actor.shopId)');
+    expect(route).toContain('"requested"');
+    expect(route).toContain('"quoted"');
+    expect(route).toContain('"approved"');
+    expect(route).toContain('"fulfilled"');
+  });
+
+  it("routes dispatch links to the fleet dispatch board", () => {
+    const tiles = read("features/shared/config/tiles.ts");
+    const operationsDashboard = read("app/dashboard/_components/OperationsDashboardView.tsx");
+    const operationsPayload = read("features/dashboard/server/getOperationsDashboardPayload.ts");
+    const quickActions = read("features/shared/components/DashboardQuickActions.tsx");
+
+    expect(tiles).toContain('href: "/fleet/dispatch"');
+    expect(operationsDashboard).toContain('href: "/fleet/dispatch"');
+    expect(operationsPayload).toContain('href: "/fleet/dispatch"');
+    expect(quickActions).toContain('href: "/fleet/dispatch"');
+    expect(operationsDashboard).not.toContain("/dashboard/manager/dispatch");
+    expect(operationsPayload).not.toContain("/dashboard/manager/dispatch");
+    expect(quickActions).not.toContain("/dashboard/manager/dispatch");
   });
 
   it("loads inspection history through server-scoped auth/data loading", () => {


### PR DESCRIPTION
### Motivation
- Recent auth/shop-context changes caused runtime regressions by relying on nonexistent `history.shop_id` filters, client-side Supabase auth in pages that must be server-scoped, and dashboard links pointing to a placeholder dispatch route.
- Fixes should be minimal and non-breaking: restore correct server-scoped patterns, preserve RLS semantics, and avoid introducing browser auth helpers on server-data pages.

### Description
- Fix service history API to set `current_shop_id` for the server session and remove the invalid `.eq("shop_id", actor.shopId)` on `history` so RLS (via work_orders/customers/vehicles) applies as intended; updated `app/api/work-orders/history/route.ts`.
- Restore dashboard dispatch links to the real fleet dispatch page by replacing `/dashboard/manager/dispatch` with `/fleet/dispatch` on dashboard surfaces and quick actions (`app/dashboard/_components/OperationsDashboardView.tsx`, `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/shared/components/DashboardQuickActions.tsx`).
- Move Parts Dashboard server scoping into a new server route `GET /api/parts/dashboard` that resolves the actor, calls `rpc('set_current_shop_id')`, and runs shop-scoped queries; update the client to fetch from this route (`app/api/parts/dashboard/route.ts`, `app/parts/page.tsx`).
- Move active Parts Requests loading and delete flow behind server routes that resolve shop context and scope queries by `actor.shopId` (`app/api/parts/requests/active/route.ts`, `app/api/parts/requests/delete-bucket/route.ts`, and updated `app/parts/requests/page.tsx`).
- Tests: add/extend regression checks to ensure pages use server-scoped routes and the correct dispatch links (`tests/auth-regression-pages.test.ts`).
- Files changed: `app/api/work-orders/history/route.ts`, `app/dashboard/_components/OperationsDashboardView.tsx`, `features/dashboard/server/getOperationsDashboardPayload.ts`, `features/shared/components/DashboardQuickActions.tsx`, `app/api/parts/dashboard/route.ts`, `app/parts/page.tsx`, `app/api/parts/requests/active/route.ts`, `app/api/parts/requests/delete-bucket/route.ts`, `app/parts/requests/page.tsx`, `tests/auth-regression-pages.test.ts`.

### Testing
- Ran the regression suites: `npx vitest run tests/auth-regression-pages.test.ts tests/work-orders-list-shop-scoping.test.ts tests/work-order-assignment-regression.test.ts` and observed all tests passing (3 test files, 25 tests total passed).
- Typecheck: `npx tsc --noEmit` completed without errors after fixes.
- Sanity diff check: `git diff --check` run as part of validation produced no issues.
- All automated validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237b1ad3a083288ebb9f3add62973d)