### PR TITLE
Omit auth `user_id` for imported customers (fix onboarding v2 import collisions)

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -56,7 +56,7 @@ function splitName(name: string | null): { firstName: string | null; lastName: s
 }
 
 
-function normalizeRow(row: ImportRow, userId: string, shopId: string): CustomerInsert | null {
+export function normalizeImportedCustomerRow(row: ImportRow, shopId: string): CustomerInsert | null {
   const businessName = cleanString(row.business_name) ?? cleanString(row.company_name);
   const explicitName = cleanString(row.name);
   const split = splitName(explicitName);
@@ -71,7 +71,6 @@ function normalizeRow(row: ImportRow, userId: string, shopId: string): CustomerI
 
   return {
     shop_id: shopId,
-    user_id: userId,
     first_name: firstName,
     last_name: lastName,
     name: explicitName ?? displayName,
@@ -162,8 +161,6 @@ export async function POST(req: Request) {
 
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
-    const userId = profile.id;
-
     if (!shopId) {
       return NextResponse.json({ error: "Missing shop context." }, { status: 400 });
     }
@@ -182,7 +179,7 @@ export async function POST(req: Request) {
 
     for (const [index, raw] of rawRows.entries()) {
       try {
-        const normalized = normalizeRow(raw as ImportRow, userId, shopId);
+        const normalized = normalizeImportedCustomerRow(raw as ImportRow, shopId);
 
         if (!normalized) {
           counts.skipped += 1;

--- a/features/agent/tools/createCustomer.ts
+++ b/features/agent/tools/createCustomer.ts
@@ -27,7 +27,6 @@ export const toolCreateCustomer: ToolDef<CreateCustomerIn, CreateCustomerOut> = 
         email: input.email ?? undefined,
         phone: input.phone ?? undefined,
         shop_id: ctx.shopId,          // ← critical for RLS
-        user_id: ctx.userId ?? null,  // ok if nullable in your schema
       })
       .select("id")
       .single();

--- a/features/vehicles/lib/importCustomers.ts
+++ b/features/vehicles/lib/importCustomers.ts
@@ -19,7 +19,7 @@ function numberOrNull(value: string | null): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-export function mapCustomerCsvRow(row: CsvRow, shopId: string, userId: string): CustomerInsert {
+export function mapCustomerCsvRow(row: CsvRow, shopId: string, _userId?: string): CustomerInsert {
   const firstName = pick(row, ["first_name", "first", "customer_first_name"]);
   const lastName = pick(row, ["last_name", "last", "customer_last_name"]);
   const businessName = pick(row, ["business_name", "company", "fleet", "customer_company"]);
@@ -28,7 +28,6 @@ export function mapCustomerCsvRow(row: CsvRow, shopId: string, userId: string): 
 
   return {
     shop_id: shopId,
-    user_id: userId,
     first_name: firstName,
     last_name: lastName,
     business_name: businessName,

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 import { GUIDED_ONBOARDING_STEP_KEYS } from "@/features/onboarding-v2/guided/steps";
 import { TILES } from "@/features/shared/config/tiles";
 import { getOwnerSidebarTiles } from "@/features/shared/lib/ownerSidebarNav";
+import { normalizeImportedCustomerRow } from "../app/api/customers/import/route";
+import { mapCustomerCsvRow } from "@/features/vehicles/lib/importCustomers";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
@@ -160,6 +162,43 @@ describe("guided onboarding v2 foundation", () => {
     expect(routeSources).toContain("@/features/onboarding-v2/guided/server");
   });
 
+  it("keeps onboarding/import customer payloads shop-scoped without auth user linkage", () => {
+    const normalized = normalizeImportedCustomerRow(
+      { name: "Ada Lovelace", email: "ADA@EXAMPLE.COM", phone: "(555) 111-2222" },
+      "shop-123",
+    );
+    const csvMapped = mapCustomerCsvRow(
+      { customer_name: "Grace Hopper", customer_email: "grace@example.com", customer_phone: "555-333-4444" },
+      "shop-123",
+      "logged-in-owner-user",
+    );
+
+    expect(normalized).toMatchObject({
+      shop_id: "shop-123",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      phone: "5551112222",
+    });
+    expect(normalized).not.toHaveProperty("user_id");
+    expect(csvMapped).toMatchObject({
+      shop_id: "shop-123",
+      name: "Grace Hopper",
+      email: "grace@example.com",
+      phone: "555-333-4444",
+    });
+    expect(csvMapped).not.toHaveProperty("user_id");
+  });
+
+  it("allows multiple imported customers in one shop without reusing the logged-in auth user id", () => {
+    const importedCustomers = [
+      normalizeImportedCustomerRow({ name: "Customer One", email: "one@example.com" }, "shop-123"),
+      normalizeImportedCustomerRow({ name: "Customer Two", email: "two@example.com" }, "shop-123"),
+    ];
+
+    expect(importedCustomers).toHaveLength(2);
+    expect(importedCustomers.every((customer) => customer?.shop_id === "shop-123")).toBe(true);
+    expect(importedCustomers.map((customer) => customer && "user_id" in customer)).toEqual([false, false]);
+  });
 
 
   it("keeps starting-from-scratch setup active while skipping import-only steps", () => {


### PR DESCRIPTION
### Motivation

- Imported customer creation during onboarding/import was assigning the logged-in profile id into `customers.user_id`, causing unique constraint collisions (`customers_user_id_uq`) when multiple imports used the same auth id. 
- The intent is to ensure imported customers are created as shop-scoped records (by `shop_id`) and not accidentally linked to the portal/auth account unless an explicit linking flow runs.

### Description

- Stop assigning the caller/profile id to imported customers by extracting and exporting `normalizeImportedCustomerRow` and removing `user_id` from import payloads in `app/api/customers/import/route.ts` so import inserts/updates are shop-scoped only. 
- Update CSV mapping helper `mapCustomerCsvRow` in `features/vehicles/lib/importCustomers.ts` to omit `user_id` from mapped payloads while preserving `shop_id` and other contact fields. 
- Avoid defaulting `user_id` in the agent helper `toolCreateCustomer` by removing the `user_id: ctx.userId` default so programmatic/shop-scoped creates do not produce portal-linked customers by accident. 
- Add tests to `tests/guided-onboarding-v2-foundation.test.ts` that assert `normalizeImportedCustomerRow` and `mapCustomerCsvRow` payloads do not include `user_id` and that multiple imported customers can be prepared for the same `shop_id` without reusing a logged-in auth id. 
- Files changed: `app/api/customers/import/route.ts`, `features/vehicles/lib/importCustomers.ts`, `features/agent/tools/createCustomer.ts`, and `tests/guided-onboarding-v2-foundation.test.ts`.

### Testing

- Ran targeted tests with `npm test -- --run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx` and all test files passed. 
- Ran typecheck with `npm run typecheck` and `tsc --noEmit` completed without new errors. 
- Verified via code inspection that import payload builders no longer include `user_id`, and portal/auth linking code paths that intentionally set `customers.user_id` were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a493fa9ad4c8328a817c15a46dd0f2a)