### PR TITLE
Add async vehicle history import jobs

### DIFF
--- a/app/api/import-jobs/[jobId]/route.ts
+++ b/app/api/import-jobs/[jobId]/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type Params = { params: { jobId: string } };
+
+export async function GET(_req: Request, { params }: Params) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ["owner", "admin", "manager", "advisor"],
+  });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
+
+  const { data, error } = await (access.supabase as unknown as { from: (table: string) => any })
+    .from("import_jobs")
+    .select("id, import_type, status, total_rows, processed_rows, imported_count, skipped_count, failed_count, error_message, summary, created_at, updated_at, completed_at")
+    .eq("id", params.jobId)
+    .eq("shop_id", shopId)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: "Import job not found." }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    job: {
+      id: data.id,
+      importType: data.import_type,
+      status: data.status,
+      totalRows: data.total_rows ?? 0,
+      processedRows: data.processed_rows ?? 0,
+      importedCount: data.imported_count ?? 0,
+      skippedCount: data.skipped_count ?? 0,
+      failedCount: data.failed_count ?? 0,
+      errorMessage: data.error_message ?? null,
+      summary: data.summary ?? null,
+      createdAt: data.created_at,
+      updatedAt: data.updated_at,
+      completedAt: data.completed_at,
+    },
+  });
+}

