### PR TITLE
Restore dashboard shop context resolution with shared server identity resolver

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import Providers from "./providers";
 import AppShell from "@/features/shared/components/AppShell";
 import { headers } from "next/headers";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
 import { VoiceProvider } from "@/features/shared/voice/VoiceProvider";
 import BrandThemeBoot from "@/features/branding/components/BrandThemeBoot";
 
@@ -54,14 +55,23 @@ export default async function RootLayout({
 
   const useAppShell = !isPublicRoute;
 
-  const session = useAppShell
-    ? (await createServerSupabaseRSC().auth.getSession()).data.session
-    : null;
+  const [session, dashboardIdentity] = useAppShell
+    ? await Promise.all([
+        createServerSupabaseRSC()
+          .auth.getSession()
+          .then((result) => result.data.session),
+        getDashboardIdentity(),
+      ])
+    : [null, null];
 
   const appContent = (
     <VoiceProvider>
       <BrandThemeBoot />
-      {useAppShell ? <AppShell>{children}</AppShell> : children}
+      {useAppShell ? (
+        <AppShell initialIdentity={dashboardIdentity}>{children}</AppShell>
+      ) : (
+        children
+      )}
     </VoiceProvider>
   );
 

--- a/features/dashboard/server/dashboard-shell-data.ts
+++ b/features/dashboard/server/dashboard-shell-data.ts
@@ -1,40 +1,140 @@
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
+
+type DashboardProfile = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "completed_onboarding" | "email" | "full_name" | "role" | "shop_id"
+>;
+
+type DashboardShop = Pick<
+  Database["public"]["Tables"]["shops"]["Row"],
+  "id" | "name" | "shop_name" | "business_name"
+>;
+
+export type DashboardServerClient = ReturnType<typeof createServerSupabaseRSC>;
 
 export type DashboardIdentity = {
   userId: string | null;
+  email: string | null;
   shopId: string | null;
   role: string | null;
   fullName: string | null;
+  profileExists: boolean;
+  shopLoaded: boolean;
+  shop: DashboardShop | null;
 };
 
-export async function getDashboardIdentity(): Promise<DashboardIdentity> {
-  const supabase = createServerComponentClient<Database>({ cookies });
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
+function logDashboardContextDiagnostics(args: {
+  userId: string | null;
+  profile: DashboardProfile | null;
+  profileError?: string | null;
+  shopLoaded: boolean;
+  shopIdUsed: string | null;
+  shopError?: string | null;
+}) {
+  console.info("[dashboard/server-context]", {
+    userId: args.userId,
+    profileExists: Boolean(args.profile),
+    profileRole: args.profile?.role ?? null,
+    profileShopId: args.profile?.shop_id ?? null,
+    shopLoaded: args.shopLoaded,
+    shopIdUsed: args.shopIdUsed,
+    profileError: args.profileError ?? null,
+    shopError: args.shopError ?? null,
+  });
+}
 
-  const userId = session?.user?.id ?? null;
+export async function resolveDashboardServerContext(
+  supabase: DashboardServerClient = createDashboardServerClient(),
+): Promise<DashboardIdentity> {
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  const userId = user?.id ?? null;
   if (!userId) {
-    return { userId: null, shopId: null, role: null, fullName: null };
+    logDashboardContextDiagnostics({
+      userId: null,
+      profile: null,
+      profileError: userError?.message ?? null,
+      shopLoaded: false,
+      shopIdUsed: null,
+    });
+    return {
+      userId: null,
+      email: null,
+      shopId: null,
+      role: null,
+      fullName: null,
+      profileExists: false,
+      shopLoaded: false,
+      shop: null,
+    };
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from("profiles")
-    .select("full_name, role, shop_id")
+    .select("completed_onboarding, email, full_name, role, shop_id")
     .eq("id", userId)
-    .maybeSingle();
+    .limit(1)
+    .maybeSingle<DashboardProfile>();
+
+  const shopId = profile?.shop_id ?? null;
+  let shop: DashboardShop | null = null;
+  let shopErrorMessage: string | null = null;
+
+  if (shopId) {
+    const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+      p_shop_id: shopId,
+    });
+
+    if (contextError) {
+      console.warn("[dashboard/server-context] set_current_shop_id failed", {
+        userId,
+        shopIdUsed: shopId,
+        error: contextError.message,
+      });
+    }
+
+    const { data: shopData, error: shopError } = await supabase
+      .from("shops")
+      .select("id, name, shop_name, business_name")
+      .eq("id", shopId)
+      .limit(1)
+      .maybeSingle<DashboardShop>();
+
+    shop = shopData ?? null;
+    shopErrorMessage = shopError?.message ?? null;
+  }
+
+  logDashboardContextDiagnostics({
+    userId,
+    profile: profile ?? null,
+    profileError: profileError?.message ?? null,
+    shopLoaded: Boolean(shop),
+    shopIdUsed: shopId,
+    shopError: shopErrorMessage,
+  });
 
   return {
     userId,
-    shopId: profile?.shop_id ?? null,
+    email: profile?.email ?? user?.email ?? null,
+    shopId,
     role: profile?.role ?? null,
     fullName: profile?.full_name ?? null,
+    profileExists: Boolean(profile),
+    shopLoaded: Boolean(shop),
+    shop,
   };
 }
 
+export async function getDashboardIdentity(
+  supabase?: DashboardServerClient,
+): Promise<DashboardIdentity> {
+  return resolveDashboardServerContext(supabase);
+}
+
 export function createDashboardServerClient() {
-  return createServerComponentClient<Database>({ cookies });
+  return createServerSupabaseRSC();
 }

--- a/features/dashboard/server/getOperationsDashboardPayload.ts
+++ b/features/dashboard/server/getOperationsDashboardPayload.ts
@@ -1,9 +1,16 @@
 import { endOfDay, startOfDay, startOfMonth } from "date-fns";
 
-import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
+import {
+  createDashboardServerClient,
+  getDashboardIdentity,
+} from "@/features/dashboard/server/dashboard-shell-data";
 
 const OPEN_PART_STATUSES = ["requested", "quoted", "approved"] as const;
-const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
+const CLOSED_LINE_STATUSES = [
+  "completed",
+  "ready_to_invoice",
+  "invoiced",
+] as const;
 const TECH_ROLES = new Set(["tech", "technician", "mechanic"]);
 
 type OpSignal = {
@@ -87,9 +94,11 @@ function elapsedLabel(updatedAt: string | null): string {
 }
 
 export async function getOperationsDashboardPayload(): Promise<OperationsDashboardPayload> {
-  const identity = await getDashboardIdentity();
+  const supabase = createDashboardServerClient();
+  const identity = await getDashboardIdentity(supabase);
   const normalizedRole = (identity.role ?? "").toLowerCase();
-  const isTechnicianScoped = Boolean(identity.userId) && TECH_ROLES.has(normalizedRole);
+  const isTechnicianScoped =
+    Boolean(identity.userId) && TECH_ROLES.has(normalizedRole);
   const payload: OperationsDashboardPayload = {
     identity,
     viewerScope: isTechnicianScoped ? "technician" : "shop",
@@ -123,7 +132,6 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     return payload;
   }
 
-  const supabase = createDashboardServerClient();
   const todayStart = startOfDay(new Date()).toISOString();
   const todayEnd = endOfDay(new Date()).toISOString();
   const monthStart = startOfMonth(new Date()).toISOString();
@@ -133,21 +141,27 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     .select("id,work_order_id,status,updated_at", { count: "exact" })
     .eq("shop_id", identity.shopId)
     .in("approval_state", ["requested", "pending", "awaiting_approval"]);
-  const scopedApprovalsQuery = isTechnicianScoped && identity.userId
-    ? approvalsQuery.eq("assigned_tech_id", identity.userId)
-    : approvalsQuery;
+  const scopedApprovalsQuery =
+    isTechnicianScoped && identity.userId
+      ? approvalsQuery.eq("assigned_tech_id", identity.userId)
+      : approvalsQuery;
 
   const activeLinesQuery = supabase
     .from("work_order_lines")
     .select("id,work_order_id,assigned_tech_id,status,updated_at")
     .eq("shop_id", identity.shopId)
-    .not("status", "in", `(${CLOSED_LINE_STATUSES.map((status) => `'${status}'`).join(",")})`)
+    .not(
+      "status",
+      "in",
+      `(${CLOSED_LINE_STATUSES.map((status) => `'${status}'`).join(",")})`,
+    )
     .not("assigned_tech_id", "is", null)
     .order("updated_at", { ascending: false })
     .limit(400);
-  const scopedActiveLinesQuery = isTechnicianScoped && identity.userId
-    ? activeLinesQuery.eq("assigned_tech_id", identity.userId)
-    : activeLinesQuery;
+  const scopedActiveLinesQuery =
+    isTechnicianScoped && identity.userId
+      ? activeLinesQuery.eq("assigned_tech_id", identity.userId)
+      : activeLinesQuery;
 
   const [
     boardResult,
@@ -159,7 +173,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   ] = await Promise.all([
     supabase
       .from("v_work_order_board_cards_shop")
-      .select("work_order_id,custom_id,display_name,overall_stage,risk_level,priority")
+      .select(
+        "work_order_id,custom_id,display_name,overall_stage,risk_level,priority",
+      )
       .eq("shop_id", identity.shopId)
       .order("activity_at", { ascending: false })
       .limit(isTechnicianScoped ? 200 : 48),
@@ -183,12 +199,16 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       .lte("created_at", todayEnd),
   ]);
 
-  const boardRows = boardResult.error ? [] : boardResult.data ?? [];
-  const activeLines = activeLinesResult.error ? [] : activeLinesResult.data ?? [];
+  const boardRows = boardResult.error ? [] : (boardResult.data ?? []);
+  const activeLines = activeLinesResult.error
+    ? []
+    : (activeLinesResult.data ?? []);
   const buildOpenPartsQuery = () =>
     supabase
       .from("part_requests")
-      .select("id,status,work_order_id,job_id,created_at,requested_by,assigned_to")
+      .select(
+        "id,status,work_order_id,job_id,created_at,requested_by,assigned_to",
+      )
       .eq("shop_id", identity.shopId)
       .in("status", OPEN_PART_STATUSES as unknown as string[]);
 
@@ -204,25 +224,40 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   let partsQueryFailed = false;
 
   if (isTechnicianScoped && identity.userId) {
-    const assignedLineIds = [...new Set(activeLines.map((line) => line.id).filter(Boolean))];
+    const assignedLineIds = [
+      ...new Set(activeLines.map((line) => line.id).filter(Boolean)),
+    ];
     const assignedWorkOrderIds = [
-      ...new Set(activeLines.map((line) => line.work_order_id).filter((id): id is string => Boolean(id))),
+      ...new Set(
+        activeLines
+          .map((line) => line.work_order_id)
+          .filter((id): id is string => Boolean(id)),
+      ),
     ];
     const partRowsById = new Map<string, (typeof partsRows)[number]>();
 
-    const [partsByJobResult, partsByWorkOrderResult, partsByOwnerResult] = await Promise.all([
-      assignedLineIds.length > 0
-        ? buildOpenPartsQuery().in("job_id", assignedLineIds).limit(200)
-        : Promise.resolve({ data: [], error: null }),
-      assignedWorkOrderIds.length > 0
-        ? buildOpenPartsQuery().in("work_order_id", assignedWorkOrderIds).limit(200)
-        : Promise.resolve({ data: [], error: null }),
-      buildOpenPartsQuery()
-        .or(`requested_by.eq.${identity.userId},assigned_to.eq.${identity.userId}`)
-        .limit(120),
-    ]);
+    const [partsByJobResult, partsByWorkOrderResult, partsByOwnerResult] =
+      await Promise.all([
+        assignedLineIds.length > 0
+          ? buildOpenPartsQuery().in("job_id", assignedLineIds).limit(200)
+          : Promise.resolve({ data: [], error: null }),
+        assignedWorkOrderIds.length > 0
+          ? buildOpenPartsQuery()
+              .in("work_order_id", assignedWorkOrderIds)
+              .limit(200)
+          : Promise.resolve({ data: [], error: null }),
+        buildOpenPartsQuery()
+          .or(
+            `requested_by.eq.${identity.userId},assigned_to.eq.${identity.userId}`,
+          )
+          .limit(120),
+      ]);
 
-    if (partsByJobResult.error || partsByWorkOrderResult.error || partsByOwnerResult.error) {
+    if (
+      partsByJobResult.error ||
+      partsByWorkOrderResult.error ||
+      partsByOwnerResult.error
+    ) {
       partsQueryFailed = true;
       console.error("[Dashboard][Operations] parts query failed", {
         shopId: identity.shopId,
@@ -233,7 +268,11 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       });
     }
 
-    [partsByJobResult.data ?? [], partsByWorkOrderResult.data ?? [], partsByOwnerResult.data ?? []]
+    [
+      partsByJobResult.data ?? [],
+      partsByWorkOrderResult.data ?? [],
+      partsByOwnerResult.data ?? [],
+    ]
       .flat()
       .forEach((row) => {
         partRowsById.set(row.id, row);
@@ -257,7 +296,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   const scopedWorkOrderIds = new Set<string>();
 
   if (isTechnicianScoped) {
-    const approvalRows = approvalsResult.error ? [] : approvalsResult.data ?? [];
+    const approvalRows = approvalsResult.error
+      ? []
+      : (approvalsResult.data ?? []);
     const scopedPartRows = partsRows;
 
     for (const row of approvalRows) {
@@ -275,10 +316,14 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   const boardRowsForViewer = isTechnicianScoped
     ? boardRows.filter((row) => scopedWorkOrderIds.has(row.work_order_id))
     : boardRows;
-  const activeBoardRows = boardRowsForViewer.filter((row) => row.overall_stage !== "completed");
+  const activeBoardRows = boardRowsForViewer.filter(
+    (row) => row.overall_stage !== "completed",
+  );
   const mostRecentBlockedWorkOrderId =
     activeBoardRows.find(
-      (row) => row.overall_stage === "waiting_parts" || row.overall_stage === "on_hold",
+      (row) =>
+        row.overall_stage === "waiting_parts" ||
+        row.overall_stage === "on_hold",
     )?.work_order_id ?? null;
 
   if (boardResult.error) {
@@ -291,7 +336,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   } else {
     payload.topSummary.activeJobs = activeBoardRows.length;
     payload.topSummary.blockedJobs = activeBoardRows.filter(
-      (row) => row.overall_stage === "waiting_parts" || row.overall_stage === "on_hold",
+      (row) =>
+        row.overall_stage === "waiting_parts" ||
+        row.overall_stage === "on_hold",
     ).length;
 
     const stageCounts = new Map<string, number>();
@@ -311,12 +358,23 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     const waitingParts = stageCounts.get("waiting parts") ?? 0;
     payload.activeJobSummary = [
       { label: "Awaiting", value: awaiting, pct: asPct(awaiting, total) },
-      { label: "In progress", value: inProgress, pct: asPct(inProgress, total) },
-      { label: "Waiting parts", value: waitingParts, pct: asPct(waitingParts, total) },
+      {
+        label: "In progress",
+        value: inProgress,
+        pct: asPct(inProgress, total),
+      },
+      {
+        label: "Waiting parts",
+        value: waitingParts,
+        pct: asPct(waitingParts, total),
+      },
       {
         label: "Tech coverage",
         value: Math.min(total, (techProfilesResult.data ?? []).length),
-        pct: asPct(Math.min(total, (techProfilesResult.data ?? []).length), Math.max(total, 1)),
+        pct: asPct(
+          Math.min(total, (techProfilesResult.data ?? []).length),
+          Math.max(total, 1),
+        ),
       },
     ];
 
@@ -346,40 +404,42 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
   }
 
   if (partsQueryFailed) {
-    payload.sectionErrors.push("Parts blocker signal is temporarily unavailable.");
+    payload.sectionErrors.push(
+      "Parts blocker signal is temporarily unavailable.",
+    );
   } else {
     payload.topSummary.waitingParts = partsRows.length;
   }
 
   const recentApprovalLine = approvalsResult.error
     ? null
-    : (approvalsResult.data ?? [])
+    : ((approvalsResult.data ?? [])
         .filter((row) => !!row.work_order_id)
         .sort(
           (a, b) =>
-            new Date(b.updated_at ?? 0).getTime() - new Date(a.updated_at ?? 0).getTime(),
-        )[0] ?? null;
+            new Date(b.updated_at ?? 0).getTime() -
+            new Date(a.updated_at ?? 0).getTime(),
+        )[0] ?? null);
   const approvalTargetHref = recentApprovalLine?.work_order_id
     ? `/work-orders/${recentApprovalLine.work_order_id}`
     : "/work-orders/board?stage=awaiting_approval";
-  const approvalTargetKind: "item" | "filtered" = recentApprovalLine?.work_order_id
-    ? "item"
-    : "filtered";
+  const approvalTargetKind: "item" | "filtered" =
+    recentApprovalLine?.work_order_id ? "item" : "filtered";
 
   const recentPartsRequest = partsQueryFailed
     ? null
-    : partsRows
+    : (partsRows
         .filter((row) => !!row.work_order_id)
         .sort(
           (a, b) =>
-            new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
-        )[0] ?? null;
+            new Date(b.created_at ?? 0).getTime() -
+            new Date(a.created_at ?? 0).getTime(),
+        )[0] ?? null);
   const waitingPartsTargetHref = recentPartsRequest?.work_order_id
     ? `/work-orders/${recentPartsRequest.work_order_id}`
     : "/parts/requests?status=requested,quoted,approved";
-  const waitingPartsTargetKind: "item" | "filtered" = recentPartsRequest?.work_order_id
-    ? "item"
-    : "filtered";
+  const waitingPartsTargetKind: "item" | "filtered" =
+    recentPartsRequest?.work_order_id ? "item" : "filtered";
 
   const blockedTargetHref = mostRecentBlockedWorkOrderId
     ? `/work-orders/${mostRecentBlockedWorkOrderId}`
@@ -397,14 +457,18 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       targetKind: approvalTargetKind,
     },
     {
-      label: isTechnicianScoped ? "My open parts requests" : "Open parts requests",
+      label: isTechnicianScoped
+        ? "My open parts requests"
+        : "Open parts requests",
       value: String(payload.topSummary.waitingParts),
       tone: payload.topSummary.waitingParts > 0 ? "accent" : "default",
       href: waitingPartsTargetHref,
       targetKind: waitingPartsTargetKind,
     },
     {
-      label: isTechnicianScoped ? "My blocked jobs (parts/on hold)" : "Blocked jobs (parts/on hold)",
+      label: isTechnicianScoped
+        ? "My blocked jobs (parts/on hold)"
+        : "Blocked jobs (parts/on hold)",
       value: String(payload.topSummary.blockedJobs),
       tone: payload.topSummary.blockedJobs > 0 ? "accent" : "default",
       href: blockedTargetHref,
@@ -418,7 +482,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       userId: identity.userId,
       error: bookingsTodayResult.error.message,
     });
-    payload.sectionErrors.push("Daily summary signal is temporarily unavailable.");
+    payload.sectionErrors.push(
+      "Daily summary signal is temporarily unavailable.",
+    );
   }
 
   payload.dailySummary = isTechnicianScoped
@@ -438,10 +504,16 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           href: waitingPartsTargetHref,
           targetKind: waitingPartsTargetKind,
         },
-        { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
+        {
+          label: "Today's bookings",
+          value: String(bookingsTodayResult.count ?? 0),
+        },
       ]
     : [
-        { label: "Today's bookings", value: String(bookingsTodayResult.count ?? 0) },
+        {
+          label: "Today's bookings",
+          value: String(bookingsTodayResult.count ?? 0),
+        },
         {
           label: "Approval queue",
           value: String(payload.topSummary.waitingApprovals),
@@ -460,10 +532,15 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       ];
 
   if (techProfilesResult.error || activeLinesResult.error) {
-    payload.sectionErrors.push("Technician activity section is degraded due to query failures.");
+    payload.sectionErrors.push(
+      "Technician activity section is degraded due to query failures.",
+    );
   } else {
     const techs = techProfilesResult.data ?? [];
-    const counts = new Map<string, { activeLines: number; latestStatus: string; lastUpdated: string | null }>();
+    const counts = new Map<
+      string,
+      { activeLines: number; latestStatus: string; lastUpdated: string | null }
+    >();
 
     activeLines.forEach((line) => {
       if (!line.assigned_tech_id) return;
@@ -475,29 +552,35 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
       });
     });
 
-    const maxLines = Math.max(1, ...[...counts.values()].map((entry) => entry.activeLines));
-    const technicianRows = techs
-      .map((tech) => {
-        const activity = counts.get(tech.id);
-        return {
-          id: tech.id,
-          name: tech.full_name ?? "Unassigned tech",
-          activeLines: activity?.activeLines ?? 0,
-          stage: activity?.latestStatus ?? "idle",
-          elapsed: elapsedLabel(activity?.lastUpdated ?? null),
-          utilizationPct: asPct(activity?.activeLines ?? 0, maxLines),
-        };
-      });
+    const maxLines = Math.max(
+      1,
+      ...[...counts.values()].map((entry) => entry.activeLines),
+    );
+    const technicianRows = techs.map((tech) => {
+      const activity = counts.get(tech.id);
+      return {
+        id: tech.id,
+        name: tech.full_name ?? "Unassigned tech",
+        activeLines: activity?.activeLines ?? 0,
+        stage: activity?.latestStatus ?? "idle",
+        elapsed: elapsedLabel(activity?.lastUpdated ?? null),
+        utilizationPct: asPct(activity?.activeLines ?? 0, maxLines),
+      };
+    });
 
     payload.technicianActivity = isTechnicianScoped
       ? technicianRows.filter((tech) => tech.id === identity.userId)
-      : technicianRows.sort((a, b) => b.activeLines - a.activeLines).slice(0, 6);
+      : technicianRows
+          .sort((a, b) => b.activeLines - a.activeLines)
+          .slice(0, 6);
   }
 
   payload.alerts = [
     payload.topSummary.blockedJobs > 0
       ? {
-          label: isTechnicianScoped ? "My blocked jobs need action" : "Blocked jobs climbing",
+          label: isTechnicianScoped
+            ? "My blocked jobs need action"
+            : "Blocked jobs climbing",
           detail: isTechnicianScoped
             ? `${payload.topSummary.blockedJobs} of your assigned jobs are waiting parts or on hold.`
             : `${payload.topSummary.blockedJobs} jobs are currently waiting parts or on hold.`,
@@ -506,7 +589,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           targetKind: blockedTargetKind,
         }
       : {
-          label: isTechnicianScoped ? "My blocker pressure stable" : "Blocker pressure stable",
+          label: isTechnicianScoped
+            ? "My blocker pressure stable"
+            : "Blocker pressure stable",
           detail: isTechnicianScoped
             ? "None of your assigned jobs are currently blocked."
             : "No blocked stage spike detected.",
@@ -516,7 +601,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
         },
     payload.topSummary.waitingApprovals > 3
       ? {
-          label: isTechnicianScoped ? "My approvals are aging" : "Approval queue aging",
+          label: isTechnicianScoped
+            ? "My approvals are aging"
+            : "Approval queue aging",
           detail: isTechnicianScoped
             ? `${payload.topSummary.waitingApprovals} of your lines need approval follow-up.`
             : `${payload.topSummary.waitingApprovals} approvals need advisor follow-up.`,
@@ -525,7 +612,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           targetKind: approvalTargetKind,
         }
       : {
-          label: isTechnicianScoped ? "My approval queue healthy" : "Approval queue healthy",
+          label: isTechnicianScoped
+            ? "My approval queue healthy"
+            : "Approval queue healthy",
           detail: isTechnicianScoped
             ? "Your approval-dependent lines are below action threshold."
             : "Approval queue is below action threshold.",
@@ -535,7 +624,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
         },
     payload.topSummary.waitingParts > 0
       ? {
-          label: isTechnicianScoped ? "My parts constraints active" : "Parts constraints active",
+          label: isTechnicianScoped
+            ? "My parts constraints active"
+            : "Parts constraints active",
           detail: isTechnicianScoped
             ? `${payload.topSummary.waitingParts} of your part requests are still unresolved.`
             : `${payload.topSummary.waitingParts} open part requests still unresolved.`,
@@ -544,7 +635,9 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
           targetKind: waitingPartsTargetKind,
         }
       : {
-          label: isTechnicianScoped ? "No parts constraints on my work" : "No parts constraints",
+          label: isTechnicianScoped
+            ? "No parts constraints on my work"
+            : "No parts constraints",
           detail: isTechnicianScoped
             ? "Your assigned jobs currently have no open parts blockers."
             : "Parts flow is currently clear.",
@@ -567,7 +660,8 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
               label: "Open my active board",
               href: "/work-orders/board",
               tone: "neutral",
-              detail: "Review your assigned jobs and move the next line forward.",
+              detail:
+                "Review your assigned jobs and move the next line forward.",
             },
         payload.topSummary.waitingApprovals > 0
           ? {
@@ -633,21 +727,30 @@ export async function getOperationsDashboardPayload(): Promise<OperationsDashboa
     payload.sectionErrors.push("Revenue snapshot is temporarily unavailable.");
   } else {
     const invoices = invoicesMonthResult.data ?? [];
-    const revenue = invoices.reduce((sum, invoice) => sum + Number(invoice.total ?? 0), 0);
+    const revenue = invoices.reduce(
+      (sum, invoice) => sum + Number(invoice.total ?? 0),
+      0,
+    );
     const profit = invoices.reduce(
-      (sum, invoice) => sum + Number(invoice.total ?? 0) - Number(invoice.labor_cost ?? 0),
+      (sum, invoice) =>
+        sum + Number(invoice.total ?? 0) - Number(invoice.labor_cost ?? 0),
       0,
     );
 
     payload.revenueEfficiency = {
       revenue: Math.round(revenue),
       profit: Math.round(profit),
-      completedLines: payload.technicianActivity.reduce((sum, tech) => sum + tech.activeLines, 0),
+      completedLines: payload.technicianActivity.reduce(
+        (sum, tech) => sum + tech.activeLines,
+        0,
+      ),
       efficiencyPct: revenue > 0 ? Math.round((profit / revenue) * 100) : 0,
     };
   }
 
-  payload.fetchAudit.push("Operations dashboard now renders from one server payload with composed panel data.");
+  payload.fetchAudit.push(
+    "Operations dashboard now renders from one server payload with composed panel data.",
+  );
 
   return payload;
 }

--- a/features/dashboard/server/getPerformanceDashboardPayload.ts
+++ b/features/dashboard/server/getPerformanceDashboardPayload.ts
@@ -1,6 +1,9 @@
 import { endOfMonth, format, startOfMonth, subMonths } from "date-fns";
 
-import { createDashboardServerClient, getDashboardIdentity } from "@/features/dashboard/server/dashboard-shell-data";
+import {
+  createDashboardServerClient,
+  getDashboardIdentity,
+} from "@/features/dashboard/server/dashboard-shell-data";
 
 type TrendPoint = {
   label: string;
@@ -24,10 +27,23 @@ export type PerformanceDashboardPayload = {
     efficiencyPct: number;
   };
   trend: TrendPoint[];
-  technicianPerformance: Array<{ label: string; completed: number; pace: string; utilizationPct: number }>;
+  technicianPerformance: Array<{
+    label: string;
+    completed: number;
+    pace: string;
+    utilizationPct: number;
+  }>;
   businessSignals: PerfSignal[];
-  revenueWatch: Array<{ label: string; value: string; tone?: "default" | "accent" }>;
-  optimizationSummary: Array<{ label: string; detail: string; tone: "critical" | "warning" | "info" }>;
+  revenueWatch: Array<{
+    label: string;
+    value: string;
+    tone?: "default" | "accent";
+  }>;
+  optimizationSummary: Array<{
+    label: string;
+    detail: string;
+    tone: "critical" | "warning" | "info";
+  }>;
   sectionErrors: string[];
   fetchAudit: string[];
 };
@@ -42,7 +58,8 @@ function pct(delta: number, baseline: number): number {
 }
 
 export async function getPerformanceDashboardPayload(): Promise<PerformanceDashboardPayload> {
-  const identity = await getDashboardIdentity();
+  const supabase = createDashboardServerClient();
+  const identity = await getDashboardIdentity(supabase);
   const payload: PerformanceDashboardPayload = {
     identity,
     kpis: { revenue: 0, profit: 0, jobs: 0, efficiencyPct: 0 },
@@ -60,11 +77,16 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
     return payload;
   }
 
-  const supabase = createDashboardServerClient();
   const rangeStart = startOfMonth(subMonths(new Date(), 5)).toISOString();
   const rangeEnd = endOfMonth(new Date()).toISOString();
 
-  const [invoiceResult, expenseResult, techProfilesResult, completedLinesResult, comebackRiskResult] = await Promise.all([
+  const [
+    invoiceResult,
+    expenseResult,
+    techProfilesResult,
+    completedLinesResult,
+    comebackRiskResult,
+  ] = await Promise.all([
     supabase
       .from("invoices")
       .select("id,total,labor_cost,created_at")
@@ -98,7 +120,9 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   ]);
 
   if (invoiceResult.error || expenseResult.error) {
-    payload.sectionErrors.push("Finance trend section is degraded due to invoice/expense query failures.");
+    payload.sectionErrors.push(
+      "Finance trend section is degraded due to invoice/expense query failures.",
+    );
   } else {
     const invoices = invoiceResult.data ?? [];
     const expenses = expenseResult.data ?? [];
@@ -146,7 +170,10 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
     payload.kpis.revenue = latest?.revenue ?? 0;
     payload.kpis.profit = latest?.profit ?? 0;
     payload.kpis.jobs = latest?.jobs ?? 0;
-    payload.kpis.efficiencyPct = payload.kpis.revenue > 0 ? Math.round((payload.kpis.profit / payload.kpis.revenue) * 100) : 0;
+    payload.kpis.efficiencyPct =
+      payload.kpis.revenue > 0
+        ? Math.round((payload.kpis.profit / payload.kpis.revenue) * 100)
+        : 0;
 
     const revenueDelta = (latest?.revenue ?? 0) - (previous?.revenue ?? 0);
     const jobsDelta = (latest?.jobs ?? 0) - (previous?.jobs ?? 0);
@@ -169,7 +196,9 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   }
 
   if (techProfilesResult.error || completedLinesResult.error) {
-    payload.sectionErrors.push("Technician performance section is degraded due to work-order line query failures.");
+    payload.sectionErrors.push(
+      "Technician performance section is degraded due to work-order line query failures.",
+    );
   } else {
     const techs = techProfilesResult.data ?? [];
     const completed = completedLinesResult.data ?? [];
@@ -177,7 +206,10 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
 
     completed.forEach((row) => {
       if (!row.assigned_tech_id) return;
-      byTech.set(row.assigned_tech_id, (byTech.get(row.assigned_tech_id) ?? 0) + 1);
+      byTech.set(
+        row.assigned_tech_id,
+        (byTech.get(row.assigned_tech_id) ?? 0) + 1,
+      );
     });
 
     const maxCompleted = Math.max(1, ...[...byTech.values()]);
@@ -187,7 +219,10 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
         return {
           label: tech.full_name ?? "Unassigned tech",
           completed: completedCount,
-          pace: completedCount >= Math.ceil(maxCompleted * 0.75) ? "On pace" : "Watch",
+          pace:
+            completedCount >= Math.ceil(maxCompleted * 0.75)
+              ? "On pace"
+              : "Watch",
           utilizationPct: Math.round((completedCount / maxCompleted) * 100),
         };
       })
@@ -196,18 +231,36 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
   }
 
   if (comebackRiskResult.error) {
-    payload.sectionErrors.push("Business signals section is degraded due to board risk query failures.");
+    payload.sectionErrors.push(
+      "Business signals section is degraded due to board risk query failures.",
+    );
   } else {
     const riskRows = comebackRiskResult.data ?? [];
-    const highRisk = riskRows.filter((row) => row.risk_level === "danger").length;
+    const highRisk = riskRows.filter(
+      (row) => row.risk_level === "danger",
+    ).length;
     const warnRisk = riskRows.filter((row) => row.risk_level === "warn").length;
-    const onHold = riskRows.filter((row) => row.overall_stage === "on_hold").length;
+    const onHold = riskRows.filter(
+      (row) => row.overall_stage === "on_hold",
+    ).length;
 
     payload.businessSignals = [
-      { label: "Comeback risk", value: String(highRisk), tone: highRisk > 0 ? "accent" : "default" },
+      {
+        label: "Comeback risk",
+        value: String(highRisk),
+        tone: highRisk > 0 ? "accent" : "default",
+      },
       { label: "Margin watch", value: `${payload.kpis.efficiencyPct}%` },
-      { label: "Warning queue", value: String(warnRisk), tone: warnRisk > 0 ? "accent" : "default" },
-      { label: "On-hold revenue", value: String(onHold), tone: onHold > 0 ? "accent" : "default" },
+      {
+        label: "Warning queue",
+        value: String(warnRisk),
+        tone: warnRisk > 0 ? "accent" : "default",
+      },
+      {
+        label: "On-hold revenue",
+        value: String(onHold),
+        tone: onHold > 0 ? "accent" : "default",
+      },
     ];
 
     payload.optimizationSummary = [
@@ -247,7 +300,9 @@ export async function getPerformanceDashboardPayload(): Promise<PerformanceDashb
     ];
   }
 
-  payload.fetchAudit.push("Performance dashboard now ships a single curated payload with finance, throughput, and risk sections.");
+  payload.fetchAudit.push(
+    "Performance dashboard now ships a single curated payload with finance, throughput, and risk sections.",
+  );
 
   return payload;
 }

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -66,8 +66,17 @@ type ProfileScope = Pick<
 
 type ShopBillingScope = Pick<
   Database["public"]["Tables"]["shops"]["Row"],
-  "stripe_subscription_status" | "stripe_trial_end" | "stripe_current_period_end"
+  | "stripe_subscription_status"
+  | "stripe_trial_end"
+  | "stripe_current_period_end"
 >;
+
+type AppShellInitialIdentity = {
+  userId: string | null;
+  email: string | null;
+  shopId: string | null;
+  role: string | null;
+};
 
 function daysUntil(iso: string | null): number | null {
   if (!iso) return null;
@@ -77,16 +86,28 @@ function daysUntil(iso: string | null): number | null {
   return Math.ceil(diff / (1000 * 60 * 60 * 24));
 }
 
-export default function AppShell({ children }: { children: React.ReactNode }) {
+export default function AppShell({
+  children,
+  initialIdentity,
+}: {
+  children: React.ReactNode;
+  initialIdentity?: AppShellInitialIdentity | null;
+}) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
   const supabase = createClientComponentClient<Database>();
   const { data: activeBrand } = useActiveBrand();
 
-  const [userId, setUserId] = useState<string | null>(null);
-  const [userRole, setUserRole] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(
+    initialIdentity?.userId ?? null,
+  );
+  const [userRole, setUserRole] = useState<string | null>(
+    initialIdentity?.role ?? null,
+  );
   const [mustChangePassword, setMustChangePassword] = useState(false);
-  const [, setShopId] = useState<string | null>(null);
+  const [, setShopId] = useState<string | null>(
+    initialIdentity?.shopId ?? null,
+  );
   const [subStatus, setSubStatus] = useState<string | null>(null);
   const [trialEndIso, setTrialEndIso] = useState<string | null>(null);
   const [periodEndIso, setPeriodEndIso] = useState<string | null>(null);
@@ -102,7 +123,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   const punchRef = useRef<HTMLDivElement | null>(null);
 
-  const isPortalRoute = pathname === "/portal" || pathname.startsWith("/portal/");
+  const isPortalRoute =
+    pathname === "/portal" || pathname.startsWith("/portal/");
   const isAppRoute =
     !isPortalRoute &&
     !NON_APP_ROUTES.some((p) => pathname === p || pathname.startsWith(p + "/"));
@@ -110,7 +132,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const canSeeAgentConsole =
     !!userRole &&
     ["owner", "manager", "admin", "advisor", "agent_admin"].includes(userRole);
-  const isMobileWorkOrderDetail = /^\/mobile\/work-orders\/[^/]+$/i.test(pathname);
+  const isMobileWorkOrderDetail = /^\/mobile\/work-orders\/[^/]+$/i.test(
+    pathname,
+  );
 
   const showBillingBadge = isBillingAttentionStatus(subStatus);
 
@@ -153,9 +177,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             .eq("id", sid)
             .maybeSingle<ShopBillingScope>();
 
-          setSubStatus((shop?.stripe_subscription_status as string | null) ?? null);
+          setSubStatus(
+            (shop?.stripe_subscription_status as string | null) ?? null,
+          );
           setTrialEndIso((shop?.stripe_trial_end as string | null) ?? null);
-          setPeriodEndIso((shop?.stripe_current_period_end as string | null) ?? null);
+          setPeriodEndIso(
+            (shop?.stripe_current_period_end as string | null) ?? null,
+          );
         } else {
           setSubStatus(null);
           setTrialEndIso(null);
@@ -176,12 +204,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           },
           (payload) => {
             const raw = payload.new as unknown;
-            const msg = raw as Database["public"]["Tables"]["messages"]["Row"] & {
-              recipients?: string[] | null;
-            };
+            const msg =
+              raw as Database["public"]["Tables"]["messages"]["Row"] & {
+                recipients?: string[] | null;
+              };
 
             if (msg.sender_id === uid) return;
-            if (Array.isArray(msg.recipients) && !msg.recipients.includes(uid)) return;
+            if (Array.isArray(msg.recipients) && !msg.recipients.includes(uid))
+              return;
 
             setIncomingConvoId(msg.conversation_id);
             setChatOpen(true);
@@ -291,8 +321,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       >
         <div className="rounded-full border border-red-500/30 bg-red-950/30 px-3 py-1 text-[11px] font-semibold text-red-100 shadow-sm backdrop-blur transition hover:border-red-400/40">
           Billing issue:
-          <span className="ml-1 uppercase tracking-[0.12em]">{statusLabel}</span>
-          {dueLabel ? <span className="ml-2 text-red-200/80">{dueLabel}</span> : null}
+          <span className="ml-1 uppercase tracking-[0.12em]">
+            {statusLabel}
+          </span>
+          {dueLabel ? (
+            <span className="ml-2 text-red-200/80">{dueLabel}</span>
+          ) : null}
         </div>
       </button>
     );
@@ -346,7 +380,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                   <span
                     className="truncate text-lg font-semibold tracking-tight"
                     style={{
-                      fontFamily: "Black Ops One, var(--font-blackops), system-ui",
+                      fontFamily:
+                        "Black Ops One, var(--font-blackops), system-ui",
                       color: "var(--brand-primary, #C1663B)",
                     }}
                   >
@@ -356,7 +391,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               </Link>
             </div>
 
-            <RoleSidebar />
+            <RoleSidebar
+              initialRole={initialIdentity?.role ?? null}
+              initialEmail={initialIdentity?.email ?? null}
+            />
 
             <div className="mt-auto h-12 border-t border-white/10" />
           </div>
@@ -455,7 +493,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 boxShadow: "0 18px 40px rgba(0,0,0,0.95)",
               }}
             >
-              <h2 className="mb-2 text-sm font-medium text-neutral-100">Shift Tracker</h2>
+              <h2 className="mb-2 text-sm font-medium text-neutral-100">
+                Shift Tracker
+              </h2>
               <ShiftTracker userId={userId} />
             </div>
           ) : null}

