### PR TITLE
Unify guided onboarding import UI

### DIFF
--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -86,6 +86,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
   const [from, setFrom] = useState<string>("");
   const [to, setTo] = useState<string>("");
   const [showImport, setShowImport] = useState(false);
+  const shouldShowImport = Boolean(vehicleHistoryGuidedQuery || showImport);
 
   useEffect(() => {
     void (async () => {
@@ -233,6 +234,12 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
     <div className="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_34%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.06),transparent_32%),#050914] px-4 py-6 text-white">
       <div className="mx-auto max-w-6xl space-y-4">
         <GuidedPageStepPanel />
+        {shouldShowImport ? (
+          <VehicleHistoryCsvImportCard
+            guidedQuery={vehicleHistoryGuidedQuery}
+            onImported={() => void load()}
+          />
+        ) : null}
         {/* existing controls kept */}
         <section className="rounded-[26px] border border-slate-700/60 bg-slate-950/70 px-4 py-5 shadow-[0_18px_48px_rgba(2,6,23,0.58)] sm:px-6 sm:py-6">
           <div className="mb-3 flex flex-wrap items-end gap-3">
@@ -274,14 +281,6 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
               Export CSV
             </button>
           </div>
-          {showImport ? (
-            <div className="mb-4">
-              <VehicleHistoryCsvImportCard
-                guidedQuery={vehicleHistoryGuidedQuery}
-                onImported={() => void load()}
-              />
-            </div>
-          ) : null}
           {err ? (
             <div className="mb-4 rounded-xl border border-red-500/60 bg-red-950/80 px-4 py-2 text-sm text-red-100">
               {err}

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -246,7 +246,8 @@ export function CustomerCsvImportCard({
     }
 
     setImportProgress({
-      phase: "Preparing rows",
+      phase: "Reading file",
+      phaseKey: "reading_file",
       processed: 0,
       total: 0,
       percent: 5,
@@ -264,7 +265,8 @@ export function CustomerCsvImportCard({
         );
         setRows(parsedRows);
         setImportProgress({
-          phase: "Preparing rows",
+          phase: "Reading file",
+          phaseKey: "reading_file",
           processed: parsedRows.length,
           total: parsedRows.length,
           percent: parsedRows.length ? 25 : 0,
@@ -320,6 +322,7 @@ export function CustomerCsvImportCard({
     setImportError(null);
     setImportProgress({
       phase: "Importing",
+      phaseKey: "importing",
       processed: 0,
       total: importableRows.length,
       percent: 30,
@@ -362,6 +365,7 @@ export function CustomerCsvImportCard({
       progressTimer = null;
       setImportProgress({
         phase: "Finalizing",
+        phaseKey: "finalizing",
         processed: importableRows.length,
         total: importableRows.length,
         percent: 95,
@@ -378,7 +382,8 @@ export function CustomerCsvImportCard({
         payload.counts.failed === 0
       ) {
         setImportProgress({
-          phase: "Completing guided step",
+          phase: "Finalizing guided step",
+          phaseKey: "finalizing",
           processed: importableRows.length,
           total: importableRows.length,
           percent: 98,
@@ -386,14 +391,24 @@ export function CustomerCsvImportCard({
         await completeOnboardingAfterImport(payload.counts);
       }
       setImportProgress({
-        phase: "Complete",
+        phase:
+          payload.counts.failed > 0
+            ? "Import completed with failures"
+            : "Completed",
+        phaseKey: payload.counts.failed > 0 ? "failed" : "completed",
         processed: importableRows.length,
         total: importableRows.length,
         percent: 100,
       });
     } catch (error) {
       if (progressTimer) window.clearInterval(progressTimer);
-      setImportProgress(null);
+      setImportProgress({
+        phase: "Import failed",
+        phaseKey: "failed",
+        processed: 0,
+        total: importableRows.length,
+        percent: 100,
+      });
       setImportError(
         error instanceof Error ? error.message : "Unable to import customers.",
       );
@@ -690,15 +705,13 @@ export function CustomerCsvImportCard({
               ? "Completing onboarding…"
               : "Confirm import"}
         </button>
-        {isOnboarding && counts ? (
+        {isOnboarding && importSucceeded ? (
           <button
             type="button"
             onClick={() => router.push(guidedQuery!.returnTo)}
             className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
           >
-            {importSucceeded
-              ? "Continue onboarding"
-              : "Return to Data Onboarding"}
+            Continue onboarding
           </button>
         ) : null}
         {isOnboarding ? (

--- a/features/shared/components/import/CsvImportProgress.tsx
+++ b/features/shared/components/import/CsvImportProgress.tsx
@@ -1,5 +1,16 @@
+export type CsvImportProgressPhase =
+  | "idle"
+  | "reading_file"
+  | "validating"
+  | "matching"
+  | "importing"
+  | "finalizing"
+  | "completed"
+  | "failed";
+
 export type CsvImportProgressState = {
   phase: string;
+  phaseKey?: CsvImportProgressPhase;
   processed: number;
   total: number;
   percent: number;
@@ -27,28 +38,40 @@ export function CsvImportProgress({
     Math.min(progress.processed, total || progress.processed),
   );
   const percent = clampPercent(progress.percent);
+  const isFailed = progress.phaseKey === "failed";
+  const isCompleted = progress.phaseKey === "completed" || percent === 100;
+  const panelClass = isFailed
+    ? "border-red-500/25 bg-red-950/25 text-red-50"
+    : isCompleted
+      ? "border-emerald-500/25 bg-emerald-950/25 text-emerald-50"
+      : "border-sky-500/25 bg-sky-950/20 text-sky-50";
 
   return (
     <div
-      className="mt-4 rounded-xl border border-sky-500/25 bg-sky-950/20 p-3 text-sm text-sky-50"
+      className={`mt-4 rounded-xl border p-3 text-sm ${panelClass}`}
       role="status"
       aria-live="polite"
       data-testid="csv-import-progress"
     >
       <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-sky-100/70">
+          <div className="text-xs font-semibold uppercase tracking-[0.16em] opacity-70">
             {label}
           </div>
-          <div className="font-semibold text-sky-50">{progress.phase}</div>
+          <div className="font-semibold">{progress.phase}</div>
         </div>
-        <div className="text-xs text-sky-100/80">
-          {processed}/{total} rows · {percent}%
+        <div className="text-xs opacity-80">
+          {total > 0 ? `${processed}/${total} rows · ` : ""}
+          {percent}%
         </div>
       </div>
       <div className="mt-3 h-2 overflow-hidden rounded-full bg-black/35">
         <div
-          className="h-full rounded-full bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] transition-all duration-300"
+          className={`h-full rounded-full transition-all duration-300 ${
+            isFailed
+              ? "bg-red-400"
+              : "bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))]"
+          }`}
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/features/shared/components/import/GuidedImportCardLayout.tsx
+++ b/features/shared/components/import/GuidedImportCardLayout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+
+type Props = {
+  testId: string;
+  eyebrow: string;
+  title: string;
+  description: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
+};
+
+export function GuidedImportCardLayout({
+  testId,
+  eyebrow,
+  title,
+  description,
+  actions,
+  children,
+}: Props) {
+  return (
+    <GuidedSetupCardShell
+      testId={testId}
+      eyebrow={eyebrow}
+      title={title}
+      description={description}
+      guided={null}
+      variant="workspace"
+      actions={actions}
+    >
+      {children}
+    </GuidedSetupCardShell>
+  );
+}

--- a/features/shared/components/import/GuidedImportFooterActions.tsx
+++ b/features/shared/components/import/GuidedImportFooterActions.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function GuidedImportFooterActions({
+  importing,
+  completing,
+  canConfirm,
+  onConfirm,
+  isOnboarding,
+  returnTo,
+  importSucceeded,
+  hasResult,
+  onContinue,
+  onSkip,
+  skipDisabled,
+  skipLabel = "Skip for now",
+  children,
+}: {
+  importing: boolean;
+  completing: boolean;
+  canConfirm: boolean;
+  onConfirm: () => void;
+  isOnboarding?: boolean;
+  returnTo?: string;
+  importSucceeded?: boolean;
+  hasResult?: boolean;
+  onContinue?: () => void;
+  onSkip?: () => void;
+  skipDisabled?: boolean;
+  skipLabel?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={importing || completing || !canConfirm}
+        className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
+      >
+        {importing
+          ? "Importing…"
+          : completing
+            ? "Completing onboarding…"
+            : "Confirm import"}
+      </button>
+      {isOnboarding && hasResult && importSucceeded && onContinue ? (
+        <button
+          type="button"
+          onClick={onContinue}
+          className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
+        >
+          Continue onboarding
+        </button>
+      ) : null}
+      {isOnboarding && onSkip ? (
+        <button
+          type="button"
+          onClick={onSkip}
+          disabled={skipDisabled || importing || completing}
+          className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
+        >
+          {skipLabel}
+        </button>
+      ) : null}
+      {isOnboarding && returnTo ? (
+        <Link
+          href={returnTo}
+          className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
+        >
+          Return to Data Onboarding
+        </Link>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/features/shared/components/import/GuidedImportProgress.tsx
+++ b/features/shared/components/import/GuidedImportProgress.tsx
@@ -1,0 +1,2 @@
+export { CsvImportProgress as GuidedImportProgress } from "./CsvImportProgress";
+export type { CsvImportProgressState as GuidedImportProgressState } from "./CsvImportProgress";

--- a/features/shared/components/import/GuidedImportSummary.tsx
+++ b/features/shared/components/import/GuidedImportSummary.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+type Tone = "success" | "error" | "warning";
+
+const toneClassName: Record<Tone, string> = {
+  success: "border-emerald-500/25 bg-emerald-950/25 text-emerald-50",
+  error: "border-red-500/25 bg-red-950/30 text-red-100",
+  warning: "border-amber-500/25 bg-amber-950/20 text-amber-50",
+};
+
+export function GuidedImportSummary({
+  tone,
+  children,
+  className = "",
+}: {
+  tone: Tone;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`mt-4 rounded-xl border p-3 text-sm ${toneClassName[tone]} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -265,7 +265,8 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     }
 
     setImportProgress({
-      phase: "Preparing rows",
+      phase: "Reading file",
+      phaseKey: "reading_file",
       processed: 0,
       total: 0,
       percent: 5,
@@ -277,7 +278,8 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     );
     setRows(parsedRows);
     setImportProgress({
-      phase: "Preparing rows",
+      phase: "Reading file",
+      phaseKey: "reading_file",
       processed: parsedRows.length,
       total: parsedRows.length,
       percent: parsedRows.length ? 25 : 0,
@@ -330,6 +332,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     setImportError(null);
     setImportProgress({
       phase: "Importing",
+      phaseKey: "importing",
       processed: 0,
       total: importableRows.length,
       percent: 30,
@@ -376,6 +379,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       progressTimer = null;
       setImportProgress({
         phase: "Finalizing",
+        phaseKey: "finalizing",
         processed: importableRows.length,
         total: importableRows.length,
         percent: 95,
@@ -393,7 +397,8 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         payload.counts.failed === 0
       ) {
         setImportProgress({
-          phase: "Completing guided step",
+          phase: "Finalizing guided step",
+          phaseKey: "finalizing",
           processed: importableRows.length,
           total: importableRows.length,
           percent: 98,
@@ -401,14 +406,24 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         await completeOnboardingAfterImport(payload.counts);
       }
       setImportProgress({
-        phase: "Complete",
+        phase:
+          payload.counts.failed > 0
+            ? "Import completed with failures"
+            : "Completed",
+        phaseKey: payload.counts.failed > 0 ? "failed" : "completed",
         processed: importableRows.length,
         total: importableRows.length,
         percent: 100,
       });
     } catch (error) {
       if (progressTimer) window.clearInterval(progressTimer);
-      setImportProgress(null);
+      setImportProgress({
+        phase: "Import failed",
+        phaseKey: "failed",
+        processed: 0,
+        total: importableRows.length,
+        percent: 100,
+      });
       setImportError(
         error instanceof Error ? error.message : "Unable to import vehicles.",
       );
@@ -575,15 +590,13 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
               ? "Completing onboarding…"
               : "Confirm import"}
         </button>
-        {isOnboarding && counts ? (
+        {isOnboarding && importSucceeded ? (
           <button
             type="button"
             onClick={() => router.push(guidedQuery!.returnTo)}
             className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
           >
-            {importSucceeded
-              ? "Continue onboarding"
-              : "Return to Data Onboarding"}
+            Continue onboarding
           </button>
         ) : null}
         {isOnboarding ? (

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -3,7 +3,9 @@
 import React, { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
-import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
+import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
+import { GuidedImportSummary } from "@/features/shared/components/import/GuidedImportSummary";
 import {
   CsvImportProgress,
   type CsvImportProgressState,
@@ -190,7 +192,8 @@ export function VehicleHistoryCsvImportCard({
       return;
     }
     setProgress({
-      phase: "Preparing rows",
+      phase: "Reading file",
+      phaseKey: "reading_file",
       processed: 0,
       total: 0,
       percent: 5,
@@ -207,7 +210,8 @@ export function VehicleHistoryCsvImportCard({
         );
         setRows(parsed);
         setProgress({
-          phase: "Preparing rows",
+          phase: "Validating rows",
+          phaseKey: "validating",
           processed: parsed.length,
           total: parsed.length,
           percent: parsed.length ? 25 : 0,
@@ -264,6 +268,7 @@ export function VehicleHistoryCsvImportCard({
     setResponse(null);
     setProgress({
       phase: "Importing",
+      phaseKey: "importing",
       processed: 0,
       total: importableRows.length,
       percent: 35,
@@ -284,7 +289,8 @@ export function VehicleHistoryCsvImportCard({
         payload.counts.failed === 0
       ) {
         setProgress({
-          phase: "Completing guided step",
+          phase: "Finalizing guided step",
+          phaseKey: "finalizing",
           processed: importableRows.length,
           total: importableRows.length,
           percent: 98,
@@ -292,14 +298,24 @@ export function VehicleHistoryCsvImportCard({
         await completeOnboardingAfterImport(payload.counts);
       }
       setProgress({
-        phase: "Complete",
+        phase:
+          payload.counts.failed > 0
+            ? "Import completed with failures"
+            : "Completed",
+        phaseKey: payload.counts.failed > 0 ? "failed" : "completed",
         processed: importableRows.length,
         total: importableRows.length,
         percent: 100,
       });
       if (payload.counts.imported > 0) onImported?.();
     } catch (error) {
-      setProgress(null);
+      setProgress({
+        phase: "Import failed",
+        phaseKey: "failed",
+        processed: 0,
+        total: importableRows.length,
+        percent: 100,
+      });
       setImportError(
         error instanceof Error
           ? error.message
@@ -311,7 +327,7 @@ export function VehicleHistoryCsvImportCard({
   }
 
   return (
-    <GuidedSetupCardShell
+    <GuidedImportCardLayout
       testId="vehicle-history-csv-import-card"
       eyebrow="Operations · History"
       title={
@@ -333,8 +349,6 @@ export function VehicleHistoryCsvImportCard({
           </p>
         </>
       }
-      guided={null}
-      variant="workspace"
       actions={
         <>
           <input
@@ -455,22 +469,24 @@ export function VehicleHistoryCsvImportCard({
         </div>
       ) : null}
       {rows.length - importableRows.length > 0 ? (
-        <div className="mt-4 rounded-xl border border-amber-500/25 bg-amber-950/20 p-3 text-sm text-amber-50">
+        <GuidedImportSummary tone="warning">
           Validation results: {rows.length - importableRows.length} row(s) need
           review before import. Fix date, match identifiers, or numeric
           odometer/labor/total values.
-        </div>
+        </GuidedImportSummary>
       ) : null}
       <CsvImportProgress
         progress={progress}
         label="Vehicle history CSV import progress"
       />
       {response?.counts ? (
-        <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
+        <GuidedImportSummary
+          tone={response.counts.failed ? "error" : "success"}
+        >
           Import results: Imported {response.counts.imported}, Skipped{" "}
           {response.counts.skipped}, Duplicates {response.counts.duplicates},
           Failed {response.counts.failed}.
-        </div>
+        </GuidedImportSummary>
       ) : null}
       {response?.skippedRows?.length ? (
         <div className="mt-4 rounded-xl border border-amber-500/25 bg-amber-950/20 p-3 text-sm text-amber-50">
@@ -491,33 +507,23 @@ export function VehicleHistoryCsvImportCard({
         </div>
       ) : null}
       {importError ? (
-        <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">
-          {importError}
-        </div>
+        <GuidedImportSummary tone="error">{importError}</GuidedImportSummary>
       ) : null}
-      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-        <button
-          type="button"
-          onClick={() => void confirmImport()}
-          disabled={importing || completingOnboarding || !importableRows.length}
-          className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
-        >
-          {importing
-            ? "Importing…"
-            : completingOnboarding
-              ? "Completing onboarding…"
-              : "Confirm import"}
-        </button>
-        {isOnboarding && response?.counts ? (
-          <button
-            type="button"
-            onClick={() => router.push(guidedQuery!.returnTo)}
-            className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
-          >
-            Continue onboarding
-          </button>
-        ) : null}
-      </div>
-    </GuidedSetupCardShell>
+      <GuidedImportFooterActions
+        importing={importing}
+        completing={completingOnboarding}
+        canConfirm={importableRows.length > 0}
+        onConfirm={() => void confirmImport()}
+        isOnboarding={isOnboarding}
+        returnTo={guidedQuery?.returnTo}
+        hasResult={Boolean(response?.counts)}
+        importSucceeded={Boolean(
+          response?.counts &&
+          response.counts.imported > 0 &&
+          response.counts.failed === 0,
+        )}
+        onContinue={() => router.push(guidedQuery!.returnTo)}
+      />
+    </GuidedImportCardLayout>
   );
 }


### PR DESCRIPTION
### Motivation
- Customers, Vehicles, and Vehicle History had divergent CSV import UIs and the Vehicle History flow felt disconnected from the guided onboarding experience. 
- Provide a single, consistent guided import surface based on the Customers import visuals so future import steps are cohesive. 
- Preserve existing import business logic, APIs, and onboarding step semantics while consolidating UI state and progress behavior.

### Description
- Added shared guided import primitives: `GuidedImportCardLayout`, `GuidedImportProgress` (alias), `GuidedImportSummary`, and `GuidedImportFooterActions` under `features/shared/components/import/` and wired them into import flows. 
- Standardized progress phases and shape via `CsvImportProgressState` / `CsvImportProgressPhase` and updated the progress component to show phase label, percent, processed/total rows, and clear success/failure styling. 
- Updated `CustomerCsvImportCard`, `VehicleCsvImportCard`, and `VehicleHistoryCsvImportCard` to emit the new standardized phases (`reading_file`, `validating`, `importing`, `finalizing`, `completed`, `failed`) and to use the shared UI pieces where appropriate (Vehicle History now uses the shared layout/summary/footer). 
- Render `VehicleHistoryCsvImportCard` inline above the history search/results when guided onboarding is active or when the import toggle is shown, preserving the existing search/results area below. 
- Did not change parsing/matching/import APIs or server endpoints; guided completion still calls the same step endpoints (`customers`, `vehicles`, `vehicle_history`) and Continue onboarding is shown only after a successful import with zero failed rows.

### Testing
- Ran `npm run typecheck` and TypeScript checks passed with no new errors. 
- Ran `npx eslint features/work-orders/components/VehicleHistoryCsvImportCard.tsx app/work-orders/history/WorkOrdersHistoryClient.tsx` with no reported lint errors for those files. 
- Ran targeted unit tests `npm test -- --run tests/guided-onboarding-page-panels.test.tsx tests/guided-onboarding-v2-foundation.test.ts` and both test files passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ad8249ee88328ac1caa56b57ac164)