### PR TITLE
Fix vehicle CSV import detail mapping

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -39,6 +39,7 @@ type VehicleImportRow = {
   name?: unknown;
 
   plate?: unknown;
+  state_province?: unknown;
 
   trim?: unknown;
 
@@ -103,27 +104,21 @@ function cleanYear(value: unknown): number | null {
   return Math.trunc(parsed);
 }
 
+function cleanDate(value: unknown): string | null {
+  const text = cleanString(value);
+  if (!text) return null;
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return text;
+}
+
 function buildVehicleImportNotes(row: VehicleImportRow): string | null {
   const notes: string[] = [];
 
   const pairs: Array<[string, unknown]> = [
     ["csv_customer_id", row.customer_id],
 
-    ["body_type", row.body_type],
-
-    ["asset_type", row.asset_type],
-
-    ["status", row.status],
-
-    ["purchase_date", row.purchase_date],
-
-    ["in_service_date", row.in_service_date],
-
-    ["last_service_date", row.last_service_date],
-
-    ["tags", row.tags],
-
-    ["notes", row.notes],
+    ["csv_notes", row.notes],
   ];
 
   for (const [label, value] of pairs) {
@@ -236,7 +231,7 @@ function normalizeRow(
 
   const odometerUnit = cleanString(row.odometer_unit);
 
-  const mileage = [odometer, odometerUnit].filter(Boolean).join(" ") || null;
+  const mileage = odometer ?? null;
 
   const rawCustomerId = cleanString(row.customer_id);
   const customerId = resolveCustomerId(row, customers);
@@ -261,6 +256,7 @@ function normalizeRow(
       unit_number: unitNumber,
       vin,
       license_plate: plate,
+      state_province: cleanString(row.state_province),
       year,
       make,
       model,
@@ -269,9 +265,18 @@ function normalizeRow(
       submodel: cleanString(row.trim),
       color: cleanString(row.color),
       mileage,
+      odometer_unit: odometerUnit,
       engine: cleanString(row.engine),
       fuel_type: cleanString(row.fuel_type),
       drivetrain: cleanString(row.drive_type),
+      body_type: cleanString(row.body_type),
+      asset_type: cleanString(row.asset_type),
+      status: cleanString(row.status),
+      purchase_date: cleanDate(row.purchase_date),
+      in_service_date: cleanDate(row.in_service_date),
+      last_service_date: cleanDate(row.last_service_date),
+      tags: cleanString(row.tags),
+      notes: cleanString(row.notes),
       import_notes: importNotes,
     },
   };
@@ -360,8 +365,6 @@ export async function POST(req: Request) {
       skipped: 0,
       failed: 0,
     };
-    const skippedRows: Array<{ row: number; reason: string }> = [];
-    const failedRows: Array<{ row: number; error: string }> = [];
     const customers = await loadCustomerResolverIndex(supabase, shopId);
 
     for (const [index, raw] of rows.entries()) {
@@ -373,7 +376,6 @@ export async function POST(req: Request) {
 
       if (!normalizedResult.ok) {
         counts.skipped += 1;
-        skippedRows.push({ row: index + 1, reason: normalizedResult.reason });
         continue;
       }
 
@@ -391,6 +393,7 @@ export async function POST(req: Request) {
             unit_number: normalized.unit_number,
             vin: normalized.vin,
             license_plate: normalized.license_plate,
+            state_province: normalized.state_province,
             year: normalized.year,
             make: normalized.make,
             model: normalized.model,
@@ -405,11 +408,29 @@ export async function POST(req: Request) {
 
             mileage: normalized.mileage,
 
+            odometer_unit: normalized.odometer_unit,
+
             engine: normalized.engine,
 
             fuel_type: normalized.fuel_type,
 
             drivetrain: normalized.drivetrain,
+
+            body_type: normalized.body_type,
+
+            asset_type: normalized.asset_type,
+
+            status: normalized.status,
+
+            purchase_date: normalized.purchase_date,
+
+            in_service_date: normalized.in_service_date,
+
+            last_service_date: normalized.last_service_date,
+
+            tags: normalized.tags,
+
+            notes: normalized.notes,
 
             import_notes: normalized.import_notes,
           };
@@ -431,7 +452,7 @@ export async function POST(req: Request) {
         counts.created += 1;
       } catch (error) {
         counts.failed += 1;
-        failedRows.push({
+        console.warn("Vehicle import row failed", {
           row: index + 1,
           error:
             error instanceof Error
@@ -447,8 +468,6 @@ export async function POST(req: Request) {
       ok: true,
       counts,
       explanation,
-      skippedRows,
-      failedRows,
     });
   } catch (error) {
     return NextResponse.json(

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -350,7 +350,7 @@ function computeVehicleExtraDetails(
     key: string;
     kind: "string" | "number";
   }> = [
-    { label: "Submodel", key: "submodel", kind: "string" },
+    { label: "Trim", key: "submodel", kind: "string" },
 
     { label: "Engine", key: "engine", kind: "string" },
     { label: "Engine Type", key: "engine_type", kind: "string" },
@@ -360,7 +360,15 @@ function computeVehicleExtraDetails(
     { label: "Transmission Type", key: "transmission_type", kind: "string" },
 
     { label: "Fuel Type", key: "fuel_type", kind: "string" },
-    { label: "Drivetrain", key: "drivetrain", kind: "string" },
+    { label: "Body Type", key: "body_type", kind: "string" },
+    { label: "Drive Type", key: "drivetrain", kind: "string" },
+    { label: "Asset Type", key: "asset_type", kind: "string" },
+    { label: "Status", key: "status", kind: "string" },
+    { label: "Purchase Date", key: "purchase_date", kind: "string" },
+    { label: "In-Service Date", key: "in_service_date", kind: "string" },
+    { label: "Last Service Date", key: "last_service_date", kind: "string" },
+    { label: "Tags", key: "tags", kind: "string" },
+    { label: "Notes", key: "notes", kind: "string" },
   ];
 
   const out: Array<{ label: string; value: string | number }> = [];
@@ -1076,6 +1084,20 @@ export default function CustomerProfilePage(): JSX.Element {
       updateRecord["fuel_type"] = vehDraft["fuel_type"] || null;
     if (typeof vehDraft["drivetrain"] === "string")
       updateRecord["drivetrain"] = vehDraft["drivetrain"] || null;
+    for (const key of [
+      "state_province",
+      "odometer_unit",
+      "body_type",
+      "asset_type",
+      "status",
+      "purchase_date",
+      "in_service_date",
+      "last_service_date",
+      "tags",
+      "notes",
+    ] as const) {
+      if (typeof vehDraft[key] === "string") updateRecord[key] = vehDraft[key] || null;
+    }
 
     const duplicateCheck = await checkVehicleDuplicates({
       vin: typeof updateRecord["vin"] === "string" ? updateRecord["vin"] : null,
@@ -1134,6 +1156,16 @@ export default function CustomerProfilePage(): JSX.Element {
     transmission_type: "",
     fuel_type: "",
     drivetrain: "",
+    state_province: "",
+    odometer_unit: "",
+    body_type: "",
+    asset_type: "",
+    status: "",
+    purchase_date: "",
+    in_service_date: "",
+    last_service_date: "",
+    tags: "",
+    notes: "",
   });
 
   const createVehicle = useCallback(async () => {
@@ -1168,6 +1200,20 @@ export default function CustomerProfilePage(): JSX.Element {
 
     if (typeof newVeh["fuel_type"] === "string") insertRecord["fuel_type"] = newVeh["fuel_type"] || null;
     if (typeof newVeh["drivetrain"] === "string") insertRecord["drivetrain"] = newVeh["drivetrain"] || null;
+    for (const key of [
+      "state_province",
+      "odometer_unit",
+      "body_type",
+      "asset_type",
+      "status",
+      "purchase_date",
+      "in_service_date",
+      "last_service_date",
+      "tags",
+      "notes",
+    ] as const) {
+      if (typeof newVeh[key] === "string") insertRecord[key] = newVeh[key] || null;
+    }
 
     const duplicateCheck = await checkVehicleDuplicates({
       vin: typeof insertRecord["vin"] === "string" ? insertRecord["vin"] : null,
@@ -1695,24 +1741,21 @@ export default function CustomerProfilePage(): JSX.Element {
                     <div className="text-sm font-semibold text-white">{fmtVehicleLabel(selectedVehicle)}</div>
 
                     <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <DetailRow label="Year / Make / Model / Trim" value={[selectedVehicle.year, selectedVehicle.make, selectedVehicle.model, selectedVehicle.submodel].filter(Boolean).join(" ") || null} />
                       <DetailRow label="VIN" value={selectedVehicle.vin} />
                       <DetailRow
-                        label="License Plate"
-                        value={
-                          ((selectedVehicle as unknown as Record<string, unknown>)["license_plate"] as
-                            | string
-                            | null
-                            | undefined) ?? selectedVehicle.license_plate
-                        }
+                        label="Plate + State/Province"
+                        value={[
+                          ((selectedVehicle as unknown as Record<string, unknown>)["license_plate"] as string | null | undefined) ?? selectedVehicle.license_plate,
+                          selectedVehicle.state_province,
+                        ].filter(Boolean).join(" / ") || null}
                       />
                       <DetailRow
-                        label="Mileage"
-                        value={
-                          ((selectedVehicle as unknown as Record<string, unknown>)["mileage"] as
-                            | string
-                            | null
-                            | undefined) ?? selectedVehicle.mileage
-                        }
+                        label="Mileage / Odometer"
+                        value={[
+                          ((selectedVehicle as unknown as Record<string, unknown>)["mileage"] as string | null | undefined) ?? selectedVehicle.mileage,
+                          selectedVehicle.odometer_unit,
+                        ].filter(Boolean).join(" ") || null}
                       />
                       <DetailRow
                         label="Unit #"
@@ -2027,10 +2070,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 ["Year", "year"],
                 ["Make", "make"],
                 ["Model", "model"],
-                ["Submodel", "submodel"],
+                ["Trim", "submodel"],
                 ["VIN", "vin"],
                 ["License plate", "license_plate"],
-                ["Mileage", "mileage"],
+                ["State / province", "state_province"],
+                ["Mileage / odometer", "mileage"],
+                ["Odometer unit", "odometer_unit"],
                 ["Unit #", "unit_number"],
                 ["Color", "color"],
                 ["Engine hours", "engine_hours"],
@@ -2040,7 +2085,15 @@ export default function CustomerProfilePage(): JSX.Element {
                 ["Transmission", "transmission"],
                 ["Transmission type", "transmission_type"],
                 ["Fuel type", "fuel_type"],
-                ["Drivetrain", "drivetrain"],
+                ["Body type", "body_type"],
+                ["Drive type", "drivetrain"],
+                ["Asset type", "asset_type"],
+                ["Status", "status"],
+                ["Purchase date", "purchase_date"],
+                ["In-service date", "in_service_date"],
+                ["Last service date", "last_service_date"],
+                ["Tags", "tags"],
+                ["Notes", "notes"],
               ] as const
             ).map(([label, key]) => (
               <div key={key} className="space-y-1">
@@ -2099,10 +2152,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 ["Year", "year"],
                 ["Make", "make"],
                 ["Model", "model"],
-                ["Submodel", "submodel"],
+                ["Trim", "submodel"],
                 ["VIN", "vin"],
                 ["License plate", "license_plate"],
-                ["Mileage", "mileage"],
+                ["State / province", "state_province"],
+                ["Mileage / odometer", "mileage"],
+                ["Odometer unit", "odometer_unit"],
                 ["Unit #", "unit_number"],
                 ["Color", "color"],
                 ["Engine hours", "engine_hours"],
@@ -2112,7 +2167,15 @@ export default function CustomerProfilePage(): JSX.Element {
                 ["Transmission", "transmission"],
                 ["Transmission type", "transmission_type"],
                 ["Fuel type", "fuel_type"],
-                ["Drivetrain", "drivetrain"],
+                ["Body type", "body_type"],
+                ["Drive type", "drivetrain"],
+                ["Asset type", "asset_type"],
+                ["Status", "status"],
+                ["Purchase date", "purchase_date"],
+                ["In-service date", "in_service_date"],
+                ["Last service date", "last_service_date"],
+                ["Tags", "tags"],
+                ["Notes", "notes"],
               ] as const
             ).map(([label, key]) => (
               <div key={key} className="space-y-1">

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -18364,8 +18364,10 @@ export type Database = {
       vehicles: {
         Row: {
           color: string | null
+          body_type: string | null
           created_at: string | null
           customer_id: string | null
+          asset_type: string | null
           drivetrain: string | null
           engine: string | null
           engine_family: string | null
@@ -18376,16 +18378,24 @@ export type Database = {
           id: string
           import_confidence: number | null
           import_notes: string | null
+          in_service_date: string | null
+          last_service_date: string | null
           license_plate: string | null
           make: string | null
           mileage: string | null
           model: string | null
+          notes: string | null
+          odometer_unit: string | null
+          purchase_date: string | null
           shop_id: string | null
           source_intake_id: string | null
           source_row_id: string | null
+          state_province: string | null
+          status: string | null
           submodel: string | null
           transmission: string | null
           transmission_type: string | null
+          tags: string | null
           unit_number: string | null
           user_id: string | null
           vin: string | null
@@ -18393,8 +18403,10 @@ export type Database = {
         }
         Insert: {
           color?: string | null
+          body_type?: string | null
           created_at?: string | null
           customer_id?: string | null
+          asset_type?: string | null
           drivetrain?: string | null
           engine?: string | null
           engine_family?: string | null
@@ -18405,16 +18417,24 @@ export type Database = {
           id?: string
           import_confidence?: number | null
           import_notes?: string | null
+          in_service_date?: string | null
+          last_service_date?: string | null
           license_plate?: string | null
           make?: string | null
           mileage?: string | null
           model?: string | null
+          notes?: string | null
+          odometer_unit?: string | null
+          purchase_date?: string | null
           shop_id?: string | null
           source_intake_id?: string | null
           source_row_id?: string | null
+          state_province?: string | null
+          status?: string | null
           submodel?: string | null
           transmission?: string | null
           transmission_type?: string | null
+          tags?: string | null
           unit_number?: string | null
           user_id?: string | null
           vin?: string | null
@@ -18422,8 +18442,10 @@ export type Database = {
         }
         Update: {
           color?: string | null
+          body_type?: string | null
           created_at?: string | null
           customer_id?: string | null
+          asset_type?: string | null
           drivetrain?: string | null
           engine?: string | null
           engine_family?: string | null
@@ -18434,16 +18456,24 @@ export type Database = {
           id?: string
           import_confidence?: number | null
           import_notes?: string | null
+          in_service_date?: string | null
+          last_service_date?: string | null
           license_plate?: string | null
           make?: string | null
           mileage?: string | null
           model?: string | null
+          notes?: string | null
+          odometer_unit?: string | null
+          purchase_date?: string | null
           shop_id?: string | null
           source_intake_id?: string | null
           source_row_id?: string | null
+          state_province?: string | null
+          status?: string | null
           submodel?: string | null
           transmission?: string | null
           transmission_type?: string | null
+          tags?: string | null
           unit_number?: string | null
           user_id?: string | null
           vin?: string | null

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -11176,8 +11176,10 @@ export type Database = {
       vehicles: {
         Row: {
           color: string | null
+          body_type: string | null
           created_at: string | null
           customer_id: string | null
+          asset_type: string | null
           drivetrain: string | null
           engine: string | null
           engine_family: string | null
@@ -11188,16 +11190,24 @@ export type Database = {
           id: string
           import_confidence: number | null
           import_notes: string | null
+          in_service_date: string | null
+          last_service_date: string | null
           license_plate: string | null
           make: string | null
           mileage: string | null
           model: string | null
+          notes: string | null
+          odometer_unit: string | null
+          purchase_date: string | null
           shop_id: string | null
           source_intake_id: string | null
           source_row_id: string | null
+          state_province: string | null
+          status: string | null
           submodel: string | null
           transmission: string | null
           transmission_type: string | null
+          tags: string | null
           unit_number: string | null
           user_id: string | null
           vin: string | null
@@ -11205,8 +11215,10 @@ export type Database = {
         }
         Insert: {
           color?: string | null
+          body_type?: string | null
           created_at?: string | null
           customer_id?: string | null
+          asset_type?: string | null
           drivetrain?: string | null
           engine?: string | null
           engine_family?: string | null
@@ -11217,16 +11229,24 @@ export type Database = {
           id?: string
           import_confidence?: number | null
           import_notes?: string | null
+          in_service_date?: string | null
+          last_service_date?: string | null
           license_plate?: string | null
           make?: string | null
           mileage?: string | null
           model?: string | null
+          notes?: string | null
+          odometer_unit?: string | null
+          purchase_date?: string | null
           shop_id?: string | null
           source_intake_id?: string | null
           source_row_id?: string | null
+          state_province?: string | null
+          status?: string | null
           submodel?: string | null
           transmission?: string | null
           transmission_type?: string | null
+          tags?: string | null
           unit_number?: string | null
           user_id?: string | null
           vin?: string | null
@@ -11234,8 +11254,10 @@ export type Database = {
         }
         Update: {
           color?: string | null
+          body_type?: string | null
           created_at?: string | null
           customer_id?: string | null
+          asset_type?: string | null
           drivetrain?: string | null
           engine?: string | null
           engine_family?: string | null
@@ -11246,16 +11268,24 @@ export type Database = {
           id?: string
           import_confidence?: number | null
           import_notes?: string | null
+          in_service_date?: string | null
+          last_service_date?: string | null
           license_plate?: string | null
           make?: string | null
           mileage?: string | null
           model?: string | null
+          notes?: string | null
+          odometer_unit?: string | null
+          purchase_date?: string | null
           shop_id?: string | null
           source_intake_id?: string | null
           source_row_id?: string | null
+          state_province?: string | null
+          status?: string | null
           submodel?: string | null
           transmission?: string | null
           transmission_type?: string | null
+          tags?: string | null
           unit_number?: string | null
           user_id?: string | null
           vin?: string | null

--- a/supabase/migrations/202607050001_vehicle_csv_detail_fields.sql
+++ b/supabase/migrations/202607050001_vehicle_csv_detail_fields.sql
@@ -1,0 +1,22 @@
+-- Add optional vehicle detail fields used by CSV imports and customer vehicle detail views.
+-- All columns are nullable and additive so existing production-like rows remain valid.
+
+alter table public.vehicles
+  add column if not exists state_province text,
+  add column if not exists odometer_unit text,
+  add column if not exists body_type text,
+  add column if not exists asset_type text,
+  add column if not exists status text,
+  add column if not exists purchase_date date,
+  add column if not exists in_service_date date,
+  add column if not exists last_service_date date,
+  add column if not exists tags text,
+  add column if not exists notes text;
+
+comment on column public.vehicles.state_province is 'Plate state/province imported from vehicle CSV or entered by staff.';
+comment on column public.vehicles.odometer_unit is 'Mileage/odometer unit, for example mi, km, or hours.';
+comment on column public.vehicles.body_type is 'Vehicle body type imported from external source.';
+comment on column public.vehicles.asset_type is 'Fleet asset type imported from external source.';
+comment on column public.vehicles.status is 'Vehicle or asset status imported from external source.';
+comment on column public.vehicles.tags is 'Source tags preserved as text from vehicle CSV import.';
+comment on column public.vehicles.notes is 'Vehicle notes preserved from source CSV or entered by staff.';

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -5,6 +5,8 @@ const routeSource = () =>
   readFileSync("app/api/vehicles/import/route.ts", "utf8");
 const cardSource = () =>
   readFileSync("features/vehicles/components/VehicleCsvImportCard.tsx", "utf8");
+const customerVehicleUiSource = () =>
+  readFileSync("features/customers/app/customers/[id]/page.tsx", "utf8");
 
 describe("vehicle CSV import route", () => {
   it("resolves CSV customer_id through customers.external_id before assigning vehicles.customer_id", () => {
@@ -26,7 +28,7 @@ describe("vehicle CSV import route", () => {
       'reason: "Customer not found for external customer_id."',
     );
     expect(source).toContain("counts.skipped += 1");
-    expect(source).toContain("failedRows.push");
+    expect(source).toContain('console.warn("Vehicle import row failed"');
   });
 
   it("matches re-imported vehicles without relying on duplicate insert conflicts", () => {
@@ -38,6 +40,49 @@ describe("vehicle CSV import route", () => {
     expect(source).toContain("findVehicleByField");
     expect(source).toContain(".limit(1)");
     expect(source).toContain("counts.updated += 1");
+  });
+
+  it("persists supported CSV vehicle detail fields and keeps response compact", () => {
+    const source = routeSource();
+
+    for (const field of [
+      "state_province",
+      "odometer_unit",
+      "body_type",
+      "asset_type",
+      "status",
+      "purchase_date",
+      "in_service_date",
+      "last_service_date",
+      "tags",
+      "notes",
+    ]) {
+      expect(source).toContain(`${field}:`);
+    }
+    expect(source).toContain("const mileage = odometer ?? null");
+    expect(source).not.toContain("skippedRows,");
+    expect(source).not.toContain("failedRows,");
+  });
+});
+
+describe("vehicle detail UI", () => {
+  it("renders imported vehicle detail fields", () => {
+    const source = customerVehicleUiSource();
+
+    for (const label of [
+      "Year / Make / Model / Trim",
+      "Plate + State/Province",
+      "Mileage / Odometer",
+      "Body Type",
+      "Asset Type",
+      "Purchase Date",
+      "In-Service Date",
+      "Last Service Date",
+      "Tags",
+      "Notes",
+    ]) {
+      expect(source).toContain(label);
+    }
   });
 });
 


### PR DESCRIPTION
### Motivation
- The vehicle CSV import was attaching vehicles but many CSV fields were not persisted or visible in the vehicle detail UI, and `customer_id` from the CSV needed to resolve to `customers.external_id` then store `customers.id` on `vehicles.customer_id`.
- The UI should display full vehicle details (mileage/odometer, plate state, engine/fuel/body/drive, dates, tags, notes) while keeping the import non-fatal on row errors and shop-scoped.

### Description
- Mapped CSV columns in `app/api/vehicles/import/route.ts` to corresponding DB columns and normalized values: `vehicle_id`→`external_id`, `trim`→`submodel`, `plate`→`license_plate`, `state_province`, `color`, `unit_number`, `vin`, `year`, `make`, `model`, `engine`, `fuel_type`, `drive_type`→`drivetrain`, `body_type`, `asset_type`, `status`, `purchase_date`, `in_service_date`, `last_service_date`, `tags`, and `notes`.
- Changed odometer handling so CSV `odometer` is stored as `vehicles.mileage` and `odometer_unit` is stored separately as `vehicles.odometer_unit` for UI display (`const mileage = odometer ?? null`).
- Preserved critical join rule: CSV `customer_id` is treated as an external id and resolved via `public.customers.external_id` (shop-scoped) to set `vehicles.customer_id` to the internal `customers.id`; unresolved external ids cause the row to be skipped (non-fatal).
- Import resilience: a single bad row no longer fails the whole import (per-row failures are `console.warn` logged), and the API response is compact and limited to `counts` and an `explanation` instead of large lists.
- Added an additive, nullable SQL migration `supabase/migrations/202607050001_vehicle_csv_detail_fields.sql` to add these columns: `state_province`, `odometer_unit`, `body_type`, `asset_type`, `status`, `purchase_date`, `in_service_date`, `last_service_date`, `tags`, and `notes`.
- Updated generated DB types (`shared/types/types/supabase.ts` and `features/shared/types/types/supabase.ts`) to include the new nullable vehicle fields.
- UI changes in `features/customers/app/customers/[id]/page.tsx` to display all supported vehicle details in the existing dark card layout and to persist these fields when editing/creating vehicles from the customer page.
- Tests updated/added for the route and UI source presence in `tests/vehicle-csv-import-route.test.ts` to assert mappings and compact response behavior.

### Testing
- Ran `npx vitest run tests/vehicle-csv-import-route.test.ts` and the test file passed (6 tests).
- Ran `npm run typecheck` (`tsc --noEmit`) and TypeScript typecheck succeeded after updating the generated types used in the code.
- Attempted `npm run build` (`next build`) but the build failed due to network issues fetching Google Fonts from `fonts.googleapis.com` used by `next/font` (environment/network limitation) and not because of code/type errors; this is unrelated to the import/UI changes.

Files of note: `app/api/vehicles/import/route.ts`, `features/customers/app/customers/[id]/page.tsx`, `supabase/migrations/202607050001_vehicle_csv_detail_fields.sql`, `shared/types/types/supabase.ts`, `features/shared/types/types/supabase.ts`, `tests/vehicle-csv-import-route.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49cb7057488328acfcfa3488802d51)