### PR TITLE
Customer CSV import: treat duplicate constraint conflicts as skipped, normalize email, and adjust onboarding card styling

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -23,7 +23,10 @@ type CustomerRow = Pick<
   | "province"
   | "postal_code"
 >;
-type CustomerMatch = Pick<CustomerRow, "id"> & { matchedBy?: string; matchedValue?: string | null };
+type CustomerMatch = Pick<CustomerRow, "id"> & {
+  matchedBy?: string;
+  matchedValue?: string | null;
+};
 
 type ImportRowSummary = {
   customerName: string | null;
@@ -34,7 +37,14 @@ type ImportRowSummary = {
 type SkippedCustomerImportRow = ImportRowSummary & {
   row: number;
   reason: string;
-  matchedBy: "email" | "phone" | "external_id" | "name_location" | "duplicate_in_csv" | "missing_identity" | "existing_customer";
+  matchedBy:
+    | "email"
+    | "phone"
+    | "external_id"
+    | "name_location"
+    | "duplicate_in_csv"
+    | "missing_identity"
+    | "existing_customer";
   matchedValue?: string | null;
 };
 
@@ -67,6 +77,13 @@ function cleanPhone(value: unknown): string | null {
   return digits || raw;
 }
 
+function normalizeEmail(value: string | null | undefined): string | null {
+  const text = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return text.length ? text : null;
+}
+
 function normalizeIdentity(value: string | null | undefined): string | null {
   const text = String(value ?? "")
     .trim()
@@ -82,7 +99,7 @@ function customerIdentityKeys(
   const externalId = normalizeIdentity(customer.external_id);
   if (externalId) keys.push(`external:${externalId}`);
 
-  const email = normalizeIdentity(customer.email);
+  const email = normalizeEmail(customer.email);
   if (email) keys.push(`email:${email}`);
 
   const phone = cleanPhone(customer.phone) ?? cleanPhone(customer.phone_number);
@@ -114,38 +131,59 @@ async function loadExistingCustomerIdentities(
     .select(
       "id, external_id, email, phone, phone_number, name, business_name, address, city, province, postal_code",
     )
-    .eq("shop_id", shopId)
-    ;
-
+    .eq("shop_id", shopId);
   if (error) throw error;
 
   const byIdentity = new Map<string, CustomerMatch>();
   for (const customer of (data ?? []) as CustomerRow[]) {
     for (const key of customerIdentityKeys(customer)) {
-      if (!byIdentity.has(key)) byIdentity.set(key, { id: customer.id, ...describeIdentityKey(key) });
+      if (!byIdentity.has(key))
+        byIdentity.set(key, { id: customer.id, ...describeIdentityKey(key) });
     }
   }
 
   return byIdentity;
 }
 
-function describeIdentityKey(key: string): Pick<CustomerMatch, "matchedBy" | "matchedValue"> {
+function describeIdentityKey(
+  key: string,
+): Pick<CustomerMatch, "matchedBy" | "matchedValue"> {
   const [prefix, ...rest] = key.split(":");
   const value = rest.join(":") || null;
-  if (prefix === "external") return { matchedBy: "external_id", matchedValue: value };
+  if (prefix === "external")
+    return { matchedBy: "external_id", matchedValue: value };
   if (prefix === "email") return { matchedBy: "email", matchedValue: value };
   if (prefix === "phone") return { matchedBy: "phone", matchedValue: value };
-  if (prefix === "name-location") return { matchedBy: "name_location", matchedValue: value };
+  if (prefix === "name-location")
+    return { matchedBy: "name_location", matchedValue: value };
   return { matchedBy: "existing_customer", matchedValue: value };
 }
 
-function importRowSummary(row: ImportRow, normalized?: CustomerInsert | null): ImportRowSummary {
-  const rawName = cleanString(row.company_name) ?? cleanString(row.business_name) ?? cleanString(row.display_name) ?? cleanString(row.name) ?? [cleanString(row.first_name), cleanString(row.last_name)].filter(Boolean).join(" ").trim();
+function importRowSummary(
+  row: ImportRow,
+  normalized?: CustomerInsert | null,
+): ImportRowSummary {
+  const rawName =
+    cleanString(row.company_name) ??
+    cleanString(row.business_name) ??
+    cleanString(row.display_name) ??
+    cleanString(row.name) ??
+    [cleanString(row.first_name), cleanString(row.last_name)]
+      .filter(Boolean)
+      .join(" ")
+      .trim();
   const name = rawName || normalized?.name || normalized?.business_name || null;
   return {
     customerName: name || null,
     email: cleanString(row.email) ?? normalized?.email ?? null,
-    phone: cleanPhone(row.phone) ?? cleanPhone(row.phone_primary) ?? cleanPhone(row.phone_number) ?? cleanPhone(row.phone_secondary) ?? normalized?.phone ?? normalized?.phone_number ?? null,
+    phone:
+      cleanPhone(row.phone) ??
+      cleanPhone(row.phone_primary) ??
+      cleanPhone(row.phone_number) ??
+      cleanPhone(row.phone_secondary) ??
+      normalized?.phone ??
+      normalized?.phone_number ??
+      null,
   };
 }
 
@@ -172,19 +210,50 @@ function extractConstraintName(error: unknown): string | null {
     const quoted = text.match(/constraint ["']([^"']+)["']/i);
     if (quoted?.[1]) return quoted[1];
 
-    const known = text.match(/(customers_user_id_uq|customers_shop_email_uq|customers_[a-z0-9_]*(?:email|phone|external|customer_id)[a-z0-9_]*)/i);
+    const known = text.match(
+      /(customers_user_id_uq|customers_shop_email_uq|customers_[a-z0-9_]*(?:email|phone|external|customer_id)[a-z0-9_]*)/i,
+    );
     if (known?.[1]) return known[1];
   }
 
   return null;
 }
 
-function describeSupabaseInsertError(error: unknown): { message: string; constraint: string | null } {
+function duplicateSkipReasonForConstraint(
+  constraint: string | null,
+): string | null {
+  if (!constraint) return null;
+  if (constraint === "customers_shop_email_uq")
+    return "Matched existing customer by email.";
+  if (/email/i.test(constraint)) return "Duplicate email for this shop.";
+  if (/phone/i.test(constraint)) return "Duplicate phone for this shop.";
+  if (/external|customer_id/i.test(constraint))
+    return "Duplicate external customer ID for this shop.";
+  return null;
+}
+
+function matchedByForConstraint(
+  constraint: string | null,
+): SkippedCustomerImportRow["matchedBy"] {
+  if (!constraint) return "existing_customer";
+  if (/email/i.test(constraint)) return "email";
+  if (/phone/i.test(constraint)) return "phone";
+  if (/external|customer_id/i.test(constraint)) return "external_id";
+  return "existing_customer";
+}
+
+function describeSupabaseInsertError(error: unknown): {
+  message: string;
+  constraint: string | null;
+} {
   const message =
     typeof (error as { message?: unknown }).message === "string"
       ? (error as { message: string }).message
       : "Customer row failed a database insert check.";
-  const details = typeof (error as { details?: unknown }).details === "string" ? (error as { details: string }).details : null;
+  const details =
+    typeof (error as { details?: unknown }).details === "string"
+      ? (error as { details: string }).details
+      : null;
   const constraint = extractConstraintName(error);
   const parts = [message];
   if (constraint) parts.push(`Constraint: ${constraint}.`);
@@ -238,18 +307,31 @@ export async function POST(req: Request) {
 
         if (!normalized) {
           counts.skipped += 1;
-          skippedRows.push({ row: index + 1, reason: "Missing customer name, company, email, and phone.", ...importRowSummary(raw as ImportRow), matchedBy: "missing_identity" });
+          skippedRows.push({
+            row: index + 1,
+            reason: "Missing customer name, company, email, and phone.",
+            ...importRowSummary(raw as ImportRow),
+            matchedBy: "missing_identity",
+          });
           continue;
         }
 
         const identityKeys = customerIdentityKeys(normalized);
 
-        const duplicateKey = identityKeys.find((key) => seenImportIdentities.has(key));
+        const duplicateKey = identityKeys.find((key) =>
+          seenImportIdentities.has(key),
+        );
         if (duplicateKey) {
           counts.duplicates += 1;
           counts.skipped += 1;
           const duplicateMatch = describeIdentityKey(duplicateKey);
-          skippedRows.push({ row: index + 1, reason: "Duplicate customer identity within this CSV.", ...importRowSummary(raw as ImportRow, normalized), matchedBy: "duplicate_in_csv", matchedValue: duplicateMatch.matchedValue });
+          skippedRows.push({
+            row: index + 1,
+            reason: "Duplicate customer identity within this CSV.",
+            ...importRowSummary(raw as ImportRow, normalized),
+            matchedBy: "duplicate_in_csv",
+            matchedValue: duplicateMatch.matchedValue,
+          });
           continue;
         }
 
@@ -257,13 +339,28 @@ export async function POST(req: Request) {
 
         if (existing?.id) {
           counts.skipped += 1;
-          skippedRows.push({ row: index + 1, reason: "Matched an existing customer for this shop.", ...importRowSummary(raw as ImportRow, normalized), matchedBy: (existing.matchedBy as SkippedCustomerImportRow["matchedBy"]) ?? "existing_customer", matchedValue: existing.matchedValue ?? existing.id });
+          const matchedBy =
+            (existing.matchedBy as SkippedCustomerImportRow["matchedBy"]) ??
+            "existing_customer";
+          skippedRows.push({
+            row: index + 1,
+            reason:
+              matchedBy === "email"
+                ? "Matched existing customer by email."
+                : "Matched an existing customer for this shop.",
+            ...importRowSummary(raw as ImportRow, normalized),
+            matchedBy,
+            matchedValue: existing.matchedValue ?? existing.id,
+          });
           continue;
         }
 
         for (const key of identityKeys) {
           seenImportIdentities.add(key);
-          existingByIdentity.set(key, { id: `pending-${index}`, ...describeIdentityKey(key) });
+          existingByIdentity.set(key, {
+            id: `pending-${index}`,
+            ...describeIdentityKey(key),
+          });
         }
 
         customersToCreate.push({
@@ -288,6 +385,25 @@ export async function POST(req: Request) {
 
       if (error) {
         const safeError = describeSupabaseInsertError(error);
+        const duplicateSkipReason = duplicateSkipReasonForConstraint(
+          safeError.constraint,
+        );
+
+        if (duplicateSkipReason) {
+          counts.skipped += 1;
+          skippedRows.push({
+            row: pending.row,
+            reason: duplicateSkipReason,
+            ...pending.summary,
+            matchedBy: matchedByForConstraint(safeError.constraint),
+            matchedValue:
+              safeError.constraint === "customers_shop_email_uq"
+                ? normalizeEmail(pending.customer.email)
+                : safeError.constraint,
+          });
+          continue;
+        }
+
         counts.failed += 1;
         errors.push({ row: pending.row, error: safeError.message });
         failedRows.push({
@@ -301,7 +417,10 @@ export async function POST(req: Request) {
 
       counts.created += 1;
       for (const key of pending.identityKeys) {
-        existingByIdentity.set(key, { id: `created-${pending.row}`, ...describeIdentityKey(key) });
+        existingByIdentity.set(key, {
+          id: `created-${pending.row}`,
+          ...describeIdentityKey(key),
+        });
       }
     }
 

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -109,10 +109,15 @@ const SUPPORTED_COLUMNS = [
   "notes",
 ] as const;
 
-const RECOMMENDED_COLUMNS = "customer_id, display_name, company_name, first_name, last_name, email, phone_primary, phone_secondary, address1, city, province, postal_code";
+const RECOMMENDED_COLUMNS =
+  "customer_id, display_name, company_name, first_name, last_name, email, phone_primary, phone_secondary, address1, city, province, postal_code";
 
 function cleanHeader(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, "");
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
 }
 
 function cleanCell(value: unknown): string | null {
@@ -142,15 +147,15 @@ function normalizeParsedRow(row: Record<string, unknown>): CustomerImportRow {
 function hasImportableIdentity(row: CustomerImportRow): boolean {
   return Boolean(
     row.email ||
-      row.phone ||
-      row.phone_primary ||
-      row.phone_number ||
-      row.phone_secondary ||
-      row.name ||
-      row.company_name ||
-      row.business_name ||
-      row.first_name ||
-      row.last_name,
+    row.phone ||
+    row.phone_primary ||
+    row.phone_number ||
+    row.phone_secondary ||
+    row.name ||
+    row.company_name ||
+    row.business_name ||
+    row.first_name ||
+    row.last_name,
   );
 }
 
@@ -170,7 +175,10 @@ function displayName(row: CustomerImportRow): string {
   );
 }
 
-export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) {
+export function CustomerCsvImportCard({
+  guidedQuery,
+  onCreateCustomer,
+}: Props) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
@@ -185,11 +193,21 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [busyAction, setBusyAction] = useState<"skip" | null>(null);
 
-  const isOnboarding = Boolean(guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "customers");
-  const importableRows = useMemo(() => rows.filter(hasImportableIdentity), [rows]);
+  const isOnboarding = Boolean(
+    guidedQuery?.onboardingSession &&
+    guidedQuery.onboardingStep === "customers",
+  );
+  const importableRows = useMemo(
+    () => rows.filter(hasImportableIdentity),
+    [rows],
+  );
   const skippedPreviewCount = rows.length - importableRows.length;
   const previewRows = importableRows.slice(0, 5);
-  const importSucceeded = Boolean(counts && counts.created + counts.updated > 0 && counts.failed === 0);
+  const importSucceeded = Boolean(
+    counts &&
+    counts.created + counts.updated + counts.skipped > 0 &&
+    counts.failed === 0,
+  );
 
   function resetImportState() {
     setRows([]);
@@ -218,8 +236,12 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
       header: true,
       skipEmptyLines: true,
       complete: (results) => {
-        const parsedRows = (results.data ?? []).map(normalizeParsedRow).filter((row) => Object.keys(row).length > 0);
-        setHeaders((results.meta.fields ?? []).map(cleanHeader).filter(Boolean));
+        const parsedRows = (results.data ?? [])
+          .map(normalizeParsedRow)
+          .filter((row) => Object.keys(row).length > 0);
+        setHeaders(
+          (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
+        );
         setRows(parsedRows);
         if (!parsedRows.length) {
           setParseError("No customer rows were found in that CSV.");
@@ -240,12 +262,20 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ summary: { importType: "customer_csv", ...nextCounts } }),
+          body: JSON.stringify({
+            summary: { importType: "customer_csv", ...nextCounts },
+          }),
         },
       );
-      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      const payload = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
       if (!response.ok || payload.ok === false) {
-        throw new Error(payload.error ?? "Customer import succeeded, but onboarding completion failed.");
+        throw new Error(
+          payload.error ??
+            "Customer import succeeded, but onboarding completion failed.",
+        );
       }
     } finally {
       setCompletingOnboarding(false);
@@ -254,7 +284,9 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
 
   async function confirmImport() {
     if (!importableRows.length) {
-      setImportError("Upload a CSV with at least one customer name, company, email, or phone before importing.");
+      setImportError(
+        "Upload a CSV with at least one customer name, company, email, or phone before importing.",
+      );
       return;
     }
     setImporting(true);
@@ -268,18 +300,29 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ rows: importableRows }),
       });
-      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as ImportResponse;
       if (!response.ok || payload.ok === false || !payload.counts) {
         throw new Error(payload.error ?? "Unable to import customers.");
       }
       setCounts(payload.counts);
       setSkippedRows(payload.skippedRows ?? []);
       setFailedRows(payload.failedRows ?? []);
-      if (isOnboarding && payload.counts.created + payload.counts.updated > 0 && payload.counts.failed === 0) {
+      if (
+        isOnboarding &&
+        payload.counts.created +
+          payload.counts.updated +
+          payload.counts.skipped >
+          0 &&
+        payload.counts.failed === 0
+      ) {
         await completeOnboardingAfterImport(payload.counts);
       }
     } catch (error) {
-      setImportError(error instanceof Error ? error.message : "Unable to import customers.");
+      setImportError(
+        error instanceof Error ? error.message : "Unable to import customers.",
+      );
     } finally {
       setImporting(false);
     }
@@ -295,16 +338,27 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ skippedReason: "Customer import skipped during onboarding." }),
+          body: JSON.stringify({
+            skippedReason: "Customer import skipped during onboarding.",
+          }),
         },
       );
-      const payload = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      const payload = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
       if (!response.ok || payload.ok === false) {
-        throw new Error(payload.error ?? "Unable to skip customer onboarding step.");
+        throw new Error(
+          payload.error ?? "Unable to skip customer onboarding step.",
+        );
       }
       router.push(guidedQuery.returnTo);
     } catch (error) {
-      setImportError(error instanceof Error ? error.message : "Unable to skip customer onboarding step.");
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "Unable to skip customer onboarding step.",
+      );
     } finally {
       setBusyAction(null);
     }
@@ -313,30 +367,42 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
   return (
     <GuidedSetupCardShell
       testId="customer-csv-import-card"
-      eyebrow={isOnboarding ? "Guided onboarding · Customers" : "Customer files"}
-      title={isOnboarding ? "Upload your customer CSV here" : "Import customers"}
+      eyebrow={
+        isOnboarding ? "Guided onboarding · Customers" : "Customer files"
+      }
+      title={
+        isOnboarding ? "Upload your customer CSV here" : "Import customers"
+      }
       description={
         <>
-          {isOnboarding ? <p>This import lives on the Customers page so you can find it later.</p> : null}
-          <p>Upload a CSV, review the parsed customer preview, then explicitly confirm the import.</p>
+          {isOnboarding ? (
+            <p>
+              This import lives on the Customers page so you can find it later.
+            </p>
+          ) : null}
           <p>
-            Supported columns include <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>. Optional fields can be omitted.
+            Upload a CSV, review the parsed customer preview, then explicitly
+            confirm the import.
+          </p>
+          <p>
+            Supported columns include{" "}
+            <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>.
+            Optional fields can be omitted.
           </p>
         </>
       }
-      guided={
-        isOnboarding
-          ? {
-              active: true,
-              highlightKey: guidedQuery?.highlight,
-              title: "Customer CSV import",
-              description: "Upload your customer list here to continue guided setup.",
-            }
-          : null
-      }
+      guided={null}
+      variant="workspace"
       actions={
         <>
-          <input ref={fileInputRef} data-testid="customer-csv-file-input" type="file" accept=".csv,text/csv" onChange={handleFileChange} className="sr-only" />
+          <input
+            ref={fileInputRef}
+            data-testid="customer-csv-file-input"
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="sr-only"
+          />
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
@@ -356,41 +422,79 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
         </>
       }
     >
-
       <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <span className="font-semibold text-neutral-100">Selected file:</span> {fileName ?? "No CSV selected"}
+            <span className="font-semibold text-neutral-100">
+              Selected file:
+            </span>{" "}
+            {fileName ?? "No CSV selected"}
           </div>
-          {headers.length ? <div className="text-xs text-neutral-400">Detected {headers.length} columns</div> : null}
+          {headers.length ? (
+            <div className="text-xs text-neutral-400">
+              Detected {headers.length} columns
+            </div>
+          ) : null}
         </div>
-        {parseError ? <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">{parseError}</div> : null}
+        {parseError ? (
+          <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">
+            {parseError}
+          </div>
+        ) : null}
         {rows.length ? (
           <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2"><div className="text-lg font-semibold text-white">{rows.length}</div><div className="text-xs text-neutral-400">Rows parsed</div></div>
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2"><div className="text-lg font-semibold text-emerald-100">{importableRows.length}</div><div className="text-xs text-neutral-400">Ready to import</div></div>
-            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2"><div className="text-lg font-semibold text-amber-100">{skippedPreviewCount}</div><div className="text-xs text-neutral-400">Missing identity</div></div>
+            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+              <div className="text-lg font-semibold text-white">
+                {rows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Rows parsed</div>
+            </div>
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2">
+              <div className="text-lg font-semibold text-emerald-100">
+                {importableRows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Ready to import</div>
+            </div>
+            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2">
+              <div className="text-lg font-semibold text-amber-100">
+                {skippedPreviewCount}
+              </div>
+              <div className="text-xs text-neutral-400">Missing identity</div>
+            </div>
           </div>
         ) : null}
       </div>
 
       {previewRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
-          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Preview</div>
+          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
+            Preview
+          </div>
           <div className="overflow-x-auto">
             <table className="w-full min-w-[720px] text-left text-sm">
               <thead className="text-xs uppercase tracking-[0.12em] text-neutral-500">
                 <tr>
-                  <th className="px-3 py-2">Customer</th><th className="px-3 py-2">Email</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">Location</th>
+                  <th className="px-3 py-2">Customer</th>
+                  <th className="px-3 py-2">Email</th>
+                  <th className="px-3 py-2">Phone</th>
+                  <th className="px-3 py-2">Location</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10 text-neutral-200">
                 {previewRows.map((row, index) => (
                   <tr key={`${displayName(row)}-${index}`}>
-                    <td className="px-3 py-2 font-medium text-white">{displayName(row)}</td>
+                    <td className="px-3 py-2 font-medium text-white">
+                      {displayName(row)}
+                    </td>
                     <td className="px-3 py-2">{row.email ?? "—"}</td>
-                    <td className="px-3 py-2">{row.phone ?? row.phone_number ?? "—"}</td>
-                    <td className="px-3 py-2">{[row.city, row.province ?? row.state].filter(Boolean).join(", ") || "—"}</td>
+                    <td className="px-3 py-2">
+                      {row.phone ?? row.phone_number ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {[row.city, row.province ?? row.state]
+                        .filter(Boolean)
+                        .join(", ") || "—"}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -401,51 +505,97 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
 
       {counts ? (
         <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
-          Import results: created {counts.created}, updated {counts.updated}, skipped {counts.skipped}, failed {counts.failed}.
+          Import results: created {counts.created}, updated {counts.updated},
+          skipped {counts.skipped}, failed {counts.failed}.
         </div>
       ) : null}
       {failedRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-red-500/25 bg-red-950/20 text-sm text-red-50">
-          <div className="border-b border-red-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-red-100">Failed rows</div>
+          <div className="border-b border-red-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-red-100">
+            Failed rows
+          </div>
           <div className="overflow-x-auto">
             <table className="w-full min-w-[820px] text-left">
               <thead className="text-xs uppercase tracking-[0.12em] text-red-100/70">
-                <tr><th className="px-3 py-2">Row</th><th className="px-3 py-2">Customer</th><th className="px-3 py-2">Email</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">Error</th><th className="px-3 py-2">Constraint</th></tr>
+                <tr>
+                  <th className="px-3 py-2">Row</th>
+                  <th className="px-3 py-2">Customer</th>
+                  <th className="px-3 py-2">Email</th>
+                  <th className="px-3 py-2">Phone</th>
+                  <th className="px-3 py-2">Error</th>
+                  <th className="px-3 py-2">Constraint</th>
+                </tr>
               </thead>
               <tbody className="divide-y divide-red-500/15 text-red-50/90">
                 {failedRows.slice(0, 25).map((row) => (
                   <tr key={`${row.row}-${row.constraint ?? row.error}`}>
-                    <td className="px-3 py-2">{row.row}</td><td className="px-3 py-2">{row.customerName ?? "—"}</td><td className="px-3 py-2">{row.email ?? "—"}</td><td className="px-3 py-2">{row.phone ?? "—"}</td><td className="px-3 py-2">{row.error}</td><td className="px-3 py-2">{row.constraint ?? "—"}</td>
+                    <td className="px-3 py-2">{row.row}</td>
+                    <td className="px-3 py-2">{row.customerName ?? "—"}</td>
+                    <td className="px-3 py-2">{row.email ?? "—"}</td>
+                    <td className="px-3 py-2">{row.phone ?? "—"}</td>
+                    <td className="px-3 py-2">{row.error}</td>
+                    <td className="px-3 py-2">{row.constraint ?? "—"}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-          {failedRows.length > 25 ? <div className="px-3 py-2 text-xs text-red-100/70">Showing first 25 of {failedRows.length} failed rows.</div> : null}
+          {failedRows.length > 25 ? (
+            <div className="px-3 py-2 text-xs text-red-100/70">
+              Showing first 25 of {failedRows.length} failed rows.
+            </div>
+          ) : null}
         </div>
       ) : null}
 
       {skippedRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-amber-500/25 bg-amber-950/20 text-sm text-amber-50">
-          <div className="border-b border-amber-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-amber-100">Skipped rows</div>
+          <div className="border-b border-amber-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-amber-100">
+            Skipped rows
+          </div>
           <div className="overflow-x-auto">
             <table className="w-full min-w-[760px] text-left">
               <thead className="text-xs uppercase tracking-[0.12em] text-amber-100/70">
-                <tr><th className="px-3 py-2">Row</th><th className="px-3 py-2">Customer</th><th className="px-3 py-2">Email</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">Reason</th><th className="px-3 py-2">Matched by</th></tr>
+                <tr>
+                  <th className="px-3 py-2">Row</th>
+                  <th className="px-3 py-2">Customer</th>
+                  <th className="px-3 py-2">Email</th>
+                  <th className="px-3 py-2">Phone</th>
+                  <th className="px-3 py-2">Reason</th>
+                  <th className="px-3 py-2">Matched by</th>
+                </tr>
               </thead>
               <tbody className="divide-y divide-amber-500/15 text-amber-50/90">
                 {skippedRows.slice(0, 25).map((row) => (
-                  <tr key={`${row.row}-${row.matchedBy}-${row.matchedValue ?? row.customerName ?? row.email ?? row.phone ?? "row"}`}>
-                    <td className="px-3 py-2">{row.row}</td><td className="px-3 py-2">{row.customerName ?? "—"}</td><td className="px-3 py-2">{row.email ?? "—"}</td><td className="px-3 py-2">{row.phone ?? "—"}</td><td className="px-3 py-2">{row.reason}</td><td className="px-3 py-2">{row.matchedBy}{row.matchedValue ? ` · ${row.matchedValue}` : ""}</td>
+                  <tr
+                    key={`${row.row}-${row.matchedBy}-${row.matchedValue ?? row.customerName ?? row.email ?? row.phone ?? "row"}`}
+                  >
+                    <td className="px-3 py-2">{row.row}</td>
+                    <td className="px-3 py-2">{row.customerName ?? "—"}</td>
+                    <td className="px-3 py-2">{row.email ?? "—"}</td>
+                    <td className="px-3 py-2">{row.phone ?? "—"}</td>
+                    <td className="px-3 py-2">{row.reason}</td>
+                    <td className="px-3 py-2">
+                      {row.matchedBy}
+                      {row.matchedValue ? ` · ${row.matchedValue}` : ""}
+                    </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-          {skippedRows.length > 25 ? <div className="px-3 py-2 text-xs text-amber-100/70">Showing first 25 of {skippedRows.length} skipped rows.</div> : null}
+          {skippedRows.length > 25 ? (
+            <div className="px-3 py-2 text-xs text-amber-100/70">
+              Showing first 25 of {skippedRows.length} skipped rows.
+            </div>
+          ) : null}
         </div>
       ) : null}
-      {importError ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">{importError}</div> : null}
+      {importError ? (
+        <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">
+          {importError}
+        </div>
+      ) : null}
 
       <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
         <button
@@ -454,7 +604,11 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
           disabled={importing || completingOnboarding || !importableRows.length}
           className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
         >
-          {importing ? "Importing…" : completingOnboarding ? "Completing onboarding…" : "Confirm import"}
+          {importing
+            ? "Importing…"
+            : completingOnboarding
+              ? "Completing onboarding…"
+              : "Confirm import"}
         </button>
         {isOnboarding && counts ? (
           <button
@@ -462,7 +616,9 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
             onClick={() => router.push(guidedQuery!.returnTo)}
             className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
           >
-            {importSucceeded ? "Continue onboarding" : "Return to Data Onboarding"}
+            {importSucceeded
+              ? "Continue onboarding"
+              : "Return to Data Onboarding"}
           </button>
         ) : null}
         {isOnboarding ? (
@@ -470,12 +626,17 @@ export function CustomerCsvImportCard({ guidedQuery, onCreateCustomer }: Props) 
             <button
               type="button"
               onClick={() => void skipOnboardingStep()}
-              disabled={busyAction !== null || importing || completingOnboarding}
+              disabled={
+                busyAction !== null || importing || completingOnboarding
+              }
               className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
             >
               {busyAction === "skip" ? "Skipping…" : "Skip for now"}
             </button>
-            <Link href={guidedQuery!.returnTo} className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30">
+            <Link
+              href={guidedQuery!.returnTo}
+              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+            >
               Return to Data Onboarding
             </Link>
           </>

--- a/features/onboarding-v2/components/GuidedSetupCardShell.tsx
+++ b/features/onboarding-v2/components/GuidedSetupCardShell.tsx
@@ -16,6 +16,7 @@ type Props = {
   actions?: React.ReactNode;
   children?: React.ReactNode;
   testId?: string;
+  variant?: "copper" | "workspace";
 };
 
 export function GuidedSetupCardShell({
@@ -26,22 +27,29 @@ export function GuidedSetupCardShell({
   actions,
   children,
   testId,
+  variant = "copper",
 }: Props) {
+  const cardClassName =
+    variant === "workspace"
+      ? "rounded-2xl border border-sky-500/20 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]"
+      : "rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.13),rgba(15,23,42,0.92)_36%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]";
+
   const card = (
-    <section
-      data-testid={testId}
-      className="rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.13),rgba(15,23,42,0.92)_36%,rgba(2,6,23,0.96))] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]"
-    >
+    <section data-testid={testId} className={cardClassName}>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="max-w-3xl">
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">
             {eyebrow}
           </div>
           <h2 className="mt-2 text-xl font-semibold text-white">{title}</h2>
-          <div className="mt-3 space-y-2 text-sm text-neutral-300">{description}</div>
+          <div className="mt-3 space-y-2 text-sm text-neutral-300">
+            {description}
+          </div>
         </div>
 
-        {actions ? <div className="flex shrink-0 flex-wrap gap-2">{actions}</div> : null}
+        {actions ? (
+          <div className="flex shrink-0 flex-wrap gap-2">{actions}</div>
+        ) : null}
       </div>
 
       {children ? <div className="mt-4">{children}</div> : null}
@@ -54,7 +62,10 @@ export function GuidedSetupCardShell({
         active
         highlightKey={guided.highlightKey}
         title={guided.title ?? title}
-        description={guided.description ?? "Use this card to complete the guided setup step."}
+        description={
+          guided.description ??
+          "Use this card to complete the guided setup step."
+        }
       >
         {card}
       </OnboardingHighlightFrame>


### PR DESCRIPTION
### Motivation
- The CSV importer misclassified DB unique constraint conflicts (notably `customers_shop_email_uq`) as failures during re-imports instead of skipping matches, causing inflated failed counts and blocking guided completion.
- Email normalization used for inserted payloads was not consistently applied to identity lookups and duplicate reporting, leading to missed pre-dedupe matches.
- The Customers guided import UI used the full copper/guided overlay (brown/orange) while Vehicles used the workspace dark/blue variant, causing a visual regression.

### Description
- Inspected schema and confirmed the unique index `customers_shop_email_uq` exists on `(shop_id, email)` and used it to guide duplicate handling.
- Added `normalizeEmail` and switched identity lookups to use normalized email so CSV row identity, existing-customer lookup, and insert payloads use consistent email normalization (`toLowerCase().trim()`).
- Added logic to classify known duplicate constraint conflicts (e.g. `customers_shop_email_uq`, phone/external id patterns) as skipped rows with user-friendly reasons and `matchedBy` values instead of counting them as failures; retained true unexpected DB/validation errors as `failed`.
- Kept `user_id: null` and preserved shop scoping / RLS by loading existing customers with `.eq('shop_id', shopId)` and not altering tenant logic.
- Prefer pre-dedupe by matching existing shop customers before inserts and still handle any row-by-row constraint hits by converting them to skipped rows when the constraint matches a known duplicate pattern.
- Adjusted guided completion logic so the Customers step can complete when there are no real failures and at least one of `created`, `updated`, or `skipped` is > 0 (so pure re-imports of the same CSV can complete); updated client-side condition accordingly.
- Changed the Customer import card to use the workspace (dark/blue) variant of `GuidedSetupCardShell` and disabled the guided overlay wrapper for the import card to match the Vehicles page styling.
- Modified and cleaned various small formatting/JSX details in `CustomerCsvImportCard.tsx` for readability (no behavior change beyond onboarding/guided styling and success condition).

Files changed:
- `app/api/customers/import/route.ts` — email normalization, identity mapping, constraint extraction, duplicate classification to skipped, counts handling.
- `features/customers/components/CustomerCsvImportCard.tsx` — onboarding success condition, UI: switched card to workspace variant and removed guided overlay wrapper, minor JSX/formatting adjustments.
- `features/onboarding-v2/components/GuidedSetupCardShell.tsx` — added `variant` option to support workspace card styling.

### Testing
- Ran `npx tsc --noEmit` (via `npm run typecheck`) and TypeScript typecheck succeeded.
- Ran `npm run build` (Next.js production build); build failed due to inability to fetch Google Fonts (`Inter`, `Black Ops One`) from fonts.googleapis.com in this environment, which is a network/font fetch issue and not a code/TypeScript regression — all code changes themselves passed typecheck.
- Verified local logic paths by manually tracing importer flow and ensuring duplicates are pre-detected and that DB constraint errors are classified as skipped when matching known patterns (email/phone/external id).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c061a2248328b952a73ad962d75f)