### PR TITLE
Move customer import normalization out of route

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  normalizeImportedCustomerRow,
+  type ImportRow,
+} from "@/features/customers/import/normalizeImportedCustomerRow";
 
 type DB = Database;
 type CustomerInsert = DB["public"]["Tables"]["customers"]["Insert"];
@@ -21,30 +25,6 @@ type CustomerRow = Pick<
 >;
 type CustomerMatch = Pick<CustomerRow, "id">;
 
-type ImportRow = {
-  first_name?: unknown;
-  last_name?: unknown;
-  name?: unknown;
-  customer_id?: unknown;
-  company_name?: unknown;
-  business_name?: unknown;
-  display_name?: unknown;
-  email?: unknown;
-  phone?: unknown;
-  phone_primary?: unknown;
-  phone_number?: unknown;
-  phone_secondary?: unknown;
-  address?: unknown;
-  address1?: unknown;
-  street?: unknown;
-  city?: unknown;
-  province?: unknown;
-  state?: unknown;
-  postal_code?: unknown;
-  zip?: unknown;
-  notes?: unknown;
-};
-
 type CustomerImportBody = {
   rows?: unknown;
 };
@@ -52,10 +32,6 @@ type CustomerImportBody = {
 function cleanString(value: unknown): string | null {
   const text = String(value ?? "").trim();
   return text.length ? text : null;
-}
-
-function cleanEmail(value: unknown): string | null {
-  return cleanString(value)?.toLowerCase() ?? null;
 }
 
 function cleanPhone(value: unknown): string | null {
@@ -101,64 +77,6 @@ function customerIdentityKeys(
   }
 
   return keys;
-}
-
-function splitName(name: string | null): {
-  firstName: string | null;
-  lastName: string | null;
-} {
-  if (!name) return { firstName: null, lastName: null };
-  const parts = name.split(/\s+/).filter(Boolean);
-  if (!parts.length) return { firstName: null, lastName: null };
-  if (parts.length === 1)
-    return { firstName: parts[0] ?? null, lastName: null };
-  return {
-    firstName: parts.slice(0, -1).join(" "),
-    lastName: parts.at(-1) ?? null,
-  };
-}
-
-export function normalizeImportedCustomerRow(
-  row: ImportRow,
-  shopId: string,
-): CustomerInsert | null {
-  const businessName =
-    cleanString(row.business_name) ?? cleanString(row.company_name);
-  const explicitName = cleanString(row.name) ?? cleanString(row.display_name);
-  const split = splitName(explicitName);
-  const firstName = cleanString(row.first_name) ?? split.firstName;
-  const lastName = cleanString(row.last_name) ?? split.lastName;
-  const email = cleanEmail(row.email);
-  const phone =
-    cleanPhone(row.phone) ??
-    cleanPhone(row.phone_primary) ??
-    cleanPhone(row.phone_number) ??
-    cleanPhone(row.phone_secondary);
-  const personName = [firstName, lastName].filter(Boolean).join(" ").trim();
-  const displayName = businessName ?? explicitName ?? (personName || null);
-
-  if (!displayName && !email && !phone) return null;
-
-  return {
-    shop_id: shopId,
-    user_id: null,
-    external_id: cleanString(row.customer_id),
-    first_name: firstName,
-    last_name: lastName,
-    name: explicitName ?? displayName,
-    business_name: businessName,
-    email,
-    phone,
-    phone_number: phone,
-    address:
-      cleanString(row.address) ??
-      cleanString(row.address1) ??
-      cleanString(row.street),
-    city: cleanString(row.city),
-    province: cleanString(row.province) ?? cleanString(row.state),
-    postal_code: cleanString(row.postal_code) ?? cleanString(row.zip),
-    notes: cleanString(row.notes),
-  } satisfies CustomerInsert;
 }
 
 async function loadExistingCustomerIdentities(

--- a/features/customers/import/normalizeImportedCustomerRow.ts
+++ b/features/customers/import/normalizeImportedCustomerRow.ts
@@ -1,0 +1,102 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+export type CustomerInsert = DB["public"]["Tables"]["customers"]["Insert"];
+
+export type ImportRow = {
+  first_name?: unknown;
+  last_name?: unknown;
+  name?: unknown;
+  customer_id?: unknown;
+  company_name?: unknown;
+  business_name?: unknown;
+  display_name?: unknown;
+  email?: unknown;
+  phone?: unknown;
+  phone_primary?: unknown;
+  phone_number?: unknown;
+  phone_secondary?: unknown;
+  address?: unknown;
+  address1?: unknown;
+  street?: unknown;
+  city?: unknown;
+  province?: unknown;
+  state?: unknown;
+  postal_code?: unknown;
+  zip?: unknown;
+  notes?: unknown;
+};
+
+function cleanString(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+
+function cleanEmail(value: unknown): string | null {
+  return cleanString(value)?.toLowerCase() ?? null;
+}
+
+function cleanPhone(value: unknown): string | null {
+  const raw = cleanString(value);
+  if (!raw) return null;
+  const digits = raw.replace(/\D/g, "");
+  return digits || raw;
+}
+
+function splitName(name: string | null): {
+  firstName: string | null;
+  lastName: string | null;
+} {
+  if (!name) return { firstName: null, lastName: null };
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (!parts.length) return { firstName: null, lastName: null };
+  if (parts.length === 1)
+    return { firstName: parts[0] ?? null, lastName: null };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts.at(-1) ?? null,
+  };
+}
+
+export function normalizeImportedCustomerRow(
+  row: ImportRow,
+  shopId: string,
+): CustomerInsert | null {
+  const businessName =
+    cleanString(row.business_name) ?? cleanString(row.company_name);
+  const explicitName = cleanString(row.name) ?? cleanString(row.display_name);
+  const split = splitName(explicitName);
+  const firstName = cleanString(row.first_name) ?? split.firstName;
+  const lastName = cleanString(row.last_name) ?? split.lastName;
+  const email = cleanEmail(row.email);
+  const phone =
+    cleanPhone(row.phone) ??
+    cleanPhone(row.phone_primary) ??
+    cleanPhone(row.phone_number) ??
+    cleanPhone(row.phone_secondary);
+  const personName = [firstName, lastName].filter(Boolean).join(" ").trim();
+  const displayName = businessName ?? explicitName ?? (personName || null);
+
+  if (!displayName && !email && !phone) return null;
+
+  return {
+    shop_id: shopId,
+    user_id: null,
+    external_id: cleanString(row.customer_id),
+    first_name: firstName,
+    last_name: lastName,
+    name: explicitName ?? displayName,
+    business_name: businessName,
+    email,
+    phone,
+    phone_number: phone,
+    address:
+      cleanString(row.address) ??
+      cleanString(row.address1) ??
+      cleanString(row.street),
+    city: cleanString(row.city),
+    province: cleanString(row.province) ?? cleanString(row.state),
+    postal_code: cleanString(row.postal_code) ?? cleanString(row.zip),
+    notes: cleanString(row.notes),
+  } satisfies CustomerInsert;
+}

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { GUIDED_ONBOARDING_STEP_KEYS } from "@/features/onboarding-v2/guided/steps";
 import { TILES } from "@/features/shared/config/tiles";
 import { getOwnerSidebarTiles } from "@/features/shared/lib/ownerSidebarNav";
-import { normalizeImportedCustomerRow } from "../app/api/customers/import/route";
+import { normalizeImportedCustomerRow } from "../features/customers/import/normalizeImportedCustomerRow";
 import { mapCustomerCsvRow } from "@/features/vehicles/lib/importCustomers";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;


### PR DESCRIPTION
### Motivation
- The Next.js route file `app/api/customers/import/route.ts` was exporting `normalizeImportedCustomerRow`, which caused a build/type issue because route modules should only export allowed Next.js route exports.
- Move the helper into a non-route module so the route only exports route handlers like `POST` while preserving behavior.

### Description
- Added `features/customers/import/normalizeImportedCustomerRow.ts` which contains `normalizeImportedCustomerRow`, `ImportRow` type, and supporting helper functions such as `cleanString`, `cleanEmail`, `cleanPhone`, and `splitName`.
- Updated `app/api/customers/import/route.ts` to import `normalizeImportedCustomerRow` and `ImportRow` from the new helper and removed the helper implementation from the route so the file only exports `POST` and related route logic.
- Updated `tests/guided-onboarding-v2-foundation.test.ts` to import `normalizeImportedCustomerRow` from the new helper module instead of from the route file.
- No behavioral changes were made to the normalization logic; only the location and imports were changed.

### Testing
- Ran `npm run typecheck`, which completed successfully with no TypeScript errors.
- Ran `npm run build`, which failed due to `next/font` failing to fetch Google Fonts (`Inter` and `Black Ops One`) and an existing `experimental.turbo` config warning; the build failure is unrelated to the moved helper and reflects external font fetch/network issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4977b69f9c8328972b1cdd9bdf02dd)