### PR TITLE
Force null user_id for CSV customer imports and add pre-insert dedupe to avoid 409s

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -5,19 +5,37 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type CustomerInsert = DB["public"]["Tables"]["customers"]["Insert"];
-type CustomerUpdate = DB["public"]["Tables"]["customers"]["Update"];
-type CustomerMatch = Pick<DB["public"]["Tables"]["customers"]["Row"], "id">;
+type CustomerRow = Pick<
+  DB["public"]["Tables"]["customers"]["Row"],
+  | "id"
+  | "external_id"
+  | "email"
+  | "phone"
+  | "phone_number"
+  | "name"
+  | "business_name"
+  | "address"
+  | "city"
+  | "province"
+  | "postal_code"
+>;
+type CustomerMatch = Pick<CustomerRow, "id">;
 
 type ImportRow = {
   first_name?: unknown;
   last_name?: unknown;
   name?: unknown;
+  customer_id?: unknown;
   company_name?: unknown;
   business_name?: unknown;
+  display_name?: unknown;
   email?: unknown;
   phone?: unknown;
+  phone_primary?: unknown;
   phone_number?: unknown;
+  phone_secondary?: unknown;
   address?: unknown;
+  address1?: unknown;
   street?: unknown;
   city?: unknown;
   province?: unknown;
@@ -47,23 +65,75 @@ function cleanPhone(value: unknown): string | null {
   return digits || raw;
 }
 
-function splitName(name: string | null): { firstName: string | null; lastName: string | null } {
+function normalizeIdentity(value: string | null | undefined): string | null {
+  const text = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+  return text.length ? text : null;
+}
+
+function customerIdentityKeys(
+  customer: Partial<CustomerRow | CustomerInsert>,
+): string[] {
+  const keys: string[] = [];
+  const externalId = normalizeIdentity(customer.external_id);
+  if (externalId) keys.push(`external:${externalId}`);
+
+  const email = normalizeIdentity(customer.email);
+  if (email) keys.push(`email:${email}`);
+
+  const phone = cleanPhone(customer.phone) ?? cleanPhone(customer.phone_number);
+  if (phone) keys.push(`phone:${phone}`);
+
+  const name = normalizeIdentity(customer.name ?? customer.business_name);
+  if (name) {
+    const location = [
+      customer.address,
+      customer.city,
+      customer.province,
+      customer.postal_code,
+    ]
+      .map((part) => normalizeIdentity(part))
+      .filter(Boolean)
+      .join("|");
+    keys.push(`name-location:${name}|${location}`);
+  }
+
+  return keys;
+}
+
+function splitName(name: string | null): {
+  firstName: string | null;
+  lastName: string | null;
+} {
   if (!name) return { firstName: null, lastName: null };
   const parts = name.split(/\s+/).filter(Boolean);
   if (!parts.length) return { firstName: null, lastName: null };
-  if (parts.length === 1) return { firstName: parts[0] ?? null, lastName: null };
-  return { firstName: parts.slice(0, -1).join(" "), lastName: parts.at(-1) ?? null };
+  if (parts.length === 1)
+    return { firstName: parts[0] ?? null, lastName: null };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts.at(-1) ?? null,
+  };
 }
 
-
-export function normalizeImportedCustomerRow(row: ImportRow, shopId: string): CustomerInsert | null {
-  const businessName = cleanString(row.business_name) ?? cleanString(row.company_name);
-  const explicitName = cleanString(row.name);
+export function normalizeImportedCustomerRow(
+  row: ImportRow,
+  shopId: string,
+): CustomerInsert | null {
+  const businessName =
+    cleanString(row.business_name) ?? cleanString(row.company_name);
+  const explicitName = cleanString(row.name) ?? cleanString(row.display_name);
   const split = splitName(explicitName);
   const firstName = cleanString(row.first_name) ?? split.firstName;
   const lastName = cleanString(row.last_name) ?? split.lastName;
   const email = cleanEmail(row.email);
-  const phone = cleanPhone(row.phone) ?? cleanPhone(row.phone_number);
+  const phone =
+    cleanPhone(row.phone) ??
+    cleanPhone(row.phone_primary) ??
+    cleanPhone(row.phone_number) ??
+    cleanPhone(row.phone_secondary);
   const personName = [firstName, lastName].filter(Boolean).join(" ").trim();
   const displayName = businessName ?? explicitName ?? (personName || null);
 
@@ -71,6 +141,8 @@ export function normalizeImportedCustomerRow(row: ImportRow, shopId: string): Cu
 
   return {
     shop_id: shopId,
+    user_id: null,
+    external_id: cleanString(row.customer_id),
     first_name: firstName,
     last_name: lastName,
     name: explicitName ?? displayName,
@@ -78,7 +150,10 @@ export function normalizeImportedCustomerRow(row: ImportRow, shopId: string): Cu
     email,
     phone,
     phone_number: phone,
-    address: cleanString(row.address) ?? cleanString(row.street),
+    address:
+      cleanString(row.address) ??
+      cleanString(row.address1) ??
+      cleanString(row.street),
     city: cleanString(row.city),
     province: cleanString(row.province) ?? cleanString(row.state),
     postal_code: cleanString(row.postal_code) ?? cleanString(row.zip),
@@ -86,83 +161,55 @@ export function normalizeImportedCustomerRow(row: ImportRow, shopId: string): Cu
   } satisfies CustomerInsert;
 }
 
-async function findExistingCustomer(
+async function loadExistingCustomerIdentities(
   supabase: SupabaseClient<DB>,
   shopId: string,
+): Promise<Map<string, CustomerMatch>> {
+  const { data, error } = await supabase
+    .from("customers")
+    .select(
+      "id, external_id, email, phone, phone_number, name, business_name, address, city, province, postal_code",
+    )
+    .eq("shop_id", shopId)
+    .limit(10000);
+
+  if (error) throw error;
+
+  const byIdentity = new Map<string, CustomerMatch>();
+  for (const customer of (data ?? []) as CustomerRow[]) {
+    for (const key of customerIdentityKeys(customer)) {
+      if (!byIdentity.has(key)) byIdentity.set(key, { id: customer.id });
+    }
+  }
+
+  return byIdentity;
+}
+
+function findExistingCustomer(
+  existingByIdentity: Map<string, CustomerMatch>,
   normalized: CustomerInsert,
-): Promise<CustomerMatch | null> {
-  if (normalized.external_id) {
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("external_id", normalized.external_id)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
+): CustomerMatch | null {
+  for (const key of customerIdentityKeys(normalized)) {
+    const existing = existingByIdentity.get(key);
+    if (existing) return existing;
   }
-
-  if (normalized.email) {
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("email", normalized.email)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
-  if (normalized.phone) {
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("phone", normalized.phone)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
-  if (normalized.name) {
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("name", normalized.name)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
-  if (normalized.business_name) {
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("business_name", normalized.business_name)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
   return null;
 }
 
 export async function POST(req: Request) {
   try {
-    const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+    const access = await requireShopScopedApiAccess({
+      allowRoles: ["owner", "admin"],
+    });
     if (!access.ok) return access.response;
 
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
     if (!shopId) {
-      return NextResponse.json({ error: "Missing shop context." }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing shop context." },
+        { status: 400 },
+      );
     }
 
     const body = (await req.json().catch(() => ({}))) as CustomerImportBody;
@@ -173,56 +220,69 @@ export async function POST(req: Request) {
       updated: 0,
       skipped: 0,
       failed: 0,
+      duplicates: 0,
     };
 
     const errors: Array<{ row: number; error: string }> = [];
+    const existingByIdentity = await loadExistingCustomerIdentities(
+      supabase,
+      shopId,
+    );
+    const seenImportIdentities = new Set<string>();
+    const customersToCreate: CustomerInsert[] = [];
 
     for (const [index, raw] of rawRows.entries()) {
       try {
-        const normalized = normalizeImportedCustomerRow(raw as ImportRow, shopId);
+        const normalized = normalizeImportedCustomerRow(
+          raw as ImportRow,
+          shopId,
+        );
 
         if (!normalized) {
           counts.skipped += 1;
           continue;
         }
 
-        const existing = await findExistingCustomer(supabase, shopId, normalized);
+        const identityKeys = customerIdentityKeys(normalized);
+
+        if (identityKeys.some((key) => seenImportIdentities.has(key))) {
+          counts.duplicates += 1;
+          counts.skipped += 1;
+          continue;
+        }
+
+        const existing = findExistingCustomer(existingByIdentity, normalized);
 
         if (existing?.id) {
-          const updatePayload: CustomerUpdate = {
-            first_name: normalized.first_name,
-            last_name: normalized.last_name,
-            name: normalized.name,
-            business_name: normalized.business_name,
-            email: normalized.email,
-            phone: normalized.phone,
-            phone_number: normalized.phone_number,
-            address: normalized.address,
-            city: normalized.city,
-            province: normalized.province,
-            postal_code: normalized.postal_code,
-            notes: normalized.notes,
-          };
-
-          const { error } = await supabase
-            .from("customers")
-            .update(updatePayload)
-            .eq("id", existing.id)
-            .eq("shop_id", shopId);
-
-          if (error) throw error;
-          counts.updated += 1;
-        } else {
-          const { error } = await supabase.from("customers").insert(normalized);
-          if (error) throw error;
-          counts.created += 1;
+          counts.skipped += 1;
+          continue;
         }
+
+        for (const key of identityKeys) {
+          seenImportIdentities.add(key);
+          existingByIdentity.set(key, { id: `pending-${index}` });
+        }
+
+        customersToCreate.push({ ...normalized, user_id: null });
       } catch (error) {
         counts.failed += 1;
         errors.push({
           row: index + 1,
-          error: error instanceof Error ? error.message : "Unable to import row.",
+          error:
+            error instanceof Error ? error.message : "Unable to import row.",
         });
+      }
+    }
+
+    if (customersToCreate.length) {
+      const { error } = await supabase
+        .from("customers")
+        .insert(customersToCreate);
+      if (error) {
+        counts.failed += customersToCreate.length;
+        errors.push({ row: 0, error: error.message });
+      } else {
+        counts.created = customersToCreate.length;
       }
     }
 
@@ -233,7 +293,12 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to import customers." },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to import customers.",
+      },
       { status: 500 },
     );
   }

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -43,6 +43,7 @@ type ImportCounts = {
   updated: number;
   skipped: number;
   failed: number;
+  duplicates?: number;
 };
 
 type ImportResponse = {

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -179,7 +179,7 @@ describe("guided onboarding v2 foundation", () => {
       email: "ada@example.com",
       phone: "5551112222",
     });
-    expect(normalized).not.toHaveProperty("user_id");
+    expect(normalized).toHaveProperty("user_id", null);
     expect(csvMapped).toMatchObject({
       shop_id: "shop-123",
       name: "Grace Hopper",
@@ -197,9 +197,28 @@ describe("guided onboarding v2 foundation", () => {
 
     expect(importedCustomers).toHaveLength(2);
     expect(importedCustomers.every((customer) => customer?.shop_id === "shop-123")).toBe(true);
-    expect(importedCustomers.map((customer) => customer && "user_id" in customer)).toEqual([false, false]);
+    expect(importedCustomers.map((customer) => customer?.user_id)).toEqual([null, null]);
   });
 
+  it("keeps the active customer CSV import route from linking rows to the logged-in auth user", () => {
+    const routeSource = read("app/api/customers/import/route.ts");
+    const componentSource = read("features/customers/components/CustomerCsvImportCard.tsx");
+
+    expect(componentSource).toContain('fetch("/api/customers/import"');
+    expect(routeSource).toContain("user_id: null");
+    expect(routeSource).not.toContain("user_id: user.id");
+    expect(routeSource).not.toContain("user_id: profile.id");
+  });
+
+  it("dedupes customer CSV imports before inserting to avoid re-import conflict spam", () => {
+    const routeSource = read("app/api/customers/import/route.ts");
+
+    expect(routeSource).toContain("loadExistingCustomerIdentities");
+    expect(routeSource).toContain("seenImportIdentities");
+    expect(routeSource).toContain("customersToCreate");
+    expect(routeSource).toContain('.from("customers")');
+    expect(routeSource).toContain(".insert(customersToCreate)");
+  });
 
   it("keeps starting-from-scratch setup active while skipping import-only steps", () => {
     const serverSource = read("features/onboarding-v2/guided/server.ts");


### PR DESCRIPTION
### Motivation
- Guided Onboarding Confirm import was posting to the real Customers CSV route and imported rows were still able to carry a non-null `user_id`, causing repeated `409 duplicate key` errors against the `customers_user_id_uq` constraint. 
- Large CSV re-imports also triggered many conflicting per-row inserts; a shop-scoped prefetch + in-memory dedupe prevents repeated conflict spam while preserving shop scoping and RLS.

### Description
- Updated the active route used by the Customers page CSV Confirm button at `app/api/customers/import/route.ts` to explicitly set `user_id: null` for imported rows and to populate `external_id` from `customer_id` when present. 
- Added identity normalization and key generation (`external:id`, `email:`, `phone:`, `name-location:`) and a shop-scoped prefetch `loadExistingCustomerIdentities` to detect existing customers and avoid inserting duplicates. 
- Implemented in-memory CSV dedupe (`seenImportIdentities`) and collect-only-then-batch-insert (`customersToCreate`) so only safe new records are inserted in one batch and duplicate/re-imported rows are skipped and counted. 
- Extended response/counting to include `duplicates` and adjusted the Customers import UI typing/formatting in `features/customers/components/CustomerCsvImportCard.tsx` to accept the new counts shape and continue posting to `/api/customers/import`. 
- Updated regression tests in `tests/guided-onboarding-v2-foundation.test.ts` to assert that normalized imported rows contain `user_id: null`, that the component calls `/api/customers/import`, and that the route contains dedupe logic.

Files changed: `app/api/customers/import/route.ts`, `features/customers/components/CustomerCsvImportCard.tsx`, `tests/guided-onboarding-v2-foundation.test.ts`.

### Testing
- Ran the guided onboarding tests with `npm test -- --run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx` and all tests passed (both files passed, 30 tests total). 
- Ran type checks with `npm run typecheck` (`tsc --noEmit`) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49759f11e083288c98946ada94d512)