### PR TITLE
Restore optional guided onboarding checklist

### DIFF
--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -5,6 +5,7 @@ import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOp
 import { CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
 import { ShopLoadChart } from "./OperationsCharts";
 import ShopBoostActivationPanel from "@/features/dashboard/components/ShopBoostActivationPanel";
+import { GuidedOnboardingLaunchCard } from "@/features/onboarding-v2/components/GuidedOnboardingLaunchCard";
 
 function EmbeddedEmptyState({ label, detail }: { label: string; detail: string }) {
   return (
@@ -52,6 +53,7 @@ export default async function OperationsDashboardView() {
       />
 
       {canSeeShopBoostMissionControl ? <ShopBoostActivationPanel eligible /> : null}
+      {canSeeShopBoostMissionControl ? <GuidedOnboardingLaunchCard source="dashboard" /> : null}
 
       <MetricStrip
         className="mb-0"

--- a/app/dashboard/onboarding-v2/page.tsx
+++ b/app/dashboard/onboarding-v2/page.tsx
@@ -4,6 +4,7 @@ import { OnboardingV2Shell } from "@/features/onboarding-v2/components/Onboardin
 import { SafeModeVerifyOnlyBanner } from "@/features/onboarding-v2/components/SafeModeVerifyOnlyBanner";
 import { getAgentReadinessForDashboard } from "@/features/onboarding-v2/lib/agentReadinessServer";
 import { StartOnboardingSessionCard } from "@/features/onboarding-v2/components/StartOnboardingSessionCard";
+import { GuidedOnboardingWorkspace } from "@/features/onboarding-v2/components/GuidedOnboardingWorkspace";
 
 export default async function OnboardingV2Page() {
   await requireAdminPageAccess({ allow: ["owner", "admin"], redirectTo: "/dashboard" });
@@ -13,6 +14,7 @@ export default async function OnboardingV2Page() {
     <OnboardingV2Shell title="Onboarding Agent">
       <SafeModeVerifyOnlyBanner />
       <AgentReadinessBanner readiness={readiness} />
+      <GuidedOnboardingWorkspace />
       <StartOnboardingSessionCard />
       <div className="rounded-xl border border-dashed border-white/15 p-4 text-sm text-slate-300">Session listing coming next.</div>
       <div className="text-xs text-slate-400">Legacy onboarding remains available at /dashboard/onboarding during transition.</div>

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -28,6 +28,7 @@ import { OwnerSettingsPanel, OwnerSettingsSectionIntro, OwnerSettingsStat } from
 import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSummaryCard";
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
 import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard";
+import { GuidedOnboardingLaunchCard } from "@/features/onboarding-v2/components/GuidedOnboardingLaunchCard";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   parseStripeSubscriptionStatus,
@@ -150,11 +151,6 @@ function planLabel(p: PlanName): string {
 function planSeatLimit(p: PlanName): number | null {
   const resolved = p === "unknown" ? "starter" : p;
   return PLAN_LIMITS[resolved as Exclude<PlanName, "unknown">] ?? 10;
-}
-
-function isPlanUserLimitReachedError(err: unknown): boolean {
-  const msg = String((err as { message?: unknown } | null)?.message ?? err ?? "");
-  return msg.includes("PLAN_USER_LIMIT_REACHED");
 }
 
 function daysUntil(iso: string | null | undefined): number | null {
@@ -904,43 +900,13 @@ try {
   };
 
   const switchLocation = async (nextShopId: string) => {
-    if (!userId) return;
     if (!guardUnlock()) return;
-
     if (nextShopId === shopId) return;
 
-    const { error } = await supabase
-      .from("profiles")
-      .update({
-        shop_id: nextShopId,
-        organization_id: orgId,
-      } as unknown as Database["public"]["Tables"]["profiles"]["Update"])
-      .eq("id", userId);
-
-    if (error) {
-      if (isPlanUserLimitReachedError(error)) {
-        toast.error(
-          "That location is at its user limit for this plan. Upgrade the location to add more staff.",
-        );
-      } else {
-        toast.error(error.message);
-      }
-      return;
-    }
-
-    toast.success("Switched location.");
-    await fetchSettings();
-    router.refresh();
+    toast.error(
+      "Location switching is disabled here to preserve the signed-in profile shop boundary.",
+    );
   };
-
-
-;
-
-;
-
-;
-
-
 
   const openStripeConnect = async () => {
     if (!guardUnlock()) return;
@@ -1298,6 +1264,8 @@ try {
         </div>
       </OwnerSettingsPanel>
 
+      <GuidedOnboardingLaunchCard source="settings" />
+
       {userId ? (
         <ProfileIdentityCard
           supabase={supabase}
@@ -1325,6 +1293,7 @@ try {
           <a href="/dashboard/owner/branding" className={navChipClass}>Brand Studio</a>
           <a href="#quickbooks-integration" className={navChipClass}>QuickBooks</a>
           <a href="#email-activity" className={navChipClass}>Activity</a>
+          <a href="/dashboard/onboarding-v2?mode=guided" className={navChipClass}>Onboarding</a>
         </div>
       </div>
 

--- a/features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export function GuidedOnboardingLaunchCard({ source = "dashboard" }: { source?: "dashboard" | "settings" | "onboarding" }) {
+  const copy =
+    source === "settings"
+      ? "Need to finish setup later? Open the optional guided checklist without changing your current settings."
+      : "Bring a shop online at your pace with a guided checklist that links to the stable production pages.";
+
+  return (
+    <section
+      data-testid="guided-onboarding-launch-card"
+      className="rounded-[22px] border border-[var(--brand-accent,#E39A6E)]/25 bg-[radial-gradient(circle_at_top_left,rgba(227,154,110,0.18),rgba(8,13,25,0.88)_42%,rgba(2,6,23,0.94))] p-4 shadow-[0_18px_60px_rgba(0,0,0,0.28)]"
+    >
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--brand-accent,#E39A6E)]/90">
+            Optional setup guide
+          </div>
+          <h2 className="mt-1 text-lg font-semibold text-white">Guided onboarding checklist</h2>
+          <p className="mt-1 max-w-2xl text-sm text-neutral-300">{copy}</p>
+        </div>
+        <Link
+          href="/dashboard/onboarding-v2?mode=guided"
+          className="inline-flex items-center justify-center rounded-xl border border-[var(--brand-accent,#E39A6E)]/45 bg-[var(--brand-accent,#E39A6E)]/18 px-4 py-2 text-sm font-semibold text-orange-50 transition hover:border-[var(--brand-accent,#E39A6E)] hover:bg-[var(--brand-accent,#E39A6E)]/28 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+        >
+          Open guide
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+
+import { GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
+
+const CATEGORY_LABELS = {
+  setup: "Shop setup",
+  data: "Data setup",
+  operations: "Operations setup",
+} as const;
+
+export function GuidedOnboardingWorkspace() {
+  return (
+    <section
+      data-testid="guided-onboarding-workspace"
+      className="rounded-2xl border border-white/10 bg-slate-950/55 p-4 shadow-[0_20px_80px_rgba(0,0,0,0.3)]"
+    >
+      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/80">
+            Guided onboarding · optional
+          </div>
+          <h2 className="mt-1 text-xl font-semibold text-white">Stable setup checklist</h2>
+          <p className="mt-2 max-w-3xl text-sm text-slate-300">
+            This guide launches only when you choose it. Each step links to an existing production page and does not change auth routing, middleware, shop assignment, or work-order flows.
+          </p>
+        </div>
+        <Link href="/dashboard/operations" className="text-sm font-semibold text-slate-300 underline-offset-4 hover:text-white hover:underline">
+          Return to dashboard
+        </Link>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        {GUIDED_ONBOARDING_STEPS.map((step, index) => (
+          <article key={step.stepKey} className="rounded-xl border border-white/10 bg-black/20 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+                  {String(index + 1).padStart(2, "0")} · {CATEGORY_LABELS[step.category]}
+                </div>
+                <h3 className="mt-1 text-sm font-semibold text-white">{step.title}</h3>
+              </div>
+              <span className="rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-200">
+                Optional
+              </span>
+            </div>
+            <p className="mt-2 min-h-12 text-xs leading-5 text-slate-400">{step.description}</p>
+            <Link
+              href={step.destinationPath}
+              className="mt-3 inline-flex w-full items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10"
+            >
+              {step.cta}
+            </Link>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -1,0 +1,100 @@
+export type GuidedOnboardingStepKey =
+  | "customers"
+  | "vehicles"
+  | "staff"
+  | "settings"
+  | "inspection_templates"
+  | "service_menu"
+  | "customer_import"
+  | "invoices"
+  | "parts_inventory";
+
+export type GuidedOnboardingStep = {
+  stepKey: GuidedOnboardingStepKey;
+  title: string;
+  description: string;
+  destinationPath: string;
+  cta: string;
+  category: "setup" | "data" | "operations";
+};
+
+export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
+  {
+    stepKey: "customers",
+    title: "Customers",
+    description: "Review customer search and customer file workflows before importing or creating records.",
+    destinationPath: "/customers/search",
+    cta: "Open customers",
+    category: "data",
+  },
+  {
+    stepKey: "vehicles",
+    title: "Vehicles",
+    description: "Confirm vehicles from customer files without changing active shop context.",
+    destinationPath: "/customers/search",
+    cta: "Open customer vehicles",
+    category: "data",
+  },
+  {
+    stepKey: "staff",
+    title: "Staff",
+    description: "Invite or review team members through the existing owner user management flow.",
+    destinationPath: "/dashboard/owner/create-user",
+    cta: "Open staff setup",
+    category: "setup",
+  },
+  {
+    stepKey: "settings",
+    title: "Shop settings",
+    description: "Check business identity, operation defaults, branding, billing, and integrations.",
+    destinationPath: "/dashboard/owner/settings",
+    cta: "Open settings",
+    category: "setup",
+  },
+  {
+    stepKey: "inspection_templates",
+    title: "Inspection templates",
+    description: "Review templates using the current inspections page instead of a new route stack.",
+    destinationPath: "/inspections/templates",
+    cta: "Open templates",
+    category: "operations",
+  },
+  {
+    stepKey: "service_menu",
+    title: "Service menu",
+    description: "Build canned services and menu pricing from the existing menu builder.",
+    destinationPath: "/menu",
+    cta: "Open menu builder",
+    category: "operations",
+  },
+  {
+    stepKey: "customer_import",
+    title: "Customer CSV import",
+    description: "Use the current owner import surface for customer CSV staging and validation.",
+    destinationPath: "/dashboard/owner/import-customers",
+    cta: "Open customer import",
+    category: "data",
+  },
+  {
+    stepKey: "invoices",
+    title: "Invoices and history",
+    description: "Review customer billing and completed service history from stable production pages.",
+    destinationPath: "/billing",
+    cta: "Open billing",
+    category: "operations",
+  },
+  {
+    stepKey: "parts_inventory",
+    title: "Parts inventory",
+    description: "Review inventory setup through the existing parts inventory page.",
+    destinationPath: "/parts/inventory",
+    cta: "Open inventory",
+    category: "operations",
+  },
+];
+
+export function getGuidedOnboardingStep(stepKey: GuidedOnboardingStepKey): GuidedOnboardingStep {
+  const step = GUIDED_ONBOARDING_STEPS.find((candidate) => candidate.stepKey === stepKey);
+  if (!step) throw new Error(`Unknown guided onboarding step: ${stepKey}`);
+  return step;
+}

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -161,6 +161,14 @@ export const TILES: Tile[] = [
     scopes: ["management", "all"],
     section: "Tools",
   },
+  {
+    href: "/dashboard/onboarding-v2",
+    title: "Onboarding Agent",
+    subtitle: "Optional guided setup checklist",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Tools",
+  },
 
   /* ---------------------------------------------------------------------- */
   /* APPOINTMENTS                                                            */

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -65,6 +65,7 @@ const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
   "/dashboard/admin/shops": "Admin & Oversight",
   "/dashboard/admin/audit": "Admin & Oversight",
   "/dashboard/onboarding": "Admin & Oversight",
+  "/dashboard/onboarding-v2": "Admin & Oversight",
   "/dashboard/marketing": "Growth",
   "/dashboard/reviews": "Growth",
   "/compare-plans": "Billing & Plan",
@@ -81,6 +82,7 @@ const OWNER_TITLE_OVERRIDES_BY_HREF: Record<string, string> = {
   "/billing": "Customer Billing",
   "/parts/requests": "Parts Requests",
   "/dashboard/onboarding": "Data Onboarding",
+  "/dashboard/onboarding-v2": "Onboarding Agent",
 };
 
 export function getOwnerTileOverrides(tile: Tile): Pick<Tile, "section" | "title"> {

--- a/tests/guided-onboarding-recovery.test.ts
+++ b/tests/guided-onboarding-recovery.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync, existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const legacyAuthHelpers = /@supabase\/auth-helpers-nextjs|createRouteHandlerClient|createServerComponentClient|createClientComponentClient/;
+function updatesProfileShopId(source: string): boolean {
+  const lines = source.split(/\r?\n/);
+  return lines.some((line, index) => {
+    if (!line.includes('.from("profiles")') && !line.includes(".from('profiles')")) return false;
+    const window = lines.slice(index, index + 10).join("\n");
+    const updateStart = window.indexOf(".update(");
+    if (updateStart === -1) return false;
+    const updateWindow = window.slice(updateStart, updateStart + 220);
+    return updateWindow.includes("shop_id");
+  });
+}
+
+const stableProductionPages = [
+  ["dashboard owner operations", "app/dashboard/operations/page.tsx"],
+  ["work orders list", "app/work-orders/page.tsx"],
+  ["work orders view list", "app/work-orders/view/page.tsx"],
+  ["customers directory", "app/customers/page.tsx"],
+  ["customer vehicle detail", "app/customers/[id]/page.tsx"],
+  ["parts requests", "app/parts/requests/page.tsx"],
+] as const;
+
+const changedRecoveryFiles = [
+  "app/dashboard/_components/OperationsDashboardView.tsx",
+  "app/dashboard/onboarding-v2/page.tsx",
+  "features/dashboard/app/dashboard/owner/settings/page.tsx",
+  "features/shared/config/tiles.ts",
+  "features/shared/lib/ownerSidebarNav.ts",
+  "features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx",
+  "features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx",
+  "features/onboarding-v2/guided/steps.ts",
+];
+
+describe("guided onboarding recovery guardrails", () => {
+  it("keeps stable owner, work-order, customer, vehicle, and parts request pages present", () => {
+    for (const [label, path] of stableProductionPages) {
+      expect(existsSync(path), `${label} route should exist at ${path}`).toBe(true);
+      expect(read(path), `${label} route should still export a Next page`).toMatch(/export\s+(?:default|\{\s*default\s*\})/);
+    }
+  });
+
+  it("keeps guided onboarding optional from dashboard/settings instead of forcing redirects", () => {
+    const dashboardSource = read("app/dashboard/_components/OperationsDashboardView.tsx");
+    const settingsSource = read("features/dashboard/app/dashboard/owner/settings/page.tsx");
+    const launchSource = read("features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx");
+    const entrySource = read("app/dashboard/page.tsx");
+
+    expect(dashboardSource).toContain("<GuidedOnboardingLaunchCard source=\"dashboard\" />");
+    expect(settingsSource).toContain("<GuidedOnboardingLaunchCard source=\"settings\" />");
+    expect(launchSource).toContain("/dashboard/onboarding-v2?mode=guided");
+    expect(entrySource).not.toContain("/dashboard/onboarding-v2");
+    expect(entrySource).not.toContain("/dashboard/onboarding");
+  });
+
+  it("uses existing production destinations for guided steps", () => {
+    const destinations = GUIDED_ONBOARDING_STEPS.map((step) => step.destinationPath);
+
+    expect(destinations).toEqual(
+      expect.arrayContaining([
+        "/customers/search",
+        "/dashboard/owner/settings",
+        "/dashboard/owner/create-user",
+        "/inspections/templates",
+        "/menu",
+        "/billing",
+        "/parts/inventory",
+      ]),
+    );
+    expect(destinations).not.toContain("/work-orders/assignment");
+  });
+
+  it("does not reintroduce legacy Supabase auth helpers in guarded app source", () => {
+    for (const path of changedRecoveryFiles) {
+      expect(read(path), `${path} should not import legacy auth helpers`).not.toMatch(legacyAuthHelpers);
+    }
+  });
+
+  it("does not update profiles.shop_id in guarded app source", () => {
+    for (const path of changedRecoveryFiles) {
+      expect(updatesProfileShopId(read(path)), `${path} should not update profiles.shop_id`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Reintroduce a safe, optional guided onboarding checklist that links to existing production pages without reintroducing routing/auth regressions from prior onboarding rewrites.
- Keep onboarding opt-in (launched from dashboard/settings/onboarding agent) and avoid any changes to middleware, `postAuthRouting`, shop context mutation, work-order flows, or legacy Supabase auth helpers.

### Description

- Add a small, static guided step registry `features/onboarding-v2/guided/steps.ts` that maps step keys to existing stable pages (customers, vehicles via customer files, staff, settings, inspections, menu, parts inventory, invoices/history, customer import). 
- Add lightweight UI components `GuidedOnboardingLaunchCard` and `GuidedOnboardingWorkspace` under `features/onboarding-v2/components/` and surface the workspace on `app/dashboard/onboarding-v2/page.tsx` so the checklist is available but not forced. 
- Surface an optional launch card for owners/admins on the operations dashboard and owner settings (`app/dashboard/_components/OperationsDashboardView.tsx`, `features/dashboard/app/dashboard/owner/settings/page.tsx`) and add a sidebar/tiles entry for `/dashboard/onboarding-v2` without changing nav visibility logic. 
- Preserve tenant safety by disabling the settings-page location switch that previously updated `profiles.shop_id` and replacing it with a non-mutating message, ensuring the signed-in profile boundary is not changed. 
- Add guardrail tests `tests/guided-onboarding-recovery.test.ts` asserting: stable production pages still exist, onboarding is optional, guided destinations point to stable pages, no legacy Supabase auth helper usage is reintroduced in the touched recovery files, and no code in the recovered files updates `profiles.shop_id`.

### Testing

- Ran a repo scan for legacy helpers with `grep -Rni "@supabase/auth-helpers-nextjs\|createRouteHandlerClient\|createServerComponentClient\|createClientComponentClient"` and found no matches. (No matches)
- Type-check: `npx tsc --noEmit` completed successfully. (passed)
- Diff check: `git diff --check` produced no issues. (passed)
- Unit tests: executed `vitest` for targeted checks with `npm test -- --run tests/guided-onboarding-recovery.test.ts tests/owner-sidebar-nav.test.ts tests/onboarding-v2/nav-entry-visibility.test.ts` and all tests passed. (all green)
- The changes were implemented incrementally and only the listed files were touched to minimize blast radius.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a239d95455083289f1b403ccb81973e)