### PR TITLE
Fix guided vehicle CSV import customer mapping

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -7,12 +7,36 @@ type DB = Database;
 type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
 type VehicleMatch = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id">;
+type CustomerResolverRow = Pick<
+  DB["public"]["Tables"]["customers"]["Row"],
+  | "id"
+  | "external_id"
+  | "email"
+  | "phone"
+  | "phone_number"
+  | "name"
+  | "business_name"
+>;
+type CustomerResolverIndex = {
+  byExternalId: Map<string, string>;
+  byEmail: Map<string, string>;
+  byPhone: Map<string, string>;
+  byName: Map<string, string>;
+};
+type NormalizedVehicleResult =
+  | { ok: true; vehicle: VehicleInsert }
+  | { ok: false; reason: string };
 
 type VehicleImportRow = {
-
   vehicle_id?: unknown;
 
   customer_id?: unknown;
+  customer_email?: unknown;
+  email?: unknown;
+  customer_phone?: unknown;
+  phone?: unknown;
+  customer_name?: unknown;
+  name?: unknown;
 
   plate?: unknown;
 
@@ -59,7 +83,11 @@ function cleanString(value: unknown): string | null {
 }
 
 function cleanVin(value: unknown): string | null {
-  return cleanString(value)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null;
+  return (
+    cleanString(value)
+      ?.toUpperCase()
+      .replace(/[^A-Z0-9]/g, "") ?? null
+  );
 }
 
 function cleanPlate(value: unknown): string | null {
@@ -76,11 +104,9 @@ function cleanYear(value: unknown): number | null {
 }
 
 function buildVehicleImportNotes(row: VehicleImportRow): string | null {
-
   const notes: string[] = [];
 
   const pairs: Array<[string, unknown]> = [
-
     ["csv_customer_id", row.customer_id],
 
     ["body_type", row.body_type],
@@ -98,60 +124,107 @@ function buildVehicleImportNotes(row: VehicleImportRow): string | null {
     ["tags", row.tags],
 
     ["notes", row.notes],
-
   ];
 
   for (const [label, value] of pairs) {
-
     const text = cleanString(value);
 
     if (text) notes.push(`${label}: ${text}`);
-
   }
 
   return notes.length ? notes.join("\n") : null;
-
 }
 
-async function findCustomerIdByExternalId(
+function normalizeLookupKey(value: unknown): string | null {
+  const text = cleanString(value)?.toLowerCase().replace(/\s+/g, " ") ?? null;
+  return text || null;
+}
 
+function normalizePhone(value: unknown): string | null {
+  const text = cleanString(value);
+  if (!text) return null;
+  return text.replace(/\D/g, "") || text;
+}
+
+async function loadCustomerResolverIndex(
   supabase: SupabaseClient<DB>,
-
   shopId: string,
-
-  externalId: string | null,
-
-): Promise<string | null> {
-
-  if (!externalId) return null;
-
+): Promise<CustomerResolverIndex> {
   const { data, error } = await supabase
-
     .from("customers")
-
-    .select("id")
-
-    .eq("shop_id", shopId)
-
-    .eq("external_id", externalId)
-
-    .maybeSingle();
+    .select("id, external_id, email, phone, phone_number, name, business_name")
+    .eq("shop_id", shopId);
 
   if (error) throw error;
 
-  return data?.id ?? null;
+  const index: CustomerResolverIndex = {
+    byExternalId: new Map(),
+    byEmail: new Map(),
+    byPhone: new Map(),
+    byName: new Map(),
+  };
 
+  for (const customer of (data ?? []) as CustomerResolverRow[]) {
+    const externalId = normalizeLookupKey(customer.external_id);
+    if (externalId && !index.byExternalId.has(externalId)) {
+      index.byExternalId.set(externalId, customer.id);
+    }
+
+    const email = normalizeLookupKey(customer.email);
+    if (email && !index.byEmail.has(email))
+      index.byEmail.set(email, customer.id);
+
+    for (const phoneValue of [customer.phone, customer.phone_number]) {
+      const phone = normalizePhone(phoneValue);
+      if (phone && !index.byPhone.has(phone))
+        index.byPhone.set(phone, customer.id);
+    }
+
+    for (const nameValue of [customer.name, customer.business_name]) {
+      const name = normalizeLookupKey(nameValue);
+      if (name && !index.byName.has(name)) index.byName.set(name, customer.id);
+    }
+  }
+
+  return index;
 }
 
-async function normalizeRow(
+function resolveCustomerId(
+  row: VehicleImportRow,
+  customers: CustomerResolverIndex,
+): string | null {
+  const externalCustomerId = normalizeLookupKey(row.customer_id);
+  if (externalCustomerId)
+    return customers.byExternalId.get(externalCustomerId) ?? null;
 
-  supabase: SupabaseClient<DB>,
+  const email = normalizeLookupKey(row.customer_email ?? row.email);
+  if (email) {
+    const match = customers.byEmail.get(email);
+    if (match) return match;
+  }
 
+  const phone = normalizePhone(row.customer_phone ?? row.phone);
+  if (phone) {
+    const match = customers.byPhone.get(phone);
+    if (match) return match;
+  }
+
+  const name = normalizeLookupKey(row.customer_name ?? row.name);
+  if (name) {
+    const match = customers.byName.get(name);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function normalizeRow(
   row: VehicleImportRow,
 
   shopId: string,
 
-): Promise<VehicleInsert | null> {
+  customers: CustomerResolverIndex,
+): NormalizedVehicleResult {
   const unitNumber = cleanString(row.unit_number);
   const vin = cleanVin(row.vin);
   const plate = cleanPlate(row.license_plate ?? row.plate);
@@ -165,30 +238,62 @@ async function normalizeRow(
 
   const mileage = [odometer, odometerUnit].filter(Boolean).join(" ") || null;
 
-  const customerId = await findCustomerIdByExternalId(supabase, shopId, cleanString(row.customer_id));
+  const rawCustomerId = cleanString(row.customer_id);
+  const customerId = resolveCustomerId(row, customers);
 
   const importNotes = buildVehicleImportNotes(row);
 
-  if (!vin && !unitNumber && !plate && !(year && make && model)) return null;
+  if (!vin && !unitNumber && !plate && !(year && make && model)) {
+    return { ok: false, reason: "Missing vehicle identity." };
+  }
+
+  if (rawCustomerId && !customerId) {
+    return {
+      ok: false,
+      reason: "Customer not found for external customer_id.",
+    };
+  }
 
   return {
-    shop_id: shopId,
-    unit_number: unitNumber,
-    vin,
-    license_plate: plate,
-    year,
-    make,
-    model,
-    customer_id: customerId,
-    external_id: cleanString(row.vehicle_id),
-    submodel: cleanString(row.trim),
-    color: cleanString(row.color),
-    mileage,
-    engine: cleanString(row.engine),
-    fuel_type: cleanString(row.fuel_type),
-    drivetrain: cleanString(row.drive_type),
-    import_notes: importNotes,
+    ok: true,
+    vehicle: {
+      shop_id: shopId,
+      unit_number: unitNumber,
+      vin,
+      license_plate: plate,
+      year,
+      make,
+      model,
+      customer_id: customerId,
+      external_id: cleanString(row.vehicle_id),
+      submodel: cleanString(row.trim),
+      color: cleanString(row.color),
+      mileage,
+      engine: cleanString(row.engine),
+      fuel_type: cleanString(row.fuel_type),
+      drivetrain: cleanString(row.drive_type),
+      import_notes: importNotes,
+    },
   };
+}
+
+async function findVehicleByField(
+  supabase: SupabaseClient<DB>,
+  shopId: string,
+  field: "external_id" | "vin" | "unit_number" | "license_plate",
+  value: string | null | undefined,
+): Promise<VehicleMatch | null> {
+  if (!value) return null;
+
+  const { data, error } = await supabase
+    .from("vehicles")
+    .select("id")
+    .eq("shop_id", shopId)
+    .eq(field, value)
+    .limit(1);
+
+  if (error) throw error;
+  return ((data ?? [])[0] as VehicleMatch | undefined) ?? null;
 }
 
 async function findExistingVehicle(
@@ -196,43 +301,27 @@ async function findExistingVehicle(
   shopId: string,
   normalized: VehicleInsert,
 ): Promise<VehicleMatch | null> {
-  if (normalized.vin) {
-    const { data, error } = await supabase
-      .from("vehicles")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("vin", normalized.vin)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
-  if (normalized.unit_number) {
-    const { data, error } = await supabase
-      .from("vehicles")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("unit_number", normalized.unit_number)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
-  if (normalized.license_plate) {
-    const { data, error } = await supabase
-      .from("vehicles")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("license_plate", normalized.license_plate)
-      .maybeSingle();
-
-    if (error) throw error;
-    if (data) return data;
-  }
-
-  return null;
+  return (
+    (await findVehicleByField(
+      supabase,
+      shopId,
+      "external_id",
+      normalized.external_id,
+    )) ??
+    (await findVehicleByField(supabase, shopId, "vin", normalized.vin)) ??
+    (await findVehicleByField(
+      supabase,
+      shopId,
+      "unit_number",
+      normalized.unit_number,
+    )) ??
+    (await findVehicleByField(
+      supabase,
+      shopId,
+      "license_plate",
+      normalized.license_plate,
+    ))
+  );
 }
 
 export async function POST(req: Request) {
@@ -249,14 +338,20 @@ export async function POST(req: Request) {
     const rows = Array.isArray(body?.rows) ? body.rows : [];
 
     if (!rows.length) {
-      return NextResponse.json({ error: "No vehicle rows provided." }, { status: 400 });
+      return NextResponse.json(
+        { error: "No vehicle rows provided." },
+        { status: 400 },
+      );
     }
 
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
 
     if (!shopId) {
-      return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
+      return NextResponse.json(
+        { error: "No active shop is selected." },
+        { status: 400 },
+      );
     }
 
     const counts = {
@@ -265,17 +360,31 @@ export async function POST(req: Request) {
       skipped: 0,
       failed: 0,
     };
+    const skippedRows: Array<{ row: number; reason: string }> = [];
+    const failedRows: Array<{ row: number; error: string }> = [];
+    const customers = await loadCustomerResolverIndex(supabase, shopId);
 
-    for (const raw of rows) {
-      const normalized = await normalizeRow(supabase, raw as VehicleImportRow, shopId);
+    for (const [index, raw] of rows.entries()) {
+      const normalizedResult = normalizeRow(
+        raw as VehicleImportRow,
+        shopId,
+        customers,
+      );
 
-      if (!normalized) {
+      if (!normalizedResult.ok) {
         counts.skipped += 1;
+        skippedRows.push({ row: index + 1, reason: normalizedResult.reason });
         continue;
       }
 
+      const normalized = normalizedResult.vehicle;
+
       try {
-        const existing = await findExistingVehicle(supabase, shopId, normalized);
+        const existing = await findExistingVehicle(
+          supabase,
+          shopId,
+          normalized,
+        );
 
         if (existing) {
           const updatePayload: VehicleUpdate = {
@@ -320,15 +429,33 @@ export async function POST(req: Request) {
 
         if (error) throw error;
         counts.created += 1;
-      } catch {
+      } catch (error) {
         counts.failed += 1;
+        failedRows.push({
+          row: index + 1,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Vehicle row failed to import.",
+        });
       }
     }
 
-    return NextResponse.json({ ok: true, counts });
+    const explanation = `Vehicle import complete: created ${counts.created}, updated ${counts.updated}, skipped ${counts.skipped}, failed ${counts.failed}.`;
+
+    return NextResponse.json({
+      ok: true,
+      counts,
+      explanation,
+      skippedRows,
+      failedRows,
+    });
   } catch (error) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to import vehicles." },
+      {
+        error:
+          error instanceof Error ? error.message : "Unable to import vehicles.",
+      },
       { status: 500 },
     );
   }

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
@@ -9,12 +11,27 @@ type Props = {
 };
 
 type VehicleImportRow = {
+  vehicle_id?: string | null;
+  customer_id?: string | null;
+  customer_email?: string | null;
+  email?: string | null;
+  customer_phone?: string | null;
+  phone?: string | null;
+  customer_name?: string | null;
+  name?: string | null;
   unit_number?: string | null;
   vin?: string | null;
   license_plate?: string | null;
   year?: string | null;
   make?: string | null;
   model?: string | null;
+  trim?: string | null;
+  color?: string | null;
+  odometer?: string | null;
+  odometer_unit?: string | null;
+  engine?: string | null;
+  fuel_type?: string | null;
+  drive_type?: string | null;
 };
 
 type ImportCounts = {
@@ -28,12 +45,21 @@ type ImportResponse = {
   ok?: boolean;
   error?: string;
   counts?: ImportCounts;
+  explanation?: string;
+  skippedRows?: Array<{ row: number; reason: string }>;
+  failedRows?: Array<{ row: number; error: string }>;
 };
 
 const SUPPORTED_COLUMNS = [
   "vehicle_id",
 
   "customer_id",
+  "customer_email",
+  "email",
+  "customer_phone",
+  "phone",
+  "customer_name",
+  "name",
 
   "unit_number",
   "unit",
@@ -44,9 +70,17 @@ const SUPPORTED_COLUMNS = [
   "year",
   "make",
   "model",
+  "trim",
+  "color",
+  "odometer",
+  "odometer_unit",
+  "engine",
+  "fuel_type",
+  "drive_type",
 ] as const;
 
-const RECOMMENDED_COLUMNS = "vehicle_id, customer_id, unit_number, year, make, model, trim, vin, plate, color, odometer, engine, fuel_type, drive_type";
+const RECOMMENDED_COLUMNS =
+  "vehicle_id, customer_id, unit_number, year, make, model, trim, vin, plate, color, odometer, engine, fuel_type, drive_type";
 
 function cleanHeader(value: string): string {
   return value
@@ -85,9 +119,9 @@ function normalizeParsedRow(row: Record<string, unknown>): VehicleImportRow {
 function hasImportableIdentity(row: VehicleImportRow): boolean {
   return Boolean(
     row.vin ||
-      row.unit_number ||
-      row.license_plate ||
-      (row.year && row.make && row.model),
+    row.unit_number ||
+    row.license_plate ||
+    (row.year && row.make && row.model),
   );
 }
 
@@ -153,6 +187,7 @@ function vehicleLabel(row: VehicleImportRow): string {
 }
 
 export function VehicleCsvImportCard({ guidedQuery }: Props) {
+  const router = useRouter();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const [rows, setRows] = useState<VehicleImportRow[]>([]);
@@ -160,11 +195,22 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
   const [importError, setImportError] = useState<string | null>(null);
   const [counts, setCounts] = useState<ImportCounts | null>(null);
   const [importing, setImporting] = useState(false);
+  const [completingOnboarding, setCompletingOnboarding] = useState(false);
 
-  const isOnboarding = Boolean(guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "vehicles");
-  const importableRows = useMemo(() => rows.filter(hasImportableIdentity), [rows]);
+  const isOnboarding = Boolean(
+    guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "vehicles",
+  );
+  const importableRows = useMemo(
+    () => rows.filter(hasImportableIdentity),
+    [rows],
+  );
   const skippedPreviewCount = rows.length - importableRows.length;
   const previewRows = importableRows.slice(0, 5);
+  const importSucceeded = Boolean(
+    counts &&
+    counts.created + counts.updated + counts.skipped > 0 &&
+    counts.failed === 0,
+  );
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
@@ -186,7 +232,9 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     }
 
     const text = await file.text();
-    const parsedRows = parseCsv(text).filter((row) => Object.keys(row).length > 0);
+    const parsedRows = parseCsv(text).filter(
+      (row) => Object.keys(row).length > 0,
+    );
     setRows(parsedRows);
 
     if (!parsedRows.length) {
@@ -197,19 +245,28 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
   async function completeOnboardingAfterImport(nextCounts: ImportCounts) {
     if (!guidedQuery) return;
 
-    await fetch(
-      `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/complete`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ summary: { importType: "vehicle_csv", ...nextCounts } }),
-      },
-    ).catch(() => null);
+    setCompletingOnboarding(true);
+    try {
+      await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            summary: { importType: "vehicle_csv", ...nextCounts },
+          }),
+        },
+      );
+    } finally {
+      setCompletingOnboarding(false);
+    }
   }
 
   async function confirmImport() {
     if (!importableRows.length) {
-      setImportError("Upload a CSV with at least one VIN, unit number, plate, or year/make/model before importing.");
+      setImportError(
+        "Upload a CSV with at least one VIN, unit number, plate, or year/make/model before importing.",
+      );
       return;
     }
 
@@ -224,7 +281,9 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         body: JSON.stringify({ rows: importableRows }),
       });
 
-      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as ImportResponse;
 
       if (!response.ok || payload.ok === false || !payload.counts) {
         throw new Error(payload.error ?? "Unable to import vehicles.");
@@ -232,11 +291,20 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
 
       setCounts(payload.counts);
 
-      if (isOnboarding && payload.counts.created + payload.counts.updated > 0 && payload.counts.failed === 0) {
+      if (
+        isOnboarding &&
+        payload.counts.created +
+          payload.counts.updated +
+          payload.counts.skipped >
+          0 &&
+        payload.counts.failed === 0
+      ) {
         await completeOnboardingAfterImport(payload.counts);
       }
     } catch (error) {
-      setImportError(error instanceof Error ? error.message : "Unable to import vehicles.");
+      setImportError(
+        error instanceof Error ? error.message : "Unable to import vehicles.",
+      );
     } finally {
       setImporting(false);
     }
@@ -250,10 +318,12 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       description={
         <>
           <p>
-            Import vehicles from a CSV. Supported columns include {RECOMMENDED_COLUMNS}.
+            Import vehicles from a CSV. Supported columns include{" "}
+            {RECOMMENDED_COLUMNS}.
           </p>
           <p>
-            This import lives on the Vehicles page so shops can add a vehicle list later without restarting setup.
+            This import lives on the Vehicles page so shops can add a vehicle
+            list later without restarting setup.
           </p>
         </>
       }
@@ -263,7 +333,8 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
               active: true,
               highlightKey: guidedQuery?.highlight,
               title: "Vehicle CSV import",
-              description: "Upload your vehicle list here to continue guided setup.",
+              description:
+                "Upload your vehicle list here to continue guided setup.",
             }
           : null
       }
@@ -287,7 +358,8 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       }
     >
       <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-neutral-300">
-        <span className="font-semibold text-neutral-100">Selected file:</span> {fileName ?? "No CSV selected"}
+        <span className="font-semibold text-neutral-100">Selected file:</span>{" "}
+        {fileName ?? "No CSV selected"}
       </div>
 
       {parseError ? (
@@ -304,7 +376,8 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
 
       {counts ? (
         <div className="mt-3 rounded-xl border border-emerald-500/35 bg-emerald-950/30 p-3 text-sm text-emerald-200">
-          Import complete. Created: {counts.created}. Updated: {counts.updated}. Skipped: {counts.skipped}. Failed: {counts.failed}.
+          Import complete. Created: {counts.created}. Updated: {counts.updated}.
+          Skipped: {counts.skipped}. Failed: {counts.failed}.
         </div>
       ) : null}
 
@@ -312,15 +385,21 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         <div className="mt-4 space-y-3">
           <div className="grid gap-3 sm:grid-cols-3">
             <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3">
-              <div className="text-lg font-semibold text-white">{rows.length}</div>
+              <div className="text-lg font-semibold text-white">
+                {rows.length}
+              </div>
               <div className="text-xs text-neutral-400">Rows found</div>
             </div>
             <div className="rounded-xl border border-emerald-500/25 bg-black/20 p-3">
-              <div className="text-lg font-semibold text-emerald-100">{importableRows.length}</div>
+              <div className="text-lg font-semibold text-emerald-100">
+                {importableRows.length}
+              </div>
               <div className="text-xs text-neutral-400">Ready to import</div>
             </div>
             <div className="rounded-xl border border-amber-500/25 bg-black/20 p-3">
-              <div className="text-lg font-semibold text-amber-100">{skippedPreviewCount}</div>
+              <div className="text-lg font-semibold text-amber-100">
+                {skippedPreviewCount}
+              </div>
               <div className="text-xs text-neutral-400">Missing identity</div>
             </div>
           </div>
@@ -335,9 +414,12 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
                   key={`${row.vin ?? row.unit_number ?? row.license_plate ?? index}`}
                   className="border-b border-[color:var(--desktop-border)] px-3 py-2 last:border-b-0"
                 >
-                  <div className="font-semibold text-white">{vehicleLabel(row)}</div>
+                  <div className="font-semibold text-white">
+                    {vehicleLabel(row)}
+                  </div>
                   <div className="text-xs text-neutral-400">
-                    VIN: {row.vin || "—"} · Unit: {row.unit_number || "—"} · Plate: {row.license_plate || "—"}
+                    VIN: {row.vin || "—"} · Unit: {row.unit_number || "—"} ·
+                    Plate: {row.license_plate || "—"}
                   </div>
                 </div>
               ))}
@@ -349,12 +431,35 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       <div className="mt-4 flex flex-wrap gap-2">
         <button
           type="button"
-          disabled={importing || !importableRows.length}
+          disabled={importing || completingOnboarding || !importableRows.length}
           onClick={() => void confirmImport()}
           className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {importing ? "Importing…" : "Confirm import"}
+          {importing
+            ? "Importing…"
+            : completingOnboarding
+              ? "Completing onboarding…"
+              : "Confirm import"}
         </button>
+        {isOnboarding && counts ? (
+          <button
+            type="button"
+            onClick={() => router.push(guidedQuery!.returnTo)}
+            className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
+          >
+            {importSucceeded
+              ? "Continue onboarding"
+              : "Return to Data Onboarding"}
+          </button>
+        ) : null}
+        {isOnboarding ? (
+          <Link
+            href={guidedQuery!.returnTo}
+            className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+          >
+            Return to Data Onboarding
+          </Link>
+        ) : null}
       </div>
     </GuidedSetupCardShell>
   );

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const routeSource = () =>
+  readFileSync("app/api/vehicles/import/route.ts", "utf8");
+const cardSource = () =>
+  readFileSync("features/vehicles/components/VehicleCsvImportCard.tsx", "utf8");
+
+describe("vehicle CSV import route", () => {
+  it("resolves CSV customer_id through customers.external_id before assigning vehicles.customer_id", () => {
+    const source = routeSource();
+
+    expect(source).toContain("byExternalId: Map<string, string>");
+    expect(source).toContain(
+      'select("id, external_id, email, phone, phone_number, name, business_name")',
+    );
+    expect(source).toContain("customers.byExternalId.get(externalCustomerId)");
+    expect(source).toContain("customer_id: customerId");
+    expect(source).not.toContain("customer_id: cleanString(row.customer_id)");
+  });
+
+  it("skips unresolved external customer ids instead of failing the whole import", () => {
+    const source = routeSource();
+
+    expect(source).toContain(
+      'reason: "Customer not found for external customer_id."',
+    );
+    expect(source).toContain("counts.skipped += 1");
+    expect(source).toContain("failedRows.push");
+  });
+
+  it("matches re-imported vehicles without relying on duplicate insert conflicts", () => {
+    const source = routeSource();
+
+    expect(source).toContain(
+      '"external_id" | "vin" | "unit_number" | "license_plate"',
+    );
+    expect(source).toContain("findVehicleByField");
+    expect(source).toContain(".limit(1)");
+    expect(source).toContain("counts.updated += 1");
+  });
+});
+
+describe("vehicle CSV import card", () => {
+  it("can complete guided onboarding after a non-fatal vehicle import", () => {
+    const source = cardSource();
+
+    expect(source).toContain("/steps/vehicles/complete");
+    expect(source).toMatch(
+      /payload\.counts\.created\s*\+\s*payload\.counts\.updated\s*\+\s*payload\.counts\.skipped\s*>\s*0/,
+    );
+    expect(source).toContain("Continue onboarding");
+  });
+});


### PR DESCRIPTION
### Motivation

- Vehicle CSV import during guided onboarding was failing with 500s and incorrectly inserting raw CSV `customer_id` values into `vehicles.customer_id` instead of resolving to the internal `customers.id` via `customers.external_id` for the current shop.  
- Preserve shop-scoped RLS behavior and avoid breaking imports when a single row is bad.  
- Ensure guided onboarding advances when the vehicle import completes with only non-fatal skips.

### Description

- Added a shop-scoped customer resolver that prefetches `customers` and builds indexes by `external_id`, and optionally by `email`, `phone`, and `name` to support future matching.  
- Updated normalization to resolve CSV `customer_id` (treated as external/source id) to the internal `customers.id` via the resolver and to return a structured result so unresolved rows can be skipped with a clear reason.  
- Changed existing-vehicle detection to attempt matching by `external_id`, then `vin`, `unit_number`, and `license_plate` (using `.limit(1)`) before inserting to avoid duplicate-insert/conflict spam.  
- Insert vehicles with `shop_id` from the authenticated profile and store CSV `vehicle_id` into the `external_id` field; do not write raw CSV customer ids to `vehicles.customer_id`.  
- Make one-bad-row non-fatal: unresolved customers produce a skipped row (reason: "Customer not found for external customer_id."), and other per-row failures are captured in `failedRows` rather than aborting the whole import.  
- Return a compact import summary (`counts`) plus optional `skippedRows` and `failedRows` and a short `explanation`.  
- Update the Vehicle CSV import UI card to accept extra customer lookup columns, keep guided onboarding completion flow if import had no true failures, and show a compact summary with a Continue/Return action during onboarding.  
- Added a focused test file covering external-id resolution, skipping unresolved customers, re-import matching, and onboarding completion behavior.

Files changed (key): `app/api/vehicles/import/route.ts`, `features/vehicles/components/VehicleCsvImportCard.tsx`, `tests/vehicle-csv-import-route.test.ts`.

### Testing

- Ran targeted unit tests: `npm run test -- tests/vehicle-csv-import-route.test.ts`, all tests passed (4/4).  
- Ran typecheck: `npm run typecheck` (`tsc --noEmit`) and it succeeded with no errors.  
- Ran full build: `npm run build` failed due to Next/font attempting to fetch Google Fonts (`Inter`, `Black Ops One`) in this environment; this is a network/font fetch issue unrelated to the import changes and not caused by the code changes here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c569cb448328ae128ef74a342ada)