### PR TITLE
Recover optional guided onboarding safely

### DIFF
--- a/app/api/onboarding-v2/guided/status/route.ts
+++ b/app/api/onboarding-v2/guided/status/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+
+import {
+  GUIDED_ONBOARDING_STEPS,
+  getGuidedOnboardingStepStatus,
+  type GuidedOnboardingStepKey,
+  type GuidedOnboardingStepStatus,
+} from "@/features/onboarding-v2/guided/steps";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+type StepStatusPayload = {
+  stepKey: GuidedOnboardingStepKey;
+  status: GuidedOnboardingStepStatus;
+  detail: string;
+};
+
+type QueryWithShopFilter = {
+  eq: (column: string, value: string) => QueryWithShopFilter;
+};
+
+function withShop<T extends QueryWithShopFilter>(query: T, shopId: string): T {
+  return query.eq("shop_id", shopId) as T;
+}
+
+export async function GET() {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id, role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 500 });
+  }
+
+  if (!profile?.shop_id) {
+    return NextResponse.json({ shopId: null, steps: [] satisfies StepStatusPayload[] });
+  }
+
+  const shopId = profile.shop_id;
+  const steps = await Promise.all(
+    GUIDED_ONBOARDING_STEPS.map(async (step): Promise<StepStatusPayload> => {
+      if (step.dataSource.kind === "shop_settings") {
+        const { data: shop } = await supabase
+          .from("shops")
+          .select(step.dataSource.fields.join(","))
+          .eq("id", shopId)
+          .maybeSingle();
+        const readyCount = step.dataSource.fields.filter((field) => {
+          const value = shop?.[field as keyof typeof shop];
+          return typeof value === "number" && Number.isFinite(value) && value > 0;
+        }).length;
+        return {
+          stepKey: step.stepKey,
+          status: readyCount === step.dataSource.fields.length ? "complete" : readyCount > 0 ? "in_progress" : "not_started",
+          detail: `${readyCount}/${step.dataSource.fields.length} defaults set`,
+        };
+      }
+
+      if (step.dataSource.kind !== "table_count") {
+        return { stepKey: step.stepKey, status: "unknown", detail: step.dataSource.label };
+      }
+
+      const query = supabase.from(step.dataSource.table).select("id", { count: "exact", head: true });
+      const { count, error } = await withShop(query, shopId);
+      const nextCount = error ? null : count ?? 0;
+      return {
+        stepKey: step.stepKey,
+        status: getGuidedOnboardingStepStatus(nextCount, step.dataSource.completeAt),
+        detail: nextCount == null ? `Could not verify ${step.dataSource.label}` : `${nextCount.toLocaleString()} ${step.dataSource.label}`,
+      };
+    }),
+  );
+
+  return NextResponse.json({ shopId, role: profile.role ?? null, steps });
+}

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -6,7 +6,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { toast } from "sonner";
-import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { InvoicesOnboardingSetupCard } from "@/features/invoices/components/InvoicesOnboardingSetupCard";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -320,7 +320,7 @@ export default function BillingPage(): JSX.Element {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 text-foreground">
-      <GuidedOnboardingStepCard stepKey="invoices_history" surface="billing" />
+      <InvoicesOnboardingSetupCard />
       <section className="overflow-hidden rounded-[28px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_0_50px_rgba(2,6,23,0.55)]">
         <div className="border-b border-[color:var(--desktop-border)] bg-[linear-gradient(180deg,rgba(56,189,248,0.12),rgba(15,23,42,0.03))] px-5 py-5 sm:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -13,7 +13,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { useUser } from "@auth/hooks/useUser";
 import { toast } from "sonner";
-import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { ServiceMenuOnboardingSetupCard } from "@/features/menu/components/ServiceMenuOnboardingSetupCard";
 
 import { PartPicker, type PickedPart } from "@parts/components/PartPicker";
 import { masterServicesList } from "@inspections/lib/inspection/masterServicesList";
@@ -589,7 +589,7 @@ export default function MenuItemsPage() {
 
   return (
     <div className="relative space-y-8 fade-in">
-      <GuidedOnboardingStepCard stepKey="service_menu" surface="service_menu" />
+      <ServiceMenuOnboardingSetupCard />
       {/* Copper wash (was orange) */}
       <div
         aria-hidden

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -6,6 +6,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
 import type { Database } from "@shared/types/types/supabase";
 import { fmtCustomerName, fmtVehicle, formatMoneyLike, historyTitle, parseHistoryNotes } from "./historyDisplay";
+import { ServiceHistoryOnboardingSetupCard } from "@/features/work-orders/components/history/ServiceHistoryOnboardingSetupCard";
 
 type DB = Database;
 type HistoryRow = DB["public"]["Tables"]["history"]["Row"];
@@ -80,7 +81,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
     const a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = `service-history-${Date.now()}.csv`; a.click();
   }
 
-  return <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_34%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.06),transparent_32%),#050914] px-4 py-6 text-white"><div className="mx-auto max-w-6xl space-y-4">{/* existing controls kept */}
+  return <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_34%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.06),transparent_32%),#050914] px-4 py-6 text-white"><div className="mx-auto max-w-6xl space-y-4"><ServiceHistoryOnboardingSetupCard />{/* existing controls kept */}
     <section className="rounded-[26px] border border-slate-700/60 bg-slate-950/70 px-4 py-5 shadow-[0_18px_48px_rgba(2,6,23,0.58)] sm:px-6 sm:py-6">
       <div className="mb-3 flex flex-wrap items-end gap-3"><input value={q} onChange={(e)=>setQ(e.target.value)} onKeyDown={(e)=>e.key==="Enter"&&load()} placeholder="Customer, VIN, WO, invoice, total, notes…" className="min-w-[220px] flex-1 rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"/><input type="date" value={from} onChange={(e)=>setFrom(e.target.value)} className="rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"/><input type="date" value={to} onChange={(e)=>setTo(e.target.value)} className="rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"/><button onClick={load} className="rounded-full border border-slate-700/70 px-3 py-1.5 text-xs">Apply</button><button onClick={exportCSV} className="rounded-full border border-sky-400/35 bg-sky-500/10 px-3 py-1.5 text-xs">Export CSV</button></div>
       {err ? <div className="mb-4 rounded-xl border border-red-500/60 bg-red-950/80 px-4 py-2 text-sm text-red-100">{err}</div> : null}

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -7,7 +7,8 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import { format } from "date-fns";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
-import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { CustomerOnboardingSetupCard } from "@/features/customers/components/CustomerOnboardingSetupCard";
+import { VehicleOnboardingSetupCard } from "@/features/customers/components/VehicleOnboardingSetupCard";
 
 type DB = Database;
 
