### PR TITLE
Increase vehicle history import batch size to 1000

### DIFF
--- a/features/work-orders/server/vehicle-history-import-job.ts
+++ b/features/work-orders/server/vehicle-history-import-job.ts
@@ -3,7 +3,7 @@ import type { Database } from "@shared/types/types/supabase";
 import { chunkArray, compactImportSummary } from "@/features/shared/lib/import/csv";
 
 type DB = Database;
-export const VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 250;
+export const VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 1000;
 export const VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT = 25;
 export const VEHICLE_HISTORY_IMPORT_MAX_ROWS = 20_000;
 

--- a/tests/vehicle-history-csv-import-architecture.test.ts
+++ b/tests/vehicle-history-csv-import-architecture.test.ts
@@ -41,7 +41,7 @@ describe("vehicle history CSV import job architecture", () => {
     expect(tick).toContain("INTERNAL_IMPORT_JOBS_SECRET");
     expect(tick).toContain("x-internal-import-jobs-secret");
     expect(tick).toContain("processVehicleHistoryImportJobBatch");
-    expect(worker).toContain("VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 250");
+    expect(worker).toContain("VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 1000");
     expect(worker).toContain(".limit(batchSize)");
     expect(worker).toContain('.from("import_job_rows")');
     expect(worker).toContain('.from("history").insert');


### PR DESCRIPTION
### Motivation
- Increase throughput of the async Vehicle History CSV import ticks while keeping the existing per-tick bounded processing to remain safe under Vercel execution time limits.

### Description
- Updated `VEHICLE_HISTORY_IMPORT_BATCH_SIZE` from `250` to `1000` in `features/work-orders/server/vehicle-history-import-job.ts` and adjusted the targeted architecture expectation in `tests/vehicle-history-csv-import-architecture.test.ts` to match the new batch size.

### Testing
- Ran `pnpm typecheck` and `pnpm test tests/vehicle-history-csv-import-architecture.test.ts`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b1247ac208328ae0708f71df698ee)