### PR TITLE
Expose Guided Setup, remove Planner header action, and add Vehicle Files page

### DIFF
--- a/app/vehicles/page.tsx
+++ b/app/vehicles/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/features/vehicles/app/vehicles/page";

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -19,6 +19,7 @@ type VehicleMedia = DB["public"]["Tables"]["vehicle_media"]["Row"];
 type CustomerSearchRow = Pick<
   Customer,
   | "id"
+  | "shop_id"
   | "first_name"
   | "last_name"
   | "name"
@@ -103,6 +104,30 @@ function bestCustomerDisplayName(c: Pick<Customer, "business_name" | "name" | "f
   const person = [c.first_name ?? "", c.last_name ?? ""].filter(Boolean).join(" ").trim();
   if (person) return person;
   return c.email ?? c.phone ?? c.phone_number ?? "—";
+}
+
+function customerSearchHaystack(c: CustomerSearchRow): string {
+  return [
+    c.business_name,
+    c.name,
+    c.first_name,
+    c.last_name,
+    c.email,
+    c.phone,
+    c.phone_number,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+}
+
+function sortCustomerRows(rows: CustomerSearchRow[]): CustomerSearchRow[] {
+  return [...rows].sort((a, b) =>
+    bestCustomerDisplayName(a).localeCompare(bestCustomerDisplayName(b), undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }),
+  );
 }
 
 function fmtVehicleLabel(v: Vehicle): string {
@@ -404,6 +429,8 @@ export default function CustomerProfilePage(): JSX.Element {
   const [query, setQuery] = useState<string>("");
   const [searching, setSearching] = useState<boolean>(false);
   const [results, setResults] = useState<CustomerSearchRow[]>([]);
+  const [directoryRows, setDirectoryRows] = useState<CustomerSearchRow[]>([]);
+  const [directoryLoaded, setDirectoryLoaded] = useState(false);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   // Create customer from directory mode
@@ -761,48 +788,62 @@ export default function CustomerProfilePage(): JSX.Element {
   }, [getOrLinkShopId, newCustomer, router, supabase]);
 
   // ------------------ Directory search ------------------
-  const runSearch = useCallback(async () => {
-    const q = query.trim();
-    if (!q) {
-      setResults([]);
-      return;
-    }
-
+  const loadDirectoryRows = useCallback(async () => {
     setSearching(true);
     try {
-      const like = `%${q.replaceAll("%", "").replaceAll("_", "")}%`;
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user?.id) {
+        setDirectoryRows([]);
+        setResults([]);
+        setDirectoryLoaded(true);
+        return;
+      }
+
+      const shopId = await getOrLinkShopId(user.id);
+      if (!shopId) {
+        setDirectoryRows([]);
+        setResults([]);
+        setDirectoryLoaded(true);
+        return;
+      }
 
       const { data, error } = await supabase
         .from("customers")
         .select(
-          "id, first_name, last_name, name, business_name, email, phone, phone_number, created_at",
+          "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at",
         )
-        .or(
-          [
-            `first_name.ilike.${like}`,
-            `last_name.ilike.${like}`,
-            `business_name.ilike.${like}`,
-            `name.ilike.${like}`,
-            `email.ilike.${like}`,
-            `phone.ilike.${like}`,
-            `phone_number.ilike.${like}`,
-          ].join(","),
-        )
-        .order("created_at", { ascending: false })
-        .limit(20);
+        .eq("shop_id", shopId);
 
       if (error) {
+        setDirectoryRows([]);
         setResults([]);
+        setDirectoryLoaded(true);
         return;
       }
 
-      setResults((data ?? []) as CustomerSearchRow[]);
+      const sortedRows = sortCustomerRows((data ?? []) as CustomerSearchRow[]);
+      setDirectoryRows(sortedRows);
+      setResults(sortedRows.slice(0, 20));
+      setDirectoryLoaded(true);
     } catch {
+      setDirectoryRows([]);
       setResults([]);
+      setDirectoryLoaded(true);
     } finally {
       setSearching(false);
     }
-  }, [query, supabase]);
+  }, [getOrLinkShopId, supabase]);
+
+  const runSearch = useCallback(() => {
+    const q = query.trim().toLowerCase();
+    const rows = q
+      ? directoryRows.filter((row) => customerSearchHaystack(row).includes(q))
+      : directoryRows;
+    setResults(sortCustomerRows(rows).slice(0, 20));
+  }, [directoryRows, query]);
 
   // Optional: prime query from ?q= ONCE (do not keep syncing, avoids focus/typing weirdness)
   useEffect(() => {
@@ -815,22 +856,22 @@ export default function CustomerProfilePage(): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDirectoryMode]);
 
