### PR TITLE
Fix Tech Assistant question handling, vehicle context, and export behavior

### DIFF
--- a/app/api/assistant/export/route.ts
+++ b/app/api/assistant/export/route.ts
@@ -36,8 +36,9 @@ export async function POST(req: Request) {
   }
 
   try {
-    const { vehicle, messages, workOrderLineId } = (await req.json()) as {
+    const { vehicle, context, messages, workOrderLineId } = (await req.json()) as {
       vehicle?: Vehicle;
+      context?: string;
       messages?: ChatMessage[];
       workOrderLineId?: string;
     };
@@ -49,8 +50,25 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Missing work order line id." }, { status: 400 });
     }
 
+    const transcript = Array.isArray(messages)
+      ? messages.filter(
+          (message) =>
+            (message.role === "user" || message.role === "assistant") &&
+            typeof message.content === "string" &&
+            message.content.trim().length > 0,
+        )
+      : [];
+
+    if (transcript.length === 0) {
+      return NextResponse.json(
+        { error: "Ask the assistant a question before exporting." },
+        { status: 400 },
+      );
+    }
+
     const prompt = [
       `Vehicle: ${vehicle.year} ${vehicle.make} ${vehicle.model}`,
+      context?.trim() ? `Shop notes / complaint: ${context.trim()}` : null,
       "You are preparing a concise work-order entry for a shop management system.",
       "From the conversation below, produce:",
       "- Cause: one or two sentences (this is the diagnosis / story of what you found).",
@@ -58,7 +76,7 @@ export async function POST(req: Request) {
       "- EstimatedLaborTime: a decimal number in hours when appropriate, else null.",
       "",
       "Conversation (latest last):",
-      ...(messages ?? []).map((m) => `${m.role.toUpperCase()}: ${m.content}`),
+      ...transcript.map((m) => `${m.role.toUpperCase()}: ${m.content}`),
       "",
       'Return JSON with these exact keys: { "cause": string, "correction": string, "estimatedLaborTime": number | null }',
     ].join("\n");

--- a/features/agent/assistant/server/answerAssistant.ts
+++ b/features/agent/assistant/server/answerAssistant.ts
@@ -1370,6 +1370,44 @@ export async function answerAssistant({
     });
   }
 
+  if (questionIncludes(q, ["vehicle:", "dtc", "code", "p0", "p1", "b0", "c0", "u0", "no start", "misfire", "heater circuit"])) {
+    const codeMatch = question.match(/\b([PBCU][0-9A-F]{4})\b/i);
+    const code = codeMatch?.[1]?.toUpperCase();
+    const vehicleMatch = question.match(/vehicle:\s*([^\n]+)/i);
+    const vehicleLabel = vehicleMatch?.[1]?.trim();
+    const subject = [vehicleLabel, code].filter(Boolean).join(" • ") || "this vehicle concern";
+
+    return buildAnswer({
+      intent: "unknown",
+      summary: `Technician triage for ${subject}: start with a code-specific diagnostic path, verify the complaint, and prove power/ground/signal before replacing parts.`,
+      bullets: dedupeStrings([
+        code === "P0141"
+          ? "P0141 is commonly an O2 sensor heater circuit fault for the downstream sensor (Bank 1 Sensor 2 on many inline engines); confirm exact bank/sensor from service information before ordering."
+          : code
+            ? `Pull freeze-frame data for ${code}, note coolant temp, run time, voltage, and whether the code resets immediately or after a drive cycle.`
+            : "Pull all DTCs and freeze-frame data before clearing anything.",
+        "Check battery voltage and charging health; low system voltage can create misleading circuit faults.",
+        "Inspect connector lock, water intrusion, rubbed harness sections, exhaust heat damage, and prior repair splices near the component.",
+        "Load-test fused power and ground/control circuits with the component connected when possible; avoid condemning the part from resistance checks alone.",
+        "If circuit tests pass, confirm component operation with scan data or a bidirectional/output test, then document the failed test result for advisor approval.",
+      ]),
+      links: [],
+      entities: vehicleLabel ? [{ type: "vehicle", label: vehicleLabel }] : [],
+      actions: [
+        {
+          type: "planner",
+          label: "Build diagnostic plan",
+          goal: `Build a technician diagnostic plan for ${subject}`,
+          context: {
+            workOrderId: resolvedContext.workOrderId,
+            vehicleId: resolvedContext.vehicleId,
+          },
+        },
+      ],
+      resolvedContext,
+    });
+  }
+
   return buildAnswer({
     intent: "unknown",
     summary:

--- a/features/ai/hooks/useTechAssistant.test.tsx
+++ b/features/ai/hooks/useTechAssistant.test.tsx
@@ -1,0 +1,164 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatAssistantAnswer,
+  hasConversationTranscript,
+  useTechAssistant,
+} from "./useTechAssistant";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/test-assistant",
+}));
+
+vi.mock("@supabase/auth-helpers-react", () => ({
+  useSession: () => ({ user: { id: "user_1" } }),
+}));
+
+describe("useTechAssistant", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("sendChat sends the actual question with vehicle context", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          answer: {
+            intent: "unknown",
+            summary: "Check the downstream O2 heater circuit first.",
+            bullets: ["Verify fuse power and ground.", "Measure heater resistance."],
+            links: [],
+            entities: [],
+            actions: [],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useTechAssistant({
+        defaultVehicle: { year: "2014", make: "Toyota", model: "Camry" },
+        defaultContext: "MIL on after cold start",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendChat("P0141 code");
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+      question: string;
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.question).toContain("Vehicle: 2014 Toyota Camry");
+    expect(body.question).toContain("Shop notes / complaint: MIL on after cold start");
+    expect(body.question).toContain("Question: P0141 code");
+    expect(body.messages).toEqual([{ role: "user", content: "P0141 code" }]);
+
+    await waitFor(() => {
+      expect(result.current.messages.at(-1)?.content).toContain(
+        "Check the downstream O2 heater circuit first.",
+      );
+    });
+  });
+
+  it("renders structured answer responses into a useful markdown message", () => {
+    const text = formatAssistantAnswer({
+      intent: "parts_inventory",
+      summary: "Likely heater circuit fault.",
+      bullets: ["Check B+ at the sensor heater.", "Load-test ground control."],
+      links: [{ label: "Open WO", href: "/work-orders/wo_1" }],
+      entities: [{ type: "work_order", id: "wo_1", label: "WO 1001", href: "/work-orders/wo_1" }],
+      actions: [],
+      partSuggestions: [
+        {
+          candidateId: "p1",
+          sku: "O2-123",
+          title: "Downstream oxygen sensor",
+          quantitySuggestion: 1,
+          unit: "each",
+          sourceTypes: ["ai_inference_only"],
+          fitmentConfidence: "needs_review",
+          historySignal: {
+            sameVehicleCount: 0,
+            sameYmmCount: 0,
+            similarComplaintCount: 0,
+            summary: "no_prior_usage_found",
+          },
+          inventorySignal: { inStockQty: null, lowStock: false, reorderPoint: null },
+          receivingSignal: { openRequestQty: 0, pendingReceiveQty: 0, openPoCount: 0 },
+          warnings: [],
+          linkedEvidence: [],
+          reviewRecommendation: "Confirm fitment before ordering.",
+          addable: false,
+          requestable: true,
+          rankScore: 0.5,
+        },
+      ],
+    });
+
+    expect(text).toContain("Likely heater circuit fault.");
+    expect(text).toContain("- Check B+ at the sensor heater.");
+    expect(text).toContain("### Part suggestions");
+    expect(text).toContain("Downstream oxygen sensor");
+    expect(text).toContain("### Related records");
+    expect(text).toContain("[WO 1001](/work-orders/wo_1)");
+    expect(text).toContain("### Links");
+  });
+
+  it("export refuses an empty transcript before calling the network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useTechAssistant({
+        defaultVehicle: { year: "2014", make: "Toyota", model: "Camry" },
+      }),
+    );
+
+    await expect(result.current.exportToWorkOrder("line_1")).rejects.toThrow(
+      "Ask the assistant a question before exporting.",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(hasConversationTranscript([])).toBe(false);
+  });
+
+  it("export uses the transcript endpoint and does not call answer", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ cause: "Failed heater circuit.", correction: "Replace sensor.", estimatedLaborTime: 0.5 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useTechAssistant({
+        defaultVehicle: { year: "2014", make: "Toyota", model: "Camry" },
+        defaultContext: "MIL on",
+      }),
+    );
+
+    act(() => {
+      result.current.setMessages([
+        { role: "user", content: "P0141 code" },
+        { role: "assistant", content: "Test O2 heater power and ground." },
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    await result.current.exportToWorkOrder("line_1");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/assistant/export");
+    expect(fetchMock.mock.calls[0][0]).not.toBe("/api/assistant/answer");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.messages).toHaveLength(2);
+    expect(body.context).toBe("MIL on");
+  });
+});

