### PR TITLE
Replace legacy @supabase/auth-helpers-nextjs with canonical Supabase helpers; fix Work Orders customer join

### DIFF
--- a/app/agent/planner/page.tsx
+++ b/app/agent/planner/page.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
@@ -359,7 +358,7 @@ export default function PlannerPage() {
 
   const [toast, setToast] = useState<string | null>(null);
 
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const draft = useWorkOrderDraft();
   const setVehicleDraft = useWorkOrderDraft((s) => s.setVehicle);
   const setCustomerDraft = useWorkOrderDraft((s) => s.setCustomer);

--- a/app/api/agent/attachments/route.ts
+++ b/app/api/agent/attachments/route.ts
@@ -1,14 +1,9 @@
 // app/api/agent/attachments/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export async function POST(req: NextRequest) {
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient<Database>({
-    cookies: () => cookieStore,
-  });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/agent/planner/fleet/route.ts
+++ b/app/api/agent/planner/fleet/route.ts
@@ -1,8 +1,7 @@
 // app/api/agent/planner/fleet/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import type { ToolContext } from "@/features/agent/lib/toolTypes";
@@ -24,7 +23,7 @@ type Body = {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/agent/requests/[id]/notify-discord/route.ts
+++ b/app/api/agent/requests/[id]/notify-discord/route.ts
@@ -1,7 +1,6 @@
 // app/api/agent/requests/[id]/notify-discord/route.ts (FULL FILE REPLACEMENT)
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
@@ -52,8 +51,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
     }
 
-    // ✅ IMPORTANT: do NOT await cookies(); createRouteHandlerClient expects sync cookies access
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    // ✅ IMPORTANT: do NOT await cookies(); createServerSupabaseRoute uses request cookies
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/agent/requests/[id]/reply/route.ts
+++ b/app/api/agent/requests/[id]/reply/route.ts
@@ -1,9 +1,7 @@
 // /app/api/agent/requests/[id]/reply/route.ts (FULL FILE REPLACEMENT)
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 /** Minimal JSON type compatible with Supabase jsonb */
 type Json =
@@ -70,7 +68,7 @@ export async function POST(req: Request, context: unknown) {
     return NextResponse.json({ error: "message is required" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/agent/requests/[id]/route.ts
+++ b/app/api/agent/requests/[id]/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type AgentRequestStatus =
   | "submitted"
@@ -62,7 +60,7 @@ function safeUuid(v: unknown): string | null {
 const PENDING_ACTION_STATUSES = ["awaiting_approval"] as const;
 
 async function approveActionsAndEnqueueJobs(params: {
-  supabase: ReturnType<typeof createRouteHandlerClient<Database>>;
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
   requestId: string;
   approvedBy: string;
 }) {
@@ -138,9 +136,7 @@ export async function PATCH(req: NextRequest) {
       { status: 400 },
     );
   }
-
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+  const supabase = createServerSupabaseRoute();
 
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -286,9 +282,7 @@ export async function PATCH(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const id = getIdFromUrl(req);
   if (!id) return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
-
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+  const supabase = createServerSupabaseRoute();
 
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -1,7 +1,6 @@
 // app/api/agent/requests/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
@@ -91,10 +90,7 @@ type CreateAgentRequestBody = {
 };
 
 export async function GET() {
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient<Database>({
-    cookies: () => cookieStore,
-  });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },
@@ -122,10 +118,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient<Database>({
-    cookies: () => cookieStore,
-  });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/ai/quote-suggest/route.ts
+++ b/app/api/ai/quote-suggest/route.ts
@@ -1,11 +1,9 @@
 //app/api/ai/quote-suggest/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database, Json } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { Json } from "@shared/types/types/supabase";
 import { ProFixAI, type QuoteEnginePart } from "@/features/integrations/ai";
 
-type DB = Database;
 
 type ConfidenceLevel = "low" | "medium" | "high";
 
@@ -81,7 +79,7 @@ function buildComplaint(input: RequestBody): string {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const rawBody: unknown = await req.json();

--- a/app/api/ai/suggestions/feedback/route.ts
+++ b/app/api/ai/suggestions/feedback/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database, Json } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -64,7 +63,7 @@ function normalizeParts(value: unknown): Json {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/ai/suggestions/route.ts
+++ b/app/api/ai/suggestions/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createOpenAIEmbedding } from "@/features/shared/lib/server/openai-embeddings";
 
-type DB = Database;
 
 type Body = {
   item?: string;
@@ -194,7 +191,7 @@ function buildIntelligenceSuggestion(
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const rpcClient = supabase as unknown as {
       rpc: (
         fn: string,

--- a/app/api/assistant/answer/route.ts
+++ b/app/api/assistant/answer/route.ts
@@ -1,18 +1,15 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { answerAssistant } from "@/features/agent/assistant/server/answerAssistant";
 import type {
   AssistantAskRequest,
   AssistantAskResponse,
 } from "@/features/agent/assistant/types";
 
-type DB = Database;
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -24,7 +21,7 @@ async function requireUser(
 }
 
 async function resolveProfile(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<{ shopId: string | null; role: string | null }> {
   const { data, error } = await supabase
@@ -44,7 +41,7 @@ async function resolveProfile(
 }
 
 export async function POST(request: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -1,20 +1,17 @@
 // app/api/assistant/route.ts
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { answerAssistant } from "@/features/agent/assistant/server/answerAssistant";
 import type {
   AssistantAskContext,
   AssistantAskSession,
 } from "@/features/agent/assistant/types";
 
-type DB = Database;
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -26,7 +23,7 @@ async function requireUser(
 }
 
 async function resolveProfile(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<{ shopId: string | null; role: string | null }> {
   const { data, error } = await supabase
@@ -46,7 +43,7 @@ async function resolveProfile(
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/assistant/suggested-actions/route.ts
+++ b/app/api/assistant/suggested-actions/route.ts
@@ -1,17 +1,14 @@
 // app/api/assistant/suggested-actions/route.ts
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import type { SuggestedActionContext } from "@/features/assistant/types/suggested-actions";
 import { getSuggestedActions } from "@/features/assistant/server/getSuggestedActions";
 
-type DB = Database;
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -23,7 +20,7 @@ async function requireUser(
 }
 
 async function resolveProfile(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<{ shopId: string | null; role: string | null }> {
   const { data, error } = await supabase
@@ -43,7 +40,7 @@ async function resolveProfile(
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {
@@ -82,7 +79,7 @@ export async function POST(req: Request) {
 }
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/dashboard/layout/route.ts
+++ b/app/api/dashboard/layout/route.ts
@@ -1,13 +1,10 @@
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import type { DashboardLayoutItem } from "@/features/dashboard/types/layout";
 
-type DB = Database;
 
 type JsonResponse = {
   ok: boolean;
@@ -17,7 +14,7 @@ type JsonResponse = {
 
 export async function GET(req: NextRequest) {
   const scope = req.nextUrl.searchParams.get("scope") || "desktop";
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { session },
@@ -48,7 +45,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function PUT(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { session },

--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
@@ -51,7 +50,7 @@ function pathBasename(path: string): string {
 }
 
 export async function POST(req: NextRequest) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/email/logs/route.ts
+++ b/app/api/email/logs/route.ts
@@ -2,17 +2,14 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 const ALLOWED_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
 
 export async function GET(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/fleet/ai-summary/route.ts
+++ b/app/api/fleet/ai-summary/route.ts
@@ -1,11 +1,8 @@
 // app/api/fleet/ai-summary/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 export type SummaryResponse = {
   summary: string;
@@ -18,7 +15,7 @@ type Body = {
 };
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -30,7 +27,7 @@ async function requireUser(
 }
 
 async function resolveFleetIdForUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   explicitFleetId?: string | null,
 ): Promise<string | null> {
   const user = await requireUser(supabase);
@@ -62,7 +59,7 @@ async function resolveFleetIdForUser(
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const body = (await req.json().catch(() => ({}))) as Body;
 

--- a/app/api/fleet/asset-detail/route.ts
+++ b/app/api/fleet/asset-detail/route.ts
@@ -1,7 +1,6 @@
 // app/api/fleet/asset-detail/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
   resolveFleetActorContext,
@@ -94,7 +93,7 @@ function normalizeIssueStatus(st: string | null): FleetIssue["status"] {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as RequestBody | null;
     const actor = await resolveFleetActorContext(supabase, {
       requestedFleetId: body?.fleetId ?? null,

--- a/app/api/fleet/forms/upload/route.ts
+++ b/app/api/fleet/forms/upload/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 const BUCKET = "fleet-forms";
@@ -36,10 +34,7 @@ function guessMimeFromName(name: string): string {
 
 export async function POST(req: NextRequest) {
   try {
-    const cookieStore = cookies();
-    const supabase = createRouteHandlerClient<Database>({
-      cookies: () => cookieStore,
-    });
+    const supabase = createServerSupabaseRoute();
     const admin = createAdminSupabase();
 
     const {

--- a/app/api/fleet/pretrip/convert-to-service-request/route.ts
+++ b/app/api/fleet/pretrip/convert-to-service-request/route.ts
@@ -1,8 +1,7 @@
 // app/api/fleet/pretrip/convert-to-service/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 
@@ -58,7 +57,7 @@ function normalizeSeverity(
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as ConvertBody | null;
 
     if (!body?.pretripId) {

--- a/app/api/fleet/pretrip/route.ts
+++ b/app/api/fleet/pretrip/route.ts
@@ -1,8 +1,7 @@
 // app/api/fleet/pretrip/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
   resolveFleetActorContext,
@@ -46,7 +45,7 @@ type ListPretripBody = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const raw = (await req
     .json()

--- a/app/api/fleet/service-requests/convert-to-work-order/route.ts
+++ b/app/api/fleet/service-requests/convert-to-work-order/route.ts
@@ -1,11 +1,8 @@
 // app/api/fleet/service-requests/convert-to-work-order/route.ts
-import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 
-type DB = Database;
 
 type ConvertBody = {
   serviceRequestId: string;
@@ -13,7 +10,7 @@ type ConvertBody = {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as ConvertBody | null;
 
     if (!body?.serviceRequestId) {

--- a/app/api/fleet/service-requests/route.ts
+++ b/app/api/fleet/service-requests/route.ts
@@ -1,8 +1,7 @@
 // app/api/fleet/service-requests/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
   resolveFleetActorContext,
@@ -34,7 +33,7 @@ type Body = {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const body = (await req.json().catch(() => ({}))) as Body;
 

--- a/app/api/fleet/tower/route.ts
+++ b/app/api/fleet/tower/route.ts
@@ -1,8 +1,7 @@
 // app/api/fleet/tower/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import type {
@@ -101,7 +100,7 @@ function normalizeDispatchState(st: string | null): DispatchAssignment["state"] 
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => ({}))) as {
       fleetId?: string | null;
       shopId?: string | null;

--- a/app/api/fleet/units/route.ts
+++ b/app/api/fleet/units/route.ts
@@ -1,8 +1,7 @@
 // app/api/fleet/units/route.ts
-import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
   resolveFleetActorContext,
@@ -78,7 +77,7 @@ function deriveUnitStatus(
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const body = (await req.json().catch(() => ({}))) as UnitsBody;
     const actor = await resolveFleetActorContext(supabase);

--- a/app/api/inspections/complete/route.ts
+++ b/app/api/inspections/complete/route.ts
@@ -4,8 +4,7 @@ import "server-only";
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database, TablesInsert } from "@shared/types/types/supabase";
 
 import type { InspectionItem } from "@/features/inspections/lib/inspection/types";
@@ -41,7 +40,7 @@ type CompleteRequest = {
 
 /* --------------------------------- Route -------------------------------- */
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     // 1) Parse & validate

--- a/app/api/inspections/finalize/pdf/route.ts
+++ b/app/api/inspections/finalize/pdf/route.ts
@@ -4,8 +4,7 @@ import "server-only";
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { generateInspectionPDF } from "@/features/inspections/lib/inspection/pdf";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
@@ -28,7 +27,7 @@ function safeFilePart(x: string): string {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // 1) Parse body
   const raw = (await req.json().catch(() => null)) as unknown;

--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database, Json } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { Json } from "@shared/types/types/supabase";
 import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
 
-type DB = Database;
 
 function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0
@@ -13,7 +11,7 @@ function asString(value: unknown): string | null {
 }
 
 export async function GET(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const inspectionId = asString(req.nextUrl.searchParams.get("inspectionId"));
   const workOrderLineId = asString(req.nextUrl.searchParams.get("workOrderLineId"));

--- a/app/api/inspections/photos/upload/route.ts
+++ b/app/api/inspections/photos/upload/route.ts
@@ -3,14 +3,12 @@ import "server-only";
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import crypto from "crypto";
 import { buildInspectionMediaCapturedEvent } from "@/features/integrations/shopreel/server/buildProFixIQStoryEvents";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
 
-type DB = Database;
 
 function asString(v: FormDataEntryValue | null): string | null {
   if (typeof v !== "string") return null;
@@ -29,7 +27,7 @@ function extFromMime(mime: string | null): "jpg" | "png" {
 }
 
 async function resolveShopId(args: {
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>;
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
   inspectionId: string;
   workOrderId: string | null;
   workOrderLineId: string | null;
@@ -117,7 +115,7 @@ async function resolveShopId(args: {
 }
 
 async function ensureInspectionRow(args: {
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>;
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
   inspectionId: string;
   shopId: string;
   workOrderId: string | null;
@@ -204,7 +202,7 @@ async function ensureInspectionRow(args: {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/inspections/reopen/route.ts
+++ b/app/api/inspections/reopen/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 const REOPEN_ALLOWED_ROLES = new Set(["admin", "advisor", "owner", "manager"]);
 
 function asString(v: unknown): string | null {
@@ -11,7 +8,7 @@ function asString(v: unknown): string | null {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/inspections/save/route.ts
+++ b/app/api/inspections/save/route.ts
@@ -5,8 +5,7 @@ import "server-only";
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database, Json } from "@shared/types/types/supabase";
 import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
 
@@ -21,7 +20,7 @@ function asString(x: unknown): string | null {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // 1) parse body
   const raw = (await req.json().catch(() => null)) as unknown;

--- a/app/api/inspections/session/create/route.ts
+++ b/app/api/inspections/session/create/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type Body = {
   workOrderId: string;
@@ -15,7 +13,7 @@ type JsonOk = { sessionId: string; reused: boolean };
 type JsonErr = { error: string };
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   let parsed: unknown;
   try {

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -2,9 +2,7 @@
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database as BaseDatabase } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 /**
  * SQL function:
@@ -55,7 +53,7 @@ function isSignRequestBody(value: unknown): value is SignRequestBody {
   return ALLOWED_ROLES.includes(role as Role);
 }
 
-type Supabase = ReturnType<typeof createRouteHandlerClient<BaseDatabase>>;
+type Supabase = ReturnType<typeof createServerSupabaseRoute>;
 
 type RpcReturn = {
   data: unknown;
@@ -108,7 +106,7 @@ async function ensureInspectionExists(args: {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<BaseDatabase>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // Require authed user
   const userRes = await supabase.auth.getUser();

--- a/app/api/inspections/smart-match/feedback/route.ts
+++ b/app/api/inspections/smart-match/feedback/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 type Body = {
   itemLabel?: string | null;
@@ -27,7 +24,7 @@ function safeTrim(v: unknown): string | null {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const body = (await req.json().catch(() => null)) as Body | null;
 
   const {

--- a/app/api/inspections/smart-match/history/route.ts
+++ b/app/api/inspections/smart-match/history/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<Database>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       inspectionId,

--- a/app/api/inspections/smart-match/route.ts
+++ b/app/api/inspections/smart-match/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { findSmartInspectionMatch } from "@/features/inspections/server/findSmartInspectionMatch";
 
-type DB = Database;
 
 type Body = {
   item?: string;
@@ -23,7 +20,7 @@ type Body = {
 };
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const body = (await req.json().catch(() => null)) as Body | null;
 
   const {

--- a/app/api/inspections/submit/route.ts
+++ b/app/api/inspections/submit/route.ts
@@ -1,14 +1,12 @@
 // app/api/inspections/submit/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 import { generateQuoteFromInspection } from "@quotes/lib/quote/generateQuoteFromInspection";
 import { generateQuotePDFBytes } from "@work-orders/lib/work-orders/generateQuotePdf";
 import { sendQuoteEmail } from "@shared/lib/email/email/sendQuoteEmail";
 import { generateInspectionSummary } from "@inspections/lib/inspection/generateInspectionSummary";
 
-import type { Database } from "@shared/types/types/supabase";
 import type {
   InspectionSession,
   QuoteLineItem,
@@ -33,7 +31,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const supabase = createRouteHandlerClient<Database>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     // 1) Structured inspection summary
     const summary = generateInspectionSummary(inspectionSession);

--- a/app/api/invoices/[id]/documents/[kind]/signed/route.ts
+++ b/app/api/invoices/[id]/documents/[kind]/signed/route.ts
@@ -2,11 +2,8 @@ import "server-only";
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 type SupportedInvoiceDocumentKind = "invoice_pdf";
 const SUPPORTED_KINDS: ReadonlySet<SupportedInvoiceDocumentKind> = new Set(["invoice_pdf"]);
@@ -34,7 +31,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ ok: false, error: "Invalid kind" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/maintenance/generate-rules/route.ts
+++ b/app/api/maintenance/generate-rules/route.ts
@@ -1,12 +1,9 @@
 // app/api/maintenance/generate-rules/route.ts
 import "server-only";
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { generateMaintenanceRulesForVehicle } from "@/features/maintenance/server/generateMaintenanceRules";
 
-type DB = Database;
 
 export const runtime = "nodejs";
 
@@ -50,7 +47,7 @@ function parseBody(json: unknown): GenerateBody {
 }
 
 export async function POST(req: Request) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   try {
     const bodyRaw = await req.json().catch(() => null);

--- a/app/api/maintenance/history/backfill/route.ts
+++ b/app/api/maintenance/history/backfill/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { backfillMaintenanceHistorySignals } from "@/features/maintenance/server/backfillMaintenanceHistorySignals";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
-type DB = Database;
 
 export async function POST() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/maintenance/mappings/route.ts
+++ b/app/api/maintenance/mappings/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getMaintenanceMappings } from "@/features/maintenance/server/getMaintenanceMappings";
 
-type DB = Database;
 
 type UpsertBody = {
   serviceCode?: string;
@@ -16,7 +13,7 @@ type UpsertBody = {
   matchSource?: string | null;
 };
 
-async function requireShopContext(supabase: ReturnType<typeof createRouteHandlerClient<DB>>) {
+async function requireShopContext(supabase: ReturnType<typeof createServerSupabaseRoute>) {
   const {
     data: { user },
     error: userError,
@@ -47,7 +44,7 @@ async function requireShopContext(supabase: ReturnType<typeof createRouteHandler
 }
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const ctx = await requireShopContext(supabase);
   if ("error" in ctx) return ctx.error;
 
@@ -66,7 +63,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const ctx = await requireShopContext(supabase);
   if ("error" in ctx) return ctx.error;
 

--- a/app/api/maintenance/mappings/suggest/route.ts
+++ b/app/api/maintenance/mappings/suggest/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { suggestMaintenanceMenuMatch } from "@/features/maintenance/server/suggestMaintenanceMenuMatch";
 
-type DB = Database;
 
 type RequestBody = {
   serviceCode?: string;
@@ -12,7 +9,7 @@ type RequestBody = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/maintenance/menu-items/search/route.ts
+++ b/app/api/maintenance/menu-items/search/route.ts
@@ -1,12 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 export async function GET(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/maintenance/suggestions/route.ts
+++ b/app/api/maintenance/suggestions/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { computeMaintenanceSuggestionsForWorkOrder } from "@/features/maintenance/server/computeMaintenanceSuggestions";
 
-type DB = Database;
 
 type MenuMeta = { name: string; price: number | null };
 
@@ -13,7 +10,7 @@ function safeTrim(value: unknown): string {
 }
 
 async function buildMenuMetaMap(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   suggestions: Array<{
     menuItemId?: string | null;
   }>,
@@ -54,7 +51,7 @@ async function buildMenuMetaMap(
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/menu-items/save-from-line/route.ts
+++ b/app/api/menu-items/save-from-line/route.ts
@@ -1,8 +1,7 @@
 // app/api/menu-items/save-from-line/route.ts
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -36,7 +35,7 @@ function clampNonNeg(n: number): number {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   /* ---------------------------------------------------------------------- */
   /* 1) AUTH                                                                */

--- a/app/api/menu-items/upsert-from-line/route.ts
+++ b/app/api/menu-items/upsert-from-line/route.ts
@@ -1,8 +1,7 @@
 // app/api/menu-items/upsert-from-line/route.ts
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 export const runtime = "nodejs";
@@ -65,7 +64,7 @@ function partNameFromJoin(j: AllocationJoined["parts"]): string | null {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   /* ---------------------------------------------------------------------- */
   /* 1) AUTH                                                                */

--- a/app/api/menu-repair-items/match/route.ts
+++ b/app/api/menu-repair-items/match/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 type Body = {
   workOrderId?: string;
@@ -73,7 +70,7 @@ function scoreText(tokens: string[], haystack: string): number {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as Body | null;
 
     const description = s(body?.description);

--- a/app/api/menu-repair-items/pricing/apply-batch/route.ts
+++ b/app/api/menu-repair-items/pricing/apply-batch/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -46,7 +45,7 @@ type BatchRow = {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as Body | null;
 
     const {

--- a/app/api/menu-repair-items/pricing/create-from-line/route.ts
+++ b/app/api/menu-repair-items/pricing/create-from-line/route.ts
@@ -1,14 +1,11 @@
 import "server-only";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createPricingSnapshotFromWorkOrderLine } from "@/features/menu-repair-items/server/createPricingSnapshotFromWorkOrderLine";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 type Body = {
   workOrderLineId?: string;
@@ -24,7 +21,7 @@ function safeTrim(v: unknown): string {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/menu-repair-items/pricing/expiring-queue/route.ts
+++ b/app/api/menu-repair-items/pricing/expiring-queue/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 type PricingStatus = "fresh" | "stale" | "expired";
 
 function computePricingStatus(validUntil: string | null): PricingStatus {
@@ -27,7 +24,7 @@ function daysUntil(validUntil: string | null): number | null {
 
 export async function GET() {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/menu-repair-items/pricing/export-batch/route.ts
+++ b/app/api/menu-repair-items/pricing/export-batch/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -17,7 +16,7 @@ function safeTrim(v: unknown): string | null {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as Body | null;
 
     const {

--- a/app/api/menu-repair-items/pricing/import-batch-rows/route.ts
+++ b/app/api/menu-repair-items/pricing/import-batch-rows/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -29,7 +28,7 @@ function finiteOrNull(v: unknown): number | null {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as Body | null;
 
     const {

--- a/app/api/menu-repair-items/pricing/map-batch-rows/route.ts
+++ b/app/api/menu-repair-items/pricing/map-batch-rows/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 function safeTrim(v: unknown): string {
   return typeof v === "string" ? v.trim() : "";
@@ -33,7 +30,7 @@ function overlapScore(a: string, b: string): number {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/menu-repair-items/pricing/refresh-from-line/route.ts
+++ b/app/api/menu-repair-items/pricing/refresh-from-line/route.ts
@@ -1,12 +1,9 @@
 import "server-only";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createPricingSnapshotFromWorkOrderLine } from "@/features/menu-repair-items/server/createPricingSnapshotFromWorkOrderLine";
 
-type DB = Database;
 
 type Body = {
   workOrderLineId?: string;
@@ -22,7 +19,7 @@ function safeTrim(v: unknown): string {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/menu-repair-items/pricing/remap-batch-row/route.ts
+++ b/app/api/menu-repair-items/pricing/remap-batch-row/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 type Body = {
   rowId?: string | null;
@@ -18,7 +15,7 @@ function safeTrim(v: unknown): string | null {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as Body | null;
 
     const {

--- a/app/api/menu-repair-items/pricing/review-batch/route.ts
+++ b/app/api/menu-repair-items/pricing/review-batch/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 function safeTrim(v: unknown): string {
   return typeof v === "string" ? v.trim() : "";
@@ -11,7 +8,7 @@ function safeTrim(v: unknown): string {
 
 export async function GET(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const url = new URL(req.url);
     const batchId = safeTrim(url.searchParams.get("batchId"));
 

--- a/app/api/menu-repair-items/upsert-from-line/route.ts
+++ b/app/api/menu-repair-items/upsert-from-line/route.ts
@@ -1,8 +1,7 @@
 import "server-only";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createPricingSnapshotFromWorkOrderLine } from "@/features/menu-repair-items/server/createPricingSnapshotFromWorkOrderLine";
 
@@ -114,7 +113,7 @@ function buildTemplateKey(args: {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/menu/item/[id]/route.ts
+++ b/app/api/menu/item/[id]/route.ts
@@ -9,8 +9,7 @@
 
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 export const runtime = "nodejs";
@@ -53,13 +52,13 @@ function toShopId(v: unknown): string | null {
   return typeof v === "string" && v.trim().length ? v.trim() : null;
 }
 
-async function setShopContext(supabase: ReturnType<typeof createRouteHandlerClient<DB>>, shopId: string) {
+async function setShopContext(supabase: ReturnType<typeof createServerSupabaseRoute>, shopId: string) {
   const { error } = await supabase.rpc("set_current_shop_id", { p_shop_id: shopId });
   return error ? error.message : null;
 }
 
 export async function GET(_req: NextRequest, ctx: Ctx) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { id } = await ctx.params;
 
   const {
@@ -121,7 +120,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
 }
 
 export async function PATCH(req: NextRequest, ctx: Ctx) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { id } = await ctx.params;
 
   const {
@@ -314,7 +313,7 @@ export async function PATCH(req: NextRequest, ctx: Ctx) {
 }
 
 export async function DELETE(_req: NextRequest, ctx: Ctx) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { id } = await ctx.params;
 
   const {

--- a/app/api/menu/match/route.ts
+++ b/app/api/menu/match/route.ts
@@ -1,11 +1,6 @@
 // app/api/menu/match/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 type Body = {
   workOrderId: string;
   description: string;
@@ -108,7 +103,7 @@ function parseYear(v: unknown): number | null {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   let body: Body;
   try {

--- a/app/api/menu/save/route.ts
+++ b/app/api/menu/save/route.ts
@@ -1,7 +1,6 @@
 // app/api/menu/save/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -40,7 +39,7 @@ function clampNonNeg(n: number): number {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -1,8 +1,6 @@
 // app/api/onboarding/bootstrap-owner/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 import { OWNER_PIN_PURPOSES, setOwnerPinVerifiedCookie } from "@/features/shared/lib/server/owner-pin";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
@@ -11,7 +9,6 @@ import {
   reconcileShopBillingFromUser,
 } from "@/features/stripe/lib/server/canonical-shop-billing";
 
-type DB = Database;
 
 const NA_COUNTRIES = new Set(["US", "CA"]);
 
@@ -28,7 +25,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const {

--- a/app/api/onboarding/shop-defaults/route.ts
+++ b/app/api/onboarding/shop-defaults/route.ts
@@ -1,7 +1,6 @@
 // app/api/onboarding/shop-defaults/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -25,7 +24,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/optimization/opportunities/route.ts
+++ b/app/api/optimization/opportunities/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildOptimizationOpportunities } from "@/features/optimization/server/buildOptimizationOpportunities";
 
-type DB = Database;
 
 export async function GET(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/organizations/create/route.ts
+++ b/app/api/organizations/create/route.ts
@@ -2,8 +2,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
@@ -20,7 +19,7 @@ function safeString(value: unknown): string {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/parts/_lib/receivePartRequestItem.ts
+++ b/app/api/parts/_lib/receivePartRequestItem.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
 
@@ -56,7 +55,7 @@ export async function receivePartRequestItem(payload: ReceivePayload): Promise<N
       return NextResponse.json({ error: "Invalid po_id (must be UUID when provided)" }, { status: 400 });
     }
 
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/parts/requests/create/route.ts
+++ b/app/api/parts/requests/create/route.ts
@@ -1,8 +1,7 @@
 // app/api/parts/requests/create/route.ts
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -20,7 +19,7 @@ type Body = {
 };
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // 1) parse + validate
   const body = (await req.json().catch(() => null)) as Body | null;

--- a/app/api/parts/requests/items/[itemId]/quote-line-sync/route.ts
+++ b/app/api/parts/requests/items/[itemId]/quote-line-sync/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
 
-type DB = Database;
 
 function isUuid(v: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
@@ -21,7 +18,7 @@ export async function POST(
     return NextResponse.json({ ok: false, error: "Invalid itemId" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const {
     data: { user },
     error: userErr,

--- a/app/api/parts/requests/items/[itemId]/quote-save/route.ts
+++ b/app/api/parts/requests/items/[itemId]/quote-save/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
 
@@ -59,7 +58,7 @@ export async function POST(
     return NextResponse.json({ ok: false, error: "Invalid itemId" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const {
     data: { user },
     error: userErr,

--- a/app/api/planner/apply/route.ts
+++ b/app/api/planner/apply/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { z } from "zod";
 
-import type { Database } from "@shared/types/types/supabase";
 import type { PlannerProposal } from "@/features/agent/lib/plannerProposal";
 import { runRescheduleBooking, runSetLineApproval, runAddWorkOrderLine } from "@/features/agent/lib/toolRegistry";
 
@@ -14,7 +12,6 @@ const ApplyBodySchema = z.object({
   applyKey: z.string().min(8),
 });
 
-type DB = Database;
 
 function asProposal(value: unknown): PlannerProposal | null {
   if (!value || typeof value !== "object") return null;
@@ -24,7 +21,7 @@ function asProposal(value: unknown): PlannerProposal | null {
 }
 
 async function resolveShopId(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<string | null> {
   const { data } = await supabase.from("profiles").select("shop_id").eq("id", userId).maybeSingle();
@@ -32,7 +29,7 @@ async function resolveShopId(
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/planner/daily-summary/route.ts
+++ b/app/api/planner/daily-summary/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { getRoleDailySummary } from "@/features/agent/server/getRoleDailySummary";
 
-type DB = Database;
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -20,7 +17,7 @@ async function requireUser(
 }
 
 async function resolveProfile(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<{ shopId: string | null; role: string | null }> {
   const { data, error } = await supabase
@@ -40,7 +37,7 @@ async function resolveProfile(
 }
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/planner/events/route.ts
+++ b/app/api/planner/events/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { z } from "zod";
 
-import type { Database } from "@shared/types/types/supabase";
 
-type DB = Database;
 
 const QuerySchema = z.object({
   runId: z.string().uuid().optional(),
@@ -13,7 +10,7 @@ const QuerySchema = z.object({
 });
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -25,7 +22,7 @@ async function requireUser(
 }
 
 async function resolveShopId(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<string | null> {
   const { data, error } = await supabase
@@ -39,7 +36,7 @@ async function resolveShopId(
 }
 
 export async function GET(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/planner/notifications/[id]/ack/route.ts
+++ b/app/api/planner/notifications/[id]/ack/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 
-type DB = Database;
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -19,7 +16,7 @@ async function requireUser(
 }
 
 async function resolveProfile(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<{ shopId: string | null }> {
   const { data, error } = await supabase
@@ -44,7 +41,7 @@ type RouteContext = {
 };
 
 export async function POST(_request: Request, context: RouteContext) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/planner/notifications/route.ts
+++ b/app/api/planner/notifications/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { syncAssistantNotifications } from "@/features/agent/server/syncAssistantNotifications";
 
-type DB = Database;
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -20,7 +17,7 @@ async function requireUser(
 }
 
 async function resolveProfile(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<{ shopId: string | null; role: string | null }> {
   const { data, error } = await supabase
@@ -40,7 +37,7 @@ async function resolveProfile(
 }
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/planner/route.ts
+++ b/app/api/planner/route.ts
@@ -1,16 +1,13 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { z } from "zod";
 
-import type { Database } from "@shared/types/types/supabase";
 import type { ToolContext } from "@/features/agent/lib/toolTypes";
 import { runSimplePlan } from "@/features/agent/lib/plannerSimple";
 import { runOpenAIPlanner } from "@/features/agent/lib/plannerOpenAI";
 import { runFleetPlanner } from "@/features/agent/lib/plannerFleet";
 import { runApprovalPlanner } from "@/features/agent/lib/plannerApprovals";
 
-type DB = Database;
 
 type PlannerKind = "simple" | "openai" | "ops" | "fleet" | "approvals";
 
@@ -33,7 +30,7 @@ function toMsg(e: unknown): string {
 }
 
 async function requireUser(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
 ) {
   const {
     data: { user },
@@ -45,7 +42,7 @@ async function requireUser(
 }
 
 async function resolveShopId(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   userId: string,
 ): Promise<string | null> {
   const { data, error } = await supabase
@@ -59,7 +56,7 @@ async function resolveShopId(
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const user = await requireUser(supabase);
   if (!user) {

--- a/app/api/portal/approvals/route.ts
+++ b/app/api/portal/approvals/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { listPortalApprovalsForCustomer } from "@/features/portal/server/listPortalApprovals";
 
-type DB = Database;
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const actor = await requirePortalCustomerActor(supabase);

--- a/app/api/portal/availability/route.ts
+++ b/app/api/portal/availability/route.ts
@@ -1,7 +1,6 @@
 // app/api/portal/availability/route.ts
 import { NextResponse, NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 /** Build a Date in UTC that corresponds to local components in a given IANA tz. */
@@ -135,7 +134,7 @@ type BookingPick = Pick<BookingRow, "starts_at" | "ends_at" | "status">;
 
 export async function GET(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<Database>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const { searchParams } = new URL(req.url);
 
     const slug = searchParams.get("shop") || "";

--- a/app/api/portal/book/route.ts
+++ b/app/api/portal/book/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   createPortalBooking,
@@ -16,7 +14,7 @@ function bad(msg: string, code = 400) {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<Database>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const {
       data: { user },
       error: authErr,

--- a/app/api/portal/bookings/[id]/route.ts
+++ b/app/api/portal/bookings/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
@@ -13,7 +12,7 @@ type PatchBody = {
   ends_at?: string;
 };
 
-async function getAuthedContext(supabase: ReturnType<typeof createRouteHandlerClient<DB>>) {
+async function getAuthedContext(supabase: ReturnType<typeof createServerSupabaseRoute>) {
   const {
     data: { user },
     error: userErr,
@@ -54,7 +53,7 @@ export async function PATCH(
 ) {
   try {
     const { id } = await ctx.params;
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const auth = await getAuthedContext(supabase);
     if ("error" in auth) return auth.error;
@@ -114,7 +113,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await ctx.params;
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const auth = await getAuthedContext(supabase);
     if ("error" in auth) return auth.error;

--- a/app/api/portal/bookings/route.ts
+++ b/app/api/portal/bookings/route.ts
@@ -1,7 +1,6 @@
 // app/api/portal/bookings/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
@@ -42,7 +41,7 @@ function bad(msg: string, status = 400): NextResponse {
 }
 
 export async function GET(req: Request): Promise<Response> {
-  const supabase = createRouteHandlerClient<Db>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const url = new URL(req.url);
   const shopSlug = url.searchParams.get("shop") ?? "";
@@ -162,7 +161,7 @@ export async function GET(req: Request): Promise<Response> {
 }
 
 export async function POST(req: Request): Promise<Response> {
-  const supabase = createRouteHandlerClient<Db>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/portal/customer-bookings/[id]/route.ts
+++ b/app/api/portal/customer-bookings/[id]/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { cancelCustomerBooking } from "@/features/portal/server/customerBookings";
 
-type DB = Database;
 
 type Body = {
   status?: "cancelled";
@@ -21,7 +18,7 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }>
     return NextResponse.json({ error: "Only cancellation is allowed" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const actor = await requirePortalCustomerActor(supabase);

--- a/app/api/portal/customer-bookings/route.ts
+++ b/app/api/portal/customer-bookings/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { listCustomerBookings } from "@/features/portal/server/customerBookings";
 
-type DB = Database;
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const actor = await requirePortalCustomerActor(supabase);

--- a/app/api/portal/payments/checkout/route.ts
+++ b/app/api/portal/payments/checkout/route.ts
@@ -1,14 +1,11 @@
 // app/api/portal/payments/checkout/route.ts
 import { NextResponse } from "next/server";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
-import { cookies as nextCookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { PortalAccessError, requireWorkOrderOwnedByCustomer } from "@/features/portal/server/portalAuth";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 
-type DB = Database;
 
 const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY ?? "");
 
@@ -70,7 +67,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const supabase = createRouteHandlerClient<DB>({ cookies: nextCookies });
+    const supabase = createServerSupabaseRoute();
 
     const actor = await requirePortalCustomerActor(supabase);
     const userId = actor.userId;

--- a/app/api/portal/request/add-custom-line/route.ts
+++ b/app/api/portal/request/add-custom-line/route.ts
@@ -1,7 +1,6 @@
 // app/api/portal/request/add-custom-line/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 export const runtime = "nodejs";
@@ -21,7 +20,7 @@ function bad(msg: string, status = 400) {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/portal/request/add-inspection-line/route.ts
+++ b/app/api/portal/request/add-inspection-line/route.ts
@@ -1,7 +1,6 @@
 // app/api/portal/request/add-inspection-line/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 export const runtime = "nodejs";
@@ -19,7 +18,7 @@ type Body = {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/portal/request/add-menu-line/route.ts
+++ b/app/api/portal/request/add-menu-line/route.ts
@@ -1,7 +1,6 @@
 // app/api/portal/request/add-menu-line/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 export const runtime = "nodejs";
@@ -38,7 +37,7 @@ type MenuItemPartPick = {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/portal/request/add-quote-only/route.ts
+++ b/app/api/portal/request/add-quote-only/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 export const runtime = "nodejs";
@@ -51,7 +50,7 @@ function parseBody(raw: unknown): Body | null {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     // 1) Auth (portal user)
     const {

--- a/app/api/portal/request/ai/common-problems/route.ts
+++ b/app/api/portal/request/ai/common-problems/route.ts
@@ -4,13 +4,10 @@
 // For now: internal-only (uses your own historical lines). Later we can add web search + citations
 // via your existing AI layer once you confirm the exact server OpenAI helper + allowed egress.
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 type Body = {
   workOrderId: string;
@@ -33,7 +30,7 @@ type Suggestion = {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/portal/request/ai/similar-labor/route.ts
+++ b/app/api/portal/request/ai/similar-labor/route.ts
@@ -6,13 +6,10 @@
 // NOTE: This is a safe, internal-first baseline. We can later swap in embeddings via ai_training_data
 // once you confirm your existing vector setup and OpenAI helper path.
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 type Body = {
   workOrderId: string;
@@ -29,7 +26,7 @@ function norm(s: string) {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/portal/request/start/route.ts
+++ b/app/api/portal/request/start/route.ts
@@ -1,14 +1,11 @@
 // app/api/portal/request/start/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 type Body = {
   vehicleId?: string | null;
@@ -51,7 +48,7 @@ function isDuplicateKeyError(err: { code?: string | null; message?: string | nul
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const actor = await requirePortalCustomerActor(supabase);
 

--- a/app/api/portal/request/submit/route.ts
+++ b/app/api/portal/request/submit/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { extractPortalIntakeConcern } from "@/features/portal/lib/request/portalIntake";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
@@ -51,7 +50,7 @@ function parseIsoDate(v: unknown): string | null {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const actor = await requirePortalCustomerActor(supabase);
 

--- a/app/api/portal/send-invite/route.ts
+++ b/app/api/portal/send-invite/route.ts
@@ -2,14 +2,11 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { supabaseAdmin } from "@/features/shared/lib/supabase/admin";
 import { sendPortalInviteEmail } from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
 
-type DB = Database;
 
 type Body = {
   email?: string;
@@ -61,7 +58,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/profile/signature/route.ts
+++ b/app/api/profile/signature/route.ts
@@ -1,9 +1,7 @@
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type ProfileSigRow = {
   tech_signature_path: string | null;
@@ -11,7 +9,7 @@ type ProfileSigRow = {
 };
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/quotes/approval-webhook/route.ts
+++ b/app/api/quotes/approval-webhook/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createClient } from "@supabase/supabase-js";
-import { cookies } from "next/headers";
 import type { Database } from "@shared/types/types/supabase";
 import { applyAndPropagateWorkOrderLineApprovalDecision } from "@/features/work-orders/server/workOrderLineApproval";
 import { applyWorkOrderQuoteLineDecision } from "@/features/work-orders/server/workOrderQuoteLineApproval";
@@ -47,7 +46,7 @@ export async function POST(req: Request) {
   // Compatibility note:
   // This route is an authenticated approval-submission endpoint (not an anonymous third-party webhook).
   // Keep this path for backward compatibility; future cleanup may alias/rename to /api/quotes/approve.
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/receive-scan/route.ts
+++ b/app/api/receive-scan/route.ts
@@ -1,8 +1,7 @@
 // app/api/receive-scan/route.ts (FULL FILE REPLACEMENT)
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 
@@ -10,7 +9,7 @@ type DB = Database;
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const body = (await req.json().catch(() => ({}))) as Partial<{
       part_id: string;

--- a/app/api/shop-boost/intakes/[id]/report/route.ts
+++ b/app/api/shop-boost/intakes/[id]/report/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
@@ -79,7 +78,7 @@ async function renderPdf(report: Record<string, unknown>): Promise<Buffer> {
 
 export async function GET(req: Request, context: RouteContext) {
   const { id } = await context.params;
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/intakes/latest/route.ts
+++ b/app/api/shop-boost/intakes/latest/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { toIntakeProgress } from "@/features/integrations/shopBoost/status";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
@@ -13,13 +11,12 @@ import {
   summarizeRunJobsDetailed,
 } from "@/features/integrations/shopBoost/orchestrator";
 
-type DB = Database;
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
 export async function GET() {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/shop-boost/intakes/process/route.ts
+++ b/app/api/shop-boost/intakes/process/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
@@ -21,7 +20,7 @@ function asRecord(value: unknown): Record<string, unknown> {
 export async function POST(req: NextRequest) {
   // Public control-plane route: enqueue/trigger only.
   // Execution happens in /api/internal/shop-boost/run.
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/shop-boost/refresh/route.ts
+++ b/app/api/shop-boost/refresh/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 
-type DB = Database;
 
 export async function POST() {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
     error: authErr,

--- a/app/api/shop-boost/review-items/[id]/route.ts
+++ b/app/api/shop-boost/review-items/[id]/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { resolveAndMaterializeReviewItem } from "@/features/integrations/shopBoost/reviewMaterialization";
 
-type DB = Database;
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function PATCH(req: Request, context: RouteContext) {
   const { id } = await context.params;
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/review-items/reprocess/route.ts
+++ b/app/api/shop-boost/review-items/reprocess/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { reprocessReviewItems } from "@/features/integrations/shopBoost/reviewMaterialization";
 
-type DB = Database;
 
 export async function POST(req: Request) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/review-items/resolve-bulk/route.ts
+++ b/app/api/shop-boost/review-items/resolve-bulk/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { applyHighConfidenceRecommendations, bulkResolveReviewItems } from "@/features/integrations/shopBoost/reviewMaterialization";
 
-type DB = Database;
 
 export async function POST(req: Request) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
@@ -101,7 +100,7 @@ function deriveRecommendationExplanation(recommendation: RecommendationDto): str
 }
 
 export async function GET(req: Request) {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
   const {
     data: { user },
   } = await supabaseUser.auth.getUser();

--- a/app/api/shop/owner-pin/set/route.ts
+++ b/app/api/shop/owner-pin/set/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import {
-  getRouteHandlerCookies,
   OWNER_PIN_PURPOSES,
   setOwnerPinVerifiedCookie,
 } from "@/features/shared/lib/server/owner-pin";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { hashOwnerPin, isValidOwnerPin, normalizeOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 
-type DB = Database;
 
 type Body = {
   shopId?: string;
@@ -18,7 +15,7 @@ type Body = {
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies: getRouteHandlerCookies() });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/shop/owner-pin/verify/route.ts
+++ b/app/api/shop/owner-pin/verify/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import {
-  getRouteHandlerCookies,
   OWNER_PIN_PURPOSES,
   type OwnerPinPurpose,
   setOwnerPinVerifiedCookie,
 } from "@/features/shared/lib/server/owner-pin";
 import { normalizeOwnerPin, verifyOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
 
-type DB = Database;
 
 type Body = {
   shopId?: string;
@@ -21,7 +18,7 @@ const OWNER_PIN_PURPOSE_VALUES = new Set<OwnerPinPurpose>(Object.values(OWNER_PI
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies: getRouteHandlerCookies() });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/shopreel/operational-signals/route.ts
+++ b/app/api/shopreel/operational-signals/route.ts
@@ -1,14 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 import { postOperationalStoryCandidatesToShopReel } from "@/features/integrations/shopreel/server/postOperationalStoryCandidatesToShopReel";
 
-type DB = Database;
 
 async function getOwnerShopContext() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const {
     data: { user },
     error: userError,

--- a/app/api/shopreel/retry/route.ts
+++ b/app/api/shopreel/retry/route.ts
@@ -1,15 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
 import { signShopReelPayload } from "@/features/integrations/shopreel/server/signShopReelPayload";
 import { getShopReelBaseUrl } from "@/features/integrations/shopreel/server/shopreelConfig";
 
-type DB = Database;
 
 async function getOwnerShopContext() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -4,8 +4,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
@@ -150,7 +149,7 @@ function isUuid(v: unknown): v is string {
 export async function POST(req: Request) {
   try {
     const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/app/api/stripe/connect/onboard/route.ts
+++ b/app/api/stripe/connect/onboard/route.ts
@@ -2,9 +2,8 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
@@ -54,7 +53,7 @@ export async function POST() {
   try {
     const stripe = createStripeClient(mustEnv("STRIPE_SECRET_KEY"));
 
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/stripe/payments/checkout/route.ts
+++ b/app/api/stripe/payments/checkout/route.ts
@@ -2,11 +2,8 @@
 
 import { NextResponse } from "next/server";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
-import { cookies as nextCookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 const stripe = createStripeClient(process.env.STRIPE_SECRET_KEY ?? "");
 
@@ -57,7 +54,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const supabase = createRouteHandlerClient<DB>({ cookies: nextCookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/time/labor-segments/backfill/route.ts
+++ b/app/api/time/labor-segments/backfill/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
@@ -19,7 +18,7 @@ function mustEnv(name: string) {
 }
 
 export async function POST() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/work-orders/[id]/intake/route.ts
+++ b/app/api/work-orders/[id]/intake/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 import { IntakeV1Schema } from "@/features/work-orders/intake/schema.zod";
@@ -35,7 +34,7 @@ function getMode(url: string): IntakeMode {
 }
 
 async function requireFleetIntakeAccess(params: {
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>;
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
   userId: string;
   workOrder: Pick<
     DB["public"]["Tables"]["work_orders"]["Row"],
@@ -81,7 +80,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
   const { id } = await ctx.params;
   const mode = getMode(req.url);
 
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const { data: auth } = await supabase.auth.getUser();
   if (!auth.user) return text("Not authenticated.", 401);
@@ -195,7 +194,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
 
 export async function PUT(req: Request, ctx: { params: Promise<{ id: string }> }) {
   const { id } = await ctx.params;
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   let body: { intake?: IntakeV1; mode?: IntakeMode } | null = null;
   try {
@@ -245,7 +244,7 @@ export async function PUT(req: Request, ctx: { params: Promise<{ id: string }> }
 
 export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
   const { id } = await ctx.params;
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   let body: { intake?: IntakeV1; mode?: IntakeMode } | null = null;
   try {

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -3,8 +3,7 @@
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { PDFDocument, rgb, StandardFonts, type PDFImage } from "pdf-lib";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -139,7 +138,7 @@ export async function GET(
   req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const { data: auth } = await supabase.auth.getUser();
   if (!auth?.user?.id) {

--- a/app/api/work-orders/[id]/invoice/route.ts
+++ b/app/api/work-orders/[id]/invoice/route.ts
@@ -4,13 +4,10 @@
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { reviewWorkOrder } from "../_lib/reviewWorkOrder";
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
 
-type DB = Database;
 
 function isError(x: unknown): x is Error {
   return typeof x === "object" && x !== null && "message" in x;
@@ -20,7 +17,7 @@ export async function POST(
   _req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const params = await ctx.params;
   const woId = typeof params?.id === "string" ? params.id : "";
@@ -75,7 +72,7 @@ export async function GET(
   _req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const params = await ctx.params;
   const woId = typeof params?.id === "string" ? params.id : "";
   if (!woId) return NextResponse.json({ error: "Missing work order id" }, { status: 400 });

--- a/app/api/work-orders/[id]/mark-ready/route.ts
+++ b/app/api/work-orders/[id]/mark-ready/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildWorkOrderCompletedEvent } from "@/features/integrations/shopreel/server/buildProFixIQStoryEvents";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
 import { syncWorkOrderToHistory } from "@/features/work-orders/server/syncWorkOrderToHistory";
 import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
 import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
 
-type DB = Database;
 
 function getIdFromUrl(url: string): string | null {
   const parts = new URL(url).pathname.split("/"); // ["", "api", "work-orders", "<id>", "mark-ready"]
@@ -20,7 +17,7 @@ function isError(x: unknown): x is Error {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const woId = getIdFromUrl(req.url);
   if (!woId) {
     return NextResponse.json({ ok: false, error: "Missing work order id" }, { status: 400 });

--- a/app/api/work-orders/add-suggested-lines/route.ts
+++ b/app/api/work-orders/add-suggested-lines/route.ts
@@ -3,8 +3,7 @@
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -43,7 +42,7 @@ function cleanNumber(value: unknown): number | null {
 }
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/work-orders/dtc-suggest/route.ts
+++ b/app/api/work-orders/dtc-suggest/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { openai } from "lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
@@ -165,7 +164,7 @@ function parseSummary(value: unknown): DtcAnalysisSummary | null {
 }
 
 async function loadRouteContext(jobId: string): Promise<RouteContext | null> {
-  const routeSupabase = createRouteHandlerClient<DB>({ cookies });
+  const routeSupabase = createServerSupabaseRoute();
   const admin = await createAdminSupabase();
 
   const {

--- a/app/api/work-orders/import-from-inspection/route.ts
+++ b/app/api/work-orders/import-from-inspection/route.ts
@@ -5,12 +5,9 @@ export const dynamic = "force-dynamic";
 import "server-only";
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { insertPrioritizedJobsFromInspection } from "@/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection";
 
-type DB = Database;
 
 type ImportBody = {
   workOrderId: string;
@@ -20,7 +17,7 @@ type ImportBody = {
 };
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const body = (await req.json()) as Partial<ImportBody>;

--- a/app/api/work-orders/lines/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/lines/[id]/approval-decision/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { applyAndPropagateWorkOrderLineApprovalDecision } from "@/features/work-orders/server/workOrderLineApproval";
 
-type DB = Database;
 type RouteContext = { params: Promise<{ id: string }> };
 type Decision = "approve" | "decline" | "defer";
 type Body = {
@@ -18,7 +15,7 @@ function safeString(v: unknown): string {
 }
 
 export async function POST(req: NextRequest, ctx: RouteContext) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { id } = await ctx.params;
   const lineId = safeString(id);
 

--- a/app/api/work-orders/lines/[id]/delete-or-void/route.ts
+++ b/app/api/work-orders/lines/[id]/delete-or-void/route.ts
@@ -1,7 +1,6 @@
 // /app/api/work-orders/lines/[id]/delete-or-void/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -30,7 +29,7 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> }, // ✅ folder is [id]
 ) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const { id: rawId } = await ctx.params; // ✅ params key is "id"
     const id = safeTrim(rawId);

--- a/app/api/work-orders/lines/[id]/finish/route.ts
+++ b/app/api/work-orders/lines/[id]/finish/route.ts
@@ -1,9 +1,7 @@
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
 
 type Body = {
@@ -22,7 +20,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/work-orders/lines/[id]/pause/route.ts
+++ b/app/api/work-orders/lines/[id]/pause/route.ts
@@ -1,9 +1,7 @@
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
 
 function getId(req: NextRequest) {
@@ -15,7 +13,7 @@ export async function POST(req: NextRequest) {
   const id = getId(req);
   if (!id) return NextResponse.json({ error: "Missing id" }, { status: 400 });
 
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { data: auth, error: authErr } = await supabase.auth.getUser();
   if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
   if (!auth?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/work-orders/lines/[id]/resume/route.ts
+++ b/app/api/work-orders/lines/[id]/resume/route.ts
@@ -1,9 +1,7 @@
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
 
 function getId(req: NextRequest) {
@@ -15,7 +13,7 @@ export async function POST(req: NextRequest) {
   const id = getId(req);
   if (!id) return NextResponse.json({ error: "Missing id" }, { status: 400 });
 
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { data: auth, error: authErr } = await supabase.auth.getUser();
   if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
   if (!auth?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/work-orders/lines/[id]/start/route.ts
+++ b/app/api/work-orders/lines/[id]/start/route.ts
@@ -1,9 +1,7 @@
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
 
 function getId(req: NextRequest) {
@@ -15,7 +13,7 @@ export async function POST(req: NextRequest) {
   const id = getId(req);
   if (!id) return NextResponse.json({ error: "Missing id" }, { status: 400 });
 
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { data: auth, error: authErr } = await supabase.auth.getUser();
   if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
   if (!auth?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/work-orders/lines/add-from-menu/route.ts
+++ b/app/api/work-orders/lines/add-from-menu/route.ts
@@ -1,10 +1,7 @@
 // app/api/work-orders/lines/add-from-menu/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 type Body = {
   workOrderId: string;
@@ -77,7 +74,7 @@ function parseMenu(row: unknown): MenuItemRow | null {
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   let body: Body;
   try {

--- a/app/api/work-orders/lines/refresh-pricing-snapshot/route.ts
+++ b/app/api/work-orders/lines/refresh-pricing-snapshot/route.ts
@@ -1,13 +1,10 @@
 import "server-only";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { findMenuRepairItemForWorkOrderLine } from "@/features/menu-repair-items/server/findMenuRepairItemForWorkOrderLine";
 import { createPricingSnapshotFromWorkOrderLine } from "@/features/menu-repair-items/server/createPricingSnapshotFromWorkOrderLine";
 
-type DB = Database;
 
 type Body = {
   workOrderLineId?: string;
@@ -21,7 +18,7 @@ function safeTrim(v: unknown): string {
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
 
     const {
       data: { user },

--- a/app/api/work-orders/maintenance-suggestions/add-bundle/route.ts
+++ b/app/api/work-orders/maintenance-suggestions/add-bundle/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { addMaintenanceSuggestionToWorkOrder } from "@/features/maintenance/server/addMaintenanceSuggestionToWorkOrder";
 
-type DB = Database;
 
 type RequestBody = {
   workOrderId?: string;
@@ -12,7 +9,7 @@ type RequestBody = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/work-orders/maintenance-suggestions/add/route.ts
+++ b/app/api/work-orders/maintenance-suggestions/add/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { addMaintenanceSuggestionToWorkOrder } from "@/features/maintenance/server/addMaintenanceSuggestionToWorkOrder";
 
-type DB = Database;
 
 type RequestBody = {
   workOrderId?: string;
@@ -12,7 +9,7 @@ type RequestBody = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/work-orders/maintenance-suggestions/route.ts
+++ b/app/api/work-orders/maintenance-suggestions/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { computeMaintenanceSuggestionsForWorkOrder } from "@/features/maintenance/server/computeMaintenanceSuggestions";
 
-type DB = Database;
 
 function getWorkOrderId(req: NextRequest): string | null {
   const url = new URL(req.url);
@@ -13,7 +10,7 @@ function getWorkOrderId(req: NextRequest): string | null {
 }
 
 export async function GET(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/api/work-orders/quotes/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval-decision/route.ts
@@ -1,9 +1,8 @@
 import "server-only";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
 import { createClient } from "@supabase/supabase-js";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
   applyWorkOrderQuoteLineDecision,
@@ -33,7 +32,7 @@ function serviceSupabase() {
 }
 
 export async function POST(req: NextRequest, ctx: RouteContext) {
-  const routeSupabase = createRouteHandlerClient<DB>({ cookies });
+  const routeSupabase = createServerSupabaseRoute();
   const { id } = await ctx.params;
   const routeQuoteLineId = safeTrim(id);
 

--- a/app/api/work-orders/quotes/[id]/approval/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval/route.ts
@@ -1,8 +1,7 @@
 // app/api/work-orders/quotes/[id]/approval/route.ts
 import "server-only";
 import { NextResponse, NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { buildWorkOrderApprovedEvent } from "@/features/integrations/shopreel/server/buildProFixIQStoryEvents";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
@@ -20,7 +19,7 @@ type DecisionBody = {
 };
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // URL shape: /api/work-orders/quotes/:id/approval
   const segments = req.nextUrl.pathname.split("/").filter(Boolean);

--- a/app/api/work-orders/quotes/[id]/authorize/route.ts
+++ b/app/api/work-orders/quotes/[id]/authorize/route.ts
@@ -1,18 +1,15 @@
 // app/api/work-orders/quotes/[id]/authorize/route.ts
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { applyWorkOrderQuoteLineDecision } from "@/features/work-orders/server/workOrderQuoteLineApproval";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const {

--- a/app/api/work-orders/quotes/[id]/decline/route.ts
+++ b/app/api/work-orders/quotes/[id]/decline/route.ts
@@ -1,16 +1,13 @@
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 export async function POST(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const {

--- a/app/api/work-orders/quotes/[id]/mark-quoted/route.ts
+++ b/app/api/work-orders/quotes/[id]/mark-quoted/route.ts
@@ -1,16 +1,13 @@
 // app/api/work-orders/quotes/[id]/mark-quoted/route.ts
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 export async function PATCH(req: NextRequest) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     // Extract `[id]` from the pathname .../quotes/<id>/mark-quoted

--- a/app/api/work-orders/quotes/add-from-menu-repair/route.ts
+++ b/app/api/work-orders/quotes/add-from-menu-repair/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { getActiveMenuRepairPricingSnapshot } from "@/features/parts/server/getActiveMenuRepairPricingSnapshot";
 import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
@@ -179,7 +178,7 @@ function partTotal(parts: ReusePart[], usePricing: boolean): number | null {
 }
 
 async function createPartRequestForQuoteLine(
-  supabase: ReturnType<typeof createRouteHandlerClient<DB>>,
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
   input: {
     shopId: string;
     workOrderId: string;
@@ -245,7 +244,7 @@ async function createPartRequestForQuoteLine(
 
 export async function POST(req: Request) {
   try {
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const body = (await req.json().catch(() => null)) as Body | null;
 
     const workOrderId = safeTrim(body?.workOrderId);

--- a/app/api/work-orders/quotes/add/route.ts
+++ b/app/api/work-orders/quotes/add/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import {
   createCanonicalQuoteLines,
   safeTrim,
   type CanonicalQuoteItem,
 } from "@/features/work-orders/lib/work-orders/canonicalQuoteLines";
 
-type DB = Database;
 
 type Body = {
   workOrderId: string;
@@ -17,7 +14,7 @@ type Body = {
 };
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   try {
     const body = (await req.json().catch(() => null)) as Body | null;

--- a/app/api/work-orders/smart-repair-match/route.ts
+++ b/app/api/work-orders/smart-repair-match/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { findSmartInspectionMatch } from "@/features/inspections/server/findSmartInspectionMatch";
 
-type DB = Database;
 
 type Body = {
   item?: string;
@@ -23,7 +20,7 @@ type Body = {
 };
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const body = (await req.json().catch(() => null)) as Body | null;
 
   const {

--- a/app/api/work-orders/suggest-lines/route.ts
+++ b/app/api/work-orders/suggest-lines/route.ts
@@ -1,9 +1,7 @@
 // app/api/work-orders/suggest-lines/route.ts
 import "server-only";
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { openai } from "lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
@@ -16,7 +14,6 @@ import {
 
 export const runtime = "nodejs";
 
-type DB = Database;
 
 type VehicleLite = {
   id: string | null;
@@ -87,7 +84,7 @@ export async function POST(req: Request) {
   const startedAt = Date.now();
   const policy = getAIPolicy("work_orders_suggest_lines");
   const model = getOpenAIModelForPurpose(policy.modelPurpose);
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   let userId: string | null = null;
   let shopIdForContext: string | null = null;
 

--- a/app/auth/reset/page.tsx
+++ b/app/auth/reset/page.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 
 function parseHashParams(hash: string): URLSearchParams {
   const raw = hash.startsWith("#") ? hash.slice(1) : hash;
@@ -14,7 +13,7 @@ function parseHashParams(hash: string): URLSearchParams {
 export default function AuthResetPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [message, setMessage] = useState("Preparing password reset…");
   const [details, setDetails] = useState<string | null>(null);

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
@@ -24,7 +24,7 @@ function getReturnPath(role: string | null | undefined): string {
 export default function SetPasswordPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -87,7 +87,7 @@ function formatMoney(value: number | null | undefined): string {
 }
 
 export default function BillingPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/chat/[chatId]/page.tsx
+++ b/app/chat/[chatId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import ChatWindow from "@/features/ai/components/chat/ChatWindow";
@@ -20,7 +20,7 @@ export default function ChatThreadPage(): JSX.Element {
   const params = useParams<{ chatId: string }>();
   const conversationId = params.chatId;
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [userId, setUserId] = useState<string | null>(null);
   const [title, setTitle] = useState<string>("Conversation");
 

--- a/app/dashboard/_components/CuratedDashboardPage.tsx
+++ b/app/dashboard/_components/CuratedDashboardPage.tsx
@@ -2,9 +2,8 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import DashboardAlertStrip from "@/features/dashboard/components/DashboardAlertStrip";
 import DashboardWidgetBoard from "@/features/dashboard/components/DashboardWidgetBoard";
 import {
@@ -23,7 +22,6 @@ import type {
 } from "@/features/dashboard/types/layout";
 import DashboardViewSwitcher from "./DashboardViewSwitcher";
 
-type DB = Database;
 
 const CLOSED_PART_STATUSES = ["fulfilled", "rejected", "cancelled"] as const;
 const CLOSED_LINE_STATUSES = ["completed", "ready_to_invoice", "invoiced"] as const;
@@ -49,7 +47,7 @@ type Props = {
 };
 
 export default function CuratedDashboardPage({ view }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestLayoutRef = useRef<DashboardWidgetLayout[] | undefined>(undefined);
 

--- a/app/dashboard/appointments/page.tsx
+++ b/app/dashboard/appointments/page.tsx
@@ -30,7 +30,7 @@ import React, {
   useState,
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast, Toaster } from "sonner";
 
 import WeeklyCalendar from "./WeeklyCalendar";
@@ -191,7 +191,7 @@ function canCreateWorkOrderFromBooking(b: Booking): boolean {
 /* ----------------------------- page ----------------------------- */
 
 export default function PortalAppointmentsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const search = useSearchParams();
   const router = useRouter();
 

--- a/app/dashboard/bookings/BookingsTableWrapper.tsx
+++ b/app/dashboard/bookings/BookingsTableWrapper.tsx
@@ -1,12 +1,9 @@
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import BookingsTable, { type BookingRow } from "./BookingsTable";
 
-type DB = Database;
 
 export default async function BookingsTableWrapper() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/app/dashboard/owner/marketing/page.tsx
+++ b/app/dashboard/owner/marketing/page.tsx
@@ -1,14 +1,11 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import PageShell from "@/features/shared/components/PageShell";
 import OwnerMarketingSettingsCard from "@/features/integrations/shopreel/components/OwnerMarketingSettingsCard";
 import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "@/features/integrations/shopreel/server/shopreelConfig";
 
-type DB = Database;
 
 export default async function OwnerMarketingPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   const {
     data: { user },

--- a/app/dashboard/owner/payments/page.tsx
+++ b/app/dashboard/owner/payments/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
@@ -38,7 +38,7 @@ function calcNet(amountCents: number | null, feeCents: number | null): number {
 }
 
 export default function OwnerPaymentsPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [forbidden, setForbidden] = useState<string | null>(null);

--- a/app/dashboard/owner/reports/technicians/page.tsx
+++ b/app/dashboard/owner/reports/technicians/page.tsx
@@ -2,9 +2,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import type { TimeRange } from "@shared/lib/stats/getShopStats";
 import {
   getTechLeaderboard,
@@ -43,7 +42,7 @@ const T = {
 
 export default function TechLeaderboardPage() {
   const supabase = useMemo(
-    () => createClientComponentClient<Database>(),
+    () => createBrowserSupabase(),
     [],
   );
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import {
   DASHBOARD_LAST_VIEW_KEY,
@@ -19,7 +18,7 @@ export default function DashboardEntryPage() {
   const router = useRouter();
 
   useEffect(() => {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createBrowserSupabase();
 
     (async () => {
       const {

--- a/app/dashboard/reviews/page.tsx
+++ b/app/dashboard/reviews/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 import ReviewForm from "@/features/shared/components/reviews/ReviewForm";
@@ -14,7 +14,7 @@ type Profile = Pick<
 >;
 
 export default function ReviewsPage() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [loading, setLoading] = useState(true);
   const [shopId, setShopId] = useState<string | null>(null);
 

--- a/app/dashboard/setup/review/page.tsx
+++ b/app/dashboard/setup/review/page.tsx
@@ -3,8 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 type Recommendation = {
   recommendedAction: "link_existing" | "create_new" | "merge_candidate" | "ignore";
@@ -135,7 +134,7 @@ function toResolutionAction(action: Recommendation["recommendedAction"]): "linke
 
 export default function ShopBoostReviewPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [domain, setDomain] = useState("");
   const [items, setItems] = useState<ReviewItem[]>([]);
   const [summary, setSummary] = useState<ReviewSummary | null>(null);

--- a/app/dashboard/tech/settings/page.tsx
+++ b/app/dashboard/tech/settings/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import SignaturePad, {
   openSignaturePad,
@@ -41,7 +40,7 @@ async function sha256Base64(dataUrl: string): Promise<string> {
 }
 
 export default function TechSettingsPage() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);

--- a/app/debug/client/page.tsx
+++ b/app/debug/client/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 type AuthInfo = {
   hasSession: boolean;
@@ -12,7 +11,7 @@ type AuthInfo = {
 };
 
 export default function ClientDebug(): JSX.Element {
-  const sb = createClientComponentClient<Database>();
+  const sb = createBrowserSupabase();
 
   const [info, setInfo] = useState<AuthInfo | null>(null);
   const [repl, setRepl] = useState<Record<string, unknown> | null>(null);

--- a/app/debug/session/page.tsx
+++ b/app/debug/session/page.tsx
@@ -1,8 +1,7 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 export default async function SessionDebug() {
-  const sb = createServerComponentClient({ cookies });
+  const sb = createServerSupabaseRSC();
 
   // session + user
   const { data: s } = await sb.auth.getSession();
@@ -24,7 +23,7 @@ export default async function SessionDebug() {
   // current shop id from session (via accessor RPC)
   let currentShopId = null;
   try {
-    const { data } = await sb.rpc("get_current_shop_id");
+    const { data } = await sb.rpc("get_current_shop_id" as never);
     currentShopId = data || null;
   } catch {}
 

--- a/app/fleet/assets/[id]/page.tsx
+++ b/app/fleet/assets/[id]/page.tsx
@@ -1,9 +1,7 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import AssetDetailScreen from "@/features/fleet/components/AssetDetailScreen";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
@@ -11,11 +9,10 @@ interface FleetAssetPageProps {
   params: Promise<{ id: string }>;
 }
 
-type DB = Database;
 
 export default async function FleetAssetPage({ params }: FleetAssetPageProps) {
   const { id } = await params;
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <AssetDetailScreen unitId={id} uiContext={uiContext} />;

--- a/app/fleet/dispatch/page.tsx
+++ b/app/fleet/dispatch/page.tsx
@@ -1,16 +1,13 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import FleetDispatchBoard from "@/features/fleet/components/FleetDispatchBoard";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function Page() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <FleetDispatchBoard uiContext={uiContext} />;

--- a/app/fleet/layout.tsx
+++ b/app/fleet/layout.tsx
@@ -1,17 +1,14 @@
 import { redirect } from "next/navigation";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import type { ReactNode } from "react";
-import type { Database } from "@shared/types/types/supabase";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 
-type DB = Database;
 export default async function FleetLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase);
 
   if (!actor.userId) {

--- a/app/fleet/pretrip/page.tsx
+++ b/app/fleet/pretrip/page.tsx
@@ -1,16 +1,13 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import PretripReportsPage from "@/features/fleet/components/PretripReportsPage";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function Page() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <PretripReportsPage uiContext={uiContext} />;

--- a/app/fleet/service-requests/page.tsx
+++ b/app/fleet/service-requests/page.tsx
@@ -1,13 +1,10 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import FleetServiceRequestsPage from "@/features/fleet/components/FleetServiceRequestsPage";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function FleetServiceRequestsRoutePage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <FleetServiceRequestsPage uiContext={uiContext} />;

--- a/app/fleet/tower/page.tsx
+++ b/app/fleet/tower/page.tsx
@@ -1,12 +1,9 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import Container from "@shared/components/ui/Container";
 import FleetControlTower from "@/features/fleet/components/FleetControlTower";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import { getFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 type ProfileWithShop = {
   id: string;
@@ -16,7 +13,7 @@ type ProfileWithShop = {
 };
 
 export default async function FleetTowerPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase);
   const uiContext = getFleetUiContext(actor);
 

--- a/app/fleet/units/page.tsx
+++ b/app/fleet/units/page.tsx
@@ -1,15 +1,12 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import Container from "@shared/components/ui/Container";
 import FleetUnitsPage from "@/features/fleet/components/FleetUnitsPage";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 
-type DB = Database;
 
 export default async function FleetUnitsRoutePage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase);
   const uiContext = await resolveFleetUiContext(supabase);
 

--- a/app/inspection_template_suggestions/page.tsx
+++ b/app/inspection_template_suggestions/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type InspectionSuggestion = DB["public"]["Tables"]["inspection_template_suggestions"]["Row"];
 
 export default function InspectionTemplateSuggestionsPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<InspectionSuggestion[]>([]);
   const [error, setError] = useState<string>("");
 

--- a/app/inspections/fleet-review/page.tsx
+++ b/app/inspections/fleet-review/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 import { replaceFleetTireSectionWithGrid } from "@/features/inspections/lib/fleet/replaceFleetTireSectionWithGrid";
@@ -74,7 +74,7 @@ function normalizeParsedSections(
 export default function FleetFormReviewPage() {
   const router = useRouter();
   const sp = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const uploadId = sp.get("uploadId");
   const uploadIds = sp.get("uploadIds");

--- a/app/menu/item/[id]/page.tsx
+++ b/app/menu/item/[id]/page.tsx
@@ -12,7 +12,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import { PartPicker, type PickedPart } from "@parts/components/PartPicker";
@@ -95,7 +95,7 @@ function money(n: number | null | undefined): string {
 }
 
 export default function MenuItemDetailPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const params = useParams<{ id: string }>();
   const router = useRouter();
 

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { useUser } from "@auth/hooks/useUser";
 import { toast } from "sonner";
@@ -91,7 +91,7 @@ type PartsRequestBody = {
 };
 
 export default function MenuItemsPage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const router = useRouter();
   const { user, isLoading } = useUser();
 

--- a/app/menu_item_suggestions/page.tsx
+++ b/app/menu_item_suggestions/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type MenuSuggestion = DB["public"]["Tables"]["menu_item_suggestions"]["Row"];
 
 export default function MenuItemSuggestionsPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<MenuSuggestion[]>([]);
   const [error, setError] = useState<string>("");
 

--- a/app/mobile/appointments/page.tsx
+++ b/app/mobile/appointments/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -39,7 +39,7 @@ function startOfToday(): Date {
 /* -------------------------------------------------------------------------- */
 
 export default function MobileAppointmentsPage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const search = useSearchParams();
   const router = useRouter();
 

--- a/app/mobile/customers/[id]/page.tsx
+++ b/app/mobile/customers/[id]/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 
@@ -46,7 +46,7 @@ export default function MobileCustomerProfilePage() {
     return paramToString(raw);
   }, [params]);
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);

--- a/app/mobile/fleet/pretrip/[unitId]/page.tsx
+++ b/app/mobile/fleet/pretrip/[unitId]/page.tsx
@@ -3,16 +3,14 @@
 
 import { useParams, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import PretripForm from "@/features/fleet/components/PretripForm";
 
-type DB = Database;
 
 export default function MobileFleetPretripPage() {
   const params = useParams<{ unitId: string }>();
   const search = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const unitId = params?.unitId ? String(params.unitId) : null;
   const driverHint = search.get("driver"); // optional query param for name prefill

--- a/app/mobile/inspections/[id]/page.tsx
+++ b/app/mobile/inspections/[id]/page.tsx
@@ -3,8 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import GenericInspectionScreen from "@/features/inspections/screens/GenericInspectionScreen";
@@ -158,7 +157,7 @@ export default function MobileInspectionRunnerPage() {
   const search = useSearchParams();
   const searchKey = search.toString(); // ✅ stable snapshot for deps
 
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const lineId = params?.id ? String(params.id) : null;
 

--- a/app/mobile/inspections/page.tsx
+++ b/app/mobile/inspections/page.tsx
@@ -4,10 +4,8 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { format } from "date-fns";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-type DB = Database;
 
 /** Only the columns we actually care about for mobile */
 type InspectionRow = {
@@ -36,7 +34,7 @@ function statusChip(status: string | null | undefined): string {
 }
 
 export default function MobileInspectionsListPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<InspectionRow[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/mobile/messages/[chatId]/page.tsx
+++ b/app/mobile/messages/[chatId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import ChatWindow from "@/features/ai/components/chat/ChatWindow";
 
@@ -23,7 +23,7 @@ export default function MobileChatThreadPage() {
   const router = useRouter();
   const conversationId = params.chatId;
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [userId, setUserId] = useState<string | null>(null);
   const [title, setTitle] = useState<string>("Conversation");
 

--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
 import { canonicalizeRole, getActorCapabilities } from "@/features/shared/lib/rbac";
@@ -70,7 +70,7 @@ function calcEfficiencyPct(worked: number, billed: number): number | null {
 }
 
 export default function MobileHome() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [profile, setProfile] = useState<Profile | null>(null);
   const [shop, setShop] = useState<Shop | null>(null);

--- a/app/mobile/reports/page.tsx
+++ b/app/mobile/reports/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -53,7 +53,7 @@ type ProfileRole = DB["public"]["Tables"]["profiles"]["Row"]["role"];
 const OWNER_ROLES: ProfileRole[] = ["owner", "admin", "manager"];
 
 export default function MobileReportsPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<string | null>(null);
   const [role, setRole] = useState<ProfileRole | null>(null);

--- a/app/mobile/tech/performance/page.tsx
+++ b/app/mobile/tech/performance/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -26,7 +26,7 @@ const RANGE_LABELS: Record<Range, string> = {
 };
 
 export default function MobileTechPerformancePage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
   const [shopId, setShopId] = useState<string | null>(null);

--- a/app/mobile/tech/queue/page.tsx
+++ b/app/mobile/tech/queue/page.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { getOfflineSyncSummary, subscribeOfflineMutations } from "@/features/shared/lib/offline/mutations";
 
@@ -123,7 +123,7 @@ type WorkOrderMapRow = {
 };
 
 export default function MobileTechQueuePage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [lines, setLines] = useState<Line[]>([]);

--- a/app/mobile/technicians/page.tsx
+++ b/app/mobile/technicians/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import type { TimeRange } from "@shared/lib/stats/getShopStats";
@@ -27,7 +27,7 @@ type ProfileRole = DB["public"]["Tables"]["profiles"]["Row"]["role"];
 const OWNER_ROLES: ProfileRole[] = ["owner", "admin", "manager"];
 
 export default function MobileTechniciansPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<string | null>(null);
   const [role, setRole] = useState<ProfileRole | null>(null);

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -22,7 +22,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import type {
@@ -106,7 +106,7 @@ function numStringOrNull(v: unknown): string | null {
  * - If none, tries shops.owner_id = userId and writes back to profile
  */
 async function getOrLinkShopId(
-  supabase: ReturnType<typeof createClientComponentClient<DB>>,
+  supabase: ReturnType<typeof createBrowserSupabase>,
   userId: string,
 ): Promise<string | null> {
   // ✅ prefer user_id (new)
@@ -190,7 +190,7 @@ function CustomerSearch({
   value,
   onPick,
 }: {
-  supabase: ReturnType<typeof createClientComponentClient<DB>>;
+  supabase: ReturnType<typeof createBrowserSupabase>;
   shopId: string | null;
   value: string;
   onPick: (c: CustomerPick) => void;
@@ -343,7 +343,7 @@ function VehicleSearch({
   value,
   onPick,
 }: {
-  supabase: ReturnType<typeof createClientComponentClient<DB>>;
+  supabase: ReturnType<typeof createBrowserSupabase>;
   shopId: string | null;
   customerId: string | null;
   value: string;
@@ -448,7 +448,7 @@ function VehicleSearch({
 
 export default function MobileCreateWorkOrderPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const draft = useWorkOrderDraft();
 
   const [wo, setWo] = useState<WorkOrderRow | null>(null);

--- a/app/mobile/work-orders/page.tsx
+++ b/app/mobile/work-orders/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { format } from "date-fns";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
@@ -128,7 +128,7 @@ function MiniStat({
 }
 
 export default function MobileWorkOrdersListPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/mobile/work-orders/view/page.tsx
+++ b/app/mobile/work-orders/view/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
 import { toast } from "sonner";
 
@@ -94,7 +94,7 @@ const BUTTON_MUTED =
 /* ------------------------------------------------------------------ */
 
 export default function MobileWorkOrdersViewPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -3,15 +3,13 @@
 
 import { useEffect, useMemo, useState, FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import {
   SHOP_BOOST_UPLOAD_DATASETS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
 
-type DB = Database;
 
 type QuestionnaireState = {
   hasExistingCustomers: boolean;
@@ -68,7 +66,7 @@ function uuidv4(): string {
 }
 
 export default function ShopBoostOnboardingPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [loadingProfile, setLoadingProfile] = useState(true);

--- a/app/parts/allocations/page.tsx
+++ b/app/parts/allocations/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 import PageShell from "@/features/shared/components/PageShell";
@@ -25,7 +25,7 @@ function movementReasonLabel(reason: string | null | undefined): string {
   return key ? key.replaceAll("_", " ") : "—";
 }
 
-async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
+async function resolveShopId(supabase: ReturnType<typeof createBrowserSupabase>) {
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
   if (!uid) return "";
@@ -36,7 +36,7 @@ async function resolveShopId(supabase: ReturnType<typeof createClientComponentCl
 }
 
 export default function AllocationsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState("");
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
 import Link from "next/link";
@@ -223,7 +223,7 @@ function errMsg(err: unknown): string {
  * fall back to the 5-arg legacy shape. Strictly typed; ignores return value.
  */
 async function applyStockMoveRPC(
-  supabase: ReturnType<typeof createClientComponentClient<DB>>,
+  supabase: ReturnType<typeof createBrowserSupabase>,
   args: {
     p_part: string;
     p_loc: string;
@@ -274,7 +274,7 @@ async function applyStockMoveRPC(
 /* ---------------------------- Page ---------------------------- */
 
 export default function InventoryPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string>("");
 
   const [search, setSearch] = useState<string>("");

--- a/app/parts/movements/page.tsx
+++ b/app/parts/movements/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 import PageShell from "@/features/shared/components/PageShell";
@@ -18,7 +18,7 @@ type AllocationLite = Pick<DB["public"]["Tables"]["work_order_part_allocations"]
 type RefContext = { workOrderId?: string | null; requestItemId?: string | null; sourceLabel: string };
 
 function n(v: unknown): number { const num = typeof v === "number" ? v : Number(v); return Number.isFinite(num) ? num : 0; }
-async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
+async function resolveShopId(supabase: ReturnType<typeof createBrowserSupabase>) {
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
   if (!uid) return "";
@@ -49,7 +49,7 @@ function reasonLabel(reason: string | null): string {
 }
 
 export default function StockMovementsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState("");
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);

--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
@@ -74,7 +74,7 @@ function sourceLabel(kind: string | null, reason: string | null): string {
 }
 
 export default function PartsDashboardPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(true);
   const [skuTotal, setSkuTotal] = useState(0);
   const [skuNewThis7d, setSkuNewThis7d] = useState(0);

--- a/app/parts/po/[id]/page.tsx
+++ b/app/parts/po/[id]/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import { partIdentifierLabel, partOptionLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
@@ -60,7 +60,7 @@ type UiLine = POLineRow & {
 export default function PurchaseOrderDetailPage(): JSX.Element {
   const { id: poId } = useParams<{ id: string }>();
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState<boolean>(true);
   const [loadedOnce, setLoadedOnce] = useState<boolean>(false);

--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveScannedCode } from "@/features/parts/server/scanActions";
 import {
@@ -74,7 +74,7 @@ function n(v: unknown): number {
 }
 
 async function resolveShopId(
-  supabase: ReturnType<typeof createClientComponentClient<DB>>,
+  supabase: ReturnType<typeof createBrowserSupabase>,
 ): Promise<string> {
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
@@ -125,7 +125,7 @@ function extractReceiveResult(data: unknown): ReceiveResult | null {
 }
 
 export default function PoReceivePage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const params = useParams<{ id: string }>();
   const router = useRouter();
 

--- a/app/parts/po/page.tsx
+++ b/app/parts/po/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
 import { partOptionLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
@@ -61,7 +61,7 @@ type LineDraft = {
 const DEFAULT_SUPPLIER_NAME = "General / Stock";
 
 export default function PurchaseOrdersPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<string>("");
 

--- a/app/parts/po/receive/page.tsx
+++ b/app/parts/po/receive/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { receiveProgressLabel } from "@/features/parts/lib/status-display";
 import PageShell from "@/features/shared/components/PageShell";
@@ -27,7 +27,7 @@ function fmtDate(d: string | null | undefined): string {
 }
 
 export default function ReceiveFromPOPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState<boolean>(true);
   const [err, setErr] = useState<string | null>(null);

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveScannedCode } from "@/features/parts/server/scanActions";
 import Link from "next/link";
@@ -64,7 +64,7 @@ type ReceiveResult =
   | { error: string };
 
 export default function ReceivePage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string>("");
 
   const [pos, setPOs] = useState<PurchaseOrder[]>([]);

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   itemFlowLabel,
@@ -49,7 +49,7 @@ function n(v: unknown): number {
   return Number.isFinite(num) ? num : 0;
 }
 
-async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>) {
+async function resolveShopId(supabase: ReturnType<typeof createBrowserSupabase>) {
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
   if (!uid) return "";
@@ -62,7 +62,7 @@ async function resolveShopId(supabase: ReturnType<typeof createClientComponentCl
 const ReceiveDrawer = dynamic(() => import("@/features/parts/components/ReceiveDrawer"), { ssr: false });
 
 export default function ReceivingInboxPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(true);
   const [err, setErr] = useState<string | null>(null);

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import {
@@ -185,7 +185,7 @@ function lineLabelFrom(line?: LineLite): string {
 export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const { id: routeId } = useParams<{ id: string }>();
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [wo, setWo] = useState<WorkOrderRow | null>(null);
   const [lineById, setLineById] = useState<Map<string, LineLite>>(

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import { requestFlowLabel, toItemFlowDisplay, toRequestFlowDisplay } from "@/features/parts/lib/status-display";
@@ -97,7 +97,7 @@ function buildVehicleLabel(input: {
 }
 
 export default function PartsRequestsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");

--- a/app/parts/vendors/page.tsx
+++ b/app/parts/vendors/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
@@ -90,7 +90,7 @@ function formatDate(v: string | null): string {
   return d.toLocaleDateString();
 }
 
-async function resolveShopId(supabase: ReturnType<typeof createClientComponentClient<DB>>): Promise<string> {
+async function resolveShopId(supabase: ReturnType<typeof createBrowserSupabase>): Promise<string> {
   const { data: userRes } = await supabase.auth.getUser();
   const uid = userRes.user?.id ?? null;
   if (!uid) return "";
@@ -130,7 +130,7 @@ function KpiCard({ title, value, hint, href }: { title: string; value: string; h
 }
 
 export default function PartsVendorsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/app/portal/auth/confirm/page.tsx
+++ b/app/portal/auth/confirm/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER = "#C57A4A";
@@ -27,7 +27,7 @@ export default function PortalConfirmPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/app/portal/auth/sign-up/PortalSignUpForm.tsx
+++ b/app/portal/auth/sign-up/PortalSignUpForm.tsx
@@ -4,15 +4,14 @@
 import React, { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import AuthShell from "@/features/auth/components/AuthShell";
 
 const COPPER = "#C57A4A";
 
 export default function PortalSignUpForm() {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");

--- a/app/portal/booking/BookingPageClient.tsx
+++ b/app/portal/booking/BookingPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -35,7 +35,7 @@ const fmtTime = (iso: string, tz: string) =>
   }).format(new Date(iso));
 
 export default function PortalBookingPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const search = useSearchParams();
   const router = useRouter();

--- a/app/portal/booking/confirmation/BookingConfirmationClient.tsx
+++ b/app/portal/booking/confirmation/BookingConfirmationClient.tsx
@@ -2,15 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-type DB = Database;
 
 export default function BookingConfirmationClient() {
   const params = useSearchParams();
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const id = params.get("wo");
   const [data, setData] = useState<{

--- a/app/portal/confirm/page.tsx
+++ b/app/portal/confirm/page.tsx
@@ -3,12 +3,11 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function PortalConfirmPage() {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   useEffect(() => {
     let cancelled = false;

--- a/app/portal/customer-appointments/page.tsx
+++ b/app/portal/customer-appointments/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -59,7 +59,7 @@ function fmtRange(startsAtIso: string, endsAtIso: string) {
 }
 
 export default function PortalCustomerAppointmentsPage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);

--- a/app/portal/fleet/_lib/requireFleetPortalActor.ts
+++ b/app/portal/fleet/_lib/requireFleetPortalActor.ts
@@ -1,17 +1,14 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import {
   getFleetUiContext,
   type FleetUiContext,
 } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export async function requireFleetPortalActor(): Promise<FleetUiContext> {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/app/portal/fleet/board/page.tsx
+++ b/app/portal/fleet/board/page.tsx
@@ -1,13 +1,10 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import FleetDispatchBoard from "@/features/fleet/components/FleetDispatchBoard";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function PortalFleetBoardPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <FleetDispatchBoard uiContext={uiContext} routePrefix="/portal/fleet" />;

--- a/app/portal/fleet/page.tsx
+++ b/app/portal/fleet/page.tsx
@@ -1,14 +1,11 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import FleetControlTower from "@/features/fleet/components/FleetControlTower";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import { getFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function PortalFleetPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase);
   const uiContext = getFleetUiContext(actor);
 

--- a/app/portal/fleet/pretrip-history/page.tsx
+++ b/app/portal/fleet/pretrip-history/page.tsx
@@ -1,13 +1,10 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import PretripReportsPage from "@/features/fleet/components/PretripReportsPage";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function PortalFleetPretripHistoryPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <PretripReportsPage uiContext={uiContext} routePrefix="/portal/fleet" />;

--- a/app/portal/fleet/pretrip/[unitId]/page.tsx
+++ b/app/portal/fleet/pretrip/[unitId]/page.tsx
@@ -1,17 +1,14 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import PretripForm from "@/features/fleet/components/PretripForm";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 type Props = {
   params: Promise<{ unitId: string }>;
 };
 
 export default async function PortalFleetPretripPage({ params }: Props) {
   const { unitId } = await params;
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return (

--- a/app/portal/fleet/service-requests/page.tsx
+++ b/app/portal/fleet/service-requests/page.tsx
@@ -1,13 +1,10 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import FleetServiceRequestsPage from "@/features/fleet/components/FleetServiceRequestsPage";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 
 export default async function PortalFleetServiceRequestsPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return <FleetServiceRequestsPage uiContext={uiContext} />;

--- a/app/portal/fleet/units/[unitId]/page.tsx
+++ b/app/portal/fleet/units/[unitId]/page.tsx
@@ -1,17 +1,14 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import AssetDetailScreen from "@/features/fleet/components/AssetDetailScreen";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
-type DB = Database;
 type Props = {
   params: Promise<{ unitId: string }>;
 };
 
 export default async function PortalFleetUnitPage({ params }: Props) {
   const { unitId } = await params;
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
 
   return (

--- a/app/portal/history/page.tsx
+++ b/app/portal/history/page.tsx
@@ -3,8 +3,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 import Link from "next/link";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import { requirePortalCustomerActor, } from "@/features/portal/server/requirePortalActor";
@@ -66,10 +65,7 @@ function vehicleLabel(v: VehicleLite | undefined): string {
 }
 
 export default async function HistoryPage() {
-  const cookieStore = cookies();
-  const supabase = createServerComponentClient<DB>({
-    cookies: () => cookieStore,
-  });
+  const supabase = createServerSupabaseRSC();
 
   try {
     const actor = await requirePortalCustomerActor(supabase);

--- a/app/portal/invoices/[id]/page.tsx
+++ b/app/portal/invoices/[id]/page.tsx
@@ -1,8 +1,7 @@
 // app/portal/invoices/[id]/page.tsx (FULL FILE REPLACEMENT)
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import {
@@ -152,8 +151,7 @@ export default async function PortalInvoicePage({
 }) {
   const { id: workOrderId } = await params;
 
-  const cookieStore = cookies();
-  const supabase = createServerComponentClient<DB>({ cookies: () => cookieStore });
+  const supabase = createServerSupabaseRSC();
 
   let workOrder: WorkOrderForPortalInvoice | null = null;
   let invoice: InvoiceLite | null = null;

--- a/app/portal/invoices/page.tsx
+++ b/app/portal/invoices/page.tsx
@@ -1,7 +1,6 @@
 // app/portal/invoices/page.tsx (FULL FILE REPLACEMENT)
 import Link from "next/link";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
@@ -122,8 +121,7 @@ function invoiceTotalOrNull(invTotal: unknown): number | null {
 }
 
 export default async function PortalInvoicesIndexPage() {
-  const cookieStore = cookies();
-  const supabase = createServerComponentClient<DB>({ cookies: () => cookieStore });
+  const supabase = createServerSupabaseRSC();
 
   try {
     const actor = await requirePortalCustomerActor(supabase);

--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import WorkOrderBoardWidget from "@shared/components/workboard/WorkOrderBoardWidget";
 import { PortalActionCard, PortalEmptyState, PortalPageHeader, PortalPrimaryButton, PortalSecondaryButton, PortalSectionCard, PortalStatCard, PortalStatusChip } from "@/features/portal/components/PortalUi";
@@ -18,7 +18,7 @@ const formatWhen = (iso: string) => { const d = new Date(iso); if (Number.isNaN(
 const formatWoRef = (wo: Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state"> | null) => wo ? `#${wo.id?.slice(0, 8) ?? "—"}` : "—";
 
 export default function PortalHomePage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [vehiclesCount, setVehiclesCount] = useState<number | null>(null);

--- a/app/portal/profile/page.tsx
+++ b/app/portal/profile/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -47,7 +47,7 @@ function subtleButtonClass() {
 }
 
 export default function PortalProfilePage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [form, setForm] = useState<CustomerForm>(emptyForm);
   const [loading, setLoading] = useState(true);

--- a/app/portal/request/build/page.tsx
+++ b/app/portal/request/build/page.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -168,7 +168,7 @@ function mergeNotes(existing: string | null | undefined, intakeBlock: string) {
 }
 
 export default function PortalRequestBuildPage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const router = useRouter();
   const sp = useSearchParams();
 

--- a/app/portal/request/when/page.tsx
+++ b/app/portal/request/when/page.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -174,7 +174,7 @@ function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
 }
 
 export default function PortalRequestWhenPage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);

--- a/app/portal/requests/page.tsx
+++ b/app/portal/requests/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import PortalShell from "@/features/portal/components/PortalShell";
 import type { Database } from "@shared/types/types/supabase";
@@ -23,7 +23,7 @@ const glass =
 const muted = "text-neutral-400";
 
 export default function PortalPartsRequestsPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [requests, setRequests] = useState<

--- a/app/portal/settings/page.tsx
+++ b/app/portal/settings/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -31,7 +31,7 @@ function copperButtonStyle(): React.CSSProperties {
 }
 
 export default function PortalSettingsPage() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);

--- a/app/portal/shop/[slug]/PageClient.tsx
+++ b/app/portal/shop/[slug]/PageClient.tsx
@@ -2,8 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import ShareBox from "./ShareBox";
 import ReviewsList from "@shared/components/reviews/ReviewsList";
@@ -32,7 +31,7 @@ function SignalDot() {
 
 export default function ShopSharePage({ slug, shopId: shopIdProp }: Props) {
   const supabase = useMemo(
-    () => createClientComponentClient<Database>(),
+    () => createBrowserSupabase(),
     [],
   );
 

--- a/app/portal/shop/[slug]/ShopPublicProfileView.tsx
+++ b/app/portal/shop/[slug]/ShopPublicProfileView.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 import ReviewsList from "@shared/components/reviews/ReviewsList";
@@ -64,7 +64,7 @@ function SignalDot() {
 }
 
 export default function PublicProfileClient({ slug }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [data, setData] = useState<PublicFields>(emptyPublic);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);

--- a/app/portal/status/page.tsx
+++ b/app/portal/status/page.tsx
@@ -1,13 +1,10 @@
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import WorkOrderBoard from "@shared/components/workboard/WorkOrderBoard";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 
-type DB = Database;
 
 export default async function PortalStatusPage() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   try {
     await requirePortalCustomerActor(supabase);

--- a/app/portal/vehicles/page.tsx
+++ b/app/portal/vehicles/page.tsx
@@ -2,8 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 
 /** Minimal shapes (keep lint happy, no `any`, no big supabase types) */
@@ -79,7 +78,7 @@ function dangerButtonStyle(): React.CSSProperties {
 }
 
 export default function PortalVehiclesPage() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [customer, setCustomer] = useState<CustomerRow | null>(null);
   const [vehicles, setVehicles] = useState<VehicleRow[]>([]);

--- a/app/portal/work-orders/view/[id]/page.tsx
+++ b/app/portal/work-orders/view/[id]/page.tsx
@@ -1,9 +1,8 @@
 // /app/portal/work-orders/view/[id]/page.tsx (FULL FILE REPLACEMENT)
 
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import {
@@ -131,10 +130,7 @@ export default async function PortalWorkOrderViewerPage({
 }) {
   const { id: workOrderId } = await params;
 
-  const cookieStore = cookies();
-  const supabase = createServerComponentClient<DB>({
-    cookies: () => cookieStore,
-  });
+  const supabase = createServerSupabaseRSC();
 
   try {
     const { id: userId } = await requireAuthedUser(supabase);

--- a/app/tech/performance/page.tsx
+++ b/app/tech/performance/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -53,7 +53,7 @@ function avg(nums: number[]): number {
 }
 
 export default function TechPerformancePage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [userId, setUserId] = useState<string | null>(null);

--- a/app/tech/queue/page.tsx
+++ b/app/tech/queue/page.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -142,7 +142,7 @@ function readPrefs(): TechPrefs {
 }
 
 export default function TechQueuePage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [prefs, setPrefs] = useState<TechPrefs>({

--- a/app/work-orders/[id]/approve/page.tsx
+++ b/app/work-orders/[id]/approve/page.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import SignaturePad, {
   openSignaturePad,
@@ -253,7 +253,7 @@ export default function ApproveWorkOrderPage() {
   const params = useParams<{ id: string }>();
   const id = Array.isArray(params?.id) ? params.id[0] : params?.id;
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [wo, setWo] = useState<WorkOrder | null>(null);
   const [shop, setShop] = useState<Shop | null>(null);

--- a/app/work-orders/[id]/quote-review/page.tsx
+++ b/app/work-orders/[id]/quote-review/page.tsx
@@ -3,16 +3,13 @@
 // IMPORTANT: params.id may be a custom_id (e.g. "T0000007") OR a UUID.
 // We resolve to the real work_orders.id UUID before embedding quote review.
 
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
-import type { Database } from "@shared/types/types/supabase";
 
 import FocusedJobSplitView from "../focused-job/_components/FocusedJobSplitView";
 import WorkOrderIdClient from "../Client"; // adjust ONLY if your filename is actually ../Client
 import QuoteReviewPanelClient from "./_components/QuoteReviewPanelClient";
 
-type DB = Database;
 
 function looksLikeUuid(s: string): boolean {
   return s.includes("-") && s.length >= 36;
@@ -21,7 +18,7 @@ function looksLikeUuid(s: string): boolean {
 export default async function Page(props: { params: Promise<{ id: string }> }) {
   const { id: routeId } = await props.params;
 
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   // Resolve routeId -> real UUID + custom_id
   let resolved: { id: string; custom_id: string | null } | null = null;

--- a/app/work-orders/components/WorkOrderPreview.tsx
+++ b/app/work-orders/components/WorkOrderPreview.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database, Tables } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import type { Tables } from "@shared/types/types/supabase";
 
 type Props = { woId: string | null };
 
@@ -25,7 +25,7 @@ type WOLine = Pick<
 >;
 
 export function WorkOrderPreview({ woId }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [wo, setWO] = useState<WO | null>(null);
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [vehicle, setVehicle] = useState<Vehicle | null>(null);

--- a/app/work-orders/confirm/page.tsx
+++ b/app/work-orders/confirm/page.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
 
 export default function ApprovalConfirmPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
   const search = useSearchParams();
   const woId = search.get("woId");

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
 import type { Database } from "@shared/types/types/supabase";
 import { fmtCustomerName, fmtVehicle, formatMoneyLike, historyTitle, parseHistoryNotes } from "./historyDisplay";
@@ -29,7 +29,7 @@ function fmtDate(iso: string | null | undefined, pattern = "PPpp"): string {
 }
 
 export default function WorkOrdersHistoryClient(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string | null>(null);
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/work-orders/history/[id]/page.tsx
+++ b/app/work-orders/history/[id]/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { format } from "date-fns";
 import type { Database } from "@shared/types/types/supabase";
 import { formatMoneyLike, historyShortId, parseHistoryNotes } from "../historyDisplay";
@@ -11,7 +10,7 @@ type HistoryDetail = Pick<DB["public"]["Tables"]["history"]["Row"], "id" | "work
 
 export default async function HistoryDetailPage({ params }: { params: Promise<{ id: string }> }): Promise<JSX.Element> {
   const { id } = await params;
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) notFound();
   const { data: profile } = await supabase.from("profiles").select("shop_id").eq("id", user.id).maybeSingle();

--- a/app/work-orders/page.tsx
+++ b/app/work-orders/page.tsx
@@ -2,9 +2,7 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import type { Role } from "@shared/components/RoleHubTiles/tiles";
 import { TILES } from "@shared/components/RoleHubTiles/tiles";
 import Link from "next/link";
@@ -12,10 +10,9 @@ import PageShell from "@/features/shared/components/PageShell";
 import Card from "@/features/shared/components/ui/Card";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 
-type DB = Database;
 
 async function getUserRole(): Promise<Role | null> {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { canonicalizeRole, getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   getMobileTilesForRole,
@@ -13,7 +12,6 @@ import {
 
 import MobileShiftTracker from "@/features/mobile/components/MobileShiftTracker";
 
-type DB = Database;
 
 type NavItem = {
   href: string;
@@ -74,7 +72,7 @@ function NavSection({
 
 export function MobileBottomNav({ open, onClose }: Props) {
   const pathname = usePathname();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
   const [role, setRole] = useState<MobileRole | null>(null);

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -5,12 +5,10 @@
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { MobileBottomNav } from "./MobileBottomNav";
 import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
 
-type DB = Database;
 
 type Props = {
   children: ReactNode;
@@ -35,7 +33,7 @@ export function MobileShell({ children, title }: Props) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const resolvedTitle = title ?? getTitleFromPath(pathname);
 

--- a/features/admin/components/AdminQuickPanel.tsx
+++ b/features/admin/components/AdminQuickPanel.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 // ---- Lite shapes (kept independent from exact DB types) ----
 type ActivityLog = {
@@ -108,7 +107,7 @@ const fmtDate = (iso?: string | null) => {
 };
 
 export default function AdminQuickPanel() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   // state for cards
   const [activity, setActivity] = useState<ActivityLog[] | null>(null);

--- a/features/agent/server/supabase.ts
+++ b/features/agent/server/supabase.ts
@@ -1,9 +1,7 @@
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export function getServerSupabase() {
-  return createRouteHandlerClient<Database>({ cookies });
+  return createServerSupabaseRoute();
 }
 
 export async function getUserAndShopId() {

--- a/features/ai/components/chat/ChatWindow.tsx
+++ b/features/ai/components/chat/ChatWindow.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type Message = Database["public"]["Tables"]["messages"]["Row"];
@@ -49,7 +49,7 @@ export default function ChatWindow({
   title = "Conversation",
 }: ChatWindowProps) {
   const supabase = useMemo(
-    () => createClientComponentClient<Database>(),
+    () => createBrowserSupabase(),
     [],
   );
   const [messages, setMessages] = useState<Message[]>([]);

--- a/features/auth/app/onboarding/OnboardingPage.tsx
+++ b/features/auth/app/onboarding/OnboardingPage.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   appendActivationContextToHref,
@@ -52,7 +52,7 @@ const TIMEZONES = [
 ] as const;
 
 export default function OnboardingPage() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
   const demoId = searchParams.get("demoId");

--- a/features/auth/app/reset-password/page.tsx
+++ b/features/auth/app/reset-password/page.tsx
@@ -2,13 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function ResetPasswordPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");

--- a/features/auth/app/signup/SignUpClient.tsx
+++ b/features/auth/app/signup/SignUpClient.tsx
@@ -3,8 +3,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   appendActivationContextToHref,
   parseActivationContextFromSearchParams,
@@ -14,7 +13,7 @@ import { trackShopBoostEvent } from "@/features/analytics/shopBoostEvents";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
 
 export default function SignUpClient() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const router = useRouter();
   const sp = useSearchParams();
 

--- a/features/auth/components/ForcePasswordChangeModal.tsx
+++ b/features/auth/components/ForcePasswordChangeModal.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-type DB = Database;
 
 type Props = {
   open: boolean;
@@ -23,7 +21,7 @@ export default function ForcePasswordChangeModal({
   title = "Set your new password",
   subtitle = "This account was created by an owner/manager. You must choose a new password before continuing.",
 }: Props): JSX.Element | null {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");

--- a/features/auth/components/SignOutButton.tsx
+++ b/features/auth/components/SignOutButton.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function SignOutButton() {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();

--- a/features/auth/hooks/useUser.ts
+++ b/features/auth/hooks/useUser.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -13,7 +13,7 @@ type Role    = DB["public"]["Enums"]["user_role_enum"];
 export type UserWithShop = Profile & { shops: Shop | null };
 
 export function useUser() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
 
   const [user, setUser] = useState<UserWithShop | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/features/branding/server/brand.ts
+++ b/features/branding/server/brand.ts
@@ -1,14 +1,11 @@
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-import { getRouteHandlerCookies } from "@/features/shared/lib/server/owner-pin";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 const WRITE_ROLES = new Set(["owner", "admin", "manager"]);
 
 export type BrandReadAuth =
   | {
       ok: true;
-      supabase: ReturnType<typeof createRouteHandlerClient<DB>>;
+      supabase: ReturnType<typeof createServerSupabaseRoute>;
       userId: string;
       shopId: string;
       role: string;
@@ -24,7 +21,7 @@ export type BrandWriteAuth = BrandReadAuth;
 export async function requireBrandShopReadAccess(
   requestedShopId?: string | null
 ): Promise<BrandReadAuth> {
-  const supabase = createRouteHandlerClient<DB>({ cookies: getRouteHandlerCookies() });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/features/chat/components/ChatDock.tsx
+++ b/features/chat/components/ChatDock.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import RecipientPickerModal from "@/features/shared/chat/components/RecipientPickerModalWrapper";
 
@@ -16,7 +16,7 @@ type Conversation = {
 };
 
 export default function ChatDock(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   // dock open/close
   const [open, setOpen] = useState<boolean>(false);

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import UserAvatar from "@/features/chat/components/UserAvatar";
 import ModalShell from "@/features/shared/components/ModalShell";
@@ -121,7 +121,7 @@ export default function InboxModal({
   seedConversationId = null,
 }: Props): JSX.Element | null {
   const pathname = usePathname() ?? "/dashboard";
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [me, setMe] = useState<string | null>(null);
   const [rows, setRows] = useState<ConversationPayload[]>([]);

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -3,7 +3,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
@@ -348,7 +348,7 @@ export default function CustomerProfilePage(): JSX.Element {
   const router = useRouter();
   const sp = useSearchParams();
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const rawId = useMemo(() => {
     const raw = (params as ParamsShape)?.id;

--- a/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   AdminEmptyState,
   AdminPageHeader,
@@ -59,7 +58,7 @@ const CANONICAL_ADMIN_ROUTES = [
 ] as const;
 
 export default function AdminLandingClient() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [summary, setSummary] = useState<AdminSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 

--- a/features/dashboard/app/dashboard/admin/AuditClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AuditClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database, Json } from "@shared/types/types/supabase";
 import {
   AdminBadge,
@@ -37,7 +37,7 @@ function stringifyMetadata(metadata: Json | null): string {
 }
 
 export default function AdminAuditClient() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<AuditRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);

--- a/features/dashboard/app/dashboard/admin/CertificationsClient.tsx
+++ b/features/dashboard/app/dashboard/admin/CertificationsClient.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 
-// import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+// import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 // import type { Database } from "@shared/types/types/supabase";
 
 export default function CertificationsClient() {
   // TODO: show employee certifications & expirations
-  // const supabase = createClientComponentClient<Database>();
+  // const supabase = createBrowserSupabase();
   // const { data } = await supabase.from("employee_certifications").select("*");
 
   const sample = [

--- a/features/dashboard/app/dashboard/admin/EmployeeDocsClient.tsx
+++ b/features/dashboard/app/dashboard/admin/EmployeeDocsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { uploadEmployeeDoc, type EmployeeDocType } from "@shared/lib/hr/uploadEmployeeDoc";
 
@@ -11,7 +11,7 @@ type ProfileRow = DB["public"]["Tables"]["profiles"]["Row"];
 type DocType = EmployeeDocType;
 
 export default function EmployeeDocsClient() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const [docs, setDocs] = useState<EmpDocRow[]>([]);
   const [busy, setBusy] = useState(false);
   const [file, setFile] = useState<File | null>(null);

--- a/features/dashboard/app/dashboard/admin/EmployeesClient.tsx
+++ b/features/dashboard/app/dashboard/admin/EmployeesClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   AdminBadge,
@@ -24,7 +24,7 @@ type EmpRow = Pick<
 >;
 
 export default function AdminEmployeesClient() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<EmpRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [search, setSearch] = useState("");

--- a/features/dashboard/app/dashboard/admin/RolesClient.tsx
+++ b/features/dashboard/app/dashboard/admin/RolesClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type ProfileLite = Pick<
@@ -10,7 +10,7 @@ type ProfileLite = Pick<
 >;
 
 export default function AdminRolesClient() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [rows, setRows] = useState<ProfileLite[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
 

--- a/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
@@ -3,7 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { addMinutes, format, isValid, parseISO } from "date-fns";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
@@ -254,7 +254,7 @@ function keepEndSameDay(startLocal: string, endLocal: string): string {
 }
 
 export default function SchedulingClient(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [tab, setTab] = useState<TabKey>("shifts");
 

--- a/features/dashboard/app/dashboard/admin/ShopsClient.tsx
+++ b/features/dashboard/app/dashboard/admin/ShopsClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   AdminBadge,
@@ -36,7 +36,7 @@ function healthLabel(shop: ShopRow): "Complete" | "Needs profile" {
 }
 
 export default function AdminShopsClient() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<ShopRow[] | null>(null);
   const [err, setErr] = useState<string | null>(null);

--- a/features/dashboard/app/dashboard/admin/employee-docs/page.tsx
+++ b/features/dashboard/app/dashboard/admin/employee-docs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { uploadEmployeeDoc, type EmployeeDocType } from "@shared/lib/hr/uploadEmployeeDoc";
 
@@ -10,7 +10,7 @@ type Profile = DB["public"]["Tables"]["profiles"]["Row"];
 type EmpDoc = DB["public"]["Tables"]["employee_documents"]["Row"];
 
 export default function AdminEmployeeDocsPage() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [me, setMe] = useState<Profile | null>(null);
   const [docs, setDocs] = useState<EmpDoc[]>([]);
   const [file, setFile] = useState<File | null>(null);

--- a/features/dashboard/app/dashboard/owner/import-customers/page.tsx
+++ b/features/dashboard/app/dashboard/owner/import-customers/page.tsx
@@ -5,11 +5,10 @@ import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
 import Papa from "papaparse";
 import { toast } from "sonner";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 
-const supabase = createClientComponentClient<Database>();
+const supabase = createBrowserSupabase();
 
 const REQUIRED_FIELDS = [
   "customer_name",

--- a/features/dashboard/app/dashboard/owner/organization/create/page.tsx
+++ b/features/dashboard/app/dashboard/owner/organization/create/page.tsx
@@ -2,18 +2,16 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
-import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/input";
 
-type DB = Database;
 
 export default function CreateOrganizationPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [name, setName] = useState("");
   const [saving, setSaving] = useState(false);

--- a/features/dashboard/app/dashboard/owner/reports/page.tsx
+++ b/features/dashboard/app/dashboard/owner/reports/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import html2canvas from "html2canvas";
 import { startOfYear, endOfYear } from "date-fns";
 import {
@@ -19,7 +19,6 @@ import {
 } from "recharts";
 import { toast } from "sonner";
 
-import type { Database } from "@shared/types/types/supabase";
 import {
   getShopStats,
   type TimeRange,
@@ -74,7 +73,7 @@ const RANGE_LABELS: Record<Range, string> = {
 type TabKey = "performance" | "health";
 
 export default function ReportsPage() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
 

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -187,7 +187,7 @@ function locationName(s: { shop_name?: string | null; name?: string | null }) {
 
 export default function OwnerSettingsPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
 

--- a/features/dashboard/app/dashboard/settings/user/page.tsx
+++ b/features/dashboard/app/dashboard/settings/user/page.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
 import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard";
@@ -23,7 +22,7 @@ type TimeOffRequest = {
 
 export default function SettingsPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
   const [shopId, setShopId] = useState<string | null>(null);

--- a/features/dashboard/components/ShareBookingLink.tsx
+++ b/features/dashboard/components/ShareBookingLink.tsx
@@ -2,14 +2,13 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 
 type StaffRole = "owner" | "admin" | "manager" | "advisor" | "parts";
 
 export default function ShareBookingLink() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const [slug, setSlug] = useState<string | null>(null);
   const [isStaff, setIsStaff] = useState<boolean>(false);

--- a/features/dashboard/widgets/ApprovalRiskWidget.tsx
+++ b/features/dashboard/widgets/ApprovalRiskWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
 import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
@@ -23,7 +23,7 @@ export default function ApprovalRiskWidget({
   shopId: string | null;
   embedded?: boolean;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<BoardRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/features/dashboard/widgets/BookingsWidget.tsx
+++ b/features/dashboard/widgets/BookingsWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
 
@@ -20,7 +20,7 @@ function startOfToday() {
 }
 
 export default function BookingsWidget() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const [rows, setRows] = useState<BookingRow[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/features/dashboard/widgets/ComebackRiskWidget.tsx
+++ b/features/dashboard/widgets/ComebackRiskWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
 import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
@@ -27,7 +27,7 @@ export default function ComebackRiskWidget({
   embedded?: boolean;
   compact?: boolean;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [snapshot, setSnapshot] = useState<SnapshotRow | null>(null);

--- a/features/dashboard/widgets/ShopPulseWidget.tsx
+++ b/features/dashboard/widgets/ShopPulseWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
 import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
@@ -59,7 +59,7 @@ export default function ShopPulseWidget({
   shopId: string | null;
   embedded?: boolean;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rows, setRows] = useState<BoardRow[]>([]);

--- a/features/dashboard/widgets/WaitingPartsWidget.tsx
+++ b/features/dashboard/widgets/WaitingPartsWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import DashboardWidgetShell from "@/features/dashboard/components/DashboardWidgetShell";
 import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
@@ -23,7 +23,7 @@ export default function WaitingPartsWidget({
   shopId: string | null;
   embedded?: boolean;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<BoardRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/features/dashboard/widgets/modules/RefinedDashboardModules.tsx
+++ b/features/dashboard/widgets/modules/RefinedDashboardModules.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import {
   DashboardActionBar,
@@ -19,7 +19,6 @@ import { useTechnicianLoadMetrics } from "@/features/dashboard/hooks/useTechnici
 import { toDashboardFallbackMessage } from "@/features/dashboard/lib/widget-fallback";
 import { useWorkOrderBoard } from "@/features/shared/hooks/useWorkOrderBoard";
 import { getShopStats } from "@/features/shared/lib/stats/getShopStats";
-import type { Database } from "@shared/types/types/supabase";
 import { useEffect, useState } from "react";
 
 function actionBtn() {
@@ -129,7 +128,7 @@ export function TechLoadModule({ shopId, mode }: { shopId: string | null; mode: 
 }
 
 export function ShopPulseModule({ shopId, mode }: { shopId: string | null; mode: DashboardModuleMode }) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<Array<{ label: string; value: string }>>([]);

--- a/features/inspections/app/inspection/InspectionMenuClient.tsx
+++ b/features/inspections/app/inspection/InspectionMenuClient.tsx
@@ -4,7 +4,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 import InspectionGroupList from "@inspections/components/InspectionGroupList";
@@ -38,7 +38,7 @@ function TileLink({ href, title, subtitle }: Tile) {
 }
 
 export default function InspectionMenuClient() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const [templates, setTemplates] = useState<TemplateRow[]>([]);
   const [active, setActive] = useState<InspectionCategory[] | null>(null);
 

--- a/features/inspections/app/inspection/created/page.tsx
+++ b/features/inspections/app/inspection/created/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
@@ -12,7 +12,7 @@ type TemplateRow = DB["public"]["Tables"]["inspection_templates"]["Row"];
 type Scope = "mine" | "public";
 
 export default function CreatedTemplatesPage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
 
   const [scope, setScope] = useState<Scope>("mine");
   const [userId, setUserId] = useState<string | null>(null);

--- a/features/inspections/app/inspection/custom-draft/page.tsx
+++ b/features/inspections/app/inspection/custom-draft/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import type {
   InspectionSection,
@@ -189,7 +189,7 @@ function coerceNumberOrNull(s: string): number | null {
 export default function CustomDraftPage() {
   const router = useRouter();
   const sp = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const nextKeyRef = useRef(1);
   const mkKey = () =>

--- a/features/inspections/app/inspection/run/page.tsx
+++ b/features/inspections/app/inspection/run/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
@@ -19,7 +19,7 @@ type Section = { title: string; items: SectionItem[] };
 export default function RunInspectionPage() {
   const sp = useSearchParams();
   const router = useRouter();
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
 
   useEffect(() => {
     const templateId = sp.get("templateId");

--- a/features/inspections/app/inspection/save/route.ts
+++ b/features/inspections/app/inspection/save/route.ts
@@ -1,10 +1,8 @@
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { NextResponse } from "next/server";
-import type { Database } from "@shared/types/types/supabase";
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   let customer, vehicle;
 

--- a/features/inspections/app/inspection/saved/page.tsx
+++ b/features/inspections/app/inspection/saved/page.tsx
@@ -10,7 +10,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -118,7 +118,7 @@ function uniqStrings(list: Array<string | null | undefined>): string[] {
 }
 
 export default function SavedInspectionsPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<string | null>(null);
 

--- a/features/inspections/app/inspection/summary/page.tsx
+++ b/features/inspections/app/inspection/summary/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
@@ -27,7 +27,7 @@ import type { QuoteLine } from "@quotes/lib/quote/generateQuoteFromInspection";
 export default function SummaryPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const inspectionId = searchParams.get("inspectionId");
   const workOrderIdFromUrl = searchParams.get("workOrderId");

--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import FleetFormImportCard from "@/features/inspections/components/FleetFormImportCard";
 
@@ -12,7 +12,7 @@ type Template = DB["public"]["Tables"]["inspection_templates"]["Row"];
 type Scope = "mine" | "shared" | "all";
 
 export default function InspectionTemplatesPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [scope, setScope] = useState<Scope>("mine");
   const [search, setSearch] = useState("");
   const [mine, setMine] = useState<Template[]>([]);

--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type {
   SessionCustomer as CustomerInfo,
   SessionVehicle,
@@ -132,7 +131,7 @@ function CustomerAutocomplete({
   shopId: string | null;
   onPick: (c: CustomerRow) => void;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<CustomerRow[]>([]);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -275,7 +274,7 @@ function UnitNumberAutocomplete({
   customerId: string | null;
   onPick: (v: VehicleRow) => void;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<VehicleRow[]>([]);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -407,7 +406,7 @@ export default function CustomerVehicleForm({
   selectedVehicleId = null,
   handlers,
 }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const {
     onCustomerChange = () => {},

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -3,8 +3,7 @@
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export type SignatureRole = "technician" | "customer" | "advisor";
 
@@ -86,7 +85,7 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
   techSettingsHref,
   lockNameInput,
 }) => {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const defaultLock = role === "technician";
   const [autoFilledName, setAutoFilledName] = useState<string | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);

--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -1,8 +1,7 @@
 // /features/integrations/shopBoost/runIntakeHandler.ts
 import { randomUUID } from "crypto";
 import type { NextRequest } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
@@ -145,7 +144,7 @@ export async function runShopBoostIntake(
   req: NextRequest,
   mode: RunMode,
 ): Promise<ShopBoostRunResp> {
-  const supabaseUser = createRouteHandlerClient<DB>({ cookies });
+  const supabaseUser = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/features/integrations/shopreel/server/getMarketingDashboardData.ts
+++ b/features/integrations/shopreel/server/getMarketingDashboardData.ts
@@ -1,5 +1,4 @@
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 import type { Database } from "@shared/types/types/supabase";
 import { DEFAULT_SHOPREEL_EVENT_TYPES, getShopReelBaseUrl } from "./shopreelConfig";
@@ -55,7 +54,7 @@ function toDeliveryStatus(value: string): DeliveryStatus {
 }
 
 export async function getMarketingDashboardData() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const lifecycleSupabase = supabase as unknown as {
     from: (table: string) => ReturnType<typeof supabase.from>
   };

--- a/features/integrations/shopreel/server/getOwnerShopContext.ts
+++ b/features/integrations/shopreel/server/getOwnerShopContext.ts
@@ -1,11 +1,8 @@
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 export async function getOwnerShopContext() {
-  const supabase = createRouteHandlerClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
 import { fetchMobileShiftState } from "@/features/mobile/shifts/client";
@@ -55,7 +55,7 @@ export function MobileTechHome({
   jobs,
   loadingStats = false,
 }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [userId, setUserId] = useState<string | null>(null);
 
   const [shiftStatus, setShiftStatus] = useState<ShiftStatus>("none");

--- a/features/mobile/settings/MobileSettingsScreen.tsx
+++ b/features/mobile/settings/MobileSettingsScreen.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 import SignaturePad, {
@@ -44,7 +44,7 @@ async function sha256Base64(dataUrl: string): Promise<string> {
 }
 
 export default function MobileTechSettingsPage(): JSX.Element {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   // profile fields (from profiles table)
   const [loading, setLoading] = useState(true);

--- a/features/operations/components/OperationsPortalShell.tsx
+++ b/features/operations/components/OperationsPortalShell.tsx
@@ -3,15 +3,13 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import ForcePasswordChangeModal from "@/features/auth/components/ForcePasswordChangeModal";
 
 const COPPER = "#C57A4A";
 const DEFAULT_ACCENT = "#38BDF8";
 
-type DB = Database;
 
 export type OperationsPortalNavItem = { href: string; label: string };
 export type OperationsPortalShellProps = {
@@ -38,7 +36,7 @@ function NavPill({ href, label, active, accentColor, onClick }: { href: string; 
 export function OperationsPortalShell({ title, subtitle, badgeLabel, accentColor = DEFAULT_ACCENT, nav, signInRedirectPath = "/portal/auth/sign-in", enableAuthControls = true, children }: OperationsPortalShellProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const supabase = useMemo(() => (enableAuthControls ? createClientComponentClient<DB>() : null), [enableAuthControls]);
+  const supabase = useMemo(() => (enableAuthControls ? createBrowserSupabase() : null), [enableAuthControls]);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [desktopOpen, setDesktopOpen] = useState(true);
   const [signingOut, setSigningOut] = useState(false);

--- a/features/owner/reports/OwnerReportsWidget.tsx
+++ b/features/owner/reports/OwnerReportsWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -71,7 +71,7 @@ export default function OwnerReportsWidget({
 }: {
   canView: boolean;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(true);
   const [snapshot, setSnapshot] = useState<SnapshotRow | null>(null);
 

--- a/features/owner/reports/ReportsPerformanceWidget.tsx
+++ b/features/owner/reports/ReportsPerformanceWidget.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import {
   getShopStats,
   type TimeRange,
@@ -84,7 +83,7 @@ function SummaryMiniCard({
 }
 
 export default function ReportsPerformanceWidget({ compact = false }: { compact?: boolean }) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<string | null>(null);
   const [range, setRange] = useState<TimeRange>("monthly");

--- a/features/owner/reports/ReportsShopHealthPanel.tsx
+++ b/features/owner/reports/ReportsShopHealthPanel.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 
@@ -153,7 +153,7 @@ function isShopBoostRunResp(v: unknown): v is ShopBoostRunResp {
 }
 
 export default function ReportsShopHealthPanel({ shopId }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [latest, setLatest] = useState<ShopHealthLatestRow | null>(null);

--- a/features/parts/_archive/legacy-app-pages/app/parts/warranties/page.tsx
+++ b/features/parts/_archive/legacy-app-pages/app/parts/warranties/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { v4 as uuidv4 } from "uuid";
 import { format, addMonths, isBefore, differenceInDays } from "date-fns";
 import { toast } from "sonner";
@@ -77,7 +77,7 @@ function PartPickerDialog({
   shopId: string;
   onPick: (p: PartLite) => void;
 }): JSX.Element | null {
-  const supabase = useMemo(() => createClientComponentClient(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [q, setQ] = useState<string>("");
   const [rows, setRows] = useState<PartLite[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -191,7 +191,7 @@ function PartPickerDialog({
 /*                               PAGE                                    */
 /* ===================================================================== */
 export default function WarrantiesPage(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<string>("");
   const [ready, setReady] = useState(false);

--- a/features/parts/actions.ts
+++ b/features/parts/actions.ts
@@ -2,8 +2,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -37,7 +36,7 @@ export async function createPart(input: {
   subcategory?: string;
   low_stock_threshold?: number;
 }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const { data, error } = await supabase
     .from("parts")
@@ -66,7 +65,7 @@ export async function adjustStock(input: {
   reference_kind?: string | null;
   reference_id?: string | null; // UUID or null
 }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // Build args using a Record to allow nulls for uuid/text fields safely
   const rpcArgs: Record<string, unknown> = {

--- a/features/parts/components/PartPicker.tsx
+++ b/features/parts/components/PartPicker.tsx
@@ -8,7 +8,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   useAiPartSuggestions,
@@ -107,7 +107,7 @@ export function PartPicker({
   onPick,
   variant = "modal",
 }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shopId, setShopId] = useState<UUID>("");
   const [search, setSearch] = useState(initialSearch);

--- a/features/parts/components/PartsRequestChat.tsx
+++ b/features/parts/components/PartsRequestChat.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
 import { toast } from "sonner";
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export default function PartsRequestChat({ requestId, senderId }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [newMsg, setNewMsg] = useState("");

--- a/features/parts/components/PartsStaffQueue.tsx
+++ b/features/parts/components/PartsStaffQueue.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { toast } from "sonner";
 
@@ -31,7 +31,7 @@ function s(v: unknown): string {
 }
 
 export default function PartsStaffQueue() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [rows, setRows] = useState<QueueRow[]>([]);

--- a/features/parts/components/VehiclePhotoGallery.tsx
+++ b/features/parts/components/VehiclePhotoGallery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Dialog } from "@headlessui/react";
 import {
   PencilIcon,
@@ -21,7 +21,7 @@ export default function VehiclePhotoGallery({
   vehicleId,
   currentUserId,
 }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const [photos, setPhotos] = useState<VehiclePhoto[]>([]);
   const [editingCaptionId, setEditingCaptionId] = useState<string | null>(null);

--- a/features/parts/components/VehiclePhotoUploader.tsx
+++ b/features/parts/components/VehiclePhotoUploader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { v4 as uuidv4 } from "uuid";
 import { toast } from "sonner";
 
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export default function VehiclePhotoUploader({ vehicleId, onUpload }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const [file, setFile] = useState<File | null>(null);
   const [caption, setCaption] = useState("");

--- a/features/parts/lib/locations.ts
+++ b/features/parts/lib/locations.ts
@@ -1,11 +1,8 @@
 "use server";
-import { cookies } from "next/headers";
-import { createServerComponentClient, createServerActionClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-type DB = Database;
+import { createServerSupabaseRSC, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export async function ensureMainLocation(shopId: string) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { data, error } = await supabase
     .from("stock_locations")
     .select("id, code, name")
@@ -24,7 +21,7 @@ export async function ensureMainLocation(shopId: string) {
 }
 
 export async function listLocations(shopId: string) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const { data, error } = await supabase
     .from("stock_locations")
     .select("id, code, name")
@@ -35,7 +32,7 @@ export async function listLocations(shopId: string) {
 }
 
 export async function createLocation(input: { shop_id: string; code: string; name: string }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { data, error } = await supabase
     .from("stock_locations")
     .insert(input)

--- a/features/parts/lib/parts.queries.ts
+++ b/features/parts/lib/parts.queries.ts
@@ -1,11 +1,8 @@
 "use server";
-import { cookies } from "next/headers";
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-type DB = Database;
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 export async function listParts(shopId: string) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const { data, error } = await supabase
     .from("parts")
     .select("id, sku, name, category, default_price, low_stock_threshold")
@@ -16,7 +13,7 @@ export async function listParts(shopId: string) {
 }
 
 export async function getPart(id: string) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const { data, error } = await supabase
     .from("parts")
     .select("*, part_suppliers(*), v_part_stock(*)")

--- a/features/parts/lib/requests/setPartRequestItemStatus.ts
+++ b/features/parts/lib/requests/setPartRequestItemStatus.ts
@@ -1,13 +1,10 @@
 // features/parts/lib/requests/setPartRequestItemStatus.ts
 "use server";
 
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
 
-type DB = Database;
 
 export async function setPartRequestItemStatus(input: {
   partRequestItemId: string;
@@ -27,7 +24,7 @@ export async function setPartRequestItemStatus(input: {
   // optional: revalidate targets (work order pages, parts pages)
   revalidate?: { paths?: string[] };
 }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const { data: updatedItem, error } = await supabase
     .from("part_request_items")

--- a/features/parts/lib/suppliers.ts
+++ b/features/parts/lib/suppliers.ts
@@ -1,11 +1,8 @@
 "use server";
-import { cookies } from "next/headers";
-import { createServerComponentClient, createServerActionClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-type DB = Database;
+import { createServerSupabaseRSC, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 export async function listSuppliers(shopId: string) {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
   const { data, error } = await supabase
     .from("suppliers")
     .select("id, name, email, phone, is_active")
@@ -16,7 +13,7 @@ export async function listSuppliers(shopId: string) {
 }
 
 export async function createSupplier(input: { shop_id: string; name: string; email?: string; phone?: string }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const { data, error } = await supabase
     .from("suppliers")
     .insert(input)

--- a/features/parts/server/poActions.ts
+++ b/features/parts/server/poActions.ts
@@ -1,12 +1,9 @@
 // /features/parts/server/poActions.ts (FULL FILE REPLACEMENT)
 "use server";
 
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-type DB = Database;
 
 function pickShopIdFromJoin(v: unknown): string | null {
   // Supabase generated types often model joins as arrays, even for !inner single row.
@@ -32,7 +29,7 @@ export async function createPurchaseOrder(input: {
   supplier_id?: string | null;
   notes?: string | null;
 }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const {
     data: { user },
@@ -69,7 +66,7 @@ export async function addPoLine(input: {
   unit_cost?: number | null;
   location_id?: string | null;
 }) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   if (input.qty <= 0) throw new Error("Quantity must be > 0");
 
@@ -89,7 +86,7 @@ export async function addPoLine(input: {
 }
 
 export async function markPoSent(po_id: string) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   const { error } = await supabase
     .from("purchase_orders")
@@ -103,7 +100,7 @@ export async function markPoSent(po_id: string) {
 
 /** Receive all remaining qty for lines (simple MVP). */
 export async function receivePo(po_id: string) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // Load PO lines + joined shop_id
   const { data: lines, error: le } = await supabase

--- a/features/parts/server/scanActions.ts
+++ b/features/parts/server/scanActions.ts
@@ -1,9 +1,6 @@
 "use server";
 
-import { cookies } from "next/headers";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
-type DB = Database;
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 /**
  * Resolve a scanned code (barcode or SKU) to a part_id.
@@ -16,7 +13,7 @@ export async function resolveScannedCode(input: {
   code: string;
   supplier_id?: string | null;
 }): Promise<{ part_id: string | null }> {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
   const code = (input.code || "").trim();
   if (!code) return { part_id: null };
 

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import QuoteApprovalActions from "@/features/portal/components/QuoteApprovalActions";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
@@ -227,7 +227,7 @@ export default function QuotePageClient(): JSX.Element {
   const router = useRouter();
   const params = useParams();
   const workOrderId = useMemo(() => paramToString((params as ParamsShape).id), [params]);
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [workOrder, setWorkOrder] = useState<WorkOrderRow | null>(null);

--- a/features/portal/components/PortalNotificationsBell.tsx
+++ b/features/portal/components/PortalNotificationsBell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -14,7 +14,7 @@ function classNames(...parts: Array<string | false | null | undefined>) {
 const COPPER = "#C57A4A";
 
 export default function PortalNotificationsBell() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [items, setItems] = useState<PortalNotificationRow[]>([]);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/features/portal/components/PortalShell.tsx
+++ b/features/portal/components/PortalShell.tsx
@@ -4,11 +4,9 @@
 import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import PortalNotificationsBell from "@/features/portal/components/PortalNotificationsBell";
 
-type DB = Database;
 
 type NavItem = {
   href: string;
@@ -92,7 +90,7 @@ export default function PortalShell({
 }) {
   const pathname = usePathname();
   const router = useRouter();
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
 
   const [mobileOpen, setMobileOpen] = useState(false);
   const [desktopOpen, setDesktopOpen] = useState(true);

--- a/features/quotes/components/QuoteViewer.tsx
+++ b/features/quotes/components/QuoteViewer.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { generateQuotePDFBytes } from "@work-orders/lib/work-orders/generateQuotePdf";
 import type { QuoteLine } from "@quotes/lib/quote/generateQuoteFromInspection";
 import type { QuoteLineItem as BaseQuoteLineItem } from "@inspections/lib/inspection/types";
@@ -22,7 +21,7 @@ interface QuoteViewerProps {
   quote: (QuoteLine | BaseQuoteLineItem)[];
 }
 
-const supabase = createClientComponentClient<Database>();
+const supabase = createBrowserSupabase();
 
 /** Minimal inline save; adjust table/columns if yours differ */
 async function updateQuoteLine(item: EditableQuoteLineItem) {

--- a/features/shared/chat/components/RecipientPickerModal.tsx
+++ b/features/shared/chat/components/RecipientPickerModal.tsx
@@ -1,7 +1,7 @@
 // features/chat/components/RecipientPickerModal.tsx
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import debounce from "lodash-es/debounce";
 
@@ -29,7 +29,7 @@ export default function RecipientPickerModal({
   onStartChat,
   allowGroup = true,
 }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [query, setQuery] = useState<string>("");
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { Toaster } from "sonner";
 
@@ -95,7 +95,7 @@ export default function AppShell({
 }) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const { data: activeBrand } = useActiveBrand();
 
   const [userId, setUserId] = useState<string | null>(

--- a/features/shared/components/ProFixIQLanding.tsx
+++ b/features/shared/components/ProFixIQLanding.tsx
@@ -4,8 +4,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Toaster } from "sonner";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import LandingHero from "@shared/components/ui/LandingHero";
 import LandingShopBoost from "@shared/components/ui/LandingShopBoost";
@@ -21,7 +20,7 @@ import LandingReviews from "@shared/components/ui/LandingReviews";
 type Interval = "monthly" | "yearly";
 
 export default function ProFixIQLanding() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [sessionExists, setSessionExists] = useState(false);
 
   useEffect(() => {

--- a/features/shared/components/RoleNavAdmin.tsx
+++ b/features/shared/components/RoleNavAdmin.tsx
@@ -3,12 +3,11 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 
 export default function RoleNavAdmin() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isAdmin, setIsAdmin] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavAdvisor.tsx
+++ b/features/shared/components/RoleNavAdvisor.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavManager.tsx
+++ b/features/shared/components/RoleNavManager.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavOwner.tsx
+++ b/features/shared/components/RoleNavOwner.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavOwner() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [userId, setUserId] = useState<string | null>(null);
   const [isOwner, setIsOwner] = useState(false);
 

--- a/features/shared/components/RoleNavParts.tsx
+++ b/features/shared/components/RoleNavParts.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleNavTech.tsx
+++ b/features/shared/components/RoleNavTech.tsx
@@ -2,13 +2,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ShiftTracker from "@shared/components/ShiftTracker";
 import Link from "next/link";
 
 export default function RoleNavTech() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [isTech, setIsTech] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
 

--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   TILES,
   canShowTileForEmail,
@@ -64,7 +63,7 @@ export default function RoleSidebar({
   initialRole?: string | null;
   initialEmail?: string | null;
 }) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const pathname = usePathname();
 

--- a/features/shared/components/ShiftTracker.tsx
+++ b/features/shared/components/ShiftTracker.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { formatDistanceToNow } from "date-fns";
-import type { Database } from "@shared/types/types/supabase";
 
-type DB = Database;
 
 type ShiftType = "shift" | "break" | "lunch";
 type Mode = "none" | "shift" | "break" | "lunch" | "ended";
@@ -45,7 +43,7 @@ export default function ShiftTracker({
   userId: string;
   defaultShiftType?: ShiftType;
 }): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [shiftId, setShiftId] = useState<string | null>(null);
   const [startTime, setStartTime] = useState<string | null>(null);

--- a/features/shared/components/nav/NavFromTiles.tsx
+++ b/features/shared/components/nav/NavFromTiles.tsx
@@ -2,8 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import RoleHubTiles from "@/features/shared/components/RoleHubTiles/RoleHubTiles";
 import type { Role, Scope } from "@/features/shared/components/RoleHubTiles/tiles";
@@ -19,7 +18,7 @@ export default function NavFromTiles({
   description?: string;
   rolesOverride?: Role[];
 }) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [roles, setRoles] = useState<Role[]>([]);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);

--- a/features/shared/components/reviews/ReviewForm.tsx
+++ b/features/shared/components/reviews/ReviewForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER_LIGHT = "var(--accent-copper-light)";
@@ -31,7 +31,7 @@ function Star({ filled }: { filled: boolean }) {
 }
 
 export default function ReviewForm({ shopId, onCreated }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [rating, setRating] = useState<number>(5);
   const [comment, setComment] = useState<string>("");
   const [submitting, setSubmitting] = useState<boolean>(false);

--- a/features/shared/components/reviews/ReviewsList.tsx
+++ b/features/shared/components/reviews/ReviewsList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER = "var(--pfq-copper)";
@@ -42,7 +42,7 @@ function StarsRow({ rating }: { rating: number }) {
 }
 
 export default function ReviewsList({ shopId }: Props) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [reviews, setReviews] = useState<ReviewRow[]>([]);
   const [me, setMe] = useState<Profile | null>(null);
   const [loading, setLoading] = useState<boolean>(true);

--- a/features/shared/components/summary.tsx
+++ b/features/shared/components/summary.tsx
@@ -3,14 +3,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { extractSummaryFromSession } from "@inspections/lib/inspection/summary";
 import type { InspectionSession } from "@inspections/lib/inspection/types";
 
 export default function InspectionSummaryPage() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [summary, setSummary] = useState("");
   const [loading, setLoading] = useState(false);

--- a/features/shared/components/ui/LandingReviews.tsx
+++ b/features/shared/components/ui/LandingReviews.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 const COPPER_LIGHT = "var(--accent-copper-light)";
@@ -101,7 +101,7 @@ function StatPill({ label, value }: { label: string; value: string }) {
 }
 
 export default function LandingReviews() {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [reviews, setReviews] = useState<PublicReview[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/features/shared/components/ui/PunchController.tsx
+++ b/features/shared/components/ui/PunchController.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import PunchInOutButton from "@shared/components/PunchInOutButton";
@@ -28,7 +28,7 @@ function safeMsg(e: unknown, fallback: string): string {
 }
 
 export default function PunchController(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
   const [shopId, setShopId] = useState<string | null>(null);

--- a/features/shared/components/ui/ShopBoostWidget.tsx
+++ b/features/shared/components/ui/ShopBoostWidget.tsx
@@ -4,8 +4,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 type VHealthLatestRow = {
   snapshot_id: string;
@@ -66,7 +65,7 @@ const TONE_STYLES: Record<
 };
 
 export default function ShopBoostWidget({ shopId, canViewShopHealth }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/features/shared/hooks/useWorkOrderBoard.ts
+++ b/features/shared/hooks/useWorkOrderBoard.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { WorkOrderBoardRow, WorkOrderBoardVariant } from "../lib/workboard/types";
 
 type ViewName =
@@ -23,7 +22,7 @@ export function useWorkOrderBoard(
     fleetId?: string | null;
   },
 ) {
-  const supabase = useMemo(() => createClientComponentClient<Database>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<WorkOrderBoardRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/features/shared/lib/getUserRoles.ts
+++ b/features/shared/lib/getUserRoles.ts
@@ -1,12 +1,10 @@
 // app/(wherever)/getUserRoles.ts
 "use server";
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 export async function getUserRoles(): Promise<string[]> {
-  const supabase = createServerComponentClient<Database>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   // Check auth session
   const {

--- a/features/shared/lib/getUserSession.ts
+++ b/features/shared/lib/getUserSession.ts
@@ -1,9 +1,6 @@
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { redirect } from "next/navigation";
 
-type DB = Database;
 
 /**
  * Fetch the user's session and related profile/shop info without using
@@ -15,7 +12,7 @@ type DB = Database;
  */
 
 export async function requireUserSession() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   const {
     data: { session },
@@ -66,7 +63,7 @@ export async function requireUserSession() {
 }
 
 export async function getUserSession() {
-  const supabase = createServerComponentClient<DB>({ cookies });
+  const supabase = createServerSupabaseRSC();
 
   const {
     data: { session },

--- a/features/shared/lib/hr/uploadEmployeeDoc.ts
+++ b/features/shared/lib/hr/uploadEmployeeDoc.ts
@@ -1,7 +1,7 @@
 // features/shared/lib/hr/uploadEmployeeDoc.ts
 "use client";
 
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   Database,
@@ -26,7 +26,7 @@ export async function uploadEmployeeDoc(
   userId: string
 ) {
   // 🔒 make sure the client is strongly typed to your Database + "public"
-  const raw = createClientComponentClient<DB>();
+  const raw = createBrowserSupabase();
   const supabase = raw as unknown as SupabaseClient<DB, "public">;
 
   // ---------- 1) Upload to Storage (bucket: employee_docs)

--- a/features/shared/lib/pdf/generateStatsPDF.ts
+++ b/features/shared/lib/pdf/generateStatsPDF.ts
@@ -2,9 +2,8 @@
 
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import { formatCurrency } from "@shared/lib/formatters";
 
 /* -------------------------------------------------------------------------- */
@@ -38,7 +37,7 @@ export async function generateStatsPDF(
   range: string,
   chartImgData: string,
 ): Promise<Blob> {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const { data: shop } = await supabase
     .from("shops")

--- a/features/shared/lib/stats/getShopStats.ts
+++ b/features/shared/lib/stats/getShopStats.ts
@@ -14,7 +14,7 @@ import {
   eachQuarterOfInterval,
   format,
 } from "date-fns";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 export type TimeRange = "weekly" | "monthly" | "quarterly" | "yearly";
@@ -76,7 +76,7 @@ export async function getShopStats(
   filters: ShopStatsFilters = {},
   options: ShopStatsOptions = {},
 ): Promise<ShopStats> {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const now = new Date();
 

--- a/features/shared/lib/stats/getTechLeaderboard.ts
+++ b/features/shared/lib/stats/getTechLeaderboard.ts
@@ -10,9 +10,8 @@ import {
   startOfYear,
   endOfYear,
 } from "date-fns";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import type { TimeRange } from "./getShopStats";
 
 type SlimProfile = {
@@ -127,7 +126,7 @@ export async function getTechLeaderboard(
   shopId: string,
   timeRange: TimeRange,
 ): Promise<TechLeaderboardResult> {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const now = new Date();
   let start: Date;

--- a/features/shared/lib/stats/getTechnicianLoadMetrics.ts
+++ b/features/shared/lib/stats/getTechnicianLoadMetrics.ts
@@ -1,8 +1,7 @@
 "use client";
 
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-import type { Database } from "@shared/types/types/supabase";
 import {
   getTechnicianLoadMetricsWithClient,
   type TechnicianIdleBreakdown,
@@ -11,7 +10,6 @@ import {
   type TechnicianLoadMetricSummary,
 } from "@shared/lib/stats/getTechnicianLoadMetricsCore";
 
-type DB = Database;
 
 export type {
   TechnicianIdleBreakdown,
@@ -23,6 +21,6 @@ export type {
 export async function getTechnicianLoadMetrics(
   shopId: string,
 ): Promise<TechnicianLoadMetricResult> {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   return getTechnicianLoadMetricsWithClient(supabase, shopId);
 }

--- a/features/shared/lib/supabase/server.ts
+++ b/features/shared/lib/supabase/server.ts
@@ -1,7 +1,7 @@
 // features/shared/lib/supabase/server.ts
 import "server-only";
 
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -23,7 +23,7 @@ function createCookieBackedServerClient() {
 
   const { supabaseUrl, supabaseAnonKey } = readSupabaseServerEnv();
 
-  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+  const client = createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll();
@@ -40,6 +40,52 @@ function createCookieBackedServerClient() {
       },
     },
   });
+
+  const originalGetUser = client.auth.getUser.bind(client.auth);
+  client.auth.getUser = async (...args) => {
+    const result = await originalGetUser(...args);
+    const user = result.data.user;
+    let profile: Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "shop_id"> | null = null;
+
+    if (user?.id) {
+      const { data } = await client
+        .from("profiles")
+        .select("id, shop_id")
+        .eq("id", user.id)
+        .maybeSingle();
+      profile = data ?? null;
+    }
+
+    try {
+      const headerStore = headers() as unknown as { get: (name: string) => string | null };
+      console.info("[auth/server-get-user]", {
+        pathname:
+          headerStore.get("x-pathname") ??
+          headerStore.get("x-invoke-path") ??
+          headerStore.get("next-url") ??
+          headerStore.get("referer") ??
+          "unknown",
+        routeName: headerStore.get("x-matched-path") ?? "unknown",
+        hasUser: Boolean(user),
+        userId: user?.id ?? null,
+        profileExists: Boolean(profile),
+        profileShopId: profile?.shop_id ?? null,
+      });
+    } catch {
+      console.info("[auth/server-get-user]", {
+        pathname: "unknown",
+        routeName: "unknown",
+        hasUser: Boolean(user),
+        userId: user?.id ?? null,
+        profileExists: Boolean(profile),
+        profileShopId: profile?.shop_id ?? null,
+      });
+    }
+
+    return result;
+  };
+
+  return client;
 }
 
 /**

--- a/features/shared/lib/tech/index.ts
+++ b/features/shared/lib/tech/index.ts
@@ -1,10 +1,10 @@
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type JobLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
 
 export async function getQueuedJobsForTech(): Promise<JobLine[]> {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
 
   const { data, error } = await supabase
     .from("work_order_lines")

--- a/features/shared/lib/utils/uploadSignature.ts
+++ b/features/shared/lib/utils/uploadSignature.ts
@@ -1,10 +1,9 @@
 // features/shared/lib/utils/uploadSignature.ts
 "use client";
 
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-const supabase = createClientComponentClient<Database>();
+const supabase = createBrowserSupabase();
 
 function dataUrlToBlob(dataUrl: string): Blob {
   const [header, base64] = dataUrl.split(",");

--- a/features/shops/components/OwnerShopHealthWidget.tsx
+++ b/features/shops/components/OwnerShopHealthWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 import type { ShopHealthSnapshot } from "@/features/integrations/ai/shopBoostType";
@@ -44,7 +44,7 @@ function isShopHealthSnapshot(v: unknown): v is ShopHealthSnapshot {
 }
 
 export default function OwnerShopHealthWidget({ shopId }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [aiProfile, setAiProfile] = useState<ShopAiProfileRow | null>(null);
   const [snapshot, setSnapshot] = useState<ShopHealthSnapshot | null>(null);

--- a/features/shops/components/ShopPublicProfileSection.tsx
+++ b/features/shops/components/ShopPublicProfileSection.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { Input } from "@shared/components/ui/input";
 import { Button } from "@shared/components/ui/Button";
@@ -51,7 +51,7 @@ const EMPTY_FORM: Form = {
 };
 
 export default function ShopPublicProfileSection({ shopId, isUnlocked }: Props) {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState<Form>(EMPTY_FORM);

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
@@ -22,7 +21,7 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
       return NextResponse.json({ error: "Stripe is not configured" }, { status: 500 });
     }
 
-    const supabase = createRouteHandlerClient<DB>({ cookies });
+    const supabase = createServerSupabaseRoute();
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/features/tech/components/TechPerformanceTiles.tsx
+++ b/features/tech/components/TechPerformanceTiles.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import type { TimeRange } from "@shared/lib/stats/getShopStats";
@@ -47,7 +47,7 @@ export default function TechPerformanceTiles({
   range = "weekly",
   assignedJobsCount,
 }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [row, setRow] = useState<TechLeaderboardRow | null>(null);

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { useTabState } from "@/features/shared/hooks/useTabState";
 import { toast } from "sonner";
@@ -339,7 +339,7 @@ function extractInspectionTemplateId(
 export default function CreateWorkOrderPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const queryCustomerId =
     searchParams.get("customerId")?.trim() ||
     searchParams.get("customer_id")?.trim() ||

--- a/features/work-orders/app/work-orders/editor/page.tsx
+++ b/features/work-orders/app/work-orders/editor/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
@@ -34,7 +34,7 @@ type LineDraft = {
 const fieldClass = ui.input;
 
 export default function WorkOrderEditorPage() {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
   const [query, setQuery] = useState("");
   const [filtered, setFiltered] = useState<MenuItem[]>([]);

--- a/features/work-orders/app/work-orders/queue/page.tsx
+++ b/features/work-orders/app/work-orders/queue/page.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useMemo, useState } from "react";
 import WorkOrderAiIndicatorBadge from "@/features/work-orders/components/WorkOrderAiIndicatorBadge";
 import type { WorkOrderRecommendationIndicatorMap } from "@/features/ai/server/domains/workOrders/getWorkOrderRecommendationIndicators";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import Link from "next/link";
 import PageShell from "@/features/shared/components/PageShell";
@@ -72,7 +72,7 @@ type WorkOrderWaiterFlags = {
 };
 
 export default function QueuePage() {
-  const supabase = createClientComponentClient<DB>();
+  const supabase = createBrowserSupabase();
 
   // auth / profile
   const [userId, setUserId] = useState<string | null>(null);

--- a/features/work-orders/app/work-orders/quote-review/page.tsx
+++ b/features/work-orders/app/work-orders/quote-review/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
@@ -66,7 +66,7 @@ function approvalProgress(lines: WorkOrderWithMeta["work_order_lines"] | undefin
 }
 
 function ApprovalsList(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<WorkOrderWithMeta[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -267,7 +267,7 @@ function priorityChip(priority: number | null | undefined): string {
 }
 
 export default function WorkOrdersView(): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -346,7 +346,6 @@ export default function WorkOrdersView(): JSX.Element {
       .from("work_orders")
       .select(`
         *,
-        customers:customers(first_name,last_name,phone,email),
         vehicles:vehicles(year,make,model,license_plate)
       `)
       .order("created_at", { ascending: false })
@@ -432,6 +431,33 @@ export default function WorkOrdersView(): JSX.Element {
     }
 
     const workOrders = (data ?? []) as Row[];
+    const customerIds = Array.from(
+      new Set(
+        workOrders
+          .map((row) => row.customer_id)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    if (customerIds.length > 0) {
+      const { data: customerRows, error: customerErr } = await supabase
+        .from("customers")
+        .select("id,first_name,last_name,phone,email")
+        .in("id", customerIds);
+
+      if (customerErr) {
+        console.warn("[WorkOrdersView] customer lookup failed; showing work orders without customer details:", customerErr.message);
+      } else {
+        const customersById = new Map(
+          (customerRows ?? []).map((customer) => [customer.id, customer]),
+        );
+
+        workOrders.forEach((row) => {
+          row.customers = row.customer_id ? customersById.get(row.customer_id) ?? null : null;
+        });
+      }
+    }
+
     const qlc = q.trim().toLowerCase();
 
     const filtered =

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -4,7 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 import type { Database } from "@shared/types/types/supabase";
 import type { RepairLine } from "@ai/lib/parseRepairOutput";
@@ -212,7 +212,7 @@ export default function InvoicePreviewPageClient({
   onSent,
 }: Props) {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(false);
   const [shopId, setShopId] = useState<string | null>(null);

--- a/features/work-orders/components/MenuQuickAdd.tsx
+++ b/features/work-orders/components/MenuQuickAdd.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 import type { Database, TablesInsert } from "@shared/types/types/supabase";
 import { AiSuggestModal } from "@work-orders/components/AiSuggestModal";
@@ -284,7 +284,7 @@ function extractInspectionTemplateIdFromMenuItem(mi: MenuItemRow): string | null
 }
 
 export function MenuQuickAdd({ workOrderId }: { workOrderId: string }) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [addingId, setAddingId] = useState<string | null>(null);

--- a/features/work-orders/components/NewWorkOrderLineForm.tsx
+++ b/features/work-orders/components/NewWorkOrderLineForm.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -81,7 +81,7 @@ export function NewWorkOrderLineForm(props: {
 }) {
   const { workOrderId, vehicleId, defaultJobType, shopId, onCreated } = props;
 
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [complaint, setComplaint] = useState("");
   const [infoNote, setInfoNote] = useState("");

--- a/features/work-orders/components/TechJobScreen.tsx
+++ b/features/work-orders/components/TechJobScreen.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import JobQueueCard from "@shared/components/JobQueueCard";
 import { toast } from "sonner";
@@ -11,7 +11,7 @@ import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransi
 type JobLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
 
 export default function TechJobScreen() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const [jobs, setJobs] = useState<JobLine[]>([]);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);

--- a/features/work-orders/components/WorkOrderAssignedSummary.tsx
+++ b/features/work-orders/components/WorkOrderAssignedSummary.tsx
@@ -2,10 +2,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-type DB = Database;
 
 type Props = {
   workOrderId: string;
@@ -19,7 +17,7 @@ type AssignmentRow = {
 };
 
 export function WorkOrderAssignedSummary({ workOrderId }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [rows, setRows] = useState<AssignmentRow[]>([]);

--- a/features/work-orders/components/dashboard/AdvisorQueueWidget.tsx
+++ b/features/work-orders/components/dashboard/AdvisorQueueWidget.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import WorkOrderAiIndicatorBadge from "@/features/work-orders/components/WorkOrderAiIndicatorBadge";
 import type { WorkOrderRecommendationIndicatorMap } from "@/features/ai/server/domains/workOrders/getWorkOrderRecommendationIndicators";
@@ -139,7 +139,7 @@ function BucketButton({
 }
 
 export default function AdvisorQueueWidget({ embedded = false }: { embedded?: boolean }): JSX.Element {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   
   const [role, setRole] = useState<string | null>(null);

--- a/features/work-orders/components/workorders/LinePartsSummary.tsx
+++ b/features/work-orders/components/workorders/LinePartsSummary.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -28,7 +28,7 @@ function num(v: unknown): number {
 }
 
 export default function LinePartsSummary({ workOrderLineId }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [s, setS] = useState<Summary>({
     requested: 0,
     approved: 0,

--- a/features/work-orders/components/workorders/PartsRequestModal.tsx
+++ b/features/work-orders/components/workorders/PartsRequestModal.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModalShell from "@/features/shared/components/ModalShell";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -49,7 +49,7 @@ export default function PartsRequestModal({
   closeEventName = "parts-request:close",
   submittedEventName = "parts-request:submitted",
 }: Props) {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [headerNotes, setHeaderNotes] = useState(requestNote ?? "");
   const [rows, setRows] = useState<Item[]>([

--- a/features/work-orders/lib/parts/allocateMenuItemParts.ts
+++ b/features/work-orders/lib/parts/allocateMenuItemParts.ts
@@ -1,9 +1,8 @@
 // features/work-orders/lib/parts/allocateMenuItemParts.ts
 "use server";
 
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { consumePart } from "@/features/work-orders/lib/parts/consumePart";
 import { ensureMainLocation } from "@parts/lib/locations";
@@ -29,7 +28,7 @@ function asFiniteNumberOrUndefined(v: unknown): number | undefined {
 }
 
 export async function allocateMenuItemParts(input: AllocateMenuItemPartsInput) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   // 1) Load line (source of truth for shop + work order)
   const { data: woLine, error: wlErr } = await supabase

--- a/features/work-orders/lib/parts/consumePart.ts
+++ b/features/work-orders/lib/parts/consumePart.ts
@@ -1,9 +1,8 @@
 // features/work-orders/lib/parts/consumePart.ts
 "use server";
 
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { ensureMainLocation } from "@parts/lib/locations";
 
@@ -41,7 +40,7 @@ function asFiniteNumber(v: unknown): number | null {
  * This is defensive: any schema mismatch falls back silently.
  */
 async function resolveBestLocationId(args: {
-  supabase: ReturnType<typeof createServerActionClient<DB>>;
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
   shopId: string;
   partId: string;
 }): Promise<string> {
@@ -88,7 +87,7 @@ async function resolveBestLocationId(args: {
 }
 
 export async function consumePart(input: ConsumePartInput) {
-  const supabase = createServerActionClient<DB>({ cookies });
+  const supabase = createServerSupabaseRoute();
 
   if (!input.qty || input.qty <= 0) {
     throw new Error("Quantity must be greater than 0");

--- a/features/work-orders/lib/work-orders/getQueuedJobsForTech.ts
+++ b/features/work-orders/lib/work-orders/getQueuedJobsForTech.ts
@@ -1,5 +1,5 @@
 // features/work-orders/lib/work-orders/getQueuedJobsForTech.ts
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   getWorkOrderLineStatusDbFilter,
@@ -15,7 +15,7 @@ type JobLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
  * - Ordered by parent work order priority first, then oldest → newest
  */
 export async function getQueuedJobsForTech(techId?: string): Promise<JobLine[]> {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createBrowserSupabase();
   const queueStatuses: WorkOrderLineStatus[] = ["in_progress", "awaiting", "on_hold"];
 
   // join work_orders so we can sort by work order priority

--- a/features/work-orders/mobile/MobileJobLineAdd.tsx
+++ b/features/work-orders/mobile/MobileJobLineAdd.tsx
@@ -5,11 +5,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@shared/types/types/supabase";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import NewWorkOrderLineForm from "@/features/work-orders/components/NewWorkOrderLineForm";
 
-type DB = Database;
 
 type JobType = "diagnosis" | "inspection" | "maintenance" | "repair";
 
@@ -26,7 +24,7 @@ export function MobileJobLineAdd({
   defaultJobType = "diagnosis",
   onCreated,
 }: Props): JSX.Element | null {
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string | null>(null);
 
   // look up shop_id from the work order once

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -3,7 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 import type { Database, Json } from "@shared/types/types/supabase";
 
@@ -313,7 +313,7 @@ export default function QuoteReviewView(props: {
   const router = useRouter();
   const woId = String(props.workOrderId ?? "").trim();
   const embedded = Boolean(props.embedded);
-  const supabase = useMemo(() => createClientComponentClient<DB>(), []);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
   const [loadedOnce, setLoadedOnce] = useState(false);


### PR DESCRIPTION
### Motivation
- Production requests were invoking legacy `@supabase/auth-helpers-nextjs` helpers which caused `GET /auth/v1/user 403 bad_jwt` (anon/no-sub JWT) and produced “You must be signed in” errors.
- Replace all remaining legacy helpers with the project’s canonical helpers for browser/RSC/route/server-action paths while preserving UI and flows.
- Add safe diagnostics around server auth reads to aid debugging without exposing tokens/cookies/JWTs.

### Description
- Replaced imports/usages of `createClientComponentClient`, `createServerComponentClient`, `createRouteHandlerClient`, and `createServerActionClient` from `@supabase/auth-helpers-nextjs` with the project canonical helpers: `createBrowserSupabase` (browser), `createServerSupabaseRSC` (RSC), and `createServerSupabaseRoute` (route handlers) in `features/shared/lib/supabase/*` across the app (approx. 351 files modified).
- Centralized safe server diagnostics by wrapping `client.auth.getUser` in `features/shared/lib/supabase/server.ts` to log `pathname`, `routeName`, `hasUser`, `userId`, `profileExists`, and `profileShopId` only (no tokens/cookies/JWTs).
- Replaced route-handler cookie patterns that used `cookies()`/cookieStore with `createServerSupabaseRoute()` where appropriate and adjusted type usages accordingly.
- Patched Work Orders list (`features/work-orders/app/work-orders/view/page.tsx`) to remove the embedded `customers:customers(...)` join and instead fetch customers separately by `customer_id`, tolerating customer lookup failures so work orders still display.

### Testing
- Searched for legacy helpers and verified removal with `grep -Rni "@supabase/auth-helpers-nextjs|createRouteHandlerClient|createServerComponentClient|createClientComponentClient" app features components lib middleware.ts` (no remaining matches after changes).
- Verified the Work Orders change with `grep -Rni "customers:customers" app/work-orders features/work-orders app/api/work-orders` and confirmed the Work Orders list no longer uses the embedded `customers:customers(...)` join while historical/other contexts remain unchanged.
- Type checking: ran `npx tsc --noEmit` and addressed introduced type/import issues; final `tsc` run completed without blocking errors.
- Ran `git diff --check` to ensure no diff-check problems (no failures).

Commit: `6df83b34302428e117863c4e890421aebc88b5da`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a239803e9ec83289b917ef05a3c7738)