### PR TITLE
Show guided setup nav and remove Planner header button

### DIFF
--- a/features/assistant/components/AskAssistantEntry.tsx
+++ b/features/assistant/components/AskAssistantEntry.tsx
@@ -190,14 +190,6 @@ export default function AskAssistantEntry({
           <span>Assistant</span>
         </button>
 
-        <Link
-          href={plannerHref}
-          title={plannerLabel}
-          className="inline-flex h-8 items-center justify-center rounded-md border border-slate-400/20 bg-slate-950/70 px-2.5 text-xs font-medium text-slate-100 shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)]/60 hover:bg-slate-900/80 hover:text-white"
-        >
-          <span>Planner</span>
-        </Link>
-
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogContent className="max-w-3xl border-[color:var(--metal-border-soft,#1f2937)] bg-neutral-950/95 text-white shadow-[0_24px_80px_rgba(0,0,0,0.95)]">
             <DialogHeader>

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -463,6 +463,14 @@ export const TILES: Tile[] = [
     section: "Admin",
   },
   {
+    href: "/dashboard/onboarding-v2",
+    title: "Guided Setup",
+    subtitle: "Step-by-step shop configuration",
+    roles: ["owner", "admin"],
+    scopes: ["management", "all"],
+    section: "Admin",
+  },
+  {
     href: "/dashboard/admin/people",
     title: "People & Staff",
     subtitle: "Canonical staff directory and governance workspace",

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -62,6 +62,7 @@ const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
   "/dashboard/admin/payroll-time": "Workforce",
   "/dashboard/owner/create-user": "Workforce",
   "/dashboard/admin": "Admin & Oversight",
+  "/dashboard/onboarding-v2": "Admin & Oversight",
   "/dashboard/admin/shops": "Admin & Oversight",
   "/dashboard/admin/audit": "Admin & Oversight",
   "/dashboard/marketing": "Growth",

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -6,6 +6,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { GUIDED_ONBOARDING_STEP_KEYS } from "@/features/onboarding-v2/guided/steps";
+import { TILES } from "@/features/shared/config/tiles";
+import { getOwnerSidebarTiles } from "@/features/shared/lib/ownerSidebarNav";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
@@ -41,6 +43,44 @@ describe("guided onboarding v2 foundation", () => {
     expect(dashboardSource).not.toContain("SafeModeVerifyOnlyBanner");
     expect(dashboardSource).not.toContain("AgentReadinessBanner");
     expect(dashboardSource).not.toContain("Materialization");
+  });
+
+  it("exposes guided setup in owner/admin dashboard navigation without legacy onboarding labels", () => {
+    const guidedTile = TILES.find(
+      (tile) => tile.href === "/dashboard/onboarding-v2",
+    );
+
+    expect(guidedTile).toMatchObject({
+      title: "Guided Setup",
+      href: "/dashboard/onboarding-v2",
+      roles: ["owner", "admin"],
+      scopes: ["management", "all"],
+    });
+
+    const ownerGuidedTile = getOwnerSidebarTiles(TILES).find(
+      (tile) => tile.href === "/dashboard/onboarding-v2",
+    );
+
+    expect(ownerGuidedTile).toMatchObject({
+      title: "Guided Setup",
+      section: "Admin & Oversight",
+    });
+    expect(guidedTile?.title).not.toBe("Onboarding Agent");
+  });
+
+  it("keeps Planner out of the dashboard header while retaining other header actions", () => {
+    const appShellSource = read("features/shared/components/AppShell.tsx");
+    const assistantEntrySource = read(
+      "features/assistant/components/AskAssistantEntry.tsx",
+    );
+
+    expect(appShellSource).toContain("Shift");
+    expect(appShellSource).toContain("Inbox");
+    expect(appShellSource).toContain("Agent Request");
+    expect(appShellSource).toContain("Agent Console");
+    expect(appShellSource).toContain("Sign out");
+    expect(assistantEntrySource).toContain("<span>Assistant</span>");
+    expect(assistantEntrySource).not.toContain("<span>Planner</span>");
   });
 
   it("uses the new guided onboarding tables in server code", () => {


### PR DESCRIPTION
### Motivation
- Make the new Guided Onboarding (v2) discoverable by adding a clear entry under the existing Admin & Oversight sidebar section for owner/admin users. 
- Remove the duplicated "Planner" affordance from the dashboard header so the header action area focuses on Assistant, Agent request/console, Inbox/Shift, and Sign out.

### Description
- Added a new sidebar tile for the guided flow at `href: /dashboard/onboarding-v2` with `title: Guided Setup` and `roles: ["owner","admin"]` in `features/shared/config/tiles.ts`.
- Mapped `/dashboard/onboarding-v2` into the owner sidebar section overrides so it appears under `Admin & Oversight` via `features/shared/lib/ownerSidebarNav.ts`.
- Removed the header-mode Planner link from the Assistant header entry by deleting the Planner `Link` in `features/assistant/components/AskAssistantEntry.tsx`, leaving non-header Planner links and planner routes untouched.
- Added focused assertions to `tests/guided-onboarding-v2-foundation.test.ts` that verify the Guided Setup tile presence/placement and that the header no longer renders the Planner label while retaining Assistant, Agent Request, Agent Console, Inbox/Shift, and Sign out.

### Testing
- Ran `npx tsc --noEmit --pretty false` and it completed successfully without type errors.
- Ran `npx vitest run tests/dashboard-server-context.test.ts tests/smoke.test.ts tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx` and all test files passed (4 files, 23 tests total).
- Ran `git diff --check` and there were no whitespace or diff-check issues.
- Ran the grep checks for legacy Supabase auth helpers, forbidden onboarding labels, and `profiles.shop_id` mutations and found no matches, confirming no forbidden regressions were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a261aeda2a08328aff03715127e4757)