### PR TITLE
Fix guided onboarding route param typing

### DIFF
--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts
@@ -3,7 +3,11 @@ import { setExistingSystem } from "@/features/onboarding-v2/guided/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(req: NextRequest, { params }: { params: { sessionId: string } }) {
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await context.params;
   const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-  return setExistingSystem(params.sessionId, body);
+  return setExistingSystem(sessionId, body);
 }

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts
@@ -3,11 +3,19 @@ import { getGuidedSession, patchGuidedSession } from "@/features/onboarding-v2/g
 
 export const dynamic = "force-dynamic";
 
-export async function GET(_req: NextRequest, { params }: { params: { sessionId: string } }) {
-  return getGuidedSession(params.sessionId);
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await context.params;
+  return getGuidedSession(sessionId);
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { sessionId: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await context.params;
   const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-  return patchGuidedSession(params.sessionId, body);
+  return patchGuidedSession(sessionId, body);
 }

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts
@@ -3,7 +3,11 @@ import { answerGuidedStep } from "@/features/onboarding-v2/guided/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(req: NextRequest, { params }: { params: { sessionId: string; stepKey: string } }) {
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ sessionId: string; stepKey: string }> }
+) {
+  const { sessionId, stepKey } = await context.params;
   const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-  return answerGuidedStep(params.sessionId, params.stepKey, body);
+  return answerGuidedStep(sessionId, stepKey, body);
 }

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts
@@ -3,6 +3,10 @@ import { completeGuidedStep } from "@/features/onboarding-v2/guided/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(_req: NextRequest, { params }: { params: { sessionId: string; stepKey: string } }) {
-  return completeGuidedStep(params.sessionId, params.stepKey);
+export async function POST(
+  _req: NextRequest,
+  context: { params: Promise<{ sessionId: string; stepKey: string }> }
+) {
+  const { sessionId, stepKey } = await context.params;
+  return completeGuidedStep(sessionId, stepKey);
 }

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts
@@ -3,6 +3,10 @@ import { skipGuidedStep } from "@/features/onboarding-v2/guided/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(_req: NextRequest, { params }: { params: { sessionId: string; stepKey: string } }) {
-  return skipGuidedStep(params.sessionId, params.stepKey);
+export async function POST(
+  _req: NextRequest,
+  context: { params: Promise<{ sessionId: string; stepKey: string }> }
+) {
+  const { sessionId, stepKey } = await context.params;
+  return skipGuidedStep(sessionId, stepKey);
 }

--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts
@@ -3,7 +3,11 @@ import { setGuidedStepStatus } from "@/features/onboarding-v2/guided/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(req: NextRequest, { params }: { params: { sessionId: string; stepKey: string } }) {
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ sessionId: string; stepKey: string }> }
+) {
+  const { sessionId, stepKey } = await context.params;
   const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-  return setGuidedStepStatus(params.sessionId, params.stepKey, body);
+  return setGuidedStepStatus(sessionId, stepKey, body);
 }


### PR DESCRIPTION
### Motivation
- Next.js App Router route handlers with dynamic params must type `context.params` as a `Promise<...>` and be awaited, otherwise the exported route handler types are invalid and cause Vercel/TypeScript build failures.
- The guided onboarding dynamic API routes were using plain `{ params: { ... } }` signatures which triggered the type error and prevented successful builds.

### Description
- Updated all guided onboarding dynamic route handler signatures to use `context: { params: Promise<...> }` and `await context.params` before using route params. 
- Applied the pattern to `GET`/`PATCH`/`POST` handlers in the following files: `app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts`, `app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts`, `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts`, `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts`, `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts`, and `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts`.
- No onboarding behavior or business logic was changed; only parameter typing and extraction were updated to satisfy the App Router typing requirements.

### Testing
- Ran `npx tsc --noEmit --pretty false` and it completed successfully with no TypeScript errors. 
- Ran `npx vitest run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx tests/dashboard-server-context.test.ts tests/smoke.test.ts` and all tests passed (4 test files, 21 tests passed). 
- Ran `git diff --check` and project grep checks for forbidden auth helpers returned no hits, with no diff-check issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260fe7e70483289b5baef4dcc21b07)