### PR TITLE
Fix guided onboarding customer import assertion

### DIFF
--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -233,8 +233,9 @@ describe("guided onboarding v2 foundation", () => {
     expect(routeSource).toContain("loadExistingCustomerIdentities");
     expect(routeSource).toContain("seenImportIdentities");
     expect(routeSource).toContain("customersToCreate");
+    expect(routeSource).toContain("for (const pending of customersToCreate)");
     expect(routeSource).toContain('.from("customers")');
-    expect(routeSource).toContain(".insert(customersToCreate)");
+    expect(routeSource).toContain(".insert(payload)");
   });
 
   it("keeps starting-from-scratch setup active while skipping import-only steps", () => {


### PR DESCRIPTION
### Motivation
- A test expected the customer importer to call `.insert(customersToCreate)` but the importer was changed to insert per-pending `payload` inside a loop, so the stale assertion caused the guided onboarding foundation test to fail.

### Description
- Updated `tests/guided-onboarding-v2-foundation.test.ts` to assert the current importer behavior by checking for the processing loop (`for (const pending of customersToCreate)`) and the per-row insert (`.insert(payload)`), keeping the change strictly to the test file and not modifying importer or onboarding logic.

### Testing
- Ran `npm test -- --run tests/guided-onboarding-v2-foundation.test.ts tests/guided-onboarding-page-panels.test.tsx` and `npm run typecheck`, and both the targeted tests and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aab38cf008328a47a53d6bca6762f)