### PR TITLE
Guard OpenAI temperature parameters

### DIFF
--- a/app/api/ai/interpret/route.ts
+++ b/app/api/ai/interpret/route.ts
@@ -1,7 +1,7 @@
 // /app/api/ai/interpret/route.ts (FULL FILE REPLACEMENT)
 import { NextResponse } from "next/server";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 
 export const runtime = "nodejs";
 
@@ -373,7 +373,7 @@ Optional section hint (may be empty): ${norm(ctx?.sectionTitle ?? "")}
 
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("extraction"),
-      temperature: 0.2,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("extraction"), 0.2),
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: transcript },

--- a/app/api/ai/parts/suggest/route.ts
+++ b/app/api/ai/parts/suggest/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { openai } from "lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { buildPartSuggestions } from "@/features/parts/server/buildPartSuggestions";
 import type { CanonicalPartSuggestion } from "@/features/parts/types/partSuggestions";
@@ -67,7 +67,7 @@ async function inferAiOnlySuggestions(args: {
         },
         { role: "user", content: query },
       ],
-      temperature: 0.2,
+      ...openAITemperatureParam(MODEL, 0.2),
     });
 
     const raw = completion.choices[0]?.message?.content || "{}";

--- a/app/api/ai/summarize-tech-performance/route.ts
+++ b/app/api/ai/summarize-tech-performance/route.ts
@@ -1,7 +1,7 @@
 // app/api/ai/summarize-tech-performance/route.ts
 import { NextResponse } from "next/server";
 import { openai } from "lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
 type Range = "weekly" | "monthly" | "quarterly" | "yearly";
@@ -94,7 +94,7 @@ export async function POST(req: Request) {
 
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("fast"),
-      temperature: 0.4,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("fast"), 0.4),
       max_tokens: 260,
       messages: [
         {

--- a/app/api/assistant/export/route.ts
+++ b/app/api/assistant/export/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
@@ -83,7 +83,7 @@ export async function POST(req: Request) {
 
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("reasoning"),
-      temperature: 0.3,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("reasoning"), 0.3),
       stream: false,
       messages: [{ role: "user", content: prompt }],
       response_format: { type: "json_object" },

--- a/app/api/generate-inspection/route.ts
+++ b/app/api/generate-inspection/route.ts
@@ -1,7 +1,7 @@
 // app/api/generate-inspection/route.ts
 import { NextResponse } from "next/server";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import { toInspectionCategories } from "@/features/inspections/lib/inspection/normalize";
 
 const openai = getOpenAIClient();
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
 
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("extraction"),
-      temperature: 0.2,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("extraction"), 0.2),
       response_format: { type: "json_object" },
       messages: [
         { role: "system", content: system },

--- a/app/api/ocr/registration/route.ts
+++ b/app/api/ocr/registration/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
 
 export const runtime = "nodejs";
@@ -156,7 +156,7 @@ export async function POST(req: NextRequest) {
     const completion = await client.chat.completions.create({
       model: getOpenAIModelForPurpose("extraction"),
       messages,
-      temperature: 0,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("extraction"), 0),
       // Ensures a valid JSON object string
       response_format: { type: "json_object" },
     });

--- a/app/api/stats/summarize/route.ts
+++ b/app/api/stats/summarize/route.ts
@@ -1,7 +1,7 @@
 // features/ai/api/stats/summarize/route.ts
 import { NextResponse } from "next/server";
 import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 
 if (!isOpenAIConfigured()) {
   // Don’t throw at import-time in Next; return a clean error on request.
@@ -49,7 +49,7 @@ Output in paragraph form.
 
     const response = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("reasoning"),
-      temperature: 0.7,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("reasoning"), 0.7),
       messages: [{ role: "user", content: prompt }],
     });
 

