### PR TITLE
Add AI assistant diagnostic photo evidence

### DIFF
--- a/app/api/assistant/attachments/route.ts
+++ b/app/api/assistant/attachments/route.ts
@@ -1,0 +1,117 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const BUCKET = "work_order_media";
+const MAX_IMAGE_BYTES = 6 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"]);
+
+type WorkOrderMediaInsert = Database["public"]["Tables"]["work_order_media"]["Insert"] & {
+  work_order_line_id?: string | null;
+  storage_bucket?: string | null;
+  storage_path?: string | null;
+  file_name?: string | null;
+  content_type?: string | null;
+  file_size?: number | null;
+  note?: string | null;
+  source?: string | null;
+};
+
+function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/-+/g, "-").slice(0, 80) || "assistant-photo";
+}
+
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "Profile for current user not found" }, { status: 403 });
+
+  const form = await req.formData();
+  const file = form.get("file");
+  const note = typeof form.get("note") === "string" ? String(form.get("note")).trim().slice(0, 500) : "";
+  const workOrderLineId = typeof form.get("workOrderLineId") === "string" ? String(form.get("workOrderLineId")) : "";
+  const explicitWorkOrderId = typeof form.get("workOrderId") === "string" ? String(form.get("workOrderId")) : "";
+
+  if (!(file instanceof File)) return NextResponse.json({ error: "Image file is required." }, { status: 400 });
+  if (!ALLOWED_IMAGE_TYPES.has(file.type)) return NextResponse.json({ error: "Unsupported image type." }, { status: 400 });
+  if (file.size > MAX_IMAGE_BYTES) return NextResponse.json({ error: "Image must be 6 MB or smaller." }, { status: 413 });
+
+  let workOrderId = explicitWorkOrderId || null;
+  if (workOrderLineId) {
+    const { data: line, error } = await access.supabase
+      .from("work_order_lines")
+      .select("id, work_order_id, shop_id")
+      .eq("id", workOrderLineId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: "Failed to resolve work order line." }, { status: 500 });
+    if (!line?.work_order_id) return NextResponse.json({ error: "Work order line not found." }, { status: 404 });
+    workOrderId = line.work_order_id;
+  }
+
+  if (!workOrderId) return NextResponse.json({ error: "Missing work order context." }, { status: 400 });
+
+  const { data: wo, error: woErr } = await access.supabase
+    .from("work_orders")
+    .select("id, shop_id")
+    .eq("id", workOrderId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+  if (woErr) return NextResponse.json({ error: "Failed to verify work order." }, { status: 500 });
+  if (!wo) return NextResponse.json({ error: "Work order not found." }, { status: 404 });
+
+  const safeName = sanitizeName(file.name);
+  const storagePath = `${shopId}/${workOrderId}/ai-assistant/${Date.now()}-${crypto.randomUUID()}-${safeName}`;
+  const { error: uploadErr } = await access.supabase.storage.from(BUCKET).upload(storagePath, file, {
+    contentType: file.type,
+    upsert: false,
+  });
+  if (uploadErr) return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
+
+  const publicUrl = access.supabase.storage.from(BUCKET).getPublicUrl(storagePath).data.publicUrl;
+  const row: WorkOrderMediaInsert = {
+    shop_id: shopId,
+    work_order_id: workOrderId as string,
+    work_order_line_id: workOrderLineId || null,
+    user_id: access.profile.id,
+    url: publicUrl,
+    kind: "photo",
+    storage_bucket: BUCKET,
+    storage_path: storagePath,
+    file_name: file.name,
+    content_type: file.type,
+    file_size: file.size,
+    note: note || null,
+    source: "ai_assistant",
+  };
+
+  const { data: media, error: insertErr } = await access.supabase
+    .from("work_order_media")
+    .insert(row as Database["public"]["Tables"]["work_order_media"]["Insert"])
+    .select("id, url")
+    .single();
+  if (insertErr) {
+    await access.supabase.storage.from(BUCKET).remove([storagePath]).catch(() => undefined);
+    return NextResponse.json({ error: `Failed to save evidence: ${insertErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    attachment: {
+      id: media.id,
+      url: media.url ?? publicUrl,
+      storageBucket: BUCKET,
+      storagePath,
+      fileName: file.name,
+      contentType: file.type,
+      note: note || null,
+      workOrderId,
+      workOrderLineId: workOrderLineId || null,
+    },
+  });
+}

--- a/app/api/assistant/export/route.ts
+++ b/app/api/assistant/export/route.ts
@@ -16,7 +16,7 @@ type Vehicle = {
   model?: string | null;
 };
 
-type ChatMessage = { role: "user" | "assistant"; content: string };
+type ChatMessage = { role: "user" | "assistant"; content: string; attachments?: Array<{ id?: string; fileName?: string | null; note?: string | null }> };
 
 function normalizeMarkdown(s: string): string {
   let out = (s ?? "").trim();
@@ -76,7 +76,13 @@ export async function POST(req: Request) {
       "- EstimatedLaborTime: a decimal number in hours when appropriate, else null.",
       "",
       "Conversation (latest last):",
-      ...transcript.map((m) => `${m.role.toUpperCase()}: ${m.content}`),
+      ...transcript.map((m) => {
+        const evidence = (m.attachments ?? [])
+          .map((attachment) => attachment.fileName || attachment.id)
+          .filter(Boolean)
+          .join(", ");
+        return `${m.role.toUpperCase()}: ${m.content}${evidence ? `\nEvidence images already saved to work_order_media: ${evidence}` : ""}`;
+      }),
       "",
       'Return JSON with these exact keys: { "cause": string, "correction": string, "estimatedLaborTime": number | null }',
     ].join("\n");
@@ -121,6 +127,7 @@ export async function POST(req: Request) {
 
     const updates: Database["public"]["Tables"]["work_order_lines"]["Update"] = {
       cause,
+      correction,
       labor_time: estimatedLaborTime,
     };
 

--- a/features/agent/assistant/server/answerAssistant.ts
+++ b/features/agent/assistant/server/answerAssistant.ts
@@ -376,6 +376,22 @@ function buildDiagnosticMessages(args: {
       message.content.trim() === args.question.trim(),
   );
 
+  const images = (args.request.imageAttachments ?? [])
+    .filter((image) => typeof image.url === "string" && image.url.trim().length > 0)
+    .slice(-3);
+  const latestUserContent: ChatCompletionMessageParam = images.length > 0
+    ? {
+        role: "user",
+        content: [
+          { type: "text", text: args.question },
+          ...images.map((image) => ({
+            type: "image_url" as const,
+            image_url: { url: image.url as string, detail: "low" as const },
+          })),
+        ],
+      }
+    : { role: "user", content: args.question };
+
   return [
     {
       role: "system",
@@ -402,15 +418,13 @@ function buildDiagnosticMessages(args: {
         content: message.content,
       }),
     ),
-    ...(hasCurrentMessage
-      ? []
-      : ([
-          { role: "user" as const, content: args.question },
-        ] satisfies ChatCompletionMessageParam[])),
+    ...(hasCurrentMessage ? [] : [latestUserContent]),
     {
       role: "system",
       content:
-        "Current request: Continue diagnosing from the latest technician finding. Return only the technician-facing response.",
+        images.length > 0
+          ? "Current request: Continue diagnosing from the latest technician finding. Inspect the attached image(s) as visual diagnostic evidence, but mention uncertainty when the image is not conclusive. Return only the technician-facing response."
+          : "Current request: Continue diagnosing from the latest technician finding. Return only the technician-facing response.",
     },
   ];
 }

--- a/features/agent/assistant/types.ts
+++ b/features/agent/assistant/types.ts
@@ -2,6 +2,18 @@ import type { CanonicalPartSuggestion } from "@/features/parts/types/partSuggest
 
 // features/agent/assistant/types.ts
 
+export type AssistantImageAttachment = {
+  id: string;
+  url?: string | null;
+  storageBucket?: string | null;
+  storagePath?: string | null;
+  fileName?: string | null;
+  contentType?: string | null;
+  note?: string | null;
+  workOrderId?: string | null;
+  workOrderLineId?: string | null;
+};
+
 export type AssistantEntityType =
   | "work_order"
   | "vehicle"
@@ -115,6 +127,7 @@ export type AssistantAskRequest = {
   session?: AssistantAskSession;
   messages?: AssistantConversationMessage[];
   vehicle?: AssistantVehicleContext;
+  imageAttachments?: AssistantImageAttachment[];
 };
 
 export type AssistantAskResponse =

--- a/features/ai/hooks/useTechAssistant.ts
+++ b/features/ai/hooks/useTechAssistant.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTabState } from "@/features/shared/hooks/useTabState";
-import type { AssistantAnswer, AssistantAskResponse } from "@/features/agent/assistant/types";
+import type { AssistantAnswer, AssistantAskResponse, AssistantImageAttachment } from "@/features/agent/assistant/types";
 
-export type ChatMessage = { role: "user" | "assistant"; content: string };
+export type ChatMessage = { role: "user" | "assistant"; content: string; attachments?: AssistantImageAttachment[] };
 
 export type Vehicle = {
   year?: string | null;
@@ -12,22 +12,12 @@ export type Vehicle = {
   model?: string | null;
 };
 
-type AssistantOptions = { defaultVehicle?: Vehicle; defaultContext?: string };
+type AssistantOptions = { defaultVehicle?: Vehicle; defaultContext?: string; workOrderLineId?: string; workOrderId?: string };
 
 type AnswerPayload = Record<string, unknown> & {
   question?: string;
   messages?: ChatMessage[];
 };
-
-// Browser-safe: convert File → data URL using FileReader
-async function fileToDataUrl(file: File): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const fr = new FileReader();
-    fr.onerror = () => reject(fr.error);
-    fr.onload = () => resolve(String(fr.result));
-    fr.readAsDataURL(file);
-  });
-}
 
 async function postJSON(url: string, data: unknown, signal?: AbortSignal): Promise<Response> {
   return fetch(url, {
@@ -127,10 +117,11 @@ export function useTechAssistant(opts?: AssistantOptions) {
 
   // Ephemeral UI state
   const [sending, setSending] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const [partial, setPartial] = useState<string>("");
   const [error, setError]     = useState<string | null>(null);
 
-  const lastImageRef = useRef<string | null>(null);
+  const lastImageRef = useRef<AssistantImageAttachment | null>(null);
   const abortRef     = useRef<AbortController | null>(null);
 
   const canSend = useMemo(
@@ -156,7 +147,7 @@ export function useTechAssistant(opts?: AssistantOptions) {
           vehicle,
           context,
           messages,
-          image_data: lastImageRef.current ?? null,
+          imageAttachments: lastImageRef.current ? [lastImageRef.current] : [],
           ...payload,
           question: withVehicleContext(payload.question ?? "", vehicle, context),
         };
@@ -202,14 +193,36 @@ export function useTechAssistant(opts?: AssistantOptions) {
   const sendPhoto = useCallback(
     async (file: File, note?: string) => {
       if (!file) return;
-      const image_data = await fileToDataUrl(file);
-      lastImageRef.current = image_data;
-      const userContent = `Uploaded a photo.${note ? `\nNote: ${note}` : ""}`;
-      const nextMessages: ChatMessage[] = [...messages, { role: "user", content: userContent }];
-      setMessages(nextMessages);
-      await ask({ question: note?.trim() || "Review the uploaded vehicle photo and provide technician guidance.", messages: nextMessages });
+      if (!opts?.workOrderLineId && !opts?.workOrderId) {
+        setError("Open the assistant from a work order line before attaching evidence photos.");
+        return;
+      }
+      setUploading(true);
+      setError(null);
+      try {
+        const form = new FormData();
+        form.append("file", file);
+        if (note?.trim()) form.append("note", note.trim());
+        if (opts?.workOrderLineId) form.append("workOrderLineId", opts.workOrderLineId);
+        if (opts?.workOrderId) form.append("workOrderId", opts.workOrderId);
+
+        const res = await fetch("/api/assistant/attachments", { method: "POST", body: form });
+        if (!res.ok) throw new Error((await res.text().catch(() => "")) || "Photo upload failed.");
+        const data = (await res.json()) as { ok?: boolean; error?: string; attachment?: AssistantImageAttachment };
+        if (!data.ok || !data.attachment) throw new Error(data.error || "Photo upload failed.");
+
+        lastImageRef.current = data.attachment;
+        const userContent = `Uploaded photo: ${data.attachment.fileName ?? file.name}.${note ? `\nNote: ${note}` : ""}`;
+        const nextMessages: ChatMessage[] = [...messages, { role: "user", content: userContent, attachments: [data.attachment] }];
+        setMessages(nextMessages);
+        await ask({ question: note?.trim() || "Review the uploaded vehicle photo and provide technician guidance.", messages: nextMessages });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Photo upload failed.");
+      } finally {
+        setUploading(false);
+      }
     },
-    [ask, messages, setMessages],
+    [ask, messages, opts?.workOrderId, opts?.workOrderLineId, setMessages],
   );
 
   const cancel = useCallback(() => abortRef.current?.abort(), []);
@@ -253,6 +266,7 @@ export function useTechAssistant(opts?: AssistantOptions) {
     setContext,
     setMessages,
     sending,
+    uploading,
     error,
     sendChat,
     sendPhoto,

--- a/features/shared/components/TechAssistant.tsx
+++ b/features/shared/components/TechAssistant.tsx
@@ -28,6 +28,7 @@ export default function TechAssistant({
     setContext,
     messages,
     sending,
+    uploading,
     partial,
     error,
     sendChat,
@@ -35,7 +36,7 @@ export default function TechAssistant({
     exportToWorkOrder,
     resetConversation,
     cancel,
-  } = useTechAssistant({ defaultVehicle });
+  } = useTechAssistant({ defaultVehicle, workOrderLineId });
 
   // Seed default vehicle once (without clobbering restored vehicle)
   useEffect(() => {
@@ -154,22 +155,22 @@ export default function TechAssistant({
                     setNoteForPhoto("");
                   });
                 }}
-                disabled={sending}
+                disabled={sending || uploading}
               />
-              Attach Photo
+              {uploading ? "Saving Photo…" : "Attach Photo"}
             </label>
             <input
               className={`${inputBase} min-w-44 flex-1 py-1.5 text-xs`}
               placeholder="Optional note for this photo"
               value={noteForPhoto}
               onChange={(e) => setNoteForPhoto(e.target.value)}
-              disabled={sending}
+              disabled={sending || uploading}
             />
             <button
               className="rounded-full border border-[var(--metal-border-soft)] bg-black/70 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-100 hover:bg-white/5 disabled:opacity-60"
               onClick={resetConversation}
               type="button"
-              disabled={sending}
+              disabled={sending || uploading}
             >
               Reset
             </button>
@@ -203,6 +204,19 @@ export default function TechAssistant({
                   className={`${bubble} bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] text-black font-semibold`}
                 >
                   {m.content}
+                  {m.attachments?.length ? (
+                    <div className="mt-2 space-y-1 text-[11px] font-medium text-black/80">
+                      {m.attachments.map((attachment) => (
+                        <div key={attachment.id} className="flex items-center gap-2 rounded-lg bg-black/10 p-1">
+                          {attachment.url ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img src={attachment.url} alt={attachment.fileName ?? "Attached diagnostic photo"} className="h-12 w-12 rounded object-cover" />
+                          ) : null}
+                          <span className="truncate">{attachment.fileName ?? "Diagnostic photo saved"}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               </div>
             ) : (
@@ -264,7 +278,7 @@ export default function TechAssistant({
             placeholder={
               canSend ? "Ask the assistant…" : "Enter year, make, model first"
             }
-            disabled={sending}
+            disabled={sending || uploading}
           />
           <button
             className="rounded-full bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-black shadow-[0_0_20px_rgba(212,118,49,0.7)] hover:brightness-110 disabled:opacity-60"
@@ -281,7 +295,7 @@ export default function TechAssistant({
         <div className="pt-1">
           <button
             className="rounded-full bg-purple-600 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white shadow-[0_0_18px_rgba(147,51,234,0.7)] hover:bg-purple-500 disabled:opacity-60"
-            disabled={sending}
+            disabled={sending || uploading}
             onClick={async () => {
               try {
                 const res = await exportToWorkOrder(workOrderLineId);

--- a/features/shared/components/TechAssistantMobile.tsx
+++ b/features/shared/components/TechAssistantMobile.tsx
@@ -18,10 +18,10 @@ export default function TechAssistantMobile({
   const {
     vehicle, setVehicle,
     context, setContext,
-    messages, partial, sending, error,
+    messages, partial, sending, uploading, error,
     sendChat, sendPhoto,
     exportToWorkOrder, resetConversation,
-  } = useTechAssistant({ defaultVehicle });
+  } = useTechAssistant({ defaultVehicle, workOrderLineId });
 
   // refs
   const chatInputRef = useRef<HTMLInputElement>(null);
@@ -101,6 +101,19 @@ export default function TechAssistantMobile({
                 <div key={i} className="flex justify-end">
                   <div className="max-w-[85%] whitespace-pre-wrap break-words rounded px-3 py-2 text-sm bg-orange-600 text-black font-header">
                     {m.content}
+                    {m.attachments?.length ? (
+                      <div className="mt-2 space-y-1 text-[11px] text-black/80">
+                        {m.attachments.map((attachment) => (
+                          <div key={attachment.id} className="flex items-center gap-2 rounded bg-black/10 p-1">
+                            {attachment.url ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img src={attachment.url} alt={attachment.fileName ?? "Attached diagnostic photo"} className="h-10 w-10 rounded object-cover" />
+                            ) : null}
+                            <span className="truncate">{attachment.fileName ?? "Diagnostic photo saved"}</span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               );
@@ -176,16 +189,16 @@ export default function TechAssistantMobile({
                   });
                 }
               }}
-              disabled={sending}
+              disabled={sending || uploading}
             />
-            Attach Photo
+            {uploading ? "Saving Photo…" : "Attach Photo"}
           </label>
 
           <button
             type="button"
             className="rounded bg-neutral-800 px-3 py-2 text-sm hover:bg-neutral-700 disabled:opacity-60 font-header"
             onClick={resetConversation}
-            disabled={sending}
+            disabled={sending || uploading}
           >
             Reset
           </button>
@@ -200,12 +213,12 @@ export default function TechAssistantMobile({
             ref={chatInputRef}
             className={`${inputBase} flex-1 py-3`}
             placeholder={canSend ? "Ask the assistant…" : "Enter year, make, model first"}
-            disabled={sending}
+            disabled={sending || uploading}
           />
           <button
             type="submit"
             className="rounded bg-orange-600 px-4 py-3 text-sm font-header text-black hover:bg-orange-700 disabled:opacity-60"
-            disabled={sending || !canSend}
+            disabled={sending || uploading || !canSend}
           >
             {sending ? "…" : "Send"}
           </button>
@@ -224,7 +237,7 @@ export default function TechAssistantMobile({
         <div className="px-3 pb-3">
           <button
             className="w-full rounded bg-purple-600 px-3 py-3 text-sm font-header hover:bg-purple-700 disabled:opacity-60"
-            disabled={sending}
+            disabled={sending || uploading}
             onClick={async () => {
               try {
                 const res = await exportToWorkOrder(workOrderLineId);

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -20350,6 +20350,14 @@ export type Database = {
           url: string
           user_id: string | null
           work_order_id: string
+          work_order_line_id: string | null
+          storage_bucket: string | null
+          storage_path: string | null
+          file_name: string | null
+          content_type: string | null
+          file_size: number | null
+          note: string | null
+          source: string | null
         }
         Insert: {
           created_at?: string | null
@@ -20359,6 +20367,14 @@ export type Database = {
           url: string
           user_id?: string | null
           work_order_id: string
+          work_order_line_id?: string | null
+          storage_bucket?: string | null
+          storage_path?: string | null
+          file_name?: string | null
+          content_type?: string | null
+          file_size?: number | null
+          note?: string | null
+          source?: string | null
         }
         Update: {
           created_at?: string | null
@@ -20368,6 +20384,14 @@ export type Database = {
           url?: string
           user_id?: string | null
           work_order_id?: string
+          work_order_line_id?: string | null
+          storage_bucket?: string | null
+          storage_path?: string | null
+          file_name?: string | null
+          content_type?: string | null
+          file_size?: number | null
+          note?: string | null
+          source?: string | null
         }
         Relationships: [
           {

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -12832,6 +12832,14 @@ export type Database = {
           url: string
           user_id: string | null
           work_order_id: string
+          work_order_line_id: string | null
+          storage_bucket: string | null
+          storage_path: string | null
+          file_name: string | null
+          content_type: string | null
+          file_size: number | null
+          note: string | null
+          source: string | null
         }
         Insert: {
           created_at?: string | null
@@ -12841,6 +12849,14 @@ export type Database = {
           url: string
           user_id?: string | null
           work_order_id: string
+          work_order_line_id?: string | null
+          storage_bucket?: string | null
+          storage_path?: string | null
+          file_name?: string | null
+          content_type?: string | null
+          file_size?: number | null
+          note?: string | null
+          source?: string | null
         }
         Update: {
           created_at?: string | null
@@ -12850,6 +12866,14 @@ export type Database = {
           url?: string
           user_id?: string | null
           work_order_id?: string
+          work_order_line_id?: string | null
+          storage_bucket?: string | null
+          storage_path?: string | null
+          file_name?: string | null
+          content_type?: string | null
+          file_size?: number | null
+          note?: string | null
+          source?: string | null
         }
         Relationships: [
           {

--- a/supabase/manual/assistant-work-order-media-evidence.sql
+++ b/supabase/manual/assistant-work-order-media-evidence.sql
@@ -1,0 +1,86 @@
+-- AI Assistant diagnostic image evidence for work orders.
+-- Additive metadata on the existing canonical work_order_media table.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'work_order_media',
+  'work_order_media',
+  true,
+  6291456,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']
+)
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+alter table public.work_order_media
+  add column if not exists work_order_line_id uuid references public.work_order_lines(id) on delete set null,
+  add column if not exists storage_bucket text,
+  add column if not exists storage_path text,
+  add column if not exists file_name text,
+  add column if not exists content_type text,
+  add column if not exists file_size bigint,
+  add column if not exists note text,
+  add column if not exists source text;
+
+create index if not exists idx_work_order_media_line_id on public.work_order_media(work_order_line_id);
+create index if not exists idx_work_order_media_shop_source on public.work_order_media(shop_id, source);
+create index if not exists idx_work_order_media_storage_path on public.work_order_media(storage_path) where storage_path is not null;
+
+create or replace function public.validate_work_order_media_scope()
+returns trigger
+language plpgsql
+as $$
+declare
+  wo_shop_id uuid;
+  line_shop_id uuid;
+  line_work_order_id uuid;
+begin
+  select shop_id into wo_shop_id from public.work_orders where id = new.work_order_id;
+  if wo_shop_id is null or wo_shop_id <> new.shop_id then
+    raise exception 'work_order_media.shop_id must match work_orders.shop_id';
+  end if;
+
+  if new.work_order_line_id is not null then
+    select shop_id, work_order_id into line_shop_id, line_work_order_id
+    from public.work_order_lines
+    where id = new.work_order_line_id;
+
+    if line_shop_id is null or line_shop_id <> new.shop_id then
+      raise exception 'work_order_media.work_order_line_id must match shop_id';
+    end if;
+    if line_work_order_id is distinct from new.work_order_id then
+      raise exception 'work_order_media.work_order_line_id must match work_order_id';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_validate_work_order_media_scope on public.work_order_media;
+create trigger trg_validate_work_order_media_scope
+before insert or update on public.work_order_media
+for each row execute function public.validate_work_order_media_scope();
+
+alter table public.work_order_media enable row level security;
+
+-- Keep policies conservative and shop-scoped. These are additive/replaceable names only.
+drop policy if exists work_order_media_shop_select on public.work_order_media;
+create policy work_order_media_shop_select on public.work_order_media
+for select using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.shop_id = work_order_media.shop_id
+  )
+);
+
+drop policy if exists work_order_media_shop_insert on public.work_order_media;
+create policy work_order_media_shop_insert on public.work_order_media
+for insert with check (
+  exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.shop_id = work_order_media.shop_id
+  )
+);


### PR DESCRIPTION
### Motivation
- The assistant previously kept attached photos as transient base64 data which were not persisted or linked to work-order evidence for later inspection or export.
- Technicians need uploaded images to be usable by the assistant for visual reasoning and preserved as durable evidence on the work order/work-order-line.
- Changes must preserve shop-scoped auth, Supabase RLS, and reuse the existing canonical media table instead of adding a parallel media system.

### Description
- Add a shop-scoped attachment upload API at `app/api/assistant/attachments/route.ts` that validates image type/size, resolves `work_order_id` from `work_order_line_id`, uploads to the `work_order_media` storage bucket, and inserts a `work_order_media` row with metadata and `source = 'ai_assistant'`.
- Update the Tech Assistant hook `features/ai/hooks/useTechAssistant.ts` to upload files via the new route (no long-term base64), track `uploading` state, attach saved `AssistantImageAttachment` metadata to chat messages, and send `imageAttachments` to the assistant request only when present.
- Wire image evidence into assistant reasoning by adding image support in `features/agent/assistant/server/answerAssistant.ts` (vision-capable message format only when images exist, cap latest 3 images, use low detail to control token usage) and add attachment rendering/UX in `features/shared/components/TechAssistant.tsx` and `TechAssistantMobile.tsx` (thumbnails, filename, upload state and errors).
- Ensure export persists assistant outputs and evidence context by updating `app/api/assistant/export/route.ts` to include saved evidence references in the export prompt and to persist `correction` along with `cause` and `labor_time` to `work_order_lines`.
- Add types for image attachments (`features/agent/assistant/types.ts`) and update generated Supabase types to reflect the new `work_order_media` metadata fields.
- Add an additive Supabase SQL migration `supabase/manual/assistant-work-order-media-evidence.sql` that creates/updates the `work_order_media` storage bucket, adds metadata columns and indexes, installs a scope-validation trigger, and creates conservative shop-scoped RLS policies.

### Testing
- `npm run typecheck` (`npx tsc --noEmit`) completed successfully with no new type errors introduced. (PASS)
- `npm run lint` (ESLint) reported failures, but these are pre-existing unrelated lint issues across the repo and not introduced by this change. (FAIL — unrelated warnings/errors remain)
- `npm run build` (Next build) failed in this environment due to inability to fetch Google Fonts via `next/font` during build, which is an environment/network issue not caused by these code changes. (FAIL — environment font fetch)

Notes: No dedicated automated route/unit tests were added in this patch; key server behaviors to cover are: image upload requires shop access, uploaded image rows link to correct `work_order_id`/`work_order_line_id`, assistant requests include `imageAttachments` only when present, and export includes evidence references. The migration script is additive and includes validation triggers and conservative RLS policies to preserve tenant isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a493ca5fd888328929760dde7167a4a)