### PR TITLE
Fix GET route signature for import job params

### DIFF
--- a/app/api/import-jobs/[jobId]/route.ts
+++ b/app/api/import-jobs/[jobId]/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-type Params = { params: { jobId: string } };
-
-export async function GET(_req: Request, { params }: Params) {
+export async function GET(_req: Request, context: { params: Promise<{ jobId: string }> }) {
+  const { jobId } = await context.params;
   const access = await requireShopScopedApiAccess({
     allowRoles: ["owner", "admin", "manager", "advisor"],
   });
@@ -14,7 +13,7 @@ export async function GET(_req: Request, { params }: Params) {
   const { data, error } = await (access.supabase as unknown as { from: (table: string) => any })
     .from("import_jobs")
     .select("id, import_type, status, total_rows, processed_rows, imported_count, skipped_count, failed_count, error_message, summary, created_at, updated_at, completed_at")
-    .eq("id", params.jobId)
+    .eq("id", jobId)
     .eq("shop_id", shopId)
     .single();
 


### PR DESCRIPTION
### Motivation
- Fix an invalid Next.js App Router `GET` handler signature in `app/api/import-jobs/[jobId]/route.ts` that caused a type error during deployment.

### Description
- Updated the handler signature to `export async function GET(_req: Request, context: { params: Promise<{ jobId: string }> })` and extracted the id with `const { jobId } = await context.params;`, replacing `params.jobId` usage while preserving all auth, polling, business logic, and response payloads.

### Testing
- Ran `npm run typecheck` which passed.
- Ran `npm run build` which failed in this environment due to network/proxy 403 errors fetching Google Fonts (`Inter`, `Black Ops One`), which is unrelated to the route signature change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aebc4140c8328b70428828d272fdb)