### PR TITLE
Fix onboarding removal regressions

### DIFF
--- a/features/integrations/shopBoost/runIntakeHandler.ts
+++ b/features/integrations/shopBoost/runIntakeHandler.ts
@@ -40,7 +40,7 @@ export type ShopBoostRunResp =
         menuSuggestions: number;
         inspectionSuggestions: number;
       };
-      optimization: {
+      onboardingOptimization: {
         summary: {
           totalOpportunities: number;
           criticalCount: number;
@@ -468,7 +468,7 @@ export async function runShopBoostIntake(
         menuSuggestions: 0,
         inspectionSuggestions: 0,
       },
-      optimization: { summary: null, nextActions: [] },
+      onboardingOptimization: { summary: null, nextActions: [] },
     };
   }
 
@@ -529,7 +529,7 @@ export async function runShopBoostIntake(
     });
   }
 
-  let optimization: {
+  let onboardingOptimization: {
     summary: {
       totalOpportunities: number;
       criticalCount: number;
@@ -552,7 +552,7 @@ export async function runShopBoostIntake(
       lookbackDays: 365,
     });
 
-    optimization = {
+    onboardingOptimization = {
       summary: optimizationOutput.summary,
       nextActions: selectTopShopBoostOptimizationActions(optimizationOutput, 5),
     };
@@ -567,6 +567,6 @@ export async function runShopBoostIntake(
     snapshot,
     importSummary,
     shopBuildSummary: importSummary.shopBuildSummary,
-    optimization,
+    onboardingOptimization,
   };
 }

--- a/features/shared/lib/openai-models.ts
+++ b/features/shared/lib/openai-models.ts
@@ -17,7 +17,7 @@ export type OpenAIModelEnv = Partial<Record<
 
 export const DEFAULT_OPENAI_MODELS: Record<OpenAIModelPurpose, string> = {
   reasoning: "gpt-5.5",
-  fast: "gpt-5.5",
+  fast: "gpt-5.4-mini",
   extraction: "gpt-5.5",
   embedding: "text-embedding-3-small",
   vision: "gpt-5.5",
@@ -30,7 +30,6 @@ function clean(value: string | undefined): string | null {
 
 export function resolveOpenAIModel(purpose: OpenAIModelPurpose, env: OpenAIModelEnv = {}): string {
   const globalModel = clean(env.OPENAI_MODEL);
-
 
   if (purpose === "reasoning") {
     return clean(env.OPENAI_REASONING_MODEL) ?? globalModel ?? DEFAULT_OPENAI_MODELS.reasoning;


### PR DESCRIPTION
### Motivation

- The onboarding removal PR intentionally stripped onboarding UI/routes, but two accidental regressions touched shared behavior (OpenAI defaults and Shop Boost API shape) that could break runtime behavior and tests.
- The goal was to keep onboarding removals while leaving non-onboarding contracts and deterministic behavior intact so downstream consumers and tests remain stable.

### Description

- Restore the fast OpenAI default by setting `DEFAULT_OPENAI_MODELS.fast` back to `"gpt-5.4-mini"` in `features/shared/lib/openai-models.ts` to match the test contract.
- Preserve the Shop Boost intake response contract by returning `onboardingOptimization` (summary + nextActions) from `runShopBoostIntake` while using the renamed internal selector `selectTopShopBoostOptimizationActions`; changes are in `features/integrations/shopBoost/runIntakeHandler.ts`.
- Keep deterministic work-order history IDs by inlining the SHA-1 `stableUuidFromParts` helper into `features/work-orders/server/syncWorkOrderToHistory.ts` so history behavior no longer depends on removed onboarding modules.

### Testing

- Ran `npx tsc --noEmit --pretty false` and it completed successfully with no type errors.
- Ran `npx vitest run features/shared/lib/server/openai-models.test.ts` and initially saw a failing assertion for the `fast` default, then after restoring `gpt-5.4-mini` the test suite passed (`3 tests` all passed).
- Ran `npx vitest run tests/dashboard-server-context.test.ts tests/user-auth-normalization.test.ts tests/smoke.test.ts` and all listed tests passed.
- Ran `git diff --check` and no whitespace or diff-check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ed86124483288adf6cb775737994)