### PR TITLE
Restore guided onboarding session workspace

### DIFF
--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { isGuidedOnboardingStepKey, loadGuidedOnboardingSession, updateGuidedOnboardingSession } from "@/features/onboarding-v2/server/guidedSessions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const UpdateGuidedSessionSchema = z.object({
+  title: z.string().trim().min(1).max(120).optional(),
+  notes: z.string().max(2000).nullable().optional(),
+  existingSystem: z.string().trim().min(1).max(80).nullable().optional(),
+  currentStepKey: z.string().optional(),
+});
+
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function GET(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId } = await context.params;
+  try {
+    const session = await loadGuidedOnboardingSession(access.supabase, { shopId, sessionId });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not load guided onboarding session" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const { sessionId } = await context.params;
+  const parsed = UpdateGuidedSessionSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: "Invalid guided onboarding session update" }, { status: 400 });
+
+  const currentStepKey = isGuidedOnboardingStepKey(parsed.data.currentStepKey) ? parsed.data.currentStepKey : null;
+
+  try {
+    const session = await updateGuidedOnboardingSession(access.supabase, {
+      shopId,
+      sessionId,
+      title: parsed.data.title,
+      notes: parsed.data.notes,
+      existingSystem: parsed.data.existingSystem,
+      currentStepKey,
+    });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not update guided onboarding session" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { isGuidedOnboardingStepKey, updateGuidedOnboardingStep } from "@/features/onboarding-v2/server/guidedSessions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const AnswerSchema = z.object({ answers: z.record(z.string(), z.unknown()).optional() });
+type RouteContext = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+  const { sessionId, stepKey } = await context.params;
+  if (!isGuidedOnboardingStepKey(stepKey)) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+  const parsed = AnswerSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: "Invalid guided onboarding step answer" }, { status: 400 });
+
+  try {
+    const session = await updateGuidedOnboardingStep(access.supabase, { shopId, sessionId, stepKey, action: "answer", answers: parsed.data.answers });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not save guided onboarding step answer" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { isGuidedOnboardingStepKey, updateGuidedOnboardingStep } from "@/features/onboarding-v2/server/guidedSessions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+  const { sessionId, stepKey } = await context.params;
+  if (!isGuidedOnboardingStepKey(stepKey)) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+
+  try {
+    const session = await updateGuidedOnboardingStep(access.supabase, { shopId, sessionId, stepKey, action: "complete" });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not complete guided onboarding step" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { isGuidedOnboardingStepKey, updateGuidedOnboardingStep } from "@/features/onboarding-v2/server/guidedSessions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function POST(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+  const { sessionId, stepKey } = await context.params;
+  if (!isGuidedOnboardingStepKey(stepKey)) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+
+  try {
+    const session = await updateGuidedOnboardingStep(access.supabase, { shopId, sessionId, stepKey, action: "skip" });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not skip guided onboarding step" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { isGuidedOnboardingStepKey, loadGuidedOnboardingSession, updateGuidedOnboardingStep } from "@/features/onboarding-v2/server/guidedSessions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const StepStatusSchema = z.object({ status: z.enum(["not_started", "in_progress", "complete", "skipped"]) });
+type RouteContext = { params: Promise<{ sessionId: string; stepKey: string }> };
+
+export async function GET(_: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+  const { sessionId, stepKey } = await context.params;
+  if (!isGuidedOnboardingStepKey(stepKey)) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+
+  try {
+    const session = await loadGuidedOnboardingSession(access.supabase, { shopId, sessionId });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ stepKey, state: session.guided.steps[stepKey] ?? null });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not load guided onboarding step status" }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+  const { sessionId, stepKey } = await context.params;
+  if (!isGuidedOnboardingStepKey(stepKey)) return NextResponse.json({ error: "Unknown guided onboarding step" }, { status: 400 });
+  const parsed = StepStatusSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: "Invalid guided onboarding step status" }, { status: 400 });
+
+  try {
+    const session = await updateGuidedOnboardingStep(access.supabase, { shopId, sessionId, stepKey, action: "status", status: parsed.data.status });
+    if (!session) return NextResponse.json({ error: "Guided onboarding session not found" }, { status: 404 });
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not update guided onboarding step status" }, { status: 500 });
+  }
+}

--- a/app/api/onboarding-v2/guided/sessions/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { isGuidedOnboardingStepKey, createGuidedOnboardingSession, listGuidedOnboardingSessions } from "@/features/onboarding-v2/server/guidedSessions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const CreateGuidedSessionSchema = z.object({
+  title: z.string().trim().min(1).max(120).optional(),
+  existingSystem: z.string().trim().min(1).max(80).nullable().optional(),
+  currentStepKey: z.string().optional(),
+});
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  try {
+    const sessions = await listGuidedOnboardingSessions(access.supabase, shopId);
+    return NextResponse.json({ sessions });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not load guided onboarding sessions" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Missing shop context" }, { status: 403 });
+
+  const parsed = CreateGuidedSessionSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ error: "Invalid guided onboarding session request" }, { status: 400 });
+
+  const currentStepKey = isGuidedOnboardingStepKey(parsed.data.currentStepKey) ? parsed.data.currentStepKey : null;
+
+  try {
+    const session = await createGuidedOnboardingSession(access.supabase, {
+      shopId,
+      userId: access.profile.id,
+      title: parsed.data.title,
+      existingSystem: parsed.data.existingSystem ?? null,
+      currentStepKey,
+    });
+    return NextResponse.json({ session }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Could not create guided onboarding session" }, { status: 500 });
+  }
+}

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -1,6 +1,10 @@
-import Link from "next/link";
+"use client";
 