--- a/app/api/work-orders/suggest-lines/route.ts
+++ b/app/api/work-orders/suggest-lines/route.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { openai } from "lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
 import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 import {
@@ -257,7 +257,7 @@ export async function POST(req: Request) {
     const completion = await Promise.race([
       openai.chat.completions.create({
         model,
-        temperature: 0.4,
+        ...openAITemperatureParam(model, 0.4),
         messages: [
           { role: "system", content: system },
           { role: "user", content: userContext },

--- a/features/agent/assistant/server/answerAssistant.ts
+++ b/features/agent/assistant/server/answerAssistant.ts
@@ -18,7 +18,7 @@ import {
   getOpenAIClient,
   isOpenAIConfigured,
 } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
 import type {
@@ -473,7 +473,7 @@ async function answerDiagnosticConversation(args: {
   const completion = await getOpenAIClient().chat.completions.create({
     model: getOpenAIModelForPurpose("reasoning"),
     messages: buildDiagnosticMessages(args),
-    temperature: 0.2,
+    ...openAITemperatureParam(getOpenAIModelForPurpose("reasoning"), 0.2),
   });
 
   const content = completion.choices[0]?.message?.content?.trim();

--- a/features/agent/lib/plannerOpenAI.ts
+++ b/features/agent/lib/plannerOpenAI.ts
@@ -2,7 +2,7 @@
 import type { ToolContext } from "./toolTypes";
 import { getServerSupabase } from "../server/supabase";
 import { buildPartSuggestions } from "@/features/parts/server/buildPartSuggestions";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/openai-models";
 import {
   buildInspectionTemplateEfficiencyRecommendations,
   buildMenuItemEfficiencyRecommendations,
@@ -233,7 +233,7 @@ async function llmParseGoal(
         { role: "system", content: system },
         { role: "user", content: user },
       ],
-      temperature: 0.1,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("reasoning"), 0.1),
     }),
   });
 

--- a/features/ai/api/ai/generateInspectionList/route.ts
+++ b/features/ai/api/ai/generateInspectionList/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 
 const openai = getOpenAIClient();
 
@@ -25,14 +25,14 @@ export async function POST(req: Request) {
         content: prompt,
       },
     ],
-    temperature: 0.4, // Optional but recommended
+    ...openAITemperatureParam(getOpenAIModelForPurpose("extraction"), 0.4),
   });
 
   const json = response.choices[0].message.content;
 
   try {
     return NextResponse.json(JSON.parse(json!));
-  } catch (_error) {
+  } catch {
     return NextResponse.json(
       { error: "Failed to parse response from OpenAI", raw: json },
       { status: 500 },

--- a/features/ai/api/chatbot/route.ts
+++ b/features/ai/api/chatbot/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 // IMPORTANT: use your alias-based import so Vercel resolves it consistently.
 // If your project uses a different alias, adjust this one line.
 import { openai } from "lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 
 type Variant = "marketing" | "full";
 type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
@@ -65,7 +65,7 @@ export async function POST(req: Request) {
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("fast"),
       messages: safeMsgs,
-      temperature: 0.4,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("fast"), 0.4),
       max_tokens: 600,
     });
 

--- a/features/ai/lib/ai/generateLaborTimeEstimate.ts
+++ b/features/ai/lib/ai/generateLaborTimeEstimate.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
-import {  resolveOpenAIModel  } from "@/features/shared/lib/openai-models";
+import { openAITemperatureParam, resolveOpenAIModel } from "@/features/shared/lib/openai-models";
 
 const openai = getOpenAIClient();
 
@@ -18,11 +18,12 @@ Complaint: ${complaint}
 
 Response:`;
 
+    const model = resolveOpenAIModel("reasoning");
     const response = await openai.chat.completions.create({
-      model: resolveOpenAIModel("reasoning"),
+      model,
       messages: [{ role: "user", content: prompt }],
       max_tokens: 10,
-      temperature: 0.3,
+      ...openAITemperatureParam(model, 0.3),
     });
 
     const raw = response.choices[0]?.message.content || "";

--- a/features/ai/lib/ai/mapColumns.ts
+++ b/features/ai/lib/ai/mapColumns.ts
@@ -1,4 +1,4 @@
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/openai-models";
 
 async function getRuntimeOpenAIClient() {
   const { getOpenAIClient } = await import("@/features/shared/lib/server/openai");
@@ -26,7 +26,7 @@ JSON:
   const response = await (await getRuntimeOpenAIClient()).chat.completions.create({
     model: getOpenAIModelForPurpose("extraction"),
     messages: [{ role: "user", content: prompt }],
-    temperature: 0.1,
+    ...openAITemperatureParam(getOpenAIModelForPurpose("extraction"), 0.1),
   });
 
   const content = response.choices[0].message.content;

--- a/features/assistant/server/runAssistant.ts
+++ b/features/assistant/server/runAssistant.ts
@@ -9,7 +9,7 @@ import type {
 } from "../types/assistant";
 import { getRoleDailySummary } from "@/features/agent/server/getRoleDailySummary";
 import { getOpenAIClient as getCanonicalOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 
 type RunAssistantParams = {
   shopId: string;
@@ -287,7 +287,7 @@ export async function runAssistant(
   try {
     const response = await client.chat.completions.create({
       model: getOpenAIModelForPurpose("reasoning"),
-      temperature: 0.2,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("reasoning"), 0.2),
       response_format: { type: "json_object" },
       messages: [
         {

--- a/features/integrations/ai/index.ts
+++ b/features/integrations/ai/index.ts
@@ -7,7 +7,7 @@ async function getRuntimeOpenAIClient() {
 
 //features/integrations/ai/index.ts
 
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 /* ========================================================================== */
 /*  QUOTE ENGINE – CENTRAL AI ENTRYPOINT                                      */
@@ -61,7 +61,7 @@ export const ProFixAI = {
 
     const completion = await (await getRuntimeOpenAIClient()).chat.completions.create({
       model: getOpenAIModelForPurpose("fast"),
-      temperature: 0.4,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("fast"), 0.4),
       max_tokens: 600,
       messages: [
         { role: "system", content: system },

--- a/features/integrations/ai/shopBoost.ts
+++ b/features/integrations/ai/shopBoost.ts
@@ -8,7 +8,7 @@ async function getRuntimeOpenAIClient() {
 // /features/integrations/ai/shopBoost.ts
 import { randomUUID, createHash } from "crypto";
 
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import type {
@@ -1653,7 +1653,7 @@ async function generateSnapshotWithAI(
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
-      temperature: 0.2,
+      ...openAITemperatureParam(getOpenAIModelForPurpose("fast"), 0.2),
     });
 
     const raw = completion.choices[0]?.message?.content ?? "{}";

--- a/features/maintenance/server/generateMaintenanceRules.ts
+++ b/features/maintenance/server/generateMaintenanceRules.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { openai } from "lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 
 type DB = Database;
 
@@ -226,7 +226,7 @@ export async function generateMaintenanceRulesForVehicle(opts: {
 
   const completion = await openai.chat.completions.create({
     model: getOpenAIModelForPurpose("fast"),
-    temperature: 0.4,
+    ...openAITemperatureParam(getOpenAIModelForPurpose("fast"), 0.4),
     max_tokens: 900,
     messages: [
       { role: "system", content: systemPrompt },

--- a/features/shared/lib/openai-models.ts
+++ b/features/shared/lib/openai-models.ts
@@ -67,3 +67,24 @@ export function getOpenAIModelForPurpose(
 ): string {
   return resolveOpenAIModel(purpose, env);
 }
+
+export function supportsOpenAITemperature(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+
+  if (!normalized) return true;
+
+  return !(
+    normalized.startsWith("gpt-5") ||
+    normalized.includes("reasoning") ||
+    normalized.startsWith("o1") ||
+    normalized.startsWith("o3") ||
+    normalized.startsWith("o4")
+  );
+}
+
+export function openAITemperatureParam(
+  model: string,
+  temperature: number,
+): { temperature: number } | Record<string, never> {
+  return supportsOpenAITemperature(model) ? { temperature } : {};
+}

--- a/features/shared/lib/server/openai-models.ts
+++ b/features/shared/lib/server/openai-models.ts
@@ -1,13 +1,17 @@
 import "server-only";
 
 import {
-  DEFAULT_OPENAI_MODELS,
   resolveOpenAIModel,
   type OpenAIModelEnv,
   type OpenAIModelPurpose,
 } from "@/features/shared/lib/openai-models";
 
-export { DEFAULT_OPENAI_MODELS, resolveOpenAIModel };
+export {
+  DEFAULT_OPENAI_MODELS,
+  openAITemperatureParam,
+  resolveOpenAIModel,
+  supportsOpenAITemperature,
+} from "@/features/shared/lib/openai-models";
 export type { OpenAIModelEnv, OpenAIModelPurpose };
 
 function readOpenAIModelEnv(): OpenAIModelEnv {

--- a/features/shared/lib/server/openai-structured.ts
+++ b/features/shared/lib/server/openai-structured.ts
@@ -3,25 +3,9 @@ import "server-only";
 import { getOpenAIClient, isOpenAIConfigured } from "@/features/shared/lib/server/openai";
 import {
   getOpenAIModelForPurpose,
+  openAITemperatureParam,
   type OpenAIModelPurpose,
 } from "@/features/shared/lib/server/openai-models";
-
-function supportsTemperature(model: string): boolean {
-  const normalized = model.toLowerCase();
-
-  // GPT-5 / reasoning-style models reject temperature in the Responses API.
-  if (
-    normalized.startsWith("gpt-5") ||
-    normalized.includes("reasoning") ||
-    normalized.startsWith("o1") ||
-    normalized.startsWith("o3") ||
-    normalized.startsWith("o4")
-  ) {
-    return false;
-  }
-
-  return true;
-}
 
 export async function runOpenAIStructuredJson<T>(params: {
   purpose: OpenAIModelPurpose;
@@ -57,7 +41,7 @@ export async function runOpenAIStructuredJson<T>(params: {
 
     const response = await client.responses.create({
       model,
-      ...(supportsTemperature(model) ? { temperature: params.temperature ?? 0.1 } : {}),
+      ...openAITemperatureParam(model, params.temperature ?? 0.1),
       ...(params.maxOutputTokens ? { max_output_tokens: params.maxOutputTokens } : {}),
       text: {
         format: {


### PR DESCRIPTION
### Motivation
- Some OpenAI models (GPT‑5 / reasoning-style names) reject custom `temperature` fields and caused a 400 error, so requests must omit `temperature` when the selected model does not support it.

### Description
- Add `supportsOpenAITemperature` and `openAITemperatureParam` helpers in `features/shared/lib/openai-models.ts` and re-export them from the server model helper at `features/shared/lib/server/openai-models.ts` to centralize detection and parameter shaping.
- Replace literal `temperature: <value>` parameters with conditional spreads like `...openAITemperatureParam(model, <value>)` in the structured Responses call and audited Chat Completions call sites so the `temperature` field is only sent when supported.
- Updated assistant/AI endpoints and helpers to use the new helper, including (not exhaustive) `features/shared/lib/server/openai-structured.ts`, `features/assistant/server/runAssistant.ts`, `features/agent/assistant/server/answerAssistant.ts`, `app/api/assistant/export/route.ts`, `app/api/work-orders/suggest-lines/route.ts`, `features/ai/*` endpoints, `features/integrations/ai/*`, and related files modified in this rollout.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it passed after the changes.
- Ran `npm run lint` and it failed with pre-existing lint errors unrelated to this change (various `@typescript-eslint` and React lint issues), so lint warnings/errors remain but were not introduced by this PR.
- Ran `npm run build` and it failed due to Next.js failing to fetch Google Fonts from the network in this environment, which is unrelated to the OpenAI changes.
- Verified locally in the code that when the resolved model is a GPT‑5 / reasoning-style name the helper returns `{}` and the `temperature` key is omitted, while for other models it returns `{ temperature }`, and the project typechecks successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a489e5d2f8c8328b096e10b759dd474)