### PR TITLE
Remove Shop Boost panel from operations dashboard

### DIFF
--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -4,7 +4,6 @@ import { ActivitySquare, AlertTriangle, ArrowRight, ChevronRight, TriangleAlert 
 import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
 import { CompactSignalList, DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
 import { ShopLoadChart } from "./OperationsCharts";
-import ShopBoostActivationPanel from "@/features/dashboard/components/ShopBoostActivationPanel";
 
 function EmbeddedEmptyState({ label, detail }: { label: string; detail: string }) {
   return (
@@ -21,19 +20,12 @@ function getCountSeverity(count: number): "neutral" | "amber" | "red" {
   return "neutral";
 }
 
-function isOwnerAdminRole(role: string | null): boolean {
-  const normalizedRole = (role ?? "").toLowerCase();
-  return normalizedRole === "owner" || normalizedRole === "admin";
-}
-
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
   const displayName = payload.identity.fullName?.trim() || "Operator";
   const isTechnicianView = payload.viewerScope === "technician";
   const hasTechnicianActivity = payload.technicianActivity.length > 0;
   const hasRightRailSignals = payload.blockerStack.length > 0 || payload.alerts.length > 0 || payload.suggestedActions.length > 0;
-  const canSeeShopBoostMissionControl = isOwnerAdminRole(payload.identity.role);
-
   return (
     <DashboardShell>
       <DashboardTopStrip
@@ -50,8 +42,6 @@ export default async function OperationsDashboardView() {
           { label: "Dispatch", href: "/dashboard/manager/dispatch", tone: "secondary" },
         ]}
       />
-
-      {canSeeShopBoostMissionControl ? <ShopBoostActivationPanel eligible /> : null}
 
       <MetricStrip
         className="mb-0"

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,7 +1,88 @@
-import { describe, expect, it } from "vitest";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { OperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+vi.mock("@/features/dashboard/server/getOperationsDashboardPayload", () => ({
+  getOperationsDashboardPayload: vi.fn(async (): Promise<OperationsDashboardPayload> => ({
+    identity: {
+      userId: "user-1",
+      email: "owner@example.com",
+      shopId: "shop-1",
+      role: "owner",
+      fullName: "Operations Owner",
+      profileExists: true,
+      shopLoaded: true,
+      shop: {
+        id: "shop-1",
+        name: "ProFixIQ Demo Shop",
+        shop_name: null,
+        business_name: null,
+      },
+    },
+    viewerScope: "shop",
+    topSummary: {
+      activeJobs: 8,
+      blockedJobs: 2,
+      waitingApprovals: 3,
+      waitingParts: 4,
+    },
+    activeJobSummary: [{ label: "In progress", value: 8, pct: 80 }],
+    liveShopLoad: [{ label: "Today", count: 8, pct: 80 }],
+    dailySummary: [{ label: "Approval queue", value: "3", tone: "accent" }],
+    liveWork: [
+      {
+        id: "work-order-1",
+        label: "WO-1001",
+        stage: "In progress",
+        risk: "normal",
+        priority: 1,
+      },
+    ],
+    technicianActivity: [],
+    blockerStack: [],
+    alerts: [],
+    suggestedActions: [],
+    flowMix: [{ label: "In Progress", value: 8 }],
+    revenueEfficiency: {
+      revenue: 12500,
+      profit: 4200,
+      completedLines: 14,
+      efficiencyPct: 92,
+    },
+    sectionErrors: [],
+    fetchAudit: [],
+  })),
+}));
+
+vi.mock("../app/dashboard/_components/OperationsCharts", () => ({
+  ShopLoadChart: () => React.createElement("div", null, "Shop load chart"),
+}));
 
 describe("smoke", () => {
   it("runs tests", () => {
     expect(true).toBe(true);
+  });
+
+  it("keeps the operations dashboard focused on core command surfaces", async () => {
+    const { default: OperationsDashboardView } = await import(
+      "../app/dashboard/_components/OperationsDashboardView"
+    );
+
+    const markup = renderToStaticMarkup(await OperationsDashboardView());
+
+    expect(markup).not.toContain("SHOP BOOST OPERATIONAL STATUS");
+    expect(markup).not.toContain("Materialization running");
+    expect(markup).not.toContain("Open legacy guided review");
+    expect(markup).not.toContain("Download migration report");
+
+    expect(markup).toMatch(/Active jobs/i);
+    expect(markup).toContain("Blocked");
+    expect(markup).toContain("Approvals");
+    expect(markup).toMatch(/Waiting parts/i);
+    expect(markup).toContain("Live Work Command Surface");
   });
 });


### PR DESCRIPTION
### Motivation
- Remove the leftover Shop Boost materialization/status panel from the main Operations dashboard so the dashboard shows core command surfaces first and to prepare for a clean guided-onboarding rebuild.
- Ensure no other dashboard metrics, work-order flows, Shop Health pages, or backend Shop Boost APIs are disturbed by this UI-only removal.

### Description
- Removed the `ShopBoostActivationPanel` import and the conditional render that displayed the Shop Boost operational status above the metric strip in `app/dashboard/_components/OperationsDashboardView.tsx`.
- Removed the owner/admin helper that was only used to gate the dashboard-only Shop Boost panel and left shared Shop Boost/Shop Health code intact.
- Added/updated `tests/smoke.test.ts` to render `OperationsDashboardView` and assert the Shop Boost strings do not appear while core dashboard labels (Active Jobs, Blocked, Approvals, Waiting Parts, Live Work Command Surface) are still present.
- Changed no backend, middleware, onboarding, or work-order code; Shop Boost backend and Shop Health/report UI remain available where used.

### Testing
- Ran a targeted grep to confirm Shop Boost strings only remain in preserved Shop Boost/Shop Health code with `grep -Rni "SHOP BOOST OPERATIONAL STATUS\|Materialization running\|Open legacy guided review\|Download migration report" app features components lib tests` and observed remaining matches are outside the operations dashboard.
- Type-checked the repo with `npx tsc --noEmit --pretty false` which succeeded.
- Executed unit tests with `npx vitest run tests/dashboard-server-context.test.ts tests/smoke.test.ts` and all tests passed.
- Files changed: `app/dashboard/_components/OperationsDashboardView.tsx` and `tests/smoke.test.ts`.
- Commit hash: `0c2dfe90c1b7188c744491f061ef834f8834c82f` and PR created with this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2604b8f2ac8328b233a226c29c805b)