-  // Debounced search while typing (no URL updates; avoids remount/focus loss)
   useEffect(() => {
     if (!(isDirectoryMode || sp.get("mode") === "search")) return;
+    void loadDirectoryRows();
+  }, [isDirectoryMode, sp, loadDirectoryRows]);
 
-    const q = query.trim();
-    if (!q) {
-      setResults([]);
-      return;
-    }
+  // Debounced live filtering while typing (no URL updates; avoids remount/focus loss)
+  useEffect(() => {
+    if (!(isDirectoryMode || sp.get("mode") === "search")) return;
+    if (!directoryLoaded) return;
 
     const t = window.setTimeout(() => {
-      void runSearch();
-    }, 250);
+      runSearch();
+    }, 150);
 
     return () => window.clearTimeout(t);
-  }, [query, isDirectoryMode, sp, runSearch]);
+  }, [query, isDirectoryMode, sp, directoryLoaded, runSearch]);
 
   // ------------------ Upload ------------------
   const handleUpload = useCallback(
@@ -1203,10 +1244,10 @@ export default function CustomerProfilePage(): JSX.Element {
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     e.preventDefault();
-                    void runSearch();
+                    runSearch();
                   }
                 }}
-                placeholder="Search customers…"
+                placeholder="Search customers..."
                 className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
               />
               <button
