### PR TITLE
Make guided onboarding migration policies re-runnable

### DIFF
--- a/db/sql/2026-06-07_guided_onboarding_v2_foundation.sql
+++ b/db/sql/2026-06-07_guided_onboarding_v2_foundation.sql
@@ -58,6 +58,9 @@ alter table public.guided_onboarding_sessions enable row level security;
 alter table public.guided_onboarding_steps enable row level security;
 alter table public.guided_onboarding_events enable row level security;
 
+drop policy if exists guided_onboarding_sessions_shop_select
+  on public.guided_onboarding_sessions;
+
 create policy guided_onboarding_sessions_shop_select
   on public.guided_onboarding_sessions
   for select to authenticated
@@ -71,6 +74,9 @@ create policy guided_onboarding_sessions_shop_select
     )
   );
 
+drop policy if exists guided_onboarding_sessions_shop_insert
+  on public.guided_onboarding_sessions;
+
 create policy guided_onboarding_sessions_shop_insert
   on public.guided_onboarding_sessions
   for insert to authenticated
@@ -83,6 +89,9 @@ create policy guided_onboarding_sessions_shop_insert
         and lower(coalesce(p.role, '')) in ('owner', 'admin')
     )
   );
+
+drop policy if exists guided_onboarding_sessions_shop_update
+  on public.guided_onboarding_sessions;
 
 create policy guided_onboarding_sessions_shop_update
   on public.guided_onboarding_sessions
@@ -106,6 +115,9 @@ create policy guided_onboarding_sessions_shop_update
     )
   );
 
+drop policy if exists guided_onboarding_steps_shop_select
+  on public.guided_onboarding_steps;
+
 create policy guided_onboarding_steps_shop_select
   on public.guided_onboarding_steps
   for select to authenticated
@@ -119,6 +131,9 @@ create policy guided_onboarding_steps_shop_select
     )
   );
 
+drop policy if exists guided_onboarding_steps_shop_insert
+  on public.guided_onboarding_steps;
+
 create policy guided_onboarding_steps_shop_insert
   on public.guided_onboarding_steps
   for insert to authenticated
@@ -131,6 +146,9 @@ create policy guided_onboarding_steps_shop_insert
         and lower(coalesce(p.role, '')) in ('owner', 'admin')
     )
   );
+
+drop policy if exists guided_onboarding_steps_shop_update
+  on public.guided_onboarding_steps;
 
 create policy guided_onboarding_steps_shop_update
   on public.guided_onboarding_steps
@@ -154,6 +172,9 @@ create policy guided_onboarding_steps_shop_update
     )
   );
 
+drop policy if exists guided_onboarding_events_shop_select
+  on public.guided_onboarding_events;
+
 create policy guided_onboarding_events_shop_select
   on public.guided_onboarding_events
   for select to authenticated
@@ -166,6 +187,9 @@ create policy guided_onboarding_events_shop_select
         and lower(coalesce(p.role, '')) in ('owner', 'admin')
     )
   );
+
+drop policy if exists guided_onboarding_events_shop_insert
+  on public.guided_onboarding_events;
 
 create policy guided_onboarding_events_shop_insert
   on public.guided_onboarding_events
@@ -180,17 +204,26 @@ create policy guided_onboarding_events_shop_insert
     )
   );
 
+drop policy if exists service_role_manage_guided_onboarding_sessions
+  on public.guided_onboarding_sessions;
+
 create policy service_role_manage_guided_onboarding_sessions
   on public.guided_onboarding_sessions
   to service_role
   using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
 
+drop policy if exists service_role_manage_guided_onboarding_steps
+  on public.guided_onboarding_steps;
+
 create policy service_role_manage_guided_onboarding_steps
   on public.guided_onboarding_steps
   to service_role
   using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
+
+drop policy if exists service_role_manage_guided_onboarding_events
+  on public.guided_onboarding_events;
 
 create policy service_role_manage_guided_onboarding_events
   on public.guided_onboarding_events


### PR DESCRIPTION
### Motivation
- Re-running the guided onboarding v2 SQL migration in Supabase failed when a policy already existed (e.g. `policy "service_role_manage_guided_onboarding_sessions" already exists`).
- The migration should be safe to run multiple times without dropping tables, deleting data, or changing table definitions.

### Description
- Added `drop policy if exists <policy_name> on <table>;` immediately before each `create policy` statement for the guided onboarding policies listed in the migration file.
- Applied the changes to `db/sql/2026-06-07_guided_onboarding_v2_foundation.sql` for these policies: `guided_onboarding_sessions_shop_select`, `guided_onboarding_sessions_shop_insert`, `guided_onboarding_sessions_shop_update`, `guided_onboarding_steps_shop_select`, `guided_onboarding_steps_shop_insert`, `guided_onboarding_steps_shop_update`, `guided_onboarding_events_shop_select`, `guided_onboarding_events_shop_insert`, `service_role_manage_guided_onboarding_sessions`, `service_role_manage_guided_onboarding_steps`, and `service_role_manage_guided_onboarding_events`.
- Did not drop tables, delete data, change table definitions, or modify runtime app code or middleware.
- Commit: `de4af73e494161bcbad179edbb487cf468b7d296`.

### Testing
- Ran `npx tsc --noEmit --pretty false` and it completed successfully with no type errors.
- Ran `npx vitest run tests/guided-onboarding-v2-foundation.test.ts tests/dashboard-server-context.test.ts tests/smoke.test.ts` and all tests passed (`3 files, 13 tests` passed).
- Ran `git diff --check` and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260b37228c832885cdb6840ce87f16)