### PR TITLE
Batch history duplicate lookups to avoid oversized customer_id filters

### DIFF
--- a/app/api/work-orders/history/import/route.ts
+++ b/app/api/work-orders/history/import/route.ts
@@ -191,8 +191,33 @@ function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null {
 }
 
 const HISTORY_IMPORT_BATCH_SIZE = 250;
+const HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE = 50;
 const HISTORY_IMPORT_SAMPLE_LIMIT = 25;
 const HISTORY_IMPORT_MAX_ROWS = 20_000;
+
+async function findDuplicateHistoryId(
+  supabase: SupabaseClient<DB>,
+  customerIds: string[],
+  column: "work_order_number" | "invoice_number",
+  value: string,
+): Promise<string | null> {
+  for (const customerIdChunk of chunkArray(
+    customerIds,
+    HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE,
+  )) {
+    if (!customerIdChunk.length) continue;
+    const { data, error } = await supabase
+      .from("history")
+      .select("id")
+      .in("customer_id", customerIdChunk)
+      .eq(column as "id", value)
+      .limit(1);
+    if (error) throw error;
+    const duplicate = data?.[0]?.id;
+    if (duplicate) return duplicate;
+  }
+  return null;
+}
 
 type ImportCounts = {
   imported: number;
@@ -343,24 +368,24 @@ export async function POST(req: Request) {
         }
         let duplicateFound = false;
         if (repairOrderNumber) {
-          const { data, error } = await supabase
-            .from("history")
-            .select("id")
-            .in("customer_id", resolver.shopCustomerIds)
-            .eq("work_order_number" as "id", repairOrderNumber)
-            .limit(1);
-          if (error) throw error;
-          duplicateFound = (data ?? []).length > 0;
+          duplicateFound = Boolean(
+            await findDuplicateHistoryId(
+              supabase,
+              resolver.shopCustomerIds,
+              "work_order_number",
+              repairOrderNumber,
+            ),
+          );
         }
         if (!duplicateFound && invoiceNumber) {
-          const { data, error } = await supabase
-            .from("history")
-            .select("id")
-            .in("customer_id", resolver.shopCustomerIds)
-            .eq("invoice_number" as "id", invoiceNumber)
-            .limit(1);
-          if (error) throw error;
-          duplicateFound = (data ?? []).length > 0;
+          duplicateFound = Boolean(
+            await findDuplicateHistoryId(
+              supabase,
+              resolver.shopCustomerIds,
+              "invoice_number",
+              invoiceNumber,
+            ),
+          );
         }
         if (duplicateFound) {
           counts.skipped++;

--- a/tests/vehicle-history-csv-import-architecture.test.ts
+++ b/tests/vehicle-history-csv-import-architecture.test.ts
@@ -94,4 +94,16 @@ describe("vehicle history CSV import multipart architecture", () => {
     const footer = readFileSync("features/shared/components/import/GuidedImportFooterActions.tsx", "utf8");
     expect(footer).toContain("Continue onboarding");
   });
+
+  it("batches history duplicate reload lookups instead of sending oversized customer_id filters", () => {
+    const source = routeSource();
+
+    expect(source).toContain("HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE = 50");
+    expect(source).toContain("findDuplicateHistoryId");
+    expect(source).toContain(`chunkArray(
+    customerIds,
+    HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE,`);
+    expect(source).not.toContain('.in("customer_id", resolver.shopCustomerIds)');
+    expect(source).not.toContain('.from("work_orders")');
+  });
 });


### PR DESCRIPTION
### Motivation
- Vehicle History CSV import triggered oversized PostgREST queries using `.in("customer_id", resolver.shopCustomerIds)` which caused `400` errors and prevented the UI from showing imported history.
- The intent is to avoid changing import architecture or matching logic while making the duplicate-detection queries safe and shop-scoped.

### Description
- Replaced the direct oversized query `.in("customer_id", resolver.shopCustomerIds)` in `app/api/work-orders/history/import/route.ts` with a chunked lookup helper `findDuplicateHistoryId` that batches customer IDs into `HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE = 50` and queries `history` in small `.in(...)` chunks.
- Updated duplicate checks for `work_order_number` and `invoice_number` to call `findDuplicateHistoryId` instead of a single large `.in(...)` call.
- Added a regression test `tests/vehicle-history-csv-import-architecture.test.ts` to ensure the new batching helper exists, the chunk size constant is present, the oversized `.in("customer_id", resolver.shopCustomerIds)` pattern is not reintroduced, and that the importer does not touch `work_orders` (import remains history-only).
- Verified the UI reload path still calls `onImported?.()` so imported history appears after import without a manual refresh, and confirmed the progress copy already reads `"Vehicle history CSV import progress"` so no copy change was necessary.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npx eslint app/api/work-orders/history/import/route.ts features/work-orders/components/VehicleHistoryCsvImportCard.tsx app/work-orders/history/WorkOrdersHistoryClient.tsx` and lint passed without errors.
- Ran `npx vitest run tests/vehicle-history-csv-import-architecture.test.ts` and the test file passed (1 file, 8 tests all green).

Notes:
- Exact oversized query source found: `app/api/work-orders/history/import/route.ts` where the pattern `.in("customer_id", resolver.shopCustomerIds)` was previously used for duplicate detection and has been replaced by `findDuplicateHistoryId`.
- Confirmed no live work orders are created by the importer; tests explicitly assert the route does not reference `.from("work_orders")` and the import code still inserts only into `history`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ae08ebf9c8328b6c6b903ec47a880)