### PR TITLE
Guided onboarding: customer-first flow and DB metadata fix

### DIFF
--- a/db/sql/2026-06-07_guided_onboarding_v2_foundation.sql
+++ b/db/sql/2026-06-07_guided_onboarding_v2_foundation.sql
@@ -19,6 +19,10 @@ create table if not exists public.guided_onboarding_steps (
   session_id uuid not null references public.guided_onboarding_sessions(id) on delete cascade,
   shop_id uuid not null references public.shops(id) on delete cascade,
   step_key text not null,
+  destination_path text not null,
+  title text not null,
+  question text not null,
+  description text not null default '',
   status text not null default 'not_started',
   answer jsonb not null default '{}'::jsonb,
   started_at timestamptz,
@@ -53,6 +57,31 @@ create index if not exists guided_onboarding_events_shop_id_idx on public.guided
 create index if not exists guided_onboarding_events_session_id_idx on public.guided_onboarding_events(session_id);
 create index if not exists guided_onboarding_events_step_key_idx on public.guided_onboarding_events(step_key);
 create index if not exists guided_onboarding_events_event_type_idx on public.guided_onboarding_events(event_type);
+
+alter table public.guided_onboarding_steps
+  add column if not exists destination_path text;
+alter table public.guided_onboarding_steps
+  add column if not exists title text;
+alter table public.guided_onboarding_steps
+  add column if not exists question text;
+alter table public.guided_onboarding_steps
+  add column if not exists description text not null default '';
+
+update public.guided_onboarding_steps
+set
+  destination_path = coalesce(destination_path, '/dashboard/onboarding-v2'),
+  title = coalesce(title, step_key),
+  question = coalesce(question, 'Continue this guided setup step.'),
+  description = coalesce(description, '')
+where destination_path is null
+  or title is null
+  or question is null
+  or description is null;
+
+alter table public.guided_onboarding_steps
+  alter column destination_path set not null,
+  alter column title set not null,
+  alter column question set not null;
 
 alter table public.guided_onboarding_sessions enable row level security;
 alter table public.guided_onboarding_steps enable row level security;

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -437,6 +437,7 @@ export default function CustomerProfilePage(): JSX.Element {
   const [createCustomerOpen, setCreateCustomerOpen] = useState(false);
   const [creatingCustomer, setCreatingCustomer] = useState(false);
   const [createCustomerError, setCreateCustomerError] = useState<string | null>(null);
+  const [customerImportPlaceholderVisible, setCustomerImportPlaceholderVisible] = useState(false);
   const [newCustomer, setNewCustomer] = useState<NewCustomerDraft>(EMPTY_NEW_CUSTOMER);
 
   const selectedVehicle = useMemo(() => {
@@ -1210,7 +1211,32 @@ export default function CustomerProfilePage(): JSX.Element {
       <PageShell>
         <TopBar rightLabel="Customers" onBack={() => router.back()} />
 
-        <GuidedPageStepPanel />
+        <GuidedPageStepPanel
+          actions={{
+            customers: {
+              label: "Prepare customer CSV import",
+              description: "Customer CSV import will be connected here. You can safely create customers manually now without leaving this page.",
+              onClick: () => setCustomerImportPlaceholderVisible(true),
+            },
+          }}
+        />
+
+        {customerImportPlaceholderVisible ? (
+          <div className={`${CARD_BASE} border-[var(--accent-copper-soft)]/55 p-4 text-sm text-neutral-200`} data-guided-customer-import-placeholder>
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper,#C57A4A)]">Customer import</div>
+            <p className="mt-2">Customer CSV import will be connected here. For now, use <span className="font-semibold text-white">+ Create Customer</span> to add records safely.</p>
+            <button
+              type="button"
+              onClick={() => {
+                setCreateCustomerError(null);
+                setCreateCustomerOpen(true);
+              }}
+              className="mt-3 rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black hover:brightness-110"
+            >
+              + Create Customer
+            </button>
+          </div>
+        ) : null}
 
         <div className={`${CARD_BASE} p-4`}>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { buildGuidedDestination, GUIDED_ONBOARDING_STEPS, getGuidedOnboardingStep } from "@/features/onboarding-v2/guided/steps";
 import type { GuidedOnboardingSessionDetail, GuidedOnboardingStepRow } from "@/features/onboarding-v2/guided/types";
@@ -11,6 +10,8 @@ type Props = {
 };
 
 type LoadState = "idle" | "loading" | "ready" | "error";
+
+type ActionResult = GuidedOnboardingSessionDetail | { redirectTo: string; detail?: GuidedOnboardingSessionDetail };
 
 function stepStatusLabel(status: string) {
   if (status === "completed") return "Done";
@@ -23,13 +24,34 @@ function getStoredStep(step: GuidedOnboardingStepRow[] | undefined, key: string)
   return step?.find((row) => row.step_key === key) ?? null;
 }
 
+async function readJsonError(response: Response, fallback: string) {
+  const text = await response.text();
+  if (!text) return fallback;
+  try {
+    const parsed = JSON.parse(text) as { error?: string };
+    return parsed.error || text;
+  } catch {
+    return text;
+  }
+}
+
 async function postJson(path: string, body: Record<string, unknown> = {}) {
   const response = await fetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!response.ok) throw new Error((await response.text()) || "Request failed");
+  if (!response.ok) throw new Error(await readJsonError(response, "Request failed"));
+  return (await response.json()) as GuidedOnboardingSessionDetail;
+}
+
+async function patchJson(path: string, body: Record<string, unknown> = {}) {
+  const response = await fetch(path, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(await readJsonError(response, "Request failed"));
   return (await response.json()) as GuidedOnboardingSessionDetail;
 }
 
@@ -40,8 +62,9 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
   const [busyAction, setBusyAction] = useState<string | null>(null);
 
   const activeStep = useMemo(() => {
-    if (detail?.currentStep) return detail.currentStep;
-    return getGuidedOnboardingStep(detail?.session.current_step_key ?? null) ?? GUIDED_ONBOARDING_STEPS[0] ?? null;
+    if (!detail) return null;
+    if (detail.currentStep) return detail.currentStep;
+    return getGuidedOnboardingStep(detail.session.current_step_key ?? null);
   }, [detail]);
 
   const loadSession = useCallback(async (sessionId?: string) => {
@@ -50,17 +73,18 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
     try {
       if (sessionId) {
         const response = await fetch(`/api/onboarding-v2/guided/sessions/${sessionId}`);
-        if (!response.ok) throw new Error((await response.text()) || "Unable to load guided setup");
+        if (!response.ok) throw new Error(await readJsonError(response, "Unable to load guided setup"));
         setDetail((await response.json()) as GuidedOnboardingSessionDetail);
       } else {
         const response = await fetch("/api/onboarding-v2/guided/sessions");
-        if (!response.ok) throw new Error((await response.text()) || "Unable to list guided setup sessions");
+        if (!response.ok) throw new Error(await readJsonError(response, "Unable to list guided setup sessions"));
         const payload = (await response.json()) as { sessions?: { id: string; status: string }[] };
-        const active = payload.sessions?.find((session) => session.status === "active") ?? payload.sessions?.[0];
+        const active = payload.sessions?.find((session) => session.status === "active");
         if (active) {
           await loadSession(active.id);
           return;
         }
+        setDetail(null);
       }
       setLoadState("ready");
     } catch (err) {
@@ -73,14 +97,20 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
     void loadSession(initialSessionId);
   }, [initialSessionId, loadSession]);
 
-  const runAction = useCallback(async (label: string, action: () => Promise<GuidedOnboardingSessionDetail>) => {
+  const runAction = useCallback(async (label: string, action: () => Promise<ActionResult>) => {
     setBusyAction(label);
     setError(null);
     try {
-      const next = await action();
-      setDetail(next);
-      if (next.session.id && window.location.pathname === "/dashboard/onboarding-v2") {
-        window.history.replaceState(null, "", `/dashboard/onboarding-v2/${next.session.id}`);
+      const result = await action();
+      const nextDetail = "redirectTo" in result ? result.detail : result;
+      if (nextDetail) {
+        setDetail(nextDetail);
+        if (nextDetail.session.id && window.location.pathname === "/dashboard/onboarding-v2") {
+          window.history.replaceState(null, "", `/dashboard/onboarding-v2/${nextDetail.session.id}`);
+        }
+      }
+      if ("redirectTo" in result) {
+        window.location.assign(result.redirectTo);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Action failed");
@@ -90,9 +120,41 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
     }
   }, []);
 
+  const startOrResume = useCallback(() => postJson("/api/onboarding-v2/guided/sessions"), []);
+
+  const answerNoExistingSystem = useCallback(async () => {
+    const started = await startOrResume();
+    const skipped = await postJson(`/api/onboarding-v2/guided/sessions/${started.session.id}/existing-system`, {
+      existing_system: "starting_from_scratch",
+      skip_guided_setup: true,
+    });
+    return { detail: skipped, redirectTo: "/dashboard" };
+  }, [startOrResume]);
+
+  const answerYesExistingSystem = useCallback(async () => {
+    const started = await startOrResume();
+    return postJson(`/api/onboarding-v2/guided/sessions/${started.session.id}/existing-system`, {
+      existing_system: "importing_existing_system",
+    });
+  }, [startOrResume]);
+
+  const answerImportCustomers = useCallback(async () => {
+    if (!detail || !activeStep || activeStep.key !== "customers") throw new Error("Customer step is not ready yet.");
+    const answered = await postJson(`/api/onboarding-v2/guided/sessions/${detail.session.id}/steps/customers/answer`, {
+      answer: { hasCustomerFile: true, intent: "import_customers" },
+    });
+    return { detail: answered, redirectTo: buildGuidedDestination(activeStep, detail.session.id) };
+  }, [activeStep, detail]);
+
+  const skipCustomers = useCallback(async () => {
+    if (!detail) throw new Error("Guided session is not ready yet.");
+    return postJson(`/api/onboarding-v2/guided/sessions/${detail.session.id}/steps/customers/skip`);
+  }, [detail]);
+
   const sessionId = detail?.session.id;
   const progress = detail?.progress ?? { total: GUIDED_ONBOARDING_STEPS.length, completed: 0, skipped: 0, inProgress: 0, percent: 0 };
-  const destination = activeStep && sessionId ? buildGuidedDestination(activeStep, sessionId) : "#";
+  const isBusy = Boolean(busyAction);
+  const loadingCopy = busyAction ? `${busyAction}…` : null;
 
   return (
     <main className="mx-auto w-full max-w-7xl space-y-6 px-4 pb-10 pt-6 text-neutral-100 sm:px-6 lg:px-8">
@@ -102,114 +164,113 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
           <div>
             <h1 className="text-3xl font-semibold text-white sm:text-4xl">Guided Setup</h1>
             <p className="mt-3 max-w-3xl text-sm leading-6 text-neutral-300">
-              Configure and import the shop step by step. This optional control room keeps progress, sends you to real production pages, and brings you back to the exact guided setup session.
+              Start with customers only. If you are importing from an existing shop system, ProFixIQ will send you to the real Customer Files page and bring you back here.
             </p>
           </div>
-          <button
-            type="button"
-            className="rounded-full bg-orange-400 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-lg shadow-orange-500/20 transition hover:bg-orange-300 disabled:cursor-not-allowed disabled:opacity-60"
-            disabled={Boolean(busyAction)}
-            onClick={() => runAction("start", () => postJson("/api/onboarding-v2/guided/sessions"))}
-          >
-            {sessionId ? "Resume guided setup" : "Start guided setup"}
-          </button>
+          {sessionId ? (
+            <button
+              type="button"
+              className="rounded-full bg-orange-400 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-lg shadow-orange-500/20 transition hover:bg-orange-300 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isBusy}
+              onClick={() => runAction("Resuming", () => startOrResume())}
+            >
+              Resume guided setup
+            </button>
+          ) : null}
         </div>
       </header>
 
       {error ? <div className="rounded-2xl border border-red-400/30 bg-red-950/30 px-4 py-3 text-sm text-red-100">{error}</div> : null}
+      {loadingCopy ? <div className="rounded-2xl border border-orange-300/25 bg-orange-400/10 px-4 py-3 text-sm text-orange-100">{loadingCopy}</div> : null}
       {loadState === "loading" ? <div className="rounded-2xl border border-white/10 bg-black/30 p-5 text-sm text-neutral-300">Loading guided setup…</div> : null}
 
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
         <section className="space-y-5">
-          <OnboardingHighlightFrame
-            title={activeStep?.title ?? "Ready when you are"}
-            description={activeStep?.shortDescription ?? "Start a guided setup session to begin preserving shop setup progress."}
-          >
-            <div className="grid gap-4 md:grid-cols-3">
-              <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-                <p className="text-xs uppercase tracking-[0.16em] text-neutral-400">Progress</p>
-                <p className="mt-2 text-3xl font-semibold text-white">{progress.percent}%</p>
-                <p className="mt-1 text-xs text-neutral-400">{progress.completed} done · {progress.skipped} skipped · {progress.total} total</p>
-              </div>
-              <div className="rounded-2xl border border-white/10 bg-black/30 p-4 md:col-span-2">
+          {!detail ? (
+            <OnboardingHighlightFrame
+              title="Start customer setup"
+              description="Answer one question so ProFixIQ knows whether to launch the guided customer import flow."
+            >
+              <div className="rounded-2xl border border-white/10 bg-black/30 p-5">
                 <p className="text-xs uppercase tracking-[0.16em] text-neutral-400">Starting point</p>
-                <p className="mt-2 text-sm text-neutral-200">Is this shop starting from scratch or importing from an existing system?</p>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {[
-                    ["starting_from_scratch", "Starting from scratch"],
-                    ["importing_existing_system", "Importing existing system"],
-                    ["undecided", "Not sure yet"],
-                  ].map(([value, label]) => (
-                    <button
-                      key={value}
-                      type="button"
-                      disabled={!sessionId || Boolean(busyAction)}
-                      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition ${detail?.session.existing_system === value ? "border-orange-300 bg-orange-300 text-slate-950" : "border-white/15 bg-white/5 text-neutral-200 hover:border-orange-300/60"}`}
-                      onClick={() => sessionId && runAction(value, () => postJson(`/api/onboarding-v2/guided/sessions/${sessionId}/existing-system`, { existing_system: value }))}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {activeStep ? (
-              <div className="mt-5 rounded-2xl border border-white/10 bg-black/30 p-4">
-                <p className="text-xs uppercase tracking-[0.16em] text-neutral-400">Current step</p>
-                <h3 className="mt-2 text-lg font-semibold text-white">{activeStep.title}</h3>
-                <p className="mt-1 text-sm text-neutral-300">{activeStep.question}</p>
-                <p className="mt-2 text-xs text-neutral-500">Production owner/page: {activeStep.productionOwnerPage}</p>
-                <div className="mt-4 flex flex-wrap gap-2">
+                <h2 className="mt-2 text-2xl font-semibold text-white">Do you have an existing shop/system to import?</h2>
+                <div className="mt-5 flex flex-wrap gap-3">
                   <button
                     type="button"
-                    disabled={!sessionId || Boolean(busyAction)}
-                    className="rounded-full border border-emerald-300/40 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100 hover:bg-emerald-300/20 disabled:opacity-50"
-                    onClick={() => sessionId && runAction("yes", () => postJson(`/api/onboarding-v2/guided/sessions/${sessionId}/steps/${activeStep.key}/answer`, { answer: { needsSetup: true } }))}
+                    disabled={isBusy}
+                    className="rounded-full bg-orange-400 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-lg shadow-orange-500/20 transition hover:bg-orange-300 disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={() => runAction("Starting customer setup", answerYesExistingSystem)}
                   >
-                    Yes, guide this
+                    Yes
                   </button>
                   <button
                     type="button"
-                    disabled={!sessionId || Boolean(busyAction)}
-                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:border-orange-300/60 disabled:opacity-50"
-                    onClick={() => sessionId && runAction("no", () => postJson(`/api/onboarding-v2/guided/sessions/${sessionId}/steps/${activeStep.key}/answer`, { answer: { needsSetup: false } }))}
+                    disabled={isBusy}
+                    className="rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-semibold text-neutral-100 transition hover:border-emerald-300/60 hover:bg-emerald-300/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={() => runAction("Saving starting point", answerNoExistingSystem)}
                   >
-                    No, already handled
-                  </button>
-                  <Link
-                    className={`rounded-full px-4 py-1.5 text-xs font-semibold ${sessionId ? "bg-orange-400 text-slate-950 hover:bg-orange-300" : "pointer-events-none bg-neutral-700 text-neutral-400"}`}
-                    href={destination}
-                  >
-                    {activeStep.ctaLabel}
-                  </Link>
-                  <button
-                    type="button"
-                    disabled={!sessionId || Boolean(busyAction)}
-                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:border-emerald-300/60 disabled:opacity-50"
-                    onClick={() => sessionId && runAction("done", () => postJson(`/api/onboarding-v2/guided/sessions/${sessionId}/steps/${activeStep.key}/complete`))}
-                  >
-                    Mark done
-                  </button>
-                  <button
-                    type="button"
-                    disabled={!sessionId || Boolean(busyAction)}
-                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-300 hover:border-yellow-300/60 disabled:opacity-50"
-                    onClick={() => sessionId && runAction("skip", () => postJson(`/api/onboarding-v2/guided/sessions/${sessionId}/steps/${activeStep.key}/skip`))}
-                  >
-                    {activeStep.skipLabel}
+                    No
                   </button>
                 </div>
               </div>
-            ) : null}
-          </OnboardingHighlightFrame>
+            </OnboardingHighlightFrame>
+          ) : activeStep ? (
+            <OnboardingHighlightFrame title={activeStep.title} description={activeStep.shortDescription}>
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+                  <p className="text-xs uppercase tracking-[0.16em] text-neutral-400">Progress</p>
+                  <p className="mt-2 text-3xl font-semibold text-white">{progress.percent}%</p>
+                  <p className="mt-1 text-xs text-neutral-400">{progress.completed} done · {progress.skipped} skipped · {progress.total} total</p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-black/30 p-4 md:col-span-2">
+                  <p className="text-xs uppercase tracking-[0.16em] text-neutral-400">Current step</p>
+                  <h2 className="mt-2 text-2xl font-semibold text-white">{activeStep.question}</h2>
+                  {activeStep.key === "customers" ? (
+                    <div className="mt-5 flex flex-wrap gap-3">
+                      <button
+                        type="button"
+                        disabled={isBusy}
+                        className="rounded-full bg-orange-400 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-lg shadow-orange-500/20 transition hover:bg-orange-300 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={() => runAction("Opening Customer Files", answerImportCustomers)}
+                      >
+                        Yes, import customers
+                      </button>
+                      <button
+                        type="button"
+                        disabled={isBusy}
+                        className="rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-semibold text-neutral-100 transition hover:border-yellow-300/60 hover:bg-yellow-300/10 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={() => runAction("Skipping customers", skipCustomers)}
+                      >
+                        No, skip customers for now
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        disabled={!sessionId || isBusy}
+                        className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-neutral-300 hover:border-yellow-300/60 disabled:opacity-50"
+                        onClick={() => sessionId && runAction("Skipping step", () => postJson(`/api/onboarding-v2/guided/sessions/${sessionId}/steps/${activeStep.key}/skip`))}
+                      >
+                        {activeStep.skipLabel}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </OnboardingHighlightFrame>
+          ) : (
+            <OnboardingHighlightFrame title="Guided setup complete" description="There are no remaining guided setup steps.">
+              <div className="rounded-2xl border border-white/10 bg-black/30 p-5 text-sm text-neutral-300">Return to the dashboard when you are ready.</div>
+            </OnboardingHighlightFrame>
+          )}
         </section>
 
         <aside className="rounded-3xl border border-white/10 bg-black/35 p-4 shadow-[0_18px_55px_rgba(0,0,0,0.35)] backdrop-blur-xl">
           <div className="flex items-center justify-between gap-3 border-b border-white/10 pb-3">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">Step rail</p>
-              <p className="mt-1 text-sm text-neutral-300">Ordered setup path</p>
+              <p className="mt-1 text-sm text-neutral-300">Customer-first setup path</p>
             </div>
             <span className="rounded-full border border-white/15 bg-white/5 px-2 py-1 text-xs text-neutral-300">{progress.completed}/{progress.total}</span>
           </div>
@@ -229,17 +290,9 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
                   {sessionId ? (
                     <button
                       type="button"
-                      disabled={Boolean(busyAction)}
+                      disabled={isBusy}
                       className="mt-3 text-xs font-semibold text-orange-200 hover:text-orange-100 disabled:opacity-50"
-                      onClick={() => runAction(`resume-${step.key}`, async () => {
-                        const response = await fetch(`/api/onboarding-v2/guided/sessions/${sessionId}`, {
-                          method: "PATCH",
-                          headers: { "Content-Type": "application/json" },
-                          body: JSON.stringify({ current_step_key: step.key }),
-                        });
-                        if (!response.ok) throw new Error((await response.text()) || "Unable to resume step");
-                        return (await response.json()) as GuidedOnboardingSessionDetail;
-                      })}
+                      onClick={() => runAction(`Resuming ${step.title}`, () => patchJson(`/api/onboarding-v2/guided/sessions/${sessionId}`, { current_step_key: step.key }))}
                     >
                       Resume this step
                     </button>

--- a/features/onboarding-v2/guided/pageContext.ts
+++ b/features/onboarding-v2/guided/pageContext.ts
@@ -45,7 +45,7 @@ export function sanitizeGuidedReturnTo(value: string | null, sessionId: string):
 export function getGuidedStepPageInstructions(stepKey: GuidedOnboardingStepKey): string {
   switch (stepKey) {
     case "customers":
-      return "Create a customer, search existing files, or use your stable customer import path if your shop already has records ready.";
+      return "Import or create your customer records.";
     case "vehicles":
       return "Open a customer file and add the vehicles or fleet units that should be ready before advisors build work orders.";
     case "staff":

--- a/features/onboarding-v2/guided/server.ts
+++ b/features/onboarding-v2/guided/server.ts
@@ -37,6 +37,20 @@ function nowPatch() {
   return { updated_at: new Date().toISOString() };
 }
 
+function stepInsertPayload(step: (typeof GUIDED_ONBOARDING_STEPS)[number], sessionId: string, shopId: string) {
+  return {
+    session_id: sessionId,
+    shop_id: shopId,
+    step_key: step.key,
+    status: "not_started",
+    answer: {},
+    destination_path: step.destinationPath,
+    title: step.title,
+    question: step.question,
+    description: step.shortDescription,
+  };
+}
+
 async function logGuidedEvent(
   access: Access,
   sessionId: string,
@@ -163,12 +177,7 @@ export async function createOrResumeGuidedSession() {
     const { error: insertStepsError } = await db(access)
       .from(STEPS_TABLE)
       .insert(
-        missingSteps.map((step) => ({
-          session_id: session!.id,
-          shop_id: access.profile.shop_id,
-          step_key: step.key,
-          status: "not_started",
-        })),
+        missingSteps.map((step) => stepInsertPayload(step, session!.id, access.profile.shop_id!)),
       );
 
     if (insertStepsError) return jsonError(insertStepsError.message, 500);
@@ -224,14 +233,19 @@ export async function setExistingSystem(sessionId: string, body: JsonPayload) {
   if (!access.ok) return access.response;
 
   const value = typeof body.existing_system === "string" ? body.existing_system.trim() : null;
+  const skipGuidedSetup = body.skip_guided_setup === true;
+  const sessionPatch = skipGuidedSetup
+    ? { existing_system: value, status: "skipped", current_step_key: null, completed_at: new Date().toISOString(), ...nowPatch() }
+    : { existing_system: value, status: "active", completed_at: null, ...nowPatch() };
+
   const { error } = await db(access)
     .from(SESSIONS_TABLE)
-    .update({ existing_system: value, ...nowPatch() })
+    .update(sessionPatch)
     .eq("id", sessionId)
     .eq("shop_id", access.profile.shop_id);
 
   if (error) return jsonError(error.message, 500);
-  await logGuidedEvent(access, sessionId, null, "existing_system_answered", { existing_system: value });
+  await logGuidedEvent(access, sessionId, null, "existing_system_answered", { existing_system: value, skipGuidedSetup });
   return detailResponse(access, sessionId);
 }
 

--- a/features/onboarding-v2/guided/steps.ts
+++ b/features/onboarding-v2/guided/steps.ts
@@ -5,14 +5,14 @@ export const GUIDED_ONBOARDING_STEPS: GuidedOnboardingStepDefinition[] = [
     key: "customers",
     title: "Customers",
     shortDescription: "Create or import the customer records your advisors will use every day.",
-    question: "Do you already have a customer list to bring into ProFixIQ?",
-    destinationPath: "/customers/directory",
-    ctaLabel: "Open customers",
-    skipLabel: "Skip customers for now",
+    question: "Do you have a customer file to import?",
+    destinationPath: "/customers/search",
+    ctaLabel: "Yes, import customers",
+    skipLabel: "No, skip customers for now",
     category: "data",
     order: 10,
     productionOwnerPage: "Customers workspace",
-    highlightQuery: { setup: "guided", focus: "customers" },
+    highlightQuery: { highlight: "customer-import" },
   },
   {
     key: "vehicles",
@@ -133,11 +133,14 @@ export function isGuidedOnboardingStepKey(value: string): value is GuidedOnboard
 export function buildGuidedDestination(step: GuidedOnboardingStepDefinition, sessionId: string) {
   const params = new URLSearchParams({
     ...step.highlightQuery,
-    highlight: step.key,
     returnTo: `/dashboard/onboarding-v2/${sessionId}`,
     guidedSessionId: sessionId,
     guidedStep: step.key,
   });
+
+  if (!params.has("highlight")) {
+    params.set("highlight", step.key);
+  }
 
   return `${step.destinationPath}?${params.toString()}`;
 }

--- a/features/onboarding-v2/guided/types.ts
+++ b/features/onboarding-v2/guided/types.ts
@@ -11,7 +11,7 @@ export type GuidedOnboardingStepKey =
 
 export type GuidedOnboardingStepStatus = "not_started" | "in_progress" | "completed" | "skipped";
 
-export type GuidedOnboardingSessionStatus = "active" | "completed" | "paused";
+export type GuidedOnboardingSessionStatus = "active" | "completed" | "paused" | "skipped";
 
 export type GuidedOnboardingStepCategory = "data" | "team" | "settings" | "workflow" | "finance";
 
@@ -54,6 +54,10 @@ export type GuidedOnboardingStepRow = {
   completed_at: string | null;
   skipped_at: string | null;
   created_at: string | null;
+  destination_path?: string | null;
+  title?: string | null;
+  question?: string | null;
+  description?: string | null;
   updated_at: string | null;
 };
 

--- a/tests/guided-onboarding-page-panels.test.tsx
+++ b/tests/guided-onboarding-page-panels.test.tsx
@@ -148,7 +148,7 @@ describe("guided onboarding page panels", () => {
 
   it("maps every guided step to a production destination with guided query params", () => {
     const expectedDestinations: Record<string, string> = {
-      customers: "/customers/directory",
+      customers: "/customers/search",
       vehicles: "/vehicles",
       staff: "/dashboard/owner/create-user",
       labor_tax_shop_settings: "/dashboard/owner/settings",
@@ -166,7 +166,7 @@ describe("guided onboarding page panels", () => {
       );
       expect(destination).toContain("guidedSessionId=session-xyz");
       expect(destination).toContain(`guidedStep=${step.key}`);
-      expect(destination).toContain(`highlight=${step.key}`);
+      expect(destination).toContain(`highlight=${step.key === "customers" ? "customer-import" : step.key}`);
       expect(destination).toContain(
         "returnTo=%2Fdashboard%2Fonboarding-v2%2Fsession-xyz",
       );
@@ -186,7 +186,7 @@ describe("guided onboarding page panels", () => {
       (step) => step.key === "vehicles",
     );
 
-    expect(customerStep?.destinationPath).toBe("/customers/directory");
+    expect(customerStep?.destinationPath).toBe("/customers/search");
     expect(vehicleStep?.destinationPath).toBe("/vehicles");
   });
 

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -160,6 +160,34 @@ describe("guided onboarding v2 foundation", () => {
     expect(routeSources).toContain("@/features/onboarding-v2/guided/server");
   });
 
+
+  it("creates guided step rows with destination metadata required by the database", () => {
+    const serverSource = read("features/onboarding-v2/guided/server.ts");
+    const migrationSource = read("db/sql/2026-06-07_guided_onboarding_v2_foundation.sql");
+
+    expect(migrationSource).toContain("destination_path text not null");
+    expect(serverSource).toContain("destination_path: step.destinationPath");
+    expect(serverSource).toContain("title: step.title");
+    expect(serverSource).toContain("question: step.question");
+    expect(serverSource).toContain("description: step.shortDescription");
+  });
+
+  it("implements the customer-first guided setup button flow", () => {
+    const workspaceSource = read("features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx");
+    const stepSource = read("features/onboarding-v2/guided/steps.ts");
+
+    expect(workspaceSource).toContain("Do you have an existing shop/system to import?");
+    expect(workspaceSource).toContain('existing_system: "starting_from_scratch"');
+    expect(workspaceSource).toContain("skip_guided_setup: true");
+    expect(workspaceSource).toContain('redirectTo: "/dashboard"');
+    expect(workspaceSource).toContain('existing_system: "importing_existing_system"');
+    expect(workspaceSource).toContain("Yes, import customers");
+    expect(workspaceSource).toContain("No, skip customers for now");
+    expect(workspaceSource).toContain("/steps/customers/skip");
+    expect(stepSource).toContain('destinationPath: "/customers/search"');
+    expect(stepSource).toContain('highlight: "customer-import"');
+  });
+
   it("renders progress, current step, and existing-system intake in the workspace", async () => {
     const { default: GuidedOnboardingWorkspace } =
       await import("@/features/onboarding-v2/components/GuidedOnboardingWorkspace");
@@ -168,10 +196,9 @@ describe("guided onboarding v2 foundation", () => {
     );
 
     expect(markup).toContain("Guided Setup");
-    expect(markup).toContain("Progress");
-    expect(markup).toContain("Current step");
     expect(markup).toContain("Starting point");
-    expect(markup).toContain("Starting from scratch");
-    expect(markup).toContain("Importing existing system");
+    expect(markup).toContain("Do you have an existing shop/system to import?");
+    expect(markup).toContain("Yes");
+    expect(markup).toContain("No");
   });
 });


### PR DESCRIPTION
### Motivation
- The guided setup was crashing because `guided_onboarding_steps` rows were being inserted without required metadata (`destination_path`, etc.) while the migration marks those columns `NOT NULL`.
- The onboarding UX needed a small, customer-focused first flow so owners can either skip onboarding or import customers without encountering silent failures.

### Description
- Add non-destructive schema support and backfill by making `destination_path/title/question/description` present and non-null in `db/sql/2026-06-07_guided_onboarding_v2_foundation.sql`. 
- Populate step metadata when creating missing step rows by using the in-code step registry in `features/onboarding-v2/guided/server.ts` so inserted rows satisfy the migration constraints. 
- Implement a customer-first control room in `features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx` that asks “Do you have an existing shop/system to import?” with `Yes` and `No` buttons and wires `Yes` → resume/start session and show Customers step, `No` → save `starting_from_scratch`, mark session skipped and redirect to `/dashboard`. 
- Wire Customers step actions to record answers and route to the Customer Files guided URL (`/customers/search?guidedSessionId=...&guidedStep=customers&returnTo=...&highlight=customer-import`) and add a safe CSV import placeholder on `features/customers/app/customers/[id]/page.tsx` via `GuidedPageStepPanel` without disrupting normal directory/search behavior. 

### Testing
- Typecheck: ran `npx tsc --noEmit --pretty false` and it passed. 
- Unit/UI tests: ran `npx vitest run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx tests/dashboard-server-context.test.ts tests/smoke.test.ts` and all tests passed. 
- Additional validation: ensured `git diff --check` produced no issues and confirmed the changed files include `db/sql/2026-06-07_guided_onboarding_v2_foundation.sql`, `features/onboarding-v2/guided/server.ts`, `features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx`, `features/onboarding-v2/guided/steps.ts`, `features/onboarding-v2/guided/types.ts`, `features/onboarding-v2/guided/pageContext.ts`, and `features/customers/app/customers/[id]/page.tsx` as well as updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262ac2df748328a91fc3eba51610c2)