### PR TITLE
Fix guided onboarding page params typing

### DIFF
--- a/app/dashboard/onboarding-v2/[sessionId]/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/page.tsx
@@ -1,7 +1,16 @@
 import GuidedOnboardingWorkspace from "@/features/onboarding-v2/components/GuidedOnboardingWorkspace";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 
-export default async function GuidedSetupSessionPage({ params }: { params: { sessionId: string } }) {
+type PageProps = {
+  params: Promise<{ sessionId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function GuidedSetupSessionPage({ params, searchParams }: PageProps) {
+  const { sessionId } = await params;
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  void resolvedSearchParams;
+
   await requireAdminPageAccess({ allow: ["owner", "admin"] });
-  return <GuidedOnboardingWorkspace initialSessionId={params.sessionId} />;
+  return <GuidedOnboardingWorkspace initialSessionId={sessionId} />;
 }


### PR DESCRIPTION
### Motivation
- Fix a Next.js 15 App Router typing error for the guided onboarding session page so the page props match the Promise-based `params`/`searchParams` shape introduced in Next 15.

### Description
- Updated `app/dashboard/onboarding-v2/[sessionId]/page.tsx` to use a `PageProps` type with `params: Promise<{ sessionId: string }>` and optional `searchParams?: Promise<Record<string,string|string[]|undefined>>` and awaited `params` to extract `sessionId`.
- Resolved `searchParams` with `await` (kept runtime behavior identical) and used `void resolvedSearchParams` to avoid unused-variable diagnostics.
- Audited `app/dashboard/onboarding-v2/page.tsx` and determined no typing changes were required there.

### Testing
- Ran `npx tsc --noEmit --pretty false` which succeeded. 
- Ran `npx vitest run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx tests/dashboard-server-context.test.ts tests/smoke.test.ts` which reported all test files passed (4 files, 21 tests passed).
- Ran `git diff --check` which produced no issues, and grep checks for deprecated supabase helpers and specific onboarding/profile patterns returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26162cca3883289d6f6f53503f653c)