-import { GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import { GUIDED_ONBOARDING_STEPS, type GuidedOnboardingStepKey, type GuidedOnboardingStepStatus } from "@/features/onboarding-v2/guided/steps";
+import type { GuidedOnboardingSessionPayload, GuidedStepSessionStatus } from "@/features/onboarding-v2/guided/sessionTypes";
 
 const CATEGORY_LABELS = {
   setup: "Shop setup",
@@ -8,7 +12,141 @@ const CATEGORY_LABELS = {
   operations: "Operations setup",
 } as const;
 
+const EXISTING_SYSTEM_CHOICES = ["None / new shop", "Shop-Ware", "Tekmetric", "Mitchell", "QuickBooks", "Fleetio", "Other"] as const;
+
+const STATUS_COPY: Record<GuidedStepSessionStatus | GuidedOnboardingStepStatus, { label: string; className: string }> = {
+  complete: { label: "Complete", className: "border-emerald-400/30 bg-emerald-500/10 text-emerald-100" },
+  in_progress: { label: "In progress", className: "border-sky-400/30 bg-sky-500/10 text-sky-100" },
+  not_started: { label: "Not started", className: "border-orange-300/30 bg-orange-400/10 text-orange-100" },
+  skipped: { label: "Skipped", className: "border-slate-400/25 bg-white/5 text-slate-200" },
+  unknown: { label: "Optional", className: "border-slate-400/25 bg-white/5 text-slate-200" },
+};
+
+type StepStatusPayload = {
+  stepKey: GuidedOnboardingStepKey;
+  status: GuidedOnboardingStepStatus;
+  detail: string;
+};
+
+type GuidedSessionsResponse = { sessions?: GuidedOnboardingSessionPayload[]; error?: string };
+type GuidedSessionResponse = { session?: GuidedOnboardingSessionPayload; error?: string };
+type GuidedStatusResponse = { steps?: StepStatusPayload[]; error?: string };
+
+function currentStepFromSearch(): GuidedOnboardingStepKey | null {
+  if (typeof window === "undefined") return null;
+  const value = new URLSearchParams(window.location.search).get("step");
+  return GUIDED_ONBOARDING_STEPS.some((step) => step.stepKey === value) ? (value as GuidedOnboardingStepKey) : null;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json().catch(() => ({}))) as T;
+}
+
 export function GuidedOnboardingWorkspace() {
+  const [sessionCount, setSessionCount] = useState(0);
+  const [activeSession, setActiveSession] = useState<GuidedOnboardingSessionPayload | null>(null);
+  const [stepStatuses, setStepStatuses] = useState<Record<GuidedOnboardingStepKey, StepStatusPayload | undefined>>({} as Record<GuidedOnboardingStepKey, StepStatusPayload | undefined>);
+  const [existingSystem, setExistingSystem] = useState<string>(EXISTING_SYSTEM_CHOICES[0]);
+  const [selectedStepKey, setSelectedStepKey] = useState<GuidedOnboardingStepKey>(GUIDED_ONBOARDING_STEPS[0].stepKey);
+  const [isBusy, setIsBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const requestedStep = currentStepFromSearch();
+    if (requestedStep) setSelectedStepKey(requestedStep);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadWorkspace() {
+      const [sessionsResponse, statusResponse] = await Promise.all([
+        fetch("/api/onboarding-v2/guided/sessions", { cache: "no-store" }),
+        fetch("/api/onboarding-v2/guided/status", { cache: "no-store" }),
+      ]);
+      const sessionsPayload = await readJson<GuidedSessionsResponse>(sessionsResponse);
+      const statusPayload = await readJson<GuidedStatusResponse>(statusResponse);
+      if (cancelled) return;
+      const nextSessions = sessionsPayload.sessions ?? [];
+      setSessionCount(nextSessions.length);
+      setActiveSession(nextSessions[0] ?? null);
+      const nextStatuses = (statusPayload.steps ?? []).reduce<Record<GuidedOnboardingStepKey, StepStatusPayload | undefined>>((acc, step) => {
+        acc[step.stepKey] = step;
+        return acc;
+      }, {} as Record<GuidedOnboardingStepKey, StepStatusPayload | undefined>);
+      setStepStatuses(nextStatuses);
+      if (nextSessions[0]) {
+        setExistingSystem(nextSessions[0].guided.existingSystem ?? EXISTING_SYSTEM_CHOICES[0]);
+        setSelectedStepKey(nextSessions[0].guided.currentStepKey);
+      }
+    }
+    void loadWorkspace();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const progress = useMemo(() => {
+    const sessionSteps = activeSession?.guided.steps ?? {};
+    const resolved = GUIDED_ONBOARDING_STEPS.filter((step) => {
+      const status = sessionSteps[step.stepKey]?.status;
+      return status === "complete" || status === "skipped";
+    }).length;
+    return { resolved, total: GUIDED_ONBOARDING_STEPS.length, percent: Math.round((resolved / GUIDED_ONBOARDING_STEPS.length) * 100) };
+  }, [activeSession]);
+
+  const selectedStep = GUIDED_ONBOARDING_STEPS.find((step) => step.stepKey === selectedStepKey) ?? GUIDED_ONBOARDING_STEPS[0];
+
+  async function createOrUpdateSession(nextSystem = existingSystem, nextStepKey = selectedStepKey) {
+    setIsBusy(true);
+    setMessage(null);
+    try {
+      const response = activeSession
+        ? await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(activeSession.id)}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ existingSystem: nextSystem, currentStepKey: nextStepKey }),
+          })
+        : await fetch("/api/onboarding-v2/guided/sessions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ existingSystem: nextSystem, currentStepKey: nextStepKey }),
+          });
+      const payload = await readJson<GuidedSessionResponse>(response);
+      if (!response.ok || !payload.session) throw new Error(payload.error ?? "Could not save guided onboarding session");
+      setActiveSession(payload.session);
+      setSessionCount((current) => Math.max(current, 1));
+      setMessage(activeSession ? "Guided workspace saved." : "Guided workspace started.");
+      return payload.session;
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not save guided onboarding session");
+      return null;
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function updateStep(action: "complete" | "skip") {
+    const session = activeSession ?? (await createOrUpdateSession(existingSystem, selectedStepKey));
+    if (!session) return;
+    setIsBusy(true);
+    setMessage(null);
+    try {
+      const response = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(session.id)}/steps/${encodeURIComponent(selectedStepKey)}/${action}`,
+        { method: "POST" },
+      );
+      const payload = await readJson<GuidedSessionResponse>(response);
+      if (!response.ok || !payload.session) throw new Error(payload.error ?? `Could not ${action} guided onboarding step`);
+      setActiveSession(payload.session);
+      setSessionCount((current) => Math.max(current, 1));
+      setMessage(action === "complete" ? "Step marked complete." : "Step skipped for now.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : `Could not ${action} guided onboarding step`);
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
   return (
     <section
       data-testid="guided-onboarding-workspace"
@@ -16,12 +154,10 @@ export function GuidedOnboardingWorkspace() {
     >
       <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div>
-          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/80">
-            Guided onboarding · optional
-          </div>
-          <h2 className="mt-1 text-xl font-semibold text-white">Stable setup checklist</h2>
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/80">Guided onboarding · optional</div>
+          <h2 className="mt-1 text-xl font-semibold text-white">Guided setup workspace</h2>
           <p className="mt-2 max-w-3xl text-sm text-slate-300">
-            This guide launches only when you choose it. Each step links to an existing production page and does not change auth routing, middleware, shop assignment, or work-order flows.
+            Owner/admin launched workspace for setup steps, session progress, and linked imports. It is not auth-forced and stays scoped to your current shop context.
           </p>
         </div>
         <Link href="/dashboard/operations" className="text-sm font-semibold text-slate-300 underline-offset-4 hover:text-white hover:underline">
@@ -29,40 +165,101 @@ export function GuidedOnboardingWorkspace() {
         </Link>
       </div>
 
-      <div className="mt-4 grid gap-3 lg:grid-cols-3">
-        {GUIDED_ONBOARDING_STEPS.map((step, index) => (
-          <article key={step.stepKey} className="rounded-xl border border-white/10 bg-black/20 p-3">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
-                  {String(index + 1).padStart(2, "0")} · {CATEGORY_LABELS[step.category]}
-                </div>
-                <h3 className="mt-1 text-sm font-semibold text-white">{step.title}</h3>
-              </div>
-              <span className="rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-200">
-                Optional UI
-              </span>
+      <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Session engine</div>
+              <h3 className="mt-1 text-base font-semibold text-white">{activeSession ? activeSession.title ?? "Guided onboarding workspace" : "Start a guided workspace"}</h3>
+              <p className="mt-1 text-xs text-slate-400">
+                {activeSession ? `Session ${activeSession.id.slice(0, 8)} · ${progress.resolved}/${progress.total} resolved · ${sessionCount} saved` : "No guided workspace has been started for this shop yet."}
+              </p>
             </div>
-            <p className="mt-2 min-h-12 text-xs leading-5 text-slate-400">{step.description}</p>
-            <div className="mt-2 rounded-lg border border-white/10 bg-white/[0.03] px-2 py-1 text-[11px] text-slate-400">
-              State source: {step.dataSource.label}
-            </div>
-            {step.importLaunch?.stable ? (
-              <Link
-                href={step.importLaunch.href}
-                className="mt-2 inline-flex w-full items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10"
-              >
-                {step.importLaunch.label}
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={() => void createOrUpdateSession()}
+              className="inline-flex items-center justify-center rounded-xl border border-orange-300/40 bg-orange-400/15 px-4 py-2 text-sm font-semibold text-orange-50 transition hover:bg-orange-400/25 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {activeSession ? "Save workspace" : "Start workspace"}
+            </button>
+          </div>
+          <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/10">
+            <div className="h-full rounded-full bg-orange-300 transition-all" style={{ width: `${progress.percent}%` }} />
+          </div>
+          <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.14em] text-slate-400" htmlFor="existing-system-choice">
+            Existing system choice
+          </label>
+          <select
+            id="existing-system-choice"
+            value={existingSystem}
+            onChange={(event) => {
+              setExistingSystem(event.target.value);
+              void createOrUpdateSession(event.target.value, selectedStepKey);
+            }}
+            className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-white outline-none transition focus:border-orange-300/50"
+          >
+            {EXISTING_SYSTEM_CHOICES.map((choice) => (
+              <option key={choice} value={choice}>
+                {choice}
+              </option>
+            ))}
+          </select>
+          {message ? <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-slate-300">{message}</div> : null}
+        </div>
+
+        <aside className="rounded-xl border border-white/10 bg-black/20 p-3">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Current step</div>
+          <h3 className="mt-1 text-base font-semibold text-white">{selectedStep.title}</h3>
+          <p className="mt-2 text-xs leading-5 text-slate-400">{selectedStep.description}</p>
+          <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.03] px-2 py-1 text-[11px] text-slate-400">
+            Data state: {stepStatuses[selectedStep.stepKey]?.detail ?? selectedStep.dataSource.label}
+          </div>
+          <div className="mt-3 flex flex-col gap-2">
+            {selectedStep.importLaunch?.stable ? (
+              <Link href={selectedStep.importLaunch.href} className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10">
+                {selectedStep.importLaunch.label}
               </Link>
             ) : null}
-            <Link
-              href={step.destinationPath}
-              className="mt-3 inline-flex w-full items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10"
-            >
-              {step.cta}
+            <Link href={selectedStep.destinationPath} className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-100 transition hover:border-orange-300/40 hover:bg-orange-400/10">
+              {selectedStep.cta}
             </Link>
-          </article>
-        ))}
+            <button type="button" disabled={isBusy} onClick={() => void updateStep("complete")} className="rounded-lg border border-emerald-300/30 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-50 disabled:opacity-60">
+              Mark step complete
+            </button>
+            <button type="button" disabled={isBusy} onClick={() => void updateStep("skip")} className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs font-semibold text-slate-300 disabled:opacity-60">
+              Skip for now
+            </button>
+          </div>
+        </aside>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        {GUIDED_ONBOARDING_STEPS.map((step, index) => {
+          const sessionStatus = activeSession?.guided.steps[step.stepKey]?.status;
+          const dataStatus = stepStatuses[step.stepKey]?.status ?? "unknown";
+          const badge = STATUS_COPY[sessionStatus ?? dataStatus];
+          const isSelected = selectedStepKey === step.stepKey;
+          return (
+            <article key={step.stepKey} className={`rounded-xl border p-3 ${isSelected ? "border-orange-300/40 bg-orange-400/10" : "border-white/10 bg-black/20"}`}>
+              <button type="button" className="w-full text-left" onClick={() => setSelectedStepKey(step.stepKey)}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+                      {String(index + 1).padStart(2, "0")} · {CATEGORY_LABELS[step.category]}
+                    </div>
+                    <h3 className="mt-1 text-sm font-semibold text-white">{step.title}</h3>
+                  </div>
+                  <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badge.className}`}>{badge.label}</span>
+                </div>
+                <p className="mt-2 min-h-12 text-xs leading-5 text-slate-400">{step.description}</p>
+                <div className="mt-2 rounded-lg border border-white/10 bg-white/[0.03] px-2 py-1 text-[11px] text-slate-400">
+                  {stepStatuses[step.stepKey]?.detail ?? `State source: ${step.dataSource.label}`}
+                </div>
+              </button>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/features/onboarding-v2/guided/sessionTypes.ts
+++ b/features/onboarding-v2/guided/sessionTypes.ts
@@ -1,0 +1,33 @@
+import type { GuidedOnboardingStepKey } from "@/features/onboarding-v2/guided/steps";
+
+export type GuidedStepSessionStatus = "not_started" | "in_progress" | "complete" | "skipped";
+export type GuidedSessionStatus = "active" | "complete";
+
+export type GuidedStepSessionState = {
+  status: GuidedStepSessionStatus;
+  answers: Record<string, unknown>;
+  updatedAt: string;
+  completedAt?: string;
+  skippedAt?: string;
+};
+
+export type GuidedOnboardingSessionState = {
+  version: 1;
+  sessionStatus: GuidedSessionStatus;
+  currentStepKey: GuidedOnboardingStepKey;
+  existingSystem: string | null;
+  steps: Partial<Record<GuidedOnboardingStepKey, GuidedStepSessionState>>;
+};
+
+export type GuidedOnboardingSessionPayload = {
+  id: string;
+  shopId: string;
+  createdBy: string | null;
+  status: string;
+  source: string | null;
+  title: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  guided: GuidedOnboardingSessionState;
+};