@@ -1429,8 +1430,8 @@ export default function CustomerProfilePage(): JSX.Element {
   if (!effectiveCustomerId) {
     return (
       <PageShell>
-        <GuidedOnboardingStepCard stepKey="customers" surface="customers" className="mb-4" />
-        <GuidedOnboardingStepCard stepKey="vehicles" surface="vehicles" className="mb-4" />
+        <CustomerOnboardingSetupCard className="mb-4" />
+        <VehicleOnboardingSetupCard className="mb-4" />
         <div className={`${CARD_BASE} p-4`}>
           <div className="text-sm text-neutral-200">This route expects a customer id.</div>
           <div className="mt-2 text-xs text-neutral-400">
@@ -1454,8 +1455,8 @@ export default function CustomerProfilePage(): JSX.Element {
   return (
     <PageShell>
       <TopBar rightLabel="Customer File" onBack={() => router.back()} />
-      <GuidedOnboardingStepCard stepKey="customers" surface="customers" className="mb-4" />
-      <GuidedOnboardingStepCard stepKey="vehicles" surface="vehicles" className="mb-4" />
+      <CustomerOnboardingSetupCard className="mb-4" />
+      <VehicleOnboardingSetupCard className="mb-4" />
 
       {viewError && (
         <div className="mb-4 whitespace-pre-wrap rounded-2xl border border-red-500/35 bg-red-950/50 p-3 text-sm text-red-200 shadow-[0_18px_45px_rgba(0,0,0,0.75)]">

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import { parseCsv, type CsvParseResult } from "@/features/vehicles/lib/importCsv";
+
+type CustomerCsvImportCardProps = {
+  className?: string;
+  onParsed?: (result: CsvParseResult) => void;
+};
+
+const SAMPLE_HEADERS = ["customer_name", "first_name", "last_name", "email", "phone", "street", "city", "state", "zip"];
+
+export function CustomerCsvImportCard({ className = "", onParsed }: CustomerCsvImportCardProps) {
+  const [result, setResult] = useState<CsvParseResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File | null) {
+    setError(null);
+    setResult(null);
+    if (!file) return;
+    try {
+      const parsed = parseCsv(await file.text());
+      if (parsed.headers.length === 0) throw new Error("CSV must include a header row.");
+      setResult(parsed);
+      onParsed?.(parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to parse CSV.");
+    }
+  }
+
+  return (
+    <OnboardingHighlightFrame
+      title="Customer CSV import prep"
+      description="Preview customer CSV headers before launching the stable owner import workflow. This optional card does not change auth routing or active shop context."
+      className={className}
+    >
+      <div className="space-y-3">
+        <input
+          type="file"
+          accept=".csv,text/csv"
+          onChange={(event) => void handleFile(event.target.files?.[0] ?? null)}
+          className="block w-full rounded-xl border border-slate-700/70 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 file:mr-3 file:rounded-full file:border-0 file:bg-orange-400/15 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-orange-100"
+        />
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-slate-300">
+          Suggested headers: {SAMPLE_HEADERS.join(", ")}
+        </div>
+        {error ? <div className="rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{error}</div> : null}
+        {result ? (
+          <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-3 text-sm text-emerald-100">
+            Parsed {result.rows.length.toLocaleString()} rows. <Link href="/dashboard/owner/import-customers" className="underline">Continue to import</Link>
+          </div>
+        ) : null}
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default CustomerCsvImportCard;

--- a/features/customers/components/CustomerOnboardingSetupCard.tsx
+++ b/features/customers/components/CustomerOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type CustomerOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function CustomerOnboardingSetupCard({ className = "" }: CustomerOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Customer onboarding" description="Optionally review customer records or launch imports without changing customer page loading." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="customers" surface="customers" />
+        <Link
+          href="/customers/search"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open customer setup
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default CustomerOnboardingSetupCard;

--- a/features/customers/components/VehicleOnboardingSetupCard.tsx
+++ b/features/customers/components/VehicleOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type VehicleOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function VehicleOnboardingSetupCard({ className = "" }: VehicleOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Vehicle onboarding" description="Optionally review vehicle data from the stable customer workflow." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="vehicles" surface="vehicles" />
+        <Link
+          href="/customers/search"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open vehicle setup
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default VehicleOnboardingSetupCard;

--- a/features/dashboard/app/dashboard/owner/create-user/StaffOnboardingSetupCard.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/StaffOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type StaffOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function StaffOnboardingSetupCard({ className = "" }: StaffOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Staff onboarding" description="Invite or review users from the existing owner staff tools." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="staff" surface="staff" />
+        <Link
+          href="/dashboard/owner/create-user"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open staff setup
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default StaffOnboardingSetupCard;

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import UsersList from "@/features/admin/components/UsersList";
 import InviteCandidatesList from "@/features/admin/components/InviteCandidatesList";
-import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { StaffOnboardingSetupCard } from "@/features/dashboard/app/dashboard/owner/create-user/StaffOnboardingSetupCard";
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
@@ -247,7 +247,7 @@ export default function CreateUserPage(): JSX.Element {
       title="Create User (Access Provisioning)"
       description="Provision account access, assign the initial role, and link the person to your shop. Complete workforce/profile setup in People."
     >
-      <GuidedOnboardingStepCard stepKey="staff" surface="staff" className="mb-6" />
+      <StaffOnboardingSetupCard className="mb-6" />
       {/* top 2-column content */}
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         {/* LEFT: create user */}

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -30,7 +30,7 @@ import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSu
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
 import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard";
 import { GuidedOnboardingLaunchCard } from "@/features/onboarding-v2/components/GuidedOnboardingLaunchCard";
-import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { SettingsOnboardingSetupCard } from "@/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   parseStripeSubscriptionStatus,
@@ -1267,7 +1267,7 @@ try {
       </OwnerSettingsPanel>
 
       <GuidedOnboardingLaunchCard source="settings" />
-      <GuidedOnboardingStepCard stepKey="settings" surface="settings" />
+      <SettingsOnboardingSetupCard />
 
       {userId ? (
         <ProfileIdentityCard

--- a/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard.tsx
+++ b/features/dashboard/components/owner-settings/SettingsOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type SettingsOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function SettingsOnboardingSetupCard({ className = "" }: SettingsOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Settings onboarding" description="Check labor, tax, branding, billing, and integration setup from this stable settings page." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="settings" surface="settings" />
+        <Link
+          href="/dashboard/onboarding-v2?mode=guided&step=settings"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open settings checklist
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default SettingsOnboardingSetupCard;

--- a/features/inspections/app/inspection/templates/page.tsx
+++ b/features/inspections/app/inspection/templates/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import FleetFormImportCard from "@/features/inspections/components/FleetFormImportCard";
-import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { InspectionTemplatesOnboardingSetupCard } from "@/features/inspections/components/InspectionTemplatesOnboardingSetupCard";
 
 type DB = Database;
 type Template = DB["public"]["Tables"]["inspection_templates"]["Row"];
@@ -186,7 +186,7 @@ export default function InspectionTemplatesPage() {
   return (
     <div className="px-4 py-6 text-white">
       <div className="mx-auto w-full max-w-6xl space-y-5">
-        <GuidedOnboardingStepCard stepKey="inspection_templates" surface="inspection_templates" />
+        <InspectionTemplatesOnboardingSetupCard />
         {/* Atmospheric page wash */}
         <div
           aria-hidden

--- a/features/inspections/components/InspectionTemplatesOnboardingSetupCard.tsx
+++ b/features/inspections/components/InspectionTemplatesOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type InspectionTemplatesOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function InspectionTemplatesOnboardingSetupCard({ className = "" }: InspectionTemplatesOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Inspection template onboarding" description="Optionally seed or verify templates while preserving the current inspection templates page." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="inspection_templates" surface="inspection_templates" />
+        <Link
+          href="/inspections/templates"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open templates
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default InspectionTemplatesOnboardingSetupCard;

--- a/features/invoices/components/InvoicesOnboardingSetupCard.tsx
+++ b/features/invoices/components/InvoicesOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type InvoicesOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function InvoicesOnboardingSetupCard({ className = "" }: InvoicesOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Invoice history onboarding" description="Review invoice-ready work and service history from stable billing pages." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="invoices_history" surface="billing" />
+        <Link
+          href="/dashboard/onboarding-v2?mode=guided&step=invoices_history"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open guided history step
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default InvoicesOnboardingSetupCard;

--- a/features/menu/components/ServiceMenuOnboardingSetupCard.tsx
+++ b/features/menu/components/ServiceMenuOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type ServiceMenuOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function ServiceMenuOnboardingSetupCard({ className = "" }: ServiceMenuOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Service menu onboarding" description="Optionally build canned services and menu pricing from the existing menu builder." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="service_menu" surface="service_menu" />
+        <Link
+          href="/menu"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open menu builder
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default ServiceMenuOnboardingSetupCard;

--- a/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
+++ b/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+type OnboardingHighlightFrameProps = {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+};
+
+export function OnboardingHighlightFrame({
+  eyebrow = "Guided onboarding",
+  title = "Optional setup assistant",
+  description = "Use this card when you want guided data setup. It does not redirect sign-in, switch shops, or change production workflows.",
+  children,
+  className = "",
+}: OnboardingHighlightFrameProps) {
+  return (
+    <section
+      data-onboarding-optional="true"
+      className={`rounded-2xl border border-orange-300/20 bg-[linear-gradient(135deg,rgba(15,23,42,0.88),rgba(2,6,23,0.96))] p-4 shadow-[0_24px_70px_rgba(0,0,0,0.42)] ${className}`}
+    >
+      <div className="mb-3">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-orange-200/80">{eyebrow}</div>
+        <h2 className="mt-1 text-base font-semibold text-white">{title}</h2>
+        <p className="mt-1 text-sm leading-6 text-slate-300">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+import { parseCsv, type CsvParseResult } from "@/features/vehicles/lib/importCsv";
+import { VEHICLE_ONBOARDING_SAMPLE_HEADERS } from "@/features/vehicles/lib/guided";
+
+type VehicleCsvImportCardProps = {
+  className?: string;
+  onParsed?: (result: CsvParseResult) => void;
+};
+
+export function VehicleCsvImportCard({ className = "", onParsed }: VehicleCsvImportCardProps) {
+  const [result, setResult] = useState<CsvParseResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File | null) {
+    setError(null);
+    setResult(null);
+    if (!file) return;
+    try {
+      const parsed = parseCsv(await file.text());
+      if (parsed.headers.length === 0) throw new Error("CSV must include a header row.");
+      setResult(parsed);
+      onParsed?.(parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to parse CSV.");
+    }
+  }
+
+  return (
+    <OnboardingHighlightFrame
+      title="Vehicle CSV import prep"
+      description="Preview vehicle CSV headers before using guided onboarding import routes. Parsing happens in the browser and does not mutate shop context."
+      className={className}
+    >
+      <div className="space-y-3">
+        <input
+          type="file"
+          accept=".csv,text/csv"
+          onChange={(event) => void handleFile(event.target.files?.[0] ?? null)}
+          className="block w-full rounded-xl border border-slate-700/70 bg-slate-950/80 px-3 py-2 text-sm text-slate-200 file:mr-3 file:rounded-full file:border-0 file:bg-orange-400/15 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-orange-100"
+        />
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-slate-300">
+          Suggested headers: {VEHICLE_ONBOARDING_SAMPLE_HEADERS.join(", ")}
+        </div>
+        {error ? <div className="rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{error}</div> : null}
+        {result ? (
+          <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-3 text-sm text-emerald-100">
+            Parsed {result.rows.length.toLocaleString()} rows with {result.headers.length.toLocaleString()} headers.
+          </div>
+        ) : null}
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default VehicleCsvImportCard;

--- a/features/vehicles/components/VehicleOnboardingSetupCard.tsx
+++ b/features/vehicles/components/VehicleOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type VehicleOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function VehicleOnboardingSetupCard({ className = "" }: VehicleOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Vehicle onboarding" description="Use stable customer and vehicle records while optionally preparing CSV data." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="vehicles" surface="vehicles" />
+        <Link
+          href="/customers/search"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open vehicle setup
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default VehicleOnboardingSetupCard;

--- a/features/vehicles/lib/guided.ts
+++ b/features/vehicles/lib/guided.ts
@@ -1,0 +1,15 @@
+import { getGuidedOnboardingStep } from "@/features/onboarding-v2/guided/steps";
+
+export const VEHICLE_GUIDED_ONBOARDING_STEP = getGuidedOnboardingStep("vehicles");
+
+export const VEHICLE_ONBOARDING_SAMPLE_HEADERS = [
+  "customer_name",
+  "email",
+  "phone",
+  "year",
+  "make",
+  "model",
+  "vin",
+  "license_plate",
+  "unit_number",
+];

--- a/features/vehicles/lib/importCsv.ts
+++ b/features/vehicles/lib/importCsv.ts
@@ -1,0 +1,58 @@
+export type CsvRow = Record<string, string>;
+
+export type CsvParseResult = {
+  headers: string[];
+  rows: CsvRow[];
+  skippedBlankRows: number;
+};
+
+function parseLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let quoted = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const next = line[index + 1];
+
+    if (char === '"' && quoted && next === '"') {
+      current += '"';
+      index += 1;
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else if (char === "," && !quoted) {
+      cells.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  cells.push(current.trim());
+  return cells;
+}
+
+export function parseCsv(text: string): CsvParseResult {
+  const lines = text.replace(/^\uFEFF/, "").split(/\r?\n/);
+  const headerLine = lines.shift() ?? "";
+  const headers = parseLine(headerLine).map((header) => header.trim()).filter(Boolean);
+  let skippedBlankRows = 0;
+  const rows = lines.reduce<CsvRow[]>((acc, line) => {
+    if (!line.trim()) {
+      skippedBlankRows += 1;
+      return acc;
+    }
+    const cells = parseLine(line);
+    const row = headers.reduce<CsvRow>((next, header, index) => {
+      next[header] = cells[index]?.trim() ?? "";
+      return next;
+    }, {});
+    acc.push(row);
+    return acc;
+  }, []);
+  return { headers, rows, skippedBlankRows };
+}
+
+export function normalizeCsvHeader(header: string): string {
+  return header.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}

--- a/features/vehicles/lib/importCustomers.ts
+++ b/features/vehicles/lib/importCustomers.ts
@@ -1,0 +1,66 @@
+import type { Database } from "@shared/types/types/supabase";
+import { normalizeCsvHeader, type CsvRow } from "./importCsv";
+
+type CustomerInsert = Database["public"]["Tables"]["customers"]["Insert"];
+type VehicleInsert = Database["public"]["Tables"]["vehicles"]["Insert"];
+
+function pick(row: CsvRow, names: string[]): string | null {
+  const normalized = new Map(Object.entries(row).map(([key, value]) => [normalizeCsvHeader(key), value.trim()]));
+  for (const name of names) {
+    const value = normalized.get(name);
+    if (value) return value;
+  }
+  return null;
+}
+
+function numberOrNull(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function mapCustomerCsvRow(row: CsvRow, shopId: string, userId: string): CustomerInsert {
+  const firstName = pick(row, ["first_name", "first", "customer_first_name"]);
+  const lastName = pick(row, ["last_name", "last", "customer_last_name"]);
+  const businessName = pick(row, ["business_name", "company", "fleet", "customer_company"]);
+  const inferredName = [firstName, lastName].filter(Boolean).join(" ");
+  const name = pick(row, ["name", "customer", "customer_name"]) ?? (inferredName || businessName);
+
+  return {
+    shop_id: shopId,
+    user_id: userId,
+    first_name: firstName,
+    last_name: lastName,
+    business_name: businessName,
+    name: name ?? null,
+    email: pick(row, ["email", "customer_email"]),
+    phone: pick(row, ["phone", "phone_number", "customer_phone"]),
+    phone_number: pick(row, ["phone_number", "phone", "customer_phone"]),
+    street: pick(row, ["street", "address", "address_1"]),
+    city: pick(row, ["city"]),
+    province: pick(row, ["province", "state"]),
+    postal_code: pick(row, ["postal_code", "zip", "zip_code"]),
+    external_id: pick(row, ["external_id", "customer_id", "customer_number"]),
+    import_confidence: 0.86,
+    import_notes: "Guided onboarding CSV mapping",
+  };
+}
+
+export function mapVehicleCsvRow(row: CsvRow, shopId: string, userId: string, customerId?: string | null): VehicleInsert {
+  return {
+    shop_id: shopId,
+    user_id: userId,
+    customer_id: customerId ?? null,
+    year: numberOrNull(pick(row, ["year", "vehicle_year"])),
+    make: pick(row, ["make", "vehicle_make"]),
+    model: pick(row, ["model", "vehicle_model"]),
+    submodel: pick(row, ["submodel", "trim"]),
+    vin: pick(row, ["vin", "vehicle_vin"]),
+    license_plate: pick(row, ["license_plate", "plate", "tag"]),
+    unit_number: pick(row, ["unit_number", "unit", "fleet_unit"]),
+    mileage: pick(row, ["mileage", "odometer"]),
+    external_id: pick(row, ["vehicle_id", "vehicle_external_id"]),
+    import_confidence: 0.86,
+    import_notes: "Guided onboarding CSV mapping",
+  };
+}

--- a/features/work-orders/components/history/ServiceHistoryOnboardingSetupCard.tsx
+++ b/features/work-orders/components/history/ServiceHistoryOnboardingSetupCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { GuidedOnboardingStepCard } from "@/features/onboarding-v2/components/GuidedOnboardingStepCard";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type ServiceHistoryOnboardingSetupCardProps = {
+  className?: string;
+};
+
+export function ServiceHistoryOnboardingSetupCard({ className = "" }: ServiceHistoryOnboardingSetupCardProps) {
+  return (
+    <OnboardingHighlightFrame title="Service history onboarding" description="Optionally import or review historical service data without changing work-order assignment flows." className={className}>
+      <div className="space-y-3">
+        <GuidedOnboardingStepCard stepKey="fleet_history_import" surface="billing" />
+        <Link
+          href="/dashboard/onboarding-v2?mode=guided&step=fleet_history_import"
+          className="inline-flex rounded-full border border-orange-300/30 bg-orange-400/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-orange-100 transition hover:border-orange-200/60 hover:bg-orange-400/20"
+        >
+          Open guided history import
+        </Link>
+      </div>
+    </OnboardingHighlightFrame>
+  );
+}
+
+export default ServiceHistoryOnboardingSetupCard;

--- a/tests/guided-onboarding-recovery.test.ts
+++ b/tests/guided-onboarding-recovery.test.ts
@@ -43,7 +43,9 @@ const guardedRecoveryFiles = [
   "features/onboarding-v2/components/GuidedOnboardingLaunchCard.tsx",
   "features/onboarding-v2/components/GuidedOnboardingStepCard.tsx",
   "features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx",
+  "features/onboarding-v2/components/OnboardingHighlightFrame.tsx",
   "features/onboarding-v2/guided/steps.ts",
+  "app/api/onboarding-v2/guided/status/route.ts",
 ];
 
 const stableLoaderExpectations = [
@@ -118,14 +120,15 @@ describe("guided onboarding recovery guardrails", () => {
   });
 
   it("adds onboarding cards as optional UI on requested existing pages", () => {
-    expect(read("features/customers/app/customers/[id]/page.tsx")).toContain('stepKey="customers"');
-    expect(read("features/customers/app/customers/[id]/page.tsx")).toContain('stepKey="vehicles"');
-    expect(read("features/dashboard/app/dashboard/owner/create-user/page.tsx")).toContain('stepKey="staff"');
-    expect(read("features/dashboard/app/dashboard/owner/settings/page.tsx")).toContain('stepKey="settings"');
-    expect(read("features/inspections/app/inspection/templates/page.tsx")).toContain('stepKey="inspection_templates"');
-    expect(read("app/menu/page.tsx")).toContain('stepKey="service_menu"');
+    expect(read("features/customers/app/customers/[id]/page.tsx")).toContain("CustomerOnboardingSetupCard");
+    expect(read("features/customers/app/customers/[id]/page.tsx")).toContain("VehicleOnboardingSetupCard");
+    expect(read("features/dashboard/app/dashboard/owner/create-user/page.tsx")).toContain("StaffOnboardingSetupCard");
+    expect(read("features/dashboard/app/dashboard/owner/settings/page.tsx")).toContain("SettingsOnboardingSetupCard");
+    expect(read("features/inspections/app/inspection/templates/page.tsx")).toContain("InspectionTemplatesOnboardingSetupCard");
+    expect(read("app/menu/page.tsx")).toContain("ServiceMenuOnboardingSetupCard");
     expect(read("app/parts/inventory/page.tsx")).toContain('stepKey="parts_inventory"');
-    expect(read("app/billing/page.tsx")).toContain('stepKey="invoices_history"');
+    expect(read("app/billing/page.tsx")).toContain("InvoicesOnboardingSetupCard");
+    expect(read("app/work-orders/history/WorkOrdersHistoryClient.tsx")).toContain("ServiceHistoryOnboardingSetupCard");
   });
 
   it("keeps stable page data loading paths in place", () => {


### PR DESCRIPTION
### Motivation
- Restore the optional guided/data onboarding surfaces and CSV import helpers from the historic commit while avoiding previously-introduced regressions that affected auth, shop context, dashboard, work orders, and assignment flows.
- Keep onboarding strictly opt-in and preserve the current stable production auth and Supabase helper patterns.

### Description
- Restored a shop-scoped onboarding status route using the canonical server helper (`createServerSupabaseRoute`) at `app/api/onboarding-v2/guided/status/route.ts` so status checks run server-side without legacy auth-helper imports.
- Added a shared opt-in highlight frame `features/onboarding-v2/components/OnboardingHighlightFrame.tsx` and restored onboarding setup cards and CSV preview/import helpers for customers, vehicles, staff, settings, inspections, invoices/history, menu, and service history under `features/*/components` and `features/vehicles/lib` while keeping them purely optional UI wrappers that link to existing stable pages.
- Integrated the optional onboarding cards into stable production pages (only UI insertion) so production data-loading and routing are unchanged in: `app/billing/page.tsx`, `app/menu/page.tsx`, `app/parts/inventory/page.tsx`, `app/work-orders/history/WorkOrdersHistoryClient.tsx`, `features/customers/app/customers/[id]/page.tsx`, `features/dashboard/app/dashboard/owner/create-user/page.tsx`, `features/dashboard/app/dashboard/owner/settings/page.tsx`, and `features/inspections/app/inspection/templates/page.tsx`.
- Implemented client-side CSV parsing and mapping helpers (`features/vehicles/lib/importCsv.ts`, `features/vehicles/lib/importCustomers.ts`, `features/vehicles/lib/guided.ts`) to preview imports in the browser without mutating shop or profile state.
- Ensured no legacy Supabase auth helpers or deprecated create* helper usages were reintroduced and avoided any profile.shop_id mutation or shop-switch behavior in the restored onboarding code.

### Testing
- Verified no forbidden legacy Supabase helpers were added with: `grep -Rni "@supabase/auth-helpers-nextjs\|createRouteHandlerClient\|createServerComponentClient\|createClientComponentClient\|createServerActionClient" app features components lib middleware.ts` — no matches found.
- Verified onboarding recovery sources contain no profile shop mutation with targeted grep over restored onboarding files — no matches found in the restored files.
- Typecheck: ran `npx tsc --noEmit --pretty false` and it succeeded.
- Unit tests: ran `npx vitest` for the relevant suites and they passed: `tests/guided-onboarding-recovery.test.ts` (all tests passed) and the smoke and related regression tests (`tests/smoke.test.ts`, `tests/dashboard-server-context.test.ts`, `tests/user-auth-normalization.test.ts`, `features/work-orders/lib/display/linePresentation.test.ts`, `tests/work-order-closeout-gate-preview.test.ts`, `tests/work-order-closeout-risk-rules.test.ts`) all passed; onboarding-v2 related tests also passed (`tests/onboarding-v2-signing.test.ts`, `tests/onboarding-v2/nav-entry-visibility.test.ts`, `tests/onboarding-v2/readiness-server.test.ts`, `tests/onboarding-v2/session-proxy-contract.test.ts`).

All tests reported green in CI-local runs; no regressions to auth, shop context, dashboard, work-orders, or assignment flows were detected from the added onboarding artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d445d1d483288e7b9b1a3faf44a5)