### PR TITLE
Recover optional guided data onboarding

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -6,6 +6,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { toast } from "sonner";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -319,6 +320,7 @@ export default function BillingPage(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 text-foreground">
+      <GuidedOnboardingStepCard stepKey="invoices_history" surface="billing" />
       <section className="overflow-hidden rounded-[28px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_0_50px_rgba(2,6,23,0.55)]">
         <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(56,189,248,0.12),rgba(15,23,42,0.03))] px-5 py-5 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -13,6 +13,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { useUser } from "@auth/hooks/useUser";
 import { toast } from "sonner";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 
 import { PartPicker, type PickedPart } from "@parts/components/PartPicker";
 import { masterServicesList } from "@inspections/lib/inspection/masterServicesList";
@@ -588,6 +589,7 @@ export default function MenuItemsPage() {
 
   return (
     <div className="relative space-y-8 fade-in">
+      <GuidedOnboardingStepCard stepKey="service_menu" surface="service_menu" />
       {/* Copper wash (was orange) */}
       <div
         aria-hidden

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -3,9 +3,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 import type { Database } from "@shared/types/types/supabase";
 import { v4 as uuidv4 } from "uuid";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import {
   buildPartTrustMeta,
   trustBadgeTone,
@@ -275,6 +277,7 @@ async function applyStockMoveRPC(
 
 export default function InventoryPage(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const searchParams = useSearchParams();
   const [shopId, setShopId] = useState<string>("");
 
   const [search, setSearch] = useState<string>("");
@@ -505,6 +508,12 @@ export default function InventoryPage(): JSX.Element {
     },
     [supabase, shopId, locs],
   );
+
+  useEffect(() => {
+    if (searchParams.get("import") === "csv" && shopId) {
+      setCsvOpen(true);
+    }
+  }, [searchParams, shopId]);
 
   /* boot */
   useEffect(() => {
@@ -796,6 +805,7 @@ export default function InventoryPage(): JSX.Element {
 
   return (
     <div className={pageWrap}>
+      <GuidedOnboardingStepCard stepKey="parts_inventory" surface="parts_inventory" />
       <div className={`${glassCard} overflow-hidden`}>
         <div className={`${glassHeader} px-5 py-4`}>
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -7,6 +7,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 
 type DB = Database;
 
@@ -689,23 +690,7 @@ export default function CustomerProfilePage(): JSX.Element {
       .maybeSingle();
 
     if (ownedShop.error) throw ownedShop.error;
-    if (!ownedShop.data?.id) return null;
-
-    const updByUserId = await supabase
-      .from("profiles")
-      .update({ shop_id: ownedShop.data.id })
-      .eq("user_id", userId);
-
-    if (updByUserId.error) {
-      const updById = await supabase
-        .from("profiles")
-        .update({ shop_id: ownedShop.data.id })
-        .eq("id", userId);
-
-      if (updById.error) throw updById.error;
-    }
-
-    return ownedShop.data.id;
+    return ownedShop.data?.id ?? null;
   }, [supabase]);
 
   const createCustomer = useCallback(async () => {
@@ -1444,6 +1429,8 @@ export default function CustomerProfilePage(): JSX.Element {
   if (!effectiveCustomerId) {
     return (
       <PageShell>
+        <GuidedOnboardingStepCard stepKey="customers" surface="customers" className="mb-4" />
+        <GuidedOnboardingStepCard stepKey="vehicles" surface="vehicles" className="mb-4" />
         <div className={`${CARD_BASE} p-4`}>
           <div className="text-sm text-neutral-200">This route expects a customer id.</div>
           <div className="mt-2 text-xs text-neutral-400">
@@ -1467,6 +1454,8 @@ export default function CustomerProfilePage(): JSX.Element {
   return (
     <PageShell>
       <TopBar rightLabel="Customer File" onBack={() => router.back()} />
+      <GuidedOnboardingStepCard stepKey="customers" surface="customers" className="mb-4" />
+      <GuidedOnboardingStepCard stepKey="vehicles" surface="vehicles" className="mb-4" />
 
       {viewError && (
         <div className="mb-4 whitespace-pre-wrap rounded-2xl border border-red-500/35 bg-red-950/50 p-3 text-sm text-red-200 shadow-[0_18px_45px_rgba(0,0,0,0.75)]">

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import UsersList from "@/features/admin/components/UsersList";
 import InviteCandidatesList from "@/features/admin/components/InviteCandidatesList";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
@@ -246,6 +247,7 @@ export default function CreateUserPage(): JSX.Element {
       title="Create User (Access Provisioning)"
       description="Provision account access, assign the initial role, and link the person to your shop. Complete workforce/profile setup in People."
     >
+      <GuidedOnboardingStepCard stepKey="staff" surface="staff" className="mb-6" />
       {/* top 2-column content */}
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         {/* LEFT: create user */}

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -3,6 +3,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
@@ -29,6 +30,7 @@ import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSu
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
 import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard";
 import { GuidedOnboardingLaunchCard } from "@/features/onboarding-v2/components/GuidedOnboardingLaunchCard";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   parseStripeSubscriptionStatus,
@@ -1265,6 +1267,7 @@ try {
       </OwnerSettingsPanel>
 
       <GuidedOnboardingLaunchCard source="settings" />
+      <GuidedOnboardingStepCard stepKey="settings" surface="settings" />
 
       {userId ? (
         <ProfileIdentityCard
@@ -1290,10 +1293,10 @@ try {
           <a href="#hours-settings" className={navChipClass}>Hours</a>
           <a href="#timeoff-settings" className={navChipClass}>Time off</a>
           <a href="#billing-stripe" className={navChipClass}>Billing</a>
-          <a href="/dashboard/owner/branding" className={navChipClass}>Brand Studio</a>
+          <Link href="/dashboard/owner/branding" className={navChipClass}>Brand Studio</Link>
           <a href="#quickbooks-integration" className={navChipClass}>QuickBooks</a>
           <a href="#email-activity" className={navChipClass}>Activity</a>
-          <a href="/dashboard/onboarding-v2?mode=guided" className={navChipClass}>Onboarding</a>
+          <Link href="/dashboard/onboarding-v2?mode=guided" className={navChipClass}>Onboarding</Link>
         </div>
       </div>
 

--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import FleetFormImportCard from "@/features/inspections/components/FleetFormImportCard";
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
 
 type DB = Database;
 type Template = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -185,6 +186,7 @@ export default function InspectionTemplatesPage() {
   return (
     <div className="px-4 py-6 text-white">
       <div className="mx-auto w-full max-w-6xl space-y-5">
+        <GuidedOnboardingStepCard stepKey="inspection_templates" surface="inspection_templates" />
         {/* Atmospheric page wash */}
         <div
           aria-hidden

--- a/features/onboarding-v2/components/GuidedOnboardingStepCard.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingStepCard.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  canRoleUseGuidedOnboardingStep,
+  getGuidedOnboardingStep,
+  getGuidedOnboardingStepStatus,
+  type GuidedOnboardingStepKey,
+  type GuidedOnboardingStepStatus,
+} from "@/features/onboarding-v2/guided/steps";
+import { useUser } from "@/features/auth/hooks/useUser";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+
+type GuidedOnboardingStepCardProps = {
+  stepKey: GuidedOnboardingStepKey;
+  surface: "customers" | "vehicles" | "staff" | "settings" | "inspection_templates" | "service_menu" | "parts_inventory" | "billing";
+  className?: string;
+};
+
+type StatusState = {
+  status: GuidedOnboardingStepStatus;
+  detail: string;
+};
+
+const STATUS_COPY: Record<GuidedOnboardingStepStatus, { label: string; className: string }> = {
+  complete: { label: "Looks ready", className: "border-emerald-400/30 bg-emerald-500/10 text-emerald-100" },
+  in_progress: { label: "Started", className: "border-sky-400/30 bg-sky-500/10 text-sky-100" },
+  not_started: { label: "Optional", className: "border-orange-300/30 bg-orange-400/10 text-orange-100" },
+  unknown: { label: "Optional", className: "border-slate-400/25 bg-white/5 text-slate-200" },
+};
+
+function dismissalKey(stepKey: GuidedOnboardingStepKey, shopId: string | null | undefined): string {
+  return `profixiq:onboarding-card:${shopId ?? "no-shop"}:${stepKey}`;
+}
+
+async function countRowsForStep(
+  supabase: ReturnType<typeof createBrowserSupabase>,
+  stepKey: GuidedOnboardingStepKey,
+  shopId: string | null,
+): Promise<number | null> {
+  const filterShop = <T extends { eq: (column: string, value: string) => T }>(query: T): T =>
+    shopId ? query.eq("shop_id", shopId) : query;
+
+  switch (stepKey) {
+    case "customers": {
+      const { count, error } = await filterShop(supabase.from("customers").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "vehicles": {
+      const { count, error } = await filterShop(supabase.from("vehicles").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "staff": {
+      const { count, error } = await filterShop(supabase.from("profiles").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "inspection_templates": {
+      const { count, error } = await filterShop(supabase.from("inspection_templates").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "service_menu": {
+      const { count, error } = await filterShop(supabase.from("menu_items").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "parts_inventory": {
+      const { count, error } = await filterShop(supabase.from("parts").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "invoices_history": {
+      const base = supabase.from("work_orders").select("id", { count: "exact", head: true }).in("status", ["completed", "ready_to_invoice", "invoiced"]);
+      const { count, error } = await filterShop(base);
+      return error ? null : count ?? 0;
+    }
+    case "fleet_history_import": {
+      const { count, error } = await filterShop(supabase.from("history").select("id", { count: "exact", head: true }));
+      return error ? null : count ?? 0;
+    }
+    case "settings":
+      return null;
+    default:
+      return null;
+  }
+}
+
+export function GuidedOnboardingStepCard({ stepKey, surface, className = "" }: GuidedOnboardingStepCardProps) {
+  const step = getGuidedOnboardingStep(stepKey);
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const { user, isLoading } = useUser();
+  const [dismissed, setDismissed] = useState(false);
+  const [state, setState] = useState<StatusState>({ status: "unknown", detail: "Checking setup state…" });
+
+  const key = useMemo(() => dismissalKey(stepKey, user?.shop_id), [stepKey, user?.shop_id]);
+  const canSee = canRoleUseGuidedOnboardingStep(user?.role, step);
+
+  useEffect(() => {
+    setDismissed(window.localStorage.getItem(key) === "dismissed");
+  }, [key]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStatus() {
+      if (!user?.shop_id || !canSee) return;
+
+      if (step.dataSource.kind === "shop_settings") {
+        const readyCount = step.dataSource.fields.filter((field) => {
+          const value = user.shops?.[field];
+          return typeof value === "number" && Number.isFinite(value) && value > 0;
+        }).length;
+        const nextStatus = readyCount === step.dataSource.fields.length ? "complete" : readyCount > 0 ? "in_progress" : "not_started";
+        if (!cancelled) {
+          setState({ status: nextStatus, detail: `${readyCount}/${step.dataSource.fields.length} defaults set` });
+        }
+        return;
+      }
+
+      if (step.dataSource.kind === "import_flow") {
+        if (!cancelled) {
+          setState({ status: step.dataSource.supported ? "in_progress" : "unknown", detail: step.dataSource.label });
+        }
+        return;
+      }
+
+      const count = await countRowsForStep(supabase, stepKey, user.shop_id);
+      if (!cancelled) {
+        setState({
+          status: getGuidedOnboardingStepStatus(count, step.dataSource.completeAt),
+          detail: count == null ? `Could not verify ${step.dataSource.label}` : `${count.toLocaleString()} ${step.dataSource.label}`,
+        });
+      }
+    }
+
+    void loadStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [canSee, step, stepKey, supabase, user]);
+
+  if (isLoading || !canSee || dismissed) return null;
+
+  const badge = STATUS_COPY[state.status];
+
+  return (
+    <section
+      data-testid={`guided-onboarding-step-card-${stepKey}`}
+      data-onboarding-optional="true"
+      data-onboarding-surface={surface}
+      className={`rounded-2xl border border-[var(--brand-accent,#E39A6E)]/25 bg-[radial-gradient(circle_at_top_left,rgba(227,154,110,0.14),rgba(15,23,42,0.72)_48%,rgba(2,6,23,0.88))] p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] ${className}`}
+    >
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--brand-accent,#E39A6E)]/85">
+            Optional guided onboarding
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold text-white">{step.title}</h2>
+            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badge.className}`}>
+              {badge.label}
+            </span>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-slate-300">{step.description}</p>
+          <div className="mt-2 text-xs text-slate-400">{state.detail}</div>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {step.importLaunch?.stable ? (
+            <Link
+              href={step.importLaunch.href}
+              className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-[var(--brand-accent,#E39A6E)]/12"
+            >
+              {step.importLaunch.label}
+            </Link>
+          ) : null}
+          <Link
+            href={`/dashboard/onboarding-v2?mode=guided&step=${encodeURIComponent(step.stepKey)}`}
+            className="inline-flex items-center justify-center rounded-xl border border-[var(--brand-accent,#E39A6E)]/45 bg-[var(--brand-accent,#E39A6E)]/18 px-3 py-2 text-xs font-semibold text-orange-50 transition hover:border-[var(--brand-accent,#E39A6E)] hover:bg-[var(--brand-accent,#E39A6E)]/28"
+          >
+            Open guide
+          </Link>
+          <button
+            type="button"
+            onClick={() => {
+              window.localStorage.setItem(key, "dismissed");
+              setDismissed(true);
+            }}
+            className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs font-semibold text-slate-300 transition hover:bg-white/5 hover:text-white"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -40,10 +40,21 @@ export function GuidedOnboardingWorkspace() {
                 <h3 className="mt-1 text-sm font-semibold text-white">{step.title}</h3>
               </div>
               <span className="rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-200">
-                Optional
+                Optional UI
               </span>
             </div>
             <p className="mt-2 min-h-12 text-xs leading-5 text-slate-400">{step.description}</p>
+            <div className="mt-2 rounded-lg border border-white/10 bg-white/[0.03] px-2 py-1 text-[11px] text-slate-400">
+              State source: {step.dataSource.label}
+            </div>
+            {step.importLaunch?.stable ? (
+              <Link
+                href={step.importLaunch.href}
+                className="mt-2 inline-flex w-full items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10"
+              >
+                {step.importLaunch.label}
+              </Link>
+            ) : null}
             <Link
               href={step.destinationPath}
               className="mt-3 inline-flex w-full items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10"

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -1,3 +1,5 @@
+import type { Database } from "@shared/types/types/supabase";
+
 export type GuidedOnboardingStepKey =
   | "customers"
   | "vehicles"
@@ -5,9 +7,45 @@ export type GuidedOnboardingStepKey =
   | "settings"
   | "inspection_templates"
   | "service_menu"
-  | "customer_import"
-  | "invoices"
-  | "parts_inventory";
+  | "parts_inventory"
+  | "invoices_history"
+  | "fleet_history_import";
+
+export type GuidedOnboardingStepCategory = "setup" | "data" | "operations";
+export type GuidedOnboardingStepStatus = "complete" | "in_progress" | "not_started" | "unknown";
+export type GuidedOnboardingRole = "owner" | "admin" | "manager" | "service_advisor" | "mechanic" | "tech";
+
+type PublicTables = Database["public"]["Tables"];
+export type GuidedOnboardingCountTable = keyof Pick<
+  PublicTables,
+  "customers" | "vehicles" | "profiles" | "inspection_templates" | "menu_items" | "parts" | "work_orders" | "history"
+>;
+
+export type GuidedOnboardingDataSource =
+  | {
+      kind: "table_count";
+      table: GuidedOnboardingCountTable;
+      label: string;
+      completeAt: number;
+      shopScoped?: boolean;
+    }
+  | {
+      kind: "shop_settings";
+      label: string;
+      fields: Array<"labor_rate" | "tax_rate" | "supplies_percent">;
+    }
+  | {
+      kind: "import_flow";
+      label: string;
+      supported: boolean;
+    };
+
+export type GuidedOnboardingImportLaunch = {
+  label: string;
+  href: string;
+  domains: Array<"customers" | "vehicles" | "parts" | "history" | "invoices" | "fleet">;
+  stable: boolean;
+};
 
 export type GuidedOnboardingStep = {
   stepKey: GuidedOnboardingStepKey;
@@ -15,8 +53,14 @@ export type GuidedOnboardingStep = {
   description: string;
   destinationPath: string;
   cta: string;
-  category: "setup" | "data" | "operations";
+  category: GuidedOnboardingStepCategory;
+  allowedRoles: GuidedOnboardingRole[];
+  optional: true;
+  dataSource: GuidedOnboardingDataSource;
+  importLaunch?: GuidedOnboardingImportLaunch;
 };
+
+const OWNER_ADMIN: GuidedOnboardingRole[] = ["owner", "admin"];
 
 export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
   {
@@ -26,6 +70,15 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
     destinationPath: "/customers/search",
     cta: "Open customers",
     category: "data",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "customers", label: "customer records", completeAt: 1 },
+    importLaunch: {
+      label: "Launch customer CSV import",
+      href: "/dashboard/owner/import-customers",
+      domains: ["customers"],
+      stable: true,
+    },
   },
   {
     stepKey: "vehicles",
@@ -34,6 +87,15 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
     destinationPath: "/customers/search",
     cta: "Open customer vehicles",
     category: "data",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "vehicles", label: "vehicle records", completeAt: 1 },
+    importLaunch: {
+      label: "Launch guided CSV workspace",
+      href: "/dashboard/onboarding-v2?mode=guided&step=vehicles",
+      domains: ["vehicles"],
+      stable: true,
+    },
   },
   {
     stepKey: "staff",
@@ -42,14 +104,20 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
     destinationPath: "/dashboard/owner/create-user",
     cta: "Open staff setup",
     category: "setup",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "profiles", label: "team profiles", completeAt: 2 },
   },
   {
     stepKey: "settings",
-    title: "Shop settings",
+    title: "Labor, tax, and shop settings",
     description: "Check business identity, operation defaults, branding, billing, and integrations.",
     destinationPath: "/dashboard/owner/settings",
     cta: "Open settings",
     category: "setup",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "shop_settings", label: "labor/tax defaults", fields: ["labor_rate", "tax_rate", "supplies_percent"] },
   },
   {
     stepKey: "inspection_templates",
@@ -58,6 +126,9 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
     destinationPath: "/inspections/templates",
     cta: "Open templates",
     category: "operations",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "inspection_templates", label: "inspection templates", completeAt: 1 },
   },
   {
     stepKey: "service_menu",
@@ -66,22 +137,9 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
     destinationPath: "/menu",
     cta: "Open menu builder",
     category: "operations",
-  },
-  {
-    stepKey: "customer_import",
-    title: "Customer CSV import",
-    description: "Use the current owner import surface for customer CSV staging and validation.",
-    destinationPath: "/dashboard/owner/import-customers",
-    cta: "Open customer import",
-    category: "data",
-  },
-  {
-    stepKey: "invoices",
-    title: "Invoices and history",
-    description: "Review customer billing and completed service history from stable production pages.",
-    destinationPath: "/billing",
-    cta: "Open billing",
-    category: "operations",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "menu_items", label: "service menu items", completeAt: 1 },
   },
   {
     stepKey: "parts_inventory",
@@ -90,6 +148,43 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStep[] = [
     destinationPath: "/parts/inventory",
     cta: "Open inventory",
     category: "operations",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "parts", label: "inventory parts", completeAt: 1 },
+    importLaunch: {
+      label: "Open parts CSV import",
+      href: "/parts/inventory?import=csv",
+      domains: ["parts"],
+      stable: true,
+    },
+  },
+  {
+    stepKey: "invoices_history",
+    title: "Invoices and history",
+    description: "Review customer billing and completed service history from stable production pages.",
+    destinationPath: "/billing",
+    cta: "Open billing",
+    category: "operations",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "work_orders", label: "invoice-ready work orders", completeAt: 1 },
+  },
+  {
+    stepKey: "fleet_history_import",
+    title: "Fleet and service history import",
+    description: "Use the guided workspace for supported fleet/history imports without forcing onboarding sessions.",
+    destinationPath: "/dashboard/onboarding-v2?mode=guided&step=fleet_history_import",
+    cta: "Open guided workspace",
+    category: "data",
+    allowedRoles: OWNER_ADMIN,
+    optional: true,
+    dataSource: { kind: "table_count", table: "history", label: "history records", completeAt: 1 },
+    importLaunch: {
+      label: "Launch guided import workspace",
+      href: "/dashboard/onboarding-v2?mode=guided&step=fleet_history_import",
+      domains: ["history", "invoices", "fleet"],
+      stable: true,
+    },
   },
 ];
 
@@ -97,4 +192,16 @@ export function getGuidedOnboardingStep(stepKey: GuidedOnboardingStepKey): Guide
   const step = GUIDED_ONBOARDING_STEPS.find((candidate) => candidate.stepKey === stepKey);
   if (!step) throw new Error(`Unknown guided onboarding step: ${stepKey}`);
   return step;
+}
+
+export function canRoleUseGuidedOnboardingStep(role: string | null | undefined, step: GuidedOnboardingStep): boolean {
+  if (!role) return false;
+  return step.allowedRoles.includes(role as GuidedOnboardingRole);
+}
+
+export function getGuidedOnboardingStepStatus(count: number | null | undefined, completeAt: number): GuidedOnboardingStepStatus {
+  if (count == null) return "unknown";
+  if (count >= completeAt) return "complete";
+  if (count > 0) return "in_progress";
+  return "not_started";
 }

--- a/tests/guided-onboarding-recovery.test.ts
+++ b/tests/guided-onboarding-recovery.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync, existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-import { GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
+import {
+  canRoleUseGuidedOnboardingStep,
+  GUIDED_ONBOARDING_STEPS,
+} from "@/features/onboarding-v2/guided/steps";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
@@ -24,44 +27,80 @@ const stableProductionPages = [
   ["work orders view list", "app/work-orders/view/page.tsx"],
   ["customers directory", "app/customers/page.tsx"],
   ["customer vehicle detail", "app/customers/[id]/page.tsx"],
-  ["parts requests", "app/parts/requests/page.tsx"],
+  ["parts inventory", "app/parts/inventory/page.tsx"],
 ] as const;
 
-const changedRecoveryFiles = [
-  "app/dashboard/_components/OperationsDashboardView.tsx",
-  "app/dashboard/onboarding-v2/page.tsx",
+const unchangedRoutingFiles = ["middleware.ts", "features/auth/lib/postAuthRouting.ts"] as const;
+
+const guardedRecoveryFiles = [
+  "app/billing/page.tsx",
+  "app/menu/page.tsx",
+  "app/parts/inventory/page.tsx",
+  "features/customers/app/customers/[id]/page.tsx",
+  "features/dashboard/app/dashboard/owner/create-user/page.tsx",
   "features/dashboard/app/dashboard/owner/settings/page.tsx",
-  "features/shared/config/tiles.ts",
-  "features/shared/lib/ownerSidebarNav.ts",
+  "features/inspections/app/inspection/templates/page.tsx",
   "features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx",
+  "features/onboarding-v2/components/GuidedOnboardingStepCard.tsx",
   "features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx",
   "features/onboarding-v2/guided/steps.ts",
 ];
 
+const stableLoaderExpectations = [
+  ["work orders", "app/work-orders/page.tsx", /from\("work_orders"\)|from\('work_orders'\)|WorkOrders/],
+  ["customers", "features/customers/app/customers/[id]/page.tsx", /from\("customers"\)|from\('customers'/],
+  ["vehicles", "features/customers/app/customers/[id]/page.tsx", /from\("vehicles"\)|from\('vehicles'/],
+  ["parts", "app/parts/inventory/page.tsx", /from\("parts"\)|from\('parts'/],
+] as const;
+
 describe("guided onboarding recovery guardrails", () => {
-  it("keeps stable owner, work-order, customer, vehicle, and parts request pages present", () => {
+  it("keeps stable owner, work-order, customer, vehicle, and parts pages present", () => {
     for (const [label, path] of stableProductionPages) {
       expect(existsSync(path), `${label} route should exist at ${path}`).toBe(true);
       expect(read(path), `${label} route should still export a Next page`).toMatch(/export\s+(?:default|\{\s*default\s*\})/);
     }
   });
 
-  it("keeps guided onboarding optional from dashboard/settings instead of forcing redirects", () => {
+  it("keeps middleware and post-auth routing out of the onboarding recovery", () => {
+    for (const path of unchangedRoutingFiles) {
+      expect(existsSync(path), `${path} should exist for routing guardrails`).toBe(true);
+      expect(read(path), `${path} must not import guided onboarding`).not.toMatch(/onboarding-v2|GuidedOnboarding|mode=guided/);
+    }
+  });
+
+  it("keeps guided onboarding optional from existing pages instead of forcing redirects", () => {
     const dashboardSource = read("app/dashboard/_components/OperationsDashboardView.tsx");
     const settingsSource = read("features/dashboard/app/dashboard/owner/settings/page.tsx");
     const launchSource = read("features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx");
     const entrySource = read("app/dashboard/page.tsx");
+    const cardSource = read("features/onboarding-v2/components/GuidedOnboardingStepCard.tsx");
 
     expect(dashboardSource).toContain("<GuidedOnboardingLaunchCard source=\"dashboard\" />");
     expect(settingsSource).toContain("<GuidedOnboardingLaunchCard source=\"settings\" />");
     expect(launchSource).toContain("/dashboard/onboarding-v2?mode=guided");
+    expect(cardSource).toContain('data-onboarding-optional="true"');
+    expect(cardSource).toContain("setDismissed(true)");
     expect(entrySource).not.toContain("/dashboard/onboarding-v2");
     expect(entrySource).not.toContain("/dashboard/onboarding");
   });
 
-  it("uses existing production destinations for guided steps", () => {
+  it("uses existing production destinations and data-backed state for guided steps", () => {
     const destinations = GUIDED_ONBOARDING_STEPS.map((step) => step.destinationPath);
+    const stepKeys = GUIDED_ONBOARDING_STEPS.map((step) => step.stepKey);
 
+    expect(stepKeys).toEqual(
+      expect.arrayContaining([
+        "customers",
+        "vehicles",
+        "staff",
+        "settings",
+        "inspection_templates",
+        "service_menu",
+        "parts_inventory",
+        "invoices_history",
+        "fleet_history_import",
+      ]),
+    );
     expect(destinations).toEqual(
       expect.arrayContaining([
         "/customers/search",
@@ -74,16 +113,44 @@ describe("guided onboarding recovery guardrails", () => {
       ]),
     );
     expect(destinations).not.toContain("/work-orders/assignment");
+    expect(GUIDED_ONBOARDING_STEPS.every((step) => step.optional)).toBe(true);
+    expect(GUIDED_ONBOARDING_STEPS.every((step) => step.dataSource.label.length > 0)).toBe(true);
+  });
+
+  it("adds onboarding cards as optional UI on requested existing pages", () => {
+    expect(read("features/customers/app/customers/[id]/page.tsx")).toContain('stepKey="customers"');
+    expect(read("features/customers/app/customers/[id]/page.tsx")).toContain('stepKey="vehicles"');
+    expect(read("features/dashboard/app/dashboard/owner/create-user/page.tsx")).toContain('stepKey="staff"');
+    expect(read("features/dashboard/app/dashboard/owner/settings/page.tsx")).toContain('stepKey="settings"');
+    expect(read("features/inspections/app/inspection/templates/page.tsx")).toContain('stepKey="inspection_templates"');
+    expect(read("app/menu/page.tsx")).toContain('stepKey="service_menu"');
+    expect(read("app/parts/inventory/page.tsx")).toContain('stepKey="parts_inventory"');
+    expect(read("app/billing/page.tsx")).toContain('stepKey="invoices_history"');
+  });
+
+  it("keeps stable page data loading paths in place", () => {
+    for (const [label, path, pattern] of stableLoaderExpectations) {
+      expect(read(path), `${label} loader should still use its production table path`).toMatch(pattern);
+    }
+  });
+
+  it("allows owner/admin onboarding cards while hiding them from tech/mechanic by default", () => {
+    const ownerStep = GUIDED_ONBOARDING_STEPS.find((step) => step.stepKey === "settings");
+    expect(ownerStep).toBeTruthy();
+    expect(canRoleUseGuidedOnboardingStep("owner", ownerStep!)).toBe(true);
+    expect(canRoleUseGuidedOnboardingStep("admin", ownerStep!)).toBe(true);
+    expect(canRoleUseGuidedOnboardingStep("tech", ownerStep!)).toBe(false);
+    expect(canRoleUseGuidedOnboardingStep("mechanic", ownerStep!)).toBe(false);
   });
 
   it("does not reintroduce legacy Supabase auth helpers in guarded app source", () => {
-    for (const path of changedRecoveryFiles) {
+    for (const path of guardedRecoveryFiles) {
       expect(read(path), `${path} should not import legacy auth helpers`).not.toMatch(legacyAuthHelpers);
     }
   });
 
-  it("does not update profiles.shop_id in guarded app source", () => {
-    for (const path of changedRecoveryFiles) {
+  it("does not update profiles.shop_id in onboarding recovery source", () => {
+    for (const path of guardedRecoveryFiles) {
       expect(updatesProfileShopId(read(path)), `${path} should not update profiles.shop_id`).toBe(false);
     }
   });


### PR DESCRIPTION
### Motivation
- Restore the optional guided onboarding checklist and re-introduce lightweight, non-blocking onboarding UI on key production pages so owners/admins can run a guided data setup without changing routing or reintroducing previous regressions.

### Description
- Extend the guided onboarding registry with data-backed step metadata, role gating, import launch hints, and status helpers in `features/onboarding-v2/guided/steps.ts` for: customers, vehicles, staff, labor/tax/settings, inspection templates, service menu, parts inventory, invoices/history, and fleet/history import.
- Add a reusable, client-side `GuidedOnboardingStepCard` component that: shows shop-scoped counts/settings, computes a compact status (complete/in_progress/not_started/unknown), is owner/admin gated, is optional/dismissible via localStorage, and links into the guided workspace without forcing redirects (`features/onboarding-v2/components/GuidedOnboardingStepCard.tsx`).
- Surface optional onboarding cards layered onto existing production pages (no blocking or forced redirects): customers page, customer file (vehicles) view, staff/create-user, owner settings, inspection templates, service menu, parts inventory (with CSV import launch), and billing/history; each card uses stable links to production pages and safe existing import entry points.
- Update the guided workspace UI to display each step’s declared state source and show stable import launch CTAs where supported (`features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx`).
- Remove a legacy profile mutation that previously updated `profiles.shop_id` from the customer page resolution code and ensure the pages keep their original data-loading paths and RLS patterns untouched.
- Maintain the hard constraints: middleware and post-auth routing were not changed, `profiles.shop_id` is not mutated, no reintroduction of `@supabase/auth-helpers-nextjs`, and onboarding remains optional and owner/admin visible only.

### Testing
- Ran typecheck: `npx tsc --noEmit` — succeeded.
- Unit/guardrail tests: `npx vitest run tests/guided-onboarding-recovery.test.ts` — all tests passed (9/9) verifying optional behavior, destinations, role gating, no legacy auth helpers, no profile shop_id updates, and unchanged routing surfaces.
- Lint: `npx eslint ...` run over onboarding files and touched pages to ensure Next linking rules and component imports — issues were fixed and lint succeeded for the checked files.

Files changed (high-level): `features/onboarding-v2/guided/steps.ts`, `features/onboarding-v2/components/GuidedOnboardingStepCard.tsx`, `features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx`, and lightweight UI inserts on customers, vehicles, staff/create-user, owner settings, inspection templates, service menu, parts inventory, billing pages, plus updated guardrail tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24cc870b348328996654c2f70556d9)