--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -33,9 +33,10 @@ const GROUP_ORDER = [
   "General",
 ];
 
-
 function normalizeRole(raw: string | null | undefined): Role | null {
-  const r = String(raw ?? "").toLowerCase().trim();
+  const r = String(raw ?? "")
+    .toLowerCase()
+    .trim();
   if (!r) return null;
 
   if (r === "tech" || r === "technician") return "mechanic";
@@ -56,16 +57,19 @@ function getCanonicalActiveTile(pathname: string, tiles: Tile[]): Tile | null {
   return matching.sort((a, b) => b.href.length - a.href.length)[0] ?? null;
 }
 
-export default function RoleSidebar() {
-  const supabase = useMemo(
-    () => createClientComponentClient<Database>(),
-    [],
-  );
+export default function RoleSidebar({
+  initialRole = null,
+  initialEmail = null,
+}: {
+  initialRole?: string | null;
+  initialEmail?: string | null;
+}) {
+  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
 
   const pathname = usePathname();
 
-  const [role, setRole] = useState<Role | null>(null);
-  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [role, setRole] = useState<Role | null>(normalizeRole(initialRole));
+  const [userEmail, setUserEmail] = useState<string | null>(initialEmail);
   const [scopeFilter] = useState<Scope | "all">("all");
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
 
@@ -95,7 +99,9 @@ export default function RoleSidebar() {
     const filteredTiles = TILES.filter((t) => t.roles.includes(role))
       .filter((t) => t.scopes.includes("all") || t.scopes.includes(scopeFilter))
       .filter((t) => canShowTileForEmail(t, userEmail))
-      .filter((t) => (t.href === "/dashboard/onboarding-v2" ? navV2Enabled : true));
+      .filter((t) =>
+        t.href === "/dashboard/onboarding-v2" ? navV2Enabled : true,
+      );
 
     if (role === "owner") return getOwnerSidebarTiles(filteredTiles);
     return filteredTiles;

--- a/tests/dashboard-server-context.test.ts
+++ b/tests/dashboard-server-context.test.ts
@@ -1,0 +1,165 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { resolveDashboardServerContext } from "@/features/dashboard/server/dashboard-shell-data";
+
+function createMockSupabase() {
+  const calls: Array<Record<string, unknown>> = [];
+  const profile = {
+    completed_onboarding: true,
+    email: "edwardlakin35@gmail.com",
+    full_name: "Edward Lakin",
+    role: "owner",
+    shop_id: "e9e87cda-3cbe-4785-956f-e8d05fcde539",
+  };
+  const shop = {
+    id: profile.shop_id,
+    name: "Edward's Garage",
+    shop_name: null,
+    business_name: null,
+  };
+
+  function tableQuery(table: string) {
+    const query = {
+      select(columns: string) {
+        calls.push({ table, method: "select", columns });
+        return query;
+      },
+      eq(column: string, value: string) {
+        calls.push({ table, method: "eq", column, value });
+        return query;
+      },
+      limit(count: number) {
+        calls.push({ table, method: "limit", count });
+        return query;
+      },
+      async maybeSingle() {
+        calls.push({ table, method: "maybeSingle" });
+        return { data: table === "profiles" ? profile : shop, error: null };
+      },
+    };
+
+    return query;
+  }
+
+  return {
+    calls,
+    supabase: {
+      auth: {
+        async getUser() {
+          calls.push({ method: "auth.getUser" });
+          return {
+            data: {
+              user: {
+                id: "cc4edd23-11e3-4a3c-8cd1-8851f1e13b2c",
+                email: "edwardlakin35@gmail.com",
+              },
+            },
+            error: null,
+          };
+        },
+      },
+      from(table: string) {
+        calls.push({ method: "from", table });
+        return tableQuery(table);
+      },
+      async rpc(name: string, args: Record<string, unknown>) {
+        calls.push({ method: "rpc", name, args });
+        return { error: null };
+      },
+    },
+  };
+}
+
+describe("dashboard server shop context", () => {
+  it("resolves the dashboard actor from auth user + profiles.shop_id and loads that shop", async () => {
+    const { supabase, calls } = createMockSupabase();
+
+    const identity = await resolveDashboardServerContext(supabase as never);
+
+    expect(identity).toMatchObject({
+      userId: "cc4edd23-11e3-4a3c-8cd1-8851f1e13b2c",
+      email: "edwardlakin35@gmail.com",
+      role: "owner",
+      shopId: "e9e87cda-3cbe-4785-956f-e8d05fcde539",
+      profileExists: true,
+      shopLoaded: true,
+    });
+    expect(identity.shop?.id).toBe("e9e87cda-3cbe-4785-956f-e8d05fcde539");
+
+    expect(calls).toContainEqual({
+      table: "profiles",
+      method: "select",
+      columns: "completed_onboarding, email, full_name, role, shop_id",
+    });
+    expect(calls).toContainEqual({
+      table: "profiles",
+      method: "eq",
+      column: "id",
+      value: "cc4edd23-11e3-4a3c-8cd1-8851f1e13b2c",
+    });
+    expect(calls).toContainEqual({
+      method: "rpc",
+      name: "set_current_shop_id",
+      args: { p_shop_id: "e9e87cda-3cbe-4785-956f-e8d05fcde539" },
+    });
+    expect(calls).toContainEqual({
+      table: "shops",
+      method: "eq",
+      column: "id",
+      value: "e9e87cda-3cbe-4785-956f-e8d05fcde539",
+    });
+  });
+
+  it("keeps middleware and dashboard resolver profile lookup semantics aligned", () => {
+    const middlewareSource = readFileSync("middleware.ts", "utf8");
+    const resolverSource = readFileSync(
+      "features/dashboard/server/dashboard-shell-data.ts",
+      "utf8",
+    );
+
+    expect(middlewareSource).toContain('.from("profiles")');
+    expect(middlewareSource).toContain('.eq("id", user.id)');
+    expect(middlewareSource).toContain(".limit(1)");
+    expect(middlewareSource).toContain(".maybeSingle()");
+
+    expect(resolverSource).toContain('.from("profiles")');
+    expect(resolverSource).toContain('.eq("id", userId)');
+    expect(resolverSource).toContain(".limit(1)");
+    expect(resolverSource).toContain(".maybeSingle<DashboardProfile>()");
+    expect(resolverSource).not.toContain("createServerComponentClient");
+    expect(resolverSource).not.toContain("@supabase/auth-helpers-nextjs");
+  });
+
+  it("guards the dashboard payload against stale no-shop fallbacks when profiles.shop_id exists", () => {
+    const payloadSource = readFileSync(
+      "features/dashboard/server/getOperationsDashboardPayload.ts",
+      "utf8",
+    );
+    const shellSource = readFileSync(
+      "features/dashboard/server/dashboard-shell-data.ts",
+      "utf8",
+    );
+    const appShellSource = readFileSync(
+      "features/shared/components/AppShell.tsx",
+      "utf8",
+    );
+    const roleSidebarSource = readFileSync(
+      "features/shared/components/RoleSidebar.tsx",
+      "utf8",
+    );
+
+    expect(payloadSource).toContain(
+      "const supabase = createDashboardServerClient();",
+    );
+    expect(payloadSource).toContain(
+      "const identity = await getDashboardIdentity(supabase);",
+    );
+    expect(payloadSource).toContain("if (!identity.shopId)");
+    expect(payloadSource).toContain('.eq("shop_id", identity.shopId)');
+    expect(shellSource).toContain("const shopId = profile?.shop_id ?? null;");
+    expect(shellSource).toContain("shopIdUsed: shopId");
+    expect(appShellSource).toContain("initialIdentity?.role ?? null");
+    expect(roleSidebarSource).toContain("normalizeRole(initialRole)");
+  });
+});


### PR DESCRIPTION
### Motivation
- Dashboard rendering was falling back to an Operator / no-shop state even though middleware resolved `profiles.shop_id`, causing nav and metrics to show empty/incorrect data.
- The cause was inconsistent Supabase server-client usage: middleware used the app's SSR client and `auth.getUser()` while the dashboard shell previously relied on a different RSC helper and could miss `profiles.shop_id` during server render.
- The intent is to restore correct dashboard/nav/shop context behavior on the current baseline without reintroducing onboarding v2, shop switcher, or later rewrites.

### Description
- Added a shared server resolver `resolveDashboardServerContext` in `features/dashboard/server/dashboard-shell-data.ts` that uses `createServerSupabaseRSC()`, calls `supabase.auth.getUser()`, loads `profiles` by `id`, treats `profiles.shop_id` as the source of truth, runs `rpc('set_current_shop_id')` when present, and loads the `shops` row; it logs safe diagnostics (userId/profileExists/profileRole/profileShopId/shopLoaded/shopIdUsed).
- Rewired dashboard payloads to use the same server client and resolver: `getOperationsDashboardPayload` and `getPerformanceDashboardPayload` now call `createDashboardServerClient()` and `getDashboardIdentity(supabase)` so payload queries use the same resolved shop context.
- Root layout now resolves server identity and passes it into the app shell, and `AppShell`/`RoleSidebar` accept an `initialIdentity` to seed `role`/`email`/`shopId` server-side so sidebar/nav don't show the stale "Loading navigation…" or "Operator" fallback during SSR-to-client hydration.
- Added focused regression tests `tests/dashboard-server-context.test.ts` that assert the resolver loads `profiles` and `shops`, calls `set_current_shop_id`, and that dashboard payloads and middleware use aligned profile lookup semantics.

### Testing
- Ran the new unit checks with `npx vitest run tests/dashboard-server-context.test.ts` and all tests passed (3/3). 
- Type-check validated with `npx tsc --noEmit --pretty false` (success). 
- Static diff checks (`git diff --check`) reported no whitespace/patch issues.
- Commit created for this work: `c183fc7ea3b6b3e9caa61e31ec3f0e5bfca0e5bd`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23914af2d08328a1cb12e1f3db6e19)