--- a/features/ai/hooks/useTechAssistant.ts
+++ b/features/ai/hooks/useTechAssistant.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTabState } from "@/features/shared/hooks/useTabState";
+import type { AssistantAnswer, AssistantAskResponse } from "@/features/agent/assistant/types";
 
 export type ChatMessage = { role: "user" | "assistant"; content: string };
 
@@ -12,6 +13,11 @@ export type Vehicle = {
 };
 
 type AssistantOptions = { defaultVehicle?: Vehicle; defaultContext?: string };
+
+type AnswerPayload = Record<string, unknown> & {
+  question?: string;
+  messages?: ChatMessage[];
+};
 
 // Browser-safe: convert File → data URL using FileReader
 async function fileToDataUrl(file: File): Promise<string> {
@@ -30,6 +36,80 @@ async function postJSON(url: string, data: unknown, signal?: AbortSignal): Promi
     body: JSON.stringify(data),
     signal,
   });
+}
+
+function compactVehicle(vehicle?: Vehicle): string {
+  return [vehicle?.year, vehicle?.make, vehicle?.model]
+    .map((value) => value?.trim())
+    .filter(Boolean)
+    .join(" ");
+}
+
+function withVehicleContext(question: string, vehicle?: Vehicle, context?: string): string {
+  const trimmed = question.trim();
+  const vehicleText = compactVehicle(vehicle);
+  const contextText = context?.trim();
+  const lines: string[] = [];
+
+  if (vehicleText && !trimmed.toLowerCase().includes("vehicle:")) {
+    lines.push(`Vehicle: ${vehicleText}`);
+  }
+  if (contextText && !trimmed.toLowerCase().includes("shop notes / complaint:")) {
+    lines.push(`Shop notes / complaint: ${contextText}`);
+  }
+  lines.push(`Question: ${trimmed.replace(/^question:\s*/i, "")}`);
+
+  return lines.join("\n\n");
+}
+
+function formatPartSuggestion(part: NonNullable<AssistantAnswer["partSuggestions"]>[number]): string {
+  const label = part.title || part.sku || "Suggested part";
+  const details = [
+    part.sku ? `SKU ${part.sku}` : null,
+    `qty ${part.quantitySuggestion} ${part.unit}`,
+    part.fitmentConfidence.replaceAll("_", " "),
+    part.reviewRecommendation,
+  ].filter(Boolean);
+
+  return details.length ? `${label} — ${details.join("; ")}` : label;
+}
+
+export function formatAssistantAnswer(answer?: AssistantAnswer, fallbackText?: string): string {
+  if (!answer) return (fallbackText ?? "").trim();
+
+  const sections: string[] = [];
+  if (answer.summary?.trim()) sections.push(answer.summary.trim());
+
+  if (answer.bullets.length > 0) {
+    sections.push(answer.bullets.map((item) => `- ${item}`).join("\n"));
+  }
+
+  if (answer.partSuggestions?.length) {
+    sections.push([
+      "### Part suggestions",
+      ...answer.partSuggestions.slice(0, 5).map((part) => `- ${formatPartSuggestion(part)}`),
+    ].join("\n"));
+  }
+
+  if (answer.entities.length > 0) {
+    sections.push([
+      "### Related records",
+      ...answer.entities.map((entity) => `- ${entity.href ? `[${entity.label}](${entity.href})` : entity.label}`),
+    ].join("\n"));
+  }
+
+  if (answer.links.length > 0) {
+    sections.push([
+      "### Links",
+      ...answer.links.map((link) => `- [${link.label}](${link.href})`),
+    ].join("\n"));
+  }
+
+  return sections.join("\n\n").trim();
+}
+
+export function hasConversationTranscript(messages: ChatMessage[]): boolean {
+  return messages.some((message) => message.content.trim() && (message.role === "user" || message.role === "assistant"));
 }
 
 export function useTechAssistant(opts?: AssistantOptions) {
@@ -52,7 +132,7 @@ export function useTechAssistant(opts?: AssistantOptions) {
   );
 
   const ask = useCallback(
-    async (payload: Record<string, unknown> = {}) => {
+    async (payload: AnswerPayload = {}) => {
       if (!canSend) {
         setError("Please provide vehicle info (year, make, model).");
         return;
@@ -71,6 +151,7 @@ export function useTechAssistant(opts?: AssistantOptions) {
           messages,
           image_data: lastImageRef.current ?? null,
           ...payload,
+          question: withVehicleContext(payload.question ?? "", vehicle, context),
         };
 
         const res = await postJSON("/api/assistant/answer", body, ctrl.signal);
@@ -78,12 +159,13 @@ export function useTechAssistant(opts?: AssistantOptions) {
           const txt = await res.text().catch(() => "");
           throw new Error(txt || "Request failed.");
         }
-        const data = (await res.json()) as { text?: string; error?: string };
-        if (data.error) throw new Error(data.error);
+        const data = (await res.json()) as AssistantAskResponse & { text?: string };
+        if (!data.ok) throw new Error(data.error);
 
+        const content = formatAssistantAnswer(data.answer, data.text);
         const assistantMsg: ChatMessage = {
           role: "assistant",
-          content: (data.text ?? "").trim(),
+          content: content || "I could not produce an assistant response for that question.",
         };
         setMessages((m) => [...m, assistantMsg]);
       } catch (e) {
@@ -103,10 +185,11 @@ export function useTechAssistant(opts?: AssistantOptions) {
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
-      setMessages((m) => [...m, { role: "user", content: trimmed }]);
-      await ask();
+      const nextMessages: ChatMessage[] = [...messages, { role: "user", content: trimmed }];
+      setMessages(nextMessages);
+      await ask({ question: trimmed, messages: nextMessages });
     },
-    [ask, setMessages],
+    [ask, messages, setMessages],
   );
 
   const sendPhoto = useCallback(
@@ -114,13 +197,12 @@ export function useTechAssistant(opts?: AssistantOptions) {
       if (!file) return;
       const image_data = await fileToDataUrl(file);
       lastImageRef.current = image_data;
-      setMessages((m) => [
-        ...m,
-        { role: "user", content: `Uploaded a photo.${note ? `\nNote: ${note}` : ""}` },
-      ]);
-      await ask();
+      const userContent = `Uploaded a photo.${note ? `\nNote: ${note}` : ""}`;
+      const nextMessages: ChatMessage[] = [...messages, { role: "user", content: userContent }];
+      setMessages(nextMessages);
+      await ask({ question: note?.trim() || "Review the uploaded vehicle photo and provide technician guidance.", messages: nextMessages });
     },
-    [ask, setMessages],
+    [ask, messages, setMessages],
   );
 
   const cancel = useCallback(() => abortRef.current?.abort(), []);
@@ -139,8 +221,11 @@ export function useTechAssistant(opts?: AssistantOptions) {
     async (workOrderLineId: string) => {
       if (!workOrderLineId) throw new Error("Missing work order line id.");
       if (!canSend) throw new Error("Provide vehicle info before exporting.");
+      if (!hasConversationTranscript(messages)) {
+        throw new Error("Ask the assistant a question before exporting.");
+      }
 
-      const res = await postJSON("/api/assistant/export", { vehicle, messages, workOrderLineId });
+      const res = await postJSON("/api/assistant/export", { vehicle, context, messages, workOrderLineId });
       if (!res.ok) throw new Error((await res.text().catch(() => "")) || "Export failed.");
 
       return (await res.json()) as {
@@ -149,7 +234,7 @@ export function useTechAssistant(opts?: AssistantOptions) {
         estimatedLaborTime: number | null;
       };
     },
-    [messages, vehicle, canSend],
+    [messages, vehicle, context, canSend],
   );
 
   return {

--- a/features/shared/components/TechAssistant.tsx
+++ b/features/shared/components/TechAssistant.tsx
@@ -65,22 +65,7 @@ export default function TechAssistant({
     const text = inputRef.current?.value?.trim();
     if (!text) return;
 
-    const v = vehicle ?? {};
-    const lines: string[] = [];
-
-    const vehicleLine = `Vehicle: ${[v.year, v.make, v.model]
-      .filter(Boolean)
-      .join(" ")}`.trim();
-    if (vehicleLine !== "Vehicle:") lines.push(vehicleLine);
-
-    if (context.trim()) {
-      lines.push(`Shop notes / complaint: ${context.trim()}`);
-    }
-
-    lines.push(`Question: ${text}`);
-    const payload = lines.join("\n\n");
-
-    sendChat(payload);
+    sendChat(text);
 
     if (inputRef.current) inputRef.current.value = "";
   };


### PR DESCRIPTION
### Motivation
- The composer sent a UI-prefixed question but the hook called the answer API without a `question`, causing `/api/assistant/answer` to reject requests with "Question is required" and leaving the chat transcript polluted with repeated `Vehicle:`/`Question:` lines. 
- Goal: reliably attach vehicle + shop-note context to API requests, keep chat bubbles clean, and ensure exports use the conversation transcript (not the composer input). 

### Description
- Update the assistant hook (`features/ai/hooks/useTechAssistant.ts`) so `sendChat` appends the user message locally and calls `ask({ question: trimmed, messages: nextMessages })`, and the hook enriches the sent `question` with vehicle/context via `withVehicleContext`; also format structured `{ ok: true, answer }` responses into a Markdown assistant message using `answer.summary`, `answer.bullets`, `answer.partSuggestions`, `answer.entities`, and `answer.links`. 
- Make the desktop composer (`features/shared/components/TechAssistant.tsx`) send the plain user question (avoid double-prefixing `Vehicle:`/`Question:`), relying on the hook to attach vehicle/context to the API payload; mobile uses the same hook so behavior is consistent. 
- Improve export behavior: client-side guard prevents exporting an empty transcript, and the server export route (`app/api/assistant/export/route.ts`) now validates transcript presence, accepts `context`, and builds the export prompt from the captured transcript and vehicle/context (does not call `/api/assistant/answer`). 
- Add a small vehicle-focused fallback in the assistant server (`features/agent/assistant/server/answerAssistant.ts`) to return technician-triage guidance for vehicle diagnostic queries (examples: DTC/code queries such as `P0141`). 
- Add focused unit tests (`features/ai/hooks/useTechAssistant.test.tsx`) covering `sendChat` payload, structured answer rendering, and export behavior. 
- Files changed: `features/ai/hooks/useTechAssistant.ts`, `features/shared/components/TechAssistant.tsx`, `app/api/assistant/export/route.ts`, `features/agent/assistant/server/answerAssistant.ts`, and new tests `features/ai/hooks/useTechAssistant.test.tsx`. 

### Testing
- Ran `npm run typecheck` with no new type errors. 
- Ran the new focused unit tests with Vitest: `npx vitest run features/ai/hooks/useTechAssistant.test.tsx` — all tests passed. 
- Ran ESLint targeted at touched files and the results for those files passed; repository-wide `npm run lint` still reports pre-existing unrelated lint errors. 
- Attempted `npm run build` but the build failed in this environment because Next/font could not fetch Google Fonts (`Inter`, `Black Ops One`); this is an environment/network limitation and not caused by these changes. 
- Notes / follow-ups: the DTC fallback is intentionally conservative (for technician triage) and can be extended later with OEM-specific logic; full repo lint cleanup remains a separate task; re-run `next build` in an environment with network access to Google Fonts or vendor fonts locally to verify the production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a487171c8b48328860aa3c6730718a8)