@@ -1221,11 +1262,13 @@ export default function CustomerProfilePage(): JSX.Element {
           </div>
 
           <div className="mt-4">
-            {query.trim().length === 0 ? (
-              <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>Start typing to search customers.</div>
-            ) : results.length === 0 ? (
+            {results.length === 0 ? (
               <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
-                {searching ? "Searching…" : "No matches yet."}
+                {searching
+                  ? "Searching…"
+                  : directoryRows.length === 0
+                    ? "No customers found yet."
+                    : "No customers match your search."}
               </div>
             ) : (
               <div className="space-y-2">

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -19,7 +19,7 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStepDefinition[] = [
     title: "Vehicles",
     shortDescription: "Attach vehicles and fleet units to customer records before live repair work starts.",
     question: "Do you need to import vehicles or fleet units from an existing system?",
-    destinationPath: "/customers/directory",
+    destinationPath: "/vehicles",
     ctaLabel: "Open vehicles",
     skipLabel: "Skip vehicles for now",
     category: "data",

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -127,6 +127,14 @@ export const TILES: Tile[] = [
   section: "Operations",
   },
   {
+    href: "/vehicles",
+    title: "Vehicle Files",
+    subtitle: "Search vehicle records",
+    roles: ["advisor", "manager", "owner", "admin"],
+    scopes: ["work_orders", "all"],
+    section: "Operations",
+  },
+  {
     href: "/billing",
     title: "Billing",
     subtitle: "Ready to invoice",

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -23,6 +23,8 @@ const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
   "/work-orders/view": "Operations",
   "/work-orders/quote-review": "Operations",
   "/customers/search": "Operations",
+  "/customers/directory": "Operations",
+  "/vehicles": "Operations",
   "/billing": "Operations",
   "/work-orders/history": "Operations",
   "/parts": "Parts",

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -77,6 +77,26 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     icon: "💵",
     roles: ["owner", "admin", "manager", "advisor"],
   },
+  "/customers": {
+    title: () => "Customer Files",
+    icon: "👤",
+    roles: ["owner", "admin", "manager", "advisor"],
+  },
+  "/customers/directory": {
+    title: () => "Customer Files",
+    icon: "👤",
+    roles: ["owner", "admin", "manager", "advisor"],
+  },
+  "/customers/search": {
+    title: () => "Customer Files",
+    icon: "👤",
+    roles: ["owner", "admin", "manager", "advisor"],
+  },
+  "/vehicles": {
+    title: () => "Vehicle Files",
+    icon: "🚗",
+    roles: ["owner", "admin", "manager", "advisor"],
+  },
 
   "/work-orders/[id]": {
     title: (href) => `WO #${href.split("/").pop()?.slice(0, 8) ?? "…"}`,

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
+type Customer = DB["public"]["Tables"]["customers"]["Row"];
+
+type CustomerSummary = Pick<
+  Customer,
+  | "id"
+  | "business_name"
+  | "name"
+  | "first_name"
+  | "last_name"
+  | "email"
+  | "phone"
+  | "phone_number"
+>;
+
+type VehicleSearchRow = Pick<
+  Vehicle,
+  | "id"
+  | "shop_id"
+  | "customer_id"
+  | "unit_number"
+  | "vin"
+  | "license_plate"
+  | "year"
+  | "make"
+  | "model"
+  | "created_at"
+> & {
+  customers?: CustomerSummary | null;
+};
+
+const CARD_BASE =
+  "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_18px_45px_rgba(0,0,0,0.85)] backdrop-blur-xl";
+const CARD_INNER =
+  "rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-[color:var(--desktop-item-bg)]";
+
+function customerDisplayName(
+  c: CustomerSummary | null | undefined,
+): string | null {
+  if (!c) return null;
+  const businessName = c.business_name?.trim();
+  if (businessName) return businessName;
+  const name = c.name?.trim();
+  if (name) return name;
+  const person = [c.first_name ?? "", c.last_name ?? ""]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  if (person) return person;
+  return c.email ?? c.phone ?? c.phone_number ?? null;
+}
+
+function vehicleYearMakeModel(
+  v: Pick<Vehicle, "year" | "make" | "model">,
+): string {
+  return [v.year != null ? String(v.year) : "", v.make ?? "", v.model ?? ""]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function vehicleDisplayLabel(v: VehicleSearchRow): string {
+  const unitNumber = v.unit_number?.trim();
+  if (unitNumber) return unitNumber;
+  const ymm = vehicleYearMakeModel(v).trim();
+  if (ymm) return ymm;
+  const plate = v.license_plate?.trim();
+  if (plate) return plate;
+  return v.vin?.trim() || "Vehicle";
+}
+
+function vehicleSearchHaystack(v: VehicleSearchRow): string {
+  return [
+    v.unit_number,
+    v.vin,
+    v.license_plate,
+    v.year != null ? String(v.year) : null,
+    v.make,
+    v.model,
+    customerDisplayName(v.customers),
+  ]
+    .filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    )
+    .join(" ")
+    .toLowerCase();
+}
+
+function sortVehicleRows(rows: VehicleSearchRow[]): VehicleSearchRow[] {
+  return [...rows].sort((a, b) =>
+    vehicleDisplayLabel(a).localeCompare(vehicleDisplayLabel(b), undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }),
+  );
+}
+
+export default function VehicleFilesPage() {
+  const router = useRouter();
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [allRows, setAllRows] = useState<VehicleSearchRow[]>([]);
+  const [visibleRows, setVisibleRows] = useState<VehicleSearchRow[]>([]);
+
+  const getOrLinkShopId = useCallback(
+    async (userId: string): Promise<string | null> => {
+      const byUserId = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("user_id", userId)
+        .maybeSingle();
+
+      if (byUserId.error) throw byUserId.error;
+      if (byUserId.data?.shop_id) return byUserId.data.shop_id;
+
+      const byId = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", userId)
+        .maybeSingle();
+
+      if (byId.error) throw byId.error;
+      if (byId.data?.shop_id) return byId.data.shop_id;
+
+      const ownedShop = await supabase
+        .from("shops")
+        .select("id")
+        .eq("owner_id", userId)
+        .maybeSingle();
+
+      if (ownedShop.error) throw ownedShop.error;
+      return ownedShop.data?.id ?? null;
+    },
+    [supabase],
+  );
+
+  const loadVehicles = useCallback(async () => {
+    setLoading(true);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user?.id) {
+        setAllRows([]);
+        setVisibleRows([]);
+        return;
+      }
+
+      const shopId = await getOrLinkShopId(user.id);
+      if (!shopId) {
+        setAllRows([]);
+        setVisibleRows([]);
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from("vehicles")
+        .select(
+          "id, shop_id, customer_id, unit_number, vin, license_plate, year, make, model, created_at, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)",
+        )
+        .eq("shop_id", shopId);
+
+      if (error) {
+        setAllRows([]);
+        setVisibleRows([]);
+        return;
+      }
+
+      const rows = (
+        (data ?? []) as Array<
+          VehicleSearchRow & {
+            customers?: CustomerSummary | CustomerSummary[] | null;
+          }
+        >
+      ).map((row) => ({
+        ...row,
+        customers: Array.isArray(row.customers)
+          ? (row.customers[0] ?? null)
+          : (row.customers ?? null),
+      }));
+      const sortedRows = sortVehicleRows(rows);
+      setAllRows(sortedRows);
+      setVisibleRows(sortedRows.slice(0, 20));
+    } catch {
+      setAllRows([]);
+      setVisibleRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [getOrLinkShopId, supabase]);
+
+  useEffect(() => {
+    void loadVehicles();
+  }, [loadVehicles]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const q = query.trim().toLowerCase();
+      const rows = q
+        ? allRows.filter((row) => vehicleSearchHaystack(row).includes(q))
+        : allRows;
+      setVisibleRows(sortVehicleRows(rows).slice(0, 20));
+    }, 150);
+
+    return () => window.clearTimeout(timer);
+  }, [allRows, query]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 text-neutral-100">
+      <GuidedPageStepPanel />
+
+      <div className={`${CARD_BASE} p-4`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1
+              className="text-2xl font-semibold text-white"
+              style={{ fontFamily: "var(--font-blackops), system-ui" }}
+            >
+              Vehicle Files
+            </h1>
+            <p className="mt-1 text-xs text-neutral-400">
+              Search by unit, VIN, plate, year, make, model, or customer.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:w-[680px] sm:flex-row">
+            <button
+              type="button"
+              onClick={() => router.push("/customers/directory")}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/55 bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-white hover:border-[var(--accent-copper)] hover:bg-black/55"
+              title="Select a customer file to add a vehicle."
+            >
+              + Create Vehicle
+            </button>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search vehicles..."
+              className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4">
+          {visibleRows.length === 0 ? (
+            <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
+              {loading
+                ? "Loading vehicles…"
+                : allRows.length === 0
+                  ? "No vehicles found yet."
+                  : "No vehicles match your search."}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {visibleRows.map((vehicle) => {
+                const customerName = customerDisplayName(vehicle.customers);
+                const yearMakeModel =
+                  vehicleYearMakeModel(vehicle) || "Vehicle";
+
+                return (
+                  <button
+                    key={vehicle.id}
+                    type="button"
+                    onClick={() => {
+                      if (vehicle.customer_id)
+                        router.push(`/customers/${vehicle.customer_id}`);
+                    }}
+                    className={`${CARD_INNER} w-full p-3 text-left hover:border-[var(--accent-copper-soft)]/65`}
+                  >
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-semibold text-white">
+                          {yearMakeModel}
+                        </div>
+                        <div className="mt-0.5 truncate text-[11px] text-neutral-400">
+                          {vehicle.unit_number?.trim()
+                            ? `Unit ${vehicle.unit_number}`
+                            : "No unit number"}
+                        </div>
+                        <div className="mt-0.5 text-[11px] text-neutral-400">
+                          VIN: {vehicle.vin?.trim() || "—"} · Plate:{" "}
+                          {vehicle.license_plate?.trim() || "—"}
+                        </div>
+                      </div>
+                      <div className="text-left text-[11px] text-neutral-400 sm:text-right">
+                        <div className="text-neutral-300">
+                          {customerName ?? "No linked customer"}
+                        </div>
+                        <div className="mt-0.5 text-neutral-500">
+                          {vehicleDisplayLabel(vehicle)}
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/guided-onboarding-page-panels.test.tsx
+++ b/tests/guided-onboarding-page-panels.test.tsx
@@ -1,12 +1,21 @@
 import * as React from "react";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { parseGuidedPageContext } from "@/features/onboarding-v2/guided/pageContext";
-import { GUIDED_ONBOARDING_STEPS, buildGuidedDestination } from "@/features/onboarding-v2/guided/steps";
+import {
+  GUIDED_ONBOARDING_STEPS,
+  buildGuidedDestination,
+} from "@/features/onboarding-v2/guided/steps";
 
 const routerPush = vi.fn();
 let currentSearchParams = new URLSearchParams();
@@ -22,6 +31,7 @@ function read(path: string) {
 
 const productionPageFiles = [
   "features/customers/app/customers/[id]/page.tsx",
+  "features/vehicles/app/vehicles/page.tsx",
   "features/dashboard/app/dashboard/owner/create-user/page.tsx",
   "features/dashboard/app/dashboard/owner/settings/page.tsx",
   "features/inspections/app/inspection/templates/page.tsx",
@@ -56,11 +66,19 @@ describe("guided onboarding page panels", () => {
     render(<GuidedPageStepPanel />);
 
     expect(screen.getByText("Guided setup")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Customers" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Customers" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("What to do here")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Mark step complete" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Skip for now" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Back to guided setup" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Mark step complete" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Skip for now" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to guided setup" }),
+    ).toBeInTheDocument();
   });
 
   it("rejects unknown guided steps before rendering", () => {
@@ -82,7 +100,9 @@ describe("guided onboarding page panels", () => {
       returnTo: "/dashboard/onboarding-v2/session-123",
       highlight: "inventory_parts",
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
 
     render(<GuidedPageStepPanel />);
 
@@ -93,7 +113,9 @@ describe("guided onboarding page panels", () => {
         { method: "POST" },
       );
     });
-    expect(routerPush).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123");
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/onboarding-v2/session-123",
+    );
 
     cleanup();
     routerPush.mockReset();
@@ -106,12 +128,18 @@ describe("guided onboarding page panels", () => {
         { method: "POST" },
       );
     });
-    expect(routerPush).toHaveBeenCalledWith("/dashboard/onboarding-v2/session-123");
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/onboarding-v2/session-123",
+    );
   });
 
   it("provides a safe parser and fallback return path", () => {
     const context = parseGuidedPageContext(
-      new URLSearchParams({ guidedSessionId: "abc", guidedStep: "staff", returnTo: "https://bad.example" }),
+      new URLSearchParams({
+        guidedSessionId: "abc",
+        guidedStep: "staff",
+        returnTo: "https://bad.example",
+      }),
     );
 
     expect(context?.stepKey).toBe("staff");
@@ -121,7 +149,7 @@ describe("guided onboarding page panels", () => {
   it("maps every guided step to a production destination with guided query params", () => {
     const expectedDestinations: Record<string, string> = {
       customers: "/customers/directory",
-      vehicles: "/customers/directory",
+      vehicles: "/vehicles",
       staff: "/dashboard/owner/create-user",
       labor_tax_shop_settings: "/dashboard/owner/settings",
       inspection_templates: "/inspections/templates",
@@ -133,12 +161,33 @@ describe("guided onboarding page panels", () => {
 
     for (const step of GUIDED_ONBOARDING_STEPS) {
       const destination = buildGuidedDestination(step, "session-xyz");
-      expect(destination.startsWith(`${expectedDestinations[step.key]}?`)).toBe(true);
+      expect(destination.startsWith(`${expectedDestinations[step.key]}?`)).toBe(
+        true,
+      );
       expect(destination).toContain("guidedSessionId=session-xyz");
       expect(destination).toContain(`guidedStep=${step.key}`);
       expect(destination).toContain(`highlight=${step.key}`);
-      expect(destination).toContain("returnTo=%2Fdashboard%2Fonboarding-v2%2Fsession-xyz");
+      expect(destination).toContain(
+        "returnTo=%2Fdashboard%2Fonboarding-v2%2Fsession-xyz",
+      );
     }
+  });
+
+  it("maps customer and vehicle guided destinations to real app routes", () => {
+    expect(existsSync(join(process.cwd(), "app/customers/[id]/page.tsx"))).toBe(
+      true,
+    );
+    expect(existsSync(join(process.cwd(), "app/vehicles/page.tsx"))).toBe(true);
+
+    const customerStep = GUIDED_ONBOARDING_STEPS.find(
+      (step) => step.key === "customers",
+    );
+    const vehicleStep = GUIDED_ONBOARDING_STEPS.find(
+      (step) => step.key === "vehicles",
+    );
+
+    expect(customerStep?.destinationPath).toBe("/customers/directory");
+    expect(vehicleStep?.destinationPath).toBe("/vehicles");
   });
 
   it("layers panels into production pages without removing core page labels", () => {
@@ -148,6 +197,7 @@ describe("guided onboarding page panels", () => {
       expect(read(path)).toContain("GuidedPageStepPanel");
     }
     expect(combined).toContain("Customer Files");
+    expect(combined).toContain("Vehicle Files");
     expect(combined).toContain("New team member");
     expect(combined).toContain("System summary");
     expect(combined).toContain("Inspection Templates");
@@ -157,12 +207,48 @@ describe("guided onboarding page panels", () => {
     expect(combined).toContain("service history");
   });
 
+  it("keeps Customer Files default and live-search behavior capped to 20 shop-scoped rows", () => {
+    const source = read("features/customers/app/customers/[id]/page.tsx");
+
+    expect(source).toContain('placeholder="Search customers..."');
+    expect(source).toContain('"No customers found yet."');
+    expect(source).toContain('"No customers match your search."');
+    expect(source).toContain('.eq("shop_id", shopId)');
+    expect(source).toContain("setResults(sortedRows.slice(0, 20))");
+    expect(source).toContain("setResults(sortCustomerRows(rows).slice(0, 20))");
+    expect(source).toContain("customerSearchHaystack");
+    expect(source).not.toContain("Start typing to search customers.");
+  });
+
+  it("builds Vehicle Files with default and live-search behavior capped to 20 shop-scoped rows", () => {
+    const source = read("features/vehicles/app/vehicles/page.tsx");
+
+    expect(source).toContain("Vehicle Files");
+    expect(source).toContain(
+      "Search by unit, VIN, plate, year, make, model, or customer.",
+    );
+    expect(source).toContain('placeholder="Search vehicles..."');
+    expect(source).toContain("+ Create Vehicle");
+    expect(source).toContain("GuidedPageStepPanel");
+    expect(source).toContain('"No vehicles found yet."');
+    expect(source).toContain('"No vehicles match your search."');
+    expect(source).toContain('.eq("shop_id", shopId)');
+    expect(source).toContain("setVisibleRows(sortedRows.slice(0, 20))");
+    expect(source).toContain(
+      "setVisibleRows(sortVehicleRows(rows).slice(0, 20))",
+    );
+    expect(source).toContain("vehicleSearchHaystack");
+    expect(source).not.toContain("Start typing to search vehicles.");
+  });
+
   it("does not introduce legacy guided onboarding or auth helper regressions", () => {
     const guidedSource = [
       "features/onboarding-v2/components/GuidedPageStepPanel.tsx",
       "features/onboarding-v2/guided/pageContext.ts",
       "features/onboarding-v2/guided/steps.ts",
-    ].map(read).join("\n");
+    ]
+      .map(read)
+      .join("\n");
 
     expect(guidedSource).not.toContain("Onboarding Agent");
     expect(guidedSource).not.toContain("onboarding_" + "sessions");

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -35,7 +35,9 @@ function read(path: string) {
 
 describe("guided onboarding v2 foundation", () => {
   it("adds the dedicated dashboard page without old removed control copy", () => {
-    const dashboardSource = read("app/dashboard/onboarding-v2/page.tsx") + read("features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx");
+    const dashboardSource =
+      read("app/dashboard/onboarding-v2/page.tsx") +
+      read("features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx");
 
     expect(dashboardSource).toContain("Guided Setup");
     expect(dashboardSource).not.toContain("Onboarding Agent");
@@ -63,9 +65,22 @@ describe("guided onboarding v2 foundation", () => {
 
     expect(ownerGuidedTile).toMatchObject({
       title: "Guided Setup",
+      href: "/dashboard/onboarding-v2",
+      roles: ["owner", "admin"],
       section: "Admin & Oversight",
     });
     expect(guidedTile?.title).not.toBe("Onboarding Agent");
+  });
+
+  it("adds Vehicle Files to app navigation", () => {
+    const vehicleTile = TILES.find((tile) => tile.href === "/vehicles");
+
+    expect(vehicleTile).toMatchObject({
+      title: "Vehicle Files",
+      href: "/vehicles",
+      roles: ["advisor", "manager", "owner", "admin"],
+      section: "Operations",
+    });
   });
 
   it("keeps Planner out of the dashboard header while retaining other header actions", () => {
@@ -135,16 +150,22 @@ describe("guided onboarding v2 foundation", () => {
 
   it("keeps API access shop-scoped through the stable helper", () => {
     const serverSource = read("features/onboarding-v2/guided/server.ts");
-    const routeSources = newFiles.filter((path) => path.startsWith("app/api/onboarding-v2/")).map(read).join("\n");
+    const routeSources = newFiles
+      .filter((path) => path.startsWith("app/api/onboarding-v2/"))
+      .map(read)
+      .join("\n");
 
     expect(serverSource).toContain("requireShopScopedApiAccess");
-    expect(serverSource).toContain("allowRoles: [\"owner\", \"admin\"]");
+    expect(serverSource).toContain('allowRoles: ["owner", "admin"]');
     expect(routeSources).toContain("@/features/onboarding-v2/guided/server");
   });
 
   it("renders progress, current step, and existing-system intake in the workspace", async () => {
-    const { default: GuidedOnboardingWorkspace } = await import("@/features/onboarding-v2/components/GuidedOnboardingWorkspace");
-    const markup = renderToStaticMarkup(React.createElement(GuidedOnboardingWorkspace));
+    const { default: GuidedOnboardingWorkspace } =
+      await import("@/features/onboarding-v2/components/GuidedOnboardingWorkspace");
+    const markup = renderToStaticMarkup(
+      React.createElement(GuidedOnboardingWorkspace),
+    );
 
     expect(markup).toContain("Guided Setup");
     expect(markup).toContain("Progress");


### PR DESCRIPTION
### Motivation
- Surface the Guided Setup control so owners/admins can discover onboarding v2 from Admin & Oversight.  
- Ensure guided panels appear on the actual production list/search pages (customers, vehicles, etc.) when launched from a guided flow.  
- Remove the Planner button from the main dashboard header actions to match product direction while keeping Planner routes intact.  
- Provide a dedicated Vehicle Files workspace mirroring Customer Files with shop-scoped defaults and live search for guided flows.

### Description
- Added a visible "Guided Setup" tile under owner/admin navigation and ensured it groups under "Admin & Oversight", and registered a new "Vehicle Files" tile at `/vehicles` in the app navigation metadata.  
- Updated the guided step registry so `vehicles` now targets `/vehicles` and `customers` targets the real Customer Files route, and ensured built destination URLs include `guidedSessionId`, `guidedStep`, `returnTo`, and `highlight`.  
- Layered `GuidedPageStepPanel` into the real production pages used by the app and wired the panel to render only when guided query params are present.  
- Reworked Customer Files directory mode to load the first 20 shop-scoped customers by default, add a haystack search function, stable alphabetical sorting, live filtering with a 20-row cap, and new empty states; removed the old "Start typing to search customers." helper.  
- Implemented a new Vehicle Files page (`features/vehicles/app/vehicles/page.tsx` and `app/vehicles/page.tsx`) that mirrors Customer Files behavior with shop-scoped initial load, live filtering, 20-row cap, display fields (year/make/model, unit/VIN/plate, linked customer), and `GuidedPageStepPanel` support.  
- Removed the Planner header action (keeps Shift, Inbox, Agent Request, Assistant, Agent Console, Sign out) without deleting Planner routes or backend code.  
- Updated tests to cover nav visibility, header actions, guided panel presence/absence, customer and vehicle default/list/search behavior, guided destinations, and regression checks for legacy auth/onboarding artifacts.

### Testing
- Ran TypeScript check with `npx tsc --noEmit` and it completed successfully.  
- Ran unit tests with Vitest: `npx vitest run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx tests/dashboard-server-context.test.ts tests/smoke.test.ts` and all tests passed (4 test files, 27 tests).  
- Verified no legacy Supabase auth helpers or removed onboarding agent text were introduced via grep checks, and ran `git diff --check` to ensure no whitespace/errors; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a261c535c448328ad75e7607bc086d3)