### PR TITLE
Handle per-row failures in customer CSV import and scope onboarding highlight styling

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -25,14 +25,30 @@ type CustomerRow = Pick<
 >;
 type CustomerMatch = Pick<CustomerRow, "id"> & { matchedBy?: string; matchedValue?: string | null };
 
-type SkippedCustomerImportRow = {
-  row: number;
-  reason: string;
+type ImportRowSummary = {
   customerName: string | null;
   email: string | null;
   phone: string | null;
+};
+
+type SkippedCustomerImportRow = ImportRowSummary & {
+  row: number;
+  reason: string;
   matchedBy: "email" | "phone" | "external_id" | "name_location" | "duplicate_in_csv" | "missing_identity" | "existing_customer";
   matchedValue?: string | null;
+};
+
+type FailedCustomerImportRow = ImportRowSummary & {
+  row: number;
+  error: string;
+  constraint?: string | null;
+};
+
+type PendingCustomerInsert = {
+  row: number;
+  customer: CustomerInsert;
+  summary: ImportRowSummary;
+  identityKeys: string[];
 };
 
 type CustomerImportBody = {
@@ -99,7 +115,7 @@ async function loadExistingCustomerIdentities(
       "id, external_id, email, phone, phone_number, name, business_name, address, city, province, postal_code",
     )
     .eq("shop_id", shopId)
-    .limit(10000);
+    ;
 
   if (error) throw error;
 
@@ -123,7 +139,7 @@ function describeIdentityKey(key: string): Pick<CustomerMatch, "matchedBy" | "ma
   return { matchedBy: "existing_customer", matchedValue: value };
 }
 
-function importRowSummary(row: ImportRow, normalized?: CustomerInsert | null) {
+function importRowSummary(row: ImportRow, normalized?: CustomerInsert | null): ImportRowSummary {
   const rawName = cleanString(row.company_name) ?? cleanString(row.business_name) ?? cleanString(row.display_name) ?? cleanString(row.name) ?? [cleanString(row.first_name), cleanString(row.last_name)].filter(Boolean).join(" ").trim();
   const name = rawName || normalized?.name || normalized?.business_name || null;
   return {
@@ -142,6 +158,38 @@ function findExistingCustomer(
     if (existing) return existing;
   }
   return null;
+}
+
+function extractConstraintName(error: unknown): string | null {
+  const fields = [
+    (error as { constraint?: unknown }).constraint,
+    (error as { details?: unknown }).details,
+    (error as { message?: unknown }).message,
+  ];
+
+  for (const field of fields) {
+    const text = typeof field === "string" ? field : "";
+    const quoted = text.match(/constraint ["']([^"']+)["']/i);
+    if (quoted?.[1]) return quoted[1];
+
+    const known = text.match(/(customers_user_id_uq|customers_shop_email_uq|customers_[a-z0-9_]*(?:email|phone|external|customer_id)[a-z0-9_]*)/i);
+    if (known?.[1]) return known[1];
+  }
+
+  return null;
+}
+
+function describeSupabaseInsertError(error: unknown): { message: string; constraint: string | null } {
+  const message =
+    typeof (error as { message?: unknown }).message === "string"
+      ? (error as { message: string }).message
+      : "Customer row failed a database insert check.";
+  const details = typeof (error as { details?: unknown }).details === "string" ? (error as { details: string }).details : null;
+  const constraint = extractConstraintName(error);
+  const parts = [message];
+  if (constraint) parts.push(`Constraint: ${constraint}.`);
+  if (details && !details.includes(message)) parts.push(details);
+  return { message: parts.join(" "), constraint };
 }
 
 export async function POST(req: Request) {
@@ -173,12 +221,13 @@ export async function POST(req: Request) {
 
     const errors: Array<{ row: number; error: string }> = [];
     const skippedRows: SkippedCustomerImportRow[] = [];
+    const failedRows: FailedCustomerImportRow[] = [];
     const existingByIdentity = await loadExistingCustomerIdentities(
       supabase,
       shopId,
     );
     const seenImportIdentities = new Set<string>();
-    const customersToCreate: CustomerInsert[] = [];
+    const customersToCreate: PendingCustomerInsert[] = [];
 
     for (const [index, raw] of rawRows.entries()) {
       try {
@@ -217,7 +266,12 @@ export async function POST(req: Request) {
           existingByIdentity.set(key, { id: `pending-${index}`, ...describeIdentityKey(key) });
         }
 
-        customersToCreate.push({ ...normalized, user_id: null });
+        customersToCreate.push({
+          row: index + 1,
+          customer: { ...normalized, user_id: null },
+          summary: importRowSummary(raw as ImportRow, normalized),
+          identityKeys,
+        });
       } catch (error) {
         counts.failed += 1;
         errors.push({
@@ -228,15 +282,26 @@ export async function POST(req: Request) {
       }
     }
 
-    if (customersToCreate.length) {
-      const { error } = await supabase
-        .from("customers")
-        .insert(customersToCreate);
+    for (const pending of customersToCreate) {
+      const payload: CustomerInsert = { ...pending.customer, user_id: null };
+      const { error } = await supabase.from("customers").insert(payload);
+
       if (error) {
-        counts.failed += customersToCreate.length;
-        errors.push({ row: 0, error: error.message });
-      } else {
-        counts.created = customersToCreate.length;
+        const safeError = describeSupabaseInsertError(error);
+        counts.failed += 1;
+        errors.push({ row: pending.row, error: safeError.message });
+        failedRows.push({
+          row: pending.row,
+          ...pending.summary,
+          error: safeError.message,
+          constraint: safeError.constraint,
+        });
+        continue;
+      }
+
+      counts.created += 1;
+      for (const key of pending.identityKeys) {
+        existingByIdentity.set(key, { id: `created-${pending.row}`, ...describeIdentityKey(key) });
       }
     }
 
@@ -245,6 +310,7 @@ export async function POST(req: Request) {
       counts,
       errors,
       skippedRows,
+      failedRows,
     });
   } catch (error) {
     return NextResponse.json(

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -56,11 +56,21 @@ type SkippedImportRow = {
   matchedValue?: string | null;
 };
 
+type FailedImportRow = {
+  row: number;
+  error: string;
+  customerName: string | null;
+  email: string | null;
+  phone: string | null;
+  constraint?: string | null;
+};
+
 type ImportResponse = {
   ok?: boolean;
   error?: string;
   counts?: ImportCounts;
   skippedRows?: SkippedImportRow[];
+  failedRows?: FailedImportRow[];
 };
 
 type Props = {
@@ -170,6 +180,7 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
   const [importError, setImportError] = useState<string | null>(null);
   const [counts, setCounts] = useState<ImportCounts | null>(null);
   const [skippedRows, setSkippedRows] = useState<SkippedImportRow[]>([]);
+  const [failedRows, setFailedRows] = useState<FailedImportRow[]>([]);
   const [importing, setImporting] = useState(false);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [busyAction, setBusyAction] = useState<"skip" | null>(null);
@@ -185,6 +196,7 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
     setHeaders([]);
     setCounts(null);
     setSkippedRows([]);
+    setFailedRows([]);
     setParseError(null);
     setImportError(null);
   }
@@ -249,6 +261,7 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
     setImportError(null);
     setCounts(null);
     setSkippedRows([]);
+    setFailedRows([]);
     try {
       const response = await fetch("/api/customers/import", {
         method: "POST",
@@ -261,6 +274,7 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
       }
       setCounts(payload.counts);
       setSkippedRows(payload.skippedRows ?? []);
+      setFailedRows(payload.failedRows ?? []);
       if (isOnboarding && payload.counts.created + payload.counts.updated > 0 && payload.counts.failed === 0) {
         await completeOnboardingAfterImport(payload.counts);
       }
@@ -386,6 +400,27 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
           Import results: created {counts.created}, updated {counts.updated}, skipped {counts.skipped}, failed {counts.failed}.
         </div>
       ) : null}
+      {failedRows.length ? (
+        <div className="mt-4 overflow-hidden rounded-xl border border-red-500/25 bg-red-950/20 text-sm text-red-50">
+          <div className="border-b border-red-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-red-100">Failed rows</div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[820px] text-left">
+              <thead className="text-xs uppercase tracking-[0.12em] text-red-100/70">
+                <tr><th className="px-3 py-2">Row</th><th className="px-3 py-2">Customer</th><th className="px-3 py-2">Email</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">Error</th><th className="px-3 py-2">Constraint</th></tr>
+              </thead>
+              <tbody className="divide-y divide-red-500/15 text-red-50/90">
+                {failedRows.slice(0, 25).map((row) => (
+                  <tr key={`${row.row}-${row.constraint ?? row.error}`}>
+                    <td className="px-3 py-2">{row.row}</td><td className="px-3 py-2">{row.customerName ?? "—"}</td><td className="px-3 py-2">{row.email ?? "—"}</td><td className="px-3 py-2">{row.phone ?? "—"}</td><td className="px-3 py-2">{row.error}</td><td className="px-3 py-2">{row.constraint ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {failedRows.length > 25 ? <div className="px-3 py-2 text-xs text-red-100/70">Showing first 25 of {failedRows.length} failed rows.</div> : null}
+        </div>
+      ) : null}
+
       {skippedRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-amber-500/25 bg-amber-950/20 text-sm text-amber-50">
           <div className="border-b border-amber-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-amber-100">Skipped rows</div>

--- a/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
+++ b/features/onboarding-v2/components/OnboardingHighlightFrame.tsx
@@ -16,12 +16,12 @@ export function OnboardingHighlightFrame({ title, description, children, active 
   return (
     <section
       data-onboarding-highlight={highlightKey}
-      className="rounded-2xl border border-orange-400/40 bg-orange-950/20 p-4 shadow-lg shadow-orange-950/20"
+      className="rounded-2xl border border-orange-300/50 bg-transparent p-2 shadow-[0_0_0_1px_rgba(251,146,60,0.16),0_0_28px_rgba(251,146,60,0.16)]"
     >
-      <div className="mb-3">
+      <div className="mb-2 rounded-xl border border-orange-300/25 bg-black/20 px-3 py-2">
         <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/80">Upload/setup here</div>
-        <h2 className="mt-1 text-lg font-semibold text-white">{title}</h2>
-        <p className="mt-1 text-sm text-orange-100/80">{description}</p>
+        <h2 className="mt-1 text-sm font-semibold text-white">{title}</h2>
+        <p className="mt-1 text-xs text-orange-100/75">{description}</p>
       </div>
       {children}
     </section>


### PR DESCRIPTION
### Motivation
- Prevent a single DB constraint violation from failing a large CSV import batch and provide actionable per-row failure details. 
- Surface useful error information in the UI so admins can fix bad rows without losing valid inserts. 
- Limit guided onboarding highlight styling to the import card so onboarding visuals do not recolor the whole Customers workspace.

### Description
- Change import flow in `POST /api/customers/import` to stage rows, pre-dedupe against existing shop customers, then insert rows one-by-one and record per-row successes or failures instead of a single bulk insert. 
- Expose safe DB error messages and attempt to extract constraint names (e.g. `customers_shop_email_uq`) for each failed row, returning `failedRows` with `row`, `customerName`, `email`, `phone`, `error`, and `constraint`. 
- Keep `user_id: null` explicitly on staged and inserted payloads and do not alter RLS or DB constraints. 
- Remove the hard `limit(10000)` when loading existing customer identities so pre-skip checks compare against the full shop-scoped set returned by Supabase. 
- Add a Failed rows table to the customer import UI and reset failed-row state on new imports. 
- Reduce `OnboardingHighlightFrame` styling to a subtle scoped border/glow and compact header so guided highlights do not overwhelm the page color scheme.
- Audit of the checked schema shows a unique index `customers_shop_email_uq` on `(shop_id, email)` and non-unique indexes for `shop_id` and `user_id`, and no checked-in `customers_user_id_uq` was found (reported for review, not changed). 

### Testing
- Ran type checks with `npm run typecheck` and it passed. 
- Attempted production build with `npm run build` (Next.js); build failed in this environment because Google Fonts (`Inter`, `Black Ops One`) failed to fetch from `fonts.googleapis.com`, so full compilation could not complete; this is an environment/network issue rather than a code change. 
- Manual verification in code ensures `created` increments only for actually inserted rows, `failed` counts failed inserts, `skipped` remains driven by pre-check logic, and `user_id` is set to `null` for imported customers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b82ea460832895e4b095f95e6c17)