--- a/app/api/internal/import-jobs/tick/route.ts
+++ b/app/api/internal/import-jobs/tick/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { requireInternalApiSecret } from "@/features/shared/lib/server/api-route-guard";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  processVehicleHistoryImportJobBatch,
+  VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+} from "@/features/work-orders/server/vehicle-history-import-job";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function authorize(req: Request) {
+  return requireInternalApiSecret({
+    request: req,
+    envSecretName: "INTERNAL_IMPORT_JOBS_SECRET",
+    headerName: "x-internal-import-jobs-secret",
+    routeLabel: "internal/import-jobs/tick",
+  });
+}
+
+async function run(req: Request) {
+  const gate = authorize(req);
+  if (!gate.ok) return gate.response;
+  const url = new URL(req.url);
+  const jobId = url.searchParams.get("jobId") || undefined;
+  const result = await processVehicleHistoryImportJobBatch(
+    createAdminSupabase(),
+    jobId,
+    VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+  );
+  return NextResponse.json(result);
+}
+
+export async function GET(req: Request) {
+  try {
+    return await run(req);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Import job tick failed." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  return GET(req);
+}

--- a/app/api/work-orders/history/import/route.ts
+++ b/app/api/work-orders/history/import/route.ts
@@ -1,231 +1,44 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import { chunkArray, parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
 import {
-  chunkArray,
-  compactImportSummary,
-  parseCsvFileFromFormData,
-} from "@/features/shared/lib/import/csv";
+  VEHICLE_HISTORY_IMPORT_MAX_ROWS,
+  VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
+} from "@/features/work-orders/server/vehicle-history-import-job";
+import type { Database } from "@shared/types/types/supabase";
 
-type DB = Database;
-type HistoryImportRow = {
-  customer_id?: unknown;
-  vehicle_id?: unknown;
-  vin?: unknown;
-  customer_email?: unknown;
-  email?: unknown;
-  customer_phone?: unknown;
-  phone?: unknown;
-  customer_name?: unknown;
-  name?: unknown;
-  service_date?: unknown;
-  repair_order_number?: unknown;
-  work_order_number?: unknown;
-  invoice_number?: unknown;
-  odometer?: unknown;
-  service_category?: unknown;
-  complaint?: unknown;
-  cause?: unknown;
-  correction?: unknown;
-  parts?: unknown;
-  labor_hours?: unknown;
-  total?: unknown;
-  technician?: unknown;
-  advisor?: unknown;
-  notes?: unknown;
-};
-
-type CustomerRef = Pick<
-  DB["public"]["Tables"]["customers"]["Row"],
-  | "id"
-  | "external_id"
-  | "email"
-  | "phone"
-  | "phone_number"
-  | "name"
-  | "business_name"
-  | "first_name"
-  | "last_name"
->;
-type VehicleRef = Pick<
-  DB["public"]["Tables"]["vehicles"]["Row"],
-  "id" | "external_id" | "vin" | "customer_id"
->;
-
-type Resolver = {
-  shopCustomerIds: string[];
-  customersById: Map<string, CustomerRef>;
-  customersByExternal: Map<string, CustomerRef>;
-  customersByEmail: Map<string, CustomerRef>;
-  customersByPhone: Map<string, CustomerRef>;
-  customersByName: Map<string, CustomerRef>;
-  vehiclesById: Map<string, VehicleRef>;
-  vehiclesByExternal: Map<string, VehicleRef>;
-  vehiclesByVin: Map<string, VehicleRef>;
-};
-
-function clean(value: unknown): string | null {
-  const text = String(value ?? "").trim();
-  return text ? text : null;
-}
-function key(value: unknown): string | null {
-  return clean(value)?.toLowerCase().replace(/\s+/g, " ") ?? null;
-}
-function phone(value: unknown): string | null {
-  const text = clean(value);
-  if (!text) return null;
-  return text.replace(/\D/g, "") || text;
-}
-function vin(value: unknown): string | null {
-  return (
-    clean(value)
-      ?.toUpperCase()
-      .replace(/[^A-Z0-9]/g, "") ?? null
-  );
-}
-function num(value: unknown): number | null {
-  const text = clean(value);
-  if (!text) return null;
-  const parsed = Number(text.replace(/[$,]/g, ""));
-  return Number.isFinite(parsed) ? parsed : null;
-}
-function validDate(value: unknown): string | null {
-  const text = clean(value);
-  if (!text) return null;
-  const parsed = new Date(text);
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-}
-function customerName(c: CustomerRef): string | null {
-  return (
-    c.name ||
-    c.business_name ||
-    [c.first_name, c.last_name].filter(Boolean).join(" ").trim() ||
-    null
-  );
-}
-
-async function loadResolver(
-  supabase: SupabaseClient<DB>,
-  shopId: string,
-): Promise<Resolver> {
-  const [
-    { data: customers, error: customerError },
-    { data: vehicles, error: vehicleError },
-  ] = await Promise.all([
-    supabase
-      .from("customers")
-      .select(
-        "id, external_id, email, phone, phone_number, name, business_name, first_name, last_name",
-      )
-      .eq("shop_id", shopId),
-    supabase
-      .from("vehicles")
-      .select("id, external_id, vin, customer_id")
-      .eq("shop_id", shopId),
-  ]);
-  if (customerError) throw customerError;
-  if (vehicleError) throw vehicleError;
-  const r: Resolver = {
-    shopCustomerIds: [],
-    customersById: new Map(),
-    customersByExternal: new Map(),
-    customersByEmail: new Map(),
-    customersByPhone: new Map(),
-    customersByName: new Map(),
-    vehiclesById: new Map(),
-    vehiclesByExternal: new Map(),
-    vehiclesByVin: new Map(),
+type HistoryImportRow = Record<string, unknown>;
+type JsonRecord = Record<string, unknown>;
+type JobInsertBuilder = {
+  insert: (payload: unknown) => {
+    select: (columns: string) => {
+      single: () => Promise<{
+        data: { id: string; total_rows: number; status: string } | null;
+        error: Error | null;
+      }>;
+    };
   };
-  for (const c of (customers ?? []) as CustomerRef[]) {
-    r.shopCustomerIds.push(c.id);
-    r.customersById.set(c.id, c);
-    const ex = key(c.external_id);
-    if (ex && !r.customersByExternal.has(ex)) r.customersByExternal.set(ex, c);
-    const em = key(c.email);
-    if (em && !r.customersByEmail.has(em)) r.customersByEmail.set(em, c);
-    for (const p of [c.phone, c.phone_number]) {
-      const ph = phone(p);
-      if (ph && !r.customersByPhone.has(ph)) r.customersByPhone.set(ph, c);
-    }
-    for (const n of [c.name, c.business_name, customerName(c)]) {
-      const nk = key(n);
-      if (nk && !r.customersByName.has(nk)) r.customersByName.set(nk, c);
-    }
-  }
-  for (const v of (vehicles ?? []) as VehicleRef[]) {
-    r.vehiclesById.set(v.id, v);
-    const ex = key(v.external_id);
-    if (ex && !r.vehiclesByExternal.has(ex)) r.vehiclesByExternal.set(ex, v);
-    const vk = vin(v.vin);
-    if (vk && !r.vehiclesByVin.has(vk)) r.vehiclesByVin.set(vk, v);
-  }
-  return r;
-}
-
-function resolveCustomer(
-  row: HistoryImportRow,
-  r: Resolver,
-): CustomerRef | null {
-  const cid = clean(row.customer_id);
-  if (cid && r.customersById.has(cid)) return r.customersById.get(cid)!;
-  const ex = key(row.customer_id);
-  if (ex && r.customersByExternal.has(ex))
-    return r.customersByExternal.get(ex)!;
-  const em = key(row.customer_email ?? row.email);
-  if (em && r.customersByEmail.has(em)) return r.customersByEmail.get(em)!;
-  const ph = phone(row.customer_phone ?? row.phone);
-  if (ph && r.customersByPhone.has(ph)) return r.customersByPhone.get(ph)!;
-  const nm = key(row.customer_name ?? row.name);
-  if (nm && r.customersByName.has(nm)) return r.customersByName.get(nm)!;
-  return null;
-}
-function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null {
-  const vid = clean(row.vehicle_id);
-  if (vid && r.vehiclesById.has(vid)) return r.vehiclesById.get(vid)!;
-  const ex = key(row.vehicle_id);
-  if (ex && r.vehiclesByExternal.has(ex)) return r.vehiclesByExternal.get(ex)!;
-  const vk = vin(row.vin);
-  if (vk && r.vehiclesByVin.has(vk)) return r.vehiclesByVin.get(vk)!;
-  return null;
-}
-
-const HISTORY_IMPORT_BATCH_SIZE = 250;
-const HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE = 50;
-const HISTORY_IMPORT_SAMPLE_LIMIT = 25;
-const HISTORY_IMPORT_MAX_ROWS = 20_000;
-
-async function findDuplicateHistoryId(
-  supabase: SupabaseClient<DB>,
-  customerIds: string[],
-  column: "work_order_number" | "invoice_number",
-  value: string,
-): Promise<string | null> {
-  for (const customerIdChunk of chunkArray(
-    customerIds,
-    HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE,
-  )) {
-    if (!customerIdChunk.length) continue;
-    const { data, error } = await supabase
-      .from("history")
-      .select("id")
-      .in("customer_id", customerIdChunk)
-      .eq(column as "id", value)
-      .limit(1);
-    if (error) throw error;
-    const duplicate = data?.[0]?.id;
-    if (duplicate) return duplicate;
-  }
-  return null;
-}
-
-type ImportCounts = {
-  imported: number;
-  updated: number;
-  skipped: number;
-  failed: number;
-  duplicates: number;
 };
+type RowInsertBuilder = {
+  insert: (payload: unknown) => Promise<{ error: Error | null }>;
+};
+type LooseSupabase<TBuilder> = { from: (table: string) => TBuilder };
+
+type ImportJobInsert = {
+  shop_id: string;
+  created_by: string;
+  import_type: "vehicle_history";
+  status: "queued";
+  total_rows: number;
+  processed_rows: number;
+  imported_count: number;
+  skipped_count: number;
+  failed_count: number;
+  source_storage_path: string;
+  summary: JsonRecord;
+};
+
+const STAGING_INSERT_BATCH_SIZE = 500;
 
 export async function POST(req: Request) {
   try {
@@ -239,7 +52,7 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           error:
-            "Vehicle history import now requires multipart/form-data with a CSV file field.",
+            "Vehicle history import requires multipart/form-data with a CSV file field.",
         },
         { status: 415 },
       );
@@ -252,11 +65,12 @@ export async function POST(req: Request) {
           : "Unable to read CSV upload.",
       );
     });
+
     let parsed;
     try {
       parsed = await parseCsvFileFromFormData<HistoryImportRow>({
         formData,
-        maxRows: HISTORY_IMPORT_MAX_ROWS,
+        maxRows: VEHICLE_HISTORY_IMPORT_MAX_ROWS,
       });
     } catch (error) {
       return NextResponse.json(
@@ -269,236 +83,70 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     }
-    const rows = parsed.rows;
+
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
-    if (!shopId)
+    if (!shopId) {
       return NextResponse.json(
         { error: "No active shop is selected." },
         { status: 400 },
       );
-    const resolver = await loadResolver(supabase, shopId);
-    const counts: ImportCounts = {
-      imported: 0,
-      updated: 0,
-      skipped: 0,
-      failed: 0,
-      duplicates: 0,
-    };
-    const skippedRows: Array<{
-      row: number;
-      reason: string;
-      repairOrderNumber: string | null;
-      invoiceNumber: string | null;
-    }> = [];
-    const failedRows: Array<{
-      row: number;
-      error: string;
-      repairOrderNumber: string | null;
-      invoiceNumber: string | null;
-    }> = [];
-    const payloads: Array<{
-      rowNumber: number;
-      repairOrderNumber: string | null;
-      invoiceNumber: string | null;
-      payload: DB["public"]["Tables"]["history"]["Insert"] & Record<string, unknown>;
-    }> = [];
-
-    for (const [i, raw] of rows.entries()) {
-      const rowNumber = i + 1;
-      const row = raw;
-      const repairOrderNumber = clean(
-        row.repair_order_number ?? row.work_order_number,
-      );
-      const invoiceNumber = clean(row.invoice_number);
-      try {
-        const serviceDate = validDate(row.service_date);
-        if (!serviceDate) {
-          counts.skipped++;
-          skippedRows.push({
-            row: rowNumber,
-            reason: "Invalid or missing service_date.",
-            repairOrderNumber,
-            invoiceNumber,
-          });
-          continue;
-        }
-        const invalidNumber = (
-          [
-            ["odometer", row.odometer],
-            ["labor_hours", row.labor_hours],
-            ["total", row.total],
-          ] as const
-        ).find(([, value]) => clean(value) && num(value) === null);
-        if (invalidNumber) {
-          counts.skipped++;
-          skippedRows.push({
-            row: rowNumber,
-            reason: `${invalidNumber[0]} must be numeric when provided.`,
-            repairOrderNumber,
-            invoiceNumber,
-          });
-          continue;
-        }
-        const vehicle = resolveVehicle(row, resolver);
-        const customer =
-          resolveCustomer(row, resolver) ??
-          (vehicle?.customer_id
-            ? (resolver.customersById.get(vehicle.customer_id) ?? null)
-            : null);
-        if (!customer) {
-          counts.skipped++;
-          skippedRows.push({
-            row: rowNumber,
-            reason: "Existing customer could not be matched.",
-            repairOrderNumber,
-            invoiceNumber,
-          });
-          continue;
-        }
-        if ((clean(row.vehicle_id) || clean(row.vin)) && !vehicle) {
-          counts.skipped++;
-          skippedRows.push({
-            row: rowNumber,
-            reason: "Existing vehicle could not be matched.",
-            repairOrderNumber,
-            invoiceNumber,
-          });
-          continue;
-        }
-        let duplicateFound = false;
-        if (repairOrderNumber) {
-          duplicateFound = Boolean(
-            await findDuplicateHistoryId(
-              supabase,
-              resolver.shopCustomerIds,
-              "work_order_number",
-              repairOrderNumber,
-            ),
-          );
-        }
-        if (!duplicateFound && invoiceNumber) {
-          duplicateFound = Boolean(
-            await findDuplicateHistoryId(
-              supabase,
-              resolver.shopCustomerIds,
-              "invoice_number",
-              invoiceNumber,
-            ),
-          );
-        }
-        if (duplicateFound) {
-          counts.skipped++;
-          counts.duplicates++;
-          skippedRows.push({
-            row: rowNumber,
-            reason: "Duplicate repair order/invoice already exists.",
-            repairOrderNumber,
-            invoiceNumber,
-          });
-          continue;
-        }
-        const parts = clean(row.parts);
-        const notes =
-          [
-            clean(row.notes),
-            parts ? `Parts: ${parts}` : null,
-            clean(row.service_category)
-              ? `Service category: ${clean(row.service_category)}`
-              : null,
-          ]
-            .filter(Boolean)
-            .join("\n") || null;
-        const description =
-          [
-            clean(row.service_category),
-            clean(row.complaint),
-            clean(row.correction),
-          ]
-            .filter(Boolean)
-            .join(" · ") || "Imported historical service record";
-        payloads.push({
-          rowNumber,
-          repairOrderNumber,
-          invoiceNumber,
-          payload: {
-            customer_id: customer.id,
-            vehicle_id: vehicle?.id ?? null,
-            service_date: serviceDate,
-            description,
-            notes,
-            work_order_number: repairOrderNumber,
-            invoice_number: invoiceNumber,
-            odometer: num(row.odometer),
-            symptom: clean(row.complaint),
-            cause: clean(row.cause),
-            correction: clean(row.correction),
-            labor_hours: num(row.labor_hours),
-            total: num(row.total),
-            advisor_name: clean(row.advisor),
-            assigned_tech_name: clean(row.technician),
-            historical_status: "imported",
-            source_system: "vehicle_history_csv",
-            source_row_id: String(rowNumber),
-            source_payload: JSON.parse(
-              JSON.stringify({
-                imported_at: new Date().toISOString(),
-                raw_row: row,
-                service_category: clean(row.service_category),
-                parts: clean(row.parts),
-              }),
-            ) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"],
-          },
-        });
-      } catch (error) {
-        counts.failed++;
-        failedRows.push({
-          row: rowNumber,
-          error:
-            error instanceof Error
-              ? error.message
-              : "History row failed to import.",
-          repairOrderNumber,
-          invoiceNumber,
-        });
-      }
     }
 
-    for (const batch of chunkArray(payloads, HISTORY_IMPORT_BATCH_SIZE)) {
-      if (!batch.length) continue;
-      const { error } = await supabase
-        .from("history")
-        .insert(batch.map((entry) => entry.payload));
-      if (error) {
-        for (const entry of batch) {
-          const { error: rowError } = await supabase
-            .from("history")
-            .insert(entry.payload);
-          if (rowError) {
-            counts.failed++;
-            failedRows.push({
-              row: entry.rowNumber,
-              error: rowError.message,
-              repairOrderNumber: entry.repairOrderNumber,
-              invoiceNumber: entry.invoiceNumber,
-            });
-          } else {
-            counts.imported++;
-          }
-        }
-      } else {
-        counts.imported += batch.length;
-      }
+    const createdBy = profile.id;
+    const sourceRef = `staging://import_job_rows/vehicle_history/${shopId}/${Date.now()}`;
+    const jobPayload: ImportJobInsert = {
+      shop_id: shopId,
+      created_by: createdBy,
+      import_type: "vehicle_history",
+      status: "queued",
+      total_rows: parsed.rows.length,
+      processed_rows: 0,
+      imported_count: 0,
+      skipped_count: 0,
+      failed_count: 0,
+      source_storage_path: sourceRef,
+      summary: {
+        storageCleanup: "CSV rows are staged in import_job_rows with retention metadata; no Supabase Storage object is created.",
+        sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
+        skippedRows: [],
+        failedRows: [],
+      },
+    };
+
+    const { data: job, error: jobError } = await (supabase as unknown as LooseSupabase<JobInsertBuilder>)
+      .from("import_jobs")
+      .insert(jobPayload)
+      .select("id, total_rows, status")
+      .single();
+
+    if (jobError || !job) {
+      throw jobError ?? new Error("Unable to create vehicle history import job.");
+    }
+
+    const stagedRows = parsed.rows.map((row, index) => ({
+      job_id: job.id,
+      shop_id: shopId,
+      row_number: index + 1,
+      raw_row: row as Database["public"]["Tables"]["history"]["Insert"]["source_payload"],
+      status: "queued",
+    }));
+
+    for (const batch of chunkArray(stagedRows, STAGING_INSERT_BATCH_SIZE)) {
+      const { error } = await (supabase as unknown as LooseSupabase<RowInsertBuilder>)
+        .from("import_job_rows")
+        .insert(batch);
+      if (error) throw error;
     }
 
     return NextResponse.json(
-      compactImportSummary({
-        counts,
-        totalRows: rows.length,
-        skippedRows,
-        failedRows,
-        sampleLimit: HISTORY_IMPORT_SAMPLE_LIMIT,
-      }),
+      {
+        ok: true,
+        jobId: job.id,
+        status: job.status,
+        totalRows: job.total_rows,
+      },
+      { status: 202 },
     );
   } catch (error) {
     return NextResponse.json(
@@ -506,7 +154,7 @@ export async function POST(req: Request) {
         error:
           error instanceof Error
             ? error.message
-            : "Unable to import vehicle history.",
+            : "Unable to queue vehicle history import.",
       },
       { status: 500 },
     );

--- a/db/sql/2026-07-05_vehicle_history_import_jobs.sql
+++ b/db/sql/2026-07-05_vehicle_history_import_jobs.sql
@@ -1,0 +1,89 @@
+-- Vehicle History import jobs: async staging and progress tracking.
+-- Backfill first so duplicate detection can be shop-scoped without large customer_id.in(...) filters.
+alter table public.history add column if not exists shop_id uuid;
+
+update public.history h
+set shop_id = c.shop_id
+from public.customers c
+where h.customer_id = c.id
+  and h.shop_id is null
+  and c.shop_id is not null;
+
+create table if not exists public.import_jobs (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  created_by uuid references auth.users(id) on delete set null,
+  import_type text not null,
+  status text not null default 'queued',
+  total_rows integer not null default 0,
+  processed_rows integer not null default 0,
+  imported_count integer not null default 0,
+  skipped_count integer not null default 0,
+  failed_count integer not null default 0,
+  error_message text,
+  source_storage_path text,
+  summary jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz,
+  constraint import_jobs_import_type_check check (import_type in ('vehicle_history')),
+  constraint import_jobs_status_check check (status in ('queued', 'processing', 'completed', 'failed'))
+);
+
+create table if not exists public.import_job_rows (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.import_jobs(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  row_number integer not null,
+  raw_row jsonb not null,
+  status text not null default 'queued',
+  error_message text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint import_job_rows_status_check check (status in ('queued', 'imported', 'skipped', 'failed')),
+  constraint import_job_rows_job_row_unique unique (job_id, row_number)
+);
+
+create index if not exists import_jobs_shop_status_idx on public.import_jobs(shop_id, status, created_at);
+create index if not exists import_jobs_type_status_idx on public.import_jobs(import_type, status, created_at);
+create index if not exists import_job_rows_job_status_row_idx on public.import_job_rows(job_id, status, row_number);
+create index if not exists import_job_rows_shop_idx on public.import_job_rows(shop_id);
+create index if not exists history_shop_work_order_number_idx on public.history(shop_id, work_order_number) where work_order_number is not null;
+create index if not exists history_shop_invoice_number_idx on public.history(shop_id, invoice_number) where invoice_number is not null;
+
+alter table public.import_jobs enable row level security;
+alter table public.import_job_rows enable row level security;
+
+create policy "Shop members can read import jobs"
+  on public.import_jobs for select
+  using (shop_id in (select profiles.shop_id from public.profiles where profiles.id = auth.uid()));
+
+create policy "Shop members can create import jobs"
+  on public.import_jobs for insert
+  with check (shop_id in (select profiles.shop_id from public.profiles where profiles.id = auth.uid()));
+
+create policy "Shop members can read import job rows"
+  on public.import_job_rows for select
+  using (shop_id in (select profiles.shop_id from public.profiles where profiles.id = auth.uid()));
+
+create policy "Shop members can create import job rows"
+  on public.import_job_rows for insert
+  with check (shop_id in (select profiles.shop_id from public.profiles where profiles.id = auth.uid()));
+
+create or replace function public.set_import_job_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_import_jobs_updated_at on public.import_jobs;
+create trigger set_import_jobs_updated_at
+before update on public.import_jobs
+for each row execute function public.set_import_job_updated_at();
+
+drop trigger if exists set_import_job_rows_updated_at on public.import_job_rows;
+create trigger set_import_job_rows_updated_at
+before update on public.import_job_rows
+for each row execute function public.set_import_job_updated_at();

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
@@ -35,16 +35,19 @@ type HistoryImportRow = {
   notes?: string | null;
 };
 
+type ImportCounts = {
+  imported: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  duplicates: number;
+};
+
 type ImportResponse = {
   ok?: boolean;
   error?: string;
-  counts?: {
-    imported: number;
-    updated: number;
-    skipped: number;
-    failed: number;
-    duplicates: number;
-  };
+  jobId?: string;
+  counts?: ImportCounts;
   totalRows?: number;
   skippedRows?: Array<{
     row: number;
@@ -59,6 +62,20 @@ type ImportResponse = {
     invoiceNumber: string | null;
   }>;
 };
+
+type ImportJobStatus = {
+  id: string;
+  status: "queued" | "processing" | "completed" | "failed";
+  totalRows: number;
+  processedRows: number;
+  importedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  errorMessage: string | null;
+  summary?: { skippedRows?: ImportResponse["skippedRows"]; failedRows?: ImportResponse["failedRows"]; duplicates?: number } | null;
+};
+
+type ImportJobStatusResponse = { ok?: boolean; error?: string; job?: ImportJobStatus };
 
 const SUPPORTED_COLUMNS = [
   "customer_id",
@@ -160,6 +177,7 @@ export function VehicleHistoryCsvImportCard({
   const [importError, setImportError] = useState<string | null>(null);
   const [response, setResponse] = useState<ImportResponse | null>(null);
   const [importing, setImporting] = useState(false);
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
 
@@ -231,9 +249,9 @@ export function VehicleHistoryCsvImportCard({
       },
     });
   }
-  async function completeOnboardingAfterImport(
-    nextCounts: NonNullable<ImportResponse["counts"]>,
-  ) {
+  const completeOnboardingAfterImport = useCallback(async (
+    nextCounts: ImportCounts,
+  ) => {
     if (!guidedQuery || !isOnboarding) return;
     setCompletingOnboarding(true);
     try {
@@ -260,7 +278,93 @@ export function VehicleHistoryCsvImportCard({
     } finally {
       setCompletingOnboarding(false);
     }
-  }
+  }, [guidedQuery, isOnboarding]);
+
+  useEffect(() => {
+    if (!activeJobId) return;
+    const pollingJobId = activeJobId;
+    let stopped = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    async function pollJobStatus() {
+      try {
+        const res = await fetch(`/api/import-jobs/${encodeURIComponent(pollingJobId)}`);
+        const payload = (await res.json().catch(() => ({}))) as ImportJobStatusResponse;
+        if (!res.ok || payload.ok === false || !payload.job) {
+          throw new Error(payload.error ?? "Unable to load import job status.");
+        }
+        if (stopped) return;
+        const job = payload.job;
+        const total = job.totalRows || importableRows.length || 0;
+        const percent = total ? Math.min(100, Math.round((job.processedRows / total) * 100)) : 0;
+        setProgress({
+          phase:
+            job.status === "completed"
+              ? "Finalizing"
+              : job.status === "failed"
+                ? "Import failed"
+                : "Importing records",
+          phaseKey:
+            job.status === "completed"
+              ? "completed"
+              : job.status === "failed"
+                ? "failed"
+                : "importing",
+          processed: job.processedRows,
+          total,
+          percent: job.status === "completed" || job.status === "failed" ? 100 : percent,
+        });
+        if (job.status === "completed" || job.status === "failed") {
+          const counts: ImportCounts = {
+            imported: job.importedCount,
+            updated: 0,
+            skipped: job.skippedCount,
+            failed: job.failedCount,
+            duplicates: Number(job.summary?.duplicates ?? 0),
+          };
+          const nextResponse: ImportResponse = {
+            ok: job.status === "completed",
+            jobId: job.id,
+            counts,
+            totalRows: job.totalRows,
+            skippedRows: job.summary?.skippedRows ?? [],
+            failedRows: job.summary?.failedRows ?? [],
+            error: job.errorMessage ?? undefined,
+          };
+          setResponse(nextResponse);
+          setImporting(false);
+          setActiveJobId(null);
+          if (job.status === "failed") {
+            setImportError(job.errorMessage ?? "Vehicle history import job failed.");
+            return;
+          }
+          if (isOnboarding && counts.imported > 0 && counts.failed === 0) {
+            await completeOnboardingAfterImport(counts);
+          }
+          if (counts.imported > 0) onImported?.();
+          return;
+        }
+        timeoutId = setTimeout(() => void pollJobStatus(), 1500);
+      } catch (error) {
+        if (stopped) return;
+        setImportError(error instanceof Error ? error.message : "Unable to poll import status.");
+        setImporting(false);
+        setActiveJobId(null);
+      }
+    }
+
+    timeoutId = setTimeout(() => void pollJobStatus(), 1000);
+    return () => {
+      stopped = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [
+    activeJobId,
+    completeOnboardingAfterImport,
+    importableRows.length,
+    isOnboarding,
+    onImported,
+  ]);
 
   async function confirmImport() {
     if (importing || completingOnboarding) return;
@@ -273,12 +377,13 @@ export function VehicleHistoryCsvImportCard({
     setImporting(true);
     setImportError(null);
     setResponse(null);
+    setActiveJobId(null);
     setProgress({
       phase: "Uploading CSV",
       phaseKey: "importing",
       processed: 0,
       total: importableRows.length,
-      percent: 35,
+      percent: 10,
     });
     try {
       const formData = new FormData();
@@ -297,48 +402,25 @@ export function VehicleHistoryCsvImportCard({
         phaseKey: "matching",
         processed: 0,
         total: importableRows.length,
-        percent: 50,
+        percent: 20,
       });
       const res = await fetch("/api/work-orders/history/import", {
         method: "POST",
         body: formData,
       });
+      const payload = (await res.json().catch(() => ({}))) as ImportResponse;
+      if (!res.ok || payload.ok === false || !payload.jobId) {
+        throw new Error(payload.error ?? "Unable to queue vehicle history import.");
+      }
+      setResponse({ ok: true, jobId: payload.jobId, totalRows: payload.totalRows });
       setProgress({
         phase: "Importing records",
         phaseKey: "importing",
         processed: 0,
-        total: importableRows.length,
-        percent: 75,
-      });
-      const payload = (await res.json().catch(() => ({}))) as ImportResponse;
-      if (!res.ok || payload.ok === false || !payload.counts)
-        throw new Error(payload.error ?? "Unable to import vehicle history.");
-      setResponse(payload);
-      if (
-        isOnboarding &&
-        payload.counts.imported > 0 &&
-        payload.counts.failed === 0
-      ) {
-        setProgress({
-          phase: "Finalizing",
-          phaseKey: "finalizing",
-          processed: payload.totalRows ?? importableRows.length,
-          total: payload.totalRows ?? importableRows.length,
-          percent: 98,
-        });
-        await completeOnboardingAfterImport(payload.counts);
-      }
-      setProgress({
-        phase:
-          payload.counts.failed > 0
-            ? "Import completed with failures"
-            : "Finalizing",
-        phaseKey: payload.counts.failed > 0 ? "failed" : "completed",
-        processed: payload.totalRows ?? importableRows.length,
         total: payload.totalRows ?? importableRows.length,
-        percent: 100,
+        percent: 25,
       });
-      if (payload.counts.imported > 0) onImported?.();
+      setActiveJobId(payload.jobId);
     } catch (error) {
       setProgress({
         phase: "Import failed",
@@ -350,9 +432,8 @@ export function VehicleHistoryCsvImportCard({
       setImportError(
         error instanceof Error
           ? error.message
-          : "Unable to import vehicle history.",
+          : "Unable to queue vehicle history import.",
       );
-    } finally {
       setImporting(false);
     }
   }

--- a/features/work-orders/server/vehicle-history-import-job.ts
+++ b/features/work-orders/server/vehicle-history-import-job.ts
@@ -1,0 +1,125 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { chunkArray, compactImportSummary } from "@/features/shared/lib/import/csv";
+
+type DB = Database;
+export const VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 250;
+export const VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT = 25;
+export const VEHICLE_HISTORY_IMPORT_MAX_ROWS = 20_000;
+
+type HistoryImportRow = {
+  customer_id?: unknown; vehicle_id?: unknown; vin?: unknown; customer_email?: unknown; email?: unknown;
+  customer_phone?: unknown; phone?: unknown; customer_name?: unknown; name?: unknown; service_date?: unknown;
+  repair_order_number?: unknown; work_order_number?: unknown; invoice_number?: unknown; odometer?: unknown;
+  service_category?: unknown; complaint?: unknown; cause?: unknown; correction?: unknown; parts?: unknown;
+  labor_hours?: unknown; total?: unknown; technician?: unknown; advisor?: unknown; notes?: unknown;
+};
+
+type CustomerRef = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "email" | "phone" | "phone_number" | "name" | "business_name" | "first_name" | "last_name">;
+type VehicleRef = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "external_id" | "vin" | "customer_id">;
+type Resolver = { customersById: Map<string, CustomerRef>; customersByExternal: Map<string, CustomerRef>; customersByEmail: Map<string, CustomerRef>; customersByPhone: Map<string, CustomerRef>; customersByName: Map<string, CustomerRef>; vehiclesById: Map<string, VehicleRef>; vehiclesByExternal: Map<string, VehicleRef>; vehiclesByVin: Map<string, VehicleRef>; };
+type ImportCounts = { imported: number; updated: number; skipped: number; failed: number; duplicates: number };
+
+type JobRow = { id: string; shop_id: string; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
+type StagedRow = { id: string; row_number: number; raw_row: HistoryImportRow; status: string | null };
+
+function clean(value: unknown): string | null { const text = String(value ?? "").trim(); return text ? text : null; }
+function key(value: unknown): string | null { return clean(value)?.toLowerCase().replace(/\s+/g, " ") ?? null; }
+function phone(value: unknown): string | null { const text = clean(value); if (!text) return null; return text.replace(/\D/g, "") || text; }
+function vin(value: unknown): string | null { return clean(value)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null; }
+function num(value: unknown): number | null { const text = clean(value); if (!text) return null; const parsed = Number(text.replace(/[$,]/g, "")); return Number.isFinite(parsed) ? parsed : null; }
+function validDate(value: unknown): string | null { const text = clean(value); if (!text) return null; const parsed = new Date(text); return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString(); }
+function customerName(c: CustomerRef): string | null { return c.name || c.business_name || [c.first_name, c.last_name].filter(Boolean).join(" ").trim() || null; }
+
+async function loadResolver(supabase: SupabaseClient<DB>, shopId: string): Promise<Resolver> {
+  const [{ data: customers, error: customerError }, { data: vehicles, error: vehicleError }] = await Promise.all([
+    supabase.from("customers").select("id, external_id, email, phone, phone_number, name, business_name, first_name, last_name").eq("shop_id", shopId),
+    supabase.from("vehicles").select("id, external_id, vin, customer_id").eq("shop_id", shopId),
+  ]);
+  if (customerError) throw customerError; if (vehicleError) throw vehicleError;
+  const r: Resolver = { customersById: new Map(), customersByExternal: new Map(), customersByEmail: new Map(), customersByPhone: new Map(), customersByName: new Map(), vehiclesById: new Map(), vehiclesByExternal: new Map(), vehiclesByVin: new Map() };
+  for (const c of (customers ?? []) as CustomerRef[]) {
+    r.customersById.set(c.id, c); const ex = key(c.external_id); if (ex && !r.customersByExternal.has(ex)) r.customersByExternal.set(ex, c);
+    const em = key(c.email); if (em && !r.customersByEmail.has(em)) r.customersByEmail.set(em, c);
+    for (const p of [c.phone, c.phone_number]) { const ph = phone(p); if (ph && !r.customersByPhone.has(ph)) r.customersByPhone.set(ph, c); }
+    for (const n of [c.name, c.business_name, customerName(c)]) { const nk = key(n); if (nk && !r.customersByName.has(nk)) r.customersByName.set(nk, c); }
+  }
+  for (const v of (vehicles ?? []) as VehicleRef[]) { r.vehiclesById.set(v.id, v); const ex = key(v.external_id); if (ex && !r.vehiclesByExternal.has(ex)) r.vehiclesByExternal.set(ex, v); const vk = vin(v.vin); if (vk && !r.vehiclesByVin.has(vk)) r.vehiclesByVin.set(vk, v); }
+  return r;
+}
+function resolveCustomer(row: HistoryImportRow, r: Resolver): CustomerRef | null { const cid = clean(row.customer_id); if (cid && r.customersById.has(cid)) return r.customersById.get(cid)!; const ex = key(row.customer_id); if (ex && r.customersByExternal.has(ex)) return r.customersByExternal.get(ex)!; const em = key(row.customer_email ?? row.email); if (em && r.customersByEmail.has(em)) return r.customersByEmail.get(em)!; const ph = phone(row.customer_phone ?? row.phone); if (ph && r.customersByPhone.has(ph)) return r.customersByPhone.get(ph)!; const nm = key(row.customer_name ?? row.name); if (nm && r.customersByName.has(nm)) return r.customersByName.get(nm)!; return null; }
+function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null { const vid = clean(row.vehicle_id); if (vid && r.vehiclesById.has(vid)) return r.vehiclesById.get(vid)!; const ex = key(row.vehicle_id); if (ex && r.vehiclesByExternal.has(ex)) return r.vehiclesByExternal.get(ex)!; const vk = vin(row.vin); if (vk && r.vehiclesByVin.has(vk)) return r.vehiclesByVin.get(vk)!; return null; }
+
+async function findDuplicateHistoryId(supabase: SupabaseClient<DB>, shopId: string, column: "work_order_number" | "invoice_number", value: string): Promise<string | null> {
+  const { data, error } = await supabase.from("history").select("id").eq("shop_id" as "id", shopId).eq(column as "id", value).limit(1);
+  if (error) throw error; return data?.[0]?.id ?? null;
+}
+
+function compactSamples(summary: Record<string, unknown> | null) {
+  return {
+    skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as unknown[] : [],
+    failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as unknown[] : [],
+  };
+}
+
+export async function processVehicleHistoryImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = VEHICLE_HISTORY_IMPORT_BATCH_SIZE) {
+  const client = supabase as unknown as SupabaseClient;
+  let jobQuery = client.from("import_jobs").select("id, shop_id, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicle_history").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1);
+  if (jobId) jobQuery = jobQuery.eq("id", jobId);
+  const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>();
+  if (jobError) throw jobError;
+  if (!job) return { ok: true, processed: 0, completed: false, job: null };
+
+  await client.from("import_jobs").update({ status: "processing", updated_at: new Date().toISOString() }).eq("id", job.id);
+  const { data: stagedRows, error: rowsError } = await client.from("import_job_rows").select("id, row_number, raw_row, status").eq("job_id", job.id).eq("status", "queued").order("row_number", { ascending: true }).limit(batchSize);
+  if (rowsError) throw rowsError;
+  const rows = (stagedRows ?? []) as StagedRow[];
+  if (!rows.length) {
+    const finalSummary = compactImportSummary({ counts: { imported: job.imported_count ?? 0, updated: 0, skipped: job.skipped_count ?? 0, failed: job.failed_count ?? 0, duplicates: Number(job.summary?.duplicates ?? 0) }, totalRows: job.processed_rows ?? 0, skippedRows: compactSamples(job.summary).skippedRows, failedRows: compactSamples(job.summary).failedRows, sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT });
+    await client.from("import_jobs").update({ status: "completed", completed_at: new Date().toISOString(), updated_at: new Date().toISOString(), summary: finalSummary }).eq("id", job.id);
+    return { ok: true, processed: 0, completed: true, job: { id: job.id } };
+  }
+
+  const resolver = await loadResolver(supabase, job.shop_id);
+  const counts: ImportCounts = { imported: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const samples = compactSamples(job.summary);
+  const payloads: Array<{ stagedId: string; rowNumber: number; repairOrderNumber: string | null; invoiceNumber: string | null; payload: DB["public"]["Tables"]["history"]["Insert"] & Record<string, unknown> }> = [];
+
+  for (const staged of rows) {
+    const row = staged.raw_row; const rowNumber = staged.row_number; const repairOrderNumber = clean(row.repair_order_number ?? row.work_order_number); const invoiceNumber = clean(row.invoice_number);
+    try {
+      const serviceDate = validDate(row.service_date);
+      const invalidNumber = ([ ["odometer", row.odometer], ["labor_hours", row.labor_hours], ["total", row.total] ] as const).find(([, value]) => clean(value) && num(value) === null);
+      if (!serviceDate || invalidNumber) { const reason = !serviceDate ? "Invalid or missing service_date." : `${invalidNumber?.[0]} must be numeric when provided.`; counts.skipped++; samples.skippedRows.push({ row: rowNumber, reason, repairOrderNumber, invoiceNumber }); await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id); continue; }
+      const vehicle = resolveVehicle(row, resolver); const customer = resolveCustomer(row, resolver) ?? (vehicle?.customer_id ? resolver.customersById.get(vehicle.customer_id) ?? null : null);
+      if (!customer || ((clean(row.vehicle_id) || clean(row.vin)) && !vehicle)) { const reason = !customer ? "Existing customer could not be matched." : "Existing vehicle could not be matched."; counts.skipped++; samples.skippedRows.push({ row: rowNumber, reason, repairOrderNumber, invoiceNumber }); await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id); continue; }
+      let duplicateFound = false;
+      if (repairOrderNumber) duplicateFound = Boolean(await findDuplicateHistoryId(supabase, job.shop_id, "work_order_number", repairOrderNumber));
+      if (!duplicateFound && invoiceNumber) duplicateFound = Boolean(await findDuplicateHistoryId(supabase, job.shop_id, "invoice_number", invoiceNumber));
+      if (duplicateFound) { counts.skipped++; counts.duplicates++; samples.skippedRows.push({ row: rowNumber, reason: "Duplicate repair order/invoice already exists.", repairOrderNumber, invoiceNumber }); await client.from("import_job_rows").update({ status: "skipped", error_message: "Duplicate repair order/invoice already exists." }).eq("id", staged.id); continue; }
+      const parts = clean(row.parts); const notes = [clean(row.notes), parts ? `Parts: ${parts}` : null, clean(row.service_category) ? `Service category: ${clean(row.service_category)}` : null].filter(Boolean).join("\n") || null;
+      const description = [clean(row.service_category), clean(row.complaint), clean(row.correction)].filter(Boolean).join(" · ") || "Imported historical service record";
+      payloads.push({ stagedId: staged.id, rowNumber, repairOrderNumber, invoiceNumber, payload: { shop_id: job.shop_id, customer_id: customer.id, vehicle_id: vehicle?.id ?? null, service_date: serviceDate, description, notes, work_order_number: repairOrderNumber, invoice_number: invoiceNumber, odometer: num(row.odometer), symptom: clean(row.complaint), cause: clean(row.cause), correction: clean(row.correction), labor_hours: num(row.labor_hours), total: num(row.total), advisor_name: clean(row.advisor), assigned_tech_name: clean(row.technician), historical_status: "imported", source_system: "vehicle_history_csv", source_row_id: String(rowNumber), source_payload: JSON.parse(JSON.stringify({ imported_at: new Date().toISOString(), raw_row: row, service_category: clean(row.service_category), parts: clean(row.parts) })) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"] } });
+    } catch (error) { counts.failed++; const message = error instanceof Error ? error.message : "History row failed to import."; samples.failedRows.push({ row: rowNumber, error: message, repairOrderNumber, invoiceNumber }); await client.from("import_job_rows").update({ status: "failed", error_message: message }).eq("id", staged.id); }
+  }
+
+  for (const batch of chunkArray(payloads, VEHICLE_HISTORY_IMPORT_BATCH_SIZE)) {
+    const { error } = await supabase.from("history").insert(batch.map((entry) => entry.payload));
+    if (error) {
+      for (const entry of batch) {
+        const { error: rowError } = await supabase.from("history").insert(entry.payload);
+        if (rowError) { counts.failed++; samples.failedRows.push({ row: entry.rowNumber, error: rowError.message, repairOrderNumber: entry.repairOrderNumber, invoiceNumber: entry.invoiceNumber }); await client.from("import_job_rows").update({ status: "failed", error_message: rowError.message }).eq("id", entry.stagedId); }
+        else { counts.imported++; await client.from("import_job_rows").update({ status: "imported" }).eq("id", entry.stagedId); }
+      }
+    } else { counts.imported += batch.length; await client.from("import_job_rows").update({ status: "imported" }).in("id", batch.map((entry) => entry.stagedId)); }
+  }
+
+  samples.skippedRows = samples.skippedRows.slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT); samples.failedRows = samples.failedRows.slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT);
+  const processedRows = (job.processed_rows ?? 0) + rows.length;
+  const summary = { skippedRows: samples.skippedRows, failedRows: samples.failedRows, duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates };
+  const { count: remainingCount, error: remainingError } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued");
+  if (remainingError) throw remainingError;
+  const completed = (remainingCount ?? 0) === 0;
+  await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: processedRows, imported_count: (job.imported_count ?? 0) + counts.imported, skipped_count: (job.skipped_count ?? 0) + counts.skipped, failed_count: (job.failed_count ?? 0) + counts.failed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
+  return { ok: true, processed: rows.length, completed, job: { id: job.id } };
+}

--- a/tests/vehicle-history-csv-import-architecture.test.ts
+++ b/tests/vehicle-history-csv-import-architecture.test.ts
@@ -3,107 +3,97 @@ import { describe, expect, it } from "vitest";
 
 const routeSource = () =>
   readFileSync("app/api/work-orders/history/import/route.ts", "utf8");
+const workerSource = () =>
+  readFileSync("features/work-orders/server/vehicle-history-import-job.ts", "utf8");
+const tickSource = () =>
+  readFileSync("app/api/internal/import-jobs/tick/route.ts", "utf8");
+const statusSource = () =>
+  readFileSync("app/api/import-jobs/[jobId]/route.ts", "utf8");
 const cardSource = () =>
   readFileSync(
     "features/work-orders/components/VehicleHistoryCsvImportCard.tsx",
     "utf8",
   );
-const helperSource = () =>
-  readFileSync("features/shared/lib/import/csv.ts", "utf8");
+const migrationSource = () =>
+  readFileSync("db/sql/2026-07-05_vehicle_history_import_jobs.sql", "utf8");
 
-describe("vehicle history CSV import multipart architecture", () => {
-  it("sends FormData with the CSV file instead of huge JSON rows", () => {
-    const source = cardSource();
-
-    expect(source).toContain("const formData = new FormData()");
-    expect(source).toContain('formData.append("file", file)');
-    expect(source).toContain('formData.append("guidedSessionId"');
-    expect(source).toContain('formData.append("guidedStep"');
-    expect(source).toContain('formData.append("returnTo"');
-    expect(source).toContain('body: formData');
-    expect(source).not.toContain("JSON.stringify({ rows: importableRows })");
-  });
-
-  it("keeps progress wording accurate and disables duplicate import clicks", () => {
-    const source = cardSource();
-
-    for (const phase of [
-      "Uploading CSV",
-      "Processing on server",
-      "Importing records",
-      "Finalizing",
-    ]) {
-      expect(source).toContain(`phase: "${phase}"`);
-    }
-    expect(source).toContain("if (importing || completingOnboarding) return");
-    const footer = readFileSync("features/shared/components/import/GuidedImportFooterActions.tsx", "utf8");
-    expect(footer).toContain("disabled={importing || completing || !canConfirm}");
-  });
-
-  it("accepts multipart form-data and parses the CSV server-side", () => {
+describe("vehicle history CSV import job architecture", () => {
+  it("upload route accepts multipart CSV, creates a job, stages rows, and returns jobId", () => {
     const source = routeSource();
 
     expect(source).toContain('contentType.includes("multipart/form-data")');
     expect(source).toContain("await req.formData()");
     expect(source).toContain("parseCsvFileFromFormData<HistoryImportRow>");
+    expect(source).toContain('.from("import_jobs")');
+    expect(source).toContain('.from("import_job_rows")');
+    expect(source).toContain("jobId: job.id");
+    expect(source).toContain("{ status: 202 }");
+    expect(source).not.toContain('.from("history").insert');
+    expect(source).not.toContain("loadResolver");
+    expect(source).not.toContain("findDuplicateHistoryId");
     expect(source).not.toContain("await req.json()");
   });
 
-  it("rejects missing or non-CSV uploads with clear errors", () => {
-    const helper = helperSource();
-    const route = routeSource();
+  it("worker endpoint is protected and processes only a bounded batch", () => {
+    const tick = tickSource();
+    const worker = workerSource();
 
-    expect(helper).toContain("Missing CSV file");
-    expect(helper).toContain("Unsupported file type");
-    expect(helper).toContain("Malformed CSV");
-    expect(helper).toContain("CSV file is too large");
-    expect(route).toContain("{ status: 400 }");
-    expect(route).toContain("{ status: 415 }");
+    expect(tick).toContain("INTERNAL_IMPORT_JOBS_SECRET");
+    expect(tick).toContain("x-internal-import-jobs-secret");
+    expect(tick).toContain("processVehicleHistoryImportJobBatch");
+    expect(worker).toContain("VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 250");
+    expect(worker).toContain(".limit(batchSize)");
+    expect(worker).toContain('.from("import_job_rows")');
+    expect(worker).toContain('.from("history").insert');
+    expect(worker).not.toContain('.from("work_orders")');
+    expect(worker).not.toContain('.from("dispatch');
   });
 
-  it("imports valid history rows in batches without creating work orders or dispatch records", () => {
-    const source = routeSource();
+  it("job progress and compact summary are persisted", () => {
+    const worker = workerSource();
+    const status = statusSource();
 
-    expect(source).toContain("HISTORY_IMPORT_BATCH_SIZE = 250");
-    expect(source).toContain("chunkArray(payloads, HISTORY_IMPORT_BATCH_SIZE)");
-    expect(source).toContain('.from("history")');
-    expect(source).not.toContain('.from("work_orders")');
-    expect(source).not.toContain('.from("dispatch');
-    expect(source).not.toContain('.from("work_order_queue');
+    expect(worker).toContain("processed_rows: processedRows");
+    expect(worker).toContain("imported_count");
+    expect(worker).toContain("skipped_count");
+    expect(worker).toContain("failed_count");
+    expect(worker).toContain("VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT");
+    expect(worker).toContain("slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT)");
+    expect(status).toContain('.from("import_jobs")');
+    expect(status).toContain('.eq("shop_id", shopId)');
+    expect(status).toContain("processedRows");
   });
 
-  it("returns only compact import summary samples", () => {
-    const source = routeSource();
-    const helper = helperSource();
+  it("uses shop-scoped history duplicate detection without giant customer_id.in filters", () => {
+    const worker = workerSource();
+    const migration = migrationSource();
 
-    expect(source).toContain("compactImportSummary");
-    expect(source).toContain("HISTORY_IMPORT_SAMPLE_LIMIT = 25");
-    expect(helper).toContain("skippedRows.slice(0, sampleLimit)");
-    expect(helper).toContain("failedRows.slice(0, sampleLimit)");
-    expect(helper).toContain("truncated");
-    expect(source).toContain("totalRows: rows.length");
+    expect(migration).toContain("alter table public.history add column if not exists shop_id");
+    expect(migration).toContain("update public.history h");
+    expect(worker).toContain("findDuplicateHistoryId");
+    expect(worker).toContain('.eq("shop_id" as "id", shopId)');
+    expect(worker).not.toContain('.in("customer_id"');
   });
 
-  it("completes guided vehicle_history only after successful zero-failure imports", () => {
+  it("UI creates a job, polls status, and stops polling on terminal states", () => {
+    const source = cardSource();
+
+    expect(source).toContain("const formData = new FormData()");
+    expect(source).toContain('formData.append("file", file)');
+    expect(source).toContain("setActiveJobId(payload.jobId)");
+    expect(source).toContain("/api/import-jobs/${encodeURIComponent(pollingJobId)}");
+    expect(source).toContain("setTimeout(() => void pollJobStatus(), 1500)");
+    expect(source).toContain('job.status === "completed" || job.status === "failed"');
+    expect(source).toContain("setActiveJobId(null)");
+    expect(source).toContain("clearTimeout(timeoutId)");
+    expect(source).not.toContain("JSON.stringify({ rows: importableRows })");
+  });
+
+  it("continues onboarding only after completed zero-failure imported jobs", () => {
     const source = cardSource();
 
     expect(source).toContain("/steps/vehicle_history/complete");
     expect(source).toContain('summary: { importType: "vehicle_history_csv", ...nextCounts }');
-    expect(source).toContain("payload.counts.imported > 0");
-    expect(source).toContain("payload.counts.failed === 0");
-    const footer = readFileSync("features/shared/components/import/GuidedImportFooterActions.tsx", "utf8");
-    expect(footer).toContain("Continue onboarding");
-  });
-
-  it("batches history duplicate reload lookups instead of sending oversized customer_id filters", () => {
-    const source = routeSource();
-
-    expect(source).toContain("HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE = 50");
-    expect(source).toContain("findDuplicateHistoryId");
-    expect(source).toContain(`chunkArray(
-    customerIds,
-    HISTORY_DUPLICATE_LOOKUP_CUSTOMER_CHUNK_SIZE,`);
-    expect(source).not.toContain('.in("customer_id", resolver.shopCustomerIds)');
-    expect(source).not.toContain('.from("work_orders")');
+    expect(source).toContain("counts.imported > 0 && counts.failed === 0");
   });
 });


### PR DESCRIPTION
### Motivation
- The synchronous CSV import of large vehicle-history files caused Vercel runtime timeouts (300s), so the import must be converted to an asynchronous, job-based flow that returns immediately and processes rows in bounded batches.

### Description
- Replace the synchronous upload path with a multipart/form-data uploader at `POST /api/work-orders/history/import` that parses the CSV server-side, creates an `import_jobs` row, stages raw rows into `import_job_rows`, and returns `202` with a `jobId` (see `app/api/work-orders/history/import/route.ts`).
- Add a migration that backfills `history.shop_id` and creates `import_jobs` and `import_job_rows` with shop-scoped RLS and indexes (`db/sql/2026-07-05_vehicle_history_import_jobs.sql`).
- Add a worker implementation `processVehicleHistoryImportJobBatch` in `features/work-orders/server/vehicle-history-import-job.ts` plus a protected tick endpoint `GET/POST /api/internal/import-jobs/tick` which is guarded by the internal secret; the worker processes a bounded batch per call and persists `processed_rows`, counters and a compact `summary` JSON.
- Add a shop-scoped status endpoint `GET /api/import-jobs/[jobId]` and update the UI (`VehicleHistoryCsvImportCard.tsx`) to queue the job, poll `/api/import-jobs/{jobId}` every ~1–1.5s, update the progress bar from `processedRows / totalRows`, stop polling on terminal states, and only allow onboarding continuation when `imported_count > 0` and `failed_count === 0`.
- Duplicate detection was changed to be shop-scoped (query by `shop_id` and `work_order_number`/`invoice_number`) instead of using oversized `customer_id.in(...)` filters, and staged rows are retained in `import_job_rows` (no Supabase Storage object is created) with retention metadata recorded in the job summary.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully.
- Ran ESLint for the modified files with `npx eslint app/api/work-orders/history/import/route.ts features/work-orders/components/VehicleHistoryCsvImportCard.tsx` (no blocking errors; only non-blocking warnings were reviewed during development).
- Ran the architecture tests with `npx vitest run tests/vehicle-history-csv-import-architecture.test.ts`, and all tests passed (`6 tests` in the suite passed).

Additional notes
- Worker batch size: `250` rows per tick (`VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 250`).
- Worker trigger: call `GET` or `POST /api/internal/import-jobs/tick` with optional `?jobId=<uuid>` to target a specific job; otherwise it claims the next queued/processing `vehicle_history` job.
- Required env var / secret: set `INTERNAL_IMPORT_JOBS_SECRET` and call the tick endpoint with header `x-internal-import-jobs-secret: <INTERNAL_IMPORT_JOBS_SECRET>`.
- Files changed: `app/api/work-orders/history/import/route.ts`, `app/api/internal/import-jobs/tick/route.ts`, `app/api/import-jobs/[jobId]/route.ts`, `features/work-orders/server/vehicle-history-import-job.ts`, `features/work-orders/components/VehicleHistoryCsvImportCard.tsx`, `db/sql/2026-07-05_vehicle_history_import_jobs.sql`, and updated tests `tests/vehicle-history-csv-import-architecture.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ae64dd2e48328b97589e41a89f0c5)