--- a/features/onboarding-v2/server/guidedSessions.ts
+++ b/features/onboarding-v2/server/guidedSessions.ts
@@ -1,0 +1,233 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { GUIDED_ONBOARDING_STEPS, getGuidedOnboardingStep, type GuidedOnboardingStepKey } from "@/features/onboarding-v2/guided/steps";
+import type { GuidedOnboardingSessionPayload, GuidedOnboardingSessionState, GuidedStepSessionState, GuidedStepSessionStatus } from "@/features/onboarding-v2/guided/sessionTypes";
+
+type Supabase = SupabaseClient<Database>;
+type JsonRecord = Record<string, unknown>;
+
+type OnboardingSessionRow = Pick<
+  Database["public"]["Tables"]["onboarding_sessions"]["Row"],
+  "id" | "shop_id" | "created_by" | "status" | "source" | "title" | "notes" | "summary" | "stats" | "created_at" | "updated_at"
+>;
+
+export const GUIDED_ONBOARDING_SOURCE = "guided_onboarding";
+export const GUIDED_ONBOARDING_SUMMARY_KEY = "guidedOnboarding";
+
+const stepKeys = GUIDED_ONBOARDING_STEPS.map((step) => step.stepKey);
+
+export function isGuidedOnboardingStepKey(value: unknown): value is GuidedOnboardingStepKey {
+  return typeof value === "string" && stepKeys.includes(value as GuidedOnboardingStepKey);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function emptyGuidedSessionState(existingSystem: string | null = null): GuidedOnboardingSessionState {
+  return {
+    version: 1,
+    sessionStatus: "active",
+    currentStepKey: GUIDED_ONBOARDING_STEPS[0].stepKey,
+    existingSystem,
+    steps: {},
+  };
+}
+
+function normalizeStepState(value: unknown): GuidedStepSessionState | undefined {
+  if (!isRecord(value)) return undefined;
+  const status = value.status;
+  if (status !== "not_started" && status !== "in_progress" && status !== "complete" && status !== "skipped") return undefined;
+  return {
+    status,
+    answers: isRecord(value.answers) ? value.answers : {},
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : nowIso(),
+    completedAt: typeof value.completedAt === "string" ? value.completedAt : undefined,
+    skippedAt: typeof value.skippedAt === "string" ? value.skippedAt : undefined,
+  };
+}
+
+function normalizeGuidedState(summary: unknown): GuidedOnboardingSessionState {
+  if (!isRecord(summary) || !isRecord(summary[GUIDED_ONBOARDING_SUMMARY_KEY])) return emptyGuidedSessionState();
+  const guided = summary[GUIDED_ONBOARDING_SUMMARY_KEY];
+  const currentStepKey = isGuidedOnboardingStepKey(guided.currentStepKey) ? guided.currentStepKey : GUIDED_ONBOARDING_STEPS[0].stepKey;
+  const sessionStatus = guided.sessionStatus === "complete" ? "complete" : "active";
+  const existingSystem = typeof guided.existingSystem === "string" && guided.existingSystem.trim() ? guided.existingSystem.trim() : null;
+  const rawSteps = isRecord(guided.steps) ? guided.steps : {};
+  const steps = stepKeys.reduce<GuidedOnboardingSessionState["steps"]>((acc, stepKey) => {
+    const next = normalizeStepState(rawSteps[stepKey]);
+    if (next) acc[stepKey] = next;
+    return acc;
+  }, {});
+
+  return { version: 1, sessionStatus, currentStepKey, existingSystem, steps };
+}
+
+function mergeGuidedSummary(summary: unknown, guided: GuidedOnboardingSessionState): JsonRecord {
+  const base = isRecord(summary) ? { ...summary } : {};
+  base[GUIDED_ONBOARDING_SUMMARY_KEY] = guided;
+  return base;
+}
+
+function toPayload(row: OnboardingSessionRow): GuidedOnboardingSessionPayload {
+  return {
+    id: row.id,
+    shopId: row.shop_id,
+    createdBy: row.created_by,
+    status: row.status,
+    source: row.source,
+    title: row.title,
+    notes: row.notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    guided: normalizeGuidedState(row.summary),
+  };
+}
+
+export async function listGuidedOnboardingSessions(supabase: Supabase, shopId: string): Promise<GuidedOnboardingSessionPayload[]> {
+  const { data, error } = await supabase
+    .from("onboarding_sessions")
+    .select("id, shop_id, created_by, status, source, title, notes, summary, stats, created_at, updated_at")
+    .eq("shop_id", shopId)
+    .eq("source", GUIDED_ONBOARDING_SOURCE)
+    .order("updated_at", { ascending: false })
+    .limit(10);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row) => toPayload(row as OnboardingSessionRow));
+}
+
+export async function createGuidedOnboardingSession(
+  supabase: Supabase,
+  params: { shopId: string; userId: string; title?: string | null; existingSystem?: string | null; currentStepKey?: GuidedOnboardingStepKey | null },
+): Promise<GuidedOnboardingSessionPayload> {
+  const guided = emptyGuidedSessionState(params.existingSystem ?? null);
+  if (params.currentStepKey) guided.currentStepKey = params.currentStepKey;
+  const title = params.title?.trim() || "Guided onboarding workspace";
+
+  const { data, error } = await supabase
+    .from("onboarding_sessions")
+    .insert({
+      shop_id: params.shopId,
+      created_by: params.userId,
+      status: "draft",
+      source: GUIDED_ONBOARDING_SOURCE,
+      title,
+      summary: mergeGuidedSummary({}, guided),
+      stats: { guidedStepCount: GUIDED_ONBOARDING_STEPS.length },
+    })
+    .select("id, shop_id, created_by, status, source, title, notes, summary, stats, created_at, updated_at")
+    .single();
+
+  if (error) throw new Error(error.message);
+  return toPayload(data as OnboardingSessionRow);
+}
+
+export async function loadGuidedOnboardingSession(
+  supabase: Supabase,
+  params: { shopId: string; sessionId: string },
+): Promise<GuidedOnboardingSessionPayload | null> {
+  const { data, error } = await supabase
+    .from("onboarding_sessions")
+    .select("id, shop_id, created_by, status, source, title, notes, summary, stats, created_at, updated_at")
+    .eq("shop_id", params.shopId)
+    .eq("id", params.sessionId)
+    .eq("source", GUIDED_ONBOARDING_SOURCE)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data ? toPayload(data as OnboardingSessionRow) : null;
+}
+
+export async function updateGuidedOnboardingSession(
+  supabase: Supabase,
+  params: { shopId: string; sessionId: string; title?: string | null; notes?: string | null; existingSystem?: string | null; currentStepKey?: GuidedOnboardingStepKey | null },
+): Promise<GuidedOnboardingSessionPayload | null> {
+  const existing = await loadGuidedOnboardingSession(supabase, params);
+  if (!existing) return null;
+
+  const guided: GuidedOnboardingSessionState = {
+    ...existing.guided,
+    existingSystem: params.existingSystem === undefined ? existing.guided.existingSystem : params.existingSystem,
+    currentStepKey: params.currentStepKey ?? existing.guided.currentStepKey,
+  };
+
+  const update: JsonRecord = {
+    summary: mergeGuidedSummary(existing.guided ? { [GUIDED_ONBOARDING_SUMMARY_KEY]: existing.guided } : {}, guided),
+    updated_at: nowIso(),
+  };
+  if (params.title !== undefined) update.title = params.title?.trim() || "Guided onboarding workspace";
+  if (params.notes !== undefined) update.notes = params.notes;
+
+  const { data, error } = await supabase
+    .from("onboarding_sessions")
+    .update(update)
+    .eq("shop_id", params.shopId)
+    .eq("id", params.sessionId)
+    .eq("source", GUIDED_ONBOARDING_SOURCE)
+    .select("id, shop_id, created_by, status, source, title, notes, summary, stats, created_at, updated_at")
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data ? toPayload(data as OnboardingSessionRow) : null;
+}
+
+export async function updateGuidedOnboardingStep(
+  supabase: Supabase,
+  params: { shopId: string; sessionId: string; stepKey: GuidedOnboardingStepKey; action: "answer" | "complete" | "skip" | "status"; answers?: JsonRecord; status?: GuidedStepSessionStatus },
+): Promise<GuidedOnboardingSessionPayload | null> {
+  getGuidedOnboardingStep(params.stepKey);
+  const existing = await loadGuidedOnboardingSession(supabase, params);
+  if (!existing) return null;
+
+  const timestamp = nowIso();
+  const currentStep = existing.guided.steps[params.stepKey] ?? { status: "not_started", answers: {}, updatedAt: timestamp };
+  const answers = params.answers ? { ...currentStep.answers, ...params.answers } : currentStep.answers;
+  const nextStep: GuidedStepSessionState = { ...currentStep, answers, updatedAt: timestamp };
+
+  if (params.action === "answer") {
+    nextStep.status = currentStep.status === "complete" || currentStep.status === "skipped" ? currentStep.status : "in_progress";
+  } else if (params.action === "complete") {
+    nextStep.status = "complete";
+    nextStep.completedAt = timestamp;
+    delete nextStep.skippedAt;
+  } else if (params.action === "skip") {
+    nextStep.status = "skipped";
+    nextStep.skippedAt = timestamp;
+    delete nextStep.completedAt;
+  } else if (params.status) {
+    nextStep.status = params.status;
+    if (params.status === "complete") nextStep.completedAt = timestamp;
+    if (params.status === "skipped") nextStep.skippedAt = timestamp;
+  }
+
+  const steps = { ...existing.guided.steps, [params.stepKey]: nextStep };
+  const allResolved = stepKeys.every((stepKey) => steps[stepKey]?.status === "complete" || steps[stepKey]?.status === "skipped");
+  const guided: GuidedOnboardingSessionState = {
+    ...existing.guided,
+    sessionStatus: allResolved ? "complete" : "active",
+    currentStepKey: params.stepKey,
+    steps,
+  };
+
+  const { data, error } = await supabase
+    .from("onboarding_sessions")
+    .update({
+      summary: mergeGuidedSummary({ [GUIDED_ONBOARDING_SUMMARY_KEY]: existing.guided }, guided),
+      updated_at: timestamp,
+    })
+    .eq("shop_id", params.shopId)
+    .eq("id", params.sessionId)
+    .eq("source", GUIDED_ONBOARDING_SOURCE)
+    .select("id, shop_id, created_by, status, source, title, notes, summary, stats, created_at, updated_at")
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data ? toPayload(data as OnboardingSessionRow) : null;
+}

