### PR TITLE
Add vehicle history CSV import

### DIFF
--- a/app/api/work-orders/history/import/route.ts
+++ b/app/api/work-orders/history/import/route.ts
@@ -1,0 +1,372 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type HistoryImportRow = {
+  customer_id?: unknown;
+  vehicle_id?: unknown;
+  vin?: unknown;
+  customer_email?: unknown;
+  email?: unknown;
+  customer_phone?: unknown;
+  phone?: unknown;
+  customer_name?: unknown;
+  name?: unknown;
+  service_date?: unknown;
+  repair_order_number?: unknown;
+  work_order_number?: unknown;
+  invoice_number?: unknown;
+  odometer?: unknown;
+  service_category?: unknown;
+  complaint?: unknown;
+  cause?: unknown;
+  correction?: unknown;
+  parts?: unknown;
+  labor_hours?: unknown;
+  total?: unknown;
+  technician?: unknown;
+  advisor?: unknown;
+  notes?: unknown;
+};
+
+type CustomerRef = Pick<
+  DB["public"]["Tables"]["customers"]["Row"],
+  | "id"
+  | "external_id"
+  | "email"
+  | "phone"
+  | "phone_number"
+  | "name"
+  | "business_name"
+  | "first_name"
+  | "last_name"
+>;
+type VehicleRef = Pick<
+  DB["public"]["Tables"]["vehicles"]["Row"],
+  "id" | "external_id" | "vin" | "customer_id"
+>;
+
+type Resolver = {
+  customersById: Map<string, CustomerRef>;
+  customersByExternal: Map<string, CustomerRef>;
+  customersByEmail: Map<string, CustomerRef>;
+  customersByPhone: Map<string, CustomerRef>;
+  customersByName: Map<string, CustomerRef>;
+  vehiclesById: Map<string, VehicleRef>;
+  vehiclesByExternal: Map<string, VehicleRef>;
+  vehiclesByVin: Map<string, VehicleRef>;
+};
+
+function clean(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+function key(value: unknown): string | null {
+  return clean(value)?.toLowerCase().replace(/\s+/g, " ") ?? null;
+}
+function phone(value: unknown): string | null {
+  const text = clean(value);
+  if (!text) return null;
+  return text.replace(/\D/g, "") || text;
+}
+function vin(value: unknown): string | null {
+  return (
+    clean(value)
+      ?.toUpperCase()
+      .replace(/[^A-Z0-9]/g, "") ?? null
+  );
+}
+function num(value: unknown): number | null {
+  const text = clean(value);
+  if (!text) return null;
+  const parsed = Number(text.replace(/[$,]/g, ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+function validDate(value: unknown): string | null {
+  const text = clean(value);
+  if (!text) return null;
+  const parsed = new Date(text);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+function customerName(c: CustomerRef): string | null {
+  return (
+    c.name ||
+    c.business_name ||
+    [c.first_name, c.last_name].filter(Boolean).join(" ").trim() ||
+    null
+  );
+}
+
+async function loadResolver(
+  supabase: SupabaseClient<DB>,
+  shopId: string,
+): Promise<Resolver> {
+  const [
+    { data: customers, error: customerError },
+    { data: vehicles, error: vehicleError },
+  ] = await Promise.all([
+    supabase
+      .from("customers")
+      .select(
+        "id, external_id, email, phone, phone_number, name, business_name, first_name, last_name",
+      )
+      .eq("shop_id", shopId),
+    supabase
+      .from("vehicles")
+      .select("id, external_id, vin, customer_id")
+      .eq("shop_id", shopId),
+  ]);
+  if (customerError) throw customerError;
+  if (vehicleError) throw vehicleError;
+  const r: Resolver = {
+    customersById: new Map(),
+    customersByExternal: new Map(),
+    customersByEmail: new Map(),
+    customersByPhone: new Map(),
+    customersByName: new Map(),
+    vehiclesById: new Map(),
+    vehiclesByExternal: new Map(),
+    vehiclesByVin: new Map(),
+  };
+  for (const c of (customers ?? []) as CustomerRef[]) {
+    r.customersById.set(c.id, c);
+    const ex = key(c.external_id);
+    if (ex && !r.customersByExternal.has(ex)) r.customersByExternal.set(ex, c);
+    const em = key(c.email);
+    if (em && !r.customersByEmail.has(em)) r.customersByEmail.set(em, c);
+    for (const p of [c.phone, c.phone_number]) {
+      const ph = phone(p);
+      if (ph && !r.customersByPhone.has(ph)) r.customersByPhone.set(ph, c);
+    }
+    for (const n of [c.name, c.business_name, customerName(c)]) {
+      const nk = key(n);
+      if (nk && !r.customersByName.has(nk)) r.customersByName.set(nk, c);
+    }
+  }
+  for (const v of (vehicles ?? []) as VehicleRef[]) {
+    r.vehiclesById.set(v.id, v);
+    const ex = key(v.external_id);
+    if (ex && !r.vehiclesByExternal.has(ex)) r.vehiclesByExternal.set(ex, v);
+    const vk = vin(v.vin);
+    if (vk && !r.vehiclesByVin.has(vk)) r.vehiclesByVin.set(vk, v);
+  }
+  return r;
+}
+
+function resolveCustomer(
+  row: HistoryImportRow,
+  r: Resolver,
+): CustomerRef | null {
+  const cid = clean(row.customer_id);
+  if (cid && r.customersById.has(cid)) return r.customersById.get(cid)!;
+  const ex = key(row.customer_id);
+  if (ex && r.customersByExternal.has(ex))
+    return r.customersByExternal.get(ex)!;
+  const em = key(row.customer_email ?? row.email);
+  if (em && r.customersByEmail.has(em)) return r.customersByEmail.get(em)!;
+  const ph = phone(row.customer_phone ?? row.phone);
+  if (ph && r.customersByPhone.has(ph)) return r.customersByPhone.get(ph)!;
+  const nm = key(row.customer_name ?? row.name);
+  if (nm && r.customersByName.has(nm)) return r.customersByName.get(nm)!;
+  return null;
+}
+function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null {
+  const vid = clean(row.vehicle_id);
+  if (vid && r.vehiclesById.has(vid)) return r.vehiclesById.get(vid)!;
+  const ex = key(row.vehicle_id);
+  if (ex && r.vehiclesByExternal.has(ex)) return r.vehiclesByExternal.get(ex)!;
+  const vk = vin(row.vin);
+  if (vk && r.vehiclesByVin.has(vk)) return r.vehiclesByVin.get(vk)!;
+  return null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const access = await requireShopScopedApiAccess({
+      allowRoles: ["owner", "admin", "manager", "advisor"],
+    });
+    if (!access.ok) return access.response;
+    const body = await req.json().catch(() => null);
+    const rows = Array.isArray(body?.rows) ? body.rows : null;
+    if (!rows?.length)
+      return NextResponse.json(
+        { error: "No history rows provided." },
+        { status: 400 },
+      );
+    const { supabase, profile } = access;
+    const shopId = profile.shop_id;
+    if (!shopId)
+      return NextResponse.json(
+        { error: "No active shop is selected." },
+        { status: 400 },
+      );
+    const resolver = await loadResolver(supabase, shopId);
+    const counts = { imported: 0, skipped: 0, failed: 0, duplicates: 0 };
+    const skippedRows: Array<{
+      row: number;
+      reason: string;
+      repairOrderNumber: string | null;
+      invoiceNumber: string | null;
+    }> = [];
+    const failedRows: Array<{
+      row: number;
+      error: string;
+      repairOrderNumber: string | null;
+      invoiceNumber: string | null;
+    }> = [];
+    for (const [i, raw] of (rows as HistoryImportRow[]).entries()) {
+      const rowNumber = i + 1;
+      const row = raw;
+      const repairOrderNumber = clean(
+        row.repair_order_number ?? row.work_order_number,
+      );
+      const invoiceNumber = clean(row.invoice_number);
+      try {
+        const serviceDate = validDate(row.service_date);
+        if (!serviceDate) {
+          counts.skipped++;
+          skippedRows.push({
+            row: rowNumber,
+            reason: "Invalid or missing service_date.",
+            repairOrderNumber,
+            invoiceNumber,
+          });
+          continue;
+        }
+        const invalidNumber = (
+          [
+            ["odometer", row.odometer],
+            ["labor_hours", row.labor_hours],
+            ["total", row.total],
+          ] as const
+        ).find(([, value]) => clean(value) && num(value) === null);
+        if (invalidNumber) {
+          counts.skipped++;
+          skippedRows.push({
+            row: rowNumber,
+            reason: `${invalidNumber[0]} must be numeric when provided.`,
+            repairOrderNumber,
+            invoiceNumber,
+          });
+          continue;
+        }
+        const vehicle = resolveVehicle(row, resolver);
+        const customer =
+          resolveCustomer(row, resolver) ??
+          (vehicle?.customer_id
+            ? (resolver.customersById.get(vehicle.customer_id) ?? null)
+            : null);
+        if (!customer) {
+          counts.skipped++;
+          skippedRows.push({
+            row: rowNumber,
+            reason: "Existing customer could not be matched.",
+            repairOrderNumber,
+            invoiceNumber,
+          });
+          continue;
+        }
+        if ((clean(row.vehicle_id) || clean(row.vin)) && !vehicle) {
+          counts.skipped++;
+          skippedRows.push({
+            row: rowNumber,
+            reason: "Existing vehicle could not be matched.",
+            repairOrderNumber,
+            invoiceNumber,
+          });
+          continue;
+        }
+        if (repairOrderNumber || invoiceNumber) {
+          let q = supabase
+            .from("history")
+            .select("id")
+            .eq("customer_id", customer.id)
+            .limit(1);
+          if (repairOrderNumber)
+            q = q.eq("work_order_number" as "id", repairOrderNumber);
+          if (invoiceNumber) q = q.eq("invoice_number" as "id", invoiceNumber);
+          const { data, error } = await q;
+          if (error) throw error;
+          if ((data ?? []).length) {
+            counts.skipped++;
+            counts.duplicates++;
+            skippedRows.push({
+              row: rowNumber,
+              reason: "Duplicate repair order/invoice already exists.",
+              repairOrderNumber,
+              invoiceNumber,
+            });
+            continue;
+          }
+        }
+        const parts = clean(row.parts);
+        const notes =
+          [
+            clean(row.notes),
+            parts ? `Parts: ${parts}` : null,
+            clean(row.service_category)
+              ? `Service category: ${clean(row.service_category)}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join("\n") || null;
+        const description =
+          [
+            clean(row.service_category),
+            clean(row.complaint),
+            clean(row.correction),
+          ]
+            .filter(Boolean)
+            .join(" · ") || "Imported historical service record";
+        const payload: DB["public"]["Tables"]["history"]["Insert"] &
+          Record<string, unknown> = {
+          customer_id: customer.id,
+          vehicle_id: vehicle?.id ?? null,
+          service_date: serviceDate,
+          description,
+          notes,
+          work_order_number: repairOrderNumber,
+          invoice_number: invoiceNumber,
+          odometer: num(row.odometer),
+          symptom: clean(row.complaint),
+          cause: clean(row.cause),
+          correction: clean(row.correction),
+          labor_hours: num(row.labor_hours),
+          total: num(row.total),
+          advisor_name: clean(row.advisor),
+          assigned_tech_name: clean(row.technician),
+          historical_status: "imported",
+          source_system: "vehicle_history_csv",
+          source_row_id: String(rowNumber),
+        };
+        const { error } = await supabase.from("history").insert(payload);
+        if (error) throw error;
+        counts.imported++;
+      } catch (error) {
+        counts.failed++;
+        failedRows.push({
+          row: rowNumber,
+          error:
+            error instanceof Error
+              ? error.message
+              : "History row failed to import.",
+          repairOrderNumber,
+          invoiceNumber,
+        });
+      }
+    }
+    return NextResponse.json({ ok: true, counts, skippedRows, failedRows });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to import vehicle history.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/work-orders/history/import/route.ts
+++ b/app/api/work-orders/history/import/route.ts
@@ -49,6 +49,7 @@ type VehicleRef = Pick<
 >;
 
 type Resolver = {
+  shopCustomerIds: string[];
   customersById: Map<string, CustomerRef>;
   customersByExternal: Map<string, CustomerRef>;
   customersByEmail: Map<string, CustomerRef>;
@@ -121,6 +122,7 @@ async function loadResolver(
   if (customerError) throw customerError;
   if (vehicleError) throw vehicleError;
   const r: Resolver = {
+    shopCustomerIds: [],
     customersById: new Map(),
     customersByExternal: new Map(),
     customersByEmail: new Map(),
@@ -131,6 +133,7 @@ async function loadResolver(
     vehiclesByVin: new Map(),
   };
   for (const c of (customers ?? []) as CustomerRef[]) {
+    r.shopCustomerIds.push(c.id);
     r.customersById.set(c.id, c);
     const ex = key(c.external_id);
     if (ex && !r.customersByExternal.has(ex)) r.customersByExternal.set(ex, c);
@@ -278,28 +281,37 @@ export async function POST(req: Request) {
           });
           continue;
         }
-        if (repairOrderNumber || invoiceNumber) {
-          let q = supabase
+        let duplicateFound = false;
+        if (repairOrderNumber) {
+          const { data, error } = await supabase
             .from("history")
             .select("id")
-            .eq("customer_id", customer.id)
+            .in("customer_id", resolver.shopCustomerIds)
+            .eq("work_order_number" as "id", repairOrderNumber)
             .limit(1);
-          if (repairOrderNumber)
-            q = q.eq("work_order_number" as "id", repairOrderNumber);
-          if (invoiceNumber) q = q.eq("invoice_number" as "id", invoiceNumber);
-          const { data, error } = await q;
           if (error) throw error;
-          if ((data ?? []).length) {
-            counts.skipped++;
-            counts.duplicates++;
-            skippedRows.push({
-              row: rowNumber,
-              reason: "Duplicate repair order/invoice already exists.",
-              repairOrderNumber,
-              invoiceNumber,
-            });
-            continue;
-          }
+          duplicateFound = (data ?? []).length > 0;
+        }
+        if (!duplicateFound && invoiceNumber) {
+          const { data, error } = await supabase
+            .from("history")
+            .select("id")
+            .in("customer_id", resolver.shopCustomerIds)
+            .eq("invoice_number" as "id", invoiceNumber)
+            .limit(1);
+          if (error) throw error;
+          duplicateFound = (data ?? []).length > 0;
+        }
+        if (duplicateFound) {
+          counts.skipped++;
+          counts.duplicates++;
+          skippedRows.push({
+            row: rowNumber,
+            reason: "Duplicate repair order/invoice already exists.",
+            repairOrderNumber,
+            invoiceNumber,
+          });
+          continue;
         }
         const parts = clean(row.parts);
         const notes =
@@ -340,6 +352,14 @@ export async function POST(req: Request) {
           historical_status: "imported",
           source_system: "vehicle_history_csv",
           source_row_id: String(rowNumber),
+          source_payload: JSON.parse(
+            JSON.stringify({
+              imported_at: new Date().toISOString(),
+              raw_row: row,
+              service_category: clean(row.service_category),
+              parts: clean(row.parts),
+            }),
+          ) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"],
         };
         const { error } = await supabase.from("history").insert(payload);
         if (error) throw error;

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -5,8 +5,15 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
 import type { Database } from "@shared/types/types/supabase";
-import { fmtCustomerName, fmtVehicle, formatMoneyLike, historyTitle, parseHistoryNotes } from "./historyDisplay";
+import {
+  fmtCustomerName,
+  fmtVehicle,
+  formatMoneyLike,
+  historyTitle,
+  parseHistoryNotes,
+} from "./historyDisplay";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
+import { VehicleHistoryCsvImportCard } from "@/features/work-orders/components/VehicleHistoryCsvImportCard";
 
 type DB = Database;
 type HistoryRow = DB["public"]["Tables"]["history"]["Row"];
@@ -16,10 +23,41 @@ type ProfileRow = DB["public"]["Tables"]["profiles"]["Row"];
 
 type Row = Pick<
   HistoryRow,
-  "id" | "customer_id" | "vehicle_id" | "work_order_id" | "service_date" | "description" | "notes" | "created_at" | "work_order_number" | "invoice_number" | "historical_status" | "payment_state" | "approval_state" | "odometer" | "advisor_name" | "assigned_tech_name" | "labor_sale" | "parts_sale" | "tax" | "total" | "symptom" | "cause" | "correction" | "source_external_id" | "source_row_id" | "imported_from_session_id"
+  | "id"
+  | "customer_id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "service_date"
+  | "description"
+  | "notes"
+  | "created_at"
+  | "work_order_number"
+  | "invoice_number"
+  | "historical_status"
+  | "payment_state"
+  | "approval_state"
+  | "odometer"
+  | "advisor_name"
+  | "assigned_tech_name"
+  | "labor_sale"
+  | "parts_sale"
+  | "tax"
+  | "total"
+  | "symptom"
+  | "cause"
+  | "correction"
+  | "source_external_id"
+  | "source_row_id"
+  | "imported_from_session_id"
 > & {
-  customers: Pick<CustomerRow, "first_name" | "last_name" | "email" | "phone"> | null;
-  vehicles: Pick<VehicleRow, "year" | "make" | "model" | "license_plate" | "vin" | "unit_number"> | null;
+  customers: Pick<
+    CustomerRow,
+    "first_name" | "last_name" | "email" | "phone"
+  > | null;
+  vehicles: Pick<
+    VehicleRow,
+    "year" | "make" | "model" | "license_plate" | "vin" | "unit_number"
+  > | null;
 };
 
 function fmtDate(iso: string | null | undefined, pattern = "PPpp"): string {
@@ -38,62 +76,366 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
   const [q, setQ] = useState("");
   const [from, setFrom] = useState<string>("");
   const [to, setTo] = useState<string>("");
+  const [showImport, setShowImport] = useState(false);
 
-  useEffect(() => { void (async () => {
-      const { data: { user }, error: userErr } = await supabase.auth.getUser();
-      if (userErr || !user) return setErr("You must be signed in to view service history."), setLoading(false);
-      const { data: profile, error: profileErr } = await supabase.from("profiles").select("shop_id").eq("id", user.id).maybeSingle<Pick<ProfileRow, "shop_id">>();
-      if (profileErr) return setErr(profileErr.message), setLoading(false);
-      if (!profile?.shop_id) return setErr("No shop is linked to your profile yet."), setLoading(false);
-      setShopId(profile.shop_id); setLoading(false);
-  })(); }, [supabase]);
+  useEffect(() => {
+    void (async () => {
+      const {
+        data: { user },
+        error: userErr,
+      } = await supabase.auth.getUser();
+      if (userErr || !user)
+        return (
+          setErr("You must be signed in to view service history."),
+          setLoading(false)
+        );
+      const { data: profile, error: profileErr } = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", user.id)
+        .maybeSingle<Pick<ProfileRow, "shop_id">>();
+      if (profileErr) return (setErr(profileErr.message), setLoading(false));
+      if (!profile?.shop_id)
+        return (
+          setErr("No shop is linked to your profile yet."),
+          setLoading(false)
+        );
+      setShopId(profile.shop_id);
+      setLoading(false);
+    })();
+  }, [supabase]);
 
   const load = useCallback(async () => {
     if (!shopId) return;
-    setLoading(true); setErr(null);
-    let query = supabase.from("history").select("id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_sale, parts_sale, tax, total, symptom, cause, correction, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)").order("service_date", { ascending: false }).limit(300);
-    if (from) query = query.gte("service_date", new Date(`${from}T00:00:00Z`).toISOString());
-    if (to) { const toEnd = new Date(`${to}T00:00:00Z`); toEnd.setHours(23, 59, 59, 999); query = query.lte("service_date", toEnd.toISOString()); }
+    setLoading(true);
+    setErr(null);
+    let query = supabase
+      .from("history")
+      .select(
+        "id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_sale, parts_sale, tax, total, symptom, cause, correction, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)",
+      )
+      .order("service_date", { ascending: false })
+      .limit(300);
+    if (from)
+      query = query.gte(
+        "service_date",
+        new Date(`${from}T00:00:00Z`).toISOString(),
+      );
+    if (to) {
+      const toEnd = new Date(`${to}T00:00:00Z`);
+      toEnd.setHours(23, 59, 59, 999);
+      query = query.lte("service_date", toEnd.toISOString());
+    }
     const { data, error } = await query;
-    if (error) return setErr(error.message), setRows([]), setLoading(false);
+    if (error) return (setErr(error.message), setRows([]), setLoading(false));
     const list = (data ?? []) as unknown as Row[];
     const qlc = q.trim().toLowerCase();
-    const filtered = qlc ? list.filter((r) => {
-      const p = parseHistoryNotes(r.notes);
-      const haystack = [
-        r.id, fmtCustomerName(r.customers), fmtVehicle(r.vehicles), r.vehicles?.vin ?? "", r.description ?? "", r.notes ?? "",
-        p.workOrderLabel ?? "", p.invoiceLabel ?? "", p.totalLabel ?? "", p.laborLabel ?? "", p.sourceExternalId ?? "", p.sourceRowId ?? "", p.onboardingSessionId ?? "", p.liveWorkOrderId ?? "", ...p.extraLines, ...p.importLines, fmtDate(r.service_date, "yyyy-MM-dd"),
-      ].join(" ").toLowerCase();
-      return haystack.includes(qlc);
-    }) : list;
-    setRows(filtered); setLoading(false);
+    const filtered = qlc
+      ? list.filter((r) => {
+          const p = parseHistoryNotes(r.notes);
+          const haystack = [
+            r.id,
+            fmtCustomerName(r.customers),
+            fmtVehicle(r.vehicles),
+            r.vehicles?.vin ?? "",
+            r.description ?? "",
+            r.notes ?? "",
+            p.workOrderLabel ?? "",
+            p.invoiceLabel ?? "",
+            p.totalLabel ?? "",
+            p.laborLabel ?? "",
+            p.sourceExternalId ?? "",
+            p.sourceRowId ?? "",
+            p.onboardingSessionId ?? "",
+            p.liveWorkOrderId ?? "",
+            ...p.extraLines,
+            ...p.importLines,
+            fmtDate(r.service_date, "yyyy-MM-dd"),
+          ]
+            .join(" ")
+            .toLowerCase();
+          return haystack.includes(qlc);
+        })
+      : list;
+    setRows(filtered);
+    setLoading(false);
   }, [from, q, shopId, supabase, to]);
 
-  useEffect(() => { if (shopId) void load(); }, [load, shopId]);
+  useEffect(() => {
+    if (shopId) void load();
+  }, [load, shopId]);
 
   function exportCSV() {
-    const header = ["History ID","Service Date","Customer","Email","Phone","Vehicle","Plate","VIN","Work Order","Invoice","Total","Labor","Description","Details","Source External ID","Source Row ID","Onboarding Session","Live Work Order ID"];
+    const header = [
+      "History ID",
+      "Service Date",
+      "Customer",
+      "Email",
+      "Phone",
+      "Vehicle",
+      "Plate",
+      "VIN",
+      "Work Order",
+      "Invoice",
+      "Total",
+      "Labor",
+      "Description",
+      "Details",
+      "Source External ID",
+      "Source Row ID",
+      "Onboarding Session",
+      "Live Work Order ID",
+    ];
     const lines = rows.map((r) => {
       const p = parseHistoryNotes(r.notes);
-      return [r.id, fmtDate(r.service_date, "yyyy-MM-dd HH:mm"), fmtCustomerName(r.customers), r.customers?.email ?? "", r.customers?.phone ?? "", fmtVehicle(r.vehicles), r.vehicles?.license_plate ?? "", r.vehicles?.vin ?? "", p.workOrderLabel ?? "", p.invoiceLabel ?? "", p.totalLabel ?? "", p.laborLabel ?? "", r.description ?? "", p.extraLines.join(" | "), p.sourceExternalId ?? "", p.sourceRowId ?? "", p.onboardingSessionId ?? "", p.liveWorkOrderId ?? ""].map((x)=>`"${String(x ?? "").replace(/"/g,'""')}"`).join(",");
+      return [
+        r.id,
+        fmtDate(r.service_date, "yyyy-MM-dd HH:mm"),
+        fmtCustomerName(r.customers),
+        r.customers?.email ?? "",
+        r.customers?.phone ?? "",
+        fmtVehicle(r.vehicles),
+        r.vehicles?.license_plate ?? "",
+        r.vehicles?.vin ?? "",
+        p.workOrderLabel ?? "",
+        p.invoiceLabel ?? "",
+        p.totalLabel ?? "",
+        p.laborLabel ?? "",
+        r.description ?? "",
+        p.extraLines.join(" | "),
+        p.sourceExternalId ?? "",
+        p.sourceRowId ?? "",
+        p.onboardingSessionId ?? "",
+        p.liveWorkOrderId ?? "",
+      ]
+        .map((x) => `"${String(x ?? "").replace(/"/g, '""')}"`)
+        .join(",");
     });
-    const blob = new Blob([header.join(",") + "\n" + lines.join("\n")], { type: "text/csv;charset=utf-8" });
-    const a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = `service-history-${Date.now()}.csv`; a.click();
+    const blob = new Blob([header.join(",") + "\n" + lines.join("\n")], {
+      type: "text/csv;charset=utf-8",
+    });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = `service-history-${Date.now()}.csv`;
+    a.click();
   }
 
-  return <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_34%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.06),transparent_32%),#050914] px-4 py-6 text-white"><div className="mx-auto max-w-6xl space-y-4"><GuidedPageStepPanel />{/* existing controls kept */}
-    <section className="rounded-[26px] border border-slate-700/60 bg-slate-950/70 px-4 py-5 shadow-[0_18px_48px_rgba(2,6,23,0.58)] sm:px-6 sm:py-6">
-      <div className="mb-3 flex flex-wrap items-end gap-3"><input value={q} onChange={(e)=>setQ(e.target.value)} onKeyDown={(e)=>e.key==="Enter"&&load()} placeholder="Customer, VIN, WO, invoice, total, notes…" className="min-w-[220px] flex-1 rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"/><input type="date" value={from} onChange={(e)=>setFrom(e.target.value)} className="rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"/><input type="date" value={to} onChange={(e)=>setTo(e.target.value)} className="rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"/><button onClick={load} className="rounded-full border border-slate-700/70 px-3 py-1.5 text-xs">Apply</button><button onClick={exportCSV} className="rounded-full border border-sky-400/35 bg-sky-500/10 px-3 py-1.5 text-xs">Export CSV</button></div>
-      {err ? <div className="mb-4 rounded-xl border border-red-500/60 bg-red-950/80 px-4 py-2 text-sm text-red-100">{err}</div> : null}
-      {loading ? <div>Loading service history…</div> : rows.length===0 ? <div>No service history found.</div> : <div className="grid gap-2">{rows.map((r)=>{const p=parseHistoryNotes(r.notes); const title=historyTitle({id:r.id,workOrderLabel:p.workOrderLabel,invoiceLabel:p.invoiceLabel});
-        return <article key={r.id} className="rounded-2xl border border-slate-700/60 bg-slate-950/70 p-3 shadow-[0_14px_38px_rgba(2,6,23,0.82)]"><div className="flex items-start justify-between gap-3"><div><h3 className="font-mono text-sm text-sky-200">{title}</h3><div className="text-sm text-neutral-200">{fmtCustomerName(r.customers)}</div><div className="text-xs text-neutral-400">{fmtVehicle(r.vehicles)}</div>{r.vehicles?.vin ? <div className="text-[11px] text-neutral-500">VIN: {r.vehicles.vin}</div> : null}</div><div className="text-right"><div className="font-mono text-xs text-sky-200">{fmtDate(r.service_date ?? r.created_at)}</div><span className="mt-1 inline-flex rounded-full border border-sky-400/35 bg-sky-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-sky-100">Read only</span></div></div>
-          <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.12em]">{r.historical_status ? <span className="rounded-full border border-slate-600 px-2 py-0.5">{r.historical_status}</span> : null}{r.payment_state ? <span className="rounded-full border border-cyan-700/60 px-2 py-0.5">{r.payment_state}</span> : null}{r.approval_state ? <span className="rounded-full border border-sky-700/60 px-2 py-0.5">{r.approval_state}</span> : null}</div>
-          <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2 lg:grid-cols-4"><div>Work order: <span className="text-neutral-100">{r.work_order_number ?? p.workOrderLabel ?? "—"}</span></div><div>Invoice: <span className="text-neutral-100">{r.invoice_number ?? p.invoiceLabel ?? "—"}</span></div><div>Total: <span className="text-neutral-100">{formatMoneyLike(String(r.total ?? "")) ?? formatMoneyLike(p.totalLabel) ?? "—"}</span></div><div>Labor: <span className="text-neutral-100">{formatMoneyLike(String(r.labor_sale ?? "")) ?? formatMoneyLike(p.laborLabel) ?? "—"}</span></div></div>
-          <div className="mt-2 text-xs text-neutral-300">Advisor: <span className="text-neutral-100">{r.advisor_name ?? "—"}</span> · Tech: <span className="text-neutral-100">{r.assigned_tech_name ?? "—"}</span> · Odometer: <span className="text-neutral-100">{r.odometer ?? "—"}</span></div>
-          <div className="mt-2 rounded-xl border border-slate-700/55 bg-slate-900/60 px-3 py-2 text-sm text-neutral-200"><div className="mb-1 text-[10px] uppercase tracking-[0.14em] text-neutral-400">Service summary</div>{r.description?.trim() || p.invoiceLabel || p.workOrderLabel || "Imported historical service record"}</div>
-          {p.extraLines.length>0 ? <div className="mt-2 rounded-xl border border-slate-700/55 bg-slate-900/50 px-3 py-2 text-[11px] text-neutral-400"><div className="mb-1 uppercase tracking-[0.14em] text-neutral-500">Details</div>{p.extraLines.map((line,idx)=><div key={`${r.id}-line-${idx}`}>{line}</div>)}</div>:null}
-          <div className="mt-2 rounded-xl border border-cyan-900/40 bg-slate-900/40 px-3 py-2 text-[11px] text-slate-400"><div className="mb-1 uppercase tracking-[0.14em] text-cyan-300/80">Import trace</div><div>Source external ID: {p.sourceExternalId ?? "—"}</div><div>Source row ID: {p.sourceRowId ?? "—"}</div><div>Onboarding session: {p.onboardingSessionId ?? "—"}</div><div>Live work order ID: {p.liveWorkOrderId ?? r.work_order_id ?? "—"}</div></div>
-          <div className="mt-3 flex flex-wrap items-center gap-3"><Link href={`/work-orders/history/${r.id}`} className="text-xs uppercase tracking-[0.16em] text-sky-200 hover:text-sky-100">View history details</Link>{r.work_order_id ? <Link href={`/work-orders/view/${r.work_order_id}`} className="text-xs text-cyan-300/85 hover:text-cyan-200">Open linked work order</Link> : null}</div>
-        </article>;})}</div>}
-    </section></div></div>;
+  return (
+    <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_34%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.06),transparent_32%),#050914] px-4 py-6 text-white">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <GuidedPageStepPanel />
+        {/* existing controls kept */}
+        <section className="rounded-[26px] border border-slate-700/60 bg-slate-950/70 px-4 py-5 shadow-[0_18px_48px_rgba(2,6,23,0.58)] sm:px-6 sm:py-6">
+          <div className="mb-3 flex flex-wrap items-end gap-3">
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && load()}
+              placeholder="Customer, VIN, WO, invoice, total, notes…"
+              className="min-w-[220px] flex-1 rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"
+            />
+            <input
+              type="date"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              className="rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"
+            />
+            <input
+              type="date"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              className="rounded-lg border border-slate-700/70 bg-slate-900/70 px-3 py-1.5 text-sm"
+            />
+            <button
+              onClick={load}
+              className="rounded-full border border-slate-700/70 px-3 py-1.5 text-xs"
+            >
+              Apply
+            </button>
+            <button
+              onClick={() => setShowImport((current) => !current)}
+              className="rounded-full border border-[var(--accent-copper-soft)]/45 bg-[var(--accent-copper)]/10 px-3 py-1.5 text-xs text-orange-100"
+            >
+              {showImport ? "Hide import" : "Import CSV"}
+            </button>
+            <button
+              onClick={exportCSV}
+              className="rounded-full border border-sky-400/35 bg-sky-500/10 px-3 py-1.5 text-xs"
+            >
+              Export CSV
+            </button>
+          </div>
+          {showImport ? (
+            <div className="mb-4">
+              <VehicleHistoryCsvImportCard onImported={() => void load()} />
+            </div>
+          ) : null}
+          {err ? (
+            <div className="mb-4 rounded-xl border border-red-500/60 bg-red-950/80 px-4 py-2 text-sm text-red-100">
+              {err}
+            </div>
+          ) : null}
+          {loading ? (
+            <div>Loading service history…</div>
+          ) : rows.length === 0 ? (
+            <div>No service history found.</div>
+          ) : (
+            <div className="grid gap-2">
+              {rows.map((r) => {
+                const p = parseHistoryNotes(r.notes);
+                const title = historyTitle({
+                  id: r.id,
+                  workOrderLabel: p.workOrderLabel,
+                  invoiceLabel: p.invoiceLabel,
+                });
+                return (
+                  <article
+                    key={r.id}
+                    className="rounded-2xl border border-slate-700/60 bg-slate-950/70 p-3 shadow-[0_14px_38px_rgba(2,6,23,0.82)]"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-mono text-sm text-sky-200">
+                          {title}
+                        </h3>
+                        <div className="text-sm text-neutral-200">
+                          {fmtCustomerName(r.customers)}
+                        </div>
+                        <div className="text-xs text-neutral-400">
+                          {fmtVehicle(r.vehicles)}
+                        </div>
+                        {r.vehicles?.vin ? (
+                          <div className="text-[11px] text-neutral-500">
+                            VIN: {r.vehicles.vin}
+                          </div>
+                        ) : null}
+                      </div>
+                      <div className="text-right">
+                        <div className="font-mono text-xs text-sky-200">
+                          {fmtDate(r.service_date ?? r.created_at)}
+                        </div>
+                        <span className="mt-1 inline-flex rounded-full border border-sky-400/35 bg-sky-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-sky-100">
+                          Read only
+                        </span>
+                      </div>
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.12em]">
+                      {r.historical_status ? (
+                        <span className="rounded-full border border-slate-600 px-2 py-0.5">
+                          {r.historical_status}
+                        </span>
+                      ) : null}
+                      {r.payment_state ? (
+                        <span className="rounded-full border border-cyan-700/60 px-2 py-0.5">
+                          {r.payment_state}
+                        </span>
+                      ) : null}
+                      {r.approval_state ? (
+                        <span className="rounded-full border border-sky-700/60 px-2 py-0.5">
+                          {r.approval_state}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2 lg:grid-cols-4">
+                      <div>
+                        Work order:{" "}
+                        <span className="text-neutral-100">
+                          {r.work_order_number ?? p.workOrderLabel ?? "—"}
+                        </span>
+                      </div>
+                      <div>
+                        Invoice:{" "}
+                        <span className="text-neutral-100">
+                          {r.invoice_number ?? p.invoiceLabel ?? "—"}
+                        </span>
+                      </div>
+                      <div>
+                        Total:{" "}
+                        <span className="text-neutral-100">
+                          {formatMoneyLike(String(r.total ?? "")) ??
+                            formatMoneyLike(p.totalLabel) ??
+                            "—"}
+                        </span>
+                      </div>
+                      <div>
+                        Labor:{" "}
+                        <span className="text-neutral-100">
+                          {formatMoneyLike(String(r.labor_sale ?? "")) ??
+                            formatMoneyLike(p.laborLabel) ??
+                            "—"}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="mt-2 text-xs text-neutral-300">
+                      Advisor:{" "}
+                      <span className="text-neutral-100">
+                        {r.advisor_name ?? "—"}
+                      </span>{" "}
+                      · Tech:{" "}
+                      <span className="text-neutral-100">
+                        {r.assigned_tech_name ?? "—"}
+                      </span>{" "}
+                      · Odometer:{" "}
+                      <span className="text-neutral-100">
+                        {r.odometer ?? "—"}
+                      </span>
+                    </div>
+                    <div className="mt-2 rounded-xl border border-slate-700/55 bg-slate-900/60 px-3 py-2 text-sm text-neutral-200">
+                      <div className="mb-1 text-[10px] uppercase tracking-[0.14em] text-neutral-400">
+                        Service summary
+                      </div>
+                      {r.description?.trim() ||
+                        p.invoiceLabel ||
+                        p.workOrderLabel ||
+                        "Imported historical service record"}
+                    </div>
+                    {p.extraLines.length > 0 ? (
+                      <div className="mt-2 rounded-xl border border-slate-700/55 bg-slate-900/50 px-3 py-2 text-[11px] text-neutral-400">
+                        <div className="mb-1 uppercase tracking-[0.14em] text-neutral-500">
+                          Details
+                        </div>
+                        {p.extraLines.map((line, idx) => (
+                          <div key={`${r.id}-line-${idx}`}>{line}</div>
+                        ))}
+                      </div>
+                    ) : null}
+                    <div className="mt-2 rounded-xl border border-cyan-900/40 bg-slate-900/40 px-3 py-2 text-[11px] text-slate-400">
+                      <div className="mb-1 uppercase tracking-[0.14em] text-cyan-300/80">
+                        Import trace
+                      </div>
+                      <div>Source external ID: {p.sourceExternalId ?? "—"}</div>
+                      <div>Source row ID: {p.sourceRowId ?? "—"}</div>
+                      <div>
+                        Onboarding session: {p.onboardingSessionId ?? "—"}
+                      </div>
+                      <div>
+                        Live work order ID:{" "}
+                        {p.liveWorkOrderId ?? r.work_order_id ?? "—"}
+                      </div>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-3">
+                      <Link
+                        href={`/work-orders/history/${r.id}`}
+                        className="text-xs uppercase tracking-[0.16em] text-sky-200 hover:text-sky-100"
+                      >
+                        View history details
+                      </Link>
+                      {r.work_order_id ? (
+                        <Link
+                          href={`/work-orders/view/${r.work_order_id}`}
+                          className="text-xs text-cyan-300/85 hover:text-cyan-200"
+                        >
+                          Open linked work order
+                        </Link>
+                      ) : null}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
 }

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
@@ -14,6 +15,7 @@ import {
 } from "./historyDisplay";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { VehicleHistoryCsvImportCard } from "@/features/work-orders/components/VehicleHistoryCsvImportCard";
+import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type DB = Database;
 type HistoryRow = DB["public"]["Tables"]["history"]["Row"];
@@ -68,6 +70,13 @@ function fmtDate(iso: string | null | undefined, pattern = "PPpp"): string {
 }
 
 export default function WorkOrdersHistoryClient(): JSX.Element {
+  const searchParams = useSearchParams();
+  const guidedQuery = useMemo(
+    () => parseGuidedOnboardingQuery(searchParams),
+    [searchParams],
+  );
+  const vehicleHistoryGuidedQuery =
+    guidedQuery?.onboardingStep === "vehicle_history" ? guidedQuery : null;
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string | null>(null);
   const [rows, setRows] = useState<Row[]>([]);
@@ -267,7 +276,10 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
           </div>
           {showImport ? (
             <div className="mb-4">
-              <VehicleHistoryCsvImportCard onImported={() => void load()} />
+              <VehicleHistoryCsvImportCard
+                guidedQuery={vehicleHistoryGuidedQuery}
+                onImported={() => void load()}
+              />
             </div>
           ) : null}
           {err ? (

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import React, { useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
 import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type HistoryImportRow = {
   customer_id?: string | null;
@@ -138,10 +140,13 @@ function downloadSample() {
 }
 
 export function VehicleHistoryCsvImportCard({
+  guidedQuery,
   onImported,
 }: {
+  guidedQuery?: GuidedOnboardingQuery | null;
   onImported?: () => void;
 }) {
+  const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const [headers, setHeaders] = useState<string[]>([]);
@@ -150,8 +155,13 @@ export function VehicleHistoryCsvImportCard({
   const [importError, setImportError] = useState<string | null>(null);
   const [response, setResponse] = useState<ImportResponse | null>(null);
   const [importing, setImporting] = useState(false);
+  const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
 
+  const isOnboarding = Boolean(
+    guidedQuery?.onboardingSession &&
+    guidedQuery.onboardingStep === "vehicle_history",
+  );
   const rowValidation = useMemo(() => rows.map(localValidation), [rows]);
   const importableRows = useMemo(
     () => rows.filter((_, index) => !rowValidation[index]),
@@ -211,6 +221,37 @@ export function VehicleHistoryCsvImportCard({
       },
     });
   }
+  async function completeOnboardingAfterImport(
+    nextCounts: NonNullable<ImportResponse["counts"]>,
+  ) {
+    if (!guidedQuery || !isOnboarding) return;
+    setCompletingOnboarding(true);
+    try {
+      const res = await fetch(
+        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicle_history/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            summary: { importType: "vehicle_history_csv", ...nextCounts },
+          }),
+        },
+      );
+      const payload = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!res.ok || payload.ok === false) {
+        throw new Error(
+          payload.error ??
+            "Vehicle history import succeeded, but onboarding completion failed.",
+        );
+      }
+    } finally {
+      setCompletingOnboarding(false);
+    }
+  }
+
   async function confirmImport() {
     if (!importableRows.length) {
       setImportError(
@@ -237,6 +278,19 @@ export function VehicleHistoryCsvImportCard({
       if (!res.ok || payload.ok === false || !payload.counts)
         throw new Error(payload.error ?? "Unable to import vehicle history.");
       setResponse(payload);
+      if (
+        isOnboarding &&
+        payload.counts.imported > 0 &&
+        payload.counts.failed === 0
+      ) {
+        setProgress({
+          phase: "Completing guided step",
+          processed: importableRows.length,
+          total: importableRows.length,
+          percent: 98,
+        });
+        await completeOnboardingAfterImport(payload.counts);
+      }
       setProgress({
         phase: "Complete",
         processed: importableRows.length,
@@ -260,7 +314,9 @@ export function VehicleHistoryCsvImportCard({
     <GuidedSetupCardShell
       testId="vehicle-history-csv-import-card"
       eyebrow="Operations · History"
-      title="Import vehicle history"
+      title={
+        isOnboarding ? "Upload vehicle history CSV" : "Import vehicle history"
+      }
       description={
         <>
           <p>
@@ -271,7 +327,9 @@ export function VehicleHistoryCsvImportCard({
             Supported columns include{" "}
             <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>.
             Rows link to existing customers and vehicles by customer_id,
-            vehicle_id, VIN, name, email, or phone where available.
+            vehicle_id, VIN, name, email, or phone where available. Imported
+            rows remain historical records only and do not create active work
+            orders.
           </p>
         </>
       }
@@ -441,11 +499,24 @@ export function VehicleHistoryCsvImportCard({
         <button
           type="button"
           onClick={() => void confirmImport()}
-          disabled={importing || !importableRows.length}
+          disabled={importing || completingOnboarding || !importableRows.length}
           className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
         >
-          {importing ? "Importing…" : "Confirm import"}
+          {importing
+            ? "Importing…"
+            : completingOnboarding
+              ? "Completing onboarding…"
+              : "Confirm import"}
         </button>
+        {isOnboarding && response?.counts ? (
+          <button
+            type="button"
+            onClick={() => router.push(guidedQuery!.returnTo)}
+            className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
+          >
+            Continue onboarding
+          </button>
+        ) : null}
       </div>
     </GuidedSetupCardShell>
   );

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import React, { useMemo, useRef, useState } from "react";
+import Papa from "papaparse";
+import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import {
+  CsvImportProgress,
+  type CsvImportProgressState,
+} from "@/features/shared/components/import/CsvImportProgress";
+
+type HistoryImportRow = {
+  customer_id?: string | null;
+  vehicle_id?: string | null;
+  vin?: string | null;
+  customer_name?: string | null;
+  customer_email?: string | null;
+  customer_phone?: string | null;
+  service_date?: string | null;
+  repair_order_number?: string | null;
+  invoice_number?: string | null;
+  odometer?: string | null;
+  service_category?: string | null;
+  complaint?: string | null;
+  cause?: string | null;
+  correction?: string | null;
+  parts?: string | null;
+  labor_hours?: string | null;
+  total?: string | null;
+  technician?: string | null;
+  advisor?: string | null;
+  notes?: string | null;
+};
+
+type ImportResponse = {
+  ok?: boolean;
+  error?: string;
+  counts?: {
+    imported: number;
+    skipped: number;
+    failed: number;
+    duplicates: number;
+  };
+  skippedRows?: Array<{
+    row: number;
+    reason: string;
+    repairOrderNumber: string | null;
+    invoiceNumber: string | null;
+  }>;
+  failedRows?: Array<{
+    row: number;
+    error: string;
+    repairOrderNumber: string | null;
+    invoiceNumber: string | null;
+  }>;
+};
+
+const SUPPORTED_COLUMNS = [
+  "customer_id",
+  "vehicle_id",
+  "vin",
+  "customer_name",
+  "customer_email",
+  "customer_phone",
+  "service_date",
+  "repair_order_number",
+  "invoice_number",
+  "odometer",
+  "service_category",
+  "complaint",
+  "cause",
+  "correction",
+  "parts",
+  "labor_hours",
+  "total",
+  "technician",
+  "advisor",
+  "notes",
+] as const;
+const RECOMMENDED_COLUMNS =
+  "customer_id, vehicle_id, vin, service_date, repair_order_number, invoice_number, odometer, service_category, complaint, cause, correction, parts, labor_hours, total, technician, advisor, notes";
+const SAMPLE = `${RECOMMENDED_COLUMNS}\nCUST-1001,VEH-204,1HGCM82633A004352,2024-03-18,RO-9182,INV-9182,84520,Brakes,Brake pedal pulsation,Front rotors warped,Replaced front pads and rotors,Front pads; front rotors,2.4,689.42,Sam Tech,Avery Advisor,Imported from legacy system`;
+
+function cleanHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
+}
+function cleanCell(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+function normalizeParsedRow(row: Record<string, unknown>): HistoryImportRow {
+  const normalized: HistoryImportRow = {};
+  for (const [header, value] of Object.entries(row)) {
+    const key = cleanHeader(header);
+    if (!(SUPPORTED_COLUMNS as readonly string[]).includes(key)) continue;
+    normalized[key as keyof HistoryImportRow] = cleanCell(value);
+  }
+  return normalized;
+}
+function hasLinkIdentity(row: HistoryImportRow): boolean {
+  return Boolean(
+    row.customer_id ||
+    row.vehicle_id ||
+    row.vin ||
+    row.customer_email ||
+    row.customer_phone ||
+    row.customer_name,
+  );
+}
+function hasValidDate(row: HistoryImportRow): boolean {
+  if (!row.service_date) return false;
+  return !Number.isNaN(new Date(row.service_date).getTime());
+}
+function validOptionalNumber(value: string | null | undefined): boolean {
+  if (!value) return true;
+  return Number.isFinite(Number(value.replace(/[$,]/g, "")));
+}
+function localValidation(row: HistoryImportRow): string | null {
+  if (!hasValidDate(row))
+    return "service_date is required and must be a valid date";
+  if (!hasLinkIdentity(row)) return "Needs a customer/vehicle identifier";
+  if (!validOptionalNumber(row.odometer)) return "odometer must be numeric";
+  if (!validOptionalNumber(row.labor_hours))
+    return "labor_hours must be numeric";
+  if (!validOptionalNumber(row.total)) return "total must be numeric";
+  return null;
+}
+function downloadSample() {
+  const blob = new Blob([SAMPLE], { type: "text/csv;charset=utf-8" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "vehicle-history-import-template.csv";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+export function VehicleHistoryCsvImportCard({
+  onImported,
+}: {
+  onImported?: () => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<HistoryImportRow[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [response, setResponse] = useState<ImportResponse | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
+
+  const rowValidation = useMemo(() => rows.map(localValidation), [rows]);
+  const importableRows = useMemo(
+    () => rows.filter((_, index) => !rowValidation[index]),
+    [rows, rowValidation],
+  );
+  const previewRows = importableRows.slice(0, 5);
+
+  function reset() {
+    setRows([]);
+    setHeaders([]);
+    setParseError(null);
+    setImportError(null);
+    setResponse(null);
+    setProgress(null);
+  }
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    reset();
+    if (!file) {
+      setFileName(null);
+      return;
+    }
+    setFileName(file.name);
+    if (!file.name.toLowerCase().endsWith(".csv")) {
+      setParseError("Please choose a .csv file.");
+      return;
+    }
+    setProgress({
+      phase: "Preparing rows",
+      processed: 0,
+      total: 0,
+      percent: 5,
+    });
+    Papa.parse<Record<string, unknown>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (results) => {
+        const parsed = (results.data ?? [])
+          .map(normalizeParsedRow)
+          .filter((row) => Object.keys(row).length > 0);
+        setHeaders(
+          (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
+        );
+        setRows(parsed);
+        setProgress({
+          phase: "Preparing rows",
+          processed: parsed.length,
+          total: parsed.length,
+          percent: parsed.length ? 25 : 0,
+        });
+        if (!parsed.length)
+          setParseError("No vehicle history rows were found in that CSV.");
+      },
+      error: (error) => {
+        setProgress(null);
+        setParseError(error.message || "Unable to parse that CSV file.");
+      },
+    });
+  }
+  async function confirmImport() {
+    if (!importableRows.length) {
+      setImportError(
+        "Upload a CSV with at least one valid history row before importing.",
+      );
+      return;
+    }
+    setImporting(true);
+    setImportError(null);
+    setResponse(null);
+    setProgress({
+      phase: "Importing",
+      processed: 0,
+      total: importableRows.length,
+      percent: 35,
+    });
+    try {
+      const res = await fetch("/api/work-orders/history/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows: importableRows }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as ImportResponse;
+      if (!res.ok || payload.ok === false || !payload.counts)
+        throw new Error(payload.error ?? "Unable to import vehicle history.");
+      setResponse(payload);
+      setProgress({
+        phase: "Complete",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 100,
+      });
+      if (payload.counts.imported > 0) onImported?.();
+    } catch (error) {
+      setProgress(null);
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "Unable to import vehicle history.",
+      );
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <GuidedSetupCardShell
+      testId="vehicle-history-csv-import-card"
+      eyebrow="Operations · History"
+      title="Import vehicle history"
+      description={
+        <>
+          <p>
+            Upload a CSV, review the parsed service-history preview, then
+            explicitly confirm the import.
+          </p>
+          <p>
+            Supported columns include{" "}
+            <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>.
+            Rows link to existing customers and vehicles by customer_id,
+            vehicle_id, VIN, name, email, or phone where available.
+          </p>
+        </>
+      }
+      guided={null}
+      variant="workspace"
+      actions={
+        <>
+          <input
+            ref={fileInputRef}
+            data-testid="vehicle-history-csv-file-input"
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="sr-only"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-white hover:border-[var(--accent-copper-soft)]/65"
+          >
+            Choose CSV file
+          </button>
+          <button
+            type="button"
+            onClick={downloadSample}
+            className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08]"
+          >
+            Download template
+          </button>
+        </>
+      }
+    >
+      <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <span className="font-semibold text-neutral-100">
+              Selected file:
+            </span>{" "}
+            {fileName ?? "No CSV selected"}
+          </div>
+          {headers.length ? (
+            <div className="text-xs text-neutral-400">
+              Detected {headers.length} columns
+            </div>
+          ) : null}
+        </div>
+        {parseError ? (
+          <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">
+            {parseError}
+          </div>
+        ) : null}
+        {rows.length ? (
+          <div className="mt-3 grid gap-2 sm:grid-cols-3">
+            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+              <div className="text-lg font-semibold text-white">
+                {rows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Rows parsed</div>
+            </div>
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2">
+              <div className="text-lg font-semibold text-emerald-100">
+                {importableRows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Ready to import</div>
+            </div>
+            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2">
+              <div className="text-lg font-semibold text-amber-100">
+                {rows.length - importableRows.length}
+              </div>
+              <div className="text-xs text-neutral-400">Need review</div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+      {previewRows.length ? (
+        <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
+          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
+            Preview
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[900px] text-left text-sm">
+              <thead className="text-xs uppercase tracking-[0.12em] text-neutral-500">
+                <tr>
+                  <th className="px-3 py-2">Date</th>
+                  <th className="px-3 py-2">Customer / Vehicle</th>
+                  <th className="px-3 py-2">RO / Invoice</th>
+                  <th className="px-3 py-2">Category</th>
+                  <th className="px-3 py-2">Total</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-neutral-200">
+                {previewRows.map((row, index) => (
+                  <tr
+                    key={`${row.repair_order_number ?? row.invoice_number ?? row.service_date}-${index}`}
+                  >
+                    <td className="px-3 py-2 font-medium text-white">
+                      {row.service_date ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.customer_id ??
+                        row.customer_name ??
+                        row.customer_email ??
+                        "—"}
+                      <div className="text-xs text-neutral-500">
+                        {row.vehicle_id ?? row.vin ?? "Vehicle match optional"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.repair_order_number ?? "—"}
+                      <div className="text-xs text-neutral-500">
+                        {row.invoice_number ?? "—"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.service_category ?? row.complaint ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">{row.total ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+      {rows.length - importableRows.length > 0 ? (
+        <div className="mt-4 rounded-xl border border-amber-500/25 bg-amber-950/20 p-3 text-sm text-amber-50">
+          Validation results: {rows.length - importableRows.length} row(s) need
+          review before import. Fix date, match identifiers, or numeric
+          odometer/labor/total values.
+        </div>
+      ) : null}
+      <CsvImportProgress
+        progress={progress}
+        label="Vehicle history CSV import progress"
+      />
+      {response?.counts ? (
+        <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
+          Import results: Imported {response.counts.imported}, Skipped{" "}
+          {response.counts.skipped}, Duplicates {response.counts.duplicates},
+          Failed {response.counts.failed}.
+        </div>
+      ) : null}
+      {response?.skippedRows?.length ? (
+        <div className="mt-4 rounded-xl border border-amber-500/25 bg-amber-950/20 p-3 text-sm text-amber-50">
+          Skipped rows:{" "}
+          {response.skippedRows
+            .slice(0, 8)
+            .map((r) => `Row ${r.row}: ${r.reason}`)
+            .join(" · ")}
+        </div>
+      ) : null}
+      {response?.failedRows?.length ? (
+        <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/20 p-3 text-sm text-red-50">
+          Failed rows:{" "}
+          {response.failedRows
+            .slice(0, 8)
+            .map((r) => `Row ${r.row}: ${r.error}`)
+            .join(" · ")}
+        </div>
+      ) : null}
+      {importError ? (
+        <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">
+          {importError}
+        </div>
+      ) : null}
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <button
+          type="button"
+          onClick={() => void confirmImport()}
+          disabled={importing || !importableRows.length}
+          className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
+        >
+          {importing ? "Importing…" : "Confirm import"}
+        </button>
+      </div>
+    </GuidedSetupCardShell>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a guided CSV import workflow for Vehicle History to match the existing Customer Import UX and remove the current one-off “No service history found.” state.  
- Allow shops to bring in legacy service/history rows and link them to existing customers and vehicles using available identifiers.  
- Validate rows before writing to the canonical `history` table to avoid duplicates and bad data.

### Description
- Added a new guided import UI component at `features/work-orders/components/VehicleHistoryCsvImportCard.tsx` that reuses the customer-import pattern (upload card, accepted-columns guidance, download template, preview, validation summary, import progress, results).  
- Implemented a shop-scoped API endpoint at `app/api/work-orders/history/import/route.ts` that resolves customers and vehicles (by `id`, `external_id`, email, phone, name, VIN), validates `service_date` and numeric fields, skips/flags duplicate repair order/invoice rows, and inserts into the existing `history` table using `source_system:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ace4412ac8328a9d8a1247e4923b1)