### PR TITLE
Add CSV import progress UI and fix vehicle guided completion flow

### DIFF
--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -5,6 +5,10 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import {
+  CsvImportProgress,
+  type CsvImportProgressState,
+} from "@/features/shared/components/import/CsvImportProgress";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type CustomerImportRow = {
@@ -196,6 +200,8 @@ export function CustomerCsvImportCard({
   const [skippedRows, setSkippedRows] = useState<SkippedImportRow[]>([]);
   const [failedRows, setFailedRows] = useState<FailedImportRow[]>([]);
   const [importing, setImporting] = useState(false);
+  const [importProgress, setImportProgress] =
+    useState<CsvImportProgressState | null>(null);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [busyAction, setBusyAction] = useState<"skip" | null>(null);
 
@@ -223,6 +229,7 @@ export function CustomerCsvImportCard({
     setFailedRows([]);
     setParseError(null);
     setImportError(null);
+    setImportProgress(null);
   }
 
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -238,6 +245,13 @@ export function CustomerCsvImportCard({
       return;
     }
 
+    setImportProgress({
+      phase: "Preparing rows",
+      processed: 0,
+      total: 0,
+      percent: 5,
+    });
+
     Papa.parse<Record<string, unknown>>(file, {
       header: true,
       skipEmptyLines: true,
@@ -249,11 +263,18 @@ export function CustomerCsvImportCard({
           (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
         );
         setRows(parsedRows);
+        setImportProgress({
+          phase: "Preparing rows",
+          processed: parsedRows.length,
+          total: parsedRows.length,
+          percent: parsedRows.length ? 25 : 0,
+        });
         if (!parsedRows.length) {
           setParseError("No customer rows were found in that CSV.");
         }
       },
       error: (error) => {
+        setImportProgress(null);
         setParseError(error.message || "Unable to parse that CSV file.");
       },
     });
@@ -297,10 +318,35 @@ export function CustomerCsvImportCard({
     }
     setImporting(true);
     setImportError(null);
+    setImportProgress({
+      phase: "Importing",
+      processed: 0,
+      total: importableRows.length,
+      percent: 30,
+    });
     setCounts(null);
     setSkippedRows([]);
     setFailedRows([]);
+    let progressTimer: number | null = null;
     try {
+      progressTimer = window.setInterval(() => {
+        setImportProgress((current) => {
+          if (!current || current.phase !== "Importing") return current;
+          const nextPercent = Math.min(90, current.percent + 3);
+          return {
+            ...current,
+            processed: Math.min(
+              importableRows.length,
+              Math.max(
+                current.processed,
+                Math.floor((nextPercent / 100) * importableRows.length),
+              ),
+            ),
+            percent: nextPercent,
+          };
+        });
+      }, 650);
+
       const response = await fetch("/api/customers/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -312,6 +358,14 @@ export function CustomerCsvImportCard({
       if (!response.ok || payload.ok === false || !payload.counts) {
         throw new Error(payload.error ?? "Unable to import customers.");
       }
+      if (progressTimer) window.clearInterval(progressTimer);
+      progressTimer = null;
+      setImportProgress({
+        phase: "Finalizing",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 95,
+      });
       setCounts(payload.counts);
       setSkippedRows(payload.skippedRows ?? []);
       setFailedRows(payload.failedRows ?? []);
@@ -323,13 +377,28 @@ export function CustomerCsvImportCard({
           0 &&
         payload.counts.failed === 0
       ) {
+        setImportProgress({
+          phase: "Completing guided step",
+          processed: importableRows.length,
+          total: importableRows.length,
+          percent: 98,
+        });
         await completeOnboardingAfterImport(payload.counts);
       }
+      setImportProgress({
+        phase: "Complete",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 100,
+      });
     } catch (error) {
+      if (progressTimer) window.clearInterval(progressTimer);
+      setImportProgress(null);
       setImportError(
         error instanceof Error ? error.message : "Unable to import customers.",
       );
     } finally {
+      if (progressTimer) window.clearInterval(progressTimer);
       setImporting(false);
     }
   }
@@ -509,9 +578,15 @@ export function CustomerCsvImportCard({
         </div>
       ) : null}
 
+      <CsvImportProgress
+        progress={importProgress}
+        label="Customer CSV import progress"
+      />
+
       {counts ? (
         <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
-          Import results: Imported {counts.created}, Updated {counts.updated}, Skipped {counts.skipped}, Failed {counts.failed}.
+          Import results: Imported {counts.created}, Updated {counts.updated},
+          Skipped {counts.skipped}, Failed {counts.failed}.
         </div>
       ) : null}
       {failedRows.length ? (

--- a/features/shared/components/import/CsvImportProgress.tsx
+++ b/features/shared/components/import/CsvImportProgress.tsx
@@ -1,0 +1,57 @@
+export type CsvImportProgressState = {
+  phase: string;
+  processed: number;
+  total: number;
+  percent: number;
+};
+
+type Props = {
+  progress: CsvImportProgressState | null;
+  label?: string;
+};
+
+function clampPercent(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+export function CsvImportProgress({
+  progress,
+  label = "CSV import progress",
+}: Props) {
+  if (!progress) return null;
+
+  const total = Math.max(0, progress.total);
+  const processed = Math.max(
+    0,
+    Math.min(progress.processed, total || progress.processed),
+  );
+  const percent = clampPercent(progress.percent);
+
+  return (
+    <div
+      className="mt-4 rounded-xl border border-sky-500/25 bg-sky-950/20 p-3 text-sm text-sky-50"
+      role="status"
+      aria-live="polite"
+      data-testid="csv-import-progress"
+    >
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-sky-100/70">
+            {label}
+          </div>
+          <div className="font-semibold text-sky-50">{progress.phase}</div>
+        </div>
+        <div className="text-xs text-sky-100/80">
+          {processed}/{total} rows · {percent}%
+        </div>
+      </div>
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-black/35">
+        <div
+          className="h-full rounded-full bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] transition-all duration-300"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -4,6 +4,10 @@ import React, { useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import {
+  CsvImportProgress,
+  type CsvImportProgressState,
+} from "@/features/shared/components/import/CsvImportProgress";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type Props = {
@@ -212,9 +216,15 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
   const [parseError, setParseError] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [counts, setCounts] = useState<ImportCounts | null>(null);
-  const [skippedRows, setSkippedRows] = useState<Array<{ row: number; reason: string }>>([]);
-  const [failedRows, setFailedRows] = useState<Array<{ row: number; error: string }>>([]);
+  const [skippedRows, setSkippedRows] = useState<
+    Array<{ row: number; reason: string }>
+  >([]);
+  const [failedRows, setFailedRows] = useState<
+    Array<{ row: number; error: string }>
+  >([]);
   const [importing, setImporting] = useState(false);
+  const [importProgress, setImportProgress] =
+    useState<CsvImportProgressState | null>(null);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
 
   const isOnboarding = Boolean(
@@ -238,6 +248,9 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     setCounts(null);
     setParseError(null);
     setImportError(null);
+    setSkippedRows([]);
+    setFailedRows([]);
+    setImportProgress(null);
 
     if (!file) {
       setFileName(null);
@@ -251,11 +264,24 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       return;
     }
 
+    setImportProgress({
+      phase: "Preparing rows",
+      processed: 0,
+      total: 0,
+      percent: 5,
+    });
+
     const text = await file.text();
     const parsedRows = parseCsv(text).filter(
       (row) => Object.keys(row).length > 0,
     );
     setRows(parsedRows);
+    setImportProgress({
+      phase: "Preparing rows",
+      processed: parsedRows.length,
+      total: parsedRows.length,
+      percent: parsedRows.length ? 25 : 0,
+    });
 
     if (!parsedRows.length) {
       setParseError("No vehicle rows were found in that CSV.");
@@ -267,7 +293,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
 
     setCompletingOnboarding(true);
     try {
-      await fetch(
+      const response = await fetch(
         `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicles/complete`,
         {
           method: "POST",
@@ -277,6 +303,16 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
           }),
         },
       );
+      const payload = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!response.ok || payload.ok === false) {
+        throw new Error(
+          payload.error ??
+            "Vehicle import succeeded, but onboarding completion failed.",
+        );
+      }
     } finally {
       setCompletingOnboarding(false);
     }
@@ -292,11 +328,36 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
 
     setImporting(true);
     setImportError(null);
+    setImportProgress({
+      phase: "Importing",
+      processed: 0,
+      total: importableRows.length,
+      percent: 30,
+    });
     setCounts(null);
     setSkippedRows([]);
     setFailedRows([]);
 
+    let progressTimer: number | null = null;
     try {
+      progressTimer = window.setInterval(() => {
+        setImportProgress((current) => {
+          if (!current || current.phase !== "Importing") return current;
+          const nextPercent = Math.min(90, current.percent + 3);
+          return {
+            ...current,
+            processed: Math.min(
+              importableRows.length,
+              Math.max(
+                current.processed,
+                Math.floor((nextPercent / 100) * importableRows.length),
+              ),
+            ),
+            percent: nextPercent,
+          };
+        });
+      }, 650);
+
       const response = await fetch("/api/vehicles/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -311,6 +372,14 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         throw new Error(payload.error ?? "Unable to import vehicles.");
       }
 
+      if (progressTimer) window.clearInterval(progressTimer);
+      progressTimer = null;
+      setImportProgress({
+        phase: "Finalizing",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 95,
+      });
       setCounts(payload.counts);
       setSkippedRows(payload.skippedRows ?? []);
       setFailedRows(payload.failedRows ?? []);
@@ -323,13 +392,28 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
           0 &&
         payload.counts.failed === 0
       ) {
+        setImportProgress({
+          phase: "Completing guided step",
+          processed: importableRows.length,
+          total: importableRows.length,
+          percent: 98,
+        });
         await completeOnboardingAfterImport(payload.counts);
       }
+      setImportProgress({
+        phase: "Complete",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 100,
+      });
     } catch (error) {
+      if (progressTimer) window.clearInterval(progressTimer);
+      setImportProgress(null);
       setImportError(
         error instanceof Error ? error.message : "Unable to import vehicles.",
       );
     } finally {
+      if (progressTimer) window.clearInterval(progressTimer);
       setImporting(false);
     }
   }
@@ -398,16 +482,33 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         </div>
       ) : null}
 
+      <CsvImportProgress
+        progress={importProgress}
+        label="Vehicle CSV import progress"
+      />
+
       {counts ? (
         <div className="mt-3 rounded-xl border border-emerald-500/35 bg-emerald-950/30 p-3 text-sm text-emerald-200">
-          Import complete. Imported: {counts.created}. Updated: {counts.updated}. Skipped: {counts.skipped}. Failed: {counts.failed}.
+          Import complete. Imported: {counts.created}. Updated: {counts.updated}
+          . Skipped: {counts.skipped}. Failed: {counts.failed}.
           {failedRows.length || skippedRows.length ? (
             <details className="mt-2 text-xs text-emerald-50/80">
-              <summary className="cursor-pointer font-semibold">Developer diagnostics</summary>
+              <summary className="cursor-pointer font-semibold">
+                Developer diagnostics
+              </summary>
               <div className="mt-2 max-h-48 overflow-auto rounded-lg border border-white/10 bg-black/25 p-2 text-left">
-                {[...failedRows.map((row) => `Failed row ${row.row}: ${row.error}`), ...skippedRows.map((row) => `Skipped row ${row.row}: ${row.reason}`)].slice(0, 25).map((line) => (
-                  <div key={line}>{line}</div>
-                ))}
+                {[
+                  ...failedRows.map(
+                    (row) => `Failed row ${row.row}: ${row.error}`,
+                  ),
+                  ...skippedRows.map(
+                    (row) => `Skipped row ${row.row}: ${row.reason}`,
+                  ),
+                ]
+                  .slice(0, 25)
+                  .map((line) => (
+                    <div key={line}>{line}</div>
+                  ))}
               </div>
             </details>
           ) : null}

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -74,7 +74,9 @@ describe("vehicle detail UI", () => {
     expect(source).toContain("formatOdometer");
     expect(source).toContain("formatPlateWithRegion");
     expect(source).toContain("Customer since");
-    expect(source).toContain("compactDate(customer?.customer_since ?? customer?.created_at)");
+    expect(source).toContain(
+      "compactDate(customer?.customer_since ?? customer?.created_at)",
+    );
     expect(source).toContain("🚗");
 
     for (const label of [
@@ -107,5 +109,73 @@ describe("vehicle CSV import card", () => {
       /payload\.counts\.created\s*\+\s*payload\.counts\.updated\s*\+\s*payload\.counts\.skipped\s*>\s*0/,
     );
     expect(source).toContain("Continue onboarding");
+  });
+});
+
+describe("guided CSV import progress UI", () => {
+  it("shares the CSV import progress component across customer and vehicle import cards", () => {
+    const customerSource = readFileSync(
+      "features/customers/components/CustomerCsvImportCard.tsx",
+      "utf8",
+    );
+    const vehicleSource = cardSource();
+    const progressSource = readFileSync(
+      "features/shared/components/import/CsvImportProgress.tsx",
+      "utf8",
+    );
+
+    expect(progressSource).toContain("CsvImportProgress");
+    expect(progressSource).toContain("processed}/{total} rows");
+    expect(progressSource).toContain("percent");
+    expect(customerSource).toContain("Customer CSV import progress");
+    expect(vehicleSource).toContain("Vehicle CSV import progress");
+    expect(customerSource).toContain('phase: "Preparing rows"');
+    expect(vehicleSource).toContain('phase: "Preparing rows"');
+    expect(customerSource).toContain('phase: "Completing guided step"');
+    expect(vehicleSource).toContain('phase: "Completing guided step"');
+  });
+
+  it("keeps stale results cleared and duplicate import clicks disabled", () => {
+    const customerSource = readFileSync(
+      "features/customers/components/CustomerCsvImportCard.tsx",
+      "utf8",
+    );
+    const vehicleSource = cardSource();
+
+    expect(customerSource).toContain("setCounts(null)");
+    expect(vehicleSource).toContain("setCounts(null)");
+    expect(customerSource).toContain("setImportProgress(null)");
+    expect(vehicleSource).toContain("setImportProgress(null)");
+    expect(customerSource).toContain(
+      "disabled={importing || completingOnboarding || !importableRows.length}",
+    );
+    expect(vehicleSource).toContain(
+      "disabled={importing || completingOnboarding || !importableRows.length}",
+    );
+  });
+
+  it("only shows guided Continue onboarding after successful zero-failure imports", () => {
+    const customerSource = readFileSync(
+      "features/customers/components/CustomerCsvImportCard.tsx",
+      "utf8",
+    );
+    const vehicleSource = cardSource();
+
+    expect(customerSource).toContain("counts.failed === 0");
+    expect(vehicleSource).toContain("counts.failed === 0");
+    expect(customerSource).toContain("importSucceeded");
+    expect(vehicleSource).toContain("importSucceeded");
+    expect(customerSource).toContain("Continue onboarding");
+    expect(vehicleSource).toContain("Continue onboarding");
+  });
+
+  it("calls the vehicle guided completion endpoint with the vehicles step key", () => {
+    const vehicleSource = cardSource();
+
+    expect(vehicleSource).toContain("/steps/vehicles/complete");
+    expect(vehicleSource).toContain(
+      'summary: { importType: "vehicle_csv", ...nextCounts }',
+    );
+    expect(vehicleSource).toContain("payload.error ??");
   });
 });


### PR DESCRIPTION
### Motivation
- Improve user feedback during large CSV imports so the card UI does not appear frozen while parsing and importing. 
- Ensure vehicle CSV imports mirror customer imports by reliably marking the guided onboarding "vehicles" step complete when imports succeed with zero failures. 
- Provide a small, reusable progress UI so other import cards can show phased progress without duplicating logic.

### Description
- Added a reusable `CsvImportProgress` component that shows a phase label, processed/total rows, percentage, and a branded progress bar at `features/shared/components/import/CsvImportProgress.tsx`.
- Wired client-side phased progress into customer and vehicle import cards with phases `Preparing rows`, `Importing`, `Finalizing`, `Completing guided step`, and `Complete`, plus a small interval-driven progress updater during the POST so the UI does not look stale; stale results/errors/progress are cleared when a new CSV is selected and duplicate clicks are disabled while importing. 
- Hardened the vehicle guided completion flow to POST `/api/onboarding-v2/guided/sessions/:sessionId/steps/vehicles/complete`, parse/validate its JSON response the same way customers do, and only show the compact import summary and `Continue onboarding` primary action after successful zero-failure imports. 
- Files changed: `features/shared/components/import/CsvImportProgress.tsx`, `features/customers/components/CustomerCsvImportCard.tsx`, `features/vehicles/components/VehicleCsvImportCard.tsx`, and an added test coverage file update `tests/vehicle-csv-import-route.test.ts` that asserts usage and behavior.

### Testing
- Ran the focused unit/source tests with `npm run test -- tests/vehicle-csv-import-route.test.ts` and all tests in that file passed. 
- Ran type checking with `npm run typecheck` (executed `tsc --noEmit`) and it succeeded. 
- Attempted a production build with `npm run build`, which reached the Next.js build step but failed in this environment due to network/font fetching errors for Google fonts (`Inter` and `Black Ops One`) and not due to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8dab22d483288f06ecfc774c5512)