--- a/tests/guided-onboarding-recovery.test.ts
+++ b/tests/guided-onboarding-recovery.test.ts
@@ -46,6 +46,14 @@ const guardedRecoveryFiles = [
   "features/onboarding-v2/components/OnboardingHighlightFrame.tsx",
   "features/onboarding-v2/guided/steps.ts",
   "app/api/onboarding-v2/guided/status/route.ts",
+  "app/api/onboarding-v2/guided/sessions/route.ts",
+  "app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts",
+  "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts",
+  "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts",
+  "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts",
+  "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts",
+  "features/onboarding-v2/guided/sessionTypes.ts",
+  "features/onboarding-v2/server/guidedSessions.ts",
 ];
 
 const stableLoaderExpectations = [
@@ -144,6 +152,23 @@ describe("guided onboarding recovery guardrails", () => {
     expect(canRoleUseGuidedOnboardingStep("admin", ownerStep!)).toBe(true);
     expect(canRoleUseGuidedOnboardingStep("tech", ownerStep!)).toBe(false);
     expect(canRoleUseGuidedOnboardingStep("mechanic", ownerStep!)).toBe(false);
+  });
+
+
+  it("restores shop-scoped guided session and step routes without shop switching", () => {
+    const sessionRoute = read("app/api/onboarding-v2/guided/sessions/route.ts");
+    const sessionServer = read("features/onboarding-v2/server/guidedSessions.ts");
+    const workspace = read("features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx");
+
+    expect(sessionRoute).toContain('allowRoles: ["owner", "admin"]');
+    expect(sessionRoute).toContain("access.profile.shop_id");
+    expect(sessionServer).toContain('GUIDED_ONBOARDING_SOURCE = "guided_onboarding"');
+    expect(sessionServer).toContain('.eq("shop_id", params.shopId)');
+    expect(sessionServer).toContain('summary: mergeGuidedSummary');
+    expect(workspace).toContain("Existing system choice");
+    expect(workspace).toContain("/api/onboarding-v2/guided/sessions");
+    expect(workspace).toContain("Mark step complete");
+    expect(workspace).not.toContain("/api/shops/switch");
   });
 
   it("does not reintroduce legacy Supabase auth helpers in guarded app source", () => {


### PR DESCRIPTION
### Motivation

- Restore the Phase 2 guided onboarding session/workspace engine so owners/admins can optionally launch a richer guided setup without touching auth routing, middleware, dashboard server context, work-orders, assignment, or shop switching. 
- Keep the implementation shop-scoped and RLS-friendly by using the existing `onboarding_sessions` table and storing guided state under `summary.guidedOnboarding` instead of adding schema or changing `profiles.shop_id` semantics. 
- Ensure no legacy Supabase auth helpers are reintroduced and preserve the current production pages and flows as optional entry points. 

### Description

- Added a server-side guided session helper implementing create/list/load/update and per-step `answer`/`complete`/`skip`/`status` operations that read/write `onboarding_sessions.summary.guidedOnboarding` and keep all queries scoped by `shop_id` via the current server Supabase helpers (`requireShopScopedApiAccess`).
- Added route handlers under `app/api/onboarding-v2/guided/sessions` and nested step routes to expose the session engine to the frontend while enforcing owner/admin shop-scoped access with `requireShopScopedApiAccess`.
- Implemented a client workspace UI `features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx` that loads session and step status, shows progress, tracks current step, supports an existing-system choice, and links to stable production import/destination pages.
- Introduced shared TypeScript types `features/onboarding-v2/guided/sessionTypes.ts` and server logic `features/onboarding-v2/server/guidedSessions.ts`, and extended the guided-onboarding guardrail test to assert the new session engine routes and constraints.

Files added/modified (key):
- `features/onboarding-v2/server/guidedSessions.ts` (new server helpers)
- `features/onboarding-v2/guided/sessionTypes.ts` (shared types)
- `app/api/onboarding-v2/guided/sessions/route.ts` (list/create)
- `app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts` (get/patch)
- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/{answer,complete,skip,status}/route.ts` (step actions)
- `features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx` (client UI)
- `tests/guided-onboarding-recovery.test.ts` (extended assertions)

Notes on scope and safety:
- No changes to `middleware.ts`, `features/auth/lib/postAuthRouting.ts`, dashboard server context, AppShell/RoleSidebar, work-order board/detail/assignment files, `/api/shops/switch`, or ShopSwitcher.
- No mutation of `profiles.shop_id` and no auth-forced onboarding redirects were added. The guided workspace is owner/admin launched and optional.

### Testing

- Ran the legacy-helper grep to ensure no reintroduction of old Supabase helpers with `rg "@supabase/auth-helpers-nextjs|createRouteHandlerClient|createServerComponentClient|createClientComponentClient"`, and the check passed (no matches in guarded sources).
- Verified there are no onboarding-route sources that update `profiles.shop_id` via targeted `rg` checks, and the check passed (no matches in the guarded onboarding sources).
- Type-checked the repo with `npx tsc --noEmit --pretty false`, and the typecheck succeeded with no new errors.
- Ran focused test suites: `npx vitest run tests/guided-onboarding-recovery.test.ts` which passed, and a set of dashboard/auth/work-order smoke tests (`tests/dashboard-server-context.test.ts`, `tests/user-auth-normalization.test.ts`, `tests/work-order-closeout-gate-preview.test.ts`, `tests/work-order-closeout-risk-rules.test.ts`, `features/work-orders/lib/display/linePresentation.test.ts`) which all passed.

All automated checks and tests listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24da0353c08328a5b1818bfe28f75d)